### PR TITLE
feat(template): split .meta Bunch/Obsidian tasks into add + install

### DIFF
--- a/.claude/skills/standardize-repo/references/mode-new-repo.md
+++ b/.claude/skills/standardize-repo/references/mode-new-repo.md
@@ -121,8 +121,10 @@ project directory):
    plus `uv sync` / `pnpm install` if applicable).
 5. `task release:init` — when `github_release_init` (tags `v0.1.0`, pushes it,
    `gh release create`). Requires the remote to exist (step 3).
-6. `task util:bunch-add` — when `bunch_add` (macOS-only).
-7. `task util:obsidian-add` — when `obsidian_project_add` (macOS-only).
+6. `task util:bunch-install` — when `bunch_add` (macOS-only); moves the
+   generated `.meta/*.bunch` to iCloud and symlinks it back.
+7. `task util:obsidian-install` — when `obsidian_project_add` (macOS-only);
+   moves the generated `.meta/*.md` to the vault and symlinks it back.
 
 If you left the side-effectful answers at their `no` defaults (the CI-safe,
 recommended path for unattended generation), only steps 1–2 run and you finish

--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -125,7 +125,7 @@ Universal task targets every repo has (from the template):
 (Snyk), `security:sca` (Snyk), `bootstrap`, `install`, `install:hooks`,
 `release:init`, `release:patch`, `release:minor`, `release:major`, `clean`,
 `status` (+ `status:git|gh|code|env`), `status:setup`, `util:bunch-add`,
-`util:obsidian-add`.
+`util:bunch-install`, `util:obsidian-add`, `util:obsidian-install`.
 
 `status:setup` is a **setup-completeness audit** (run by hand, not part of the
 default dashboard): it checks the repo against `docs/CHECKLIST.md` and reports
@@ -536,7 +536,8 @@ Like `general` (no `build`/framework). [copier]
 
 - **[manual] CHECKLIST:** decide the docs toolchain (plain markdown / Obsidian
   vault / static site generator).
-- `obsidian_project_add` (default no) wires `util:obsidian-add` + a vault note.
+- `obsidian_project_add` (default no) generates a vault note and runs
+  `util:obsidian-install` post-gen; `util:obsidian-add` scaffolds one later.
 
 ---
 
@@ -565,8 +566,9 @@ Legitimately repo- or type-specific differences. An auditor should treat these a
   repos (`github_org == author_git_provider_username`). Org repos get all three.
 - **`design-language.md` / DESIGN.md web section** only for web types; shadcn/ui
   named only for `web-app`.
-- **macOS-only meta** (`util:bunch-add`/`util:obsidian-add`, `.meta/`, Bunch
-  cask) gated by `bunch_add`/`obsidian_project_add` (default no).
+- **macOS-only meta** (`util:bunch-add`/`util:bunch-install` /
+  `util:obsidian-add`/`util:obsidian-install`, `.meta/`, Bunch cask) gated by
+  `bunch_add`/`obsidian_project_add` (default no).
 
 ### 3.2 Tech-stack preferences (web), expected to vary by repo
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,10 @@
-Harmon Platform License Agreement
+Harmon Init License Agreement
 
 Version 1.0,
 
 1. Grant of License
 
-This software and associated documentation files (the “Software”) are licensed, not sold, to you by Harmon Ops (“Licensor”) for use strictly in accordance with the terms of this License Agreement. Subject to your compliance with the terms of this License, Licensor grants you a limited, non-exclusive, non-transferable, and revocable license to use the Software solely for your personal or internal business purposes.
+This software and associated documentation files (the “Software”) are licensed, not sold, to you by Evan Harmon (“Licensor”) for use strictly in accordance with the terms of this License Agreement. Subject to your compliance with the terms of this License, Licensor grants you a limited, non-exclusive, non-transferable, and revocable license to use the Software solely for your personal or internal business purposes.
 
 2. Restrictions
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -416,13 +416,23 @@ tasks:
 
   # ── Utilities ─────────────────────────────────────────────────
   util:bunch-add:
-    desc: Move Bunch file to iCloud and replace with symlink
+    desc: Scaffold the Bunch launcher in .meta (mirrors what the template generates)
     cmds:
