### PR TITLE
docs(template): fix stale branch-protection ruleset + seed glossary

### DIFF
--- a/.github/Branch Protection Ruleset - Protect Main.json
+++ b/.github/Branch Protection Ruleset - Protect Main.json
@@ -57,7 +57,7 @@
     {
       "actor_id": 5,
       "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
+      "bypass_mode": "pull_request"
     }
   ]
 }

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -149,9 +149,9 @@ The ruleset targets branches matching `~DEFAULT_BRANCH` and `refs/heads/main`. T
 
 ### `bypass_actors`
 
-Only the **Maintain** repository role (`RepositoryRole` id `5`, `bypass_mode: always`)
+Only the **Repository admin** role (`RepositoryRole` id `5`, `bypass_mode: always`)
 can bypass these rules — an escape hatch for emergency hotfixes. The bot has only
-Write access (below Maintain), so it can never bypass. Day to day, even you go through
+Write access (below Admin), so it can never bypass. Day to day, even you go through
 the full PR process.
 
 ### `deletion`

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -149,6 +149,16 @@ The ruleset targets branches matching `~DEFAULT_BRANCH` and `refs/heads/main`. T
 
 ### `bypass_actors`
 
+> **Design intent — leave this `pull_request`, not `always`.** Every bypass actor is
+> scoped to `bypass_mode: pull_request` on purpose: an admin may *merge* a
+> non-compliant PR (a solo maintainer's own PR, which GitHub won't let them
+> self-approve, or a genuinely stuck check) but **cannot push directly to `main`**.
+> Widening any bypass to `always` re-enables accidental (or malicious) direct pushes
+> to `main` and is a real security loosening — only do it deliberately, and call it
+> out in review. A bypass actor is required at all (rather than `bypass_actors: []`)
+> because a solo maintainer otherwise can't merge anything; with multiple human
+> reviewers you can drop the bypass entirely instead.
+
 Only the **Repository admin** role (`RepositoryRole` id `5`) can bypass these rules,
 and only in `pull_request` mode — you can **merge** a PR that hasn't met every
 requirement (e.g. your own PR, which GitHub won't let you self-approve, or a stuck

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -135,7 +135,7 @@ This mirrors the importable
     {
       "actor_id": 5,
       "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
+      "bypass_mode": "pull_request"
     }
   ]
 }
@@ -149,10 +149,13 @@ The ruleset targets branches matching `~DEFAULT_BRANCH` and `refs/heads/main`. T
 
 ### `bypass_actors`
 
-Only the **Repository admin** role (`RepositoryRole` id `5`, `bypass_mode: always`)
-can bypass these rules — an escape hatch for emergency hotfixes. The bot has only
-Write access (below Admin), so it can never bypass. Day to day, even you go through
-the full PR process.
+Only the **Repository admin** role (`RepositoryRole` id `5`) can bypass these rules,
+and only in `pull_request` mode — you can **merge** a PR that hasn't met every
+requirement (e.g. your own PR, which GitHub won't let you self-approve, or a stuck
+check), but you **cannot push directly to `main`**: a direct push isn't a pull
+request, so the bypass doesn't apply and the ruleset rejects it. This prevents
+accidental `git push origin main` while still letting a solo maintainer merge. The
+bot has only Write access (below Admin), so it can never bypass.
 
 ### `deletion`
 

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -36,7 +36,7 @@ Three independent layers enforce the boundary between AI agent work and producti
 2. **Repository ruleset on `main`** — Server-side enforcement that blocks direct pushes, requires PR reviews from a code owner, and mandates passing status checks before merge.
 3. **CODEOWNERS file** — Designates the human owner as the required reviewer for all file changes, ensuring the bot's PRs always require human approval.
 
-No single layer is sufficient alone. The PAT controls *what operations the token can attempt*. The ruleset controls *what operations GitHub allows on `main`*. The CODEOWNERS file controls *whose approval counts*.
+No single layer is sufficient alone. The PAT controls _what operations the token can attempt_. The ruleset controls _what operations GitHub allows on `main`_. The CODEOWNERS file controls _whose approval counts_.
 
 ## Prerequisites
 
