### PR TITLE
docs(template): apply branch ruleset via UI import, not gh api

### DIFF
--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -14,16 +14,11 @@ config, toolchain, devcontainer, and dev environment — against the items below
 
 ## 2. GitHub repo settings
 
-- [ ] Import the branch ruleset (see [architecture/branch-protection.md](architecture/branch-protection.md)):
+- [ ] **Automated settings** — run `task setup:github` (idempotent, safe to
+      re-run): enables **Dependabot alerts** and **private vulnerability
+      reporting**, sets the `FULL_SECURITY_SCAN` variable (CodeQL). Do NOT add dependabot.yml — Renovate owns version updates.
+- [ ] Import the branch ruleset (see [architecture/branch-protection.md](architecture/branch-protection.md)) — do this once `build.yml` is on `main` so the required `verify`/`security` checks resolve. **Use the UI import:** Settings → Rules → Rulesets → **New ruleset ▸ Import a ruleset** → select `.github/Branch Protection Ruleset - Protect Main.json`. (Prefer the UI over `gh api … rulesets`: the API `POST` is not idempotent — re-running creates a duplicate ruleset — and currently rejects the `merge_queue` rule. To later change the ruleset, edit the existing one in the UI rather than re-importing.)
 
-  ```bash
-  gh api "repos/evanharmon1/harmon-init/rulesets" --method POST \
-    --input ".github/Branch Protection Ruleset - Protect Main.json"
-  ```
-
-- [ ] Settings → Advanced Security: enable **Dependabot alerts** and
-      **Private vulnerability reporting** (do NOT add dependabot.yml —
-      Renovate owns version updates)
 - [ ] Install the [Renovate app](https://github.com/apps/renovate) on the repo
 - [ ] Install the [CodeRabbit app](https://github.com/apps/coderabbitai) on the repo (`.coderabbit.yaml` is pre-configured)
 - [ ] Actions secrets: `CLAUDE_CODE_OAUTH_TOKEN` (claude-* workflows),
@@ -35,7 +30,6 @@ config, toolchain, devcontainer, and dev environment — against the items below
       **variable**) + `CI_APP_PRIVATE_KEY` (Actions **secret**) — org-level for
       an org, per-repo for a personal account. Drives release-please, the
       claude-* workflows, and project-automation. See docs/architecture/security.md.
-- [ ] Actions variables: set `FULL_SECURITY_SCAN=true` to enable CodeQL
 - [ ] GHCR: ensure the org/user allows publishing packages; the first
       devcontainer prebuild populates `ghcr.io/evanharmon1/harmon-init-devcontainer` on merge to main
 
@@ -45,10 +39,15 @@ config, toolchain, devcontainer, and dev environment — against the items below
 
 ## 4. Secrets & environment
 
-- [ ] For local `.env` needs, use 1Password: `op inject`/`op run` or the
-      1Password Developer Environments feature; commit only `.env.example`-style files
-- [ ] Devcontainer secrets land in `.devcontainer/devcontainer.env` via
-      `init-env.sh` (1Password locally, host env on Coder) — never committed
+- [ ] For local `.env` needs, use **1Password Environments** (mounts a virtual
+      `.env`; secrets never hit disk or git) or `op run`/`op inject`. Commit only
+      `.env.example`-style files
+- [ ] Devcontainer secrets: create a **1Password environment** that mounts
+      `.devcontainer/devcontainer.env` (and `.devcontainer/dev/devcontainer.env`)
+      with `GH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `AGENT_DECK_TELEGRAM_KEY`
+      (+ `TS_AUTHKEY` for the dev profile). `init-env.sh` enforces the per-profile
+      allow-list; on Coder the values come from workspace parameters. See
+      [guides/devcontainers.md](guides/devcontainers.md)
 
 ## 5. Docs & meta
 

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -7,14 +7,21 @@ This document explains the branch protection ruleset applied to `main` and how i
 ## Applying the Ruleset
 
 An importable copy of the ruleset ships in this repo at
-`.github/Branch Protection Ruleset - Protect Main.json`. Import it via the UI
-(Settings → Rules → Rulesets → Import a ruleset) or the API:
+`.github/Branch Protection Ruleset - Protect Main.json`. Apply it through the
+GitHub **UI import** (do this once `build.yml` is on `main`, so the required
+`verify`/`security` checks resolve):
 
-```bash
-gh api "repos/evanharmon1/harmon-init/rulesets" \
-  --method POST \
-  --input ".github/Branch Protection Ruleset - Protect Main.json"
-```
+> Settings → Rules → Rulesets → **New ruleset ▸ Import a ruleset** → select
+> `.github/Branch Protection Ruleset - Protect Main.json`.
+
+To change the ruleset later, **edit the existing one in the UI** (Settings →
+Rules → Rulesets → Protect Main) — don't re-import.
+
+**Why the UI, not `gh api … rulesets`:** the REST `POST` is **not idempotent**
+(every run creates another "Protect Main" ruleset — silent duplicates), the
+`PUT` form needs the live ruleset id, and both currently reject the
+`merge_queue` rule with `422 Invalid rule 'merge_queue'`. The UI import handles
+every rule type and is the GitHub-native way to apply an exported ruleset.
 
 ## Dependabot and Renovate
 

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -19,12 +19,7 @@ config, toolchain, devcontainer, and dev environment — against the items below
       reporting**, sets the `FULL_SECURITY_SCAN` variable (CodeQL)[% if github_org != author_git_provider_username %], and adds
       the `[[ author_git_provider_username ]]-bot` machine account as a Write
       collaborator[% endif %]. Do NOT add dependabot.yml — Renovate owns version updates.
-- [ ] Import the branch ruleset (see [architecture/branch-protection.md](architecture/branch-protection.md)) — run once `build.yml` is on `main`, so the required `verify`/`security` checks resolve:
-
-  ```bash
-  gh api "repos/[[ github_org ]]/[[ project_slug ]]/rulesets" --method POST \
-    --input ".github/Branch Protection Ruleset - Protect Main.json"
-  ```
+- [ ] Import the branch ruleset (see [architecture/branch-protection.md](architecture/branch-protection.md)) — do this once `build.yml` is on `main` so the required `verify`/`security` checks resolve. **Use the UI import:** Settings → Rules → Rulesets → **New ruleset ▸ Import a ruleset** → select `.github/Branch Protection Ruleset - Protect Main.json`. (Prefer the UI over `gh api … rulesets`: the API `POST` is not idempotent — re-running creates a duplicate ruleset — and currently rejects the `merge_queue` rule. To later change the ruleset, edit the existing one in the UI rather than re-importing.)
 
 - [ ] Install the [Renovate app](https://github.com/apps/renovate) on the repo
 - [ ] Install the [CodeRabbit app](https://github.com/apps/coderabbitai) on the repo (`.coderabbit.yaml` is pre-configured)

--- a/template/docs/architecture/branch-protection.md.jinja
+++ b/template/docs/architecture/branch-protection.md.jinja
@@ -7,14 +7,21 @@ This document explains the branch protection ruleset applied to `main` and how i
 ## Applying the Ruleset
 
 An importable copy of the ruleset ships in this repo at
-`.github/Branch Protection Ruleset - Protect Main.json`. Import it via the UI
-(Settings → Rules → Rulesets → Import a ruleset) or the API:
+`.github/Branch Protection Ruleset - Protect Main.json`. Apply it through the
+GitHub **UI import** (do this once `build.yml` is on `main`, so the required
+`verify`/`security` checks resolve):
 
-```bash
-gh api "repos/[[ github_org ]]/[[ project_slug ]]/rulesets" \
-  --method POST \
-  --input ".github/Branch Protection Ruleset - Protect Main.json"
-```
+> Settings → Rules → Rulesets → **New ruleset ▸ Import a ruleset** → select
+> `.github/Branch Protection Ruleset - Protect Main.json`.
+
+To change the ruleset later, **edit the existing one in the UI** (Settings →
+Rules → Rulesets → Protect Main) — don't re-import.
+
+**Why the UI, not `gh api … rulesets`:** the REST `POST` is **not idempotent**
+(every run creates another "Protect Main" ruleset — silent duplicates), the
+`PUT` form needs the live ruleset id, and both currently reject the
+`merge_queue` rule with `422 Invalid rule 'merge_queue'`. The UI import handles
+every rule type and is the GitHub-native way to apply an exported ruleset.
 
 ## Dependabot and Renovate
 


### PR DESCRIPTION
The documented ruleset-application command (`gh api … rulesets --method POST`) has two real problems:

- **Not idempotent** — `POST` *creates* a ruleset, so re-running it leaves duplicate "Protect Main" rulesets.
- **Rejects `merge_queue`** — both `POST` and `PUT` currently return `422 Invalid rule 'merge_queue'`, so the org ruleset can't be imported via the API at all. (`PUT` also needs the live ruleset id.)

## Change
Switch the documented process to the **GitHub UI import** in both `docs/CHECKLIST.md` and `docs/architecture/branch-protection.md`:

> Settings → Rules → Rulesets → **New ruleset ▸ Import a ruleset** → select `.github/Branch Protection Ruleset - Protect Main.json`

…with a note that later changes should **edit the existing ruleset in the UI** rather than re-import (and a short "why not the API" explanation). The UI import handles every rule type including merge queue. Root dogfood copies re-rendered; `task test:template` + markdownlint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)