### PR TITLE
chore(dogfood): sync root docs/config with current template conventions

### DIFF
--- a/.devcontainer/dev/devcontainer.json
+++ b/.devcontainer/dev/devcontainer.json
@@ -47,6 +47,11 @@
     "source=shell-history-${devcontainerId},target=/home/vscode/.shell-history,type=volume",
     "source=zoxide-data-${devcontainerId},target=/home/vscode/.local/share/zoxide,type=volume"
   ],
+  // CLAUDE_CODE_EFFORT_LEVEL: default Claude Code thinking effort. Set here
+  // (not in settings.json) because Claude Code's settings schema only accepts
+  // low|medium|high for the persisted effortLevel field, while the env var
+  // accepts low|medium|high|max. Resolution order at runtime: env var >
+  // settings.json effortLevel > model default.
   "containerEnv": {
     "CODER": "${localEnv:CODER}",
     "DEVCONTAINER_TAILSCALE": "true",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,6 +51,12 @@
   // Do NOT forward them via containerEnv — ${localEnv:...} resolves to ""
   // when the host shell doesn't export them, which overrides the env-file
   // values (Docker --env takes precedence over --env-file).
+  //
+  // CLAUDE_CODE_EFFORT_LEVEL: default Claude Code thinking effort. Set here
+  // (not in settings.json) because Claude Code's settings schema only accepts
+  // low|medium|high for the persisted effortLevel field, while the env var
+  // accepts low|medium|high|max. Resolution order at runtime: env var >
+  // settings.json effortLevel > model default.
   "containerEnv": {
     "CODER": "${localEnv:CODER}",
     "CLAUDE_CODE_EFFORT_LEVEL": "max"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: [ "ubuntu-latest" ]
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,6 +2,7 @@
   "default": true,
   "MD003": { "style": "atx" },
   "MD013": false,
+  "MD024": { "siblings_only": true },
   "MD034": false,
   "MD036": false,
   "MD041": false,

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -329,6 +329,23 @@ tasks:
     cmds:
       - lefthook install
 
+  setup:github:
+    desc: Apply idempotent GitHub repo settings via gh (Dependabot alerts, private vulnerability reporting, CodeQL variable)
+    vars:
+      REPO: "evanharmon1/harmon-init"
+    cmds:
+      - gh api "repos/{{.REPO}}/vulnerability-alerts" --method PUT
+      # Private vulnerability reporting is a public-repo-only feature; harmon-init
+      # creates repos --private, so guard on visibility to avoid a 404 that would
+      # abort the task. Applies cleanly if the repo is later made public.
+      - |
+        if [ "$(gh api "repos/{{.REPO}}" --jq '.private')" = "false" ]; then
+          gh api "repos/{{.REPO}}/private-vulnerability-reporting" --method PUT
+        else
+          echo "Skipping private vulnerability reporting ({{.REPO}} is private; public-repo-only feature)."
+        fi
+      - gh variable set FULL_SECURITY_SCAN --repo "{{.REPO}}" --body true
+
   # ── Release ───────────────────────────────────────────────────
   # Releases are intentional — never automated on merge to main.
   release:init:

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -6,7 +6,21 @@ export default {
     'type-enum': [
       2,
       'always',
-      ['build', 'change', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'remove', 'revert', 'style', 'test']
+      [
+        'build',
+        'change',
+        'chore',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'remove',
+        'revert',
+        'style',
+        'test'
+      ]
     ]
   }
 }

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -62,3 +62,6 @@ config, toolchain, devcontainer, and dev environment — against the items below
 - [ ] Fill in the `TODO:` markers in README.md and docs/ (architecture diagram first)
 - [ ] Confirm README badges render (Actions URLs are correct once CI runs)
 - [ ] Initial release when ready: `task release:init` (v0.1.0) — releases stay manual
+- [ ] Stay current with harmon-init: periodically run `copier update --trust` to pull
+      template improvements (a three-way merge — your own edits are preserved). The
+      standardize-repo skill (`update` mode) automates this and verifies the result.

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -13,44 +13,10 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
 
 ## Workflows
 
-- `build.yml` — on push/PR to `main`: `lint`, `security`, the `template-test`
-  matrix (renders every copier profile and validates the output), then the
-  aggregate **`verify`** job.
+- `build.yml` — on push/PR to `main`: lint, security, then the aggregate **`verify`** job.
 - `claude-plan` / `claude-implement` / `claude-review` — `@claude …` on issues and PRs.
-- `devcontainer-build.yml` — builds the root's bot + dev devcontainers on
-  `.devcontainer/**` changes (and pushes a GHCR cache on merge to `main`).
+- `devcontainer-build.yml` — prebuilds the devcontainer images to GHCR on `.devcontainer/**` changes.
 - `release.yml` — release-please maintains the rolling release PR.
-
-## Devcontainer build verification
-
-Split deliberately by cost:
-
-- **The image is built once, by dogfooding.** `devcontainer-build.yml` runs a real
-  `devcontainers/ci` build of the root repo's own bot + dev devcontainers on every
-  PR touching `.devcontainer/**` (and pushes a GHCR cache on merge to `main`).
-- **Rendered template configs are validated, not built.** `build.yml`'s
-  `template-test` matrix runs `devcontainer read-configuration` on each rendered
-  profile (via `scripts/test-template.sh`) — it parses `devcontainer.json` and
-  resolves its `features`, but does not build the image.
-
-We **do not** build the rendered devcontainer per copier profile: that would be
-~5× the same build for almost no extra coverage, because of one load-bearing
-invariant —
-
-> **The template Dockerfile (`template/…/Dockerfile`) stays profile-invariant: no
-> `[% … %]` copier conditionals.**
-
-Since it renders identically for every `project_type`, the single dogfood build
-above covers the image for all profiles. The only per-profile variation is in
-`devcontainer.json` (`forwardPorts`, a few extensions, and the `terraform` feature
-when `include_terraform`) — config that `read-configuration` already validates. The
-one build path the dogfood does not exercise is the upstream, version-pinned
-`terraform` devcontainer feature, whose ref `read-configuration` still resolves.
-
-**If a Dockerfile conditional is ever added** (e.g. branching on `use_node`), this
-invariant breaks and the dogfood stops covering all profiles — at that point add a
-path-filtered, per-profile rendered build (mirroring `devcontainer-build.yml`) for
-the profiles that now differ.
 
 ## Authentication
 

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -9,9 +9,13 @@ current — it is the reference for "where do secrets live and who can do what".
 
 - **Least privilege.** Every token, account, and workflow gets the narrowest
   scope that still works.
-- **Secrets via 1Password.** Local env comes from 1Password (`op run` /
-  `op inject`); CI reads from GitHub Actions secrets. TODO: list the 1Password
-  vault/items this project uses.
+- **Secrets via 1Password.** Local env comes from **1Password Environments**
+  (a virtual `.env` mounted over a UNIX pipe — never written to disk or git) or
+  `op run`/`op inject`; CI reads from GitHub Actions secrets.
+  Devcontainer secrets are `GH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`,
+  `AGENT_DECK_TELEGRAM_KEY` (+ `TS_AUTHKEY`, dev profile only) — see
+  [../guides/devcontainers.md](../guides/devcontainers.md).
+  TODO: list the 1Password vault/items this project uses.
 - **Auditable changes.** `main` is protected; changes land via reviewed PRs
   (see [branch-protection.md](branch-protection.md)).
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -57,7 +57,9 @@ it points here.
 
 ## YAML, Markdown & shell
 
-- **YAML:** 2-space indent, `.yml` extension (not `.yaml`), linted by yamllint.
+- **YAML:** 2-space indent, linted by yamllint. Use whichever extension
+  (`.yml` or `.yaml`) each tool conventionally uses (e.g. `Taskfile.yml`,
+  `.coderabbit.yaml`) — don't normalize extensions repo-wide.
 - **Markdown:** markdownlint — ATX headings, no duplicate headings, emphasis and
   strong markers consistent within a file; line-length and first-line-heading
   rules are off.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -10,6 +10,9 @@ Calm, repeatable how-tos read *in advance* (the crisis counterpart is
 - [troubleshooting.md](troubleshooting.md) — symptom → cause → fix for **dev**
   problems (broken build, failing local setup). Distinct from runbooks, which
   cover prod incidents.
+- [devcontainers.md](devcontainers.md) — the dual-profile devcontainer (bot vs
+  dev), local secrets via **1Password Environments**, GHCR prebuilds, and
+  **Coder** setup.
 - [devcontainer-performance.md](devcontainer-performance.md) — tuning CPU/RAM
   for the devcontainer; the real levers live in Coder and WSL2, not this repo.
 

--- a/docs/guides/devcontainer-performance.md
+++ b/docs/guides/devcontainer-performance.md
@@ -72,4 +72,5 @@ process is memory — bump `memory` (and `swap` on WSL2) accordingly.
 
 ## See also
 
+- [devcontainers.md](devcontainers.md) — the dual-profile devcontainer overall.
 - [troubleshooting.md](troubleshooting.md) — other devcontainer issues.

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -1,0 +1,138 @@
+# Devcontainers
+
+Harmon Init ships a **dual-profile** devcontainer. Both profiles share
+one `Dockerfile` and the baked `.devcontainer/config/` tree; they differ in
+which secrets and capabilities they allow.
+
+| Profile | Path | For | Tailscale |
+|---|---|---|---|
+| **Bot** | `.devcontainer/devcontainer.json` | AI agents (Claude Code, Codex, Gemini) | no |
+| **Dev** | `.devcontainer/dev/devcontainer.json` | humans | yes (`TS_AUTHKEY`, `--device=/dev/net/tun`) |
+
+The bot profile intentionally omits `TS_AUTHKEY` from its allow-list so a tailnet
+key never reaches an agent container.
+
+**Claude permission mode differs by profile.** The **bot** defaults to
+`bypassPermissions` (Claude runs tools without per-action prompts — the container
+is the isolation boundary); the **dev** profile keeps the normal prompt-on-action
+default so a human stays in the loop. The shared managed settings
+(`config/claude-settings.json`) deliberately omit `defaultMode`; the bot opts in
+at create time via `scripts/enable-claude-bypass.sh`. `bypassPermissions` is only
+safe because it is container-scoped — it is never set on the host.
+
+## Run it locally
+
+- **VS Code:** "Dev Containers: Reopen in Container" → pick the **Dev** profile
+  (`.devcontainer/dev/`) for human use.
+- **CLI:** `devcontainer up --workspace-folder . --config .devcontainer/dev/devcontainer.json`
+
+Prebuilt images are pulled from GHCR as a build cache
+(`ghcr.io/evanharmon1/harmon-init-devcontainer` / `ghcr.io/evanharmon1/harmon-init-devcontainer-dev`), so a warm rebuild
+is fast. A cache miss is non-fatal — it just rebuilds from the `Dockerfile`.
+
+## Secrets — 1Password Environments (the standard)
+
+Don't hand-write or copy `devcontainer.env`. The standard is **1Password
+Environments**, which mounts a virtual `.env` over a UNIX pipe — the values are
+**never written to disk or committed** (the path is gitignored anyway).
+
+1. In the **1Password** app → **Developer** → **Environments**, create an
+   environment for this repo (import an existing `.env` or add the variables
+   below, each referencing a vault item).
+2. Set the destination to **Local .env file** and point the mount at
+   `.devcontainer/devcontainer.env` (bot). Add a second destination at
+   `.devcontainer/dev/devcontainer.env` for the dev profile.
+3. Authorize access when prompted. The container's `--env-file` then reads it
+   like any `.env`.
+
+Variables per profile:
+
+| Variable | Bot | Dev | What it's for |
+|---|---|---|---|
+| `GH_TOKEN` | ✅ | ✅ | `gh` CLI / API |
+| `CLAUDE_CODE_OAUTH_TOKEN` | ✅ | ✅ | Claude Code |
+| `AGENT_DECK_TELEGRAM_KEY` | ✅ | ✅ | agent-deck bridge (optional) |
+| `TS_AUTHKEY` | — | ✅ | Tailscale (dev only) |
+
+`ANTHROPIC_API_KEY` is deliberately **forbidden** — it silently overrides
+`CLAUDE_CODE_OAUTH_TOKEN`, so `init-env.sh` strips it from the env-file.
+
+### What `init-env.sh` does
+
+On container init the devcontainer runs `.devcontainer/scripts/init-env.sh` on
+the **host**. It enforces the per-profile allow-list (e.g. evicts `TS_AUTHKEY`
+and `ANTHROPIC_API_KEY` from the bot env-file on every rebuild) and, in
+environments where the 1Password app isn't present (**Coder / Codespaces**),
+captures the same variables from the **host environment**, where they arrive as
+workspace/template parameters. It does **not** call `op` itself — 1Password
+Environments is what supplies the values locally.
+
+## Run it in Coder
+
+The devcontainers are Coder-ready: the `CODER` env is passed through, the
+`config/` tree is baked to `/usr/local/share/devcontainer-config/` so it
+survives Coder's `/tmp` mount shadowing, and `init-env.sh` reads secrets from
+the host environment (above).
+
+What Coder needs is a **workspace template** that clones this repo and builds the
+devcontainer — that template is **org-level infrastructure, not part of this
+repo** (one template serves every repo). To stand this repo up in Coder:
+
+1. Use your org's Coder "devcontainer" template (the canonical example is
+   `terraform/coder/devcontainer/` in
+   [harmonops/harmon-infra](https://github.com/harmonops/harmon-infra)). It uses
+   the Coder `git-clone` + `devcontainers-cli` modules.
+2. Create a workspace from it and set the parameters:
+   - **repo** → `https://github.com/evanharmon1/harmon-init`
+   - secrets → `GH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `AGENT_DECK_TELEGRAM_KEY`
+     (+ `TS_AUTHKEY` if you want Tailscale). Coder passes these into the
+     workspace's host environment, where `init-env.sh` picks them up.
+3. The build pulls `ghcr.io/evanharmon1/harmon-init-devcontainer` from GHCR as a cache. If that
+   package is private, give the Coder builder a read token (or make the package
+   public); a cache miss only makes the first build slower.
+
+> Unlike harmon-infra, this repo's `Dockerfile` uses the **public** Microsoft
+> base image, so the classic-PAT / private-base-image (`ghcr_read_token`)
+> complication does not apply here — only the repo's own `-devcontainer` cache
+> image matters.
+
+## Working on related repos
+
+To work across several repos in one container, list them in
+`.devcontainer/related-repos.txt` (one `owner/repo` per line; `@branch`, full
+URLs, and ssh URLs also work). They are:
+
+- **cloned** into `/workspaces/`, beside this repo, on container **create**
+  (`scripts/bootstrap-related-repos.sh`) — so a rebuilt or persistence-lost
+  container re-populates them;
+- **fetched** non-destructively on container **start**
+  (`scripts/fetch-related-repos.sh`).
+
+Both are safe to re-run: an already-cloned sibling is **never clobbered** —
+clone skips it, and start runs `git fetch` only (never pull / merge / checkout),
+so uncommitted work, local commits, and the checked-out branch stay put. The
+list is preserved across `copier update` (an empty list is a no-op).
+
+To let Claude read and search the cloned siblings, add them to
+`.claude/settings.json` in **two** places — `permissions.additionalDirectories`
+(Claude's own Read/Grep/Glob tools) and `sandbox.filesystem.allowRead` (the Bash
+sandbox):
+
+```json
+{
+  "permissions": {
+    "additionalDirectories": ["../sibling-repo"]
+  },
+  "sandbox": {
+    "filesystem": {
+      "allowRead": ["../sibling-repo"]
+    }
+  }
+}
+```
+
+## See also
+
+- [architecture/security.md](../architecture/security.md) — full secret strategy.
+- [troubleshooting.md](troubleshooting.md) — devcontainer issues.
+- `.github/workflows/devcontainer-build.yml` — the GHCR prebuild.

--- a/docs/guides/onboarding.md
+++ b/docs/guides/onboarding.md
@@ -10,7 +10,9 @@ Getting productive in Harmon Init.
 4. Verify everything works: `task verify`
 
 Prefer the devcontainer? Open the repo in VS Code and "Reopen in Container"
-(human profile: `.devcontainer/dev/`), or use the Coder workspace.
+(human profile: `.devcontainer/dev/`), or use a Coder workspace. See
+[devcontainers.md](devcontainers.md) for local secrets (1Password Environments)
+and Coder setup.
 
 ## Daily workflow
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -10,7 +10,7 @@ Common issues in Harmon Init and how to fix them.
 ## Devcontainer
 
 - **Stale tools after a Dockerfile change** — rebuild the container; prebuilt images come from GHCR (see `.github/workflows/devcontainer-build.yml`).
-- **Missing secrets in the container** — the env-file is seeded by `.devcontainer/scripts/init-env.sh` from 1Password or host env on rebuild.
+- **Missing secrets in the container** — locally, the env-file is provided by a **1Password environment** mounted at `.devcontainer/devcontainer.env` (see [devcontainers.md](devcontainers.md)); on Coder/Codespaces it's seeded from host/workspace env by `.devcontainer/scripts/init-env.sh`. Note `init-env.sh` does **not** call `op` — if values are missing locally, check the 1Password environment is authorized and mounted at the right path.
 
 ## CI
 


### PR DESCRIPTION
The harmon-init root had drifted behind several merged template updates (its local dogfood was never re-synced). This brings it back in line with the template it ships — verified by rendering the template with root's own answers and reconciling only genuine staleness, leaving the documented intentional divergences alone.

## Re-synced (root was stale)
- **docs** — `conventions.md` (YAML-extension guidance), `architecture/ci-cd.md` + `architecture/security.md` (1Password Environments, devcontainer secrets), `guides/` (onboarding/README/troubleshooting/devcontainer-performance), `CHECKLIST.md` ("Stay current with `copier update`" item), and the **missing `guides/devcontainers.md`**.
- **config** — `.markdownlint.json` (`MD024: siblings_only`), `commitlint.config.mjs` (prettier reflow — same content), `release.yml` (`runs-on` list form), `.devcontainer/*.json` (new template comments).
- **Taskfile** — added the `setup:github` task (root simply lacked it).

## Deliberately left as-is
Intentional divergences per the dogfood setup: `README.md`, `AGENTS.md` body, `build.yml` (template-test matrix), `Brewfile` extras, `.coderabbit.yaml`, `renovate.json`, `.yamllint`/`.gitleaks.toml` template excludes, `LICENSE`, `lefthook.yml` (has `template/**` excludes + a `test:template` hook), extended `.gitignore`, seeded `.release-please-manifest.json`, and `.vscode/settings.json` (gitignored at root). Also skipped `validate` (root's `verify` gate is intentionally different, so it'd be orphaned) and `SECURITY.md` (root's "release of the template" wording is more accurate for root).

`docs/project-management.md` + the `setup:github-project` task/script ride in with #185.

Verified: `task check` and `task test:tasks` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)