### PR TITLE
ci(claude): run plan/implement/review on Opus with effort + runaway guards

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -23,6 +23,7 @@ jobs:
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-implement'))
     runs-on: [ "ubuntu-latest" ]
+    timeout-minutes: 180
     permissions:
       contents: write
       issues: write
@@ -65,7 +66,10 @@ jobs:
           base_branch: main
           branch_prefix: claude/
           branch_name_template: "{{prefix}}issue-{{entityNumber}}-{{description}}-{{sha}}"
-          claude_args: "--model sonnet --max-turns 200"
+          # --max-budget-usd caps API-key spend; likely a no-op under
+          # CLAUDE_CODE_OAUTH_TOKEN (subscription) billing. Real runaway guards
+          # are timeout-minutes (job-level) and --max-turns.
+          claude_args: "--model opus --effort high --max-budget-usd 25 --max-turns 200"
           prompt: |
             Implement the change requested in this issue or comment.
 

--- a/.github/workflows/claude-plan.yml
+++ b/.github/workflows/claude-plan.yml
@@ -23,6 +23,7 @@ jobs:
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-plan'))
     runs-on: [ "ubuntu-latest" ]
+    timeout-minutes: 120
     permissions:
       contents: read
       issues: write
@@ -50,7 +51,10 @@ jobs:
           track_progress: true
           base_branch: main
           branch_prefix: claude/
-          claude_args: "--model opus --disallowedTools Edit Write Bash --max-turns 80"
+          # --max-budget-usd caps API-key spend; likely a no-op under
+          # CLAUDE_CODE_OAUTH_TOKEN (subscription) billing. Real runaway guards
+          # are timeout-minutes (job-level) and --max-turns.
+          claude_args: "--model opus --effort max --max-budget-usd 10 --disallowedTools Edit Write Bash --max-turns 120"
           prompt: |
             Post the plan as a comment. Do not write code or modify files.
             Focus on the specific task described in the triggering comment or

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,6 +24,7 @@ jobs:
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-review'))
     runs-on: [ "ubuntu-latest" ]
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: write
@@ -71,7 +72,10 @@ jobs:
           allowed_bots: "renovate[bot],coderabbitai[bot],dependabot[bot]"
           base_branch: main
           branch_prefix: claude/
-          claude_args: "--model sonnet --disallowedTools Edit Write Bash --max-turns 40"
+          # --max-budget-usd caps API-key spend; likely a no-op under
+          # CLAUDE_CODE_OAUTH_TOKEN (subscription) billing. Real runaway guards
+          # are timeout-minutes (job-level) and --max-turns.
+          claude_args: "--model opus --effort max --max-budget-usd 6 --disallowedTools Edit Write Bash --max-turns 60"
           prompt: |
             Review the PR diff and post a code review comment. Flag security,
             correctness, and convention concerns (see AGENTS.md). Do not write

--- a/template/.github/workflows/claude-implement.yml.jinja
+++ b/template/.github/workflows/claude-implement.yml.jinja
@@ -23,6 +23,7 @@ jobs:
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-implement'))
     runs-on: [ [[ ci_runner_labels ]] ]
+    timeout-minutes: 180
     permissions:
       contents: write
       issues: write
@@ -111,7 +112,10 @@ jobs:
           base_branch: main
           branch_prefix: claude/
           branch_name_template: "{{prefix}}issue-{{entityNumber}}-{{description}}-{{sha}}"
-          claude_args: "--model sonnet --max-turns 200"
+          # --max-budget-usd caps API-key spend; likely a no-op under
+          # CLAUDE_CODE_OAUTH_TOKEN (subscription) billing. Real runaway guards
+          # are timeout-minutes (job-level) and --max-turns.
+          claude_args: "--model opus --effort high --max-budget-usd 25 --max-turns 200"
           prompt: |
             Implement the change requested in this issue or comment.
 