-      - mv '.meta/Code Project - Harmon Platform.bunch' '/Users/evan/Library/Mobile Documents/com~apple~CloudDocs/Bunches/'
-      - ln -s '/Users/evan/Library/Mobile Documents/com~apple~CloudDocs/Bunches/Code Project - Harmon Platform.bunch' .meta
+      - ./scripts/meta-create.sh bunch 'Harmon Init' 'harmon-init' '~/git'
+
+  util:bunch-install:
+    desc: Move the Bunch file to iCloud and replace it with a symlink (macOS)
+    cmds:
+      - mv '.meta/Code Project - Harmon Init.bunch' '/Users/evan/Library/Mobile Documents/com~apple~CloudDocs/Bunches/'
+      - ln -s '/Users/evan/Library/Mobile Documents/com~apple~CloudDocs/Bunches/Code Project - Harmon Init.bunch' .meta
 
   util:obsidian-add:
-    desc: Move Obsidian note to Memex and replace with symlink
+    desc: Scaffold the Obsidian project note in .meta (mirrors what the template generates)
     cmds:
-      - mv '.meta/Harmon Platform.md' '/Users/evan/Local/Memex/Professional/'
-      - ln -s '/Users/evan/Local/Memex/Professional/Harmon Platform.md' .meta
+      - ./scripts/meta-create.sh obsidian 'Harmon Init' 'Evan Harmon'
+
+  util:obsidian-install:
+    desc: Move the Obsidian note to the vault and replace it with a symlink (macOS)
+    cmds:
+      - mv '.meta/Harmon Init.md' '/Users/evan/Local/Memex/Professional/'
+      - ln -s '/Users/evan/Local/Memex/Professional/Harmon Init.md' .meta

--- a/copier.yml
+++ b/copier.yml
@@ -260,9 +260,9 @@ _tasks:
     when: "[[ run_task_install ]]"
   - command: 'git tag | grep -q . || task release:init'
     when: "[[ git_init and github_release_init and _copier_operation == 'copy' ]]"
-  - command: task util:bunch-add
+  - command: task util:bunch-install
     when: "[[ git_init and bunch_add and _copier_operation == 'copy' ]]"
-  - command: task util:obsidian-add
+  - command: task util:obsidian-install
     when: "[[ git_init and obsidian_project_add and _copier_operation == 'copy' ]]"
 
 # ── Copier settings ─────────────────────────────────────────────────

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -14,7 +14,7 @@ config, toolchain, devcontainer, and dev environment — against the items below
 - [ ] Verify `harmon-init.code-workspace` opens the repo's folder in VS Code and has a unique VS Code Workspace color. Then add any other related repos (e.g. other org repos) to the `folders` list in the workspace file so you have quick access to those repos
 - [ ] Extend `.gitignore` for your stack — the template ships a base; add stack-specific entries via [gitignore.io](https://www.toptal.com/developers/gitignore)
 - [ ] macOS: add a Raycast quicklink/alias that opens the `harmon-init.code-workspace`
-- [ ] macOS (Bunch): add/confirm the project in your Bunch via `task util:bunch-add` — tracks a `.meta/*.bunch` symlink → iCloud (re-run if missing)
+- [ ] macOS (Bunch): scaffold the launcher with `task util:bunch-add` (if not generated at copier time), then `task util:bunch-install` to move it to iCloud and leave a `.meta/*.bunch` symlink (re-run install if missing)
 
 ## 2. GitHub repo settings
 

--- a/scripts/meta-create.sh
+++ b/scripts/meta-create.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# meta-create.sh — scaffold a project's .meta sidecar (a Bunch launcher or an
+# Obsidian project note) for a repo where it was not generated at copier time.
+# The emitted content mirrors template/.meta/, so a project can opt into a Bunch
+# or Obsidian note after the fact. Run via `task util:bunch-add` /
+# `task util:obsidian-add`; pair with `util:*-install` to move the file into its
+# system folder and symlink it back into .meta.
+#
+# Usage:
+#   meta-create.sh bunch    <project_name> <project_slug> <projects_directory>
+#   meta-create.sh obsidian <project_name> <author_full_name>
+set -euo pipefail
+
+repo="$(git rev-parse --show-toplevel)"
+cd "$repo"
+
+fail() {
+    echo "meta-create: $*" >&2
+    exit 1
+}
+
+kind="${1:-}"
+mkdir -p .meta
+
+case "$kind" in
+bunch)
+    name="${2:?project name required}"
+    slug="${3:?project slug required}"
+    projects_dir="${4:?projects directory required}"
+    dest=".meta/Code Project - ${name}.bunch"
+    if [ -e "$dest" ]; then
+        fail "$dest already exists"
+    fi
+    cat >"$dest" <<EOF
+---
+title: Code Project - ${name} 🪛
+---
+< snippet.code
+
+\$ open -a 'Visual Studio Code' ${projects_dir}/${slug}/${slug}.code-workspace
+%Visual Studio Code^
+
+< snippet.maximize
+EOF
+    ;;
+obsidian)
+    name="${2:?project name required}"
+    author="${3:?author full name required}"
+    today="$(date +%Y-%m-%d)"
+    dest=".meta/${name}.md"
+    if [ -e "$dest" ]; then
+        fail "$dest already exists"
+    fi
+    cat >"$dest" <<EOF
+---
+aliases:
+tags:
+  - Type/Intent/Project
+  - seed
+publish: false
+status:
+due:
+priority:
+version: 1.1
+dateCreated: ${today}
+dateModified: ${today}
+startDate:
+by: "[[${author}|Me]]"
+for:
+of:
+from:
+
+  - "[[Projects]]"
+  - "[[Professional]]"
+related: []
+contra: []
+to: []
+---
+# ${name}
+
+## Inbox
+EOF
+    ;;
+*)
+    fail "usage: meta-create.sh {bunch|obsidian} <project_name> [args...]"
+    ;;
+esac
+
+echo "meta-create: wrote $dest"

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -620,13 +620,23 @@ tasks:
 
   # ── Utilities ──────────────────────────────────────────────────
   util:bunch-add:
