### PR TITLE
fix(ci): repair project-automation issue-link grep + document CLI key-setting

### DIFF
--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -32,7 +32,9 @@ config, toolchain, devcontainer, and dev environment — against the items below
       org's existing one;
       install it on this repo, then set `CI_APP_CLIENT_ID` (Actions
       **variable**) + `CI_APP_PRIVATE_KEY` (Actions **secret**) — org-level for
-      an org, per-repo for a personal account. Drives release-please, the
+      an org, per-repo for a personal account. Set the private key by piping the
+      `.pem` in (`gh secret set CI_APP_PRIVATE_KEY … < key.pem`), not by pasting —
+      flattened newlines make the key undecodable. Drives release-please, the
       claude-* workflows, and project-automation. See docs/architecture/security.md.
 - [ ] GHCR: ensure the org/user allows publishing packages; the first
       devcontainer prebuild populates `ghcr.io/evanharmon1/harmon-init-devcontainer` on merge to main

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -73,7 +73,19 @@ a machine-readable reference; mirror it in the form.
 4. **Install App** → on this org, **Only select repositories** (not "All").
 5. Set `CI_APP_CLIENT_ID` (Actions variable = the App's Client ID) and `CI_APP_PRIVATE_KEY`
    (Actions secret = the `.pem` contents) — org-level for an org, per-repo for a
-   personal account.
+   personal account. **Set the private key by piping the `.pem` file in, never by
+   pasting it** — redirecting the file preserves its newlines, whereas a copy-paste
+   into the web UI (or a `gh secret set -b "…"` string) can flatten them and leave
+   the key undecodable. `create-github-app-token` then fails at JWT-signing time
+   with `error:1E08010C:DECODER routines::unsupported` (or `Invalid keyData`):
+
+   ```bash
+   # personal account / single repo:
+   gh secret set CI_APP_PRIVATE_KEY --repo <owner>/<repo> < evanharmon1-ci.*.private-key.pem
+
+   # org-wide (all repos):
+   gh secret set CI_APP_PRIVATE_KEY --org evanharmon1 --visibility all < evanharmon1-ci.*.private-key.pem
+   ```
 
 **Set the secrets by hand — don't script it.** Run the `gh variable set` /
 `gh secret set` commands (or use the GitHub UI) deliberately; **key rotation is

--- a/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
@@ -94,7 +94,7 @@ jobs:
           # Extract issue number from claude/issue-N branch or PR body Closes/Fixes/Resolves #N
           ISSUE_NUMBER=$(echo "$BRANCH" | grep -oP '(?<=claude/issue-)\d+' || true)
           if [ -z "$ISSUE_NUMBER" ] && [ -n "$PR_BODY" ]; then
-            ISSUE_NUMBER=$(echo "$PR_BODY" | grep -oP '(?<=(Closes|Fixes|Resolves) #)\d+' | head -1 || true)
+            ISSUE_NUMBER=$(echo "$PR_BODY" | grep -oiP '(?:Closes|Fixes|Resolves):?\s+#\K\d+' | head -1 || true)
           fi
           [ -z "$ISSUE_NUMBER" ] && echo "No issue number derivable from event, skipping" && exit 0
           echo "event=$EVENT_NAME issue=#$ISSUE_NUMBER target=$TARGET_STATUS"

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -34,7 +34,9 @@ config, toolchain, devcontainer, and dev environment — against the items below
       org's existing one;
       install it on this repo, then set `CI_APP_CLIENT_ID` (Actions
       **variable**) + `CI_APP_PRIVATE_KEY` (Actions **secret**) — org-level for
-      an org, per-repo for a personal account. Drives release-please, the
+      an org, per-repo for a personal account. Set the private key by piping the
+      `.pem` in (`gh secret set CI_APP_PRIVATE_KEY … < key.pem`), not by pasting —
+      flattened newlines make the key undecodable. Drives release-please, the
       claude-* workflows, and project-automation. See docs/architecture/security.md.
 [% if devcontainer %]
 - [ ] GHCR: ensure the org/user allows publishing packages; the first

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -81,7 +81,19 @@ a machine-readable reference; mirror it in the form.
 4. **Install App** → on this org, **Only select repositories** (not "All").
 5. Set `CI_APP_CLIENT_ID` (Actions variable = the App's Client ID) and `CI_APP_PRIVATE_KEY`
    (Actions secret = the `.pem` contents) — org-level for an org, per-repo for a
-   personal account.
+   personal account. **Set the private key by piping the `.pem` file in, never by
+   pasting it** — redirecting the file preserves its newlines, whereas a copy-paste
+   into the web UI (or a `gh secret set -b "…"` string) can flatten them and leave
+   the key undecodable. `create-github-app-token` then fails at JWT-signing time
+   with `error:1E08010C:DECODER routines::unsupported` (or `Invalid keyData`):
+
+   ```bash
+   # personal account / single repo:
+   gh secret set CI_APP_PRIVATE_KEY --repo <owner>/<repo> < [[ github_org ]]-ci.*.private-key.pem
+
+   # org-wide (all repos):
+   gh secret set CI_APP_PRIVATE_KEY --org [[ github_org ]] --visibility all < [[ github_org ]]-ci.*.private-key.pem
+   ```
 
 **Set the secrets by hand — don't script it.** Run the `gh variable set` /
 `gh secret set` commands (or use the GitHub UI) deliberately; **key rotation is


### PR DESCRIPTION
Two related fixes that came out of debugging the CI GitHub-App rollout in a generated repo (harmonops/harmon-infra#344 ships the same workflow fix downstream).

## 1. `fix(ci)` — variable-length lookbehind in `project-automation`

The template's `Sync project status` job extracts an issue number from the PR body with:

```bash
grep -oP '(?<=(Closes|Fixes|Resolves) #)\d+'
```

That PCRE **lookbehind is variable-length** (`Closes`=6, `Fixes`=5, `Resolves`=8 chars), which `grep -oP` rejects at runtime:

```
grep: lookbehind assertion is not fixed length
```

`|| true` masked it, so generated repos' jobs stayed **green while silently never matching** the `Closes/Fixes/Resolves #N` body path; only the fixed-length `claude/issue-N` branch path worked. Fixed with PCRE `\K` (resets match start — exempt from the fixed-length rule), case-insensitive + optional colon to match GitHub's own closing-keyword behavior:

```bash
grep -oiP '(?:Closes|Fixes|Resolves):?\s+#\K\d+'
```

## 2. `docs(ci)` — set `CI_APP_PRIVATE_KEY` from the `.pem` file

Pasting a GitHub App private key into the Actions-secret web UI (or a `gh secret set -b "…"` string) can flatten its PEM newlines, leaving the key undecodable — `create-github-app-token` then fails at JWT-signing time with `error:1E08010C:DECODER routines::unsupported` / `Invalid keyData`. Documented piping the file in (`gh secret set … < key.pem`), which preserves newlines, in both `security.md` (provisioning runbook) and the setup `CHECKLIST` — template and rendered root copies.

## Verification

- `task verify` (renders the full template, all profiles + lint + gitleaks) → exit 0
- markdownlint clean on changed docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)