### PR TITLE
chore(skills): re-vendor standardize-repo skill from harmon-devkit

### DIFF
--- a/.claude/skills/standardize-repo/SKILL.md
+++ b/.claude/skills/standardize-repo/SKILL.md
@@ -53,11 +53,16 @@ differently.
 
 These are load-bearing. Full rationale and edge cases in `references/copier-gotchas.md`.
 
-- **Always pass `--vcs-ref=HEAD` when the template source is a local path.** Without
-  it, copier renders the **latest git tag** of harmon-init and silently ignores all
-  uncommitted *and* committed-but-untagged work. With it, copier auto-includes
-  dirty/untracked changes via a throwaway commit in a temp clone
-  (`DirtyLocalWarning`) — the working tree is never touched.
+- **When *rendering* from a local path (`copier copy`), always pass `--vcs-ref=HEAD`.**
+  Without it, copier renders the **latest git tag** of harmon-init and silently
+  ignores all uncommitted *and* committed-but-untagged work. With it, copier
+  auto-includes dirty/untracked changes via a throwaway commit in a temp clone
+  (`DirtyLocalWarning`) — the working tree is never touched. This rule is about
+  *which ref* to render, not *where* the template lives — and it applies to
+  `copier copy`, **not** `copier update`. An update reuses the recorded `_src_path`
+  and tracks released **tags**: a generated repo's committed `_src_path` should be
+  the GitHub URL (not a machine-local path), and a normal `copier update` takes
+  **no** `--vcs-ref`. See `copier-gotchas.md` gotchas 1 (render ref) & 8 (`_src_path`).
 - **Side-effectful answers default to `no`** in `copier.yml` (`github_remote_create`,
   `github_release_init`, `bunch_add`, `obsidian_project_add`, `run_task_install`).
   Leave them off unless the user explicitly asks; only flip them on with confirmation.

--- a/.claude/skills/standardize-repo/assets/verify-applied.sh
+++ b/.claude/skills/standardize-repo/assets/verify-applied.sh
@@ -107,6 +107,29 @@ if { [ -f Taskfile.yml ] || [ -f Taskfile.yaml ]; } && have task; then
     done
 fi
 
+# ── 3c. Workflow ↔ Taskfile contract ────────────────────────────────
+# Every CI job / git hook delegates to a `task` target; enforce the CONVERSE —
+# every `task <target>` a workflow invokes MUST exist in the Taskfile. CI's
+# lint/build jobs call targets `task verify` never runs (e.g. test:tasks,
+# test:hooks, test:devcontainer:permissions). A Taskfile that drifted from the
+# template — or was restored wholesale from a pre-template `main` during a
+# Path-B adopt while the template's workflows were taken as-is — can omit them,
+# so `task verify` (and this script's §1 gate) stays GREEN while CI goes RED.
+# This existence check catches that class at apply time. We anchor on a command
+# CONTEXT — `run: task <t>`, a run-block line starting with `task <t>`, or
+# `&& task <t>` — so prose ("the specific task described"), renovate comments
+# (`go-task/task extractVersion`), and `setup-task@<sha>` never match.
+if [ -d .github/workflows ] && { [ -f Taskfile.yml ] || [ -f Taskfile.yaml ]; } && have task; then
+    tasklist="$(task --list-all 2>/dev/null || true)"
+    called="$(grep -rhoE '(run:[[:space:]]*|^[[:space:]]*|&&[[:space:]]*)task +[a-z][a-z0-9:_-]*' .github/workflows/ 2>/dev/null |
+        sed -E 's/.*task +//' | sort -u)"
+    for t in $called; do
+        if ! printf '%s\n' "$tasklist" | grep -qE "^[* ]*${t}:([[:space:]]|\$)"; then
+            err "workflow calls 'task ${t}' but the Taskfile has no such target"
+        fi
+    done
+fi
+
 # ── 4. No unrendered template markers leaked into the repo ──────────
 # harmon-init uses CUSTOM jinja delimiters ([[ var ]], [% block %]). Legitimate
 # look-alikes must NOT trip this: go-task uses {{.VAR}} (dot, no space), GitHub

--- a/.claude/skills/standardize-repo/references/mode-adopt-existing.md
+++ b/.claude/skills/standardize-repo/references/mode-adopt-existing.md
@@ -38,7 +38,7 @@ Copier's first decision is `project_type`, which drives the Taskfile, CI jobs, a
 devcontainer tooling. Don't guess it — run the detector against the target repo:
 
 ```bash
-~/git/harmon-devkit/ai/skills/repo/standardize-repo/assets/detect-project-type.sh .
+assets/detect-project-type.sh .
 ```
 
 It inspects the repo and prints the matching `project_type`, one of the five values
