### PR TITLE
feat(template): add project-management doc gated by new copier question

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -169,6 +169,16 @@ organization_email:
   default: "evan@evanharmon.com"
   when: false
 
+# Formal display name of the GitHub org, used for the org-level Project title
+# ("<name> Project" — see docs/project-management.md). Distinct from
+# `organization` (the copyright entity): here the org Project is "Harmon Platform
+# Project" while the copyright holder is "Harmon Lab". Override per client org
+# (e.g. "Sommer Lawn").
+org_formal_name:
+  type: str
+  default: "Harmon Platform"
+  when: false
+
 repo_url:
   type: str
   default: "https://github.com/[[ github_org ]]/[[ project_slug ]]"

--- a/copier.yml
+++ b/copier.yml
@@ -113,6 +113,15 @@ devcontainer:
   help: "DEVCONTAINER: Add dual-profile .devcontainer (AI bot + human dev)?"
   default: yes
 
+project_management:
+  type: str
+  help: "PROJECT MGMT: Add a project-management doc (docs/project-management.md)?"
+  choices:
+    none: none
+    GitHub Projects: github
+    Linear (TODO stub): linear
+  default: none
+
 git_init:
   type: bool
   help: "GIT INIT: Initialize git repo?"

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ This is the **hub** — read it when you're unsure where something belongs. It
 | Decisions (ADRs) | [decisions/](decisions/) |
 | Guides (calm how-tos) | [guides/](guides/) — onboarding, deploying, troubleshooting |
 | Runbooks (crisis procedures) | [runbooks/](runbooks/) |
