### PR TITLE
fix: don't enforce a repo-wide YAML extension convention

### DIFF
--- a/docs/sourceRepoFollowUps.md
+++ b/docs/sourceRepoFollowUps.md
@@ -46,9 +46,6 @@ source of truth going forward), not by hand-editing them ad hoc.
 5. **CHECKLIST.md is stale** (mentions pre-commit/cookiecutter).
 6. **validate.yml reinstalls lint tools inline every run** — candidates for
     the prebuilt devcontainer image or a composite action.
-7. **YAML extension drift** — harmon-infra uses `.yaml` for
-    `Taskfile`/`lefthook`/`.github/workflows/*`; the template standard is `.yml`
-    (matches sommerlawn-web + the harmon-init root). Re-templating renames them.
 
 ## sommerlawn-web
 

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -67,7 +67,9 @@ it points here.
 
 ## YAML, Markdown & shell
 
-- **YAML:** 2-space indent, `.yml` extension (not `.yaml`), linted by yamllint.
+- **YAML:** 2-space indent, linted by yamllint. Use whichever extension
+  (`.yml` or `.yaml`) each tool conventionally uses (e.g. `Taskfile.yml`,
+  `.coderabbit.yaml`) — don't normalize extensions repo-wide.
 - **Markdown:** markdownlint — ATX headings, no duplicate headings, emphasis and
   strong markers consistent within a file; line-length and first-line-heading
   rules are off.


### PR DESCRIPTION
## Why

Convention correction: **don't standardize `.yml` vs `.yaml`** — use whichever extension each tool conventionally uses (`Taskfile.yml`, `lefthook.yml`, `.coderabbit.yaml`, GitHub Actions accepts either). Don't fight a tool's own convention just to make a repo's YAML extensions uniform.

The template was shipping the opposite rule into every generated repo.

## Changes

- **`template/docs/conventions.md.jinja`** — the generated conventions doc said *"`.yml` extension (not `.yaml`)"*, which every new repo inherited. Reworded to "use whichever extension each tool conventionally uses — don't normalize repo-wide".
- **`docs/sourceRepoFollowUps.md`** — dropped the "YAML extension drift" follow-up (renaming harmon-infra's `.yaml` files to `.yml` is no longer a goal).

Detection/handling that already accepts **both** extensions is unaffected. `task test:template:minimal` green; rendered `docs/conventions.md` verified.

> Note: the `standardize-repo` skill (harmon-devkit#13) carried the same wrong rule in its catalog/audit/adopt guidance — corrected there in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)