### PR TITLE
fix(template): let Prettier own *.mdx (markdownlint is .md-only)

### DIFF
--- a/template/[% if use_node %].prettierignore[% endif %]
+++ b/template/[% if use_node %].prettierignore[% endif %]
@@ -2,13 +2,15 @@
 #   - YAML      -> yamllint        (task lint:yaml)
 #   - Markdown  -> markdownlint    (task lint:markdown)
 #   - Shell     -> shfmt           (task lint:shell)
-# Prettier owns the rest (js/ts/jsx/tsx/json/css/astro). Keeping it out of YAML
-# also avoids its flow-sequence normalization (`[ "x" ]` -> `["x"]`) fighting the
-# rendered GitHub Actions / jinja workflow style.
+# Prettier owns the rest (js/ts/jsx/tsx/json/css/astro) and *.mdx: markdownlint
+# only globs *.md, and MDX with YAML frontmatter (e.g. Astro content collections)
+# defeats eslint-plugin-mdx's parser -- so Prettier is the one formatter that
+# covers MDX. Keeping Prettier out of YAML also avoids its flow-sequence
+# normalization (`[ "x" ]` -> `["x"]`) fighting the rendered GitHub Actions /
+# jinja workflow style.
 *.yml
 *.yaml
 *.md
-*.mdx
 
 # Machine-/agent-specific, generated, or vendored — not ours to format.
 .claude/


### PR DESCRIPTION
## What

Drop `*.mdx` from the shared `.prettierignore` so **Prettier owns MDX formatting**. `*.md` stays on markdownlint.

## Why

The "one tool per file type" model assigned Markdown to markdownlint and kept Prettier out of `*.md`/`*.mdx`. But:

- **markdownlint only globs `*.md`** — it never touches `.mdx`.
- **`eslint-plugin-mdx` can't parse MDX with YAML frontmatter** (e.g. Astro content collections) — projects that wire it up have to `.eslintignore` their content MDX.

So `*.mdx` ended up with **no formatter or linter at all**. Prettier handles MDX fine (it parses frontmatter + MDX without trouble), so the cleanest fix is to let Prettier own it.

Surfaced while bringing `sommerlawn-web` current with v3.10.0: its 8 Astro service-definition `.mdx` files were silently unowned after adopting the template's `.prettierignore`.

## Scope

All node projects (`use_node`). MDX-owned-by-Prettier is a fine universal default, and non-Astro project types rarely ship `.mdx`. The template itself ships **no** `.mdx`, so rendered projects are unaffected until they author their own content.

## Validation

- `task test:template` — ✅ `test-template (full): PASS` + `test-template-update: PASS` (template renders, rendered output lints clean, JSON parses, no leaks).
- `task lint` — ✅ green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
