### PR TITLE
docs: make devcontainer + Coder setup and 1Password secret flow clear

### DIFF
--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -67,11 +67,16 @@ that don't apply, then keep this file as a record of what was configured.
 
 ## 4. Secrets & environment
 
-- [ ] For local `.env` needs, use 1Password: `op inject`/`op run` or the
-      1Password Developer Environments feature; commit only `.env.example`-style files
+- [ ] For local `.env` needs, use **1Password Environments** (mounts a virtual
+      `.env`; secrets never hit disk or git) or `op run`/`op inject`. Commit only
+      `.env.example`-style files
 [% if devcontainer %]
-- [ ] Devcontainer secrets land in `.devcontainer/devcontainer.env` via
-      `init-env.sh` (1Password locally, host env on Coder) — never committed
+- [ ] Devcontainer secrets: create a **1Password environment** that mounts
+      `.devcontainer/devcontainer.env` (and `.devcontainer/dev/devcontainer.env`)
+      with `GH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `AGENT_DECK_TELEGRAM_KEY`
+      (+ `TS_AUTHKEY` for the dev profile). `init-env.sh` enforces the per-profile
+      allow-list; on Coder the values come from workspace parameters. See
+      [guides/devcontainers.md](guides/devcontainers.md)
 [% endif %]
 
 ## 5. Docs & meta

--- a/template/docs/README.md.jinja
+++ b/template/docs/README.md.jinja
@@ -31,7 +31,7 @@ This is the **hub** — read it when you're unsure where something belongs. It
 | Product — vision, roadmap, domain | [product/](product/) |
 | Architecture (subject hubs) | [architecture/](architecture/) — ci-cd, security, branch-protection, tests[% if project_type in ['web-astro', 'web-app'] %], design-language[% endif %] |
 | Decisions (ADRs) | [decisions/](decisions/) |
-| Guides (calm how-tos) | [guides/](guides/) — onboarding, deploying, troubleshooting |
+| Guides (calm how-tos) | [guides/](guides/) — onboarding, deploying, troubleshooting[% if devcontainer %], devcontainers[% endif %] |
 | Runbooks (crisis procedures) | [runbooks/](runbooks/) |
 | Post-generation setup | [CHECKLIST.md](CHECKLIST.md) |
 

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -9,9 +9,15 @@ current — it is the reference for "where do secrets live and who can do what".
 
 - **Least privilege.** Every token, account, and workflow gets the narrowest
   scope that still works.
-- **Secrets via 1Password.** Local env comes from 1Password (`op run` /
-  `op inject`); CI reads from GitHub Actions secrets. TODO: list the 1Password
-  vault/items this project uses.
+- **Secrets via 1Password.** Local env comes from **1Password Environments**
+  (a virtual `.env` mounted over a UNIX pipe — never written to disk or git) or
+  `op run`/`op inject`; CI reads from GitHub Actions secrets.
+[% if devcontainer %]
+  Devcontainer secrets are `GH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`,
+  `AGENT_DECK_TELEGRAM_KEY` (+ `TS_AUTHKEY`, dev profile only) — see
+  [../guides/devcontainers.md](../guides/devcontainers.md).
+[% endif %]
+  TODO: list the 1Password vault/items this project uses.
 - **Auditable changes.** `main` is protected; changes land via reviewed PRs
   (see [branch-protection.md](branch-protection.md)).
 [% if devcontainer %]

--- a/template/docs/guides/README.md.jinja
+++ b/template/docs/guides/README.md.jinja
@@ -12,5 +12,10 @@ advance*. The crisis counterpart is [runbooks/](../runbooks/) — procedures rea
 - [troubleshooting.md](troubleshooting.md) — symptom → cause → fix for **dev**
   problems (broken build, failing local setup). Distinct from runbooks, which
   cover prod incidents.
+[% if devcontainer %]
+- [devcontainers.md](devcontainers.md) — the dual-profile devcontainer (bot vs
+  dev), local secrets via **1Password Environments**, GHCR prebuilds, and
+  **Coder** setup.
+[% endif %]
 
 TODO: add more guides, e.g. "local development setup", "add a feature", "how X works".

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -1,0 +1,95 @@
+# Devcontainers
+
+[[ project_name ]] ships a **dual-profile** devcontainer. Both profiles share
+one `Dockerfile` and the baked `.devcontainer/config/` tree; they differ in
+which secrets and capabilities they allow.
+
+| Profile | Path | For | Tailscale |
+|---|---|---|---|
+| **Bot** | `.devcontainer/devcontainer.json` | AI agents (Claude Code, Codex, Gemini) | no |
+| **Dev** | `.devcontainer/dev/devcontainer.json` | humans | yes (`TS_AUTHKEY`, `--device=/dev/net/tun`) |
+
+The bot profile intentionally omits `TS_AUTHKEY` from its allow-list so a tailnet
+key never reaches an agent container.
+
+## Run it locally
+
+- **VS Code:** "Dev Containers: Reopen in Container" → pick the **Dev** profile
+  (`.devcontainer/dev/`) for human use.
+- **CLI:** `devcontainer up --workspace-folder . --config .devcontainer/dev/devcontainer.json`
+
+Prebuilt images are pulled from GHCR as a build cache
+(`[[ devcontainer_image ]]` / `[[ devcontainer_image ]]-dev`), so a warm rebuild
+is fast. A cache miss is non-fatal — it just rebuilds from the `Dockerfile`.
+
+## Secrets — 1Password Environments (the standard)
+
+Don't hand-write or copy `devcontainer.env`. The standard is **1Password
+Environments**, which mounts a virtual `.env` over a UNIX pipe — the values are
+**never written to disk or committed** (the path is gitignored anyway).
+
+1. In the **1Password** app → **Developer** → **Environments**, create an
+   environment for this repo (import an existing `.env` or add the variables
+   below, each referencing a vault item).
+2. Set the destination to **Local .env file** and point the mount at
+   `.devcontainer/devcontainer.env` (bot). Add a second destination at
+   `.devcontainer/dev/devcontainer.env` for the dev profile.
+3. Authorize access when prompted. The container's `--env-file` then reads it
+   like any `.env`.
+
+Variables per profile:
+
+| Variable | Bot | Dev | What it's for |
+|---|---|---|---|
+| `GH_TOKEN` | ✅ | ✅ | `gh` CLI / API |
+| `CLAUDE_CODE_OAUTH_TOKEN` | ✅ | ✅ | Claude Code |
+| `AGENT_DECK_TELEGRAM_KEY` | ✅ | ✅ | agent-deck bridge (optional) |
+| `TS_AUTHKEY` | — | ✅ | Tailscale (dev only) |
+
+`ANTHROPIC_API_KEY` is deliberately **forbidden** — it silently overrides
+`CLAUDE_CODE_OAUTH_TOKEN`, so `init-env.sh` strips it from the env-file.
+
+### What `init-env.sh` does
+
+On container init the devcontainer runs `.devcontainer/scripts/init-env.sh` on
+the **host**. It enforces the per-profile allow-list (e.g. evicts `TS_AUTHKEY`
+and `ANTHROPIC_API_KEY` from the bot env-file on every rebuild) and, in
+environments where the 1Password app isn't present (**Coder / Codespaces**),
+captures the same variables from the **host environment**, where they arrive as
+workspace/template parameters. It does **not** call `op` itself — 1Password
+Environments is what supplies the values locally.
+
+## Run it in Coder
+
+The devcontainers are Coder-ready: the `CODER` env is passed through, the
+`config/` tree is baked to `/usr/local/share/devcontainer-config/` so it
+survives Coder's `/tmp` mount shadowing, and `init-env.sh` reads secrets from
+the host environment (above).
+
+What Coder needs is a **workspace template** that clones this repo and builds the
+devcontainer — that template is **org-level infrastructure, not part of this
+repo** (one template serves every repo). To stand this repo up in Coder:
+
+1. Use your org's Coder "devcontainer" template (the canonical example is
+   `terraform/coder/devcontainer/` in
+   [harmonops/harmon-infra](https://github.com/harmonops/harmon-infra)). It uses
+   the Coder `git-clone` + `devcontainers-cli` modules.
+2. Create a workspace from it and set the parameters:
+   - **repo** → `[[ repo_url ]]`
+   - secrets → `GH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `AGENT_DECK_TELEGRAM_KEY`
+     (+ `TS_AUTHKEY` if you want Tailscale). Coder passes these into the
+     workspace's host environment, where `init-env.sh` picks them up.
+3. The build pulls `[[ devcontainer_image ]]` from GHCR as a cache. If that
+   package is private, give the Coder builder a read token (or make the package
+   public); a cache miss only makes the first build slower.
+
+> Unlike harmon-infra, this repo's `Dockerfile` uses the **public** Microsoft
+> base image, so the classic-PAT / private-base-image (`ghcr_read_token`)
+> complication does not apply here — only the repo's own `-devcontainer` cache
+> image matters.
+
+## See also
+
+- [architecture/security.md](../architecture/security.md) — full secret strategy.
+- [troubleshooting.md](troubleshooting.md) — devcontainer issues.
+- `.github/workflows/devcontainer-build.yml` — the GHCR prebuild.

