### PR TITLE
refactor(template): adopt create-github-app-token client-id + rename CI_APP_ID → CI_APP_CLIENT_ID

### DIFF
--- a/.claude/skills/standardize-repo/references/post-generation-checklist.md
+++ b/.claude/skills/standardize-repo/references/post-generation-checklist.md
@@ -94,7 +94,7 @@ push so the remote exists.
   ```
 
 - [ ] **[human-only]** Create or reuse the CI **GitHub App** `<org>-ci`, then
-      set `CI_APP_ID` (Actions **variable**) + `CI_APP_PRIVATE_KEY` (Actions
+      set `CI_APP_CLIENT_ID` (Actions **variable**) + `CI_APP_PRIVATE_KEY` (Actions
       **secret**). This App authenticates `release.yml` (release-please) and the
       `claude-*` workflows; minting an App-authored commit is what lets a release
       PR's required checks actually run (the built-in `GITHUB_TOKEN` would not
@@ -129,7 +129,7 @@ push so the remote exists.
 
     ```bash
     # personal-account repo only; org-level should be set in the UI / non-destructively
-    gh variable set CI_APP_ID --repo "<org>/<repo>" --body "<app-id>"
+    gh variable set CI_APP_CLIENT_ID --repo "<org>/<repo>" --body "<app-id>"
     gh secret set CI_APP_PRIVATE_KEY --repo "<org>/<repo>" < path/to/app.pem
     ```
 

--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -314,7 +314,7 @@ Workflow inventory:
 **GitHub App auth** (the claude-* workflows, `release.yml`, and
 `project-automation.yml`): authenticate as a **`<owner>-ci` GitHub App** (one App
 per org/account), not a PAT. Each job mints a short-lived (~1h) token via
-`actions/create-github-app-token` reading **`CI_APP_ID`** (Actions **variable**) +
+`actions/create-github-app-token` reading **`CI_APP_CLIENT_ID`** (Actions **variable**) +
 **`CI_APP_PRIVATE_KEY`** (Actions **secret**), with **least-privilege
 `permission-*` inputs** (e.g. plan: `permission-contents: read` +
 `permission-issues|pull-requests: write`; implement adds
@@ -325,7 +325,7 @@ lacks fails token minting — that's why org-only perms are jinja-gated.
 **[manual]:** create the App, install it on the repo, set the variable + secret.
 
 Required secrets/variables (**[manual]**, in CHECKLIST): `CLAUDE_CODE_OAUTH_TOKEN`
-(secret), `SNYK_TOKEN` (secret), `CI_APP_ID` (variable) + `CI_APP_PRIVATE_KEY`
+(secret), `SNYK_TOKEN` (secret), `CI_APP_CLIENT_ID` (variable) + `CI_APP_PRIVATE_KEY`
 (secret), `FULL_SECURITY_SCAN=true` (variable, to enable CodeQL).
 
 ### 1.8 Security

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -1,7 +1,7 @@
 name: Claude Implement
 run-name: ${{ github.actor }} is running Claude Implement
 # Requires: CLAUDE_CODE_OAUTH_TOKEN secret, plus the CI GitHub App
-# (CI_APP_ID variable + CI_APP_PRIVATE_KEY secret). See docs/CHECKLIST.md
+# (CI_APP_CLIENT_ID variable + CI_APP_PRIVATE_KEY secret). See docs/CHECKLIST.md
 # and docs/architecture/security.md.
 on:
   issue_comment:
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: implement pushes commits (contents), opens
           # PRs (pull-requests), comments (issues), and may touch

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: implement pushes commits (contents), opens
           # PRs (pull-requests), comments (issues), and may touch

--- a/.github/workflows/claude-plan.yml
+++ b/.github/workflows/claude-plan.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: plan only comments (issues/pull-requests) and
           # reads the repo (no push). org-projects gated to org repos only —

--- a/.github/workflows/claude-plan.yml
+++ b/.github/workflows/claude-plan.yml
@@ -1,7 +1,7 @@
 name: Claude Plan
 run-name: ${{ github.actor }} is running Claude Plan
 # Requires: CLAUDE_CODE_OAUTH_TOKEN secret, plus the CI GitHub App
-# (CI_APP_ID variable + CI_APP_PRIVATE_KEY secret). See docs/CHECKLIST.md
+# (CI_APP_CLIENT_ID variable + CI_APP_PRIVATE_KEY secret). See docs/CHECKLIST.md
 # and docs/architecture/security.md.
 on:
   issue_comment:
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: plan only comments (issues/pull-requests) and
           # reads the repo (no push). org-projects gated to org repos only —

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: review only comments (issues/pull-requests)
           # and reads the repo (no push). members:read is gated to org repos —

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,7 @@
 name: Claude Review
 run-name: ${{ github.actor }} is running Claude Review
 # Requires: CLAUDE_CODE_OAUTH_TOKEN secret, plus the CI GitHub App
-# (CI_APP_ID variable + CI_APP_PRIVATE_KEY secret). See docs/CHECKLIST.md
+# (CI_APP_CLIENT_ID variable + CI_APP_PRIVATE_KEY secret). See docs/CHECKLIST.md
 # and docs/architecture/security.md.
 on:
   issue_comment:
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: review only comments (issues/pull-requests)
           # and reads the repo (no push). members:read is gated to org repos —

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege: release-please commits/tags/releases (contents),
           # maintains the release PR (pull-requests), and applies the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege: release-please commits/tags/releases (contents),
           # maintains the release PR (pull-requests), and applies the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ task release:patch   # or release:minor / release:major
   conditionals (profile-invariant). See `docs/architecture/ci-cd.md`.
 - `.github/workflows/claude-{plan,implement,review}.yml` — Claude Code GitHub
   Actions. They (and `release.yml`) authenticate as the CI **GitHub App**
-  (`CI_APP_ID` variable + `CI_APP_PRIVATE_KEY` secret) and need the
+  (`CI_APP_CLIENT_ID` variable + `CI_APP_PRIVATE_KEY` secret) and need the
   `CLAUDE_CODE_OAUTH_TOKEN` secret. See `docs/architecture/security.md`.
 - Dependency updates via Renovate (`renovate.json`); reviews assisted by CodeRabbit
   (`.coderabbit.yaml`).

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -30,7 +30,7 @@ config, toolchain, devcontainer, and dev environment — against the items below
 - [ ] CI GitHub App `evanharmon1-ci`: create it by hand for this org (one App
       per org; **Settings → Developer settings → GitHub Apps**), or reuse the
       org's existing one;
-      install it on this repo, then set `CI_APP_ID` (Actions
+      install it on this repo, then set `CI_APP_CLIENT_ID` (Actions
       **variable**) + `CI_APP_PRIVATE_KEY` (Actions **secret**) — org-level for
       an org, per-repo for a personal account. Drives release-please, the
       claude-* workflows, and project-automation. See docs/architecture/security.md.

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -38,7 +38,7 @@ contained to a single org (no cross-org reach).
 Each job mints a short-lived (1h) installation token at runtime via
 `actions/create-github-app-token`, reading:
 
-- `CI_APP_ID` — Actions **variable** (this App's **Client ID** — the `Iv…`-style
+- `CI_APP_CLIENT_ID` — Actions **variable** (this App's **Client ID** — the `Iv…`-style
   string from the App's settings page, NOT the numeric App ID; not secret)
 - `CI_APP_PRIVATE_KEY` — Actions **secret** (this App's PEM private key)
 
@@ -71,7 +71,7 @@ a machine-readable reference; mirror it in the form.
 3. **Generate a private key** (downloads a `.pem`) and copy the **Client ID**
    (shown at the top of the App's settings page — not the numeric App ID).
 4. **Install App** → on this org, **Only select repositories** (not "All").
-5. Set `CI_APP_ID` (Actions variable = the App's Client ID) and `CI_APP_PRIVATE_KEY`
+5. Set `CI_APP_CLIENT_ID` (Actions variable = the App's Client ID) and `CI_APP_PRIVATE_KEY`
    (Actions secret = the `.pem` contents) — org-level for an org, per-repo for a
    personal account.
 
@@ -123,7 +123,7 @@ TODO: enumerate the tokens/secrets this repo depends on and where each lives:
 
 | Secret / variable | Used by | Stored in | Rotation |
 |---|---|---|---|
-| `CI_APP_ID` (var) + `CI_APP_PRIVATE_KEY` (secret) | release-please, claude-* | repo or org Actions variable + secret | rotate App key per policy |
+| `CI_APP_CLIENT_ID` (var) + `CI_APP_PRIVATE_KEY` (secret) | release-please, claude-* | repo or org Actions variable + secret | rotate App key per policy |
 | `CLAUDE_CODE_OAUTH_TOKEN` | claude-* workflows | repo Actions secret | TODO |
 | `SNYK_TOKEN` | `task security:sast`/`sca` | repo Actions secret | TODO |
 | TODO | TODO | TODO | TODO |

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -38,7 +38,8 @@ contained to a single org (no cross-org reach).
 Each job mints a short-lived (1h) installation token at runtime via
 `actions/create-github-app-token`, reading:
 
-- `CI_APP_ID` — Actions **variable** (this App's numeric id; not secret)
+- `CI_APP_ID` — Actions **variable** (this App's **Client ID** — the `Iv…`-style
+  string from the App's settings page, NOT the numeric App ID; not secret)
 - `CI_APP_PRIVATE_KEY` — Actions **secret** (this App's PEM private key)
 
 Set both once as **org-level** Actions variable + secret (every repo in the org
@@ -58,7 +59,7 @@ a machine-readable reference; mirror it in the form.
    personal account, `https://github.com/settings/apps/new`
    (**Settings → Developer settings → GitHub Apps → New GitHub App**).
 2. Set **GitHub App name** `evanharmon1-ci` (names are globally unique — if
-   it's taken, add a suffix; the workflows reference the **App ID**, not the
+   it's taken, add a suffix; the workflows reference the **Client ID**, not the
    name), **Description** = the `description` from the manifest (optional,
    cosmetic — documents what the App is for), **Homepage URL** = the owner's page
    `https://github.com/evanharmon1` (also required-but-cosmetic — it doesn't
@@ -67,9 +68,10 @@ a machine-readable reference; mirror it in the form.
    CI uses installation tokens, not the user-to-server tokens this governs), grant
    the permissions in the table below, and choose **"Only on this account"**. Then
    scroll down and click **Create GitHub App**.
