### PR TITLE
fix(template): skip lint:eslint when no ESLint config exists yet

### DIFF
--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -164,9 +164,16 @@ tasks:
       - npx --yes prettier --check {{.CLI_ARGS | default "."}}
 
   lint:eslint:
+    # Skip cleanly when there is no ESLint config yet (e.g. a fresh scaffold before
+    # the app + its framework-specific config exist) so `task check` stays green.
     desc: ESLint
     cmds:
-      - npx --yes eslint {{.CLI_ARGS | default "."}}
+      - |
+        if find . -maxdepth 1 \( -name 'eslint.config.*' -o -name '.eslintrc.*' \) 2>/dev/null | grep -q .; then
+          npx --yes eslint {{.CLI_ARGS | default "."}}
+        else
+          echo "lint:eslint: no ESLint config yet -- skipping (add one after scaffolding the app)"
+        fi
 
   typecheck:
 [% if project_type == 'web-astro' %]


### PR DESCRIPTION
## What

Guard `lint:eslint` so it **skips cleanly when no ESLint config exists yet**, instead of hard-failing.

## Why

The template ships no ESLint config — it's the one linter whose config is framework-specific (Astro vs React vs plain TS), so it's added when you scaffold the app (per the web-astro CHECKLIST). But `lint:eslint` ran `npx --yes eslint .` **unconditionally**, so on a fresh scaffold `task check` / `task verify` failed at the eslint step (ESLint v9 errors when it can't find a config) until you added one. Bad first-run DX — you couldn't get a green baseline before doing framework setup.

## Change

```yaml
lint:eslint:
  cmds:
    - |
      if find . -maxdepth 1 \( -name 'eslint.config.*' -o -name '.eslintrc.*' \) 2>/dev/null | grep -q .; then
        npx --yes eslint {{.CLI_ARGS | default "."}}
      else
        echo "lint:eslint: no ESLint config yet -- skipping (add one after scaffolding the app)"
      fi
```

Runs exactly as before once a config is present; only the empty-config case changes (fail → informative skip).

## Validation

- `task test:template` — ✅ PASS (web + full); rendered Taskfile parses.
- Guard verified under `sh`: no config → skip; `eslint.config.{js,mjs,cjs}` → run; `.eslintrc.cjs` → run; stray dotfile → skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
