### PR TITLE
docs: sync root docs index — add devcontainers to guides row

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ This is the **hub** — read it when you're unsure where something belongs. It
 | Product — vision, roadmap, domain | [product/](product/) |
 | Architecture (subject hubs) | [architecture/](architecture/) — ci-cd, security, branch-protection, tests |
 | Decisions (ADRs) | [decisions/](decisions/) |
-| Guides (calm how-tos) | [guides/](guides/) — onboarding, deploying, troubleshooting |
+| Guides (calm how-tos) | [guides/](guides/) — onboarding, deploying, troubleshooting, devcontainers |
 | Runbooks (crisis procedures) | [runbooks/](runbooks/) |
 | Post-generation setup | [CHECKLIST.md](CHECKLIST.md) |
 


### PR DESCRIPTION
## What

The root dogfood's `docs/README.md` guides row was missing the **devcontainers** guide. The template source (`template/docs/README.md.jinja`) already renders it via `[% if devcontainer %], devcontainers[% endif %]`, but the root copy was never re-synced when that guide was added — pre-existing dogfood drift, surfaced while working on #182.

One-line fix: matches a fresh render with `devcontainer=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)