### PR TITLE
docs(template): add local-dev setup items to CHECKLIST

### DIFF
--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -11,6 +11,9 @@ config, toolchain, devcontainer, and dev environment — against the items below
 
 - [ ] `task install` — Brewfile deps, and lefthook git hooks
 - [ ] `task verify` passes locally
+- [ ] Open the `harmon-init.code-workspace` in VS Code (the curated multi-root workspace)
+- [ ] Extend `.gitignore` for your stack — the template ships a base; add stack-specific entries via [gitignore.io](https://www.toptal.com/developers/gitignore)
+- [ ] macOS: add a Raycast quicklink/alias that opens the `harmon-init.code-workspace`
 
 ## 2. GitHub repo settings
 

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -11,6 +11,12 @@ config, toolchain, devcontainer, and dev environment — against the items below
 
 - [ ] `task install` — Brewfile deps[% if use_python %], `uv sync`[% endif %][% if use_node %], `pnpm install`[% endif %], and lefthook git hooks
 - [ ] `task verify` passes locally
+- [ ] Open the `[[ project_slug ]].code-workspace` in VS Code (the curated multi-root workspace)
+- [ ] Extend `.gitignore` for your stack — the template ships a base; add stack-specific entries via [gitignore.io](https://www.toptal.com/developers/gitignore)
+- [ ] macOS: add a Raycast quicklink/alias that opens the `[[ project_slug ]].code-workspace`
+[% if bunch_add %]
+- [ ] macOS: confirm the project is in your Bunch — auto-added at generation via `task util:bunch-add` (re-run it if needed)
+[% endif %]
 
 ## 2. GitHub repo settings
 


### PR DESCRIPTION
## What

Adds four machine-local setup reminders to the post-generation CHECKLIST,
folded into **section 1 (Local setup)** of `template/docs/CHECKLIST.md.jinja`
(and the re-rendered root dogfood copy):

- Open the `<slug>.code-workspace` in VS Code
- Extend `.gitignore` for the stack ([gitignore.io](https://www.toptal.com/developers/gitignore))
- macOS: a Raycast quicklink/alias that opens the workspace
- macOS: confirm the project is in Bunch — **gated on `bunch_add`**, since it's
  auto-added at generation via `task util:bunch-add`

## Why

These were useful first-run conveniences that lived in an older repo's checklist
and got dropped during standardization; promoting them into the template means
every generated repo gets them. The Bunch item is jinja-gated so it only appears
when `bunch_add` is on (root dogfood defaults it off, so no Bunch line there).

## Verification

- `task test:template:minimal` → PASS (the `.jinja` renders to valid markdown)
- `task security:secrets` → no leaks
- markdownlint on the rendered root dogfood → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)