### PR TITLE
fix(ci): name project-automation gate project-automation-verify (not verify)

### DIFF
--- a/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
@@ -131,10 +131,12 @@ jobs:
             }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$FIELD_ID" -F v="$OPTION_ID"
           echo "Set issue #$ISSUE_NUMBER to $TARGET_STATUS"
 
-  # Stable required-check target: passes when sync-status succeeded or
-  # skipped, fails only on a real error. Lets branch protection gate on one
-  # constant name regardless of which event path sync-status took.
-  verify:
+  # Stable, uniquely-named required-check target: passes when sync-status
+  # succeeded or skipped, fails only on a real error. The `<workflow>-verify`
+  # name (not a bare `verify`) keeps this status-check context distinct from
+  # other workflows' gate jobs — duplicate contexts are ambiguous in branch
+  # protection / rulesets.
+  project-automation-verify:
     if: always()
     needs: [sync-status]
     runs-on: [ [[ ci_runner_labels ]] ]


### PR DESCRIPTION
Corrects a duplicate status-check context introduced by #159.

## Problem

#159 added the project-automation gate job as `verify`. But `build.yml` ("Build & Validate") **also** names its gate job `verify`. So any org repo rendered from the template ends up with **two status-check contexts both literally named `verify`** (one per workflow).

GitHub identifies required checks by context *name*, which is **not** namespaced by workflow — duplicate contexts are ambiguous in branch protection / rulesets: you can't require one `verify` without the other, and a non-required gate failing can look like the required one failing.

## Fix

Rename the project-automation gate `verify` → `project-automation-verify`, matching the `<workflow>-verify` convention already used in practice downstream (`build-verify`, `security-verify`, `validate-verify` are the required checks in harmon-infra's ruleset). Contexts stay globally unique, and the template now **converges with harmon-infra's existing job name** instead of diverging from it.

Also expands the job comment to explain why the workflow-prefixed name (not a bare `verify`) matters.

Name + comment only; behavior is identical.

## Verification

- `task verify` (all render profiles + actionlint + gitleaks) → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)