### PR TITLE
fix(template): drop trailing blank line in .copier-answers.yml

### DIFF
--- a/template/[[ _copier_conf.answers_file ]].jinja
+++ b/template/[[ _copier_conf.answers_file ]].jinja
@@ -1,2 +1,2 @@
 # Changes here will be overwritten by Copier
-[[ _copier_answers|to_nice_yaml ]]
+[[ _copier_answers|to_nice_yaml -]]


### PR DESCRIPTION
## Problem

`to_nice_yaml` already emits a trailing newline, but the answers-file template added a second one after the `]]`, and copier's `keep_trailing_newline` preserves it. Every generated repo therefore carries a blank line at EOF that trips yamllint on the first `copier update`:

```
.copier-answers.yml
  24:1  warning  too many blank lines (1 > 0)  (empty-lines)
```

Surfaced while updating sommerlawn-infra to harmon-init v3.5.0-4 — the update applied cleanly but left this lint warning, requiring a manual fix in the consuming repo.

## Fix

Whitespace-trim the expression tag (`-]]`) so the rendered file ends with a single newline.

## Verification

- Rendered a fresh repo with `--vcs-ref=HEAD`: `.copier-answers.yml` now ends in a single newline; `yamllint` clean.
- `task verify` passes (`test-template` + `test-template-update`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)