### PR TITLE
feat(template): related-repos devcontainer bootstrap (clone + non-destructive fetch)

### DIFF
--- a/.devcontainer/related-repos.txt
+++ b/.devcontainer/related-repos.txt
@@ -1,0 +1,23 @@
+# Related repos to work on alongside this one inside the devcontainer.
+# Cloned into /workspaces/ on container CREATE, and git-fetched (non-
+# destructively) on container START. Read by:
+#   .devcontainer/scripts/bootstrap-related-repos.sh   (clone if missing)
+#   .devcontainer/scripts/fetch-related-repos.sh       (git fetch if present)
+#
+# One entry per line:
+#   owner/repo                       # default branch, cloned via gh CLI
+#   owner/repo@branch                # specific branch
+#   https://github.com/owner/repo    # full URL (also supports .git suffix)
+#   git@github.com:owner/repo.git    # ssh URL
+#
+# Lines starting with # are comments; blank lines are ignored. Existing
+# /workspaces/<repo> dirs are never clobbered (no pull, no checkout, no reset).
+#
+# To let Claude read/search the cloned siblings, also list them in
+# .claude/settings.json under permissions.additionalDirectories (Claude's file
+# tools) AND sandbox.filesystem.allowRead (the Bash sandbox). See
+# docs/guides/devcontainers.md.
+#
+# Examples — uncomment and edit:
+#   your-org/shared-libs
+#   your-org/api@main

