### PR TITLE
chore(skills): re-vendor standardize-repo skill from harmon-devkit

### DIFF
--- a/.claude/skills/standardize-repo/SKILL.md
+++ b/.claude/skills/standardize-repo/SKILL.md
@@ -42,6 +42,7 @@ Detect the situation, then follow the matching reference file end to end.
 | --- | --- | --- |
 | Target dir is empty / does not exist yet (new project) | **new-repo** | `references/mode-new-repo.md` |
 | Target is an existing repo **with git history** (retrofit) | **adopt-existing** | `references/mode-adopt-existing.md` |
+| Repo already generated from harmon-init (**v3+**, has `.copier-answers.yml`) and user wants the **latest template changes** ("update", "keep in sync", "pull latest harmon-init") | **update** | `references/mode-update.md` |
 | User says "audit" / "check" / "what's missing" / "bring up to standard" / drift report | **audit** | `references/mode-audit.md` |
 
 If it is ambiguous (e.g. a non-empty dir that is not a git repo), ask the user which

--- a/.claude/skills/standardize-repo/assets/diff-template.sh
+++ b/.claude/skills/standardize-repo/assets/diff-template.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# diff-template.sh — show how a repo's template-owned files differ from a fresh
+# harmon-init render, so the agent can find missed template improvements.
+#
+# Renders harmon-init using the TARGET repo's own .copier-answers.yml, then diffs
+# each path in template-owned-files.txt against the repo (mapping .yml<->.yaml).
+# This is a REVIEW AID for apply/update/audit, not a pass/fail gate: a listed file
+# may differ because the repo legitimately customized it (terraform tasks, a custom
+# status section) OR because it's missing template improvements (the recurring
+# status.sh / lint-hygiene / bootstrap class). For each DRIFT, inspect the diff and
+# reconcile — pull template improvements in via `copier update`, keep local edits.
+#
+# Usage: diff-template.sh [TARGET_DIR]            (default: .)
+#        diff-template.sh -v|--show TARGET_DIR    (print the full per-file diff)
+# Env:   HARMON_INIT   template checkout (default: ~/git/harmon-init)
+#
+# Exit: 0 = no drift, 1 = drift found (for callers that want a signal), 2 = setup error.
+# Portable to macOS bash 3.2 (no mapfile, no grep -P, no associative arrays).
+set -euo pipefail
+
+show=0
+case "${1:-}" in
+-v | --show)
+    show=1
+    shift
+    ;;
+esac
+target="${1:-.}"
+template="${HARMON_INIT:-$HOME/git/harmon-init}"
+here="$(cd "$(dirname "$0")" && pwd)"
+manifest="$here/template-owned-files.txt"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+for t in copier yq; do
+    have "$t" || {
+        echo "FAIL: required tool '$t' is not installed" >&2
+        exit 2
+    }
+done
+[ -d "$template" ] || {
+    echo "FAIL: template not found at $template (set HARMON_INIT)" >&2
+    exit 2
+}
+[ -f "$manifest" ] || {
+    echo "FAIL: manifest not found at $manifest" >&2
+    exit 2
+}
+
+target="$(cd "$target" && pwd)"
+answers="$target/.copier-answers.yml"
+[ -f "$answers" ] || {
+    echo "FAIL: $target has no .copier-answers.yml — not a template-linked repo" >&2
+    exit 2
+}
+
+# Reconstruct --data from the recorded answers (skip copier's _ keys and nulls).
+data_args=()
+while IFS= read -r line; do
+    [ -n "$line" ] && data_args+=(--data "$line")
+done < <(yq 'to_entries[] | select(.key | test("^_") | not) | select(.value != null) | .key + "=" + (.value | tostring)' "$answers")
+
+# Force every side-effect off in the throwaway render (later --data wins).
+data_args+=(
+    --data git_init=false
+    --data github_remote_create=false
+    --data github_release_init=false
+    --data run_task_install=false
+    --data bunch_add=false
+    --data obsidian_project_add=false
+)
+
+render="$(mktemp -d -t harmon-init-render-XXXXXX)"
+trap 'rm -rf "$render"' EXIT
+copier copy "$template" "$render" --vcs-ref=HEAD --trust --defaults "${data_args[@]}" >/dev/null 2>&1 || {
+    echo "FAIL: copier render failed" >&2
+    exit 2
+}
+
+# Resolve a repo file path, honoring .yml<->.yaml (each tool's own convention).
+repo_variant() {
+    p="$1"
+    if [ -f "$target/$p" ]; then
+        echo "$target/$p"
+        return
+    fi
+    case "$p" in
+    *.yml) [ -f "$target/${p%.yml}.yaml" ] && {
+        echo "$target/${p%.yml}.yaml"
+        return
+    } ;;
+    *.yaml) [ -f "$target/${p%.yaml}.yml" ] && {
+        echo "$target/${p%.yaml}.yml"
+        return
+    } ;;
+    esac
+    echo ""
+}
+
+drift=0
+checked=0
+while IFS= read -r f; do
+    case "$f" in '' | \#*) continue ;; esac
+    [ -f "$render/$f" ] || continue # conditional file not in this profile
+    checked=$((checked + 1))
+    rv="$(repo_variant "$f")"
+    if [ -z "$rv" ]; then
+        echo "MISSING  $f  (template ships it; repo doesn't)"
+        drift=1
+        continue
+    fi
+    if ! diff -q "$render/$f" "$rv" >/dev/null 2>&1; then
+        echo "DRIFT    ${rv#"$target"/}"
+        drift=1
+        [ "$show" -eq 1 ] && diff -u "$rv" "$render/$f" | sed 's/^/    /'
+    fi
+done <"$manifest"
+
+echo ""
+if [ "$drift" -ne 0 ]; then
+    echo "diff-template: $checked template-owned files checked; some differ from the"
+    echo "  template (above). For each, review the diff (\`diff-template.sh --show\`):"
+    echo "  pull missed template improvements in with \`copier update\`, and keep the"
+    echo "  repo's legitimate local customizations."
+    exit 1
+fi
+echo "diff-template: OK — all $checked template-owned files match the template."

