### PR TITLE
fix: macOS-portable init-env.sh eviction + MD040 in CONTRIBUTING template

### DIFF
--- a/template/CONTRIBUTING.md.jinja
+++ b/template/CONTRIBUTING.md.jinja
@@ -51,7 +51,7 @@ Feel free to submit a pull request with your improvements.
 We follow the [Conventional Commits](https://www.conventionalcommits.org) standard for writing commit messages. This helps us manage the code history, generate changelogs, and automate CI/CD tooling. Example:
 
 Example commit message:
-```
+```text
 feat(api): add support for custom endpoints
 
 Added support for creating and managing custom endpoints in the API.
@@ -59,7 +59,7 @@ Resolves issue #42.
 ```
 
 Commit message structure:
-```
+```text
 <type>[optional scope]: <description>
 
 [optional body]

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/init-env.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/init-env.sh
@@ -65,13 +65,24 @@ ALLOWED_VARS=("${FILTERED_ALLOWED_VARS[@]}")
 
 touch "$ENV_FILE"
 
+# Remove every line setting $1 from $2, portably. GNU `sed -i` is not
+# available on macOS (BSD sed needs a suffix arg after -i, so `sed -i expr
+# file` silently does nothing useful) — and initializeCommand runs this
+# script on the HOST, which is often a Mac.
+strip_var() {
+    local tmp
+    tmp="$(mktemp)"
+    grep -v "^${1}=" "$2" >"$tmp" || true
+    mv "$tmp" "$2"
+}
+
 # Strip any forbidden var (managed by the script but not in this
 # profile's allow-list). This guarantees, for example, that the bot
 # profile evicts TS_AUTHKEY even if a stale value was written to the
 # env-file by an earlier rebuild.
 for var in "${ALL_MANAGED_VARS[@]}"; do
     if ! contains "$var" "${ALLOWED_VARS[@]}"; then
-        sed -i "/^${var}=/d" "$ENV_FILE" 2>/dev/null || true
+        strip_var "$var" "$ENV_FILE"
     fi
 done
 
@@ -81,7 +92,7 @@ done
 for var in "${ALLOWED_VARS[@]}"; do
     val="${!var:-}"
     if [ -n "$val" ]; then
-        sed -i "/^${var}=/d" "$ENV_FILE" 2>/dev/null || true
+        strip_var "$var" "$ENV_FILE"
         echo "${var}=${val}" >>"$ENV_FILE"
     fi
 done


### PR DESCRIPTION
## Description

Two template bugs found while dogfooding the devcontainer setup at root (#TBD follow-up PR):

1. **`init-env.sh` env-file eviction silently broken on macOS hosts.** BSD `sed` requires a suffix argument after `-i`, so `sed -i "expr" file` did nothing useful — and `|| true` masked the failure. Consequences:
   - The **bot profile's `TS_AUTHKEY` eviction guarantee silently failed**: a stale tailnet auth key written by an earlier dev-profile rebuild survived in the env-file of the bot container, which must never see it.
   - Allowed vars were **appended instead of replaced**, accumulating duplicate entries on every rebuild.

   Fixed with a portable `grep -v` + `mv` helper (macOS bash 3.2 safe — `initializeCommand` runs this on the host, which is often a Mac).

2. **`CONTRIBUTING.md.jinja` shipped an MD040 lint failure** to every generated project — the two commit-message example fences had no language. Now labeled `text`.

## Testing

- Reproduced the sed bug on macOS (Darwin 24.6.0): stale `TS_AUTHKEY=stale` survived and `GH_TOKEN` duplicated. After the fix: `TS_AUTHKEY` evicted, `GH_TOKEN` replaced in place.
- [x] `task verify` (lint + all 5 template profiles) passes
- [x] Bot + dev devcontainer smoke tests pass locally (`task test:devcontainer:root` / `:dev` via the devcontainers CLI, on the follow-up branch that dogfoods this at root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)