### PR TITLE
fix(template): make rendered output Prettier-clean + guard it in test-template

### DIFF
--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -187,6 +187,21 @@ if [ -d .github/workflows ]; then
     fi
 fi
 
+# ── 3b. Rendered JS/TS/JSON is Prettier-clean (node projects) ────────
+# A generated repo runs `prettier --check` in its own lint:prettier; if the
+# template's RENDERED output isn't already clean, the consumer's very first
+# `task verify` fails (recurring example: jinja-bracketed workflow YAML, now
+# handed to yamllint via .prettierignore). Catch that here. Explicit options
+# match the shipped prettier-config-standard (singleQuote, no-semi,
+# trailing-comma none, width 100) so no config package needs installing; the
+# rendered .prettierignore (YAML->yamllint, Markdown->markdownlint) is honored.
+if [ -f prettier.config.cjs ] && have npx; then
+    if ! npx --yes prettier@3 --no-config --single-quote --no-semi \
+        --trailing-comma none --print-width 100 --check . >/dev/null 2>&1; then
+        err "rendered output is not Prettier-clean — a consumer's first 'task verify' would fail (run: npx prettier --check . in the render)"
+    fi
+fi
+
 # ── 4. Rendered YAML is valid (yamllint, errors only) ───────────────
 if have yamllint; then
     yamllint --no-warnings . || err "yamllint errors in rendered output"

--- a/template/[% if project_type == 'web-astro' %]lighthouserc.json[% endif %]
+++ b/template/[% if project_type == 'web-astro' %]lighthouserc.json[% endif %]
@@ -2,9 +2,7 @@
   "ci": {
     "collect": {
       "staticDistDir": "./dist",
-      "url": [
-        "http://localhost/"
-      ],
+      "url": ["http://localhost/"],
       "numberOfRuns": 1,
       "settings": {
         "chromeFlags": "--no-sandbox --headless --disable-gpu --disable-dev-shm-usage"

--- a/template/[% if use_node %].prettierignore[% endif %]
+++ b/template/[% if use_node %].prettierignore[% endif %]
@@ -1,0 +1,31 @@
+# Each file type is owned by ONE formatter/linter to avoid tools fighting:
+#   - YAML      -> yamllint        (task lint:yaml)
+#   - Markdown  -> markdownlint    (task lint:markdown)
+#   - Shell     -> shfmt           (task lint:shell)
+# Prettier owns the rest (js/ts/jsx/tsx/json/css/astro). Keeping it out of YAML
+# also avoids its flow-sequence normalization (`[ "x" ]` -> `["x"]`) fighting the
+# rendered GitHub Actions / jinja workflow style.
+*.yml
+*.yaml
+*.md
+*.mdx
+
+# Machine-/agent-specific, generated, or vendored — not ours to format.
+.claude/
+node_modules/
+dist/
+.task/
+.worktrees/
+.terraform/
+.venv/
+pnpm-lock.yaml
+
+# release-please owns CHANGELOG.md (writes double blanks Prettier would strip).
+CHANGELOG.md
+
+# Config JSON Prettier can't cleanly own: JSONC (devcontainer) and templated
+# JSON whose rendered structure differs from Prettier's. Validity is checked by
+# lint:hygiene (JSON parse), so they don't need Prettier formatting too.
+.devcontainer/
+renovate.json
+.github/github-app-manifest.json

--- a/template/commitlint.config.mjs
+++ b/template/commitlint.config.mjs
@@ -6,7 +6,21 @@ export default {
     'type-enum': [
       2,
       'always',
-      ['build', 'change', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'remove', 'revert', 'style', 'test']
+      [
+        'build',
+        'change',
+        'chore',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'remove',
+        'revert',
+        'style',
+        'test'
+      ]
     ]
   }
 }

--- a/template/scripts/[% if project_type == 'web-astro' %]validate-responsive.mjs[% endif %]
+++ b/template/scripts/[% if project_type == 'web-astro' %]validate-responsive.mjs[% endif %]
@@ -24,7 +24,8 @@ function htmlFiles(dir) {
   return out
 }
 
-const VIEWPORT_RE = /<meta\s+name=["']viewport["']\s+content=["'][^"']*width=device-width[^"']*["']/i
+const VIEWPORT_RE =
+  /<meta\s+name=["']viewport["']\s+content=["'][^"']*width=device-width[^"']*["']/i
 
 const pages = htmlFiles(DIST)
 let errors = 0


### PR DESCRIPTION
## Problem (found while `copier update`-ing a downstream repo to v3.6.0)

A freshly **generated** node repo fails its **own** `task verify` (`lint:prettier`) on the first run — the template's rendered files aren't Prettier-clean. harmon-init CI never caught it because `test-template` runs `actionlint`/`yamllint` but **not** the rendered repo's Prettier.

Worst offender is workflow YAML: Prettier normalizes flow sequences (`[ "ubuntu-latest" ]` → `["ubuntu-latest"]`), which fights the jinja-bracketed `[ [[ ci_runner_labels ]] ]` style — and that can't be made Prettier-clean in-template without breaking jinja.

## Fix

- **`template/.prettierignore`** (use_node only) — give each file type to ONE tool: **YAML→yamllint, Markdown→markdownlint**, exclude `.claude/` + build output, and exclude the JSONC (`.devcontainer`) / jinja-templated config JSON (`renovate.json`, `github-app-manifest.json`) Prettier can't cleanly own (their *validity* is still checked by `lint:hygiene`). Prettier keeps js/ts/css/astro + plain JSON.
- **Format the few plain files** that weren't clean: `commitlint.config.mjs`, `lighthouserc.json`, and wrap an over-width regex line in `validate-responsive.mjs`.
- **`test-template.sh` §3b** — a Prettier guard on rendered node output (lightweight explicit options matching `prettier-config-standard`; no config-package install needed; honors the rendered `.prettierignore`). This is the check that would have caught the original defect.

## Verification

- Fresh **web-astro** *and* **web-app** renders are **fully Prettier-clean** under the real `prettier-config-standard` config (and the lightweight guard agrees).
- `task check` + `task test:template` green — the new §3b guard passes across all profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)