### PR TITLE
feat(template): add web vscode extensions + restore effort-level comment

### DIFF
--- a/template/.vscode/extensions.json.jinja
+++ b/template/.vscode/extensions.json.jinja
@@ -12,8 +12,11 @@
 [% endif %]
 [% if project_type == 'web-astro' %]
     "astro-build.astro-vscode",
+    "unifiedjs.vscode-mdx",
 [% endif %]
 [% if use_node %]
+    "dbaeumer.vscode-eslint",
+    "bradlc.vscode-tailwindcss",
     "esbenp.prettier-vscode",
     "ms-playwright.playwright",
 [% endif %]

--- a/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
@@ -53,6 +53,11 @@
     "source=shell-history-${devcontainerId},target=/home/vscode/.shell-history,type=volume",
     "source=zoxide-data-${devcontainerId},target=/home/vscode/.local/share/zoxide,type=volume"
   ],
+  // CLAUDE_CODE_EFFORT_LEVEL: default Claude Code thinking effort. Set here
+  // (not in settings.json) because Claude Code's settings schema only accepts
+  // low|medium|high for the persisted effortLevel field, while the env var
+  // accepts low|medium|high|max. Resolution order at runtime: env var >
+  // settings.json effortLevel > model default.
   "containerEnv": {
     "CODER": "${localEnv:CODER}",
     "DEVCONTAINER_TAILSCALE": "true",
@@ -96,8 +101,13 @@
         "ms-azuretools.vscode-docker",
         "ms-python.python",
         "ms-python.black-formatter",
+[% if project_type in ['web-astro', 'web-app'] %]
+        "dbaeumer.vscode-eslint",
+        "bradlc.vscode-tailwindcss",
+[% endif %]
 [% if project_type == 'web-astro' %]
         "astro-build.astro-vscode",
+        "unifiedjs.vscode-mdx",
 [% endif %]
         "esbenp.prettier-vscode",
         "timonwong.shellcheck",

--- a/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
@@ -57,6 +57,12 @@
   // Do NOT forward them via containerEnv — ${localEnv:...} resolves to ""
   // when the host shell doesn't export them, which overrides the env-file
   // values (Docker --env takes precedence over --env-file).
+  //
+  // CLAUDE_CODE_EFFORT_LEVEL: default Claude Code thinking effort. Set here
+  // (not in settings.json) because Claude Code's settings schema only accepts
+  // low|medium|high for the persisted effortLevel field, while the env var
+  // accepts low|medium|high|max. Resolution order at runtime: env var >
+  // settings.json effortLevel > model default.
   "containerEnv": {
     "CODER": "${localEnv:CODER}",
     "CLAUDE_CODE_EFFORT_LEVEL": "max"
@@ -99,8 +105,13 @@
         "ms-azuretools.vscode-docker",
         "ms-python.python",
         "ms-python.black-formatter",
+[% if project_type in ['web-astro', 'web-app'] %]
+        "dbaeumer.vscode-eslint",
+        "bradlc.vscode-tailwindcss",
+[% endif %]
 [% if project_type == 'web-astro' %]
         "astro-build.astro-vscode",
+        "unifiedjs.vscode-mdx",
 [% endif %]
         "esbenp.prettier-vscode",
         "timonwong.shellcheck",


### PR DESCRIPTION
## Summary

Brings two devcontainer/editor conventions upstream into the template so every
generated repo gets them and they survive `copier update` — instead of living
as per-repo drift.

### 1. Web VS Code extensions

Adds the extensions web projects need but the template didn't ship:

| Extension | Project types | Why |
|-----------|---------------|-----|
| `dbaeumer.vscode-eslint` | `web-astro`, `web-app` | Both ship an ESLint config (cf. the web-app opt-in in #169) |
| `bradlc.vscode-tailwindcss` | `web-astro`, `web-app` | Both are Tailwind UIs |
| `unifiedjs.vscode-mdx` | `web-astro` | Astro content collections author in `.mdx` |

Applied to all three extension lists so the profiles stay in sync:

- `.devcontainer/devcontainer.json` (bot)
- `.devcontainer/dev/devcontainer.json` (dev)
- `.vscode/extensions.json` (workspace recommendations)

In `.vscode/extensions.json` the eslint/tailwind entries join the existing
`[% if use_node %]` block — and `use_node` is defined as
`project_type in ['web-astro', 'web-app']`, exactly the gate written
explicitly in the two devcontainer files.

### 2. Restore the `CLAUDE_CODE_EFFORT_LEVEL` rationale comment

Re-adds the explanatory comment to both devcontainer profiles. The level is set
via the env var rather than `settings.json` on purpose: the persisted
`effortLevel` field only accepts `low|medium|high`, while the env var also
accepts `max`. The setting itself was already in the template; only the *why*
was missing.

## Context

Surfaced while reviewing sommerlawn-web's copier-adoption PR: adopting the
template regenerated its devcontainer files from canonical, which dropped these
editor extensions (they had only ever existed as local drift) and the
effort-level comment. Upstreaming here is the durable fix.

## Verification

`scripts/test-template.sh` renders `--vcs-ref=HEAD` and runs the rendered repo's
own gate:

- `task test:template:web` (web-astro) → **PASS** — incl. the shipped ESLint +
  Prettier + `astro check` + build on a real app
- `task test:template:webapp` (web-app) → **PASS** — shipped ESLint lints a real
  React app cleanly
- `task test:template:minimal` (baseline) → **PASS** — confirms non-web types
  are unaffected

Manual render confirms gating: eslint + tailwind appear in both web types;
mdx + astro-vscode only in web-astro; the effort comment renders in every
profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
