### PR TITLE
feat(template): make `verify` the fast agent gate and `ci` a full CI mirror

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,11 @@ YAML/Markdown). The **rendered** output is validated by `task test:template:*`.
 # Generate a new project from this template
 copier copy harmon-init new-project --trust
 
-# Local verification gate (lint + template generation tests) — run before pushing
+# Local verification gate (lint + fast guards + template generation tests)
 task verify
+
+# Full CI mirror on demand (verify's checks + devcontainer assert + security)
+task ci
 
 # Lint only
 task check

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,16 +45,28 @@ tasks:
 
   # ── CI / Verification Pipelines ────────────────────────────────
   ci:
-    desc: Full CI pipeline (check → test → security)
+    # Full local mirror of this repo's CI — run on demand to catch everything CI
+    # would (the lint job's guards, the template render matrix, security) without
+    # waiting on a PR. test:devcontainer:permissions needs a Docker daemon.
+    desc: Full CI mirror (check → guards → test → security)
     cmds:
       - task: check
+      - task: test:tasks
+      - task: test:hooks
+      - task: test:devcontainer:permissions
       - task: test
       - task: security
 
   verify:
-    desc: Local verification gate (check → test:template)
+    # Local gate for this template repo. Unlike a generated repo's `verify` (which
+    # is tuned to stay under a minute for agents/hooks), this one renders the whole
+    # template via test:template, so it is inherently heavier — but it still runs
+    # the same fast Taskfile/hook guards a generated repo's verify does.
+    desc: Local verification gate (check → guards → test:template)
     cmds:
       - task: check
+      - task: test:tasks
+      - task: test:hooks
       - task: test:template
 
   # ── Quality Checks ────────────────────────────────────────────

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -22,12 +22,19 @@ All commands go through the Taskfile (single source of truth — CI, git hooks,
 and humans run the same targets):
 
 ```bash
-task verify      # local merge gate (lint[% if use_node %] + typecheck + build[% endif %])
+task verify      # FAST local gate (<~1 min) — run constantly; safe for hooks/agents
+task ci          # FULL CI mirror — run before/instead of opening a PR
 task check       # all linters
 task fix         # auto-format then lint
 task test        # tests
 task security    # gitleaks + dependency audit
 ```
+
+`verify` is deliberately kept fast (lint[% if use_node %] + typecheck + build[% endif %] + the quick
+Taskfile/hook guards) so editors, git hooks, and AI agents can run it on every
+change without getting bogged down. `ci` is the full pipeline — everything CI
+runs (`verify` + `test` + `security`[% if devcontainer %] + the devcontainer permission assert[% endif %]) — so you
+can reproduce a CI run locally on demand instead of waiting on a PR.
 
 ## Definition of Done
 

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -40,24 +40,35 @@ tasks:
 
   # ── CI / Verification Pipelines ────────────────────────────────
   ci:
-    desc: Full CI pipeline (check → build → validate → test → security)
+    # Full local mirror of the CI pipeline — run before (or instead of) opening
+    # a PR to catch everything CI would, on demand, without waiting on a PR run.
+    # Builds on `verify` and adds the heavier / environment-dependent checks
+    # (the devcontainer permission assert needs a Docker daemon, like CI has).
+    desc: Full CI mirror (verify → [test:devcontainer:permissions →] test → security)
     cmds:
-      - task: check
-[% if use_node %]
-      - task: build
+      - task: verify
+[% if devcontainer %]
+      - task: test:devcontainer:permissions
 [% endif %]
-      - task: validate
       - task: test
       - task: security
 
   verify:
-    desc: Local verification gate (check[% if use_node %] → build[% endif %] → validate)
+    # Fast local gate (target: well under a minute) — safe for editors, git
+    # hooks, and AI agents to run on every change without getting bogged down.
+    # Add a check here ONLY if it stays fast; heavier or environment-dependent
+    # checks (test, security, the devcontainer permission assert) live in `ci`.
+    desc: Fast local gate (check[% if use_node %] → build[% endif %] → validate → guards)
     cmds:
       - task: check
 [% if use_node %]
       - task: build
 [% endif %]
       - task: validate
+      - task: test:tasks
+[% if devcontainer %]
+      - task: test:hooks
+[% endif %]
 
   # ── Quality Checks ────────────────────────────────────────────
   check:


### PR DESCRIPTION
## Problem

`task verify` — and even `task ci` — omitted the guard targets the CI lint job invokes directly (`test:tasks`, `test:hooks`, `test:devcontainer:permissions`). So **no local command mirrored CI**: `verify` could pass while CI went red, and there was no way to reproduce a full CI run locally without opening a PR.

## Design

Two clear roles, encoded in the Taskfile descriptions/comments and AGENTS.md:

- **`verify` = the fast gate.** Tuned to stay well under a minute so editors, git hooks, and **AI agents** can run it on every change without getting bogged down. Generated repos now get the cheap guards: `test:tasks` (~0.25s) always, `test:hooks` (~2s) when `devcontainer`. `build` stays gated on `use_node`; the Docker-dependent `test:devcontainer:permissions` is deliberately **excluded** (it'd break on machines without Docker and is slower).
- **`ci` = the full CI mirror.** Now `verify` + `[test:devcontainer:permissions]` + `test` + `security` — runnable **on demand** to catch everything CI would, instead of waiting on a PR.

The rule (documented): a check only belongs in `verify` if it stays fast; heavy/Docker-dependent checks live in `ci`.

## Scope

- **`template/Taskfile.yml.jinja`** (generated repos) — the main change.
- **`Taskfile.yml`** (harmon-init's own dogfood) — same philosophy, adapted to its template-dev shape (`verify` renders the template via `test:template`, so it's inherently heavier, but still runs the fast guards).
- **`template/AGENTS.md.jinja` + `AGENTS.md`** — explain `verify` (fast, constant) vs `ci` (full, on demand).

## Verification

- Renders for `web-astro`+devcontainer and `general` (no node, no devcontainer) gate the guards correctly (`test:hooks` only with devcontainer, `build` only with node, `test:tasks` always) and the rendered Taskfiles compile.
- `task check` + `task test:template` green. Pairs with harmon-devkit's catalog update documenting the same `verify`/`ci` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)