### PR TITLE
fix(template): make `task format` resilient to un-auto-fixable lint

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -155,7 +155,10 @@ tasks:
       - |
         files=$(git ls-files '*.sh' '*.bash')
         [ -n "$files" ] && shfmt -w $files || true
-      - npx --yes markdownlint-cli2 --fix '**/*.md' '#template/**' '#.claude/**' '#**/node_modules/**' '#.worktrees/**'
+      # Best-effort: markdownlint --fix auto-fixes what it can but must NOT abort
+      # `format` on un-auto-fixable rule violations (e.g. MD024 duplicate heading,
+      # MD040 missing fence language) — `lint:markdown` (check-only) is the gate.
+      - npx --yes markdownlint-cli2 --fix '**/*.md' '#template/**' '#.claude/**' '#**/node_modules/**' '#.worktrees/**' || true
 
   format:file:
     desc: "Format a single file by extension (usage: task format:file -- <path>)"
@@ -166,7 +169,7 @@ tasks:
         [ -f "$f" ] || exit 0
         case "$f" in
         *.sh | *.bash) shfmt -w "$f" ;;
-        *.md | *.mdx) npx --yes markdownlint-cli2 --fix "$f" ;;
+        *.md | *.mdx) npx --yes markdownlint-cli2 --fix "$f" || true ;;
         esac
 
   fix:

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -288,7 +288,10 @@ tasks:
       - |
         files=$(git ls-files '*.sh' '*.bash')
         [ -n "$files" ] && shfmt -w $files || true
-      - npx --yes markdownlint-cli2 --fix '**/*.md' '#.claude/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**'
+      # Best-effort: markdownlint --fix auto-fixes what it can but must NOT abort
+      # `format` on un-auto-fixable rule violations (e.g. MD024 duplicate heading,
+      # MD040 missing fence language) — `lint:markdown` (check-only) is the gate.
+      - npx --yes markdownlint-cli2 --fix '**/*.md' '#.claude/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' || true
 
   format:file:
     desc: "Format a single file by extension (usage: task format:file -- <path>)"
@@ -308,7 +311,7 @@ tasks:
         *.tf | *.tfvars) terraform fmt "$f" ;;
 [% endif %]
         *.sh | *.bash) shfmt -w "$f" ;;
-        *.md | *.mdx) npx --yes markdownlint-cli2 --fix "$f" ;;
+        *.md | *.mdx) npx --yes markdownlint-cli2 --fix "$f" || true ;;
         esac
 
   fix:


### PR DESCRIPTION
## Problem
`task format` runs `markdownlint-cli2 **--fix**`, which exits **non-zero** when it hits rule violations it can't auto-fix (MD024 duplicate heading, MD040 missing fence language, MD033 inline HTML). go-task then **aborts the whole `format` task**.

A formatter should fix what it can and move on — the **gate** (`lint:markdown`, now check-only) is what should fail on un-auto-fixable nits.

## Why it matters
This bit the **standardize-repo adopt/update flow** hard: its reference says *"run `task format` first"* (so freshly-rendered files match the formatter before `task verify`). On a repo with pre-existing markdown nits, `format` aborts → the whole reconciliation strands. Observed live during the **harmon-ops v2→v3 re-template** (format exited 201 on a duplicate heading + bare fences in the machine CHECKLIST docs).

## Fix
Append `|| true` to the `markdownlint --fix` step in **`format`** and **`format:file`** (template + root dogfood), with a comment explaining it's best-effort and `lint:markdown` is the gate.

## Verified
- With an unfixable MD040 present, `task format` now exits **0** (was **201**).
- `task verify` → exit 0; all profiles pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)