### PR TITLE
chore(skills): re-vendor standardize-repo skill from harmon-devkit

### DIFF
--- a/.claude/skills/standardize-repo/assets/diff-template.sh
+++ b/.claude/skills/standardize-repo/assets/diff-template.sh
@@ -69,10 +69,18 @@ data_args+=(
     --data obsidian_project_add=false
 )
 
+# Render at the version the repo is PINNED to (_commit), not the template's HEAD.
+# Drift should mean "what this repo customized relative to its own template
+# baseline" — rendering at HEAD instead conflates that with template changes the
+# repo simply hasn't pulled yet (which is what made early audits look huge).
+# Falls back to HEAD if _commit is somehow absent.
+src_ref="$(yq -r '._commit // "HEAD"' "$answers" 2>/dev/null || echo HEAD)"
+[ -n "$src_ref" ] || src_ref=HEAD
+
 render="$(mktemp -d -t harmon-init-render-XXXXXX)"
 trap 'rm -rf "$render"' EXIT
-copier copy "$template" "$render" --vcs-ref=HEAD --trust --defaults "${data_args[@]}" >/dev/null 2>&1 || {
-    echo "FAIL: copier render failed" >&2
+copier copy "$template" "$render" --vcs-ref="$src_ref" --trust --defaults "${data_args[@]}" >/dev/null 2>&1 || {
+    echo "FAIL: copier render failed (template ref: $src_ref)" >&2
     exit 2
 }
 

--- a/.claude/skills/standardize-repo/assets/verify-applied.sh
+++ b/.claude/skills/standardize-repo/assets/verify-applied.sh
@@ -129,14 +129,20 @@ fi
 varpfx='project_|author_|github_|organization|repo_url|ci_runner|include_|use_|devcontainer|git_init|bunch_add|obsidian_|run_task_install|projects_directory|bunches_directory|license|current_|country|state'
 blockkw='if|for|set|else|elif|endif|endfor|endset|raw|endraw|macro|endmacro|block|endblock|include|extends|with|endwith|filter|endfilter'
 marker_re="\[\[-? ($varpfx)|\{\{-? ($varpfx)|\[%-? ($blockkw) "
+# Exclude *.j2 / *.jinja from the scan: those are legitimately full of standard
+# Jinja ({{ x }} / {% x %}) — Ansible templates, nginx configs, etc. — and the
+# {{ <stem> }} branch of marker_re can't tell `{{ github_runner_image }}` (a real
+# Ansible var) from a copier leak. Copier's own delimiters are [[ ]] / [% %], so
+# dropping these files loses no real-leak coverage.
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     leaks=$(git ls-files --cached --others --exclude-standard -z 2>/dev/null |
-        xargs -0 grep -IlE "$marker_re" 2>/dev/null || true)
+        xargs -0 grep -IlE "$marker_re" 2>/dev/null |
+        grep -vE '\.(j2|jinja)$' || true)
 else
     leaks=$(grep -rIlE "$marker_re" \
         --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=.venv \
         --exclude-dir=.terraform --exclude-dir=.task --exclude-dir=.worktrees \
-        --exclude-dir=dist . 2>/dev/null || true)
+        --exclude-dir=dist --exclude='*.j2' --exclude='*.jinja' . 2>/dev/null || true)
 fi
 if [ -n "$leaks" ]; then
     err "unrendered template markers found in:"

--- a/.claude/skills/standardize-repo/references/copier-gotchas.md
+++ b/.claude/skills/standardize-repo/references/copier-gotchas.md
@@ -176,9 +176,41 @@ remote/release task ahead of the scaffold commit.
 
 ---
 