@@ -54,7 +54,7 @@ Replace `@evanharmon1` with the GitHub username of the human who should approve 
 ### Bot Account PAT Permissions
 
 > This covers the **devcontainer agent's** push token (Claude Code running in the
-> container). CI *workflows* (release-please, claude-*, project-automation)
+> container). CI _workflows_ (release-please, claude-*, project-automation)
 > authenticate separately as the CI **GitHub App** — see
 > [security.md](security.md) for that App and its permissions. The ruleset below
 > protects `main` from every actor (App, bot PAT, or human) equally.
@@ -72,9 +72,11 @@ The machine user account's fine-grained PAT should have these permissions and no
 
 ## Ruleset Configuration
 
+This mirrors the importable
+`.github/Branch Protection Ruleset - Protect Main.json` — keep the two in sync.
+
 ```json
 {
-  "id": 14110902,
   "name": "Protect Main",
   "target": "branch",
   "source_type": "Repository",
@@ -82,8 +84,8 @@ The machine user account's fine-grained PAT should have these permissions and no
   "enforcement": "active",
   "conditions": {
     "ref_name": {
-      "exclude": [],
-      "include": ["~DEFAULT_BRANCH", "refs/heads/main"]
+      "include": ["~DEFAULT_BRANCH", "refs/heads/main"],
+      "exclude": []
     }
   },
   "rules": [
@@ -118,20 +120,12 @@ The machine user account's fine-grained PAT should have these permissions and no
         "do_not_enforce_on_create": true,
         "required_status_checks": [
           {
-            "context": "secrets",
-            "integration_id": 15368
-          },
-          {
-            "context": "validate",
-            "integration_id": 15368
-          },
-          {
-            "context": "build-homepage",
+            "context": "verify",
             "integration_id": 15368
           },
           {
             "context": "security",
-            "integration_id": null
+            "integration_id": 15368
           }
         ]
       }
@@ -141,7 +135,7 @@ The machine user account's fine-grained PAT should have these permissions and no
     {
       "actor_id": 5,
       "actor_type": "RepositoryRole",
-      "bypass_mode": "pull_request"
+      "bypass_mode": "always"
     }
   ]
 }
@@ -153,9 +147,12 @@ The machine user account's fine-grained PAT should have these permissions and no
 
 The ruleset targets branches matching `~DEFAULT_BRANCH` and `refs/heads/main`. The `~DEFAULT_BRANCH` is a GitHub alias that always resolves to whatever the repo's default branch is, so even if the default branch name changes, the ruleset follows. Including `refs/heads/main` explicitly is belt-and-suspenders.
 
-### `bypass_actors: []`
+### `bypass_actors`
 
-**No one can bypass these rules.** This is intentional. Even the repo owner must go through the full PR process. If you later need an emergency bypass (e.g., for a hotfix), you would temporarily add yourself as a bypass actor, but the default posture is zero exceptions.
+Only the **Maintain** repository role (`RepositoryRole` id `5`, `bypass_mode: always`)
+can bypass these rules — an escape hatch for emergency hotfixes. The bot has only
+Write access (below Maintain), so it can never bypass. Day to day, even you go through
+the full PR process.
 
 ### `deletion`
 
@@ -190,15 +187,16 @@ This is the core rule that prevents the AI agent from pushing directly to `main`
 
 All specified CI checks must pass before the PR can merge. The `strict_required_status_checks_policy: true` setting means the PR branch must be up-to-date with `main` before merging — if `main` advances after the checks ran, the checks must re-run. The `do_not_enforce_on_create: true` setting skips enforcement when the branch is first created (before any CI has had a chance to run).
 
-The required checks for this repo are:
+The required checks are the two aggregate jobs from `build.yml` (see
+[ci-cd.md](ci-cd.md)):
 
-| Check                | Purpose                                  |
-| -------------------- | ---------------------------------------- |
-| `secrets`            | Scans for leaked secrets (Gitleaks)      |
-| `validate-compose`   | Validates Docker Compose configuration   |
-| `validate`           | General validation (linting, formatting) |
-| `validate-templates` | Validates infrastructure templates       |
-| `build-homepage`     | Ensures the homepage builds successfully |
+| Check      | Purpose                                                                                          |
+| ---------- | ----------------------------------------------------------------------------------------------- |
+| `verify`   | Aggregate gate — rolls up `lint`, and `security` so one check reports overall pass/fail |
+| `security` | Secret scanning (gitleaks) + dependency audit                                                    |
+
+Requiring the aggregate `verify` (rather than each leaf job) keeps the required-check
+list stable as jobs are added inside `build.yml`.
 
 ## What the AI Agent Can and Cannot Do
 
@@ -228,7 +226,7 @@ This ruleset ships with every repo generated from harmon-init. To replicate manu
 4. Update the `required_status_checks` to match that repo's CI checks
 5. Verify by attempting a direct push to main from the bot account — it should be rejected
 
-If repos move to the `ponderous` organization in the future, consider creating an **org-level ruleset** (requires GitHub Team plan) that applies these rules across all repos automatically, eliminating the need to configure each repo individually.
+For an organization with many repos, consider creating an **org-level ruleset** (requires GitHub Team plan) that applies these rules across all repos automatically, eliminating the need to configure each repo individually.
 
 ## Future Considerations
 

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -150,7 +150,7 @@ The ruleset targets branches matching `~DEFAULT_BRANCH` and `refs/heads/main`. T
 ### `bypass_actors`
 
 > **Design intent — leave this `pull_request`, not `always`.** Every bypass actor is
-> scoped to `bypass_mode: pull_request` on purpose: an admin may *merge* a
+> scoped to `bypass_mode: pull_request` on purpose: an admin may _merge_ a
 > non-compliant PR (a solo maintainer's own PR, which GitHub won't let them
 > self-approve, or a genuinely stuck check) but **cannot push directly to `main`**.
 > Widening any bypass to `always` re-enables accidental (or malicious) direct pushes

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -5,6 +5,17 @@ This is the **dictionary projection** of [the domain model](product/domain.md): 
 points at the model for the real relationships and reasoning — it never restates
 them. A flat lookup: scan for a term, don't read top-to-bottom.
 
+Terms below are part of the harmon-init toolchain this repo is built on; add
+project-specific (domain) terms as the model firms up.
+
 | Term | Meaning |
 |---|---|
-| TODO: term | TODO: definition |
+| `verify` | The aggregate CI job in `build.yml` that rolls up the other jobs into one required status check (the merge gate). See [architecture/ci-cd.md](architecture/ci-cd.md). |
+| `security` (check) | The CI job running secret scanning (gitleaks) + dependency audit; the second required status check. |
+| `task` / Taskfile | go-task is the single source of truth for commands; lefthook hooks and CI both delegate to `task` targets so local and CI runs are identical. |
+| release-please | Bot that maintains a rolling "release" PR from Conventional Commits; merging it cuts the tag, GitHub release, and CHANGELOG. Releases are intentional, never automatic on merge. |
+| `evanharmon1-ci` (GitHub App) | The CI automation app that mints short-lived tokens for CI workflows (not a PAT). See [architecture/security.md](architecture/security.md). |
+| bot profile / dev profile | The two devcontainer profiles: `bot` (`.devcontainer/`, AI agents, no Tailscale) and `dev` (`.devcontainer/dev/`, human, with Tailscale). See [guides/devcontainers.md](guides/devcontainers.md). |
+| 1Password Environments | How devcontainer/local secrets are supplied — a virtual `.env` mounted over a pipe, never written to disk or git. |
+| bot vs operator | Two identities: the AI **bot** account (scoped, can't merge `main`) and the human **operator** (full access). See [architecture/security.md](architecture/security.md). |
+| TODO: term | TODO: project-specific definition |

--- a/template/.github/Branch Protection Ruleset - Protect Main.json.jinja
+++ b/template/.github/Branch Protection Ruleset - Protect Main.json.jinja
@@ -70,7 +70,7 @@
     {
       "actor_id": null,
       "actor_type": "OrganizationAdmin",
-      "bypass_mode": "always"
+      "bypass_mode": "pull_request"
     }
   ]
 [% else %]
@@ -80,7 +80,7 @@
     {
       "actor_id": 5,
       "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
+      "bypass_mode": "pull_request"
     }
   ]
 [% endif %]

--- a/template/docs/architecture/branch-protection.md.jinja
+++ b/template/docs/architecture/branch-protection.md.jinja
@@ -72,9 +72,11 @@ The machine user account's fine-grained PAT should have these permissions and no
 
 ## Ruleset Configuration
 
+This mirrors the importable
+`.github/Branch Protection Ruleset - Protect Main.json` — keep the two in sync.
+
 ```json
 {
-  "id": 14110902,
   "name": "Protect Main",
   "target": "branch",
   "source_type": "Repository",
@@ -82,8 +84,8 @@ The machine user account's fine-grained PAT should have these permissions and no
   "enforcement": "active",
   "conditions": {
     "ref_name": {
-      "exclude": [],
-      "include": ["~DEFAULT_BRANCH", "refs/heads/main"]
+      "include": ["~DEFAULT_BRANCH", "refs/heads/main"],
+      "exclude": []
     }
   },
   "rules": [
@@ -118,32 +120,48 @@ The machine user account's fine-grained PAT should have these permissions and no
         "do_not_enforce_on_create": true,
         "required_status_checks": [
           {
-            "context": "secrets",
-            "integration_id": 15368
-          },
-          {
-            "context": "validate",
-            "integration_id": 15368
-          },
-          {
-            "context": "build-homepage",
+            "context": "verify",
             "integration_id": 15368
           },
           {
             "context": "security",
-            "integration_id": null
+            "integration_id": 15368
           }
         ]
       }
+[% if github_org != author_git_provider_username %]
+    },
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": null,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    }
+  ]
+[% else %]
     }
   ],
   "bypass_actors": [
     {
       "actor_id": 5,
       "actor_type": "RepositoryRole",
-      "bypass_mode": "pull_request"
+      "bypass_mode": "always"
     }
   ]
