### PR TITLE
fix: ensure rendered LICENSE ends with a trailing newline

### DIFF
--- a/template/LICENSE.jinja
+++ b/template/LICENSE.jinja
@@ -1,4 +1,4 @@
-[%- if license == "mit" -%]
+[% if license == "mit" %]
 MIT License
 
 Copyright (c) [[ current_year ]] [[ author_full_name ]]
@@ -20,8 +20,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-[%- elif license == "private" -%]
+[% elif license == "private" %]
 [[ project_name ]] License Agreement
 
 Version 1.0, [[ current_year ]]
@@ -62,5 +61,4 @@ This License shall be governed by and construed in accordance with the laws of [
 8. Entire Agreement
 
 This License constitutes the entire agreement between you and Licensor regarding the use of the Software and supersedes all prior agreements, whether written or oral, relating to its subject matter.
-
 [% endif %]


### PR DESCRIPTION
## Problem

Every repo generated from harmon-init failed its **own** `task verify` out of the box:

```
FAIL: LICENSE: no newline at end of file
task: Failed to run task "verify" → "check" → "lint" → "lint:hygiene": exit status 1
```

The default `license=mit` branch rendered with **no trailing newline**.

## Cause

In `template/LICENSE.jinja`, the branch boundary `[%- elif license == "private" -%]` had a **left whitespace-control dash** (`[%-`). With copier's `_envops` `trim_blocks`/`lstrip_blocks` enabled, that dash strips all whitespace immediately before the tag — including the `\n` after `SOFTWARE.` — so the MIT render ended at `SOFTWARE.` with zero trailing newline. (The `private` branch ended in a trailing blank line for the same family of reasons.)

## Fix

Dropped the boundary dashes and the cosmetic blank lines before `elif`/`endif` so each branch's final newline is preserved. With `trim_blocks`/`lstrip_blocks` on, both branches now render with **exactly one** trailing newline and no leading blank line.

## Verification

- `license=mit` → rendered `LICENSE` ends in a single `\n` (first line `MIT License`); `lint-hygiene` clean.
- `license=private` → ends in a single `\n` (first line `<project> License Agreement`); `lint-hygiene` clean.
- `task test:template:all` green (minimal / web / iac / full / meta).

## Follow-up (not in this PR)

The template test harness (`scripts/test-template.sh`) didn't catch this because it runs its own checks but never runs the **generated** project's `task verify`/`lint:hygiene`. Worth adding a "rendered project passes its own hygiene" assertion so this class of bug can't recur. (Found via the new `standardize-repo` skill's `verify-applied.sh`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)