### PR TITLE
fix(template): make generated CI correct on hosted and self-hosted runners

### DIFF
--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -54,6 +54,19 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Free up runner disk space
+        # Only on disposable GitHub-hosted runners: these rm -rf / prune commands
+        # would permanently delete real SDKs and Docker images on a persistent
+        # self-hosted runner. The devcontainer image is large (toolchains,
+        # browsers, language runtimes), and hosted ubuntu-latest's free space is
+        # too small — the build fails with "no space left on device" — so reclaim
+        # ~13GB of preinstalled SDKs we don't use. Self-hosted machines are
+        # assumed to have adequate disk and are skipped entirely.
+        if: runner.environment == 'github-hosted'
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/share/swift
+          sudo docker image prune --all --force || true
+          df -h /
       - name: Build ${{ matrix.name }} devcontainer
         uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3
         env:
@@ -82,7 +95,7 @@ jobs:
   devcontainer-verify:
     if: always()
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: [ "ubuntu-latest" ]
     steps:
       - name: Check job results
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,19 @@ the authoritative repo-conventions catalog.
 Root lint tasks deliberately exclude `template/` (jinja files are not valid
 YAML/Markdown). The **rendered** output is validated by `task test:template:*`.
 
+**Dogfood parity — edit both layers in lockstep.** Most root files have a
+`template/` counterpart they are the rendered form of (e.g.
+`.devcontainer/Dockerfile` ↔ `template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile`,
+`.github/workflows/devcontainer-build.yml` ↔ its `…devcontainer-build.yml….jinja`).
+A change to one MUST be applied to the other in the same PR, or the template and
+the dogfood drift — the repo stops practicing what it ships, and `task
+test:template` will not catch it (it validates the *rendered* template against
+itself, not against the root copy). The root form is the template rendered with
+harmon-init's own answers (e.g. `[[ ci_runner_labels ]]` → `[ "ubuntu-latest" ]`),
+and template-only logic (`[% if … %]`, `${VERSION}` arg substitution) collapses to
+its concrete value. When you touch a templated file, grep for the sibling and edit
+both.
+
 ## Common Commands
 
 ```bash

--- a/template/.github/workflows/[% if devcontainer %]devcontainer-build.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if devcontainer %]devcontainer-build.yml[% endif %].jinja
@@ -54,6 +54,19 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Free up runner disk space
+        # Only on disposable GitHub-hosted runners: these rm -rf / prune commands
+        # would permanently delete real SDKs and Docker images on a persistent
+        # self-hosted runner. The devcontainer image is large (toolchains,
+        # browsers, language runtimes), and hosted ubuntu-latest's free space is
+        # too small — the build fails with "no space left on device" — so reclaim
+        # ~13GB of preinstalled SDKs we don't use. Self-hosted machines are
+        # assumed to have adequate disk and are skipped entirely.
+        if: runner.environment == 'github-hosted'
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/share/swift
+          sudo docker image prune --all --force || true
+          df -h /
       - name: Build ${{ matrix.name }} devcontainer
         uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3
         env:
@@ -82,7 +95,7 @@ jobs:
   devcontainer-verify:
     if: always()
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: [ [[ ci_runner_labels ]] ]
     steps:
       - name: Check job results
         run: |

--- a/template/.github/workflows/[% if use_node or use_python %]codeql.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_node or use_python %]codeql.yml[% endif %].jinja
@@ -56,7 +56,7 @@ jobs:
   codeql-verify:
     if: always()
     needs: [analyze]
-    runs-on: ubuntu-latest
+    runs-on: [ [[ ci_runner_labels ]] ]
     steps:
       - name: Check analyze result
         run: |

--- a/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: [ [[ ci_runner_labels ]] ]
     timeout-minutes: 10
     permissions:
       contents: write

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -192,8 +192,11 @@ jobs:
         uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1.7.3
         id: setup-chrome
         with:
-          install-dependencies: true
-          no-sudo: true
+          # Hosted runners need apt (via sudo) to install Chrome's shared libs;
+          # persistent self-hosted machines already have them, so skip apt/sudo
+          # there to avoid requiring passwordless sudo.
+          install-dependencies: ${{ runner.environment == 'github-hosted' }}
+          no-sudo: ${{ runner.environment != 'github-hosted' }}
       - name: Build
         run: task build
       - name: Lighthouse CI
@@ -266,7 +269,7 @@ jobs:
   verify:
     if: always()
     needs: [lint, security[% if use_node %], build-test[% endif %][% if project_type == 'web-astro' %], lighthouse[% endif %]]
-    runs-on: ubuntu-latest
+    runs-on: [ [[ ci_runner_labels ]] ]
     steps:
       - name: Check job results
         run: |


### PR DESCRIPTION
## Summary

Generated repos' CI carried three runner-environment defects (all confirmed against v3.5.1 while adopting/updating a downstream web-astro repo). Each breaks CI for consumers on a stock GitHub-hosted runner, the self-hosted path, or both.

1. **devcontainer-build runs out of disk on hosted runners.** Only a *post*-build dangling cleanup existed; the large devcontainer image overflows ubuntu-latest's free space and the build dies with `no space left on device` mid-feature-compile. Added a **`github-hosted`-gated** pre-build reclaim (~13GB of unused SDKs). It is skipped on self-hosted runners — whose real SDKs and Docker images must never be `rm -rf`'d / `prune --all`'d.
2. **web-astro lighthouse job always fails.** `setup-chrome` shipped `no-sudo: true` *with* `install-dependencies: true`; apt can't lock without sudo on a hosted runner, so the required check never passed. Now both inputs are driven off `runner.environment` — apt+sudo on hosted, neither on self-hosted (which already has Chrome's libs).
3. **Aggregate/release jobs hardcoded `runs-on: ubuntu-latest`.** `verify`, `devcontainer-verify`, `codeql-verify`, and `release-please` ignored `ci_runner_labels`. A consumer choosing `ci_runner: self-hosted` would have these **required** checks queue forever → PRs unmergeable and releases never cut. Templated to `ci_runner_labels` like every other job.

The unifying theme: the template advertises a self-hosted `ci_runner` option but had **zero** `runner.environment` awareness.

## Verification

- `task test:template` (renders + actionlints) green.
- A `web-astro` + `ci_runner: self-hosted` render produces valid workflows: `runs-on: [ "self-hosted", "linux" ]`, the disk step gated off, lighthouse inputs as runner-environment expressions; `actionlint` clean on the rendered `build.yml` + `devcontainer-build.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)