### PR TITLE
feat(template): status:setup audits the GitHub PM setup tasks

### DIFF
--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -424,6 +424,21 @@ if [[ "${SECTION}" == "setup" ]]; then
                 -f query='query($o:String!,$r:String!){repository(owner:$o,name:$r){projectsV2(first:10){nodes{title number}}}}' \
                 -F o="${OWNER}" -F r="${REPO}" \
                 >"${d}/projects.json" 2>/dev/null || echo '{}' >"${d}/projects.json") &
+            # PM setup surface — audit the results of the setup:github-* tasks the
+            # repo actually ships (each script is the marker it opted in).
+            if [ -f scripts/setup-github-labels.sh ]; then
+                (timeout "${NETWORK_TIMEOUT}" gh label list -R "${OWNER}/${REPO}" --json name \
+                    >"${d}/labels.json" 2>/dev/null || echo '[]' >"${d}/labels.json") &
+            fi
+            if [ -f scripts/setup-github-issue-types.sh ]; then
+                (timeout "${NETWORK_TIMEOUT}" gh api "orgs/${OWNER}/issue-types" --paginate \
+                    >"${d}/issue-types.json" 2>/dev/null || echo 'null' >"${d}/issue-types.json") &
+            fi
+            if [ -f scripts/setup-github-issue-fields.sh ]; then
+                (timeout "${NETWORK_TIMEOUT}" gh api "orgs/${OWNER}/issue-fields" \
+                    -H "X-GitHub-Api-Version: 2026-03-10" --paginate \
+                    >"${d}/issue-fields.json" 2>/dev/null || echo 'null' >"${d}/issue-fields.json") &
+            fi
             # App installs — definitive when we hold admin scope, else 'null'.
             (timeout "${NETWORK_TIMEOUT}" gh api "${APPS_PATH}" \
                 --jq '[.installations[].app_slug]' \
@@ -604,6 +619,33 @@ if [[ "${SECTION}" == "setup" ]]; then
                     fi
                 else
                     checkline unknown "GitHub Project linked" "needs read:project scope"
+                fi
+                if [ -f scripts/setup-github-labels.sh ]; then
+                    if jq -e 'any(.[]?; .name == "needs-triage")' "${d}/labels.json" >/dev/null 2>&1; then
+                        checkline ok "Starter labels" "seeded"
+                    else
+                        checkline no "Starter labels" "run task setup:github-labels"
+                    fi
+                fi
+                if [ -f scripts/setup-github-issue-types.sh ]; then
+                    type_names="$(jq -r 'if type == "array" then (map(.name) | join(",")) else "" end' "${d}/issue-types.json" 2>/dev/null || echo "")"
+                    if [ -z "${type_names}" ]; then
+                        checkline unknown "Org issue types" "needs admin:org"
+                    elif printf '%s' "${type_names}" | grep -q 'Research'; then
+                        checkline ok "Org issue types" "Bug/Feature/Task/Research"
+                    else
+                        checkline no "Org issue types" "run task setup:github-issue-types"
+                    fi
+                fi
+                if [ -f scripts/setup-github-issue-fields.sh ]; then
+                    field_names="$(jq -r '(if type == "object" then (.issue_fields // []) elif type == "array" then . else [] end) | map(.name) | join(",")' "${d}/issue-fields.json" 2>/dev/null || echo "")"
+                    if [ -z "${field_names}" ]; then
+                        checkline unknown "Org issue fields" "needs admin:org (public preview)"
+                    elif printf '%s' "${field_names}" | grep -q 'Agent'; then
+                        checkline ok "Org issue fields" "Product + Agent"
+                    else
+                        checkline no "Org issue fields" "run task setup:github-issue-fields"
+                    fi
                 fi
                 if [ "${has_release_wf}" = 1 ]; then
                     if [ -s "${d}/release.txt" ]; then

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -424,6 +424,21 @@ if [[ "${SECTION}" == "setup" ]]; then
                 -f query='query($o:String!,$r:String!){repository(owner:$o,name:$r){projectsV2(first:10){nodes{title number}}}}' \
                 -F o="${OWNER}" -F r="${REPO}" \
                 >"${d}/projects.json" 2>/dev/null || echo '{}' >"${d}/projects.json") &
