### PR TITLE
docs(ci): document org-secret scoping process (CLI sets value, UI owns repo list)

### DIFF
--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -34,7 +34,9 @@ config, toolchain, devcontainer, and dev environment — against the items below
       **variable**) + `CI_APP_PRIVATE_KEY` (Actions **secret**) — org-level for
       an org, per-repo for a personal account. Set the private key by piping the
       `.pem` in (`gh secret set CI_APP_PRIVATE_KEY … < key.pem`), not by pasting —
-      flattened newlines make the key undecodable. Drives release-please, the
+      flattened newlines make the key undecodable. For an org, scope it
+      (`--visibility selected --repos …`) and then finalize/audit repo access in
+      the UI. Drives release-please, the
       claude-* workflows, and project-automation. See docs/architecture/security.md.
 - [ ] GHCR: ensure the org/user allows publishing packages; the first
       devcontainer prebuild populates `ghcr.io/evanharmon1/harmon-init-devcontainer` on merge to main

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -83,17 +83,30 @@ a machine-readable reference; mirror it in the form.
    # personal account / single repo:
    gh secret set CI_APP_PRIVATE_KEY --repo <owner>/<repo> < evanharmon1-ci.*.private-key.pem
 
-   # org-wide (all repos):
-   gh secret set CI_APP_PRIVATE_KEY --org evanharmon1 --visibility all < evanharmon1-ci.*.private-key.pem
+   # org: set the value once, scoped to the repos that need it now (add the
+   # variable the same way). Then finalize/audit repo access in the UI — see below.
+   gh secret set CI_APP_PRIVATE_KEY --org evanharmon1 \
+     --visibility selected --repos <repo>[,<repo2>] < evanharmon1-ci.*.private-key.pem
    ```
 
 **Set the secrets by hand — don't script it.** Run the `gh variable set` /
-`gh secret set` commands (or use the GitHub UI) deliberately; **key rotation is
-manual too.** Do **not** automate org `selected`-visibility secret-setting: the
-bulk `--repos` form *replaces* the secret's value and its repo allow-list, so
-running it from a second repo silently evicts the first. (To add a repo to an
-existing org secret non-destructively, grant it in the GitHub UI or
-`PUT /orgs/{org}/actions/secrets/{name}/repositories/{repo_id}`.)
+`gh secret set` commands deliberately; **key rotation is manual too.**
+
+**Recommended process — the CLI sets the value, the UI owns the repo list.** Set
+the value once from the `.pem` file (above), scoped with `--visibility selected
+--repos` to whatever repos make sense at the time (selecting them all is fine if
+that's the reality). From then on, **finalize and maintain which repos can read
+it in the GitHub UI** — org → *Settings → Secrets and variables → Actions* → the
+secret → **Repository access**. Editing the list there changes scope **without**
+re-entering the value, and the page doubles as a sanity check of exactly who has
+access. Don't reach for `--visibility all` as a shortcut: it exposes the key to
+every org repo until you narrow it.
+
+Keep list-management in the UI because `gh secret set` is **declarative** — the
+`--repos` form *replaces* the secret's value **and** its whole repo allow-list on
+every run, so re-running it from a second repo silently evicts the first. The UI
+(or `PUT /orgs/{org}/actions/secrets/{name}/repositories/{repo_id}`) is the
+non-destructive way to add a repo.
 
 **Why an App, not a PAT:** tokens are short-lived (nothing to rotate yearly), the
 App consumes no user seat, permissions are granular, and — unlike the built-in

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -36,7 +36,9 @@ config, toolchain, devcontainer, and dev environment — against the items below
       **variable**) + `CI_APP_PRIVATE_KEY` (Actions **secret**) — org-level for
       an org, per-repo for a personal account. Set the private key by piping the
       `.pem` in (`gh secret set CI_APP_PRIVATE_KEY … < key.pem`), not by pasting —
-      flattened newlines make the key undecodable. Drives release-please, the
+      flattened newlines make the key undecodable. For an org, scope it
+      (`--visibility selected --repos …`) and then finalize/audit repo access in
+      the UI. Drives release-please, the
       claude-* workflows, and project-automation. See docs/architecture/security.md.
 [% if devcontainer %]
 - [ ] GHCR: ensure the org/user allows publishing packages; the first

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -91,17 +91,30 @@ a machine-readable reference; mirror it in the form.
    # personal account / single repo:
    gh secret set CI_APP_PRIVATE_KEY --repo <owner>/<repo> < [[ github_org ]]-ci.*.private-key.pem
 
-   # org-wide (all repos):
-   gh secret set CI_APP_PRIVATE_KEY --org [[ github_org ]] --visibility all < [[ github_org ]]-ci.*.private-key.pem
+   # org: set the value once, scoped to the repos that need it now (add the
+   # variable the same way). Then finalize/audit repo access in the UI — see below.
+   gh secret set CI_APP_PRIVATE_KEY --org [[ github_org ]] \
+     --visibility selected --repos <repo>[,<repo2>] < [[ github_org ]]-ci.*.private-key.pem
    ```
 
 **Set the secrets by hand — don't script it.** Run the `gh variable set` /