+| Project management (GitHub Projects) | [project-management.md](project-management.md) |
 | Post-generation setup | [CHECKLIST.md](CHECKLIST.md) |
 
 Design intent is at [`../DESIGN.md`](../DESIGN.md); specs (WHAT to build) in

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -1,0 +1,169 @@
+# Project Management
+
+How work is tracked for Harmon Init in **GitHub Projects**.
+
+## One project per org
+
+The standard strategy is a single GitHub **Project (V2)** per org, titled
+`<Org Formal Name> Project` (here: **Harmon Lab Project**). Issues and PRs
+from every repo in the org feed that one board — an issue can belong to multiple
+projects, but the org project is its default home. Reach for a second, focused
+project only when a body of work needs its own board.
+
+## Status pipeline
+
+`Status` is a single-select field with exactly one meaning: **where in the flow
+toward delivery is this.** The columns, grouped:
+
+**Backlog** — triage; not yet committed
+
+- Inbox — newly landed, unsorted
+- Icebox — real, but not now
+- Next — will pull in soon
+
+**Unstarted** — committed to a cycle, not yet in motion
+
+- Todo
+- Shaping — problem/approach still being defined
+- Ready — shaped, ready to pick up
+- Agent Queue — queued for an AI agent to implement
+
+**Started** — in motion, partial progress
+
+- In Progress
+- Verifying — CI/checks running
+- In Review — under human review
+- Ready to Merge — approved, awaiting merge
+
+**Completed**
+
+- Done — merged/shipped; the single terminal status
+- Deployed
+- Accepted — smoke/QA/manual check passed, communicated, released
+- Archived
+
+## Status is not issue state
+
+GitHub has **two independent state machines**, and conflating them is the most
+common way to make a board lie:
+
+- **Issue state** — `open` / `closed`, native to the issue.
+- **Status** — the custom pipeline field above, layered on top.
+
+`Status` answers *"where in the delivery flow is this."* It is **not** where you
+record *why something left the flow without shipping* — GitHub has a dedicated
+axis for that, the **close reason**.
+
+### Canceled and Duplicate are close reasons, not statuses
+
+They aren't pipeline positions; they're terminal closure reasons, and GitHub
+already has an axis for those that's separate from `Status` by design. When you
+close an issue you pick **Completed**, **Not planned**, or **Duplicate**:
+
+- **Cancel / won't-fix / stale** → close as **Not planned** — explicitly the
+  bucket for exactly this.
+- **Duplicate** → close as **Duplicate** (shipped December 2024). You select the
+  duplicated issue, which produces a timeline event and a note at the top making
+  the closure reason clear.
+
+Neither needs a `Status` value, and **Done** stays the single terminal status
+meaning "shipped." Why not add `Canceled`/`Duplicate` columns anyway, given
+Linear has a Canceled group? Because in Linear the status *is* the state, so
+"Canceled" closes the work atomically with that meaning. GitHub split them:
+`Status` is a custom field layered on an issue that keeps its own independent
+open/closed state.
+
+### Automation gotcha
+
+The built-in **"issue closed → Done"** rule doesn't look at *why* the issue
+closed, so closing something as Not planned or Duplicate would paint it **Done**
+on the board — wrong. Gate it:
+
+- Drive Done off **"PR merged → Done"** for the success path.
+- On a raw close event, check `state_reason == completed` before setting Done.
+
+Items closed as not-planned/duplicate just stay closed and fall off the board;
+their `Status` value goes vestigial, which is fine — nothing open-filtered shows
+them.
+
+## Blocked is not a status
+
+A `Blocked` column buys you visibility you already get for free, and it fights
+automation: statuses are artifact-driven (PR opened → Verifying) while "blocked"
+is a manual human overlay — an item that's "Blocked" but has an open PR is a
+contradiction the automation can't resolve. Blocked is **orthogonal** to pipeline
+position; keep it off that axis. There are two kinds, and they want different
+tools:
+
+- **Blocked by another issue** (the common case) — use the native **"Mark as
+  blocked by"** relationship (issue dependencies, GA 2025-08-21). It records
+  *what's* blocking (the actual issue, not a bare flag), shows the **Blocked**
+  icon on the board and Issues page automatically, is queryable with
+  `is:blocked`, and is fully programmatic (`gh issue view` shows Blocked by /
+  Blocking; `--json blockedBy,blocking`; REST endpoints add/list/remove).
+  When the blocker closes, the relationship reflects it. Up to 50 issues per
+  relationship type.
+- **Blocked by a non-issue** — waiting on a Twilio 10DLC approval, an upstream
+  library fix, a pricing decision, info from a customer. The native feature can't
+  express this (an issue only becomes "blocked" by depending on another issue),
+  so this is the **`blocked` label's** job: it means "stuck on a non-issue
+  thing," with the actual reason in a comment.
+
+One upgrade for that second case: model a *significant or shared* external
+blocker as its own **tracking issue** ("Twilio 10DLC brand approval") and mark
+the real work blocked-by it — that pulls the external dependency into the native
+mechanism (board icon, `is:blocked`, auto-resolve). Worth it when several items
+wait on the same thing; reserve the bare label for one-off, transient blockers.
+
+## Automations
+
+Projects are **org-level** objects, but automations trigger from **events**, and
+issue/PR events are repo-local. That splits automation three ways:
+
+1. **Triggered by repo activity (issue/PR events)** — the workflow *must* live in
+   the repo where the activity happens; a workflow in one repo never sees
+   another's PR events. In a polyrepo org the same automation runs in every repo
+   whose issues/PRs feed the project.
+2. **Triggered by a schedule or `workflow_dispatch`** — no per-repo trigger to
+   distribute, so pick one hub/ops repo and run it there.
+3. **Not an Action at all** — the project's **built-in workflows**.
+
+Start with #3: **push everything you can onto the built-in workflows.** They're
+configured on the project itself, fire on project-item events, and work
+org-project-wide across every repo with zero Actions and zero per-repo setup —
+Backlog on add, In Review on review-requested, Done on merge, Done on close,
+auto-close, auto-archive. Drop to Actions only for the gaps built-ins don't
+cover.
+
+TODO: finalize exactly what to automate. The intended event → status shape:
+
+- New issue → **Inbox**
+- Branch/PR started → **In Progress**
+- PR opened → **In Review**
+- Deployment complete → verification (if applicable)
+- Issue closed (`state_reason == completed`) → **Done**
+- 30–60 days in Done → **Archived**
+
+## Custom fields
+
+Beyond `Status`, the project carries:
+
+- **Priority**
+- **Estimate** — size/effort
+- **Product** — which product/area it belongs to
+- **Agent** — which agent should implement it (e.g. Claude vs Codex) and how
+  (effort level, model)
+
+TODO: finalize each field's options/values.
+
+## Notes
+
+- **Labels vs Type** — `Type` is a first-class issue field (Bug / Feature / …),
+  separate from labels; don't reproduce it as a label.
+- **Views** — save per-slice views off the one board (by iteration, product, or
+  agent) rather than spinning up more projects.
+- **Owner**, **Iteration/cycle**, **Milestone** — additional fields/axes as the
+  work needs them.
+- **Sub-issues** — break a large issue down natively instead of with a checklist.
+- An issue can belong to **multiple projects** — the org project plus a focused
+  one is fine.

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -5,10 +5,11 @@ How work is tracked for Harmon Init in **GitHub Projects**.
 ## One project per org
 
 The standard strategy is a single GitHub **Project (V2)** per org, titled