--- a/.devcontainer/scripts/bootstrap-related-repos.sh
+++ b/.devcontainer/scripts/bootstrap-related-repos.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Clone "related" repos listed in .devcontainer/related-repos.txt into
+# /workspaces/, adjacent to the main repo. Idempotent and NON-DESTRUCTIVE: if a
+# target dir already exists it is left completely untouched (no fetch, no pull,
+# no checkout, no warning) — fetching is fetch-related-repos.sh's job at start.
+#
+# Runs on devcontainer create (post-create-common.sh), so a rebuilt or
+# persistence-lost container re-clones any sibling that is missing.
+#
+# Config format (.devcontainer/related-repos.txt):
+#   owner/repo                       # default branch, cloned via gh CLI
+#   owner/repo@branch                # specific branch
+#   https://github.com/owner/repo    # full URL (also supports .git suffix)
+#   git@github.com:owner/repo.git    # ssh URL
+#
+# Lines starting with # are comments. Blank lines are ignored.
+#
+# Failures (missing config, bad URL, network errors) log a warning and
+# continue — this script never causes post-create to fail.
+
+# Prevent VS Code's JS debug bootloader from breaking child Node processes
+# spawned by gh. See post-create-common.sh for the full explanation.
+unset NODE_OPTIONS
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/../related-repos.txt"
+WORKSPACES_DIR="/workspaces"
+
+# --- Pre-flight checks ---
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "==> No related-repos.txt found at ${CONFIG_FILE}; skipping."
+    exit 0
+fi
+
+if [ ! -d "$WORKSPACES_DIR" ]; then
+    echo "==> WARNING: ${WORKSPACES_DIR} does not exist; skipping related-repo bootstrap." >&2
+    exit 0
+fi
+
+# /workspaces is owned by root in the devcontainer image — VS Code only fixes
+# ownership on the workspace folder itself, not its parent. Make it writable
+# by vscode so subsequent `git clone` calls can create sibling directories.
+# Idempotent: chown is a no-op if ownership already matches.
+if [ ! -w "$WORKSPACES_DIR" ]; then
+    sudo chown vscode:vscode "$WORKSPACES_DIR"
+fi
+
+# --- Parse and clone ---
+
+cloned=0
+skipped=0
+failed=0
+
+while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+    # Strip inline comments (everything from the first # onward), then trim
+    # leading and trailing whitespace.
+    line="${raw_line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+
+    # Skip blank lines (and lines that were comment-only).
+    [ -z "$line" ] && continue
+
+    # Split optional @branch suffix. Only split on the LAST @ so ssh URLs
+    # like git@github.com:o/r.git are not mangled — those URLs always end
+    # in .git, so a trailing @branch on the same line is unambiguous.
+    branch=""
+    target_spec="$line"
+    if [[ "$line" == *"@"* ]]; then
+        suffix="${line##*@}"
+        # Treat the suffix as a branch only if it doesn't look like a host
+        # (no dots, no colons, no slashes). This keeps `git@github.com:...`
+        # intact while still splitting `owner/repo@feature/foo` correctly
+        # only when the user wrote a plain branch name.
+        if [[ "$suffix" != *.* && "$suffix" != *:* && "$suffix" != */* ]]; then
+            branch="$suffix"
+            target_spec="${line%@*}"
+        fi
+    fi
+
+    # Derive the target basename.
+    #   owner/repo                  -> repo
+    #   https://host/owner/repo.git -> repo
+    #   git@host:owner/repo.git     -> repo
+    basename_raw="${target_spec##*/}"  # strip everything up to last /
+    basename_raw="${basename_raw##*:}" # strip ssh "host:" prefix if any
+    basename="${basename_raw%.git}"    # strip optional .git
+
+    if [ -z "$basename" ]; then
+        echo "==> WARNING: could not derive directory name for entry '${raw_line}'; skipping." >&2
+        failed=$((failed + 1))
+        continue
+    fi
+
+    target="${WORKSPACES_DIR}/${basename}"
+
+    if [ -e "$target" ]; then
+        echo "==> Skipping ${basename} (already present at ${target})"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    # Decide whether to use gh (for owner/repo shorthand) or git (for URLs).
+    use_gh=false
+    if [[ "$target_spec" != *://* && "$target_spec" != *@*:* && "$target_spec" == */* ]]; then
+        use_gh=true
+    fi
+
+    branch_label="${branch:-default branch}"
+    echo "==> Cloning ${target_spec} (${branch_label}) -> ${target}"
+
+    set +e
+    if [ "$use_gh" = true ]; then
+        if [ -n "$branch" ]; then
+            gh repo clone "$target_spec" "$target" -- --branch "$branch" --quiet
+        else
+            gh repo clone "$target_spec" "$target" -- --quiet
+        fi
+    else
+        if [ -n "$branch" ]; then
+            git clone --quiet --branch "$branch" "$target_spec" "$target"
+        else
+            git clone --quiet "$target_spec" "$target"
+        fi
+    fi
+    rc=$?
+    set -e
+
+    if [ "$rc" -eq 0 ]; then
+        cloned=$((cloned + 1))
+    else
+        echo "==> WARNING: failed to clone ${target_spec} (exit ${rc}); continuing." >&2
+        failed=$((failed + 1))
+        # Clean up partial clone if gh/git left a stub directory behind.
+        [ -d "$target" ] && rm -rf "$target"
+    fi
+done <"$CONFIG_FILE"
+
+# --- Summary ---
+
+total=$((cloned + skipped + failed))
+if [ "$total" -eq 0 ]; then
+    echo "==> No repos configured in ${CONFIG_FILE}; nothing to do."
+else
+    echo "==> Bootstrap complete: ${cloned} cloned, ${skipped} skipped, ${failed} failed"
+fi
+
+# Always exit 0 — failures are logged but never block post-create.
+exit 0

--- a/.devcontainer/scripts/fetch-related-repos.sh
+++ b/.devcontainer/scripts/fetch-related-repos.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Freshen already-cloned related repos in /workspaces/ on devcontainer START
+# (post-start-common.sh), so siblings track their remotes without a manual
+# fetch. Reads the same config as bootstrap-related-repos.sh:
+# .devcontainer/related-repos.txt.
+#
+# STRICTLY NON-DESTRUCTIVE: runs `git fetch` only (updates remote-tracking refs
+# and prunes deleted ones). It NEVER pulls, merges, checks out, or resets — so
+# uncommitted changes, local commits, and the checked-out branch are left
+# exactly as they are. Repos not yet cloned are skipped (bootstrap clones those
+# at create time). Failures log a warning and continue; this never blocks start.
+
+# Prevent VS Code's JS debug bootloader from breaking child Node processes.
+unset NODE_OPTIONS
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/../related-repos.txt"
+WORKSPACES_DIR="/workspaces"
+
+[ -f "$CONFIG_FILE" ] || exit 0
+[ -d "$WORKSPACES_DIR" ] || exit 0
+
+fetched=0
+skipped=0
+failed=0
+
+while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+    # Strip inline comments, then trim leading/trailing whitespace.
+    line="${raw_line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ -z "$line" ] && continue
+
+    # Derive the target basename, mirroring bootstrap-related-repos.sh: drop an
+    # optional plain @branch suffix (but keep ssh git@host:... intact), then
+    # strip the path, any ssh "host:" prefix, and a trailing .git.
+    target_spec="$line"
+    if [[ "$line" == *"@"* ]]; then
+        suffix="${line##*@}"
+        if [[ "$suffix" != *.* && "$suffix" != *:* && "$suffix" != */* ]]; then
+            target_spec="${line%@*}"
+        fi
+    fi
+    basename_raw="${target_spec##*/}"
+    basename_raw="${basename_raw##*:}"
+    basename="${basename_raw%.git}"
+    [ -z "$basename" ] && continue
+
+    dir="${WORKSPACES_DIR}/${basename}"
+
+    # Only fetch repos that are already cloned; bootstrap handles the rest.
+    if [ ! -d "${dir}/.git" ]; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    if git -C "$dir" fetch --all --prune --quiet 2>/dev/null; then
+        fetched=$((fetched + 1))
+    else
+        echo "==> WARNING: fetch failed for ${basename}; continuing." >&2
+        failed=$((failed + 1))
+    fi
+done <"$CONFIG_FILE"
+
+total=$((fetched + skipped + failed))
+if [ "$total" -gt 0 ]; then
+    echo "==> Related-repo fetch: ${fetched} fetched, ${skipped} not-yet-cloned, ${failed} failed"
+fi
+
+# Always exit 0 — never block container start.
+exit 0

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -209,4 +209,9 @@ if command -v direnv &>/dev/null && [ -f .envrc ]; then
     direnv allow
 fi
 
+# Clone related repos into /workspaces/ (idempotent + non-destructive; reads
+# .devcontainer/related-repos.txt). Runs on create so a rebuilt container
+# re-populates siblings. No-op when the list is empty/absent.
+bash .devcontainer/scripts/bootstrap-related-repos.sh
+
 echo "==> Setup complete! Run 'task verify' to validate your environment."

--- a/.devcontainer/scripts/post-start-common.sh
+++ b/.devcontainer/scripts/post-start-common.sh
@@ -42,6 +42,14 @@ if command -v jq &>/dev/null; then
     fi
 fi
 
+# --- Freshen related repos in the background (non-destructive git fetch) ---
+# Reads .devcontainer/related-repos.txt and git-fetches already-cloned siblings
+# in /workspaces/ so they track their remotes. NEVER pulls/merges/checks out —
+# local work is left untouched. nohup'd + backgrounded so it neither delays the
+# session nor is killed with the postStart process group. No-op for an empty list.
+nohup bash .devcontainer/scripts/fetch-related-repos.sh \
+    >>"$HOME/.related-repos-fetch.log" 2>&1 &
+
 echo "==> Starting tmux session..."
 if command -v tmux &>/dev/null; then
     tmux has-session -t default 2>/dev/null || tmux new-session -d -s default

--- a/copier.yml
+++ b/copier.yml
@@ -292,6 +292,11 @@ _skip_if_exists:
   # regression). Freeze it: a fresh scaffold still gets `* @code_owner`; an
   # existing CODEOWNERS is never clobbered on adopt/update.
   - .github/CODEOWNERS
+  # related-repos.txt is the repo's curated list of sibling repos to clone/fetch
+  # in the devcontainer (the bootstrap/fetch scripts are template-owned and keep
+  # updating; only the list is per-repo). Ship an empty stub on first scaffold,
+  # then freeze it so `copier update` never overwrites a populated list.
+  - .devcontainer/related-repos.txt
 
 # Keep CLAUDE.md/GEMINI.md as symlinks to AGENTS.md in generated projects
 # (without this, copier dereferences symlinks into duplicate files).

--- a/template/[% if devcontainer %].devcontainer[% endif %]/related-repos.txt
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/related-repos.txt
@@ -1,0 +1,23 @@
+# Related repos to work on alongside this one inside the devcontainer.
+# Cloned into /workspaces/ on container CREATE, and git-fetched (non-
+# destructively) on container START. Read by:
+#   .devcontainer/scripts/bootstrap-related-repos.sh   (clone if missing)
+#   .devcontainer/scripts/fetch-related-repos.sh       (git fetch if present)
+#
+# One entry per line:
+#   owner/repo                       # default branch, cloned via gh CLI
+#   owner/repo@branch                # specific branch
+#   https://github.com/owner/repo    # full URL (also supports .git suffix)
+#   git@github.com:owner/repo.git    # ssh URL
+#
+# Lines starting with # are comments; blank lines are ignored. Existing
+# /workspaces/<repo> dirs are never clobbered (no pull, no checkout, no reset).
+#
+# To let Claude read/search the cloned siblings, also list them in
+# .claude/settings.json under permissions.additionalDirectories (Claude's file
+# tools) AND sandbox.filesystem.allowRead (the Bash sandbox). See
+# docs/guides/devcontainers.md.
+#
+# Examples — uncomment and edit:
+#   your-org/shared-libs
+#   your-org/api@main

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/bootstrap-related-repos.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/bootstrap-related-repos.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Clone "related" repos listed in .devcontainer/related-repos.txt into
+# /workspaces/, adjacent to the main repo. Idempotent and NON-DESTRUCTIVE: if a
+# target dir already exists it is left completely untouched (no fetch, no pull,
+# no checkout, no warning) — fetching is fetch-related-repos.sh's job at start.
+#
+# Runs on devcontainer create (post-create-common.sh), so a rebuilt or
+# persistence-lost container re-clones any sibling that is missing.
+#
+# Config format (.devcontainer/related-repos.txt):
+#   owner/repo                       # default branch, cloned via gh CLI
+#   owner/repo@branch                # specific branch
+#   https://github.com/owner/repo    # full URL (also supports .git suffix)
+#   git@github.com:owner/repo.git    # ssh URL
+#
+# Lines starting with # are comments. Blank lines are ignored.
+#
+# Failures (missing config, bad URL, network errors) log a warning and
+# continue — this script never causes post-create to fail.
+
+# Prevent VS Code's JS debug bootloader from breaking child Node processes
+# spawned by gh. See post-create-common.sh for the full explanation.
+unset NODE_OPTIONS
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/../related-repos.txt"
+WORKSPACES_DIR="/workspaces"
+
+# --- Pre-flight checks ---
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "==> No related-repos.txt found at ${CONFIG_FILE}; skipping."
+    exit 0
+fi
+
+if [ ! -d "$WORKSPACES_DIR" ]; then
+    echo "==> WARNING: ${WORKSPACES_DIR} does not exist; skipping related-repo bootstrap." >&2
+    exit 0
+fi
+
+# /workspaces is owned by root in the devcontainer image — VS Code only fixes
+# ownership on the workspace folder itself, not its parent. Make it writable
+# by vscode so subsequent `git clone` calls can create sibling directories.
+# Idempotent: chown is a no-op if ownership already matches.
+if [ ! -w "$WORKSPACES_DIR" ]; then
+    sudo chown vscode:vscode "$WORKSPACES_DIR"
+fi
+
+# --- Parse and clone ---
+
+cloned=0
+skipped=0
+failed=0
+
+while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+    # Strip inline comments (everything from the first # onward), then trim
+    # leading and trailing whitespace.
+    line="${raw_line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+
+    # Skip blank lines (and lines that were comment-only).
+    [ -z "$line" ] && continue
+
+    # Split optional @branch suffix. Only split on the LAST @ so ssh URLs
+    # like git@github.com:o/r.git are not mangled — those URLs always end
+    # in .git, so a trailing @branch on the same line is unambiguous.
+    branch=""
+    target_spec="$line"
+    if [[ "$line" == *"@"* ]]; then
+        suffix="${line##*@}"
+        # Treat the suffix as a branch only if it doesn't look like a host
+        # (no dots, no colons, no slashes). This keeps `git@github.com:...`
+        # intact while still splitting `owner/repo@feature/foo` correctly
+        # only when the user wrote a plain branch name.
+        if [[ "$suffix" != *.* && "$suffix" != *:* && "$suffix" != */* ]]; then
+            branch="$suffix"
+            target_spec="${line%@*}"
+        fi
+    fi
+
+    # Derive the target basename.
+    #   owner/repo                  -> repo
+    #   https://host/owner/repo.git -> repo
+    #   git@host:owner/repo.git     -> repo
+    basename_raw="${target_spec##*/}"  # strip everything up to last /
+    basename_raw="${basename_raw##*:}" # strip ssh "host:" prefix if any
+    basename="${basename_raw%.git}"    # strip optional .git
+
+    if [ -z "$basename" ]; then
+        echo "==> WARNING: could not derive directory name for entry '${raw_line}'; skipping." >&2
+        failed=$((failed + 1))
+        continue
+    fi
+
+    target="${WORKSPACES_DIR}/${basename}"
+
+    if [ -e "$target" ]; then
+        echo "==> Skipping ${basename} (already present at ${target})"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    # Decide whether to use gh (for owner/repo shorthand) or git (for URLs).
+    use_gh=false
+    if [[ "$target_spec" != *://* && "$target_spec" != *@*:* && "$target_spec" == */* ]]; then
+        use_gh=true
+    fi
+
+    branch_label="${branch:-default branch}"
+    echo "==> Cloning ${target_spec} (${branch_label}) -> ${target}"
+
+    set +e
+    if [ "$use_gh" = true ]; then
+        if [ -n "$branch" ]; then
+            gh repo clone "$target_spec" "$target" -- --branch "$branch" --quiet
+        else
+            gh repo clone "$target_spec" "$target" -- --quiet
+        fi
+    else
+        if [ -n "$branch" ]; then
+            git clone --quiet --branch "$branch" "$target_spec" "$target"
+        else
+            git clone --quiet "$target_spec" "$target"
+        fi
+    fi
+    rc=$?
+    set -e
+
+    if [ "$rc" -eq 0 ]; then
+        cloned=$((cloned + 1))
+    else
+        echo "==> WARNING: failed to clone ${target_spec} (exit ${rc}); continuing." >&2
+        failed=$((failed + 1))
+        # Clean up partial clone if gh/git left a stub directory behind.
+        [ -d "$target" ] && rm -rf "$target"
+    fi
+done <"$CONFIG_FILE"
+
+# --- Summary ---
+
+total=$((cloned + skipped + failed))
+if [ "$total" -eq 0 ]; then
+    echo "==> No repos configured in ${CONFIG_FILE}; nothing to do."
+else
+    echo "==> Bootstrap complete: ${cloned} cloned, ${skipped} skipped, ${failed} failed"
+fi
+
+# Always exit 0 — failures are logged but never block post-create.
+exit 0

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/fetch-related-repos.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/fetch-related-repos.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Freshen already-cloned related repos in /workspaces/ on devcontainer START
+# (post-start-common.sh), so siblings track their remotes without a manual
+# fetch. Reads the same config as bootstrap-related-repos.sh:
+# .devcontainer/related-repos.txt.
+#
+# STRICTLY NON-DESTRUCTIVE: runs `git fetch` only (updates remote-tracking refs
+# and prunes deleted ones). It NEVER pulls, merges, checks out, or resets — so
+# uncommitted changes, local commits, and the checked-out branch are left
+# exactly as they are. Repos not yet cloned are skipped (bootstrap clones those
+# at create time). Failures log a warning and continue; this never blocks start.
+
+# Prevent VS Code's JS debug bootloader from breaking child Node processes.
+unset NODE_OPTIONS
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/../related-repos.txt"
+WORKSPACES_DIR="/workspaces"
+
+[ -f "$CONFIG_FILE" ] || exit 0
+[ -d "$WORKSPACES_DIR" ] || exit 0
+
+fetched=0
+skipped=0
+failed=0
+
+while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+    # Strip inline comments, then trim leading/trailing whitespace.
+    line="${raw_line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ -z "$line" ] && continue
+
+    # Derive the target basename, mirroring bootstrap-related-repos.sh: drop an
+    # optional plain @branch suffix (but keep ssh git@host:... intact), then
+    # strip the path, any ssh "host:" prefix, and a trailing .git.
+    target_spec="$line"
+    if [[ "$line" == *"@"* ]]; then
+        suffix="${line##*@}"
+        if [[ "$suffix" != *.* && "$suffix" != *:* && "$suffix" != */* ]]; then
+            target_spec="${line%@*}"
+        fi
+    fi
+    basename_raw="${target_spec##*/}"
+    basename_raw="${basename_raw##*:}"
+    basename="${basename_raw%.git}"
+    [ -z "$basename" ] && continue
+
+    dir="${WORKSPACES_DIR}/${basename}"
+
+    # Only fetch repos that are already cloned; bootstrap handles the rest.
+    if [ ! -d "${dir}/.git" ]; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    if git -C "$dir" fetch --all --prune --quiet 2>/dev/null; then
+        fetched=$((fetched + 1))
+    else
+        echo "==> WARNING: fetch failed for ${basename}; continuing." >&2
+        failed=$((failed + 1))
+    fi
+done <"$CONFIG_FILE"
+
+total=$((fetched + skipped + failed))
+if [ "$total" -gt 0 ]; then
+    echo "==> Related-repo fetch: ${fetched} fetched, ${skipped} not-yet-cloned, ${failed} failed"
+fi
+
+# Always exit 0 — never block container start.
+exit 0

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -209,4 +209,9 @@ if command -v direnv &>/dev/null && [ -f .envrc ]; then
     direnv allow
 fi
 
+# Clone related repos into /workspaces/ (idempotent + non-destructive; reads
+# .devcontainer/related-repos.txt). Runs on create so a rebuilt container
+# re-populates siblings. No-op when the list is empty/absent.
+bash .devcontainer/scripts/bootstrap-related-repos.sh
+
 echo "==> Setup complete! Run 'task verify' to validate your environment."

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-start-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-start-common.sh
@@ -42,6 +42,14 @@ if command -v jq &>/dev/null; then
     fi
 fi
 
+# --- Freshen related repos in the background (non-destructive git fetch) ---
+# Reads .devcontainer/related-repos.txt and git-fetches already-cloned siblings
+# in /workspaces/ so they track their remotes. NEVER pulls/merges/checks out —
+# local work is left untouched. nohup'd + backgrounded so it neither delays the
+# session nor is killed with the postStart process group. No-op for an empty list.
+nohup bash .devcontainer/scripts/fetch-related-repos.sh \
+    >>"$HOME/.related-repos-fetch.log" 2>&1 &
+
 echo "==> Starting tmux session..."
 if command -v tmux &>/dev/null; then
     tmux has-session -t default 2>/dev/null || tmux new-session -d -s default

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -88,6 +88,41 @@ repo** (one template serves every repo). To stand this repo up in Coder:
 > complication does not apply here — only the repo's own `-devcontainer` cache
 > image matters.
 
+## Working on related repos
+
+To work across several repos in one container, list them in
+`.devcontainer/related-repos.txt` (one `owner/repo` per line; `@branch`, full
+URLs, and ssh URLs also work). They are:
+
+- **cloned** into `/workspaces/`, beside this repo, on container **create**
+  (`scripts/bootstrap-related-repos.sh`) — so a rebuilt or persistence-lost
+  container re-populates them;
+- **fetched** non-destructively on container **start**
+  (`scripts/fetch-related-repos.sh`).
+
+Both are safe to re-run: an already-cloned sibling is **never clobbered** —
+clone skips it, and start runs `git fetch` only (never pull / merge / checkout),
+so uncommitted work, local commits, and the checked-out branch stay put. The
+list is preserved across `copier update` (an empty list is a no-op).
+
+To let Claude read and search the cloned siblings, add them to
+`.claude/settings.json` in **two** places — `permissions.additionalDirectories`
+(Claude's own Read/Grep/Glob tools) and `sandbox.filesystem.allowRead` (the Bash
+sandbox):
+
+```json
+{
+  "permissions": {
+    "additionalDirectories": ["../sibling-repo"]
+  },
+  "sandbox": {
+    "filesystem": {
+      "allowRead": ["../sibling-repo"]
+    }
+  }
+}
+```
+
 ## See also
 
 - [architecture/security.md](../architecture/security.md) — full secret strategy.


### PR DESCRIPTION
Makes "work across several repos in one devcontainer" a **maintained, opt-in template feature** — so adopting/updating the template stops stripping it (the problem that surfaced on sommerlawn-web#387, where an adopt unplugged a hand-rolled version).

## What it adds

| File | Role |
|---|---|
| `scripts/bootstrap-related-repos.sh` | On container **create**: clone each repo in `related-repos.txt` into `/workspaces/`. Idempotent + **non-destructive** (existing sibling dirs never touched). Re-populates after a rebuild / persistence loss. |
| `scripts/fetch-related-repos.sh` | On container **start**: `git fetch --prune` each already-cloned sibling so they track their remotes. **Strictly non-destructive** — never pull/merge/checkout/reset, so uncommitted work + local commits + the checked-out branch are untouched. Backgrounded + `nohup`'d so it never delays or is killed with the start process group. |
| `related-repos.txt` | Per-repo list (ships as an empty stub). Frozen via `_skip_if_exists` so `copier update` never overwrites a populated list. |

Wired into the **shared** `post-create-common.sh` / `post-start-common.sh`, so **both the bot and dev profiles** get it (the original was dev-only).

## Readable by Claude

The guide documents granting Claude access to the cloned siblings — it needs **two** keys: `permissions.additionalDirectories` (Claude's own Read/Grep/Glob) **and** `sandbox.filesystem.allowRead` (the Bash sandbox). Container `bypassPermissions` for the bot is already enforced via managed settings (`claude-settings.json`) and is unchanged.

## Design notes

- **Non-destructive by construction:** clone skips existing dirs; start only fetches. Local work is never at risk — the explicit requirement.
- **Survives rebuilds:** create-time clone re-populates `/workspaces/` if persistence is lost.
- **Mechanism vs. config split:** the scripts are template-owned (improvements flow via `copier update`); only `related-repos.txt` is per-repo (and frozen).
- Empty list ⇒ no-op, so repos that don't use it pay nothing.

## Verified

- `task verify` → exit 0; rendered `bootstrap`/`fetch` scripts pass shellcheck `--severity=error` + `shfmt -d`.
- Both profiles' `post-start` delegate to the common script (fetch runs in bot + dev).
- Root dogfood updated in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