-`gh secret set` commands (or use the GitHub UI) deliberately; **key rotation is
-manual too.** Do **not** automate org `selected`-visibility secret-setting: the
-bulk `--repos` form *replaces* the secret's value and its repo allow-list, so
-running it from a second repo silently evicts the first. (To add a repo to an
-existing org secret non-destructively, grant it in the GitHub UI or
-`PUT /orgs/{org}/actions/secrets/{name}/repositories/{repo_id}`.)
+`gh secret set` commands deliberately; **key rotation is manual too.**
+
+**Recommended process — the CLI sets the value, the UI owns the repo list.** Set
+the value once from the `.pem` file (above), scoped with `--visibility selected
+--repos` to whatever repos make sense at the time (selecting them all is fine if
+that's the reality). From then on, **finalize and maintain which repos can read
+it in the GitHub UI** — org → *Settings → Secrets and variables → Actions* → the
+secret → **Repository access**. Editing the list there changes scope **without**
+re-entering the value, and the page doubles as a sanity check of exactly who has
+access. Don't reach for `--visibility all` as a shortcut: it exposes the key to
+every org repo until you narrow it.
+
+Keep list-management in the UI because `gh secret set` is **declarative** — the
+`--repos` form *replaces* the secret's value **and** its whole repo allow-list on
+every run, so re-running it from a second repo silently evicts the first. The UI
+(or `PUT /orgs/{org}/actions/secrets/{name}/repositories/{repo_id}`) is the
+non-destructive way to add a repo.
 
 **Why an App, not a PAT:** tokens are short-lived (nothing to rotate yearly), the
 App consumes no user seat, permissions are granular, and — unlike the built-in


### PR DESCRIPTION
Makes the CI App secret-provisioning strategy explicit, following the reasoning in the harmon-infra debugging thread.

## The documented process

1. **CLI sets the value** — `gh secret set CI_APP_PRIVATE_KEY --org <org> --visibility selected --repos <repo> < …pem`. Piping the file preserves PEM newlines (the original failure mode); `selected` scopes it from the start.
2. **UI owns the repo list** — finalize and maintain *Repository access* in the org UI. Editing the list there changes scope **without** re-entering the value, and doubles as a sanity check of who has access.

## Why these changes

- Replaces the old `--visibility all` example, which briefly exposes the key to **every** org repo until you narrow it — a broaden-then-narrow gap with no upside.
- Explains *why* list-management belongs in the UI: `gh secret set` is **declarative**, so the `--repos` form replaces the value **and** the whole allow-list every run (re-running from a second repo silently evicts the first). UI / `PUT …/repositories/{repo_id}` is the non-destructive way to add a repo.

Updated in `security.md` (provisioning runbook) and the `CHECKLIST` — template + rendered root copies.

## Verification

- `task verify` (all render profiles + markdownlint + gitleaks) → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)