### PR TITLE
feat(template): add web-astro quality gates (JSON-LD/OG/responsive/links) + Site Overview

### DIFF
--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -283,6 +283,26 @@ if should_show "code"; then
     fi
 fi
 
+# ── Site Overview ───────────────────────────────────────────────────────────
+# Shown only for Astro sites, detected at runtime (src/pages/) so this generic
+# status script needs no per-project-type templating.
+
+if should_show "site" && [[ -d src/pages ]]; then
+    section_header "Site Overview"
+    {
+        page_count="$(find src/pages -name '*.astro' 2>/dev/null | wc -l | tr -d ' ')"
+        kv "Pages (src/pages/*.astro)" "${page_count}"
+        if [[ -d dist ]]; then
+            html_count="$(find dist -name '*.html' 2>/dev/null | wc -l | tr -d ' ')"
+            dist_size="$(du -sh dist 2>/dev/null | cut -f1)"
+            kv "Built pages (dist/*.html)" "${html_count}"
+            kv "Build output size" "${dist_size}"
+        else
+            echo "  (no dist/ yet — run 'task build' for build stats)"
+        fi
+    } | section_box
+fi
+
 # ── Environment ─────────────────────────────────────────────────────────────
 
 if should_show "env"; then

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -112,8 +112,17 @@ jobs:
       - name: Install dependencies
         run: |
           if [ -f package.json ]; then pnpm install --frozen-lockfile; fi
+[% if project_type == 'web-astro' %]
+      - name: Install lychee
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: --version
+          fail: false
+[% endif %]
       - name: Build
         run: task build
+      - name: Validate
+        run: task validate
       - name: Test
         run: task test
 [% endif %]

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -210,14 +210,42 @@ tasks:
   validate:
     desc: Validate project config/artifacts
     cmds:
+[% if project_type == 'web-astro' %]
+      - task: validate:jsonld
+      - task: validate:og
+      - task: validate:responsive
+      - task: validate:links
+[% endif %]
 [% if include_terraform %]
       - task: lint:terraform:validate
 [% endif %]
 [% if include_ansible %]
       - task: validate:ansible:syntax
 [% endif %]
-[% if not include_terraform and not include_ansible %]
+[% if project_type != 'web-astro' and not include_terraform and not include_ansible %]
       - 'echo "No validate steps for this project type yet — see docs/CHECKLIST.md."'
+[% endif %]
+[% if project_type == 'web-astro' %]
+
+  validate:jsonld:
+    desc: Validate JSON-LD structured data in the built site (dist/)
+    cmds:
+      - node scripts/validate-jsonld.mjs
+
+  validate:og:
+    desc: Validate Open Graph / social meta tags in the built site (dist/)
+    cmds:
+      - node scripts/validate-og.mjs
+
+  validate:responsive:
+    desc: Validate mobile/responsive viewport markers in the built site (dist/)
+    cmds:
+      - node scripts/validate-responsive.mjs
+
+  validate:links:
+    desc: Check the built site (dist/) for broken internal links (lychee, offline)
+    cmds:
+      - lychee --offline --no-progress ./dist
 [% endif %]
 
   guard:no-commit-to-main:
@@ -553,6 +581,13 @@ tasks:
     desc: Setup completeness audit (GitHub, toolchain, devcontainer, dev env)
     cmds:
       - ./scripts/status.sh setup
+[% if project_type == 'web-astro' %]
+
+  status:site:
+    desc: Site overview section (page count, build output)
+    cmds:
+      - ./scripts/status.sh site
+[% endif %]
 
   # ── Utilities ──────────────────────────────────────────────────
   util:bunch-add:

--- a/template/scripts/[% if project_type == 'web-astro' %]validate-jsonld.mjs[% endif %]
+++ b/template/scripts/[% if project_type == 'web-astro' %]validate-jsonld.mjs[% endif %]
@@ -1,0 +1,67 @@
+// Validate JSON-LD structured data across the built site (dist/).
+//
+// Generic gate: auto-discovers every dist/**/*.html and checks that any JSON-LD
+// it ships is well-formed — valid JSON, a schema.org @context, and at least one
+// @type. Pages without JSON-LD are fine (it is optional); this only asserts that
+// what IS present is correct. Add page/type-specific expectations in your own
+// repo if you want stricter checks.
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+
+const DIST = resolve('dist')
+
+if (!existsSync(DIST)) {
+  console.error('FAIL: dist/ not found — run the build first (task build)')
+  process.exit(1)
+}
+
+function htmlFiles(dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry)
+    if (statSync(p).isDirectory()) out.push(...htmlFiles(p))
+    else if (entry.endsWith('.html')) out.push(p)
+  }
+  return out
+}
+
+const JSONLD_RE = /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi
+
+const pages = htmlFiles(DIST)
+let errors = 0
+let blocks = 0
+
+for (const file of pages) {
+  const label = relative(DIST, file)
+  const html = readFileSync(file, 'utf-8')
+
+  for (const [, content] of html.matchAll(JSONLD_RE)) {
+    blocks++
+    let data
+    try {
+      data = JSON.parse(content)
+    } catch (e) {
+      console.error(`FAIL [${label}] malformed JSON-LD: ${e.message}`)
+      errors++
+      continue
+    }
+
+    // Accept a single node, an array of nodes, or a @graph container.
+    const nodes = Array.isArray(data) ? data : data['@graph'] || [data]
+    const ctx = data['@context'] || nodes.find((n) => n && n['@context'])?.['@context']
+    if (!ctx || !String(ctx).includes('schema.org')) {
+      console.error(`FAIL [${label}] JSON-LD missing a schema.org @context`)
+      errors++
+    }
+    if (!nodes.some((n) => n && n['@type'])) {
+      console.error(`FAIL [${label}] JSON-LD has no @type`)
+      errors++
+    }
+  }
+}
+
+if (errors > 0) {
+  console.error(`\n${errors} JSON-LD error(s) across ${pages.length} page(s)`)
+  process.exit(1)
+}
+console.log(`JSON-LD OK: ${blocks} block(s) across ${pages.length} page(s) are well-formed`)

