### PR TITLE
chore(skills): re-vendor standardize-repo skill (missing-file scan)

### DIFF
--- a/.claude/skills/standardize-repo/assets/diff-template.sh
+++ b/.claude/skills/standardize-repo/assets/diff-template.sh
@@ -2,13 +2,22 @@
 # diff-template.sh — show how a repo's template-owned files differ from a fresh
 # harmon-init render, so the agent can find missed template improvements.
 #
-# Renders harmon-init using the TARGET repo's own .copier-answers.yml, then diffs
-# each path in template-owned-files.txt against the repo (mapping .yml<->.yaml).
-# This is a REVIEW AID for apply/update/audit, not a pass/fail gate: a listed file
-# may differ because the repo legitimately customized it (terraform tasks, a custom
-# status section) OR because it's missing template improvements (the recurring
-# status.sh / lint-hygiene / bootstrap class). For each DRIFT, inspect the diff and
-# reconcile — pull template improvements in via `copier update`, keep local edits.
+# Renders harmon-init using the TARGET repo's own .copier-answers.yml, then runs
+# two checks against that render:
+#   • DRIFT   — content differences in the curated template-owned-files.txt set
+#               (mapping .yml<->.yaml). A listed file may differ because the repo
+#               legitimately customized it (terraform tasks, a custom status
+#               section) OR because it's missing template improvements (the
+#               recurring status.sh / lint-hygiene / bootstrap class).
+#   • MISSING — template files the repo lacks ENTIRELY. This scan is
+#               manifest-INDEPENDENT (it walks the whole render), because the
+#               manifest is hand-maintained and lags the template — a file added
+#               after the last manifest edit, or dropped by a hand-reconciled
+#               `copier update`, would otherwise slip through silently. (.gitkeep
+#               dir-stubs are listed as benign ABSENT, not flagged as drift.)
+# This is a REVIEW AID for apply/update/audit, not a pass/fail gate. For each
+# DRIFT/MISSING, inspect and reconcile — pull template improvements in via
+# `copier update`, keep legit local customizations.
 #
 # Usage: diff-template.sh [TARGET_DIR]            (default: .)
 #        diff-template.sh -v|--show TARGET_DIR    (print the full per-file diff)
@@ -123,12 +132,35 @@ while IFS= read -r f; do
     fi
 done <"$manifest"
 