-3. **Generate a private key** (downloads a `.pem`) and note the **App ID**.
+3. **Generate a private key** (downloads a `.pem`) and copy the **Client ID**
+   (shown at the top of the App's settings page — not the numeric App ID).
 4. **Install App** → on this org, **Only select repositories** (not "All").
-5. Set `CI_APP_ID` (Actions variable = the App ID) and `CI_APP_PRIVATE_KEY`
+5. Set `CI_APP_ID` (Actions variable = the App's Client ID) and `CI_APP_PRIVATE_KEY`
    (Actions secret = the `.pem` contents) — org-level for an org, per-repo for a
    personal account.
 

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -628,10 +628,10 @@ if [[ "${SECTION}" == "setup" ]]; then
                     checkline na "CLAUDE_CODE_OAUTH_TOKEN" "no claude-* workflows"
                 fi
                 if [ "${uses_ci_app}" = 1 ]; then
-                    if has_cred "${d}/vars.json" "CI_APP_ID"; then
-                        checkline ok "CI_APP_ID (variable)"
+                    if has_cred "${d}/vars.json" "CI_APP_CLIENT_ID"; then
+                        checkline ok "CI_APP_CLIENT_ID (variable)"
                     else
-                        checkline no "CI_APP_ID (variable)" "gh variable set"
+                        checkline no "CI_APP_CLIENT_ID (variable)" "gh variable set"
                     fi
                     if has_cred "${d}/secrets.json" "CI_APP_PRIVATE_KEY"; then
                         checkline ok "CI_APP_PRIVATE_KEY (secret)"

--- a/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
@@ -1,7 +1,7 @@
 name: Project Automation
 # Syncs the org-level GitHub Project V2 "Status" field from PR/CI events.
 # Requires: an org Project (number 1) with a Status field, and the CI GitHub App
-# (CI_APP_ID variable + CI_APP_PRIVATE_KEY secret) installed on the org with
+# (CI_APP_CLIENT_ID variable + CI_APP_PRIVATE_KEY secret) installed on the org with
 # Projects: Read and write (see docs/CHECKLIST.md and docs/architecture/security.md).
 on:
   pull_request:
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: read CI run conclusions (actions) and PR/
           # repo data, then update the org Project V2 Status field

--- a/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: read CI run conclusions (actions) and PR/
           # repo data, then update the org Project V2 Status field

--- a/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege: release-please commits/tags/releases (contents),
           # maintains the release PR (pull-requests), and applies the

--- a/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege: release-please commits/tags/releases (contents),
           # maintains the release PR (pull-requests), and applies the

--- a/template/.github/workflows/claude-implement.yml.jinja
+++ b/template/.github/workflows/claude-implement.yml.jinja
@@ -1,7 +1,7 @@
 name: Claude Implement
 run-name: ${{ github.actor }} is running Claude Implement
 # Requires: CLAUDE_CODE_OAUTH_TOKEN secret, plus the CI GitHub App
-# (CI_APP_ID variable + CI_APP_PRIVATE_KEY secret). See docs/CHECKLIST.md
+# (CI_APP_CLIENT_ID variable + CI_APP_PRIVATE_KEY secret). See docs/CHECKLIST.md
 # and docs/architecture/security.md.
 on:
   issue_comment:
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: implement pushes commits (contents), opens
           # PRs (pull-requests), comments (issues), and may touch

--- a/template/.github/workflows/claude-implement.yml.jinja
+++ b/template/.github/workflows/claude-implement.yml.jinja
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: implement pushes commits (contents), opens
           # PRs (pull-requests), comments (issues), and may touch

--- a/template/.github/workflows/claude-plan.yml.jinja
+++ b/template/.github/workflows/claude-plan.yml.jinja
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: plan only comments (issues/pull-requests) and
           # reads the repo (no push). org-projects gated to org repos only —

--- a/template/.github/workflows/claude-plan.yml.jinja
+++ b/template/.github/workflows/claude-plan.yml.jinja
@@ -1,7 +1,7 @@
 name: Claude Plan
 run-name: ${{ github.actor }} is running Claude Plan
 # Requires: CLAUDE_CODE_OAUTH_TOKEN secret, plus the CI GitHub App
-# (CI_APP_ID variable + CI_APP_PRIVATE_KEY secret). See docs/CHECKLIST.md
+# (CI_APP_CLIENT_ID variable + CI_APP_PRIVATE_KEY secret). See docs/CHECKLIST.md
 # and docs/architecture/security.md.
 on:
   issue_comment:
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: plan only comments (issues/pull-requests) and
           # reads the repo (no push). org-projects gated to org repos only —

--- a/template/.github/workflows/claude-review.yml.jinja
+++ b/template/.github/workflows/claude-review.yml.jinja
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: review only comments (issues/pull-requests)
           # and reads the repo (no push). members:read is gated to org repos —

--- a/template/.github/workflows/claude-review.yml.jinja
+++ b/template/.github/workflows/claude-review.yml.jinja
@@ -1,7 +1,7 @@
 name: Claude Review
 run-name: ${{ github.actor }} is running Claude Review
 # Requires: CLAUDE_CODE_OAUTH_TOKEN secret, plus the CI GitHub App
-# (CI_APP_ID variable + CI_APP_PRIVATE_KEY secret). See docs/CHECKLIST.md
+# (CI_APP_CLIENT_ID variable + CI_APP_PRIVATE_KEY secret). See docs/CHECKLIST.md
 # and docs/architecture/security.md.
 on:
   issue_comment:
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: review only comments (issues/pull-requests)
           # and reads the repo (no push). members:read is gated to org repos —

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -32,7 +32,7 @@ config, toolchain, devcontainer, and dev environment — against the items below
 - [ ] CI GitHub App `[[ github_org ]]-ci`: create it by hand for this org (one App
       per org; **Settings → Developer settings → GitHub Apps**), or reuse the
       org's existing one;
-      install it on this repo, then set `CI_APP_ID` (Actions
+      install it on this repo, then set `CI_APP_CLIENT_ID` (Actions
       **variable**) + `CI_APP_PRIVATE_KEY` (Actions **secret**) — org-level for
       an org, per-repo for a personal account. Drives release-please, the
       claude-* workflows, and project-automation. See docs/architecture/security.md.

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -46,7 +46,8 @@ contained to a single org (no cross-org reach).
 Each job mints a short-lived (1h) installation token at runtime via
 `actions/create-github-app-token`, reading:
 
-- `CI_APP_ID` — Actions **variable** (this App's numeric id; not secret)
+- `CI_APP_ID` — Actions **variable** (this App's **Client ID** — the `Iv…`-style
+  string from the App's settings page, NOT the numeric App ID; not secret)
 - `CI_APP_PRIVATE_KEY` — Actions **secret** (this App's PEM private key)
 
 Set both once as **org-level** Actions variable + secret (every repo in the org
@@ -66,7 +67,7 @@ a machine-readable reference; mirror it in the form.
    personal account, `https://github.com/settings/apps/new`
    (**Settings → Developer settings → GitHub Apps → New GitHub App**).
 2. Set **GitHub App name** `[[ github_org ]]-ci` (names are globally unique — if
-   it's taken, add a suffix; the workflows reference the **App ID**, not the
+   it's taken, add a suffix; the workflows reference the **Client ID**, not the
    name), **Description** = the `description` from the manifest (optional,
    cosmetic — documents what the App is for), **Homepage URL** = the owner's page
    `https://github.com/[[ github_org ]]` (also required-but-cosmetic — it doesn't
@@ -75,9 +76,10 @@ a machine-readable reference; mirror it in the form.
    CI uses installation tokens, not the user-to-server tokens this governs), grant
    the permissions in the table below, and choose **"Only on this account"**. Then
    scroll down and click **Create GitHub App**.
-3. **Generate a private key** (downloads a `.pem`) and note the **App ID**.
+3. **Generate a private key** (downloads a `.pem`) and copy the **Client ID**
+   (shown at the top of the App's settings page — not the numeric App ID).
 4. **Install App** → on this org, **Only select repositories** (not "All").
-5. Set `CI_APP_ID` (Actions variable = the App ID) and `CI_APP_PRIVATE_KEY`
+5. Set `CI_APP_ID` (Actions variable = the App's Client ID) and `CI_APP_PRIVATE_KEY`
    (Actions secret = the `.pem` contents) — org-level for an org, per-repo for a
    personal account.
 

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -46,7 +46,7 @@ contained to a single org (no cross-org reach).
 Each job mints a short-lived (1h) installation token at runtime via
 `actions/create-github-app-token`, reading:
 
-- `CI_APP_ID` — Actions **variable** (this App's **Client ID** — the `Iv…`-style
+- `CI_APP_CLIENT_ID` — Actions **variable** (this App's **Client ID** — the `Iv…`-style
   string from the App's settings page, NOT the numeric App ID; not secret)
 - `CI_APP_PRIVATE_KEY` — Actions **secret** (this App's PEM private key)
 
@@ -79,7 +79,7 @@ a machine-readable reference; mirror it in the form.
 3. **Generate a private key** (downloads a `.pem`) and copy the **Client ID**
    (shown at the top of the App's settings page — not the numeric App ID).
 4. **Install App** → on this org, **Only select repositories** (not "All").
-5. Set `CI_APP_ID` (Actions variable = the App's Client ID) and `CI_APP_PRIVATE_KEY`
+5. Set `CI_APP_CLIENT_ID` (Actions variable = the App's Client ID) and `CI_APP_PRIVATE_KEY`
    (Actions secret = the `.pem` contents) — org-level for an org, per-repo for a
    personal account.
 
@@ -136,7 +136,7 @@ TODO: enumerate the tokens/secrets this repo depends on and where each lives:
 
 | Secret / variable | Used by | Stored in | Rotation |
 |---|---|---|---|
-| `CI_APP_ID` (var) + `CI_APP_PRIVATE_KEY` (secret) | [% if use_release_please %]release-please, [% endif %]claude-*[% if github_org != author_git_provider_username %], project-automation[% endif %] | repo or org Actions variable + secret | rotate App key per policy |
+| `CI_APP_CLIENT_ID` (var) + `CI_APP_PRIVATE_KEY` (secret) | [% if use_release_please %]release-please, [% endif %]claude-*[% if github_org != author_git_provider_username %], project-automation[% endif %] | repo or org Actions variable + secret | rotate App key per policy |
 | `CLAUDE_CODE_OAUTH_TOKEN` | claude-* workflows | repo Actions secret | TODO |
 | `SNYK_TOKEN` | `task security:sast`/`sca` | repo Actions secret | TODO |
 | TODO | TODO | TODO | TODO |

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -628,10 +628,10 @@ if [[ "${SECTION}" == "setup" ]]; then
                     checkline na "CLAUDE_CODE_OAUTH_TOKEN" "no claude-* workflows"
                 fi
                 if [ "${uses_ci_app}" = 1 ]; then
-                    if has_cred "${d}/vars.json" "CI_APP_ID"; then
-                        checkline ok "CI_APP_ID (variable)"
+                    if has_cred "${d}/vars.json" "CI_APP_CLIENT_ID"; then
+                        checkline ok "CI_APP_CLIENT_ID (variable)"
                     else
-                        checkline no "CI_APP_ID (variable)" "gh variable set"
+                        checkline no "CI_APP_CLIENT_ID (variable)" "gh variable set"
                     fi
                     if has_cred "${d}/secrets.json" "CI_APP_PRIVATE_KEY"; then
                         checkline ok "CI_APP_PRIVATE_KEY (secret)"


### PR DESCRIPTION
`actions/create-github-app-token` deprecated `app-id` in favor of `client-id`. Switches the input across the claude-* / release / project-automation workflows (template + root dogfood).

**Value change:** `CI_APP_ID` now holds the App's **Client ID** (the `Iv…`-style string from the App settings page), not the numeric App ID. I kept the variable *name* so existing setups only need to repoint the *value* (vs creating a new variable everywhere). `docs/architecture/security.md` updated — the creation steps now copy the Client ID, and the "numeric id" wording is corrected.

⚠️ **Operational note:** any repo already using the App must repoint its `CI_APP_ID` variable to the App's **Client ID** when it takes this update, or `create-github-app-token` rejects the numeric value.

## Verification
- `task verify` → exit 0 (incl. `test-template-update: PASS`).
- Rendered output uses `client-id: ${{ vars.CI_APP_ID }}`; no `app-id:` or "numeric id" left.

Sibling PRs apply the same change to the live repos: sommerlawn/sommerlawn-web#387 and evanharmon1/harmon-devkit#40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)