### PR TITLE
test(template): lint rendered Markdown in test-template.sh

### DIFF
--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -202,6 +202,23 @@ if [ -f prettier.config.cjs ] && have npx; then
     fi
 fi
 
+# ── 3c. Rendered Markdown is markdownlint-clean ─────────────────────
+# Markdown is excluded from prettier (.prettierignore hands it to markdownlint),
+# and nothing else above covers it — so a rendered .md that breaks a markdownlint
+# rule (a jinja emitting a bad heading level, list, or fenced block) ships and
+# only fails when a consumer runs `task lint:markdown`. Run markdownlint-cli2 in
+# CHECK mode with the same globs as that target — NOT `task lint:markdown`, which
+# runs `--fix` (it would mutate the render and mask issues). The rendered
+# .markdownlint(.json/.jsonc) config is auto-discovered.
+if have npx; then
+    if ! md_out=$(npx --yes markdownlint-cli2 '**/*.md' '#.claude/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' '#**/.terraform/**' '#**/.venv/**' '#**/.task/**' 2>&1); then
+        printf '%s\n' "$md_out" >&2
+        err "rendered Markdown fails markdownlint"
+    fi
+else
+    required npx "rendered Markdown lint (markdownlint-cli2 via npx)" || fail=1
+fi
+
 # ── 4. Rendered YAML is valid (yamllint, errors only) ───────────────
 if have yamllint; then
     yamllint --no-warnings . || err "yamllint errors in rendered output"

--- a/template/CONTRIBUTING.md.jinja
+++ b/template/CONTRIBUTING.md.jinja
@@ -51,6 +51,7 @@ Feel free to submit a pull request with your improvements.
 We follow the [Conventional Commits](https://www.conventionalcommits.org) standard for writing commit messages. This helps us manage the code history, generate changelogs, and automate CI/CD tooling. Example:
 
 Example commit message:
+
 ```text
 feat(api): add support for custom endpoints
 
@@ -59,6 +60,7 @@ Resolves issue #42.
 ```
 
 Commit message structure:
+
 ```text
 <type>[optional scope]: <description>
 


### PR DESCRIPTION
`test-template.sh` already lints the rendered output's YAML (`yamllint`), shell (`shellcheck`+`shfmt`), workflows (`actionlint`), JSON, lefthook, and runs `prettier` + the rendered `lint:hygiene` — but **never ran markdownlint**. So a rendered `.md` that breaks a markdownlint rule (a jinja emitting a bad heading level / list / fenced block) shipped unseen and only surfaced when a consumer ran `task lint:markdown`. This is the long-standing follow-up from the LICENSE-newline bug, applied to Markdown.

## Change
- **§3c**: a read-only `markdownlint-cli2` check over the render, with the same globs as the generated `lint:markdown` target (gated on `npx`, like the other linters are gated on availability).
- It **immediately caught a real defect**: `template/CONTRIBUTING.md.jinja` emitted two fenced blocks without surrounding blank lines (**MD031**) — fixed. (Root's `CONTRIBUTING.md` was already clean, so this re-syncs the jinja to it — a dogfood drift.)

## Why a direct check, not `task lint:markdown`
The generated `lint:markdown` runs `markdownlint-cli2 **--fix**` — it would *mutate* the render and *mask* fixable issues rather than fail. That's also an inconsistency vs the read-only `lint:yaml`/`lint:shell`/`lint:actions` targets (a `lint:` that mutates + lets fixable issues slip silently through CI). **Flagging it as a separate follow-up** — making `lint:markdown` a pure check would let those issues surface + get fixed in the template instead of auto-repaired in each consumer's working tree.

## Verified
- `task verify` → exit 0; all five profiles (minimal/web/iac/full/meta) pass.
- Injected an **MD040** (fenced block without a language) into a template `.md` → test-template now **FAILS** with the markdownlint error; reverted clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)