### PR TITLE
docs(ci-cd): explain devcontainer build-verification strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,10 @@ task release:patch   # or release:minor / release:major
   devcontainer images (bot + dev) and pushes them to GHCR as build caches. The
   root repo dogfoods the same `.devcontainer/` the template generates
   (`task test:devcontainer:root` / `test:devcontainer:dev` smoke-test them).
+  Rendered template devcontainers are config-validated (`read-configuration` in
+  `template-test`), **not** built per profile — the dogfood build covers every
+  profile only because the template `Dockerfile` is kept free of copier
+  conditionals (profile-invariant). See `docs/architecture/ci-cd.md`.
 - `.github/workflows/claude-{plan,implement,review}.yml` — Claude Code GitHub
   Actions. They (and `release.yml`) authenticate as the CI **GitHub App**
   (`CI_APP_ID` variable + `CI_APP_PRIVATE_KEY` secret) and need the

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -13,10 +13,44 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
 
 ## Workflows
 
-- `build.yml` — on push/PR to `main`: lint, security, then the aggregate **`verify`** job.
+- `build.yml` — on push/PR to `main`: `lint`, `security`, the `template-test`
+  matrix (renders every copier profile and validates the output), then the
+  aggregate **`verify`** job.
 - `claude-plan` / `claude-implement` / `claude-review` — `@claude …` on issues and PRs.
-- `devcontainer-build.yml` — prebuilds the devcontainer images to GHCR on `.devcontainer/**` changes.
+- `devcontainer-build.yml` — builds the root's bot + dev devcontainers on
+  `.devcontainer/**` changes (and pushes a GHCR cache on merge to `main`).
 - `release.yml` — release-please maintains the rolling release PR.
+
+## Devcontainer build verification
+
+Split deliberately by cost:
+
+- **The image is built once, by dogfooding.** `devcontainer-build.yml` runs a real
+  `devcontainers/ci` build of the root repo's own bot + dev devcontainers on every
+  PR touching `.devcontainer/**` (and pushes a GHCR cache on merge to `main`).
+- **Rendered template configs are validated, not built.** `build.yml`'s
+  `template-test` matrix runs `devcontainer read-configuration` on each rendered
+  profile (via `scripts/test-template.sh`) — it parses `devcontainer.json` and
+  resolves its `features`, but does not build the image.
+
+We **do not** build the rendered devcontainer per copier profile: that would be
+~5× the same build for almost no extra coverage, because of one load-bearing
+invariant —
+
+> **The template Dockerfile (`template/…/Dockerfile`) stays profile-invariant: no
+> `[% … %]` copier conditionals.**
+
+Since it renders identically for every `project_type`, the single dogfood build
+above covers the image for all profiles. The only per-profile variation is in
+`devcontainer.json` (`forwardPorts`, a few extensions, and the `terraform` feature
+when `include_terraform`) — config that `read-configuration` already validates. The
+one build path the dogfood does not exercise is the upstream, version-pinned
+`terraform` devcontainer feature, whose ref `read-configuration` still resolves.
+
+**If a Dockerfile conditional is ever added** (e.g. branching on `use_node`), this
+invariant breaks and the dogfood stops covering all profiles — at that point add a
+path-filtered, per-profile rendered build (mirroring `devcontainer-build.yml`) for
+the profiles that now differ.
 
 ## Authentication
 


### PR DESCRIPTION
## Summary

Documents *why* harmon-init verifies devcontainers the way it does, after a review
of the current setup concluded the design is sound and should stay as-is (no new
per-profile build jobs).

The reasoning, now captured so a future contributor doesn't unknowingly break it:

- The **image is built once**, by dogfooding — `devcontainer-build.yml` does a real
  `devcontainers/ci` build of the root's bot + dev devcontainers on `.devcontainer/**`
  PRs (GHCR cache on merge).
- **Rendered template configs are validated, not built** — `build.yml`'s
  `template-test` matrix runs `devcontainer read-configuration` per profile.
- We **don't** build the rendered devcontainer per copier profile because the
  template **Dockerfile is profile-invariant** (no `[% %]` conditionals), so the one
  dogfood build covers every profile. Building all 5 would be ~5× the same image for
  almost no added coverage.

The doc states the **load-bearing invariant** (keep the template Dockerfile free of
copier conditionals) and the **trigger to revisit** (if a Dockerfile conditional is
ever added, introduce a path-filtered per-profile rendered build).

## Changes

- `docs/architecture/ci-cd.md` — new **"Devcontainer build verification"** section;
  also corrects the `build.yml` bullet to mention the `template-test` matrix.
- `AGENTS.md` — concise pointer in the CI/CD section (propagates to the
  `CLAUDE.md`/`GEMINI.md`/copilot symlinks).

Docs-only; `task lint:markdown` + `lint:hygiene` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)