### PR TITLE
docs: consolidate doc-taxonomy meta into the docs hub

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,12 +1,7 @@
 # Architecture
 
-**Bucket — "how is it built / secured / governed / tested?"** The durable
-narrative of how the system *is*, and the home for **subject hubs**. This README
-is the bucket hub plus the high-level overview.
-
-**Route, don't duplicate:** the subject hubs below synthesize a picture no single
-config file shows, then point to [decisions/](../decisions/) for *why* and
-[guides/](../guides/) for *how* — they never restate that content.
+How the system is built, secured, governed, and tested — plus the **subject
+hubs** below.
 
 TODO: Describe the high-level architecture of Harmon Init.
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,8 +1,8 @@
 # Decisions (ADRs)
 
-**Bucket — "why was this choice made?"** Durable, append-only, backward-looking
-records. This is the layer that stops an agent from "helpfully" undoing a
-deliberate choice — and where **deviations from best practice** are justified.
+Append-only records of why each choice was made — they stop an agent from
+"helpfully" undoing a deliberate choice, and justify **deviations from best
+practice**.
 
 Each record captures one choice: its context, the decision, and the **explicit
 "not" reasoning** (what was rejected and why). **Supersede, don't edit:** to

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,8 +1,7 @@
 # Product
 
-**Bucket — "why does it exist / who is it for?"** Business and problem-space
-knowledge: the non-code, non-how layer. This README is the hub for `product/`; it
-routes, the files below hold the content.
+Business and problem-space knowledge: why it exists and who it's for — the
+non-code, non-how layer.
 
 **Belongs here:** why the product exists, who it serves, where it's going, and the
 conceptual model. **Not here:** how it's built (→ [../architecture/](../architecture/)),

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,8 +1,7 @@
 # Runbooks
 
-**Bucket — "how do I respond when prod breaks?" (crisis).** Named-incident,
-step-by-step procedures read *under pressure*. The calm counterpart is
-[guides/](../guides/), read in advance.
+Named-incident, step-by-step procedures read *under pressure* when prod breaks
+(the calm counterpart is [guides/](../guides/)).
 
 A runbook is one specific operational procedure — e.g. "rotate the API key",
 "restore from backup", "roll back a bad deploy" — written so someone can follow

--- a/template/docs/architecture/README.md.jinja
+++ b/template/docs/architecture/README.md.jinja
@@ -1,12 +1,7 @@
 # Architecture
 
-**Bucket — "how is it built / secured / governed / tested?"** The durable
-narrative of how the system *is*, and the home for **subject hubs**. This README
-is the bucket hub plus the high-level overview.
-
-**Route, don't duplicate:** the subject hubs below synthesize a picture no single
-config file shows, then point to [decisions/](../decisions/) for *why* and
-[guides/](../guides/) for *how* — they never restate that content.
+How the system is built, secured, governed, and tested — plus the **subject
+hubs** below.
 
 TODO: Describe the high-level architecture of [[ project_name ]].
 

--- a/template/docs/decisions/README.md
+++ b/template/docs/decisions/README.md
@@ -1,8 +1,8 @@
 # Decisions (ADRs)
 
-**Bucket — "why was this choice made?"** Durable, append-only, backward-looking
-records. This is the layer that stops an agent from "helpfully" undoing a
-deliberate choice — and where **deviations from best practice** are justified.
+Append-only records of why each choice was made — they stop an agent from
+"helpfully" undoing a deliberate choice, and justify **deviations from best
+practice**.
 
 Each record captures one choice: its context, the decision, and the **explicit
 "not" reasoning** (what was rejected and why). **Supersede, don't edit:** to

--- a/template/docs/product/README.md
+++ b/template/docs/product/README.md
@@ -1,8 +1,7 @@
 # Product
 
-**Bucket — "why does it exist / who is it for?"** Business and problem-space
-knowledge: the non-code, non-how layer. This README is the hub for `product/`; it
-routes, the files below hold the content.
+Business and problem-space knowledge: why it exists and who it's for — the
+non-code, non-how layer.
 
 **Belongs here:** why the product exists, who it serves, where it's going, and the
 conceptual model. **Not here:** how it's built (→ [../architecture/](../architecture/)),

--- a/template/docs/runbooks/README.md
+++ b/template/docs/runbooks/README.md
@@ -1,8 +1,7 @@
 # Runbooks
 
-**Bucket — "how do I respond when prod breaks?" (crisis).** Named-incident,
-step-by-step procedures read *under pressure*. The calm counterpart is
-[guides/](../guides/), read in advance.
+Named-incident, step-by-step procedures read *under pressure* when prod breaks
+(the calm counterpart is [guides/](../guides/)).
 
 A runbook is one specific operational procedure — e.g. "rotate the API key",
 "restore from backup", "roll back a bad deploy" — written so someone can follow


### PR DESCRIPTION
## Summary

Doc-taxonomy cleanup, from the repo-review batch.

Trims the repeated "hub / routes; does not hold facts / every doc has a type and lives in a bucket" meta-commentary from the **architecture, decisions, product, and runbooks** bucket READMEs (and their template twins) down to a one-line descriptor. The canonical routing overview stays in the docs hub (`docs/README.md`), and all navigational link lists + content-specific guidance (ADR supersede rule, product routing, runbook guidance) are preserved.

> The guides bucket README is handled in the devcontainer PR (#88), where the new performance guide is linked.

## Verification
`task check` (markdownlint) clean; `task test:template:all` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
