### PR TITLE
feat(status): show CHECKLIST.md completion in status:setup

### DIFF
--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -323,6 +323,26 @@ fi
 if [[ "${SECTION}" == "setup" ]]; then
     section_header "Setup Completeness"
 
+    # Checklist progress — parse the repo's docs/CHECKLIST.md task boxes and show
+    # how many are ticked as a colorful bar. Pure local file parsing (no network),
+    # so it renders even when gh is unauthenticated.
+    {
+        cl="docs/CHECKLIST.md"
+        if [ -f "${cl}" ]; then
+            cl_total="$(grep -cE '^[[:space:]]*- \[[ xX]\]' "${cl}" 2>/dev/null || true)"
+            cl_done="$(grep -cE '^[[:space:]]*- \[[xX]\]' "${cl}" 2>/dev/null || true)"
+            cl_total="${cl_total:-0}"
+            cl_done="${cl_done:-0}"
+            cl_pct=0
+            [ "${cl_total}" -gt 0 ] && cl_pct=$((cl_done * 100 / cl_total))
+            printf '  %s  %s  %s\n' "$(bar "${cl_pct}")" \
+                "$(c '1' "${cl_pct}%")" "$(c '2' "(${cl_done}/${cl_total} checked)")"
+            kv "Checklist" "${cl}"
+        else
+            printf '  %s\n' "$(c '2' "no docs/CHECKLIST.md to parse")"
+        fi
+    } | section_box
+
     if ! gh auth status &>/dev/null 2>&1; then
         echo "  (gh not authenticated -- run 'gh auth login')" | section_box
     else

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -323,6 +323,26 @@ fi
 if [[ "${SECTION}" == "setup" ]]; then
     section_header "Setup Completeness"
 
+    # Checklist progress — parse the repo's docs/CHECKLIST.md task boxes and show
+    # how many are ticked as a colorful bar. Pure local file parsing (no network),
+    # so it renders even when gh is unauthenticated.
+    {
+        cl="docs/CHECKLIST.md"
+        if [ -f "${cl}" ]; then
+            cl_total="$(grep -cE '^[[:space:]]*- \[[ xX]\]' "${cl}" 2>/dev/null || true)"
+            cl_done="$(grep -cE '^[[:space:]]*- \[[xX]\]' "${cl}" 2>/dev/null || true)"
+            cl_total="${cl_total:-0}"
+            cl_done="${cl_done:-0}"
+            cl_pct=0
+            [ "${cl_total}" -gt 0 ] && cl_pct=$((cl_done * 100 / cl_total))
+            printf '  %s  %s  %s\n' "$(bar "${cl_pct}")" \
+                "$(c '1' "${cl_pct}%")" "$(c '2' "(${cl_done}/${cl_total} checked)")"
+            kv "Checklist" "${cl}"
+        else
+            printf '  %s\n' "$(c '2' "no docs/CHECKLIST.md to parse")"
+        fi
+    } | section_box
+
     if ! gh auth status &>/dev/null 2>&1; then
         echo "  (gh not authenticated -- run 'gh auth login')" | section_box
     else


### PR DESCRIPTION
## What

`task status:setup` now parses the repo's `docs/CHECKLIST.md` task boxes and renders
a **colorful progress bar** at the top of the Setup Completeness section — how many
items are ticked over the total, plus a percentage:

```
╭──────────────────────────────────────────╮
│ ░░░░░░░░░░░░░░░░░░░░  0%  (0/15 checked) │
│   Checklist:  docs/CHECKLIST.md          │
╰──────────────────────────────────────────╯
```

(Green fill on a dim track as boxes get ticked.)

## How

- Counts `- [x]`/`- [X]` (done) vs all `- [ ]`/`- [x]` task boxes via `grep -cE`.
- Reuses the existing `bar()` / `c()` / `kv` / `section_box` helpers, so it matches
  the rest of the dashboard (same bar as the setup summary).
- Pure local file parsing, placed **before** the `gh auth` gate, so it renders even
  when unauthenticated / offline.
- Applied to **both** `template/scripts/status.sh` (so generated repos get it) and
  the root dogfood `scripts/status.sh`.

## Verification

- `shellcheck --severity=error` + `shfmt -d` → clean on both files
- `./scripts/status.sh setup` renders the bar correctly (0/15 on harmon-init's own
  all-unticked checklist)
- pre-push `secrets` + `test:template:minimal` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)