### PR TITLE
docs(conventions): restore lint-vs-format discipline (dropped from #151 squash)

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -32,6 +32,14 @@ it points here.
   `yaml:lint`).
 - Pipeline order is **`check → build → validate → test → security`**, with
   `verify` (local gate) and `ci` (full) as the aggregates.
+- **`lint:*` and `check` are read-only gates** — they report and fail, never
+  modify files. All auto-fixing lives in **`task format`**, **`task format:file
+  -- <path>`**, and **`task fix`** (= format then lint). Pre-commit hooks run the
+  read-only `lint:*`, so a failing check **blocks the commit and tells you** to
+  run `task format` rather than silently rewriting your tree.
+- Formatters (e.g. Prettier, Black, shfmt, `terraform fmt`, markdownlint) expose
+  a check side in `lint:*` and a write side in `format`; pure analyzers (e.g.
+  shellcheck, actionlint, yamllint, ESLint) are check-only by design.
 - **Workflows delegate to `task` targets** so local hooks, CI, and humans run
   identical commands — the Taskfile is the single source of truth. Don't
   reimplement command logic in a workflow or a hook.

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -34,6 +34,14 @@ it points here.
   `yaml:lint`).
 - Pipeline order is **`check → build → validate → test → security`**, with
   `verify` (local gate) and `ci` (full) as the aggregates.
+- **`lint:*` and `check` are read-only gates** — they report and fail, never
+  modify files. All auto-fixing lives in **`task format`**, **`task format:file
+  -- <path>`**, and **`task fix`** (= format then lint). Pre-commit hooks run the
+  read-only `lint:*`, so a failing check **blocks the commit and tells you** to
+  run `task format` rather than silently rewriting your tree.
+- Formatters (e.g. Prettier, Black, shfmt, `terraform fmt`, markdownlint) expose
+  a check side in `lint:*` and a write side in `format`; pure analyzers (e.g.
+  shellcheck, actionlint, yamllint, ESLint) are check-only by design.
 - **Workflows delegate to `task` targets** so local hooks, CI, and humans run
   identical commands — the Taskfile is the single source of truth. Don't
   reimplement command logic in a workflow or a hook.


### PR DESCRIPTION
Restores the `docs(conventions)` change that was authored on the #151 branch (commit `269c189`) but **did not make it into the #151 squash** — `e86c00a` on main contains only the `Taskfile.yml` change, so the documentation half was silently dropped.

This re-applies the exact commit: two bullets in the **Task runner** section of `conventions.md` (template + root dogfood) stating that `lint:*`/`check` are read-only gates and all auto-fixing lives in `task format`/`fix` — the principle the lint:markdown fix enforces and the standardize-repo catalog now audits for.

Verified: `task lint:markdown` (now read-only) passes on the restored prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