-    desc: Move Bunch file to iCloud and replace with symlink (macOS)
+    desc: Scaffold the Bunch launcher in .meta (mirrors what the template generates)
+    cmds:
+      - ./scripts/meta-create.sh bunch '[[ project_name ]]' '[[ project_slug ]]' '[[ projects_directory ]]'
+
+  util:bunch-install:
+    desc: Move the Bunch file to iCloud and replace it with a symlink (macOS)
     cmds:
       - mv '.meta/Code Project - [[ project_name ]].bunch' '[[ bunches_directory ]]/'
       - ln -s '[[ bunches_directory ]]/Code Project - [[ project_name ]].bunch' .meta
 
   util:obsidian-add:
-    desc: Move Obsidian note to the vault and replace with symlink (macOS)
+    desc: Scaffold the Obsidian project note in .meta (mirrors what the template generates)
+    cmds:
+      - ./scripts/meta-create.sh obsidian '[[ project_name ]]' '[[ author_full_name ]]'
+
+  util:obsidian-install:
+    desc: Move the Obsidian note to the vault and replace it with a symlink (macOS)
     cmds:
       - mv '.meta/[[ project_name ]].md' '[[ obsidian_directory ]]/Personal/Digital'
       - ln -s '[[ obsidian_directory ]]/Personal/Digital/[[ project_name ]].md' .meta

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -14,7 +14,7 @@ config, toolchain, devcontainer, and dev environment — against the items below
 - [ ] Verify `[[ project_slug ]].code-workspace` opens the repo's folder in VS Code and has a unique VS Code Workspace color. Then add any other related repos (e.g. other org repos) to the `folders` list in the workspace file so you have quick access to those repos
 - [ ] Extend `.gitignore` for your stack — the template ships a base; add stack-specific entries via [gitignore.io](https://www.toptal.com/developers/gitignore)
 - [ ] macOS: add a Raycast quicklink/alias that opens the `[[ project_slug ]].code-workspace`
-- [ ] macOS (Bunch): add/confirm the project in your Bunch via `task util:bunch-add` — tracks a `.meta/*.bunch` symlink → iCloud (re-run if missing)
+- [ ] macOS (Bunch): scaffold the launcher with `task util:bunch-add` (if not generated at copier time), then `task util:bunch-install` to move it to iCloud and leave a `.meta/*.bunch` symlink (re-run install if missing)
 
 ## 2. GitHub repo settings
 

--- a/template/scripts/meta-create.sh
+++ b/template/scripts/meta-create.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# meta-create.sh — scaffold a project's .meta sidecar (a Bunch launcher or an
+# Obsidian project note) for a repo where it was not generated at copier time.
+# The emitted content mirrors template/.meta/, so a project can opt into a Bunch
+# or Obsidian note after the fact. Run via `task util:bunch-add` /
+# `task util:obsidian-add`; pair with `util:*-install` to move the file into its
+# system folder and symlink it back into .meta.
+#
+# Usage:
+#   meta-create.sh bunch    <project_name> <project_slug> <projects_directory>
+#   meta-create.sh obsidian <project_name> <author_full_name>
+set -euo pipefail
+
+repo="$(git rev-parse --show-toplevel)"
+cd "$repo"
+
+fail() {
+    echo "meta-create: $*" >&2
+    exit 1
+}
+
+kind="${1:-}"
+mkdir -p .meta
+
+case "$kind" in
+bunch)
+    name="${2:?project name required}"
+    slug="${3:?project slug required}"
+    projects_dir="${4:?projects directory required}"
+    dest=".meta/Code Project - ${name}.bunch"
+    if [ -e "$dest" ]; then
+        fail "$dest already exists"
+    fi
+    cat >"$dest" <<EOF
+---
+title: Code Project - ${name} 🪛
+---
+< snippet.code
+
+\$ open -a 'Visual Studio Code' ${projects_dir}/${slug}/${slug}.code-workspace
+%Visual Studio Code^
+
+< snippet.maximize
+EOF
+    ;;
+obsidian)
+    name="${2:?project name required}"
+    author="${3:?author full name required}"
+    today="$(date +%Y-%m-%d)"
+    dest=".meta/${name}.md"
+    if [ -e "$dest" ]; then
+        fail "$dest already exists"
+    fi
+    cat >"$dest" <<EOF
+---
+aliases:
+tags:
+  - Type/Intent/Project
+  - seed
+publish: false
+status:
+due:
+priority:
+version: 1.1
+dateCreated: ${today}
+dateModified: ${today}
+startDate:
+by: "[[${author}|Me]]"
+for:
+of:
+from:
+
+  - "[[Projects]]"
+  - "[[Professional]]"
+related: []
+contra: []
+to: []
+---
+# ${name}
+
+## Inbox
+EOF
+    ;;
+*)
+    fail "usage: meta-create.sh {bunch|obsidian} <project_name> [args...]"
+    ;;
+esac
+
+echo "meta-create: wrote $dest"


