### PR TITLE
feat(template): ship + self-validate a web-app (TanStack Router + Convex) ESLint config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        profile: [minimal, web, iac, full, meta, update]
+        profile: [minimal, web, webapp, iac, full, meta, update]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -197,6 +197,7 @@ tasks:
     deps:
       - test:template:minimal
       - test:template:web
+      - test:template:webapp
       - test:template:iac
       - test:template:full
       - test:template:meta
@@ -211,6 +212,11 @@ tasks:
     desc: Render template as project_type=web-astro and validate
     cmds:
       - ./scripts/test-template.sh web
+
+  test:template:webapp:
+    desc: Render template as project_type=web-app and validate
+    cmds:
+      - ./scripts/test-template.sh webapp
 
   test:template:iac:
     desc: Render template as project_type=iac (terraform+ansible) and validate

--- a/renovate.json
+++ b/renovate.json
@@ -75,6 +75,12 @@
       "matchFileNames": ["tests/fixtures/web-astro/package.json"],
       "groupName": "web-astro fixture",
       "separateMajorMinor": false
+    },
+    {
+      "description": "Batch the web-app test-fixture dependency bumps into one PR",
+      "matchFileNames": ["tests/fixtures/web-app/package.json"],
+      "groupName": "web-app fixture",
+      "separateMajorMinor": false
     }
   ]
 }

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -67,6 +67,9 @@ minimal)
 web)
     data_args+=(--data project_type=web-astro)
     ;;
+webapp)
+    data_args+=(--data project_type=web-app)
+    ;;
 iac)
     data_args+=(--data project_type=iac)
     ;;
@@ -318,6 +321,26 @@ if [ "$profile" = "web" ] && [ -f eslint.config.js ]; then
         fi
     else
         required pnpm "web-astro ESLint validation" || fail=1
+    fi
+fi
+
+# ── 12. web-app: the shipped ESLint config lints a real React app ────
+# Same idea as the web-astro check above, for the web-app (React) project type.
+# eslint-plugin-react is not yet ESLint-10-ready, so the fixture pins ESLint 9.
+if [ "$profile" = "webapp" ] && [ -f eslint.config.js ]; then
+    if have pnpm; then
+        cp -R "$repo_root/tests/fixtures/web-app/." .
+        pnpm install --silent >/dev/null 2>&1 || true
+        if [ ! -x node_modules/.bin/eslint ]; then
+            err "web-app fixture: install did not provide eslint (see tests/fixtures/web-app/package.json)"
+        elif ! node_modules/.bin/eslint . >/dev/null 2>&1; then
+            node_modules/.bin/eslint . || true
+            err "web-app fixture: shipped eslint.config.js failed to lint a real React app"
+        else
+            echo "web-app: shipped ESLint config lints a real React app cleanly"
+        fi
+    else
+        required pnpm "web-app ESLint validation" || fail=1
     fi
 fi
 