+# --- Missing-file scan (manifest-INDEPENDENT) --------------------------------
+# Walk the ENTIRE render and flag any template file the repo lacks. The manifest
+# loop above only catches CONTENT drift in curated files; a file the repo is
+# missing outright — added after the last manifest edit, or dropped by a
+# hand-reconciled `copier update` — needs this manifest-free scan or it slips
+# through silently. .gitkeep dir-stubs are benign (a populated dir legitimately
+# omits them), so they're shown as ABSENT but not counted as drift.
+while IFS= read -r abs; do
+    g="${abs#"$render"/}"
+    case "$g" in
+    .git/* | .copier-answers.yml | CHANGELOG.md) continue ;;
+    esac
+    grep -qxF "$g" "$manifest" 2>/dev/null && continue # manifest loop owns it
+    [ -n "$(repo_variant "$g")" ] && continue          # repo has it (or .yml/.yaml twin)
+    case "$g" in
+    *.gitkeep) echo "ABSENT   $g  (template dir-stub — benign if the dir has real content)" ;;
+    *)
+        echo "MISSING  $g  (template ships it; repo lacks it — review)"
+        drift=1
+        ;;
+    esac
+done < <(find "$render" -type f | sort)
+
 echo ""
 if [ "$drift" -ne 0 ]; then
-    echo "diff-template: $checked template-owned files checked; some differ from the"
-    echo "  template (above). For each, review the diff (\`diff-template.sh --show\`):"
-    echo "  pull missed template improvements in with \`copier update\`, and keep the"
-    echo "  repo's legitimate local customizations."
+    echo "diff-template: $checked curated files checked for drift; whole render"
+    echo "  scanned for missing files. Findings above (DRIFT/MISSING). For each,"
+    echo "  review the diff (\`diff-template.sh --show\`): pull missed template"
+    echo "  improvements in with \`copier update\`, keep legit local customizations."
     exit 1
 fi
-echo "diff-template: OK — all $checked template-owned files match the template."
+echo "diff-template: OK — $checked curated files match and no template files missing."

--- a/.claude/skills/standardize-repo/assets/template-owned-files.txt
+++ b/.claude/skills/standardize-repo/assets/template-owned-files.txt
@@ -53,3 +53,7 @@ commitlint.config.mjs
 .devcontainer/scripts/init-env.sh
 .devcontainer/scripts/post-create-common.sh
 .devcontainer/scripts/post-start-common.sh
+# config/shell-aliases.sh is meant to be adopted ~verbatim (image-baked + sourced),
+# so its content drift is worth reviewing; config/zshrc is intentionally omitted
+# (heavily per-repo customized — drift there is expected, not signal).
+.devcontainer/config/shell-aliases.sh

--- a/.claude/skills/standardize-repo/references/mode-audit.md
+++ b/.claude/skills/standardize-repo/references/mode-audit.md
@@ -276,8 +276,12 @@ everything" instead of eyeballing each file:
 # --show to see the per-file diff
 ```
 
-It renders harmon-init from the repo's own `.copier-answers.yml` and reports each
-template-owned file that differs (mapping `.yml`↔`.yaml`). Each `DRIFT` is either a
+It renders harmon-init from the repo's own `.copier-answers.yml` and reports both
+content **`DRIFT`** in the curated set and **`MISSING`** template files the repo
+lacks entirely (mapping `.yml`↔`.yaml`). The `MISSING` scan walks the whole render
+and is **manifest-independent**, so a file the template added after the curated list
+was last edited — or one a hand-reconciled update dropped — is still caught
+(`.gitkeep` dir-stubs show as benign `ABSENT`). Each `DRIFT` is either a
 **missed template improvement** or a **legitimate local customization** — read the
 diff to tell them apart. Fix the former with `copier update`
 ([`mode-update.md`](./mode-update.md)) or by copying the template's version; leave

--- a/.claude/skills/standardize-repo/references/mode-update.md
+++ b/.claude/skills/standardize-repo/references/mode-update.md
@@ -38,11 +38,19 @@ git switch -c chore/update-harmon-init
 # add --show to print the full per-file diff
 ```
 
-This renders harmon-init from the repo's own `.copier-answers.yml` and lists every
-template-owned file that differs from a fresh render (mapping `.yml`↔`.yaml`). Each
-`DRIFT` line is either a **template improvement the repo is missing** (the
-status.sh / lint-hygiene / bootstrap class) or a **legitimate local customization** —
-the diff tells you which. This is your reconciliation worklist for §3.
+This renders harmon-init from the repo's own `.copier-answers.yml` and runs two
+checks (mapping `.yml`↔`.yaml`):
+
+- **`DRIFT`** — content differences in the curated file set. Each is either a
+  **template improvement the repo is missing** (the status.sh / lint-hygiene /
+  bootstrap class) or a **legitimate local customization** — the diff tells you
+  which.
+- **`MISSING`** — a template file the repo lacks entirely. This scan walks the
+  whole render (it does **not** depend on the curated list), so a file the
+  template added later, or one a previous hand-reconciled update dropped, can't
+  slip through silently. (`.gitkeep` dir-stubs show as benign `ABSENT`.)
+
+Together these are your reconciliation worklist for §3.
 
 ## 2. Run the update
 

--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -82,10 +82,11 @@ devcontainer — full list in
 [`assets/template-owned-files.txt`](../assets/template-owned-files.txt)) are
 refreshed by `copier update`'s three-way merge, which preserves a repo's own edits.
 Customize them **normally, in place** — there is no extension-file convention a
-repo's developers need to learn. `assets/diff-template.sh` reports which
-template-owned files differ from a fresh render, so an audit/update pulls in missed
-improvements (the recurring status.sh / lint-hygiene / bootstrap class) without
-losing local customizations — see mode-audit drift class **K**.
+repo's developers need to learn. `assets/diff-template.sh` reports both content
+`DRIFT` in the curated set and `MISSING` template files the repo lacks entirely
+(a whole-render, manifest-independent scan), so an audit/update pulls in missed
+improvements (the recurring status.sh / lint-hygiene / bootstrap class) and missed
+whole files without losing local customizations — see mode-audit drift class **K**.
 
 Naming & structure conventions:
 


### PR DESCRIPTION
Syncs the vendored `.claude/skills/standardize-repo` copy with canonical harmon-devkit (**evanharmon1/harmon-devkit#34**), keeping it byte-identical to source.

## What it brings in

`diff-template.sh` previously only checked files in the curated `template-owned-files.txt` manifest, so a template file a repo lacked **entirely** — added after the manifest was last edited, or dropped by a hand-reconciled `copier update` — slipped through silently. (Surfaced auditing harmon-infra: its devcontainer was missing the image-baked `shell-aliases.sh`, uncaught because no manifest entry covered it.)

- **`diff-template.sh`** — adds a manifest-independent `MISSING` scan over the whole render (`.gitkeep` dir-stubs shown as benign `ABSENT`). Content-`DRIFT` detection on the curated set is unchanged.
- **`template-owned-files.txt`** — adds `.devcontainer/config/shell-aliases.sh` (`config/zshrc` intentionally omitted — per-repo customized).
- **docs** — `mode-update` / `mode-audit` / `standards-catalog` document the `MISSING` check.

## Notes

- Vendored copy verified **byte-identical** to canonical (devkit `feat/diff-template-missing-file-scan`).
- Merge after evanharmon1/harmon-devkit#34 lands so source and vendored copy stay in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)