### PR TITLE
feat(ci): add verify gate to project-automation template

### DIFF
--- a/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
@@ -130,3 +130,24 @@ jobs:
               updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$v}}){projectV2Item{id}}
             }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$FIELD_ID" -F v="$OPTION_ID"
           echo "Set issue #$ISSUE_NUMBER to $TARGET_STATUS"
+
+  # Stable required-check target: passes when sync-status succeeded or
+  # skipped, fails only on a real error. Lets branch protection gate on one
+  # constant name regardless of which event path sync-status took.
+  verify:
+    if: always()
+    needs: [sync-status]
+    runs-on: [ [[ ci_runner_labels ]] ]
+    steps:
+      - name: Check job results
+        run: |
+          fail=0
+          check() {
+            [ "$2" = "success" ] || [ "$2" = "skipped" ] || { echo "Job $1 result: $2"; fail=1; }
+          }
+          check sync-status "${{ needs.sync-status.result }}"
+          if [ "$fail" -ne 0 ]; then
+            echo "One or more required jobs failed."
+            exit 1
+          fi
+          echo "All required jobs passed."


### PR DESCRIPTION
Follow-up to #158. project-automation was the only requirable CI workflow in the template missing the house-style `verify` aggregator job that `build.yml` already has.

## What

Adds a final `verify` job to the template's `project-automation.yml`:

```yaml
verify:
  if: always()
  needs: [sync-status]
  runs-on: [ [[ ci_runner_labels ]] ]
  steps:
    - name: Check job results
      run: |
        check() { [ "$2" = "success" ] || [ "$2" = "skipped" ] || { echo "Job $1 result: $2"; fail=1; }; }
        check sync-status "${{ needs.sync-status.result }}"
        …
```

Treats `success`/`skipped` as pass, fails only on a real error — so branch protection gets one stable required-check name regardless of which event path `sync-status` took, and legitimate skips don't block PRs.

## Deliberately not included

harmon-infra's `Clean up buildx cache` (`docker buildx prune`) step is **not** pulled into the template — it's self-hosted-runner disk hygiene specific to that deployment, redundant with a scheduled prune, and a surprising side-effect to bake into every org repo's project-board sync.

## Verification

- `task verify` (renders all profiles: minimal/iac/meta/web/full + actionlint + gitleaks) → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)