### PR TITLE
feat(template): track the workspace file and .meta/ instead of ignoring them

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -273,6 +273,10 @@ _subdirectory: template
 #   - CHANGELOG.md — release-please owns it; template merges would fight it.
 _skip_if_exists:
   - CHANGELOG.md
+  # The workspace is generated once with a random peacock color and then tracked
+  # by the consumer; freeze it so `copier update` never regenerates a new color
+  # (which would churn a now-committed file on every update).
+  - "*.code-workspace"
 
 # Keep CLAUDE.md/GEMINI.md as symlinks to AGENTS.md in generated projects
 # (without this, copier dereferences symlinks into duplicate files).

--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -37,10 +37,9 @@ Brewfile.lock.json
 # Local editor/AI settings
 settings.local.json
 
-# Project meta (Bunch/Obsidian symlink targets) and scratch — anchored to root
-/.meta
+# Scratch — anchored to root. (`.meta/` and the `*.code-workspace` are tracked;
+# `.DS_Store` above still keeps macOS cruft out of `.meta/`.)
 /todo.md
-/*.code-workspace
 [% if use_node %]
 
 # build output


### PR DESCRIPTION
## Summary

Per intent change: generated repos should **commit** `{project_slug}.code-workspace` and `.meta/` (Bunch/Obsidian project meta) so the editor workspace and project meta travel with the repo, instead of being gitignored.

- **`.gitignore`** — drop `/.meta` and `/*.code-workspace` (keep `/todo.md` scratch). `.DS_Store` is still globally ignored, so macOS cruft stays out of `.meta/`.
- **`copier.yml`** — add `*.code-workspace` to `_skip_if_exists`. The workspace is generated **once** with a random peacock color, then tracked by the consumer; freezing it means `copier update` never regenerates a new color, so the now-committed file doesn't churn on every update.

## Verification

- A fresh render generates `<slug>.code-workspace` **un-ignored**.
- `task check` + `task test:template` green — including `test:template:update`, which exercises `copier update` and confirms `_skip_if_exists` keeps the workspace stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)