### PR TITLE
fix(template): idempotent task bootstrap + task test:tasks Taskfile guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
           sudo mv /tmp/actionlint /usr/local/bin/
           pip install yamllint
       - run: task check
+      - run: task test:tasks
       - run: task test:hooks
       - run: task test:devcontainer:permissions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,12 @@ task release:patch   # or release:minor / release:major
   (see `.editorconfig`).
 - Shell scripts must pass `shellcheck --severity=error` and `shfmt -d`, and stay
   portable across macOS bash 3.2 (no `mapfile`, no `grep -P`) and Linux.
+- Keep Taskfile `cmds:` trivial. Inline command strings are **not** seen by
+  `shellcheck`/`shfmt` (`lint:shell` only covers `scripts/*.sh`), so non-trivial
+  logic — pipelines, conditionals, loops, `curl | bash`, anything with `&&`/`||`
+  — belongs in a `scripts/*.sh` file that the task calls. `task test:tasks` guards
+  the floor (the Taskfile compiles; setup tasks are safe no-ops), but extracting
+  the shell is what actually gets it linted.
 - YAML linted with yamllint; workflows with actionlint; markdown with
   markdownlint-cli2.
 - Pin third-party GitHub Actions by commit SHA with a trailing version comment and

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -237,6 +237,11 @@ tasks:
     cmds:
       - ./scripts/test-hooks.sh
 
+  test:tasks:
+    desc: Guard the Taskfile itself (compiles; setup tasks are safe no-ops)
+    cmds:
+      - ./scripts/test-tasks.sh
+
   # ── Security ──────────────────────────────────────────────────
   security:
     desc: Run all security checks
@@ -277,7 +282,10 @@ tasks:
   bootstrap:
     desc: One-time machine setup (Homebrew)
     cmds:
-      - NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      # Idempotent: skip the installer when Homebrew is already present. The
+      # official installer's NONINTERACTIVE mode demands sudo up front and aborts
+      # even when there is nothing to install, so guard on `brew` existing.
+      - command -v brew >/dev/null 2>&1 || NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
   install:
     desc: Install all project dependencies and tools

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# test-tasks.sh — guard the Taskfile against regressions that only surface at
+# run time: a Taskfile that no longer compiles, and setup tasks that fail when
+# they should be safe no-ops. Run via `task test:tasks`.
+#
+# Coverage note: the bootstrap assertion only exercises the "Homebrew already
+# installed" path, so it is skipped on runners without brew (e.g. the default
+# ubuntu-latest CI). It still guards the common local/macOS case — the exact
+# regression where `task bootstrap` aborted on a sudo precheck despite brew
+# already being installed.
+set -euo pipefail
+
+repo="$(git rev-parse --show-toplevel)"
+cd "$repo"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+echo "==> Taskfile compiles (every task parses)"
+if ! task --list-all >/dev/null 2>&1; then
+    fail "task --list-all failed — the Taskfile does not compile"
+fi
+
+echo "==> bootstrap is a no-op when Homebrew is already installed"
+if command -v brew >/dev/null 2>&1; then
+    if ! task bootstrap >/dev/null 2>&1; then
+        fail "task bootstrap failed even though brew is already installed"
+    fi
+else
+    echo "    (skipped: brew not on PATH)"
+fi
+
+echo "==> task targets OK (compile + bootstrap idempotency)"

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -83,6 +83,7 @@ jobs:
 [% endif %]
       - name: Lint[% if use_node %] + typecheck[% endif +%]
         run: task check
+      - run: task test:tasks
 [% if devcontainer %]
       - run: task test:hooks
       - run: task test:devcontainer:permissions

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -52,6 +52,10 @@ Full reference: [docs/conventions.md](docs/conventions.md). Highlights:
   `shell:lint`); pin actions by SHA + `# vX.Y.Z`.
 - Git hooks are managed by lefthook (`lefthook.yml`) and delegate to Taskfile
   targets — don't duplicate logic in hooks or workflows.
