### PR TITLE
feat(template): ship + self-validate a web-astro ESLint config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           pipx install copier
           pip install yamllint
-          npm install -g @devcontainers/cli lefthook
+          npm install -g @devcontainers/cli lefthook pnpm
           # renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v?(?<version>.+)$
           ACTIONLINT_VERSION=1.7.12
           curl -sSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \

--- a/renovate.json
+++ b/renovate.json
@@ -69,6 +69,12 @@
       "description": "Batch all devcontainer updates (base image + annotated tools) into one PR — must come after the Docker images rule so the base image lands here instead",
       "matchFileNames": [".devcontainer/**", "template/**"],
       "groupName": "Devcontainer"
+    },
+    {
+      "description": "Batch the web-astro test-fixture dependency bumps into one PR (the fixture validates the shipped ESLint config; its deps move together)",
+      "matchFileNames": ["tests/fixtures/web-astro/package.json"],
+      "groupName": "web-astro fixture",
+      "separateMajorMinor": false
     }
   ]
 }

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -298,6 +298,29 @@ else
     required gitleaks "secrets scan" || fail=1
 fi
 
+# ── 11. web-astro: the shipped ESLint config lints a real Astro app ──
+# The render ships eslint.config.js but no app, so nothing above exercises it.
+# Overlay a minimal Astro fixture (package.json + a few src files), install, and
+# run the RENDERED config -- a broken flat config or a plugin-API bump fails HERE
+# instead of in every generated site. eslint runs via its own binary (not
+# `pnpm exec`) so the intentionally-unbuilt esbuild/sharp scripts don't gate it.
+if [ "$profile" = "web" ] && [ -f eslint.config.js ]; then
+    if have pnpm; then
+        cp -R "$repo_root/tests/fixtures/web-astro/." .
+        pnpm install --silent >/dev/null 2>&1 || true
+        if [ ! -x node_modules/.bin/eslint ]; then
+            err "web-astro fixture: install did not provide eslint (see tests/fixtures/web-astro/package.json)"
+        elif ! node_modules/.bin/eslint . >/dev/null 2>&1; then
+            node_modules/.bin/eslint . || true
+            err "web-astro fixture: shipped eslint.config.js failed to lint a real Astro app"
+        else
+            echo "web-astro: shipped ESLint config lints a real Astro app cleanly"
+        fi
+    else
+        required pnpm "web-astro ESLint validation" || fail=1
+    fi
+fi
+
 if [ "$fail" -ne 0 ]; then
     echo "test-template (${profile}): FAILED" >&2
     exit 1

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -164,9 +164,20 @@ tasks:
       - npx --yes prettier --check {{.CLI_ARGS | default "."}}
 
   lint:eslint:
+    # Skip cleanly when ESLint can't run yet -- no config (fresh scaffold) or deps
+    # not installed -- so `task check` stays green before the app is set up. Runs
+    # the project's own ESLint via `pnpm exec` so a plugin-based flat config (e.g.
+    # the web-astro eslint.config.js) resolves its plugins.
     desc: ESLint
     cmds:
-      - npx --yes eslint {{.CLI_ARGS | default "."}}
+      - |
+        if ! find . -maxdepth 1 \( -name 'eslint.config.*' -o -name '.eslintrc.*' \) 2>/dev/null | grep -q .; then
+          echo "lint:eslint: no ESLint config yet -- skipping (add one after scaffolding the app)"
+        elif [ ! -d node_modules ]; then
+          echo "lint:eslint: deps not installed yet -- skipping (run pnpm install)"
+        else
+          pnpm exec eslint {{.CLI_ARGS | default "."}}
+        fi
 
   typecheck:
 [% if project_type == 'web-astro' %]

--- a/template/[% if project_type == 'web-astro' %]eslint.config.js[% endif %]
+++ b/template/[% if project_type == 'web-astro' %]eslint.config.js[% endif %]
@@ -1,0 +1,14 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+import astro from 'eslint-plugin-astro'
+
+export default [
+  { ignores: ['dist/', '.astro/'] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  ...astro.configs.recommended,
+  { languageOptions: { globals: { ...globals.node, ...globals.browser } } },
+  // CommonJS config files (e.g. prettier.config.cjs) legitimately use require().
+  { files: ['**/*.cjs'], rules: { '@typescript-eslint/no-require-imports': 'off' } }
+]

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -56,10 +56,12 @@ config, toolchain, devcontainer, and dev environment — against the items below
 - [ ] Scaffold Astro: `pnpm create astro@latest . --template minimal` (or preferred template)
 - [ ] Add the standard stack: Tailwind v4 (`@tailwindcss/vite`), zod, vitest, lucide
 - [ ] Move lint tooling into devDependencies (prettier, eslint, markdownlint-cli2,
-      @commitlint/cli) and switch Taskfile `npx --yes` calls to `pnpm exec`
+      @commitlint/cli); switch the `lint:prettier` / `lint:markdown` `npx --yes`
+      calls to `pnpm exec` (`lint:eslint` already uses it once a config + deps exist)
 - [ ] Install the shipped `eslint.config.js`'s plugins:
       `pnpm add -D eslint @eslint/js typescript-eslint eslint-plugin-astro globals`
