### PR TITLE
docs(template): list close-milestone-on-release.yml in ci-cd.md

### DIFF
--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -17,6 +17,7 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
 - `claude-plan` / `claude-implement` / `claude-review` — `@claude …` on issues and PRs.
 - `devcontainer-build.yml` — prebuilds the devcontainer images to GHCR on `.devcontainer/**` changes.
 - `release.yml` — release-please maintains the rolling release PR.
+- `close-milestone-on-release.yml` — closes the milestone matching the tag on release publish.
 
 ## Authentication
 

--- a/template/docs/architecture/ci-cd.md.jinja
+++ b/template/docs/architecture/ci-cd.md.jinja
@@ -27,6 +27,9 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
 [% if github_org != author_git_provider_username %]
 - `project-automation.yml` — syncs the org Project board status from PR/CI events.
 [% endif %]
+[% if use_release_please and project_management == 'github' %]
+- `close-milestone-on-release.yml` — closes the milestone matching the tag on release publish.
+[% endif %]
 
 ## Authentication
 


### PR DESCRIPTION
`close-milestone-on-release.yml` shipped (in v3.13.0) but the CI/CD architecture doc's workflow list didn't mention it. Add the entry to both layers, gated `use_release_please and project_management == 'github'` (matching the workflow's filename gate).

Loose-end cleanup from the project-management overhaul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)