--- a/.claude/skills/standardize-repo/assets/template-owned-files.txt
+++ b/.claude/skills/standardize-repo/assets/template-owned-files.txt
@@ -1,0 +1,55 @@
+# Template-owned files — files harmon-init generates and keeps improving. They
+# normally track the template; a repo may still customize them in place (that's
+# fine — target repos stay plain). diff-template.sh compares each against a fresh
+# render of the template so the agent can SEE, per file, which template
+# improvements a repo is missing, then reconcile (pull the improvements in via
+# `copier update`, keep the legit local customizations). It is a review aid, not a
+# "must match exactly" gate.
+#
+# Lines starting with # and blank lines are ignored. Paths use the template's
+# default extension; diff-template.sh maps .yml<->.yaml to whatever the repo uses.
+# Entries not present in a given render (e.g. codeql.yml for a non-node/python
+# repo) are skipped automatically.
+
+# ── Task runner + git hooks ──────────────────────────────────────────────────
+Taskfile.yml
+lefthook.yml
+
+# ── Shared scripts ───────────────────────────────────────────────────────────
+scripts/status.sh
+scripts/lint-hygiene.sh
+scripts/summarize-gitleaks.mjs
+scripts/test-tasks.sh
+scripts/test-hooks.sh
+scripts/devcontainer-assert.sh
+
+# ── Lint / format / security config ──────────────────────────────────────────
+.editorconfig
+.yamllint
+.shellcheckrc
+.markdownlint.json
+.markdownlint-cli2.jsonc
+commitlint.config.mjs
+.gitleaks.toml
+.dockerignore
+.coderabbit.yaml
+
+# ── Standard CI workflows ─────────────────────────────────────────────────────
+.github/workflows/build.yml
+.github/workflows/claude-plan.yml
+.github/workflows/claude-implement.yml
+.github/workflows/claude-review.yml
+.github/workflows/codeql.yml
+.github/workflows/release.yml
+.github/workflows/devcontainer-build.yml
+.github/workflows/project-automation.yml
+
+# ── Devcontainer (template-owned lifecycle + tooling) ─────────────────────────
+.devcontainer/Dockerfile
+.devcontainer/devcontainer.json
+.devcontainer/dev/devcontainer.json
+.devcontainer/post-create.sh
+.devcontainer/post-start.sh
+.devcontainer/scripts/init-env.sh
+.devcontainer/scripts/post-create-common.sh
+.devcontainer/scripts/post-start-common.sh