-`<Org Formal Name> Project` (here: **Harmon Lab Project**). Issues and PRs
-from every repo in the org feed that one board — an issue can belong to multiple
-projects, but the org project is its default home. Reach for a second, focused
-project only when a body of work needs its own board.
+`<Org Formal Name> Project` (here: **Harmon Platform Project**) — the org's
+formal display name, not the `github_org` login. Issues and PRs from every repo
+in the org feed that one board — an issue can belong to multiple projects, but
+the org project is its default home. Reach for a second, focused project only
+when a body of work needs its own board.
 
 ## Status pipeline
 

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -77,7 +77,8 @@ full)
     # Maximize conditional coverage: web tooling + terraform + ansible +
     # devcontainer + self-hosted runner labels (exercises actionlint config)
     # + an org owner != author (renders project-automation.yml, the org
-    # branches of the claude workflows, and the merge_queue ruleset rule).
+    # branches of the claude workflows, and the merge_queue ruleset rule)
+    # + the GitHub project-management doc (docs/project-management.md).
     data_args+=(
         --data project_type=web-astro
         --data include_terraform=true
@@ -85,18 +86,21 @@ full)
         --data devcontainer=true
         --data ci_runner=self-hosted
         --data github_org=test-org
+        --data project_management=github
     )
     ;;
 meta)
     # Covers conditionally-named files the other profiles leave disabled:
-    # the Bunch + Obsidian .meta notes, license=private, and the web-app
-    # (tsc --noEmit) branch. --skip-tasks because the bunch/obsidian _tasks
-    # move files into iCloud / the Obsidian vault — real side effects.
+    # the Bunch + Obsidian .meta notes, license=private, the web-app
+    # (tsc --noEmit) branch, and the Linear project-management doc stub.
+    # --skip-tasks because the bunch/obsidian _tasks move files into iCloud /
+    # the Obsidian vault — real side effects.
     data_args+=(
         --data project_type=web-app
         --data license=private
         --data bunch_add=true
         --data obsidian_project_add=true
+        --data project_management=linear
     )
     copier_flags+=(--skip-tasks)
     ;;
@@ -293,6 +297,25 @@ if [ "$profile" = "meta" ]; then
     [ -f ".meta/Code Project - Smoke Test.bunch" ] || err "Bunch file missing from .meta/"
     [ -f ".meta/Smoke Test.md" ] || err "Obsidian note missing from .meta/"
 fi
+
+# ── 9b. docs/project-management.md rendered per project_management answer ──
+# Two mutually-exclusive conditional-named source files share the rendered name
+# docs/project-management.md; assert the right one lands (and none does when the
+# answer is 'none') so a broken filename condition can't ship silently.
+case "$profile" in
+full) # project_management=github
+    [ -f docs/project-management.md ] || err "GitHub project-management.md missing from docs/"
+    grep -q 'Not planned' docs/project-management.md || err "GitHub project-management.md missing expected content"
+    ;;
+meta) # project_management=linear
+    [ -f docs/project-management.md ] || err "Linear project-management.md missing from docs/"
+    head -1 docs/project-management.md | grep -qx '# Linear' || err "Linear project-management.md not titled 'Linear'"
+    grep -q 'TODO' docs/project-management.md || err "Linear project-management.md missing TODO marker"
+    ;;
+*) # project_management defaults to none — no doc should render
+    [ ! -f docs/project-management.md ] || err "docs/project-management.md present but project_management=none for profile '$profile'"
+    ;;
+esac
 
 # ── 10. No secrets in the rendered tree (gitleaks) ──────────────────
 if have gitleaks; then

--- a/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
@@ -62,12 +62,13 @@ jobs:
                 [ "$MERGED" = "true" ] || { echo "PR closed without merge, skipping"; exit 0; }
                 TARGET_STATUS="Done"
               else
-                TARGET_STATUS="Validating"
+                TARGET_STATUS="Verifying"
               fi
               ;;
             pull_request_review)
               BRANCH="$BRANCH_PR"
-              TARGET_STATUS="Done"
+              # Approved but not yet merged — Done is reserved for the merge event
+              TARGET_STATUS="Ready to Merge"
               ;;
             workflow_run)
               BRANCH="$BRANCH_WF"