--- a/template/docs/guides/onboarding.md.jinja
+++ b/template/docs/guides/onboarding.md.jinja
@@ -9,8 +9,12 @@ Getting productive in [[ project_name ]].
 3. Install dependencies and git hooks: `task install`
 4. Verify everything works: `task verify`
 
+[% if devcontainer %]
 Prefer the devcontainer? Open the repo in VS Code and "Reopen in Container"
-(human profile: `.devcontainer/dev/`), or use the Coder workspace.
+(human profile: `.devcontainer/dev/`), or use a Coder workspace. See
+[devcontainers.md](devcontainers.md) for local secrets (1Password Environments)
+and Coder setup.
+[% endif %]
 
 ## Daily workflow
 

--- a/template/docs/guides/troubleshooting.md.jinja
+++ b/template/docs/guides/troubleshooting.md.jinja
@@ -10,7 +10,7 @@ Common issues in [[ project_name ]] and how to fix them.
 ## Devcontainer
 
 - **Stale tools after a Dockerfile change** — rebuild the container; prebuilt images come from GHCR (see `.github/workflows/devcontainer-build.yml`).
-- **Missing secrets in the container** — the env-file is seeded by `.devcontainer/scripts/init-env.sh` from 1Password or host env on rebuild.
+- **Missing secrets in the container** — locally, the env-file is provided by a **1Password environment** mounted at `.devcontainer/devcontainer.env` (see [devcontainers.md](devcontainers.md)); on Coder/Codespaces it's seeded from host/workspace env by `.devcontainer/scripts/init-env.sh`. Note `init-env.sh` does **not** call `op` — if values are missing locally, check the 1Password environment is authorized and mounted at the right path.
 
 ## CI
 