--- a/.claude/skills/standardize-repo/assets/verify-applied.sh
+++ b/.claude/skills/standardize-repo/assets/verify-applied.sh
@@ -93,6 +93,20 @@ if { [ -f Taskfile.yml ] || [ -f Taskfile.yaml ]; } && have task; then
     fi
 fi
 
+# ── 3b. Required universal Taskfile targets are present ──────────────
+# Every standardized repo defines these regardless of project_type. A missing
+# one means the Taskfile drifted from (or predates) the current template — the
+# recurring example is status:setup (the setup-completeness audit), which older
+# forks of scripts/status.sh + Taskfile never had.
+if { [ -f Taskfile.yml ] || [ -f Taskfile.yaml ]; } && have task; then
+    tasklist="$(task --list-all 2>/dev/null || true)"
+    for t in verify check security status:setup install:hooks; do
+        if ! printf '%s\n' "$tasklist" | grep -qE "^[* ]*${t}:([[:space:]]|\$)"; then
+            err "Taskfile missing required target: ${t}"
+        fi
+    done
+fi
+
 # ── 4. No unrendered template markers leaked into the repo ──────────
 # harmon-init uses CUSTOM jinja delimiters ([[ var ]], [% block %]). Legitimate
 # look-alikes must NOT trip this: go-task uses {{.VAR}} (dot, no space), GitHub
@@ -139,6 +153,21 @@ if have gitleaks; then
     fi
 else
     echo "WARN: gitleaks not installed — skipping secrets scan"
+fi
+
+# ── 6. Template-owned file content drift (advisory) ─────────────────
+# Renders harmon-init from this repo's .copier-answers.yml and diffs the
+# template-owned file set (see diff-template.sh / template-owned-files.txt).
+# Advisory here — some drift is legitimate local customization, and the
+# update/audit modes review and reconcile it. After a `copier update` it should
+# show only intentional customizations.
+diff_tool="$(dirname "$0")/diff-template.sh"
+if [ -f .copier-answers.yml ] && [ -x "$diff_tool" ] && have copier && have yq; then
+    if ! "$diff_tool" . >/dev/null 2>&1; then
+        echo "WARN: template-owned files differ from a fresh harmon-init render —" >&2
+        echo "      review with $diff_tool --show . and reconcile (mode-update.md /" >&2
+        echo "      mode-audit.md drift class K). Legit customizations are expected." >&2
+    fi
 fi
 
 # ── Result ──────────────────────────────────────────────────────────

--- a/.claude/skills/standardize-repo/references/mode-audit.md
+++ b/.claude/skills/standardize-repo/references/mode-audit.md
@@ -176,9 +176,10 @@ shipped ruleset JSON is already `verify`+`security` — so check the JSON, not j
 the doc. Relatedly, ambiguous `verify` contexts: if both `build.yml` and the
 devcontainer workflow define a job literally named `verify`, either can satisfy
 the required check — the template renames the devcontainer job to
-**`devcontainer-verify`**. Fix: re-import the ruleset
-(`gh api repos/<org>/<repo>/rulesets --method POST --input "<ruleset>.json"`),
-rename the devcontainer job, and align CI job names to `verify` + `security`.
+**`devcontainer-verify`**. Fix: re-import the ruleset via the GitHub UI
+(Settings → Rules → Rulesets → **Import a ruleset**; avoid `gh api … rulesets`,
+which is non-idempotent and rejects the `merge_queue` rule), rename the
+devcontainer job, and align CI job names to `verify` + `security`.
 Severity: **blocker** (wrong contexts mean the gate is unenforced or unsatisfiable).
 
 **E. YAML file extensions — NOT drift; do not flag.** `.yml` vs `.yaml` is left
@@ -245,6 +246,42 @@ default; `task release:*` stays a manual override); stale `CHECKLIST.md`
 workspace/bunch/slug files and the repo slug. Map each to its catalog area and
 assign severity by the §2 rubric.
 