+## 8. `_src_path` must be a resolvable git source for `copier update`
+
+**Symptom:** `copier update` aborts with **`Updating is only supported in
+git-tracked templates`** — even though harmon-init *is* a git repo. The repo can be
+generated and pass every gate, yet never accept a template update.
+
+**Why:** `copier update` has no source argument — it reuses the `_src_path` recorded
+in `.copier-answers.yml`, which is whatever path was passed to the original `copier
+copy`. If the repo was scaffolded with a **relative or machine-local path** (e.g.
+`copier copy harmon-init <dest>` run from `~/git`, recording `_src_path:
+harmon-init`), that string doesn't resolve to a git repo from the target's directory
+later, so copier can't find a git-tracked template to diff against.
+
+**Rule:** Record a **globally resolvable** `_src_path` — the GitHub URL
+`https://github.com/evanharmon1/harmon-init` (works on any machine and in CI). When
+adopting/auditing an existing repo whose `_src_path` is relative or local-absolute,
+normalize it **before** running `copier update`:
+
+```bash
+# one-time fix, committed; copier overwrites _src_path on its next run anyway
+yq -i '._src_path = "https://github.com/evanharmon1/harmon-init"' .copier-answers.yml
+```
+
+This is independent of `--vcs-ref` (gotcha 1): `--vcs-ref` picks *which ref* of the
+source to render; `_src_path` is *where the source is*. A local checkout is fine for
+testing WIP, but the **committed** `_src_path` should be the URL so the repo stays
+updatable everywhere.
+
+---
+
 ## Quick checklist when touching the template
 
 - Rendering local WIP to test? → `--vcs-ref=HEAD`.
+- Generated repo must stay updatable? → committed `_src_path` is the GitHub URL, not
+  a relative/local path (gotcha 8).
 - New templating? → `[[ ]]` / `[% %]` / `[# #]`; POSIX `[ ]` in shell; `[% endif +%]`
   inline.
 - New side-effect question? → default `no`.

--- a/.claude/skills/standardize-repo/references/mode-adopt-existing.md
+++ b/.claude/skills/standardize-repo/references/mode-adopt-existing.md
@@ -94,18 +94,18 @@ template output, the new template output, and your current files:
 
 ```bash
 ls .copier-answers.yml          # present → use update
-copier update --trust --vcs-ref=HEAD
+copier update --trust
 ```
 
 `copier update` takes no source argument — it reuses the `_src_path` recorded in
