### PR TITLE
fix(template): freeze .github/CODEOWNERS (don't clobber repo owners on adopt)

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -276,7 +276,8 @@ _subdirectory: template
 # copier's three-way merge keeps delivering template improvements (e.g. a new
 # README section) while preserving the repo's own edits; only overlapping edits
 # conflict, and the update flow reconciles those. `_skip_if_exists` freezes a
-# file entirely, so it is reserved for content owned by another generator:
+# file entirely, so it is reserved for content owned by another generator or by
+# the consumer (their own access decisions):
 #   - CHANGELOG.md — release-please owns it; template merges would fight it.
 _skip_if_exists:
   - CHANGELOG.md
@@ -284,6 +285,13 @@ _skip_if_exists:
   # by the consumer; freeze it so `copier update` never regenerates a new color
   # (which would churn a now-committed file on every update).
   - "*.code-workspace"
+  # CODEOWNERS encodes the repo's real access control (who must review / is
+  # auto-requested). The template renders it from the single `code_owner` answer
+  # (`* @code_owner`), which can't represent a second owner or a team — so a
+  # Path-B adopt over a repo with MORE owners would silently DROP them (a security
+  # regression). Freeze it: a fresh scaffold still gets `* @code_owner`; an
+  # existing CODEOWNERS is never clobbered on adopt/update.
+  - .github/CODEOWNERS
 
 # Keep CLAUDE.md/GEMINI.md as symlinks to AGENTS.md in generated projects
 # (without this, copier dereferences symlinks into duplicate files).


### PR DESCRIPTION
**Problem:** CODEOWNERS is rendered from the single `code_owner` answer (`* @code_owner`), which can't represent a second owner or a team. A Path-B `--overwrite` adopt over a repo with more owners therefore **silently drops them** — an access-control regression. (It dropped `@AdmiralFraggle` from sommerlawn-web's CODEOWNERS during its adopt.)

**Fix:** add `.github/CODEOWNERS` to `_skip_if_exists`, next to CHANGELOG + the workspace file (consumer-/generator-owned content the template must not clobber). CODEOWNERS encodes the repo's real access decisions, so:
- a **fresh scaffold** still renders `* @code_owner`;
- an **adopt/update over an existing repo** never overwrites CODEOWNERS — the clobber becomes impossible.

**Verified:** re-rendering with `--overwrite` over a `* @evanharmon1 @AdmiralFraggle` CODEOWNERS preserves both owners; `task verify` green.

Paired with a harmon-devkit skill guardrail (verify-applied.sh fails if an adopt drops a CODEOWNERS owner) as defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)