### PR TITLE
feat(template): make Claude bypassPermissions bot-only (dev profile gets prompts)

### DIFF
--- a/.devcontainer/config/claude-settings.json
+++ b/.devcontainer/config/claude-settings.json
@@ -10,8 +10,7 @@
       "Bash(gitleaks:*)",
       "Bash(ansible-lint:*)",
       "Bash(terraform:*)"
-    ],
-    "defaultMode": "bypassPermissions"
+    ]
   },
   "hooks": {
     "PreToolUse": [

--- a/.devcontainer/dev/post-create.sh
+++ b/.devcontainer/dev/post-create.sh
@@ -5,3 +5,8 @@ export DEVCONTAINER_GIT_NAME="evanharmon1"
 export DEVCONTAINER_GIT_EMAIL="evan@evanharmon.com"
 
 bash .devcontainer/scripts/post-create-common.sh
+
+# Dev profile intentionally does NOT enable Claude bypassPermissions: a human
+# driving this container gets the normal prompt-on-action default (the baked
+# managed settings omit defaultMode). The bot profile opts in via
+# enable-claude-bypass.sh. Do not "add it here for consistency".

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -6,6 +6,11 @@ export DEVCONTAINER_GIT_EMAIL="evanharmon1-bot@users.noreply.github.com"
 
 bash .devcontainer/scripts/post-create-common.sh
 
+# Bot profile: default Claude to bypassPermissions (no per-action prompts) —
+# the container is the isolation boundary. The dev profile deliberately omits
+# this so a human gets the normal prompt-on-action default.
+bash .devcontainer/scripts/enable-claude-bypass.sh
+
 # Install repo-managed git hooks (source of truth: .devcontainer/hooks/).
 # This replaces the default git-lfs hooks with versions that also handle
 # auto-installing node_modules in new worktrees.

--- a/.devcontainer/scripts/enable-claude-bypass.sh
+++ b/.devcontainer/scripts/enable-claude-bypass.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# BOT PROFILE ONLY. Default Claude Code to `bypassPermissions` in this container
+# so the agent runs without per-action prompts — the container is the isolation
+# boundary. Called from the bot post-create.sh; the dev post-create.sh
+# intentionally does NOT call it, so a human gets the normal prompt-on-action
+# default.
+#
+# The mode is injected into the MANAGED settings (/etc/claude-code/
+# managed-settings.json) — highest precedence, so it cannot be overridden. The
+# baked managed file deliberately omits defaultMode (shared by both profiles);
+# this is the one bot-only difference. Idempotent and never fatal.
+
+MANAGED=/etc/claude-code/managed-settings.json
+
+command -v jq >/dev/null 2>&1 || {
+    echo "==> jq not found; cannot enable Claude bypass mode" >&2
+    exit 0
+}
+[ -f "$MANAGED" ] || {
+    echo "==> ${MANAGED} not found; skipping Claude bypass mode" >&2
+    exit 0
+}
+
+# Already set? nothing to do.
+if [ "$(jq -r '.permissions.defaultMode // empty' "$MANAGED")" = "bypassPermissions" ]; then
+    exit 0
+fi
+
+tmp=$(mktemp)
+if jq '.permissions.defaultMode = "bypassPermissions"' "$MANAGED" >"$tmp"; then
+    sudo install -m 0644 "$tmp" "$MANAGED"
+    echo "==> Claude: bypassPermissions enabled (bot profile)"
+else
+    echo "==> WARNING: failed to enable Claude bypass mode; leaving managed settings unchanged" >&2
+fi
+rm -f "$tmp"

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-settings.json
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-settings.json
@@ -10,8 +10,7 @@
       "Bash(gitleaks:*)",
       "Bash(ansible-lint:*)",
       "Bash(terraform:*)"
-    ],
-    "defaultMode": "bypassPermissions"
+    ]
   },
   "hooks": {
     "PreToolUse": [

--- a/template/[% if devcontainer %].devcontainer[% endif %]/dev/post-create.sh.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/dev/post-create.sh.jinja
@@ -5,3 +5,8 @@ export DEVCONTAINER_GIT_NAME="[[ author_git_provider_username ]]"
 export DEVCONTAINER_GIT_EMAIL="[[ author_email ]]"
 
 bash .devcontainer/scripts/post-create-common.sh
+
+# Dev profile intentionally does NOT enable Claude bypassPermissions: a human
+# driving this container gets the normal prompt-on-action default (the baked
+# managed settings omit defaultMode). The bot profile opts in via
+# enable-claude-bypass.sh. Do not "add it here for consistency".

--- a/template/[% if devcontainer %].devcontainer[% endif %]/post-create.sh.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/post-create.sh.jinja
@@ -6,6 +6,11 @@ export DEVCONTAINER_GIT_EMAIL="[[ author_git_provider_username ]]-bot@users.nore
 
 bash .devcontainer/scripts/post-create-common.sh
 
+# Bot profile: default Claude to bypassPermissions (no per-action prompts) —
+# the container is the isolation boundary. The dev profile deliberately omits
+# this so a human gets the normal prompt-on-action default.
+bash .devcontainer/scripts/enable-claude-bypass.sh
+
 # Install repo-managed git hooks (source of truth: .devcontainer/hooks/).
 # This replaces the default git-lfs hooks with versions that also handle
 # auto-installing node_modules in new worktrees.

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/enable-claude-bypass.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/enable-claude-bypass.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# BOT PROFILE ONLY. Default Claude Code to `bypassPermissions` in this container
+# so the agent runs without per-action prompts — the container is the isolation
+# boundary. Called from the bot post-create.sh; the dev post-create.sh
+# intentionally does NOT call it, so a human gets the normal prompt-on-action
+# default.
+#
+# The mode is injected into the MANAGED settings (/etc/claude-code/
+# managed-settings.json) — highest precedence, so it cannot be overridden. The
+# baked managed file deliberately omits defaultMode (shared by both profiles);
+# this is the one bot-only difference. Idempotent and never fatal.
+
+MANAGED=/etc/claude-code/managed-settings.json
+
+command -v jq >/dev/null 2>&1 || {
+    echo "==> jq not found; cannot enable Claude bypass mode" >&2
+    exit 0
+}
+[ -f "$MANAGED" ] || {
+    echo "==> ${MANAGED} not found; skipping Claude bypass mode" >&2
+    exit 0
+}
+
+# Already set? nothing to do.
+if [ "$(jq -r '.permissions.defaultMode // empty' "$MANAGED")" = "bypassPermissions" ]; then
+    exit 0
+fi
+
+tmp=$(mktemp)
+if jq '.permissions.defaultMode = "bypassPermissions"' "$MANAGED" >"$tmp"; then
+    sudo install -m 0644 "$tmp" "$MANAGED"
+    echo "==> Claude: bypassPermissions enabled (bot profile)"
+else
+    echo "==> WARNING: failed to enable Claude bypass mode; leaving managed settings unchanged" >&2
+fi
+rm -f "$tmp"

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -12,6 +12,14 @@ which secrets and capabilities they allow.
 The bot profile intentionally omits `TS_AUTHKEY` from its allow-list so a tailnet
 key never reaches an agent container.
 
+**Claude permission mode differs by profile.** The **bot** defaults to
+`bypassPermissions` (Claude runs tools without per-action prompts — the container
+is the isolation boundary); the **dev** profile keeps the normal prompt-on-action
+default so a human stays in the loop. The shared managed settings
+(`config/claude-settings.json`) deliberately omit `defaultMode`; the bot opts in
+at create time via `scripts/enable-claude-bypass.sh`. `bypassPermissions` is only
+safe because it is container-scoped — it is never set on the host.
+
 ## Run it locally
 
 - **VS Code:** "Dev Containers: Reopen in Container" → pick the **Dev** profile


### PR DESCRIPTION
`bypassPermissions` was baked into the **shared** managed settings (`config/claude-settings.json` → `/etc/claude-code/managed-settings.json`), so it applied to **both** devcontainer profiles identically. And managed settings are the highest precedence — they **can't be overridden downward** — so the **dev** (human) profile had no way to escape bypass.

## The split

| | Bot | Dev |
|---|---|---|
| Default Claude mode | `bypassPermissions` (no prompts) | normal prompt-on-action |
| How | `post-create.sh` → `scripts/enable-claude-bypass.sh` injects `defaultMode` into the managed settings | (nothing — baked managed settings omit `defaultMode`) |

- The baked managed settings now **omit `defaultMode`**, so both profiles fall back to prompt-on-action.
- The **bot** opts back into bypass at create time via the new idempotent `enable-claude-bypass.sh` (sudo-injects `defaultMode=bypassPermissions` into the managed file — highest precedence, can't be overridden).
- The **dev** `post-create.sh` deliberately does **not**, with a comment so nobody re-adds it "for consistency."

## Why this shape

The bot and dev images share **one profile-invariant `Dockerfile`** (the dogfood build relies on that), so a per-profile difference can't live in the bake. The natural seam is the **per-profile post-create entry scripts**, which already differ (bot vs dev git identity). `bypassPermissions` stays at the managed level where it's enforced — just bot-only now. It remains container-scoped and is never set on the host (the schema check confirmed bypass is only safe inside a container).

## Verified

- `task verify` → exit 0; `claude-settings.json` valid with `defaultMode` absent; `enable-claude-bypass.sh` passes shellcheck `--severity=error` + `shfmt -d`.
- Root dogfood updated in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