--- a/template/[% if project_type == 'web-app' %]eslint.config.js[% endif %]
+++ b/template/[% if project_type == 'web-app' %]eslint.config.js[% endif %]
@@ -1,0 +1,20 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+import react from 'eslint-plugin-react'
+import reactHooks from 'eslint-plugin-react-hooks'
+
+export default [
+  { ignores: ['dist/', '.output/', '.nitro/'] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  { ...react.configs.flat.recommended, settings: { react: { version: 'detect' } } },
+  react.configs.flat['jsx-runtime'],
+  {
+    plugins: { 'react-hooks': reactHooks },
+    rules: reactHooks.configs['recommended-latest'].rules
+  },
+  { languageOptions: { globals: { ...globals.node, ...globals.browser } } },
+  // CommonJS config files (e.g. prettier.config.cjs) legitimately use require().
+  { files: ['**/*.cjs'], rules: { '@typescript-eslint/no-require-imports': 'off' } }
+]

--- a/template/[% if project_type == 'web-app' %]eslint.config.js[% endif %]
+++ b/template/[% if project_type == 'web-app' %]eslint.config.js[% endif %]
@@ -3,9 +3,11 @@ import globals from 'globals'
 import tseslint from 'typescript-eslint'
 import react from 'eslint-plugin-react'
 import reactHooks from 'eslint-plugin-react-hooks'
+import router from '@tanstack/eslint-plugin-router'
+import convex from '@convex-dev/eslint-plugin'
 
 export default [
-  { ignores: ['dist/', '.output/', '.nitro/'] },
+  { ignores: ['dist/', '.output/', '.nitro/', 'convex/_generated/'] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   { ...react.configs.flat.recommended, settings: { react: { version: 'detect' } } },
@@ -14,6 +16,11 @@ export default [
     plugins: { 'react-hooks': reactHooks },
     rules: reactHooks.configs['recommended-latest'].rules
   },
+  // TanStack Router (route property order, param names) + Convex (args
+  // validators, table-id types, query patterns). Drop a block if a given
+  // web-app doesn't use that library.
+  ...router.configs['flat/recommended'],
+  ...convex.configs.recommended,
   { languageOptions: { globals: { ...globals.node, ...globals.browser } } },
   // CommonJS config files (e.g. prettier.config.cjs) legitimately use require().
   { files: ['**/*.cjs'], rules: { '@typescript-eslint/no-require-imports': 'off' } }

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -67,6 +67,9 @@ config, toolchain, devcontainer, and dev environment — against the items below
 - [ ] Scaffold the app: `pnpm create @tanstack/start@latest` (TanStack Start) or vite + react
 - [ ] Add the standard stack: Tailwind v4, shadcn/ui, zod, vitest, lucide
 - [ ] Move lint tooling into devDependencies and switch Taskfile `npx --yes` calls to `pnpm exec`
+- [ ] Install the shipped `eslint.config.js`'s plugins (ESLint 9 — eslint-plugin-react
+      isn't ESLint 10-ready yet): `pnpm add -D eslint@9 @eslint/js@9 typescript-eslint
+      eslint-plugin-react eslint-plugin-react-hooks globals`
 [% elif project_type == 'iac' %]
 - [ ] Lay out `terraform/` (main.tf, variables.tf, outputs.tf) and/or
       `ansible/` (site.yml, ansible.cfg, inventory/, roles/) — the lint tasks

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -71,7 +71,8 @@ config, toolchain, devcontainer, and dev environment — against the items below
 - [ ] Move lint tooling into devDependencies and switch Taskfile `npx --yes` calls to `pnpm exec`
 - [ ] Install the shipped `eslint.config.js`'s plugins (ESLint 9 — eslint-plugin-react
       isn't ESLint 10-ready yet): `pnpm add -D eslint@9 @eslint/js@9 typescript-eslint
-      eslint-plugin-react eslint-plugin-react-hooks globals`
+      eslint-plugin-react eslint-plugin-react-hooks globals @tanstack/eslint-plugin-router
+      @convex-dev/eslint-plugin` (drop the TanStack Router / Convex plugins if a given app doesn't use them)
 [% elif project_type == 'iac' %]
 - [ ] Lay out `terraform/` (main.tf, variables.tf, outputs.tf) and/or
       `ansible/` (site.yml, ansible.cfg, inventory/, roles/) — the lint tasks

--- a/tests/fixtures/web-app/convex/myFunctions.ts
+++ b/tests/fixtures/web-app/convex/myFunctions.ts
@@ -1,0 +1,9 @@
+import { query } from './_generated/server'
+import { v } from 'convex/values'
+
+export const get = query({
+  args: { id: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.id)
+  }
+})

--- a/tests/fixtures/web-app/package.json
+++ b/tests/fixtures/web-app/package.json
@@ -3,7 +3,9 @@
   "type": "module",
   "private": true,
   "devDependencies": {
+    "@convex-dev/eslint-plugin": "2.0.0",
     "@eslint/js": "9.39.4",
+    "@tanstack/eslint-plugin-router": "1.162.0",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "eslint": "9.39.4",

--- a/tests/fixtures/web-app/package.json
+++ b/tests/fixtures/web-app/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "web-app-fixture",
+  "type": "module",
+  "private": true,
+  "devDependencies": {
+    "@eslint/js": "9.39.4",
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "eslint": "9.39.4",
+    "eslint-plugin-react": "7.37.5",
+    "eslint-plugin-react-hooks": "7.1.1",
+    "globals": "17.7.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "typescript": "6.0.3",
+    "typescript-eslint": "8.62.0"
+  }
+}

--- a/tests/fixtures/web-app/src/App.tsx
+++ b/tests/fixtures/web-app/src/App.tsx
@@ -1,0 +1,3 @@
+export function Hello({ name }: { name: string }) {
+  return <h1>Hello {name}</h1>
+}

--- a/tests/fixtures/web-app/src/routes/index.tsx
+++ b/tests/fixtures/web-app/src/routes/index.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/')({
+  loader: () => ({ ok: true }),
+  component: Index
+})
+
+function Index() {
+  return <h1>Home</h1>
+}

--- a/tests/fixtures/web-app/tsconfig.json
+++ b/tests/fixtures/web-app/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What

Ships a validated ESLint config for the `web-app` project type — covering the actual web-app stack, **React + TanStack Router + Convex** — plus a self-validating fixture (the parallel to #166's web-astro config).

## Why

ESLint is the one linter whose config is framework-specific, so the template ships none — leaving web-app projects with no config and a `lint:eslint` that hard-fails on a fresh scaffold. This closes that gap for `web-app` the same way #166 did for `web-astro`.

## The config

- **React**: `@eslint/js` + `typescript-eslint` + `eslint-plugin-react` (flat recommended + `jsx-runtime`, so no `react-in-jsx-scope` under the modern transform) + `eslint-plugin-react-hooks`.
- **TanStack Router**: `@tanstack/eslint-plugin-router` — `create-route-property-order`, `route-param-names`.
- **Convex**: `@convex-dev/eslint-plugin` — `require-args-validator`, `no-old-registered-function-syntax`, `explicit-table-ids`, `no-filter-in-query`, … + a `convex/_generated/` ignore.
- node+browser globals, a `.cjs` `require()` exemption. **Pins ESLint 9** — `eslint-plugin-react@7.37.5` still calls the `context.getFilename()` API ESLint 10 removed (crashes on 10). Each library block is droppable if a given app doesn't use it.

## Self-validating fixture

`tests/fixtures/web-app/` (a minimal React app + a real `createFileRoute` route + a Convex function) + a new `test:template:webapp` profile (and CI matrix entry): renders web-app, overlays the fixture, installs, and lints with the **shipped** config — so a broken config or plugin-API bump fails in harmon-init CI instead of every site. `--print-config` confirms the Router + Convex rule sets are active on route/convex files. Renovate batches the fixture deps.

## Validation

`task test:template:webapp` → `web-app: shipped ESLint config lints a real React app cleanly`. Manually confirmed `react-hooks/rules-of-hooks` catches a conditional hook, and the TanStack/Convex rule sets are enabled.

---

Independent of #167 (merged); builds on #166 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
