### PR TITLE
fix: create the initial scaffold commit before gh repo create / release:init

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -222,6 +222,11 @@ current_year:
 _tasks:
   - command: git init -b main
     when: "[[ git_init ]]"
+  # Initial commit — gh repo create --push and task release:init both need
+  # HEAD to exist. Runs before `task install`, so lefthook hooks are not yet
+  # installed and nothing intercepts this commit.
+  - command: 'git add -A && git commit -m "chore: initial scaffold from harmon-init"'
+    when: "[[ git_init ]]"
   - command: gh repo create [[ github_org ]]/[[ project_slug ]] --private --source=. --push
     when: "[[ github_remote_create ]]"
   - command: task install

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -111,6 +111,10 @@ cd "$dest"
 # (lefthook dump) need a git repo.
 if [ ! -d .git ]; then
     git init -q
+else
+    # _tasks ran: git init must be followed by the initial scaffold commit —
+    # gh repo create --push and task release:init both require HEAD to exist.
+    git rev-parse HEAD >/dev/null 2>&1 || err "_tasks left the rendered repo without an initial commit"
 fi
 
 # ── 0. AGENTS.md is canonical; CLAUDE.md/GEMINI.md are symlinks to it ──


### PR DESCRIPTION
## What broke

`copier copy` with **GITHUB REMOTE: Yes** failed at v3.0.1:

```text
> Running task 2 of 6: gh repo create evanharmon1/four-test --private --source=. --push
--push enabled but no commits found in /Users/evan/git/four-test
```

`gh repo create --source=. --push` needs HEAD to exist, but `_tasks` only ran `git init` and never committed. v2's `ghReleaseInit` task used to do the commit; v3 dropped it. `task release:init` (RELEASE: Yes) had the same latent failure — it tags HEAD.

## Fix

- New `_task` immediately after `git init`: `git add -A && git commit -m "chore: initial scaffold from harmon-init"` (gated on `git_init`). It runs **before** `task install`, so lefthook hooks aren't installed yet and nothing intercepts the commit. The generated repo's .gitignore correctly keeps `.meta`/`todo.md` out of the commit.
- The command is YAML-quoted — the conventional `chore:` prefix is the colon-in-unquoted-scalar trap again.
- Harness now asserts the rendered repo has an initial commit whenever `_tasks` ran (all 5 profiles green).

## After merge

`task release:patch` → **v3.0.2** to make it live for `copier copy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)