+**J. Missing universal Taskfile targets (e.g. `status:setup`).** Every
+standardized repo defines the universal targets from
+[`standards-catalog.md`](./standards-catalog.md) §1.2 regardless of
+`project_type` — notably `verify`, `check`, `security`, `install:hooks`, and
+**`status:setup`** (the setup-completeness audit, `./scripts/status.sh setup`).
+Repos whose `Taskfile` / `scripts/status.sh` predate or forked away from the
+template often lack `status:setup` (the older `status.sh` had no `setup`
+section). Detect by listing targets (`task --list-all`) and checking the
+universal set; `assets/verify-applied.sh` enforces this. Fix: port the
+setup-check helpers + the "Setup Completeness" section from the template's
+`scripts/status.sh` (preserving any repo-specific sections) and add the
+`status:setup` task. Severity: **should**.
+
+**K. Template-owned file content drift (the general check).** The generalization of
+H/J and the bootstrap/idempotency class: any **template-owned** file (the set in
+[`assets/template-owned-files.txt`](../assets/template-owned-files.txt) —
+`Taskfile.yml`, `scripts/*.sh`, lint configs, the standard `.github/workflows/*`,
+devcontainer files) that no longer matches a fresh render is potentially missing
+template improvements. Detect it mechanically — this is how the audit "checks
+everything" instead of eyeballing each file:
+
+```bash
+~/git/harmon-devkit/ai/skills/repo/standardize-repo/assets/diff-template.sh "$TARGET"
+# --show to see the per-file diff
+```
+
+It renders harmon-init from the repo's own `.copier-answers.yml` and reports each
+template-owned file that differs (mapping `.yml`↔`.yaml`). Each `DRIFT` is either a
+**missed template improvement** or a **legitimate local customization** — read the
+diff to tell them apart. Fix the former with `copier update`
+([`mode-update.md`](./mode-update.md)) or by copying the template's version; leave
+the latter, reconciling **in place** (keep the customization in its normal file — do
+not extract it elsewhere). Severity: **should** (blocker if the drift breaks a
+required gate, e.g. a non-portable `lint-hygiene.sh`). Run this as a standard step of
+every audit.
+
 ---
 
 ## 4. Fix flow
@@ -285,8 +322,8 @@ Apply fixes on a branch, prefer re-templating for files copier owns, then verify
    - **Non-templated bits — hand-edit.** Copier won't *delete* or *move* files,
      so renames and relocations are manual: `git mv docs/specs specs`,
      `git mv docs/runbook docs/runbooks`, delete `-max`
-     duplicate workflows, re-import the branch ruleset JSON, repoint the
-     AGENTS.md symlinks. Use the gap report's Reconciliation plan as the work
+     duplicate workflows, re-import the branch ruleset JSON (via the GitHub UI),
+     repoint the AGENTS.md symlinks. Use the gap report's Reconciliation plan as the work
      list.
 
 3. **Verify locally.** Run the same gates the standard requires, from the target:

--- a/.claude/skills/standardize-repo/references/mode-new-repo.md
+++ b/.claude/skills/standardize-repo/references/mode-new-repo.md
@@ -155,7 +155,7 @@ companion reference:
 
 - In the new repo: work through `docs/CHECKLIST.md` (rendered from
   `template/docs/CHECKLIST.md.jinja`). It covers, in order: local setup → GitHub
