### PR TITLE
perf(template): drop npm download cache from devcontainer image layers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -321,7 +321,8 @@ RUN tic -x /usr/local/share/devcontainer-config/ghostty.terminfo
 RUN npm install -g \
         "@commitlint/cli" \
         "@commitlint/config-conventional" \
-        "markdownlint-cli2"
+        "markdownlint-cli2" \
+    && npm cache clean --force
 
 # ---------- Playwright (browser automation CLI) ----------
 # Two packages: @playwright/test for the test runner + standard CLI (screenshot,
@@ -342,7 +343,8 @@ RUN npm install -g \
     && npx playwright install --with-deps chromium \
     && (playwright-cli install --with-deps chromium 2>/dev/null || true) \
     && chmod -R o+rx ${PLAYWRIGHT_BROWSERS_PATH} \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && npm cache clean --force
 
 # ---------- Python packages for agent-deck Telegram bridge ----------
 RUN uv pip install --system --break-system-packages --no-cache toml aiogram
@@ -397,6 +399,7 @@ RUN npm install -g \
         "@google/gemini-cli@${GEMINI_CLI_VERSION}" \
         "@openai/codex@${CODEX_VERSION}" \
         "dmux@${DMUX_VERSION}" \
-        "snyk@${SNYK_VERSION}"
+        "snyk@${SNYK_VERSION}" \
+    && npm cache clean --force
 
 USER vscode

--- a/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile
@@ -321,7 +321,8 @@ RUN tic -x /usr/local/share/devcontainer-config/ghostty.terminfo
 RUN npm install -g \
         "@commitlint/cli" \
         "@commitlint/config-conventional" \
-        "markdownlint-cli2"
+        "markdownlint-cli2" \
+    && npm cache clean --force
 
 # ---------- Playwright (browser automation CLI) ----------
 # Two packages: @playwright/test for the test runner + standard CLI (screenshot,
@@ -342,7 +343,8 @@ RUN npm install -g \
     && npx playwright install --with-deps chromium \
     && (playwright-cli install --with-deps chromium 2>/dev/null || true) \
     && chmod -R o+rx ${PLAYWRIGHT_BROWSERS_PATH} \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && npm cache clean --force
 
 # ---------- Python packages for agent-deck Telegram bridge ----------
 RUN uv pip install --system --break-system-packages --no-cache toml aiogram
@@ -397,6 +399,7 @@ RUN npm install -g \
         "@google/gemini-cli@${GEMINI_CLI_VERSION}" \
         "@openai/codex@${CODEX_VERSION}" \
         "dmux@${DMUX_VERSION}" \
-        "snyk@${SNYK_VERSION}"
+        "snyk@${SNYK_VERSION}" \
+    && npm cache clean --force
 
 USER vscode


### PR DESCRIPTION
## Summary

The three `npm install -g` layers (commitlint/markdownlint, Playwright, and the volatile claude-code/gemini/codex/dmux/snyk set) never cleared npm's download cache, so hundreds of MB of `~/.npm` tarballs were baked into the image — dead weight that also adds to the peak build disk that overflows hosted CI runners. Append `npm cache clean --force` to each layer.

## Verification

- `task test:template` green; the rendered Dockerfile carries 3 `npm cache clean --force` steps and is **hadolint-clean**.
- The image build itself is exercised by the `devcontainer-build` workflow (which #125 makes buildable on hosted runners).

## Deliberately NOT touched

- **Dual Chromium install** — the Dockerfile comment documents it as intentional (`@playwright/test` and `@playwright/cli` expect different chromium revisions), so dedup would fight a deliberate design choice.
- **Heavy-tool gating** (`ffmpeg`/`imagemagick`/`pandoc`) and **pinning the `curl | sh` installers** (uv/starship/oh-my-zsh) — real wins, but they alter the build and need an actual image build to verify. Left as follow-ups (happy to drive them against the devcontainer-build CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)