@@ -77,7 +78,7 @@ jobs:
               FAILED=$(echo "$CI_RUNS" | jq '[.[] | select(.conclusion != null and (.conclusion | test("^(failure|cancelled|timed_out|action_required)$")))] | length')
               PENDING=$(echo "$CI_RUNS" | jq '[.[] | select(.status != "completed")] | length')
               if [ "$FAILED" -gt 0 ]; then
-                TARGET_STATUS="Validating"
+                TARGET_STATUS="Verifying"
               elif [ "$PENDING" -gt 0 ]; then
                 echo "CI still running ($PENDING pending), skipping"; exit 0
               elif [ "$CI_COUNT" -ge 1 ]; then

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -45,9 +45,13 @@ config, toolchain, devcontainer, and dev environment — against the items below
       devcontainer prebuild populates `[[ devcontainer_image ]]` on merge to main
 [% endif %]
 [% if github_org != author_git_provider_username %]
-- [ ] Org Project V2 (number 1) with a `Status` single-select field
-      (Shaping / In Progress / Validating / In Review / Done) for
-      project-automation.yml and the claude-* workflows
+- [ ] Org Project V2 (number 1) with a `Status` single-select field. The
+      automation writes `Shaping`, `In Progress`, `Verifying`, `In Review`,
+      `Ready to Merge`, and `Done`, so those options must exist (for
+      project-automation.yml and the claude-* workflows).
+[% if project_management == 'github' %]
+      See [project-management.md](project-management.md) for the full pipeline.
+[% endif %]
 [% endif %]
 
 ## 3. Framework scaffolding (conventions-only template)

--- a/template/docs/README.md.jinja
+++ b/template/docs/README.md.jinja
@@ -33,6 +33,11 @@ This is the **hub** — read it when you're unsure where something belongs. It
 | Decisions (ADRs) | [decisions/](decisions/) |
 | Guides (calm how-tos) | [guides/](guides/) — onboarding, deploying, troubleshooting[% if devcontainer %], devcontainers[% endif %] |
 | Runbooks (crisis procedures) | [runbooks/](runbooks/) |
+[% if project_management == 'github' %]
+| Project management (GitHub Projects) | [project-management.md](project-management.md) |
+[% elif project_management == 'linear' %]
+| Project management (Linear) | [project-management.md](project-management.md) |
+[% endif %]
 | Post-generation setup | [CHECKLIST.md](CHECKLIST.md) |
 
 Design intent is at [`../DESIGN.md`](../DESIGN.md); specs (WHAT to build) in

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -5,10 +5,11 @@ How work is tracked for [[ project_name ]] in **GitHub Projects**.
 ## One project per org
 
 The standard strategy is a single GitHub **Project (V2)** per org, titled