+- Keep Taskfile `cmds:` trivial — inline strings aren't linted (`lint:shell`
+  only covers `scripts/*.sh`). Put any pipeline/conditional/loop/`curl | bash`
+  in a `scripts/*.sh` the task calls. `task test:tasks` checks the Taskfile
+  compiles and setup tasks are safe no-ops.
 - Indentation: 2 spaces default, 4 for Python/Terraform/Shell (`.editorconfig`).
 - Secrets never go in git; local env via 1Password (`op run` / `op inject`).
 [% if include_terraform %]

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -400,7 +400,10 @@ tasks:
   bootstrap:
     desc: One-time machine setup (Homebrew[% if use_node %] + Node + pnpm[% endif %])
     cmds:
-      - NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      # Idempotent: skip the installer when Homebrew is already present. The
+      # official installer's NONINTERACTIVE mode demands sudo up front and aborts
+      # even when there is nothing to install, so guard on `brew` existing.
+      - command -v brew >/dev/null 2>&1 || NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 [% if use_node %]
       - brew install node
       - npm install -g pnpm

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -308,6 +308,11 @@ tasks:
 [% else %]
       - 'echo "TODO: wire tests for this project (see docs/architecture/tests.md); test files live in tests/"'
 [% endif %]
+
+  test:tasks:
+    desc: Guard the Taskfile itself (compiles; setup tasks are safe no-ops)
+    cmds:
+      - ./scripts/test-tasks.sh
 [% if devcontainer %]
 
   test:devcontainer:root:

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# test-tasks.sh — guard the Taskfile against regressions that only surface at
+# run time: a Taskfile that no longer compiles, and setup tasks that fail when
+# they should be safe no-ops. Run via `task test:tasks`.
+#
+# Coverage note: the bootstrap assertion only exercises the "Homebrew already
+# installed" path, so it is skipped on runners without brew (e.g. the default
+# ubuntu-latest CI). It still guards the common local/macOS case — the exact
+# regression where `task bootstrap` aborted on a sudo precheck despite brew
+# already being installed.
+set -euo pipefail
+
+repo="$(git rev-parse --show-toplevel)"
+cd "$repo"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+echo "==> Taskfile compiles (every task parses)"
+if ! task --list-all >/dev/null 2>&1; then
+    fail "task --list-all failed — the Taskfile does not compile"
+fi
+
+echo "==> bootstrap is a no-op when Homebrew is already installed"
+if command -v brew >/dev/null 2>&1; then
+    if ! task bootstrap >/dev/null 2>&1; then
+        fail "task bootstrap failed even though brew is already installed"
+    fi
+else
+    echo "    (skipped: brew not on PATH)"
+fi
+
+echo "==> task targets OK (compile + bootstrap idempotency)"


### PR DESCRIPTION
## Problem
`task bootstrap` ran Homebrew's installer unconditionally. The NONINTERACTIVE installer does a **sudo-access precheck up front** and aborts with `Need sudo access on macOS!` even when brew is already installed and there's nothing to do — breaking `task bootstrap` (and picking it from the `tv` menu) on any machine that already has Homebrew. Reported from a freshly-updated `sommerlawn-infra` checkout.

Root cause of the *class*: inline Taskfile `cmds:` are invisible to `shellcheck`/`shfmt` (`lint:shell` only covers `scripts/*.sh`), so a broken one-liner shipped unlinted.

## Changes
1. **Fix** — guard the installer on `command -v brew` so bootstrap is a no-op when Homebrew is present (template + root dogfood).
2. **Regression guard** — `scripts/test-tasks.sh` / `task test:tasks` (wired into CI), asserting:
   - the Taskfile compiles (`task --list-all`)
   - `task bootstrap` is a no-op when brew is already installed (skipped where brew is absent, e.g. ubuntu CI)
   - *This test immediately caught that the root `Taskfile.yml` still had the unguarded bootstrap — now fixed.*
3. **Convention** — both AGENTS.md files now state: keep `cmds:` trivial; non-trivial shell (pipes/conditionals/loops/`curl | bash`) goes in `scripts/*.sh` so it's actually linted.

## Verification
- `task test:tasks`, `task check`, `task test:template` (all 5 profiles) pass locally.

## Not done (deliberately)
Mass-extracting the existing 13 inline multi-line blocks was considered and dropped — several embed jinja conditionals that resist clean extraction, and the compile gate + convention cover the regression class without that churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)