+            # PM setup surface — audit the results of the setup:github-* tasks the
+            # repo actually ships (each script is the marker it opted in).
+            if [ -f scripts/setup-github-labels.sh ]; then
+                (timeout "${NETWORK_TIMEOUT}" gh label list -R "${OWNER}/${REPO}" --json name \
+                    >"${d}/labels.json" 2>/dev/null || echo '[]' >"${d}/labels.json") &
+            fi
+            if [ -f scripts/setup-github-issue-types.sh ]; then
+                (timeout "${NETWORK_TIMEOUT}" gh api "orgs/${OWNER}/issue-types" --paginate \
+                    >"${d}/issue-types.json" 2>/dev/null || echo 'null' >"${d}/issue-types.json") &
+            fi
+            if [ -f scripts/setup-github-issue-fields.sh ]; then
+                (timeout "${NETWORK_TIMEOUT}" gh api "orgs/${OWNER}/issue-fields" \
+                    -H "X-GitHub-Api-Version: 2026-03-10" --paginate \
+                    >"${d}/issue-fields.json" 2>/dev/null || echo 'null' >"${d}/issue-fields.json") &
+            fi
             # App installs — definitive when we hold admin scope, else 'null'.
             (timeout "${NETWORK_TIMEOUT}" gh api "${APPS_PATH}" \
                 --jq '[.installations[].app_slug]' \
@@ -604,6 +619,33 @@ if [[ "${SECTION}" == "setup" ]]; then
                     fi
                 else
                     checkline unknown "GitHub Project linked" "needs read:project scope"
+                fi
+                if [ -f scripts/setup-github-labels.sh ]; then
+                    if jq -e 'any(.[]?; .name == "needs-triage")' "${d}/labels.json" >/dev/null 2>&1; then
+                        checkline ok "Starter labels" "seeded"
+                    else
+                        checkline no "Starter labels" "run task setup:github-labels"
+                    fi
+                fi
+                if [ -f scripts/setup-github-issue-types.sh ]; then
+                    type_names="$(jq -r 'if type == "array" then (map(.name) | join(",")) else "" end' "${d}/issue-types.json" 2>/dev/null || echo "")"
+                    if [ -z "${type_names}" ]; then
+                        checkline unknown "Org issue types" "needs admin:org"
+                    elif printf '%s' "${type_names}" | grep -q 'Research'; then
+                        checkline ok "Org issue types" "Bug/Feature/Task/Research"
+                    else
+                        checkline no "Org issue types" "run task setup:github-issue-types"
+                    fi
+                fi
+                if [ -f scripts/setup-github-issue-fields.sh ]; then
+                    field_names="$(jq -r '(if type == "object" then (.issue_fields // []) elif type == "array" then . else [] end) | map(.name) | join(",")' "${d}/issue-fields.json" 2>/dev/null || echo "")"
+                    if [ -z "${field_names}" ]; then
+                        checkline unknown "Org issue fields" "needs admin:org (public preview)"
+                    elif printf '%s' "${field_names}" | grep -q 'Agent'; then
+                        checkline ok "Org issue fields" "Product + Agent"
+                    else
+                        checkline no "Org issue fields" "run task setup:github-issue-fields"
+                    fi
                 fi
                 if [ "${has_release_wf}" = 1 ]; then
                     if [ -s "${d}/release.txt" ]; then


### PR DESCRIPTION
`task status:setup` (scripts/status.sh) audited GitHub config (rulesets, Dependabot, Renovate, CodeRabbit, Project-linked) but had no checks for the setup tasks added in the PM overhaul. Add three, each gated on the `setup-github-*` script the repo actually ships:

- **Starter labels** — checks the seeded labels exist (repo scope; signals on `needs-triage`).
- **Org issue types** — Bug/Feature/Task/Research (org; `admin:org`, falls back to `unknown`).
- **Org issue fields** — Product + Agent (org; `admin:org` + preview, `unknown` fallback).

Applied to both template and root `status.sh` (identical). shellcheck/shfmt clean; `test:template:full` + `task check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)