### PR TITLE
docs(template): clarify code-workspace CHECKLIST item

### DIFF
--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -11,7 +11,7 @@ config, toolchain, devcontainer, and dev environment — against the items below
 
 - [ ] `task install` — Brewfile deps, and lefthook git hooks
 - [ ] `task verify` passes locally
-- [ ] Open the `harmon-init.code-workspace` in VS Code (the curated multi-root workspace)
+- [ ] Verify `harmon-init.code-workspace` opens the repo's folder in VS Code and has a unique VS Code Workspace color. Then add any other related repos (e.g. other org repos) to the `folders` list in the workspace file so you have quick access to those repos
 - [ ] Extend `.gitignore` for your stack — the template ships a base; add stack-specific entries via [gitignore.io](https://www.toptal.com/developers/gitignore)
 - [ ] macOS: add a Raycast quicklink/alias that opens the `harmon-init.code-workspace`
 

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -11,7 +11,7 @@ config, toolchain, devcontainer, and dev environment — against the items below
 
 - [ ] `task install` — Brewfile deps[% if use_python %], `uv sync`[% endif %][% if use_node %], `pnpm install`[% endif %], and lefthook git hooks
 - [ ] `task verify` passes locally
-- [ ] Open the `[[ project_slug ]].code-workspace` in VS Code (the curated multi-root workspace)
+- [ ] Verify `[[ project_slug ]].code-workspace` opens the repo's folder in VS Code and has a unique VS Code Workspace color. Then add any other related repos (e.g. other org repos) to the `folders` list in the workspace file so you have quick access to those repos
 - [ ] Extend `.gitignore` for your stack — the template ships a base; add stack-specific entries via [gitignore.io](https://www.toptal.com/developers/gitignore)
 - [ ] macOS: add a Raycast quicklink/alias that opens the `[[ project_slug ]].code-workspace`
 [% if bunch_add %]


### PR DESCRIPTION
Rephrase the local-setup CHECKLIST item about the multi-root workspace so it's actionable rather than a vague "open it."

**Before:**
> Open the `<slug>.code-workspace` in VS Code (the curated multi-root workspace)

**After:**
> Verify `<slug>.code-workspace` opens the repo's folder in VS Code and has a unique VS Code Workspace color. Then add any other related repos (e.g. other org repos) to the `folders` list in the workspace file so you have quick access to those repos

## Scope
- `template/docs/CHECKLIST.md.jinja` — template source (uses `[[ project_slug ]]`)
- `docs/CHECKLIST.md` — root dogfooded copy (literal `harmon-init`)

The harmon-devkit `standardize-repo` skill needs **no change** — its `standards-catalog.md` only lists `<slug>.code-workspace` as a generated file and doesn't carry this checklist wording.

## Verification
- `task test:template` — green; rendered output substitutes `<slug>` and keeps the new wording
- `task check` — green (markdownlint clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)