+[% endif %]
 }
 ```
 
@@ -153,9 +171,19 @@ The machine user account's fine-grained PAT should have these permissions and no
 
 The ruleset targets branches matching `~DEFAULT_BRANCH` and `refs/heads/main`. The `~DEFAULT_BRANCH` is a GitHub alias that always resolves to whatever the repo's default branch is, so even if the default branch name changes, the ruleset follows. Including `refs/heads/main` explicitly is belt-and-suspenders.
 
-### `bypass_actors: []`
+### `bypass_actors`
 
-**No one can bypass these rules.** This is intentional. Even the repo owner must go through the full PR process. If you later need an emergency bypass (e.g., for a hotfix), you would temporarily add yourself as a bypass actor, but the default posture is zero exceptions.
+[% if github_org != author_git_provider_username %]
+Only **organization admins** (`OrganizationAdmin`, `bypass_mode: always`) can bypass
+these rules — an escape hatch for emergency hotfixes. The bot has only Write
+collaborator access and is **never** an org admin, so it can never bypass. Everyone
+else, including the repo owner, goes through the full PR process.
+[% else %]
+Only the **Maintain** repository role (`RepositoryRole` id `5`, `bypass_mode: always`)
+can bypass these rules — an escape hatch for emergency hotfixes. The bot has only
+Write access (below Maintain), so it can never bypass. Day to day, even you go through
+the full PR process.
+[% endif %]
 
 ### `deletion`
 
@@ -190,16 +218,27 @@ This is the core rule that prevents the AI agent from pushing directly to `main`
 
 All specified CI checks must pass before the PR can merge. The `strict_required_status_checks_policy: true` setting means the PR branch must be up-to-date with `main` before merging — if `main` advances after the checks ran, the checks must re-run. The `do_not_enforce_on_create: true` setting skips enforcement when the branch is first created (before any CI has had a chance to run).
 
-The required checks for this repo are:
+The required checks are the two aggregate jobs from `build.yml` (see
+[ci-cd.md](ci-cd.md)):
 
-| Check                | Purpose                                  |
-| -------------------- | ---------------------------------------- |
-| `secrets`            | Scans for leaked secrets (Gitleaks)      |
-| `validate-compose`   | Validates Docker Compose configuration   |
-| `validate`           | General validation (linting, formatting) |
-| `validate-templates` | Validates infrastructure templates       |
-| `build-homepage`     | Ensures the homepage builds successfully |
+| Check      | Purpose                                                                                          |
+| ---------- | ----------------------------------------------------------------------------------------------- |
+| `verify`   | Aggregate gate — rolls up `lint`[% if use_node %], `build-test`[% endif %][% if project_type == 'web-astro' %], `lighthouse`[% endif %], and `security` so one check reports overall pass/fail |
+| `security` | Secret scanning (gitleaks) + dependency audit                                                    |
 
+Requiring the aggregate `verify` (rather than each leaf job) keeps the required-check
+list stable as jobs are added inside `build.yml`.
+
+[% if github_org != author_git_provider_username %]
+### `merge_queue`
+
+Merges go through a merge queue (`grouping_strategy: ALLGREEN`): GitHub batches queued
+PRs, re-runs the required checks against the prospective merged result, and squash-merges
+only if everything stays green. A required check whose workflow does **not** run on the
+`merge_group` event would never report and would stall the queue, so only checks wired to
+`merge_group` belong in the required set.
+
+[% endif %]
 ## What the AI Agent Can and Cannot Do
 
 | Operation                               | Allowed? | Enforced by                                     |
@@ -228,7 +267,7 @@ This ruleset ships with every repo generated from harmon-init. To replicate manu
 4. Update the `required_status_checks` to match that repo's CI checks
 5. Verify by attempting a direct push to main from the bot account — it should be rejected
 
-If repos move to the `ponderous` organization in the future, consider creating an **org-level ruleset** (requires GitHub Team plan) that applies these rules across all repos automatically, eliminating the need to configure each repo individually.
+For an organization with many repos, consider creating an **org-level ruleset** (requires GitHub Team plan) that applies these rules across all repos automatically, eliminating the need to configure each repo individually.
 
 ## Future Considerations
 

--- a/template/docs/architecture/branch-protection.md.jinja
+++ b/template/docs/architecture/branch-protection.md.jinja
@@ -179,9 +179,9 @@ these rules — an escape hatch for emergency hotfixes. The bot has only Write
 collaborator access and is **never** an org admin, so it can never bypass. Everyone
 else, including the repo owner, goes through the full PR process.
 [% else %]
-Only the **Maintain** repository role (`RepositoryRole` id `5`, `bypass_mode: always`)
+Only the **Repository admin** role (`RepositoryRole` id `5`, `bypass_mode: always`)
 can bypass these rules — an escape hatch for emergency hotfixes. The bot has only
-Write access (below Maintain), so it can never bypass. Day to day, even you go through
+Write access (below Admin), so it can never bypass. Day to day, even you go through
 the full PR process.
 [% endif %]
 

--- a/template/docs/architecture/branch-protection.md.jinja
+++ b/template/docs/architecture/branch-protection.md.jinja
@@ -148,7 +148,7 @@ This mirrors the importable
     {
       "actor_id": null,
       "actor_type": "OrganizationAdmin",
-      "bypass_mode": "always"
+      "bypass_mode": "pull_request"
     }
   ]
 [% else %]
@@ -158,7 +158,7 @@ This mirrors the importable
     {
       "actor_id": 5,
       "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
+      "bypass_mode": "pull_request"
     }
   ]
 [% endif %]
@@ -174,15 +174,20 @@ The ruleset targets branches matching `~DEFAULT_BRANCH` and `refs/heads/main`. T
 ### `bypass_actors`
 
 [% if github_org != author_git_provider_username %]
-Only **organization admins** (`OrganizationAdmin`, `bypass_mode: always`) can bypass
-these rules — an escape hatch for emergency hotfixes. The bot has only Write
-collaborator access and is **never** an org admin, so it can never bypass. Everyone
-else, including the repo owner, goes through the full PR process.
+Only **organization admins** (`OrganizationAdmin`) can bypass these rules, and only in
+`pull_request` mode — they can **merge** a PR that hasn't met every requirement (e.g.
+a stuck check, or their own PR that no one else can review), but they **cannot push
+directly to `main`**: a direct push isn't a pull request, so the bypass doesn't apply
+and the ruleset rejects it like anyone else's. The bot has only Write collaborator
+access and is **never** an org admin, so it can never bypass.
 [% else %]
-Only the **Repository admin** role (`RepositoryRole` id `5`, `bypass_mode: always`)
-can bypass these rules — an escape hatch for emergency hotfixes. The bot has only
-Write access (below Admin), so it can never bypass. Day to day, even you go through
-the full PR process.
+Only the **Repository admin** role (`RepositoryRole` id `5`) can bypass these rules,
+and only in `pull_request` mode — you can **merge** a PR that hasn't met every
+requirement (e.g. your own PR, which GitHub won't let you self-approve, or a stuck
+check), but you **cannot push directly to `main`**: a direct push isn't a pull
+request, so the bypass doesn't apply and the ruleset rejects it. This prevents
+accidental `git push origin main` while still letting a solo maintainer merge. The
+bot has only Write access (below Admin), so it can never bypass.
 [% endif %]
 
 ### `deletion`

--- a/template/docs/architecture/branch-protection.md.jinja
+++ b/template/docs/architecture/branch-protection.md.jinja
@@ -174,7 +174,7 @@ The ruleset targets branches matching `~DEFAULT_BRANCH` and `refs/heads/main`. T
 ### `bypass_actors`
 
 > **Design intent — leave this `pull_request`, not `always`.** Every bypass actor is
-> scoped to `bypass_mode: pull_request` on purpose: an admin may *merge* a
+> scoped to `bypass_mode: pull_request` on purpose: an admin may _merge_ a
 > non-compliant PR (a solo maintainer's own PR, which GitHub won't let them
 > self-approve, or a genuinely stuck check) but **cannot push directly to `main`**.
 > Widening any bypass to `always` re-enables accidental (or malicious) direct pushes

--- a/template/docs/architecture/branch-protection.md.jinja
+++ b/template/docs/architecture/branch-protection.md.jinja
@@ -173,6 +173,16 @@ The ruleset targets branches matching `~DEFAULT_BRANCH` and `refs/heads/main`. T
 
 ### `bypass_actors`
 
+> **Design intent — leave this `pull_request`, not `always`.** Every bypass actor is
+> scoped to `bypass_mode: pull_request` on purpose: an admin may *merge* a
+> non-compliant PR (a solo maintainer's own PR, which GitHub won't let them
+> self-approve, or a genuinely stuck check) but **cannot push directly to `main`**.
+> Widening any bypass to `always` re-enables accidental (or malicious) direct pushes
+> to `main` and is a real security loosening — only do it deliberately, and call it
+> out in review. A bypass actor is required at all (rather than `bypass_actors: []`)
+> because a solo maintainer otherwise can't merge anything; with multiple human
+> reviewers you can drop the bypass entirely instead.
+
 [% if github_org != author_git_provider_username %]
 Only **organization admins** (`OrganizationAdmin`) can bypass these rules, and only in
 `pull_request` mode — they can **merge** a PR that hasn't met every requirement (e.g.

--- a/template/docs/glossary.md.jinja
+++ b/template/docs/glossary.md.jinja
@@ -5,6 +5,21 @@ This is the **dictionary projection** of [the domain model](product/domain.md): 
 points at the model for the real relationships and reasoning — it never restates
 them. A flat lookup: scan for a term, don't read top-to-bottom.
 
+Terms below are part of the harmon-init toolchain this repo is built on; add
+project-specific (domain) terms as the model firms up.
+
 | Term | Meaning |
 |---|---|
-| TODO: term | TODO: definition |
+| `verify` | The aggregate CI job in `build.yml` that rolls up the other jobs into one required status check (the merge gate). See [architecture/ci-cd.md](architecture/ci-cd.md). |
+| `security` (check) | The CI job running secret scanning (gitleaks) + dependency audit; the second required status check. |
+| `task` / Taskfile | go-task is the single source of truth for commands; lefthook hooks and CI both delegate to `task` targets so local and CI runs are identical. |
+[% if use_release_please %]
+| release-please | Bot that maintains a rolling "release" PR from Conventional Commits; merging it cuts the tag, GitHub release, and CHANGELOG. Releases are intentional, never automatic on merge. |
+[% endif %]
+| `[[ github_org ]]-ci` (GitHub App) | The CI automation app that mints short-lived tokens for CI workflows (not a PAT). See [architecture/security.md](architecture/security.md). |
+[% if devcontainer %]
+| bot profile / dev profile | The two devcontainer profiles: `bot` (`.devcontainer/`, AI agents, no Tailscale) and `dev` (`.devcontainer/dev/`, human, with Tailscale). See [guides/devcontainers.md](guides/devcontainers.md). |
+| 1Password Environments | How devcontainer/local secrets are supplied — a virtual `.env` mounted over a pipe, never written to disk or git. |
+[% endif %]
+| bot vs operator | Two identities: the AI **bot** account (scoped, can't merge `main`) and the human **operator** (full access). See [architecture/security.md](architecture/security.md). |
+| TODO: term | TODO: project-specific definition |


### PR DESCRIPTION
A focused pass over the template docs (`template/docs/`). A read-only review found the docs are in good shape overall — `ci-cd.md`, `security.md`, `conventions.md`, `CHECKLIST.md`, and the devcontainer guides are accurate and appropriately specific — with **one genuinely broken doc** and one near-empty one.

## `branch-protection.md` was stale and self-contradictory

The template's `docs/architecture/branch-protection.md` still carried harmon-infra-specific content that misrepresented the ruleset the template actually ships (`verify` + `security`) and contradicted `ci-cd.md`:

- **Embedded ruleset JSON** had a hardcoded `"id": 14110902`, wrong required checks (`secrets`/`validate`/`build-homepage`), **no** `merge_queue`, and a bypass actor that didn't match the shipped `.github/Branch Protection Ruleset - Protect Main.json`. Replaced with a faithful jinja mirror of that file: `verify` + `security`, org-conditional `merge_queue` + `OrganizationAdmin` bypass vs personal `RepositoryRole` bypass, no hardcoded id. Added a "keep in sync" note.
- **`bypass_actors: []` section** claimed "no one can bypass" while the JSON above it showed a bypass actor — fixed to describe the real org/personal posture.
- **Required-checks table** (`validate-compose`/`validate-templates`/`build-homepage`) → `verify` + `security`, with what `verify` rolls up (project-type aware), consistent with `ci-cd.md`.
- Added an org-only **`merge_queue`** explanation; removed a stray `ponderous` org reference.

## `glossary.md` seeded with template-known terms

Was a single `TODO:` row. Seeded with the toolchain vocabulary the template genuinely defines — `verify`, `security`, `task`/Taskfile, release-please, the `<org>-ci` GitHub App, devcontainer bot/dev profiles, 1Password Environments, bot vs operator — gated by the relevant copier conditionals, keeping a trailing TODO for project-specific (domain) terms.

## Scope / conservative bar

Per a conservative specificity bar, docs whose content is genuinely repo-specific were **left as well-crafted TODO scaffolds** (no invented content): `product/{vision,roadmap,domain}`, `architecture/README` overview + diagram, `guides/deploying`, `design-language`, `DESIGN.md`. `tests.md` was left as-is (accurate; its only TODO is genuinely repo-specific coverage expectations).

## Verification

- Rendered both an **org** (web-astro) and a **personal** (general) profile via `copier copy --vcs-ref=HEAD`; in each, the doc's embedded JSON **matches** the rendered ruleset file exactly (org → `verify`+`security`+`merge_queue`+`OrganizationAdmin`; personal → `RepositoryRole`, no merge_queue), conditionals render cleanly, no `[[ ]]`/`[% %]` leftovers, and a leakage grep (`ponderous`/`14110902`/`validate-compose`/etc.) is clean across both trees.
- `task test:template` PASS; `task check` and markdownlint clean.
- Root dogfood copies (`docs/architecture/branch-protection.md`, `docs/glossary.md`) re-rendered to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)