-  repo settings (branch ruleset import via `gh api ... rulesets`, Dependabot
+  repo settings (branch ruleset import via the GitHub UI, Dependabot
   alerts + private vulnerability reporting, Renovate app, CodeRabbit app, Actions
   secrets/variables, the CI GitHub App, GHCR publishing) → framework scaffolding
   for the chosen `project_type` → secrets/env → docs/meta (fill `TODO:` markers,

--- a/.claude/skills/standardize-repo/references/mode-update.md
+++ b/.claude/skills/standardize-repo/references/mode-update.md
@@ -1,0 +1,96 @@
+# Mode: Update
+
+Bring a repo that was **already generated from harmon-init (v3+)** up to the latest
+template — the repeatable "keep it in sync" path. Use this when the goal is "pull
+the newest harmon-init changes into this repo," not initial setup.
+
+Routing:
+
+- **v3+ repo** (`.copier-answers.yml` present, `_commit: v3.x` or later) → this mode
+  (`copier update`).
+- **v2 repo or never templated** → [`mode-adopt-existing.md`](./mode-adopt-existing.md)
+  (v2→v3 was a breaking redesign; re-template via its Path B).
+- **Just want a drift report, no changes** → run §1 and stop, or see
+  [`mode-audit.md`](./mode-audit.md).
+
+The target repo is a **plain repo** — there is no special structure, no
+"template-owned vs custom" split a developer must learn. Customizations live
+normally in `Taskfile.yml`, `scripts/`, workflows, etc. The intelligence is here in
+the skill: `copier update` does a three-way merge that pulls template improvements
+*into* those files while preserving the repo's own edits; you reconcile anything that
+conflicts. For copier mechanics see [`copier-gotchas.md`](./copier-gotchas.md).
+
+---
+
+## 0. Branch from a clean tree
+
+```bash
+cd <repo>
+git switch main && git pull
+git status --porcelain   # MUST be empty
+git switch -c chore/update-harmon-init
+```
+
+## 1. See what's missing (read-only)
+
+```bash
+~/git/harmon-devkit/ai/skills/repo/standardize-repo/assets/diff-template.sh .
+# add --show to print the full per-file diff
+```
+
+This renders harmon-init from the repo's own `.copier-answers.yml` and lists every
+template-owned file that differs from a fresh render (mapping `.yml`↔`.yaml`). Each
+`DRIFT` line is either a **template improvement the repo is missing** (the
+status.sh / lint-hygiene / bootstrap class) or a **legitimate local customization** —
+the diff tells you which. This is your reconciliation worklist for §3.
+
+## 2. Run the update
+
+```bash
+copier update --trust --vcs-ref=HEAD
+```
+
+`copier update` reuses the `_src_path` + `_commit` from `.copier-answers.yml` and
+three-way-merges the template's changes into the repo. `--vcs-ref=HEAD` renders the
+template's working tree (a local checkout); omit it to update to the latest **tag**
+(the normal case once harmon-init has cut a release). First-run `_tasks` are guarded
+on `_copier_operation == 'copy'`, so update will **not** make a scaffold commit,
+re-init git, or re-cut a release; one-time seeds (README, CHANGELOG, AGENTS.md,
+product docs) are protected by `_skip_if_exists`.
+
+## 3. Reconcile conflicts (in place — no special files)
+
+The three-way merge applies template improvements and keeps the repo's edits when
+they don't overlap. Where they do, copier leaves inline markers / `.rej` files:
+
+```bash
+grep -rn '^<<<<<<<\|^=======\|^>>>>>>>' . ; find . -name '*.rej'
+```
+
+Resolve each like a git merge — keep **both** the template's intent and the repo's
+real customization in the same file. Example: the template improved `scripts/status.sh`
+and the repo had added an `infra` section — the merged file keeps the improved core
+*and* the `infra` section. Don't discard either side; don't extract anything into a
+separate file. Then read the full diff (`git add -A -N && git diff`) and confirm no
+app content was clobbered and no copier marker leaked (`[[`, `[%`,
+`TODO: project_description`).
+
+## 4. Verify comprehensively
+
+```bash
+~/git/harmon-devkit/ai/skills/repo/standardize-repo/assets/diff-template.sh .   # should now show only legit customizations
+task verify
+~/git/harmon-devkit/ai/skills/repo/standardize-repo/assets/verify-applied.sh .
+```
+
+Walk the [`mode-audit.md`](./mode-audit.md) drift classes too — `copier update`
+refreshes templated files, but renames/moves and GitHub-side settings it cannot do.
+Re-run `diff-template.sh`: every remaining `DRIFT` should be an intentional local
+customization you can explain, not a missed update.
+
+## 5. Hand off
+
+Commit on the branch with a Conventional-Commits message
+(`chore: update to harmon-init <version>`) and open a PR. Never bypass hooks; never
+merge to `main` directly. Re-import the branch ruleset via the GitHub UI only if the
+ruleset JSON changed (see [`post-generation-checklist.md`](./post-generation-checklist.md)).

--- a/.claude/skills/standardize-repo/references/post-generation-checklist.md
+++ b/.claude/skills/standardize-repo/references/post-generation-checklist.md
@@ -43,14 +43,16 @@ push so the remote exists.
 
 ## 2. GitHub repo settings
 
-- [ ] **[scriptable via gh]** Import the branch ruleset that protects `main`
+- [ ] **[manual — GitHub UI]** Import the branch ruleset that protects `main`
       (required reviews + the `verify`/`security` status checks). The JSON is
-      generated into the repo's `.github/`:
+      generated into the repo's `.github/`. Import it via the UI:
+      **Settings → Rules → Rulesets → New ruleset ▸ Import a ruleset** → select
+      `.github/Branch Protection Ruleset - Protect Main.json`. To change an
+      existing ruleset, edit it in the UI — don't re-import.
 
-  ```bash
-  gh api "repos/<org>/<repo>/rulesets" --method POST \
-    --input ".github/Branch Protection Ruleset - Protect Main.json"
-  ```
+  > Avoid `gh api … rulesets`: `POST` is **not idempotent** (re-running creates a
+  > duplicate ruleset) and both `POST`/`PUT` currently reject the `merge_queue`
+  > rule (`422 Invalid rule 'merge_queue'`). The UI import handles every rule type.
 
 - [ ] **[scriptable via gh]** Enable **Dependabot alerts**. Do NOT add a
       `dependabot.yml` — Renovate owns version updates; Dependabot is alerts-only.

--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -76,6 +76,17 @@ source of truth for commands** — lefthook hooks and CI workflows delegate to
 `task` targets so local/CI/hook runs are byte-identical. Never reimplement command
 logic in a workflow or a hook.
 
+**Staying in sync (no special repo structure). [copier]** `Taskfile.yml` and the
+other template-owned files (`scripts/*`, lint configs, the standard workflows,
+devcontainer — full list in
+[`assets/template-owned-files.txt`](../assets/template-owned-files.txt)) are
+refreshed by `copier update`'s three-way merge, which preserves a repo's own edits.
+Customize them **normally, in place** — there is no extension-file convention a
+repo's developers need to learn. `assets/diff-template.sh` reports which
+template-owned files differ from a fresh render, so an audit/update pulls in missed
+improvements (the recurring status.sh / lint-hygiene / bootstrap class) without
+losing local customizations — see mode-audit drift class **K**.
+
 Naming & structure conventions:
 
 - **`group:action` (kebab + colon namespacing).** Group/domain first, action
@@ -322,8 +333,11 @@ Required secrets/variables (**[manual]**, in CHECKLIST): `CLAUDE_CODE_OAUTH_TOKE
   Main.json`: blocks deletion/non-ff/creation, requires linear history, PR with 1
   code-owner approval + thread resolution + last-push approval, required status
   checks `verify` + `security`, merge methods squash/rebase; org repos add a
-  `merge_queue` rule. **[copier]** ships the file; **[manual]** import via
-  `gh api repos/<org>/<slug>/rulesets --method POST --input "…"`.
+  `merge_queue` rule. **[copier]** ships the file; **[manual]** import via the
+  GitHub UI (Settings → Rules → Rulesets → **Import a ruleset**) — not
+  `gh api … rulesets`, whose `POST` is non-idempotent (duplicates the ruleset)
+  and rejects the `merge_queue` rule (422); edit the existing ruleset in the UI
+  to change it later.
 - **`SECURITY.md`** lives in **`.github/`** (Private Vulnerability Reporting).
   **[copier]**
 - **Renovate, NOT Dependabot** for version updates. CHECKLIST explicitly says


### PR DESCRIPTION
## What

Re-sync the vendored `.claude/skills/standardize-repo` copy with the canonical harmon-devkit source (`ai/skills/repo/standardize-repo` @ `225a564`). The vendored copy had fallen behind — it was missing the **update-mode + template-drift-detection** feature.

## Why

harmon-init vendors a copy of the canonical skill (which lives in harmon-devkit and is symlinked as the global `~/.claude/skills/standardize-repo`). The canonical version moved ahead on 2026-06-26; the vendored copy stopped at the 2026-06-24 state. The vendored copy is now byte-identical to canonical.

## Changes

**New files:**
- `references/mode-update.md` — copier-update reconciliation mode
- `assets/diff-template.sh` — template-drift detection tool
- `assets/template-owned-files.txt`

**Updated:** `SKILL.md`, `assets/verify-applied.sh`, `references/mode-audit.md`, `references/mode-new-repo.md`, `references/post-generation-checklist.md`, `references/standards-catalog.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)