### PR DESCRIPTION
## Summary

Reorganizes the macOS `.meta` sidecar tasks around an **`add` (create) / `install` (move + symlink)** convention, applied in lockstep to the root dogfood and the `template/` layer.

- `util:bunch-add` / `util:obsidian-add` now **scaffold** the `.meta` file (previously these did the move+symlink). This lets a project opt into a Bunch launcher or Obsidian note **after** copier time, not only at generation.
- `util:bunch-install` / `util:obsidian-install` are the original move-to-system-folder + symlink steps, renamed for clarity.
- New `scripts/meta-create.sh` (+ identical `template/scripts/` copy) emits content byte-identical to `template/.meta/`, parameterized by the project's own answers (`project_name`/`project_slug`/`projects_directory`/`author_full_name`).
- `copier.yml` `_tasks` hooks now call `util:*-install` post-generation — at copy time the file is already rendered, so the post-gen step is the move+symlink (not a re-create). Still gated on `git_init and bunch_add` / `obsidian_project_add` (both default `no`).

## Dogfood corrections (root layer)

While here, fixed stale values in the **root** that traced back to the harmon-stack→harmon-platform rename (PR #174) — this repo's own name is **Harmon Init**, not the umbrella:

- Bunch/Obsidian task args → `Harmon Init` / `harmon-init`.
- `LICENSE` title → "Harmon Init License Agreement"; licensor → **Evan Harmon** (was "Harmon Ops", which is actually the infra GitHub org and had leaked into the licensor slot).

The `template/LICENSE.jinja` and `template/Taskfile.yml.jinja` already use the correct `[[ project_name ]]` / `[[ organization ]]` variables — only the hand-baked root copies needed the fix.

## Docs

- `docs/CHECKLIST.md` (+ jinja pair) updated for the add→install flow.
- `standardize-repo` references (`standards-catalog.md`, `mode-new-repo.md`) updated for the new task names and the post-gen `install` hooks.

## Verification

- `task verify` passes locally (lint + fast guards + template-test matrix).
- Smoke-tested `meta-create.sh bunch`/`obsidian` in a throwaway repo — output is byte-identical to a fresh `copier copy` render.
- `shellcheck --severity=error` + `shfmt -d` clean on the new script.
- Pre-push template + secrets checks passed.

Note: the working-tree `.meta/` cleanup (stale `Harmon Platform` artifacts) is intentionally **not** in this PR — handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)