### PR TITLE
docs(template): note the type-aware async-safety ESLint opt-in for web-app

### DIFF
--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -73,6 +73,11 @@ config, toolchain, devcontainer, and dev environment — against the items below
       isn't ESLint 10-ready yet): `pnpm add -D eslint@9 @eslint/js@9 typescript-eslint
       eslint-plugin-react eslint-plugin-react-hooks globals @tanstack/eslint-plugin-router
       @convex-dev/eslint-plugin` (drop the TanStack Router / Convex plugins if a given app doesn't use them)
+- [ ] (optional) Type-aware async safety: add `@typescript-eslint/no-floating-promises`
+      and `no-misused-promises` to `eslint.config.js`, scoped to `src/**` with
+      `languageOptions.parserOptions.projectService: true`, to catch a missing
+      `await` / floating promise that `tsc` won't. Makes ESLint type-check
+      (slower) and needs your tsconfig wired up — skip to keep lint instant.
 [% elif project_type == 'iac' %]
 - [ ] Lay out `terraform/` (main.tf, variables.tf, outputs.tf) and/or
       `ansible/` (site.yml, ansible.cfg, inventory/, roles/) — the lint tasks


### PR DESCRIPTION
Adds a web-app CHECKLIST opt-in for **type-aware async linting** — `@typescript-eslint/no-floating-promises` + `no-misused-promises`, scoped to `src/**` with `parserOptions.projectService: true`.

These catch a missing `await` / floating promise that `tsc` doesn't — valuable for async-heavy stacks (TanStack Router loaders, Convex). Kept an **opt-in** rather than a default because it makes ESLint type-check (slower) and needs the app's tsconfig wired up.

Validated: rendered web-app CHECKLIST is markdownlint-clean; `task lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)