--- a/template/scripts/[% if project_type == 'web-astro' %]validate-og.mjs[% endif %]
+++ b/template/scripts/[% if project_type == 'web-astro' %]validate-og.mjs[% endif %]
@@ -1,0 +1,67 @@
+// Validate Open Graph / social meta tags across the built site (dist/).
+//
+// Generic gate: auto-discovers every dist/**/*.html. For any page that ships OG
+// tags at all, the load-bearing ones must be correct — og:title and an absolute
+// https og:image (a relative og:image breaks link unfurling). og:description is
+// recommended (warned, not failed). Pages with no OG tags are skipped (utility
+// pages like 404 legitimately omit them), so this catches broken/partial OG
+// without false-failing.
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+
+const DIST = resolve('dist')
+
+if (!existsSync(DIST)) {
+  console.error('FAIL: dist/ not found — run the build first (task build)')
+  process.exit(1)
+}
+
+function htmlFiles(dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry)
+    if (statSync(p).isDirectory()) out.push(...htmlFiles(p))
+    else if (entry.endsWith('.html')) out.push(p)
+  }
+  return out
+}
+
+const ANY_OG_RE = /<meta\s+property=["']og:/i
+const OG_TITLE_RE = /<meta\s+property=["']og:title["']\s+content=["'][^"']+["']/i
+const OG_DESC_RE = /<meta\s+property=["']og:description["']\s+content=["'][^"']+["']/i
+const OG_IMAGE_RE = /<meta\s+property=["']og:image["']\s+content=["']([^"']+)["']/i
+
+const pages = htmlFiles(DIST)
+let errors = 0
+let checked = 0
+
+for (const file of pages) {
+  const label = relative(DIST, file)
+  const html = readFileSync(file, 'utf-8')
+
+  // Only enforce on pages that opt into OG at all.
+  if (!ANY_OG_RE.test(html)) continue
+  checked++
+
+  if (!OG_TITLE_RE.test(html)) {
+    console.error(`FAIL [${label}] has OG tags but is missing og:title`)
+    errors++
+  }
+  if (!OG_DESC_RE.test(html)) {
+    console.warn(`WARN [${label}] has OG tags but is missing og:description (recommended)`)
+  }
+  const image = html.match(OG_IMAGE_RE)
+  if (!image) {
+    console.error(`FAIL [${label}] has OG tags but is missing og:image`)
+    errors++
+  } else if (!image[1].startsWith('https://')) {
+    console.error(`FAIL [${label}] og:image must be an absolute https URL: ${image[1]}`)
+    errors++
+  }
+}
+
+if (errors > 0) {
+  console.error(`\n${errors} Open Graph error(s) across ${checked} OG page(s)`)
+  process.exit(1)
+}
+console.log(`Open Graph OK: ${checked} page(s) with OG tags are complete`)

--- a/template/scripts/[% if project_type == 'web-astro' %]validate-responsive.mjs[% endif %]
+++ b/template/scripts/[% if project_type == 'web-astro' %]validate-responsive.mjs[% endif %]
@@ -1,0 +1,45 @@
+// Validate mobile/responsive readiness across the built site (dist/).
+//
+// Generic gate: auto-discovers every dist/**/*.html and asserts each ships a
+// responsive viewport meta (`width=device-width`) — the one tag a page MUST have
+// to render correctly on mobile. Add repo-specific responsive checks (sticky CTA,
+// safe-area insets, no fixed widths) on top if your design needs them.
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+
+const DIST = resolve('dist')
+
+if (!existsSync(DIST)) {
+  console.error('FAIL: dist/ not found — run the build first (task build)')
+  process.exit(1)
+}
+
+function htmlFiles(dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry)
+    if (statSync(p).isDirectory()) out.push(...htmlFiles(p))
+    else if (entry.endsWith('.html')) out.push(p)
+  }
+  return out
+}
+
+const VIEWPORT_RE = /<meta\s+name=["']viewport["']\s+content=["'][^"']*width=device-width[^"']*["']/i
+
+const pages = htmlFiles(DIST)
+let errors = 0
+
+for (const file of pages) {
+  const label = relative(DIST, file)
+  const html = readFileSync(file, 'utf-8')
+  if (!VIEWPORT_RE.test(html)) {
+    console.error(`FAIL [${label}] missing responsive viewport meta (width=device-width)`)
+    errors++
+  }
+}
+
+if (errors > 0) {
+  console.error(`\n${errors} responsive error(s) across ${pages.length} page(s)`)
+  process.exit(1)
+}
+console.log(`Responsive OK: all ${pages.length} page(s) have a device-width viewport`)

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -283,6 +283,26 @@ if should_show "code"; then
     fi
 fi
 
+# ── Site Overview ───────────────────────────────────────────────────────────
+# Shown only for Astro sites, detected at runtime (src/pages/) so this generic
+# status script needs no per-project-type templating.
+
+if should_show "site" && [[ -d src/pages ]]; then
+    section_header "Site Overview"
+    {
+        page_count="$(find src/pages -name '*.astro' 2>/dev/null | wc -l | tr -d ' ')"
+        kv "Pages (src/pages/*.astro)" "${page_count}"
+        if [[ -d dist ]]; then
+            html_count="$(find dist -name '*.html' 2>/dev/null | wc -l | tr -d ' ')"
+            dist_size="$(du -sh dist 2>/dev/null | cut -f1)"
+            kv "Built pages (dist/*.html)" "${html_count}"
+            kv "Build output size" "${dist_size}"
+        else
+            echo "  (no dist/ yet — run 'task build' for build stats)"
+        fi
+    } | section_box
+fi
+
 # ── Environment ─────────────────────────────────────────────────────────────
 
 if should_show "env"; then


### PR DESCRIPTION
## Summary

Generated `web-astro` repos shipped **no build-output validation** — sommerlawn-web had to write its own. This upstreams the **generic** parts (its site-specific page lists and schema expectations stay in the consumer repo).

### New generic validators (`scripts/validate-*.mjs`, filename-gated to web-astro)
They **auto-discover `dist/**/*.html`** and assert only generic, safe invariants — *"if present, it must be correct"* so utility pages (404 etc.) don't false-fail:
- **`validate:jsonld`** — every JSON-LD block is valid JSON with a schema.org `@context` + `@type`.
- **`validate:og`** — any page that ships OG tags has `og:title` + an absolute-`https` `og:image` (relative breaks unfurls); `og:description` is *warned*, not failed.
- **`validate:responsive`** — every page has a `width=device-width` viewport.
- **`validate:links`** — `lychee --offline` over `dist/` for broken internal links (build-test installs lychee for web-astro).

### Wiring
- `validate` runs these for web-astro; the `build-test` CI job now runs `task validate`.
- **`status:site`** — a runtime-guarded "Site Overview" status section (page + build-output counts), shown only when `src/pages/` exists. Added to the template **and** the root dogfood `status.sh` (dogfood-parity rule).

## Verification (this is the important part)

Ran the generic validators against a **real 61-page Astro build** (sommerlawn's `dist/`):
- `jsonld` ✅ — 305 blocks across 61 pages all well-formed.
- `responsive` ✅ — all 61 pages have device-width viewport.
- `og` ✅ — and it **correctly surfaced a real missing `og:description`** on a page sommerlawn's own hardcoded validator never checked (now a warning, not a failure).

Plus: web-astro renders wire all of it and compile; **general renders get none of it** (0 validators/targets/lychee); `task check` + `task test:template` green; `status.sh` shellcheck/shfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)