### PR TITLE
fix(template): make lint:markdown a read-only gate + document lint-vs-format discipline

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -102,13 +102,17 @@ tasks:
         shfmt -d $files
 
   lint:markdown:
-    desc: markdownlint-cli2 (template/ excluded — jinja markdown)
+    # Check-only (no --fix) so this is a read-only gate like lint:prettier /
+    # lint:shell: CI and the pre-commit hook fail loudly instead of silently
+    # mutating the tree (and, in CI, discarding the fix while reporting green).
+    # Auto-fix lives in `task format` / `task format:file`.
+    desc: markdownlint-cli2, check mode (template/ excluded — jinja markdown)
     cmds:
       - |
         if [ -n "{{.CLI_ARGS}}" ]; then
-          npx --yes markdownlint-cli2 --fix {{.CLI_ARGS}}
+          npx --yes markdownlint-cli2 {{.CLI_ARGS}}
         else
-          npx --yes markdownlint-cli2 --fix '**/*.md' '#template/**' '#.claude/**' '#**/node_modules/**' '#.worktrees/**'
+          npx --yes markdownlint-cli2 '**/*.md' '#template/**' '#.claude/**' '#**/node_modules/**' '#.worktrees/**'
         fi
 
   lint:actions:

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -120,13 +120,17 @@ tasks:
         shfmt -d $files
 
   lint:markdown:
-    desc: markdownlint-cli2
+    # Check-only (no --fix) so this is a read-only gate like lint:prettier /
+    # lint:shell: CI and the pre-commit hook fail loudly instead of silently
+    # mutating the tree (and, in CI, discarding the fix while reporting green).
+    # Auto-fix lives in `task format` / `task format:file`.
+    desc: markdownlint-cli2 (check mode)
     cmds:
       - |
         if [ -n "{{.CLI_ARGS}}" ]; then
-          npx --yes markdownlint-cli2 --fix {{.CLI_ARGS}}
+          npx --yes markdownlint-cli2 {{.CLI_ARGS}}
         else
-          npx --yes markdownlint-cli2 --fix '**/*.md' '#.claude/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' '#**/.terraform/**' '#**/.venv/**' '#**/.task/**'
+          npx --yes markdownlint-cli2 '**/*.md' '#.claude/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' '#**/.terraform/**' '#**/.venv/**' '#**/.task/**'
         fi
 
   lint:actions:


### PR DESCRIPTION
Two commits: **enforce** the principle, then **document** it so it can't silently regress.

## 1. `lint:markdown` → read-only gate (drop `--fix`)
It ran `markdownlint-cli2 **--fix**` — the **only** `lint:*` task that mutates files. Every sibling gate is read-only (`lint:prettier` → `--check`, `lint:shell` → `shfmt -d`, `lint:python` → `black --check`, `lint:terraform` → `fmt -check`). A *gate* that auto-mutates is wrong two ways:

1. **CI lies green** — `--fix` repairs the ephemeral checkout, exits 0, the fix is discarded with the runner; the branch stays unformatted.
2. **The pre-commit hook commits the broken version** — the hook runs `task lint:markdown -- {staged_files}` with no `stage_fixed`, so `--fix` edits the working tree but the commit captures the *unfixed staged blob*, leaving a dirty tree. Prettier in the same hook uses `--check` and cleanly blocks.

Auto-fix is unchanged — it still lives in `task format` / `format:file` / `fix`.

## 2. Document the discipline (`conventions.md`, template + root)
The code already obeyed this everywhere except `lint:markdown`; it was never *written down*, which is how the regression crept in. Added to the Taskfile section of `conventions.md`: **lint:\* and check are read-only gates; all auto-fixing lives in `format`/`fix`; hooks run the read-only `lint:*` so a failing check blocks-and-tells.** (Companion standard added to the standardize-repo catalog in harmon-devkit#44 so `audit` mode flags future mutating `lint:*`.)

## Verified
- `task verify` → exit 0 (root markdown clean: 39 files, 0 errors — `--fix` wasn't hiding anything).
- The new conventions prose passes the now-strict gate (root `lint:markdown` + rendered §3c).
- Rendered a generated repo → check-only command + comment, `{{.CLI_ARGS}}` preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)