-`<Org Formal Name> Project` (here: **[[ organization ]] Project**). Issues and PRs
-from every repo in the org feed that one board — an issue can belong to multiple
-projects, but the org project is its default home. Reach for a second, focused
-project only when a body of work needs its own board.
+`<Org Formal Name> Project` (here: **[[ org_formal_name ]] Project**) — the org's
+formal display name, not the `github_org` login. Issues and PRs from every repo
+in the org feed that one board — an issue can belong to multiple projects, but
+the org project is its default home. Reach for a second, focused project only
+when a body of work needs its own board.
 
 ## Status pipeline
 

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -1,0 +1,173 @@
+# Project Management
+
+How work is tracked for [[ project_name ]] in **GitHub Projects**.
+
+## One project per org
+
+The standard strategy is a single GitHub **Project (V2)** per org, titled
+`<Org Formal Name> Project` (here: **[[ organization ]] Project**). Issues and PRs
+from every repo in the org feed that one board — an issue can belong to multiple
+projects, but the org project is its default home. Reach for a second, focused
+project only when a body of work needs its own board.
+
+## Status pipeline
+
+`Status` is a single-select field with exactly one meaning: **where in the flow
+toward delivery is this.** The columns, grouped:
+
+**Backlog** — triage; not yet committed
+
+- Inbox — newly landed, unsorted
+- Icebox — real, but not now
+- Next — will pull in soon
+
+**Unstarted** — committed to a cycle, not yet in motion
+
+- Todo
+- Shaping — problem/approach still being defined
+- Ready — shaped, ready to pick up
+- Agent Queue — queued for an AI agent to implement
+
+**Started** — in motion, partial progress
+
+- In Progress
+- Verifying — CI/checks running
+- In Review — under human review
+- Ready to Merge — approved, awaiting merge
+
+**Completed**
+
+- Done — merged/shipped; the single terminal status
+- Deployed
+- Accepted — smoke/QA/manual check passed, communicated, released
+- Archived
+
+## Status is not issue state
+
+GitHub has **two independent state machines**, and conflating them is the most
+common way to make a board lie:
+
+- **Issue state** — `open` / `closed`, native to the issue.
+- **Status** — the custom pipeline field above, layered on top.
+
+`Status` answers *"where in the delivery flow is this."* It is **not** where you
+record *why something left the flow without shipping* — GitHub has a dedicated
+axis for that, the **close reason**.
+
+### Canceled and Duplicate are close reasons, not statuses
+
+They aren't pipeline positions; they're terminal closure reasons, and GitHub
+already has an axis for those that's separate from `Status` by design. When you
+close an issue you pick **Completed**, **Not planned**, or **Duplicate**:
+
+- **Cancel / won't-fix / stale** → close as **Not planned** — explicitly the
+  bucket for exactly this.
+- **Duplicate** → close as **Duplicate** (shipped December 2024). You select the
+  duplicated issue, which produces a timeline event and a note at the top making
+  the closure reason clear.
+
+Neither needs a `Status` value, and **Done** stays the single terminal status
+meaning "shipped." Why not add `Canceled`/`Duplicate` columns anyway, given
+Linear has a Canceled group? Because in Linear the status *is* the state, so
+"Canceled" closes the work atomically with that meaning. GitHub split them:
+`Status` is a custom field layered on an issue that keeps its own independent
+open/closed state.
+
+### Automation gotcha
+
+The built-in **"issue closed → Done"** rule doesn't look at *why* the issue
+closed, so closing something as Not planned or Duplicate would paint it **Done**
+on the board — wrong. Gate it:
+
+- Drive Done off **"PR merged → Done"** for the success path.
+- On a raw close event, check `state_reason == completed` before setting Done.
+
+Items closed as not-planned/duplicate just stay closed and fall off the board;
+their `Status` value goes vestigial, which is fine — nothing open-filtered shows
+them.
+
+## Blocked is not a status
+
+A `Blocked` column buys you visibility you already get for free, and it fights
+automation: statuses are artifact-driven (PR opened → Verifying) while "blocked"
+is a manual human overlay — an item that's "Blocked" but has an open PR is a
+contradiction the automation can't resolve. Blocked is **orthogonal** to pipeline
+position; keep it off that axis. There are two kinds, and they want different
+tools:
+
+- **Blocked by another issue** (the common case) — use the native **"Mark as
+  blocked by"** relationship (issue dependencies, GA 2025-08-21). It records
+  *what's* blocking (the actual issue, not a bare flag), shows the **Blocked**
+  icon on the board and Issues page automatically, is queryable with
+  `is:blocked`, and is fully programmatic (`gh issue view` shows Blocked by /
+  Blocking; `--json blockedBy,blocking`; REST endpoints add/list/remove).
+  When the blocker closes, the relationship reflects it. Up to 50 issues per
+  relationship type.
+- **Blocked by a non-issue** — waiting on a Twilio 10DLC approval, an upstream
+  library fix, a pricing decision, info from a customer. The native feature can't
+  express this (an issue only becomes "blocked" by depending on another issue),
+  so this is the **`blocked` label's** job: it means "stuck on a non-issue
+  thing," with the actual reason in a comment.
+
+One upgrade for that second case: model a *significant or shared* external
+blocker as its own **tracking issue** ("Twilio 10DLC brand approval") and mark
+the real work blocked-by it — that pulls the external dependency into the native
+mechanism (board icon, `is:blocked`, auto-resolve). Worth it when several items
+wait on the same thing; reserve the bare label for one-off, transient blockers.
+
+## Automations
+
+Projects are **org-level** objects, but automations trigger from **events**, and
+issue/PR events are repo-local. That splits automation three ways:
+
+1. **Triggered by repo activity (issue/PR events)** — the workflow *must* live in
+   the repo where the activity happens; a workflow in one repo never sees
+   another's PR events. In a polyrepo org the same automation runs in every repo
+   whose issues/PRs feed the project.
+[% if github_org != author_git_provider_username %]
+   [[ project_name ]] ships one as `.github/workflows/project-automation.yml`,
+   syncing `Status` from PR/CI events.
+[% endif %]
+2. **Triggered by a schedule or `workflow_dispatch`** — no per-repo trigger to
+   distribute, so pick one hub/ops repo and run it there.
+3. **Not an Action at all** — the project's **built-in workflows**.
+
+Start with #3: **push everything you can onto the built-in workflows.** They're
+configured on the project itself, fire on project-item events, and work
+org-project-wide across every repo with zero Actions and zero per-repo setup —
+Backlog on add, In Review on review-requested, Done on merge, Done on close,
+auto-close, auto-archive. Drop to Actions only for the gaps built-ins don't
+cover.
+
+TODO: finalize exactly what to automate. The intended event → status shape:
+
+- New issue → **Inbox**
+- Branch/PR started → **In Progress**
+- PR opened → **In Review**
+- Deployment complete → verification (if applicable)
+- Issue closed (`state_reason == completed`) → **Done**
+- 30–60 days in Done → **Archived**
+
+## Custom fields
+
+Beyond `Status`, the project carries:
+
+- **Priority**
+- **Estimate** — size/effort
+- **Product** — which product/area it belongs to
+- **Agent** — which agent should implement it (e.g. Claude vs Codex) and how
+  (effort level, model)
+
+TODO: finalize each field's options/values.
+
+## Notes
+
+- **Labels vs Type** — `Type` is a first-class issue field (Bug / Feature / …),
+  separate from labels; don't reproduce it as a label.
+- **Views** — save per-slice views off the one board (by iteration, product, or
+  agent) rather than spinning up more projects.
+- **Owner**, **Iteration/cycle**, **Milestone** — additional fields/axes as the
+  work needs them.
+- **Sub-issues** — break a large issue down natively instead of with a checklist.
+- An issue can belong to **multiple projects** — the org project plus a focused
+  one is fine.

