### PR TITLE
fix(status): detect setup workflows by .yml and .yaml

### DIFF
--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -410,13 +410,16 @@ if [[ "${SECTION}" == "setup" ]]; then
         wait
 
         # ── Feature applicability, detected from local files ──
+        # Match both .yml and .yaml — extension is each tool's own convention.
         has_claude_wf=0
-        ls .github/workflows/claude-*.yml >/dev/null 2>&1 && has_claude_wf=1
+        find .github/workflows -maxdepth 1 \( -name 'claude-*.yml' -o -name 'claude-*.yaml' \) 2>/dev/null | grep -q . && has_claude_wf=1
         has_release_wf=0
-        ls .github/workflows/release.yml >/dev/null 2>&1 && has_release_wf=1
+        find .github/workflows -maxdepth 1 \( -name 'release.yml' -o -name 'release.yaml' \) 2>/dev/null | grep -q . && has_release_wf=1
         uses_ci_app=$((has_claude_wf || has_release_wf))
         uses_snyk=0
-        grep -rqi 'snyk' Taskfile.yml >/dev/null 2>&1 && uses_snyk=1
+        for tf in Taskfile.yml Taskfile.yaml; do
+            [ -f "$tf" ] && grep -qi 'snyk' "$tf" && uses_snyk=1
+        done
         uses_full_scan=0
         grep -rq 'FULL_SECURITY_SCAN' .github/workflows >/dev/null 2>&1 && uses_full_scan=1
 

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -410,13 +410,16 @@ if [[ "${SECTION}" == "setup" ]]; then
         wait
 
         # ── Feature applicability, detected from local files ──
+        # Match both .yml and .yaml — extension is each tool's own convention.
         has_claude_wf=0
-        ls .github/workflows/claude-*.yml >/dev/null 2>&1 && has_claude_wf=1
+        find .github/workflows -maxdepth 1 \( -name 'claude-*.yml' -o -name 'claude-*.yaml' \) 2>/dev/null | grep -q . && has_claude_wf=1
         has_release_wf=0
-        ls .github/workflows/release.yml >/dev/null 2>&1 && has_release_wf=1
+        find .github/workflows -maxdepth 1 \( -name 'release.yml' -o -name 'release.yaml' \) 2>/dev/null | grep -q . && has_release_wf=1
         uses_ci_app=$((has_claude_wf || has_release_wf))
         uses_snyk=0
-        grep -rqi 'snyk' Taskfile.yml >/dev/null 2>&1 && uses_snyk=1
+        for tf in Taskfile.yml Taskfile.yaml; do
+            [ -f "$tf" ] && grep -qi 'snyk' "$tf" && uses_snyk=1
+        done
         uses_full_scan=0
         grep -rq 'FULL_SECURITY_SCAN' .github/workflows >/dev/null 2>&1 && uses_full_scan=1
 


### PR DESCRIPTION
Follow-up to the `status:setup` work. The setup-completeness audit in `scripts/status.sh` feature-detected workflow-gated items by **`.yml` only**, so repos that use `.yaml` (each tool's own convention — not drift) saw real config reported as "n/a":

- claude-*/release workflows missed → CI App + `CLAUDE_CODE_OAUTH_TOKEN` shown as "not used", release shown as "no release workflow"
- snyk detection read `Taskfile.yml` only → missed `Taskfile.yaml` repos

## Fix
- Match both extensions via `find ... \( -name '*.yml' -o -name '*.yaml' \)` for the workflow globs.
- Loop over `Taskfile.yml`/`Taskfile.yaml` for the snyk check.
- Applied to both `template/scripts/status.sh` and the root dogfood `scripts/status.sh`.

shellcheck + shfmt clean. harmon-init's own workflows are `.yml`, so its audit output is unchanged; the fix benefits `.yaml` repos (e.g. harmon-infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)