--- a/template/.github/workflows/claude-plan.yml.jinja
+++ b/template/.github/workflows/claude-plan.yml.jinja
@@ -23,6 +23,7 @@ jobs:
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-plan'))
     runs-on: [ [[ ci_runner_labels ]] ]
+    timeout-minutes: 120
     permissions:
       contents: read
       issues: write
@@ -96,7 +97,10 @@ jobs:
           track_progress: true
           base_branch: main
           branch_prefix: claude/
-          claude_args: "--model opus --disallowedTools Edit Write Bash --max-turns 80"
+          # --max-budget-usd caps API-key spend; likely a no-op under
+          # CLAUDE_CODE_OAUTH_TOKEN (subscription) billing. Real runaway guards
+          # are timeout-minutes (job-level) and --max-turns.
+          claude_args: "--model opus --effort max --max-budget-usd 10 --disallowedTools Edit Write Bash --max-turns 120"
           prompt: |
             Post the plan as a comment. Do not write code or modify files.
             Focus on the specific task described in the triggering comment or

--- a/template/.github/workflows/claude-review.yml.jinja
+++ b/template/.github/workflows/claude-review.yml.jinja
@@ -24,6 +24,7 @@ jobs:
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-review'))
     runs-on: [ [[ ci_runner_labels ]] ]
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: write
@@ -83,7 +84,10 @@ jobs:
           allowed_bots: "renovate[bot],coderabbitai[bot],dependabot[bot]"
           base_branch: main
           branch_prefix: claude/
-          claude_args: "--model sonnet --disallowedTools Edit Write Bash --max-turns 40"
+          # --max-budget-usd caps API-key spend; likely a no-op under
+          # CLAUDE_CODE_OAUTH_TOKEN (subscription) billing. Real runaway guards
+          # are timeout-minutes (job-level) and --max-turns.
+          claude_args: "--model opus --effort max --max-budget-usd 6 --disallowedTools Edit Write Bash --max-turns 60"
           prompt: |
             Review the PR diff and post a code review comment. Flag security,
             correctness, and convention concerns (see AGENTS.md). Do not write


### PR DESCRIPTION
## Summary

Tunes the three Claude Code GitHub Actions workflows (`claude-plan`, `claude-implement`, `claude-review`), applied in lockstep to the root and the `template/` layer.

| Workflow | model | effort | --max-budget-usd | --max-turns | timeout-minutes |
|---|---|---|---|---|---|
| `claude-plan` | `opus` | `max` | $10 | 80 → **120** | **120** |
| `claude-implement` | sonnet → **`opus`** | `high` | $25 | 200 | **180** |
| `claude-review` | sonnet → **`opus`** | `max` | $6 | 40 → **60** | **60** |

## Details

- **Model** — implement + review move to Opus (plan was already Opus). Uses the `opus` **alias**, so they track the latest Opus automatically (no pinned `claude-opus-4-8` to bump later).
- **Effort** — new `--effort` flag. Safe to template: an unsupported level **silently downgrades** to the highest the active model supports (it never errors), so a generated repo can't break on it.
- **Turn caps** — plan 80→120, review 40→60; implement unchanged at 200.
- **`timeout-minutes`** (job-level) — the real runaway killswitch: GitHub-enforced wall-clock, independent of model/auth. `--max-turns` is a turn-count cap, not wall-clock, so this is a meaningful addition.
- **`--max-budget-usd`** — added as a belt-and-suspenders ceiling, but **commented inline** as a *likely no-op* under `CLAUDE_CODE_OAUTH_TOKEN` (subscription) billing, where usage is bundled rather than per-token metered. The functioning guards are `timeout-minutes` + `--max-turns`.

## Notes

- Cost-per-run logging was considered but **not** included — the action emits `total_cost_usd` in a structured result, but surfacing it in logs/comments is undocumented and needs testing first.
- Verified: `actionlint` clean on both root and the **rendered** template output (the jinja still produces valid YAML with the comment + flags intact).
- Unrelated `.meta/` cleanup is intentionally excluded, same as PR #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)