@@ -57,7 +57,7 @@ normally set explicitly when adopting an existing repo (the rest fall back to
 sensible `copier.yml` defaults):
 
 ```bash
-PROJECT_TYPE="$(~/git/harmon-devkit/ai/skills/repo/standardize-repo/assets/detect-project-type.sh .)"
+PROJECT_TYPE="$(assets/detect-project-type.sh .)"
 
 --data project_type="$PROJECT_TYPE" \
 --data project_name="<Formal Project Name>" \
@@ -158,6 +158,16 @@ from git rather than hand-merging conflict markers:
    `git checkout main -- <Taskfile.yml> <renovate.json> <.gitignore> …`. The repo
    was likely already close to current (hand-synced), so this loses little template
    improvement while preserving every customization.
+   - **If you restore a customized `Taskfile.yml` but keep the template's
+     workflows, reconcile the contract.** The template's `.github/workflows/*`
+     delegate to `task` targets (e.g. `test:tasks`, `test:hooks`,
+     `test:devcontainer:permissions`) that a pre-template Taskfile won't have.
+     `task verify` will **not** catch the gap — CI will. List every target the
+     adopted workflows call and ensure each exists, porting the missing targets +
+     their `scripts/*.sh` from the template:
+     `grep -rhoE '(run:[[:space:]]*|^[[:space:]]*|&&[[:space:]]*)task +[a-z][a-z0-9:_-]*' .github/workflows/ | sed -E 's/.*task +//' | sort -u`.
+     `verify-applied.sh` §3c enforces this (see [mode-audit.md](./mode-audit.md)
+     drift class L).
 3. **Keep** the template version for uncustomized tooling **and all additive new
    files** (docs scaffold, codeql/release-please, helper scripts, `.copier-answers.yml`).
 4. **Canonicalize AGENTS.md** — fold the old real guidance (often the pre-existing
@@ -277,7 +287,7 @@ Run the same gate the template installs, then the skill's applied-state check:
 ```bash
 task install        # one-time: brew deps + lefthook hooks (safe to run now)
 task verify         # the merge gate: lint → (build) → validate
-~/git/harmon-devkit/ai/skills/repo/standardize-repo/assets/verify-applied.sh .
+assets/verify-applied.sh .
 ```
 
 `task verify` runs `check` (all linters[, typecheck], parallel), an optional

--- a/.claude/skills/standardize-repo/references/mode-audit.md
+++ b/.claude/skills/standardize-repo/references/mode-audit.md
@@ -272,7 +272,7 @@ template improvements. Detect it mechanically — this is how the audit "checks
 everything" instead of eyeballing each file:
 
 ```bash
-~/git/harmon-devkit/ai/skills/repo/standardize-repo/assets/diff-template.sh "$TARGET"
+assets/diff-template.sh "$TARGET"
 # --show to see the per-file diff
 ```
 
@@ -289,6 +289,27 @@ the latter, reconciling **in place** (keep the customization in its normal file 
 not extract it elsewhere). Severity: **should** (blocker if the drift breaks a
 required gate, e.g. a non-portable `lint-hygiene.sh`). Run this as a standard step of
 every audit.
+
+**L. Workflow ↔ Taskfile contract.** Every `task <target>` referenced in
+`.github/workflows/*.yml` must exist in `Taskfile.yml`. CI's `lint`/`build` jobs
+call targets `task verify` never runs (e.g. `test:tasks`, `test:hooks`,
+`test:devcontainer:permissions`), so a Taskfile that drifted from the template —
+or was restored wholesale from a pre-template `main` during a Path-B adopt while
+the template's workflows were taken as-is — can omit them. The result is the worst
+kind of green: `task verify` (and `verify-applied.sh`'s §1 gate) passes locally
+while CI goes **red**, because the gate doesn't exercise what CI does. Detect the
+contract directly:
+
+```bash
+grep -rhoE '(run:[[:space:]]*|^[[:space:]]*|&&[[:space:]]*)task +[a-z][a-z0-9:_-]*' \
+  .github/workflows/ | sed -E 's/.*task +//' | sort -u
+# then assert each is in `task --list-all`
+```
+
+`assets/verify-applied.sh` (§3c) enforces this. Fix: port the missing targets and
+their `scripts/*.sh` helpers from the template (or reconcile the preserved Taskfile
+against the adopted workflows). Severity: **blocker** (the gate is unenforced and CI
+is unsatisfiable until the targets exist).
 
 ---
 
@@ -348,7 +369,7 @@ Apply fixes on a branch, prefer re-templating for files copier owns, then verify
    actually resolved by running the skill's checker:
 
    ```bash
-   ~/git/harmon-devkit/ai/skills/repo/standardize-repo/assets/verify-applied.sh "$TARGET"
+   assets/verify-applied.sh "$TARGET"
    ```
 
    (See [`../assets/verify-applied.sh`](../assets/verify-applied.sh) — it should

--- a/.claude/skills/standardize-repo/references/mode-update.md
+++ b/.claude/skills/standardize-repo/references/mode-update.md
@@ -34,7 +34,7 @@ git switch -c chore/update-harmon-init
 ## 1. See what's missing (read-only)
 
 ```bash
-~/git/harmon-devkit/ai/skills/repo/standardize-repo/assets/diff-template.sh .
+assets/diff-template.sh .
 # add --show to print the full per-file diff
 ```
 
@@ -90,6 +90,26 @@ update will **not** make a scaffold commit, re-init git, or re-cut a release. On
 > harmon-init changes from a local checkout (see [copier-gotchas.md](./copier-gotchas.md)
 > gotcha 1). It is never needed for a normal repo update — don't add it here.
 
+**Renamed templated files are skipped silently — port their delta by hand.**
+`copier update`'s three-way merge is keyed on file *path*. If the repo renamed a
+templated file (most commonly `*.yml` → `*.yaml` for the workflows, `Taskfile`,
+and `lefthook`), copier can't match it: it leaves the file **untouched** and emits
+**no warning** — the run still prints `Updating to template version <X>`, so it
+*looks* fully applied while those files stay on the old version. `diff-template.sh`
+(§1/§4) maps `.yml`↔`.yaml` for *detection*, so such a file shows as `DRIFT`
+whether the gap is a benign extension swap **or** a genuinely missed update — open
+the diff to tell which. For every renamed templated file, port the version delta
+manually:
+
+```bash
+# <old> = the repo's _commit before this update; <new> = the tag you updated to
+git -C ~/git/harmon-init diff <old>..<new> -- template/<path>
+```
+
+Apply the meaningful changes into the repo's renamed file, keeping its local
+customizations. harmon-infra is the standing example (every `.yml` renamed to
+`.yaml`, so its workflows/Taskfile/lefthook always need this hand-port).
+
 ## 3. Reconcile conflicts (in place — no special files)
 
 The three-way merge applies template improvements and keeps the repo's edits when
@@ -103,22 +123,62 @@ Resolve each like a git merge — keep **both** the template's intent and the re
 real customization in the same file. Example: the template improved `scripts/status.sh`
 and the repo had added an `infra` section — the merged file keeps the improved core
 *and* the `infra` section. Don't discard either side; don't extract anything into a
-separate file. Then read the full diff (`git add -A -N && git diff`) and confirm no
+separate file. Then read the full diff (`git add -A && git diff HEAD`) and confirm no
 app content was clobbered and no copier marker leaked (`[[`, `[%`,
-`TODO: project_description`).
+`TODO: project_description`). Use `git add -A` (not `git add -A -N`): copier
+resolves some conflicts with a delete-then-add, which a bare `git diff` renders as a
+misleading whole-file rewrite (`DA` in `git status`, every line shown as removed +
+re-added); staging first and diffing against `HEAD` shows the true, small delta.
+
+**Silent reverts have NO conflict marker.** copier only emits markers / `.rej`
+where edits *overlap*. A file the repo customized **outside copier's tracked
+answers** — anything restored wholesale from `main` during a Path-B adopt
+(`.vscode/settings.json`, `.gitignore`, `renovate.json`, a forked `Taskfile.yml`) —
+can be reverted to the template default *cleanly and invisibly*. (`.vscode/settings.json`
+is gitignored, so its revert doesn't even show in a normal `git diff`.) So the diff
+review above is not optional: eyeball every high-churn, locally-customized file by
+name and confirm your customization survived. Cross-check the §1 `diff-template.sh`
+worklist — any file that was `DRIFT` *before* the update but is now byte-identical to
+the template was silently reverted; restore the customization.
+
+**Heavily-forked files: take `--ours` and re-apply the new bits.** When a file is
+*heavily* customized (a forked `Taskfile.yml`, a bespoke `status.sh`), copier's
+three-way merge can scramble it — a single conflict hunk spanning several unrelated
+targets. Hand-resolving that is error-prone. Take the repo's complete version and
+cherry-pick only the genuinely-new pieces:
+
+```bash
+git checkout --ours Taskfile.yml   # keep the repo's complete, working file
+# then add just what the update introduced (e.g. a new `status:setup` target)
+```
+
+**The template absorbed something this repo pioneered → add/add conflict; keep
+yours.** A canonical convention repo's innovations get *generalized* and upstreamed;
+on its next update, the template's new generic version collides with the repo's
+specific original (an add/add conflict on, e.g., `scripts/validate-*.mjs`). Keep the
+repo's specific version (`git checkout --ours <file>`) — the generic one is for
+*other* repos. Recognise this when a file you know the repo authored shows up as a
+conflict against a near-identical-but-blander template version.
 
 ## 4. Verify comprehensively
 
+copier renders files in the **template's** style, which may not match the repo's
+formatter (e.g. Prettier reformatting freshly-rendered workflow YAML or config).
+Run **`task format` first**, or `task verify` can fail on formatting alone:
+
 ```bash
-~/git/harmon-devkit/ai/skills/repo/standardize-repo/assets/diff-template.sh .   # should now show only legit customizations
+task format                 # reconcile rendered files to the repo's formatter
+assets/diff-template.sh .   # should now show only legit customizations
 task verify
-~/git/harmon-devkit/ai/skills/repo/standardize-repo/assets/verify-applied.sh .
+assets/verify-applied.sh .
 ```
 
 Walk the [`mode-audit.md`](./mode-audit.md) drift classes too — `copier update`
 refreshes templated files, but renames/moves and GitHub-side settings it cannot do.
 Re-run `diff-template.sh`: every remaining `DRIFT` should be an intentional local
-customization you can explain, not a missed update.
+customization you can explain, not a missed update. In particular, a `DRIFT` on a
+file the repo *renamed* (e.g. `.yaml`) may be an update copier skipped, not a
+customization — confirm against the §2 renamed-files note before dismissing it.
 
 ## 5. Hand off
 

--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -95,8 +95,16 @@ Naming & structure conventions:
   `security:secrets`, `install:hooks`, `status:git`, `deploy:ansible:base`.
   **Never action-first** (`shell:lint`, `yaml:lint`).
 - **Pipeline order:** `check → build → validate → test → security`, with
-  `verify` (local gate) and `ci` (full) as aggregates. `verify` =
-  `check [→ build] → validate`.
+  `verify` (fast local gate) and `ci` (full CI mirror) as aggregates.
+  **`verify`** is tuned to stay well under a minute so editors, git hooks, and AI
+  agents can run it on every change: `check [→ build] → validate → test:tasks
+  [→ test:hooks]`. **`ci`** reproduces the whole CI pipeline on demand (run it
+  locally instead of opening a PR): `verify [→ test:devcontainer:permissions] →
+  test → security`. The rule: a check only belongs in `verify` if it stays fast;
+  heavy or Docker-dependent checks (`test`, `security`, `test:devcontainer:permissions`)
+  live in `ci`. Every `task` target a workflow invokes must still exist (drift
+  class L) — but `verify` is intentionally a *subset* of what CI runs, so "`verify`
+  is green" is not "CI is green"; use `ci` for that.
 - **Parallel deps:** umbrella tasks fan out via `deps:` (which run in parallel),
   e.g. `lint` deps on `lint:yaml`, `lint:shell`, `lint:markdown`,
   `lint:actions`, `lint:hygiene`; `security` deps on `security:secrets` +
@@ -425,6 +433,13 @@ install the Renovate GitHub App on the repo. Conventions:
   CHANGELOG entry (`feat`→minor, `fix`→patch; pre-1.0 `feat` bumps minor;
   chore/docs/ci → no release). Files: `release-please-config.json`,
   `.release-please-manifest.json`. **[copier]**
+- **A change that alters what the repo emits to consumers must be `fix:`/`feat:`,
+  never `chore:`.** This matters most for a *template/library* repo (e.g.
+  harmon-init): a `chore:` edit to generated output — `template/**`, `copier.yml`
+  `_tasks`, or a shipped file's mode (`chmod +x`) — cuts no release, so downstreams
+  pinned to a tagged `_commit` can never `copier update` to it (they'd have to chase
+  untagged HEAD via `--vcs-ref=HEAD`, which the update path forbids). Reserve
+  `chore:`/`docs:`/`ci:` for changes that do **not** affect what consumers receive.
 - **Keep a Changelog** format; `CHANGELOG.md` is release-please-generated (and
   ignored by markdownlint). **[copier]** seeds it.
 - `task release:init` seeds the first `v0.1.0`; `task release:patch|minor|major`


### PR DESCRIPTION
Sync the vendored `.claude/skills/standardize-repo` copy with canonical harmon-devkit (`ai/skills/repo/standardize-repo` @ `ba39326`). Everything merged since the last vendor (harmon-devkit#34):

- **#35** — `verify-applied.sh`: enforce the workflow↔Taskfile contract (every `task <t>` a workflow invokes must exist in the Taskfile; catches a green-locally / red-in-CI drift class at apply time)
- **#37** — document `verify` (fast gate) vs `ci` (full CI mirror) semantics
- **#38** — warn that `copier update` silently skips files the repo renamed (`.yml`→`.yaml`); hand-port their delta
- **#39** — `mode-update`: run `task format` before `verify`; plus heavily-forked-file (`--ours` + re-apply) and add/add (template-absorbed-an-innovation) reconciliation tactics
- **SKILL.md** — scope the `--vcs-ref=HEAD` cardinal rule to `copier copy` (#33)

Vendored copy is once again **byte-identical** to canonical (`diff -rq` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)