### PR TITLE
chore: rename harmon-stack to harmon-platform

### DIFF
--- a/.claude/skills/standardize-repo/SKILL.md
+++ b/.claude/skills/standardize-repo/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools: Bash, Read, Write, Edit, Grep, Glob, Task, WebFetch
 
 Bring a repo in line with the **harmon-init** Copier template — the shared baseline
 of DevOps tooling, CI/CD, linting, secrets scanning, lefthook git hooks, and a
-`Taskfile.yml` task runner. harmon-init is the **template** repo of harmon-stack
+`Taskfile.yml` task runner. harmon-init is the **template** repo of harmon-platform
 (siblings: harmon-devkit, harmon-dotfiles, harmon-ops, harmon-infra); this skill is
 how an agent *consumes* that template to scaffold new repos or standardize existing
 ones. harmon-init is NOT an application — it is used via

--- a/.meta/Code Project - Harmon Platform.bunch
+++ b/.meta/Code Project - Harmon Platform.bunch
@@ -1,0 +1,1 @@
+/Users/evan/Library/Mobile Documents/com~apple~CloudDocs/Bunches/Code Project - Harmon Platform.bunch

--- a/.meta/Code Project - Harmon Stack.bunch
+++ b/.meta/Code Project - Harmon Stack.bunch
@@ -1,1 +1,0 @@
-/Users/evan/Library/Mobile Documents/com~apple~CloudDocs/Bunches/Code Project - Harmon Stack.bunch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@ runners — and can also be applied to existing repos to standardize them. This 
 an application; it is a template repository used via the
 [Copier](https://copier.readthedocs.io/en/stable/) templating tool.
 
-## harmon-stack
+## harmon-platform
 
-One of five repos in **harmon-stack** (Evan's homelab + dev-ops stack):
+One of five repos in **harmon-platform** (Evan's developer & DevOps platform + homelab):
 [**harmon-init**](https://github.com/evanharmon1/harmon-init) (this repo — the template),
 [harmon-devkit](https://github.com/evanharmon1/harmon-devkit) (boilerplates/scripts/AI assets),
 [harmon-dotfiles](https://github.com/evanharmon1/harmon-dotfiles) (chezmoi dotfiles),

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Harmon Stack License Agreement
+Harmon Platform License Agreement
 
 Version 1.0,
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Author: Evan Harmon
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border-orange.json)](https://github.com/copier-org/copier)
 
-## Part of harmon-stack
+## Part of harmon-platform
 
-This repo is part of **harmon-stack** — my personal stack of homelab, dev-tooling, and automation repos that work together.
+This repo is part of **harmon-platform** — my custom development platform with machine configuration, DevOps systems, homelab infrastructure, and automation repos that work together to help me develop software and manage my homelab.
 
 | Repo | What it is |
 | --- | --- |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -418,11 +418,11 @@ tasks:
   util:bunch-add:
     desc: Move Bunch file to iCloud and replace with symlink
     cmds:
-      - mv '.meta/Code Project - Harmon Stack.bunch' '/Users/evan/Library/Mobile Documents/com~apple~CloudDocs/Bunches/'
-      - ln -s '/Users/evan/Library/Mobile Documents/com~apple~CloudDocs/Bunches/Code Project - Harmon Stack.bunch' .meta
+      - mv '.meta/Code Project - Harmon Platform.bunch' '/Users/evan/Library/Mobile Documents/com~apple~CloudDocs/Bunches/'
+      - ln -s '/Users/evan/Library/Mobile Documents/com~apple~CloudDocs/Bunches/Code Project - Harmon Platform.bunch' .meta
 
   util:obsidian-add:
     desc: Move Obsidian note to Memex and replace with symlink
     cmds:
-      - mv '.meta/Harmon Stack.md' '/Users/evan/Local/Memex/Professional/'
-      - ln -s '/Users/evan/Local/Memex/Professional/Harmon Stack.md' .meta
+      - mv '.meta/Harmon Platform.md' '/Users/evan/Local/Memex/Professional/'
+      - ln -s '/Users/evan/Local/Memex/Professional/Harmon Platform.md' .meta


### PR DESCRIPTION
Renames the **harmon-stack** identity to **harmon-platform** (the umbrella name for the dev-tooling/homelab repo group).

## Changes
- `README.md` — "Part of harmon-stack" section heading + prose
- `AGENTS.md` (and its symlinked `CLAUDE.md` / `GEMINI.md` / `.github/copilot-instructions.md`) — `## harmon-stack` section
- `.claude/skills/standardize-repo/SKILL.md` — "template repo of harmon-stack"
- `LICENSE` — title `Harmon Stack License Agreement` → `Harmon Platform License Agreement`
- `Taskfile.yml` — `util:bunch-add` / `util:obsidian-add` paths; the backing files in iCloud (`Code Project - Harmon Platform.bunch`) and Memex (`Harmon Platform.md`) were renamed in lockstep, and the tracked `.meta` symlink re-pointed

Prose that echoed the old name ("my personal **stack** of homelab…", "homelab + dev-ops **stack**") was updated to "platform" for consistency. Unrelated uses of "stack" (arr stack, Docker Compose stacks, etc.) were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)