### PR TITLE
fix(template): markdownlint — exclude artifact dirs + MD024 siblings_only

### DIFF
--- a/template/.markdownlint.json
+++ b/template/.markdownlint.json
@@ -2,6 +2,7 @@
   "default": true,
   "MD003": { "style": "atx" },
   "MD013": false,
+  "MD024": { "siblings_only": true },
   "MD034": false,
   "MD036": false,
   "MD041": false,

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -115,7 +115,7 @@ tasks:
         if [ -n "{{.CLI_ARGS}}" ]; then
           npx --yes markdownlint-cli2 --fix {{.CLI_ARGS}}
         else
-          npx --yes markdownlint-cli2 --fix '**/*.md' '#.claude/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**'
+          npx --yes markdownlint-cli2 --fix '**/*.md' '#.claude/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' '#**/.terraform/**' '#**/.venv/**' '#**/.task/**'
         fi
 
   lint:actions:


### PR DESCRIPTION
## Summary

Two markdownlint config fixes for generated repos, both surfaced while applying
the template to an existing Terraform repo (`sommerlawn/sommerlawn-infra`).

### 1. Exclude gitignored artifact/cache dirs from `lint:markdown`

The `lint:markdown` task globbed `'**/*.md'` excluding only
`.claude/node_modules/dist/.worktrees`. markdownlint-cli2 does **not** read
`.gitignore`, so a rendered **iac** repo's gitignored provider caches
(`terraform/**/.terraform/`, full of markdown CHANGELOGs) and the uv-managed
`.venv/` flooded `task verify` with errors — none of it tracked.

```diff
- npx --yes markdownlint-cli2 --fix '**/*.md' '#.claude/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**'
+ npx --yes markdownlint-cli2 --fix '**/*.md' '#.claude/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' '#**/.terraform/**' '#**/.venv/**' '#**/.task/**'
```

Chosen over `.markdownlint-cli2.jsonc` ignores because that file only ships when
`use_release_please` — the task glob covers every answer profile. The `CLI_ARGS`
(lefthook staged-files) path is unaffected; gitignored files are never staged.

### 2. `MD024: { siblings_only: true }` in `.markdownlint.json`

Default MD024 (no-duplicate-heading) flags *any* repeated heading text in a file,
tripping legitimate doc patterns like a per-host `#### Purpose` / `#### Access`
subsection in an inventory/runbook doc. `siblings_only` flags duplicates only when
they share a parent heading — genuine same-level anchor collisions (two `## Setup`)
still error.

## Test plan

- `task test:template:all` passes (all 5 profiles) after both changes. ✅
- **#1 behavioral check:** rendered the `iac` profile, planted markdownlint-violating
  files under `terraform/**/.terraform/` and `.venv/`, ran the rendered repo's
  `task lint:markdown` → 38 files, **0 errors**. ✅
- **#2 behavioral check:** rendered repo — repeated `### Purpose`/`### Access` under
  different `##` parents → 0 errors; two `## Setup` siblings → still 1 MD024 error. ✅

## Context

Companion to evanharmon1/harmon-devkit#22, which fixes the same `.gitignore`-blind
false-positive in the standardize-repo skill's `verify-applied.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)