### PR DESCRIPTION
## Why

Clarify the devcontainer story for generated repos: the secret standard is **1Password Environments** (it mounts a virtual `.env` over a UNIX pipe — never written to disk or git), and **Coder** setup wasn't documented at all. The old docs also implied `init-env.sh` reads 1Password directly — it doesn't; it seeds from the host environment (the Coder/Codespaces path) and enforces the per-profile allow-list.

## Changes (all in `template/docs/`, i.e. shipped into generated repos)

- **New `guides/devcontainers.md`** (devcontainer projects only — conditional filename like `design-language.md`):
  - The two profiles — **bot** (no Tailscale) vs **dev** (Tailscale + `--device`).
  - Running locally (VS Code / `devcontainer up`), GHCR prebuilt cache.
  - **Secrets via 1Password Environments**: create an environment, destination "Local .env file", mount at `.devcontainer/devcontainer.env` (+ `dev/`), with the per-profile variable table (`GH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `AGENT_DECK_TELEGRAM_KEY`, `TS_AUTHKEY` dev-only; `ANTHROPIC_API_KEY` forbidden).
  - **What `init-env.sh` actually does** (host-env seeding + allow-list; not `op`).
  - **Coder setup**: devcontainers are Coder-ready; the workspace *template* is org-level infra (canonical example: harmon-infra `terraform/coder/devcontainer/`) — point its `repo`/secret parameters at the repo; note the public base image means no `ghcr_read_token` dance.
- **CHECKLIST / architecture/security / guides/troubleshooting / guides/onboarding** — corrected the secret-seeding wording to 1Password Environments and linked the guide; `security.md` now lists the devcontainer secrets.
- `guides/README` → `.jinja` to list the conditional guide; `docs/README` links it.

## Verification

`task test:template:all` green. Guide renders for devcontainer repos (with the 1Password + Coder sections) and is correctly **omitted** when `devcontainer=false`.

> The matching update to the `standardize-repo` skill (harmon-devkit) lands in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)