--- a/template/docs/[% if project_management == 'linear' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'linear' %]project-management.md[% endif %].jinja
@@ -1,0 +1,8 @@
+# Linear
+
+How work is tracked for [[ project_name ]] in **Linear**.
+
+TODO: document the Linear workflow — teams, workflow states (Linear's status
+groups map cleanly onto delivery: Backlog / Unstarted / Started / Completed /
+Canceled), cycles, triage, automations, and custom fields (Priority, Estimate,
+Product, Agent).


### PR DESCRIPTION
## What

Adds a `project_management` copier question (**GitHub Projects / Linear / None**, default **none**) that gates a new `docs/project-management.md`.

- **GitHub variant** — one-project-per-org strategy; the Backlog / Unstarted / Started / Completed status pipeline; issue-state vs project-`Status` as two independent state machines (Canceled → close as *Not planned*, Duplicate → close as *Duplicate*); the "issue closed → Done" automation gotcha (`state_reason == completed`); Blocked-is-not-a-status (native "blocked by" for issues vs the `blocked` label for non-issue blockers); the three-way automation split (built-ins first); and custom fields (Priority / Estimate / Product / Agent). Automation specifics and field values are left as `TODO:` per intent.
- **Linear variant** — a titled `# Linear` `TODO:` stub. Both are mutually-exclusive conditional-named files rendering to `docs/project-management.md` (same pattern as the two `eslint.config.js` files).

## Status alignment

Aligned the org project statuses to the doc's vocabulary in `project-automation.yml`:

- `Validating` → `Verifying`
- approved review `Done` → **`Ready to Merge`** — so `Done` means *merged* only. ⚠️ This is a small **behavior** change, not just a rename.

Result: `Shaping → In Progress → Verifying → In Review → Ready to Merge → Done` (`claude-plan`/`claude-implement` already emitted `Shaping`/`In Progress`). `CHECKLIST.md` and the docs index updated to match.

## Tests

`test-template.sh`: `full` renders the GitHub variant, `meta` the Linear stub, plus a step-9b assertion that neither renders under the `none` default. Root dogfoods the GitHub variant (`docs/project-management.md`).

All profiles pass (`minimal`, `web`… via CI; verified `minimal`/`update`/`meta`/`full` locally) and `task check` is green.

## Follow-ups (separate PRs)

- **harmon-devkit**: the standardize-repo skill's `references/post-generation-checklist.md` still `createProjectV2Field`s the old options (`…/Validating/…`) — needs the new set or the renamed workflow's option lookups silently skip.
- **harmon-init**: root `docs/README.md` guides row was missing `, devcontainers` (pre-existing dogfood drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
