### PR TITLE
fix(template): make editor/prettier config project-type-aware

### DIFF
--- a/template/.vscode/settings.json.jinja
+++ b/template/.vscode/settings.json.jinja
@@ -1,11 +1,27 @@
 {
   "editor.formatOnSave": true,
+[% if use_python %]
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter"
   },
+[% endif %]
+[% if include_terraform %]
   "[terraform]": {
     "editor.defaultFormatter": "hashicorp.terraform"
   },
+[% endif %]
+[% if project_type == 'web-astro' %]
+  "[astro]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+[% endif %]
+[% if use_node %]
+  "[javascript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[javascriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[typescriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[jsonc]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[css]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+[% endif %]
   "[shellscript]": {
     "editor.defaultFormatter": "foxundermoon.shell-format"
   },

--- a/template/[% if use_node %]prettier.config.cjs[% endif %].jinja
+++ b/template/[% if use_node %]prettier.config.cjs[% endif %].jinja
@@ -8,6 +8,7 @@ module.exports = {
   semi: false,
   printWidth: 100,
   // pluginSearchDirs: [__dirname],
+[% if project_type == 'web-astro' %]
   plugins: [
     require.resolve('prettier-plugin-astro'),
     require.resolve('prettier-plugin-tailwindcss')
@@ -20,4 +21,7 @@ module.exports = {
       }
     }
   ]
+[% else %]
+  plugins: [require.resolve('prettier-plugin-tailwindcss')]
+[% endif %]
 }


### PR DESCRIPTION
## Summary

Two config files shipped generic / web-astro-specific defaults that consumers of other `project_type`s must hand-edit — and because copier's three-way merge silently re-applies the template version with **no conflict marker**, those edits revert on the next `copier update`. (`.vscode/settings.json` is gitignored, so the revert never even surfaces in `git diff` — exactly the silent regression hit while updating a downstream repo.)

- **`.vscode/settings.json`** — gate the per-language formatter bindings on the matching toggle (`python`→`use_python`, `terraform`→`include_terraform`) and add the missing `astro`/`js`/`ts`/`json`/`css`→prettier bindings under `project_type=='web-astro'` / `use_node`. Mirrors the already-gated sibling `.vscode/extensions.json` and the Taskfile's `format:file` model. `shell`/`yaml`/`markdown` stay generic.
- **`prettier.config.cjs`** — gate `prettier-plugin-astro` + the `*.astro` parser override on `project_type=='web-astro'`, so web-app (React) repos don't ship an unused astro plugin they must strip. Renamed to add the `.jinja` suffix so copier renders its **content** (a non-`.jinja` file is copied verbatim, so in-content conditionals would not have applied — verified).

## Verification

- Rendered `settings.json` parses as JSON for `web-astro`/`web-app`/`iac`/`general`, each with the correct per-type formatter blocks (`[astro]`+`[typescript]` / `[typescript]` / `[python]`+`[terraform]` / none).
- Rendered `prettier.config.cjs` is valid JS (`node --check`) for web-astro (astro+tailwind+override) and web-app (tailwind only, clean close).
- `task check` + `task test:template` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)