-      (`task lint:eslint` auto-uses `pnpm exec` once a config + deps exist)
+- [ ] Approve Astro's native build scripts so `astro build` works:
+      `pnpm approve-builds` (esbuild, sharp) — or add them to `onlyBuiltDependencies`
 - [ ] Review `lighthouserc.json` URLs once routes exist
 [% elif project_type == 'web-app' %]
 - [ ] Scaffold the app: `pnpm create @tanstack/start@latest` (TanStack Start) or vite + react

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -57,6 +57,9 @@ config, toolchain, devcontainer, and dev environment — against the items below
 - [ ] Add the standard stack: Tailwind v4 (`@tailwindcss/vite`), zod, vitest, lucide
 - [ ] Move lint tooling into devDependencies (prettier, eslint, markdownlint-cli2,
       @commitlint/cli) and switch Taskfile `npx --yes` calls to `pnpm exec`
+- [ ] Install the shipped `eslint.config.js`'s plugins:
+      `pnpm add -D eslint @eslint/js typescript-eslint eslint-plugin-astro globals`
+      (`task lint:eslint` auto-uses `pnpm exec` once a config + deps exist)
 - [ ] Review `lighthouserc.json` URLs once routes exist
 [% elif project_type == 'web-app' %]
 - [ ] Scaffold the app: `pnpm create @tanstack/start@latest` (TanStack Start) or vite + react

--- a/tests/fixtures/web-astro/astro.config.mjs
+++ b/tests/fixtures/web-astro/astro.config.mjs
@@ -1,0 +1,3 @@
+import { defineConfig } from 'astro/config'
+
+export default defineConfig({})

--- a/tests/fixtures/web-astro/package.json
+++ b/tests/fixtures/web-astro/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "web-astro-fixture",
+  "type": "module",
+  "private": true,
+  "devDependencies": {
+    "@astrojs/check": "0.9.9",
+    "@eslint/js": "10.0.1",
+    "astro": "7.0.3",
+    "eslint": "10.6.0",
+    "eslint-plugin-astro": "2.1.1",
+    "globals": "17.7.0",
+    "typescript": "6.0.3",
+    "typescript-eslint": "8.62.0"
+  }
+}

--- a/tests/fixtures/web-astro/src/content/intro.mdx
+++ b/tests/fixtures/web-astro/src/content/intro.mdx
@@ -1,0 +1,7 @@
+---
+title: Intro
+draft: false
+---
+
+Minimal MDX content with **frontmatter** — the case `eslint-plugin-mdx` can't
+parse, which is why ESLint stays off MDX (Prettier owns it, markdownlint owns md).

--- a/tests/fixtures/web-astro/src/pages/index.astro
+++ b/tests/fixtures/web-astro/src/pages/index.astro
@@ -1,0 +1,13 @@
+---
+const greeting: string = 'Hello from the web-astro fixture'
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Fixture</title>
+  </head>
+  <body>
+    <h1>{greeting}</h1>
+  </body>
+</html>

--- a/tests/fixtures/web-astro/src/sample.ts
+++ b/tests/fixtures/web-astro/src/sample.ts
@@ -1,0 +1,1 @@
+export const add = (a: number, b: number): number => a + b

--- a/tests/fixtures/web-astro/tsconfig.json
+++ b/tests/fixtures/web-astro/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## What

Ships a validated **ESLint v9 flat config** for `web-astro` projects, and makes harmon-init **self-validate** it against a real Astro app — so an upstream plugin bump can't silently break every generated site.

## Why

ESLint is the one linter whose config is framework-specific, so the template shipped none — leaving web-astro projects with no config and a `lint:eslint` that hard-failed on a fresh scaffold. This closes that gap for the `web-astro` project type.

## Changes

- **`eslint.config.js`** (web-astro only): `@eslint/js` + `typescript-eslint` + `eslint-plugin-astro`, node+browser globals, and a `*.cjs` `require()` exemption — the shipped `prettier.config.cjs` tripped `@typescript-eslint/no-require-imports`, which the new fixture test caught. Plugin devDeps are listed in the CHECKLIST.
- **`lint:eslint` guard** (supersedes #164): skips cleanly when there's no config *or* no installed deps, and runs the project's own ESLint via `pnpm exec` so a plugin-based flat config resolves its plugins.
- **`tests/fixtures/web-astro/`** — a minimal Astro app (package.json + a few sample files). `test:template:web` now renders the template, overlays this fixture, `pnpm install`s, and lints with the **rendered** config. A broken flat config or a plugin-API bump fails in **harmon-init CI**, not in every downstream site. Renovate keeps the fixture deps current.
- The `test:template` CI job gets `pnpm`.

## Scope guardrail

This is a **test fixture, not a shipped app** — harmon-init stays a conventions template, not an Astro starter. Consumers still `pnpm create astro` for their real app; only the eslint *config* ships.

## Validation

- `task lint` ✅; `task test:template:web` ✅ (`web-astro: shipped ESLint config lints a real Astro app cleanly`); `test:template:{minimal,full}` ✅.
- Proven against real versions — Astro 7, ESLint 10, eslint-plugin-astro 2.1.1: lints `.ts`/`.astro` (catches unused vars), ignores `.mdx`.

Supersedes #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
