### PR TITLE
feat(template): add `task setup:github` for idempotent repo settings

### DIFF
--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -388,6 +388,23 @@ tasks:
     cmds:
       - lefthook install
 
+  # ── GitHub setup ───────────────────────────────────────────────
+  # One-time, idempotent repo settings applied via gh (safe to re-run); run once
+  # the repo exists on GitHub. The remaining setup steps need a browser or a real
+  # credential and stay manual — see docs/CHECKLIST.md (branch ruleset import,
+  # Renovate/CodeRabbit app installs, Actions secrets, the CI GitHub App).
+  setup:github:
+    desc: Apply idempotent GitHub repo settings via gh (Dependabot alerts, private vulnerability reporting, CodeQL variable[% if github_org != author_git_provider_username %], bot collaborator[% endif %])
+    vars:
+      REPO: "[[ github_org ]]/[[ project_slug ]]"
+    cmds:
+      - gh api "repos/{{.REPO}}/vulnerability-alerts" --method PUT
+      - gh api "repos/{{.REPO}}/private-vulnerability-reporting" --method PUT
+      - gh variable set FULL_SECURITY_SCAN --repo "{{.REPO}}" --body true
+[% if github_org != author_git_provider_username %]
+      - gh api "repos/{{.REPO}}/collaborators/[[ author_git_provider_username ]]-bot" --method PUT -f permission=push
+[% endif %]
+
   # ── Release ────────────────────────────────────────────────────
 [% if use_release_please %]
   # Releases are intentional via release-please (.github/workflows/release.yml):

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -10,16 +10,18 @@ that don't apply, then keep this file as a record of what was configured.
 
 ## 2. GitHub repo settings
 
-- [ ] Import the branch ruleset (see [architecture/branch-protection.md](architecture/branch-protection.md)):
+- [ ] **Automated settings** — run `task setup:github` (idempotent, safe to
+      re-run): enables **Dependabot alerts** and **private vulnerability
+      reporting**, sets the `FULL_SECURITY_SCAN` variable (CodeQL)[% if github_org != author_git_provider_username %], and adds
+      the `[[ author_git_provider_username ]]-bot` machine account as a Write
+      collaborator[% endif %]. Do NOT add dependabot.yml — Renovate owns version updates.
+- [ ] Import the branch ruleset (see [architecture/branch-protection.md](architecture/branch-protection.md)) — run once `build.yml` is on `main`, so the required `verify`/`security` checks resolve:
 
   ```bash
   gh api "repos/[[ github_org ]]/[[ project_slug ]]/rulesets" --method POST \
     --input ".github/Branch Protection Ruleset - Protect Main.json"
   ```
 
-- [ ] Settings → Advanced Security: enable **Dependabot alerts** and
-      **Private vulnerability reporting** (do NOT add dependabot.yml —
-      Renovate owns version updates)
 - [ ] Install the [Renovate app](https://github.com/apps/renovate) on the repo
 - [ ] Install the [CodeRabbit app](https://github.com/apps/coderabbitai) on the repo (`.coderabbit.yaml` is pre-configured)
 - [ ] Actions secrets: `CLAUDE_CODE_OAUTH_TOKEN` (claude-* workflows),
@@ -31,7 +33,6 @@ that don't apply, then keep this file as a record of what was configured.
       **variable**) + `CI_APP_PRIVATE_KEY` (Actions **secret**) — org-level for
       an org, per-repo for a personal account. Drives release-please, the
       claude-* workflows, and project-automation. See docs/architecture/security.md.
-- [ ] Actions variables: set `FULL_SECURITY_SCAN=true` to enable CodeQL
 [% if devcontainer %]
 - [ ] GHCR: ensure the org/user allows publishing packages; the first
       devcontainer prebuild populates `[[ devcontainer_image ]]` on merge to main
@@ -40,7 +41,6 @@ that don't apply, then keep this file as a record of what was configured.
 - [ ] Org Project V2 (number 1) with a `Status` single-select field
       (Shaping / In Progress / Validating / In Review / Done) for
       project-automation.yml and the claude-* workflows
-- [ ] Add the `[[ author_git_provider_username ]]-bot` machine account as a Write collaborator
 [% endif %]
 
 ## 3. Framework scaffolding (conventions-only template)


### PR DESCRIPTION
## Summary

The post-generation GitHub setup (CHECKLIST §2) was entirely manual. This adds a
**`task setup:github`** target to the generated Taskfile that applies the
**fully idempotent, no-credential** settings via `gh` — safe to re-run:

- enable **Dependabot alerts** (`PUT repos/$R/vulnerability-alerts`)
- enable **private vulnerability reporting** (`PUT .../private-vulnerability-reporting`)
- set the **`FULL_SECURITY_SCAN`** variable (CodeQL)
- **(org repos only)** add the `<user>-bot` account as a **Write collaborator**

```yaml
setup:github:
  vars:
    REPO: "[[ github_org ]]/[[ project_slug ]]"
  cmds:
    - gh api "repos/{{.REPO}}/vulnerability-alerts" --method PUT
    - gh api "repos/{{.REPO}}/private-vulnerability-reporting" --method PUT
    - gh variable set FULL_SECURITY_SCAN --repo "{{.REPO}}" --body true
[% if github_org != author_git_provider_username %]
    - gh api "repos/{{.REPO}}/collaborators/[[ author_git_provider_username ]]-bot" --method PUT -f permission=push
[% endif %]
```

The collaborator step is jinja-gated to org repos (mirroring the CHECKLIST's
existing `github_org != author_git_provider_username` gate), so a personal repo's
rendered task omits it.

## Deliberately left manual

Anything needing a **browser OAuth consent** (Renovate / CodeRabbit app installs,
GHCR publishing policy, CI GitHub App creation) or a **real credential**
(`CLAUDE_CODE_OAUTH_TOKEN`, `SNYK_TOKEN`, `CI_APP_*`, Project V2). The **branch
ruleset import** also stays manual — its `POST /rulesets` isn't idempotent (a guard
keyed on the ruleset name would be needed); I added an ordering note instead.

CHECKLIST §2 now leads with `task setup:github` and drops the three folded bullets
(Advanced Security, `FULL_SECURITY_SCAN`, bot collaborator).

## Test plan

- `task test:template:all` passes (all 5 profiles). ✅
- **Org render** (`github_org=someorg`): `REPO=someorg/...`, collaborator line + "bot
  collaborator" in the desc present; `task --list-all` parses it. ✅
- **Personal render** (default org): no collaborator line (0 matches), desc without
  "bot collaborator". ✅
- Rendered `docs/CHECKLIST.md` §2 reads correctly with no leaked jinja markers. ✅

## Context

Third in the series surfaced while applying the template to `sommerlawn-infra`
(after #84 markdownlint fixes and harmon-devkit#22). Scope was confirmed with the
maintainer: only the four fully-idempotent operations, nothing requiring guards,
credentials, or a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)