### PR TITLE
fix: pin the uv and starship installers in the devcontainer image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -74,6 +74,10 @@ ARG GITLEAKS_VERSION=8.30.1
 ARG LYCHEE_VERSION=0.24.2
 # renovate: datasource=github-releases depName=alexpasmantier/television extractVersion=^v?(?<version>.+)$
 ARG TV_VERSION=0.15.7
+# renovate: datasource=github-releases depName=astral-sh/uv extractVersion=^v?(?<version>.+)$
+ARG UV_VERSION=0.11.25
+# renovate: datasource=github-releases depName=starship/starship extractVersion=^v?(?<version>.+)$
+ARG STARSHIP_VERSION=1.25.1
 ARG UV_INSTALL_DIR=/usr/local/bin
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -302,10 +306,10 @@ RUN case "${TARGETARCH}" in \
         | tar -xz -C /usr/local/bin sesh
 
 # ---------- uv (Python package manager) ----------
-RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="${UV_INSTALL_DIR}" sh
+RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | env UV_INSTALL_DIR="${UV_INSTALL_DIR}" sh
 
 # ---------- starship prompt ----------
-RUN curl -fsSL https://starship.rs/install.sh | sh -s -- --yes
+RUN curl -fsSL https://starship.rs/install.sh | sh -s -- --yes --version v${STARSHIP_VERSION}
 
 # ---------- devcontainer config files ----------
 # Bake to /usr/local/share/ rather than /tmp/ — Coder/devcontainer hosts mount

--- a/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile
@@ -74,6 +74,10 @@ ARG GITLEAKS_VERSION=8.30.1
 ARG LYCHEE_VERSION=0.24.2
 # renovate: datasource=github-releases depName=alexpasmantier/television extractVersion=^v?(?<version>.+)$
 ARG TV_VERSION=0.15.7
+# renovate: datasource=github-releases depName=astral-sh/uv extractVersion=^v?(?<version>.+)$
+ARG UV_VERSION=0.11.25
+# renovate: datasource=github-releases depName=starship/starship extractVersion=^v?(?<version>.+)$
+ARG STARSHIP_VERSION=1.25.1
 ARG UV_INSTALL_DIR=/usr/local/bin
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -302,10 +306,10 @@ RUN case "${TARGETARCH}" in \
         | tar -xz -C /usr/local/bin sesh
 
 # ---------- uv (Python package manager) ----------
-RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="${UV_INSTALL_DIR}" sh
+RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | env UV_INSTALL_DIR="${UV_INSTALL_DIR}" sh
 
 # ---------- starship prompt ----------
-RUN curl -fsSL https://starship.rs/install.sh | sh -s -- --yes
+RUN curl -fsSL https://starship.rs/install.sh | sh -s -- --yes --version v${STARSHIP_VERSION}
 
 # ---------- devcontainer config files ----------
 # Bake to /usr/local/share/ rather than /tmp/ — Coder/devcontainer hosts mount


### PR DESCRIPTION
## Summary

`uv` and `starship` were the only two tools installed via an **unpinned** `curl | sh` (latest-at-build-time), while the Dockerfile pins ~40 others via `ARG` + `# renovate:`. That made builds non-reproducible and exposed the image to an upstream-installer change landing between builds. Both are now pinned to renovate-tracked `ARG`s:

- **uv** → the versioned installer URL `https://astral.sh/uv/${UV_VERSION}/install.sh` (verified: `0.11.25` resolves **HTTP 200**).
- **starship** → the installer's `--version vX.Y.Z` flag (verified against upstream `install.sh`, which documents the `v`-prefixed tag).

Applied to **both** the template Dockerfile and harmon-init's root dogfood copy (dogfood parity, per `AGENTS.md`).

## Verification

- `hadolint` clean on both copies; rendered web-astro image carries the pinned install lines.
- `task test:template` + `task check` green.
- The real image build runs in this PR's `devcontainer-build` (it edits `.devcontainer/**`).

## Note (not fixed here)

`renovate.json`'s regex manager only watches the **root** `.devcontainer/Dockerfile` (`managerFilePatterns: ^\.devcontainer/Dockerfile$`) — true for all 40 existing pins too. So a future renovate bump updates the root, and the template copy must be synced by hand (the dogfood-parity rule in AGENTS.md). Making renovate track the template copy as well would be a separate, broader change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)