### PR TITLE
docs: add harmon-stack related-repos section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,15 @@ runners — and can also be applied to existing repos to standardize them. This 
 an application; it is a template repository used via the
 [Copier](https://copier.readthedocs.io/en/stable/) templating tool.
 
+## harmon-stack
+
+One of five repos in **harmon-stack** (Evan's homelab + dev-ops stack):
+[**harmon-init**](https://github.com/evanharmon1/harmon-init) (this repo — the template),
+[harmon-devkit](https://github.com/evanharmon1/harmon-devkit) (boilerplates/scripts/AI assets),
+[harmon-dotfiles](https://github.com/evanharmon1/harmon-dotfiles) (chezmoi dotfiles),
+[harmon-ops](https://github.com/evanharmon1/harmon-ops) (machine setup),
+[harmon-infra](https://github.com/harmonops/harmon-infra) (homelab IaC). See the README for the full table.
+
 ## Two-Layer Architecture
 
 1. **Root level** — Config for developing/maintaining the template itself

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Author: Evan Harmon
 [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border-orange.json)](https://github.com/copier-org/copier)
 [![Renovate](https://img.shields.io/badge/maintained%20with-renovate-blue?logo=renovatebot)](https://github.com/apps/renovate)
 
+## Part of harmon-stack
+
+This repo is part of **harmon-stack** — my personal stack of homelab, dev-tooling, and automation repos that work together.
+
+| Repo | What it is |
+| --- | --- |
+| [**harmon-init**](https://github.com/evanharmon1/harmon-init) **(this repo)** | Copier template that bootstraps & standardizes new repos (CI/CD, devcontainers, AI steering, tooling). |
+| [harmon-devkit](https://github.com/evanharmon1/harmon-devkit) | Reusable boilerplates & code templates, standalone scripts, and AI assets (skills, prompts, agents). |
+| [harmon-dotfiles](https://github.com/evanharmon1/harmon-dotfiles) | Shell & app dotfiles, managed declaratively with chezmoi. |
+| [harmon-ops](https://github.com/evanharmon1/harmon-ops) | Personal machine bootstrapping, package management & dev-environment setup across macOS/Windows/Linux. |
+| [harmon-infra](https://github.com/harmonops/harmon-infra) | Homelab infrastructure as code — Terraform, Ansible, and Docker Compose services. |
+
 ## Usage
 
 ### New project


### PR DESCRIPTION
Adds a consistent **Part of harmon-stack** section to the README and a short agent-facing pointer in `AGENTS.md`, naming the five sibling repos so each repo links to the others.

Part of documenting the harmon-stack repo family: harmon-init, harmon-devkit, harmon-dotfiles, harmon-ops, harmon-infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)