### PR TITLE
feat(template): validate the full web-astro toolchain in the fixture

### DIFF
--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -298,26 +298,38 @@ else
     required gitleaks "secrets scan" || fail=1
 fi
 
-# ── 11. web-astro: the shipped ESLint config lints a real Astro app ──
-# The render ships eslint.config.js but no app, so nothing above exercises it.
-# Overlay a minimal Astro fixture (package.json + a few src files), install, and
-# run the RENDERED config -- a broken flat config or a plugin-API bump fails HERE
-# instead of in every generated site. eslint runs via its own binary (not
-# `pnpm exec`) so the intentionally-unbuilt esbuild/sharp scripts don't gate it.
+# ── 11. web-astro: the shipped toolchain works on a real Astro app ───
+# The render ships eslint.config.js + prettier.config.cjs (with prettier-plugin-astro)
+# but no app, so nothing above exercises them. Overlay a minimal Astro fixture
+# (package.json + a few src files), install, and run the SHIPPED toolchain against
+# it -- a broken config, plugin-API bump, or build regression fails HERE instead of
+# in every generated site. Tools run via their binaries (not `task check`) so the
+# intentionally-unbuilt esbuild/sharp scripts don't gate them and local plugins
+# (eslint-plugin-astro, prettier-plugin-astro) resolve.
 if [ "$profile" = "web" ] && [ -f eslint.config.js ]; then
-    if have pnpm; then
+    if ! have pnpm; then
+        required pnpm "web-astro toolchain validation" || fail=1
+    else
         cp -R "$repo_root/tests/fixtures/web-astro/." .
         pnpm install --silent >/dev/null 2>&1 || true
-        if [ ! -x node_modules/.bin/eslint ]; then
-            err "web-astro fixture: install did not provide eslint (see tests/fixtures/web-astro/package.json)"
-        elif ! node_modules/.bin/eslint . >/dev/null 2>&1; then
-            node_modules/.bin/eslint . || true
-            err "web-astro fixture: shipped eslint.config.js failed to lint a real Astro app"
+        bin="node_modules/.bin"
+        if [ ! -x "$bin/eslint" ] || [ ! -x "$bin/prettier" ] || [ ! -x "$bin/astro" ]; then
+            err "web-astro fixture: install did not provide the toolchain (see tests/fixtures/web-astro/package.json)"
+        elif ! "$bin/eslint" . >/dev/null 2>&1; then
+            "$bin/eslint" . || true
+            err "web-astro fixture: ESLint failed"
+        elif ! "$bin/prettier" --check . >/dev/null 2>&1; then
+            "$bin/prettier" --check . || true
+            err "web-astro fixture: prettier --check failed (prettier-plugin-astro)"
+        elif ! "$bin/astro" check >/dev/null 2>&1; then
+            "$bin/astro" check || true
+            err "web-astro fixture: astro check (typecheck) failed"
+        elif ! "$bin/astro" build >/dev/null 2>&1; then
+            "$bin/astro" build || true
+            err "web-astro fixture: astro build failed"
         else
-            echo "web-astro: shipped ESLint config lints a real Astro app cleanly"
+            echo "web-astro: shipped toolchain (ESLint + Prettier/astro + astro check + build) clean on a real app"
         fi
-    else
-        required pnpm "web-astro ESLint validation" || fail=1
     fi
 fi
 

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -60,6 +60,8 @@ config, toolchain, devcontainer, and dev environment — against the items below
       calls to `pnpm exec` (`lint:eslint` already uses it once a config + deps exist)
 - [ ] Install the shipped `eslint.config.js`'s plugins:
       `pnpm add -D eslint @eslint/js typescript-eslint eslint-plugin-astro globals`
+- [ ] Install the shipped prettier config's plugins:
+      `pnpm add -D prettier prettier-config-standard prettier-plugin-astro prettier-plugin-tailwindcss`
 - [ ] Approve Astro's native build scripts so `astro build` works:
       `pnpm approve-builds` (esbuild, sharp) — or add them to `onlyBuiltDependencies`
 - [ ] Review `lighthouserc.json` URLs once routes exist

--- a/tests/fixtures/web-astro/package.json
+++ b/tests/fixtures/web-astro/package.json
@@ -9,6 +9,10 @@
     "eslint": "10.6.0",
     "eslint-plugin-astro": "2.1.1",
     "globals": "17.7.0",
+    "prettier": "3.9.1",
+    "prettier-config-standard": "7.0.0",
+    "prettier-plugin-astro": "0.14.1",
+    "prettier-plugin-tailwindcss": "0.8.0",
     "typescript": "6.0.3",
     "typescript-eslint": "8.62.0"
   }

--- a/tests/fixtures/web-astro/src/pages/index.astro
+++ b/tests/fixtures/web-astro/src/pages/index.astro
@@ -2,9 +2,9 @@
 const greeting: string = 'Hello from the web-astro fixture'
 ---
 
-<html lang="en">
+<html lang='en'>
   <head>
-    <meta charset="utf-8" />
+    <meta charset='utf-8' />
     <title>Fixture</title>
   </head>
   <body>


### PR DESCRIPTION
## What

Extends the web-astro fixture test (from #166) from **ESLint-only** to the **whole shipped toolchain**, so a config / plugin-API / build regression is caught in harmon-init CI rather than in every generated Astro site.

## Now validated against the real fixture app

- **`prettier --check`** — exercises the already-shipped `prettier-plugin-astro` on a real `.astro` file (the prettier twin of the ESLint gap #166 closed). The plugin + `.astro` parser override already ship in `prettier.config.cjs`; nothing *exercised* them until now.
- **`astro check`** — typecheck (0 errors across 11 files).
- **`astro build`** — the static build pipeline (builds clean; no image deps, so the unbuilt esbuild/sharp scripts don't block it).

## Changes

- `tests/fixtures/web-astro/` gains the prettier devDeps + a prettier-formatted `index.astro`.
- `test:template:web` now runs eslint + prettier + `astro check` + `astro build` (via the tools' binaries, so the intentionally-unbuilt esbuild/sharp scripts don't gate them and local plugins resolve).
- CHECKLIST lists the prettier plugins the shipped `prettier.config.cjs` references (`require.resolve('prettier-plugin-astro')` etc.) — otherwise a consumer's first `prettier --check` can't load the config.

## Validation

`task test:template:web` → `web-astro: shipped toolchain (ESLint + Prettier/astro + astro check + build) clean on a real app`.

---

Builds on **#166** (now merged); rebased onto `main`, so the diff here is just the toolchain growth on top of the existing fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