-`.copier-answers.yml`. When that `_src_path` is a **local** harmon-init checkout
-(which it is for repos adopted via Path B's `copier copy ~/git/harmon-init`),
-pass `--vcs-ref=HEAD` so update renders your working tree. Omitting it renders the
-latest **local git tag** of that checkout — silently dropping any
-committed-but-untagged + uncommitted template work, the exact trap described in
-`copier-gotchas.md`. Use `--vcs-ref=HEAD` unless you deliberately want the last
-tagged release. Override stale answers with `--data key=value` as needed (e.g. a
-changed `github_org`).
+`.copier-answers.yml`, which must be a **resolvable git URL** (see
+[copier-gotchas.md](./copier-gotchas.md) gotcha 8; normalize it first if it's a
+relative/local path). **Always do a full update to the latest released version** —
+plain `copier update` goes to harmon-init's newest tag and three-way-merges the whole
+delta into your files; don't scope it to a specific intermediate version. Override
+stale answers with `--data key=value` as needed (e.g. a changed `github_org`).
+(`--vcs-ref=HEAD` is only for a *template developer* testing unreleased local
+changes — never for a normal update.)
 
 > v2-generated repos are the exception: per the harmon-init README, v3 was a
 > breaking redesign (new question set, jinja delimiters, lefthook+gitleaks, manual

--- a/.claude/skills/standardize-repo/references/mode-audit.md
+++ b/.claude/skills/standardize-repo/references/mode-audit.md
@@ -31,7 +31,11 @@ TEMPLATE=~/git/harmon-init           # source of truth
    template: look for `.copier-answers.yml` at the target root.
    - Present → it can be reconciled with `copier update --trust` (it records
      `_commit` / `_src_path`). Note the recorded commit; drift is "template moved
-     ahead since then."
+     ahead since then." **Also check `_src_path` is a resolvable git URL** — if it's
+     a relative/machine-local path (e.g. `harmon-init`), `copier update` aborts with
+     `Updating is only supported in git-tracked templates`; normalize it to
+     `https://github.com/evanharmon1/harmon-init` first (a real finding — see
+     [copier-gotchas.md](./copier-gotchas.md) gotcha 8 / [mode-update.md](./mode-update.md) §2).
    - Absent → it was never templated (or was adopted by a raw `copier copy`).
      Reconciling the templated bits means a fresh adopt:
      `copier copy --trust ~/git/harmon-init . --vcs-ref=HEAD` (see §4). Treat

--- a/.claude/skills/standardize-repo/references/mode-update.md
+++ b/.claude/skills/standardize-repo/references/mode-update.md
@@ -46,17 +46,35 @@ the diff tells you which. This is your reconciliation worklist for §3.
 
 ## 2. Run the update
 
+**Preflight — ensure `_src_path` is a resolvable git source.** `copier update`
+reuses the `_src_path` recorded in `.copier-answers.yml`; if it's a relative or
+machine-local path (e.g. `harmon-init`), the update aborts with `Updating is only
+supported in git-tracked templates` (see [copier-gotchas.md](./copier-gotchas.md)
+gotcha 8). Normalize it to the GitHub URL first — once, committed:
+
 ```bash
-copier update --trust --vcs-ref=HEAD
+grep '^_src_path:' .copier-answers.yml   # is it a URL? if relative/local, fix it:
+yq -i '._src_path = "https://github.com/evanharmon1/harmon-init"' .copier-answers.yml
+git commit -am "chore: point copier _src_path at the harmon-init GitHub URL"
 ```
 
-`copier update` reuses the `_src_path` + `_commit` from `.copier-answers.yml` and
-three-way-merges the template's changes into the repo. `--vcs-ref=HEAD` renders the
-template's working tree (a local checkout); omit it to update to the latest **tag**
-(the normal case once harmon-init has cut a release). First-run `_tasks` are guarded
-on `_copier_operation == 'copy'`, so update will **not** make a scaffold commit,
-re-init git, or re-cut a release; one-time seeds (README, CHANGELOG, AGENTS.md,
-product docs) are protected by `_skip_if_exists`.
+```bash
+copier update --trust
+```
+
+**Always do a full update to the latest released version.** Plain `copier update`
+goes to harmon-init's newest **tag** and three-way-merges the *entire* delta from the
+repo's recorded `_commit` up to that tag, preserving local edits. Don't get fancy
+scoping the update to a specific intermediate version (no `--vcs-ref vX.Y.Z`, no
+hand-picking which template changes to take) — pull all the way to latest and
+reconcile in §3. First-run `_tasks` are guarded on `_copier_operation == 'copy'`, so
+update will **not** make a scaffold commit, re-init git, or re-cut a release. Only
+`CHANGELOG.md` is frozen (`_skip_if_exists`); every other template improvement
+(README, AGENTS.md, docs, scripts, …) flows in through the merge.
+
+> `--vcs-ref=HEAD` is **only** for a *template developer* testing **unreleased**
+> harmon-init changes from a local checkout (see [copier-gotchas.md](./copier-gotchas.md)
+> gotcha 1). It is never needed for a normal repo update — don't add it here.
 
 ## 3. Reconcile conflicts (in place — no special files)
 


### PR DESCRIPTION
Sync the vendored `.claude/skills/standardize-repo` copy with the canonical harmon-devkit source (`ai/skills/repo/standardize-repo @ main`), which moved ahead since the last re-vendor (#118).

## Why
Most notably brings in **harmon-devkit #30 "stop two audit false positives"**: `verify-applied.sh` now skips `*.j2`/`*.jinja` files in the unrendered-template-marker scan. Without it, legitimate downstream Jinja — e.g. an Ansible `{{ github_runner_image }}` — false-tripped the copier-marker check and made `verify-applied.sh` report a spurious FAIL (surfaced while standardizing harmon-infra).

## Changes
Refreshes 6 vendored files to match canonical:
- `assets/verify-applied.sh` — `.j2`/`.jinja` exclusion (#30)
- `assets/diff-template.sh`
- `references/copier-gotchas.md`, `mode-adopt-existing.md`, `mode-audit.md`, `mode-update.md`

Vendored copy is once again **byte-identical** to canonical (`diff -rq` clean).

## Verification
- Re-ran `verify-applied.sh` against harmon-infra with the updated copy → exit 0, clean
- lefthook pre-commit (shell/hygiene/markdown) + commitlint passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)