### PR TITLE
chore(dogfood): reconcile root with the project-management setup surface

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -346,6 +346,18 @@ tasks:
         fi
       - gh variable set FULL_SECURITY_SCAN --repo "{{.REPO}}" --body true
 
+  setup:github-project:
+    desc: Idempotently create/sync the owner's GitHub Project V2 board + Status pipeline (on a personal account also its metadata fields). Requires `gh auth refresh -s project`.
+    cmds:
+      - ./scripts/setup-github-project.sh --owner "evanharmon1" --title "evanharmon1 Project"
+
+  setup:github-labels:
+    desc: Idempotently create/update this repo's starter labels (see docs/project-management.md). Requires `gh` with repo write.
+    vars:
+      REPO: "evanharmon1/harmon-init"
+    cmds:
+      - ./scripts/setup-github-labels.sh --repo "{{.REPO}}"
+
   # ── Release ───────────────────────────────────────────────────
   # Releases are intentional — never automated on merge to main.
   release:init:

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -40,6 +40,30 @@ config, toolchain, devcontainer, and dev environment — against the items below
       claude-* workflows, and project-automation. See docs/architecture/security.md.
 - [ ] GHCR: ensure the org/user allows publishing packages; the first
       devcontainer prebuild populates `ghcr.io/evanharmon1/harmon-init-devcontainer` on merge to main
+- [ ] GitHub Project: run `task setup:github-project` (needs
+      `gh auth refresh -s project`) to create the owner's default project (titled
+      `evanharmon1 Project`) and idempotently sync its `Status` pipeline — see
+      [project-management.md](project-management.md).
+      On a personal account it also creates Priority/Effort/Product/Agent as
+      project fields (issue fields are org-only); status automation is a separate
+      follow-up — the board is set up, but issue/PR status isn't auto-synced yet.
+- [ ] Labels: run `task setup:github-labels` to seed this repo's starter label
+      families (concerns/source/workflow/layer/domain — see
+      [project-management.md](project-management.md)). Labels are per-repo, so run
+      it in each repo; org default labels (org Settings → Repository, UI-only) only
+      seed new repos.
+- [ ] Project views: create the starter views (Board / Triage / Agent queue /
+      Planning / Mine) in the Project UI — Projects V2 has no view API,
+      so this is a one-time manual step. Filters/layouts are in
+      [project-management.md](project-management.md).
+- [ ] GitHub Project auto-add (**adds every issue to the board**): in the
+      Project's **Settings → Workflows**, turn on **"Auto-add to project"** and
+      point it at this repo (filter `is:issue`, `is:pr`) so *every* new issue and
+      PR lands on the board automatically, however it's created. GitHub's native
+      built-in — no Actions or tokens, and it's the reliable way to guarantee
+      coverage (the issue-form `projects:` key only covers form-created issues and
+      needs a static project number). See
+      [project-management.md](project-management.md).
 
 ## 3. Framework scaffolding (conventions-only template)
 

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# setup-github-labels.sh — idempotently create/update this repo's starter label
+# set (docs/project-management.md). Colors are grouped by family (concerns=purple,
+# source=pink, workflow=orange, layer=blue, domain=yellow).
+#
+# Labels are REPO-level in GitHub — there's no shared org label pool. Run this in
+# each repo; org "default labels" (Settings → Repository, UI-only, no API) only
+# seed NEW repos and don't touch existing ones. Non-destructive: `--force`
+# creates-or-updates and it never deletes labels, so GitHub's defaults stay unless
+# you prune them yourself.
+#
+# Usage: setup-github-labels.sh --repo <owner/repo>
+# Needs: gh authed with repo write.
+#
+# NOTE: hits the live GitHub API, so it is not exercised by `task test:template`
+# (guarded by shellcheck + shfmt only). Test it against a scratch repo.
+set -euo pipefail
+
+repo=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --repo)
+        repo="${2:-}"
+        shift 2
+        ;;
+    *)
+        echo "Unknown argument: $1" >&2
+        exit 2
+        ;;
+    esac
+done
+
+if [ -z "$repo" ]; then
+    echo "Usage: $0 --repo <owner/repo>" >&2
+    exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "Required tool not found: gh" >&2
+    exit 1
+fi
+
+# name|hex-color|description — one per line. Color encodes the family.
+labels="
+sec|5319E7|Security concern
+a11y|5319E7|Accessibility concern
+perf|5319E7|Performance concern
+tech-debt|5319E7|Technical debt
+i18n|5319E7|Internationalization
+l10n|5319E7|Localization
+customer-request|EC4899|Requested by a customer
+ai-generated|EC4899|Created or authored by an AI agent
+needs-triage|E36209|Awaiting triage
+needs-requirements|E36209|Requirements not yet defined
+blocked|E36209|Blocked by a non-issue dependency (reason in a comment)
+waiting|E36209|Waiting on an external party
+needs-decision|E36209|Needs a decision before it can proceed
+needs-response|E36209|Awaiting a response
+needs-communication|E36209|An update needs to be communicated out
+layer:frontend|1D76DB|Frontend
+layer:backend|1D76DB|Backend
+layer:infra|1D76DB|Infrastructure
+domain:auth|FBCA04|Authentication and authorization
+domain:billing|FBCA04|Billing and payments
+"
+
+printf '%s\n' "$labels" | while IFS='|' read -r name color desc; do
+    [ -z "$name" ] && continue
+    echo "==> label: $name"
+    gh label create "$name" --repo "$repo" --color "$color" --description "$desc" --force
+done
+
+echo "==> Done — starter labels on $repo (existing labels left as-is)"

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# setup-github-project.sh — idempotently create and sync a GitHub Project V2 for a
+# repo owner (an organization OR a personal user account): the board and its
+# Status pipeline (docs/project-management.md). On an ORGANIZATION, the metadata
+# fields are org-level ISSUE fields (Priority + Effort are GitHub built-ins;
+# setup-github-issue-fields.sh adds Product + Agent); on a personal account (no
+# org issue fields) this script creates Priority/Effort/Product/Agent as project
+# fields instead.
+#
+# Safe to re-run and safe to run from every repo the owner controls: it looks the
+# project up by title, so the first run creates it and later runs just reconcile
+# fields. It never deletes options or fields, so your later customizations survive.
+#
+# Usage:   setup-github-project.sh --owner <org-or-user-login> --title "<Project Title>"
+# Needs:   gh authed with the 'project' scope (gh auth refresh -s project) + jq.
+#
+# NOTE: this hits the live GitHub API, so it is not exercised by `task
+# test:template` (which never touches GitHub) — it is guarded by shellcheck +
+# shfmt only. Test it against a scratch project when changing it.
+set -euo pipefail
+
+owner=""
+title=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --owner)
+        owner="${2:-}"
+        shift 2
+        ;;
+    --title)
+        title="${2:-}"
+        shift 2
+        ;;
+    *)
+        echo "Unknown argument: $1" >&2
+        exit 2
+        ;;
+    esac
+done
+
+if [ -z "$owner" ] || [ -z "$title" ]; then
+    echo "Usage: $0 --owner <org-or-user-login> --title \"<Project Title>\"" >&2
+    exit 2
+fi
+
+for tool in gh jq; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "Required tool not found: $tool" >&2
+        exit 1
+    fi
+done
+
+# Full Status pipeline (docs/project-management.md), in board order. GitHub's API
+# cannot create the visual groups, so these render as a flat, ordered list.
+status_pipeline='[
+  {"name":"Inbox","color":"GRAY","description":"Newly landed, unsorted"},
+  {"name":"Icebox","color":"GRAY","description":"Real, but not now"},
+  {"name":"Next","color":"PINK","description":"Will pull in soon"},
+  {"name":"Todo","color":"BLUE","description":"Committed, not started"},
+  {"name":"Shaping","color":"BLUE","description":"Problem/approach being defined"},
+  {"name":"Ready","color":"BLUE","description":"Shaped, ready to pick up"},
+  {"name":"Agent Queue","color":"BLUE","description":"Queued for an AI agent"},
+  {"name":"In Progress","color":"YELLOW","description":"Actively being worked"},
+  {"name":"Verifying","color":"ORANGE","description":"CI/checks running"},
+  {"name":"In Review","color":"GREEN","description":"Under human review"},
+  {"name":"Ready to Merge","color":"GREEN","description":"Approved, awaiting merge"},
+  {"name":"Done","color":"PURPLE","description":"Merged/shipped"},
+  {"name":"Deployed","color":"PURPLE","description":"Deployed"},
+  {"name":"Accepted","color":"PURPLE","description":"Smoke/QA/manual check passed"}
+]'
+
+# jq filter: a JSON array of {name,color,description} -> a GraphQL options
+# fragment. Names/descriptions are JSON-escaped; color is emitted as a bare enum.
+opts_to_graphql='[.[] | "{name:" + (.name|@json) + ",color:" + .color + ",description:" + (.description|@json) + "}"] | join(",")'
+
+# ── Resolve the owner (org or user), then find the project by title ──
+# repositoryOwner + a ProjectV2Owner fragment is one code path for both User and
+# Organization owners (both implement the interface).
+echo "==> Resolving owner '$owner'"
+owner_data=$(gh api graphql -f query='query($l:String!){repositoryOwner(login:$l){__typename id}}' \
+    -f l="$owner")
+owner_type=$(printf '%s' "$owner_data" | jq -r '.data.repositoryOwner.__typename')
+owner_id=$(printf '%s' "$owner_data" | jq -r '.data.repositoryOwner.id')
+if [ -z "$owner_id" ] || [ "$owner_id" = "null" ]; then
+    echo "Could not resolve owner '$owner' — check the login and that you have the 'project' scope." >&2
+    exit 1
+fi
+
+echo "==> Looking for a project titled '$title'"
+project_id=""
+project_number=""
+cursor=""
+while true; do
+    if [ -n "$cursor" ]; then
+        page=$(gh api graphql -f query='query($l:String!,$c:String){repositoryOwner(login:$l){... on ProjectV2Owner{projectsV2(first:100,after:$c){pageInfo{hasNextPage endCursor} nodes{id number title}}}}}' \
+            -f l="$owner" -f c="$cursor")
+    else
+        page=$(gh api graphql -f query='query($l:String!){repositoryOwner(login:$l){... on ProjectV2Owner{projectsV2(first:100){pageInfo{hasNextPage endCursor} nodes{id number title}}}}}' \
+            -f l="$owner")
+    fi
+    match=$(printf '%s' "$page" |
+        jq -r --arg t "$title" '.data.repositoryOwner.projectsV2.nodes[] | select(.title==$t) | (.id + "\t" + (.number|tostring))' |
+        head -n1)
+    if [ -n "$match" ]; then
+        project_id=$(printf '%s' "$match" | cut -f1)
+        project_number=$(printf '%s' "$match" | cut -f2)
+        break
+    fi
+    has_next=$(printf '%s' "$page" | jq -r '.data.repositoryOwner.projectsV2.pageInfo.hasNextPage')
+    [ "$has_next" = "true" ] || break
+    cursor=$(printf '%s' "$page" | jq -r '.data.repositoryOwner.projectsV2.pageInfo.endCursor')
+done
+
+created=0
+if [ -n "$project_id" ]; then
+    echo "    Found existing project #$project_number"
+else
+    echo "    Not found — creating '$title'"
+    resp=$(gh api graphql -f query='mutation($o:ID!,$t:String!){createProjectV2(input:{ownerId:$o,title:$t}){projectV2{id number}}}' \
+        -f o="$owner_id" -f t="$title")
+    project_id=$(printf '%s' "$resp" | jq -r '.data.createProjectV2.projectV2.id')
+    project_number=$(printf '%s' "$resp" | jq -r '.data.createProjectV2.projectV2.number')
+    created=1
+    echo "    Created project #$project_number"
+fi
+
+# For an organization, record the project id in the ORG_PROJECT_ID org variable
+# that project-automation.yml + the claude-* workflows read (preferred over a
+# title lookup). Personal accounts have no org-level variable scope, and their
+# status automation is a separate follow-up, so skip it there.
+if [ "$owner_type" = "Organization" ]; then
+    echo "==> Recording project id in the ORG_PROJECT_ID org variable"
+    if ! gh variable set ORG_PROJECT_ID --org "$owner" --visibility all --body "$project_id"; then
+        echo "WARNING: could not set the ORG_PROJECT_ID org variable (needs org admin)." >&2
+        echo "         Set it by hand: gh variable set ORG_PROJECT_ID --org \"$owner\" --body \"$project_id\"" >&2
+    fi
+else
+    echo "==> Owner is a user account — skipping ORG_PROJECT_ID (no user-level variable scope; personal status automation is a separate follow-up)"
+fi
+
+# ── Snapshot current fields (one read; reused for existence checks) ──
+fields_json=$(gh api graphql -f query='query($p:ID!){node(id:$p){... on ProjectV2{fields(first:50){nodes{... on ProjectV2FieldCommon{id name} ... on ProjectV2SingleSelectField{options{name color description}}}}}}}' \
+    -f p="$project_id")
+
+field_id() {
+    printf '%s' "$fields_json" |
+        jq -r --arg n "$1" '.data.node.fields.nodes[] | select(.name==$n) | .id' | head -n1
+}
+
+# ── Status field: full pipeline on a new project; preserve + append on an
+#    existing one so items already assigned to an option are never orphaned ──
+status_field_id=$(field_id "Status")
+if [ -z "$status_field_id" ]; then
+    echo "==> Creating the Status field with the full pipeline"
+    frag=$(printf '%s' "$status_pipeline" | jq -r "$opts_to_graphql")
+    gh api graphql -f p="$project_id" \
+        -f query="mutation(\$p:ID!){createProjectV2Field(input:{projectId:\$p,dataType:SINGLE_SELECT,name:\"Status\",singleSelectOptions:[$frag]}){projectV2Field{... on ProjectV2SingleSelectField{id}}}}" \
+        >/dev/null
+else
+    if [ "$created" = "1" ]; then
+        echo "==> Setting Status to the full pipeline (new project)"
+        desired="$status_pipeline"
+    else
+        echo "==> Syncing Status (keeping existing options, appending any missing)"
+        existing=$(printf '%s' "$fields_json" |
+            jq -c '[.data.node.fields.nodes[] | select(.name=="Status") | .options[] | {name, color: (.color // "GRAY" | ascii_upcase), description: (.description // "")}]')
+        desired=$(jq -cn --argjson ex "$existing" --argjson pl "$status_pipeline" \
+            '$ex + [ $pl[] | select( ([ $ex[].name ] | index(.name)) == null ) ]')
+    fi
+    frag=$(printf '%s' "$desired" | jq -r "$opts_to_graphql")
+    gh api graphql -f f="$status_field_id" \
+        -f query="mutation(\$f:ID!){updateProjectV2Field(input:{fieldId:\$f,singleSelectOptions:[$frag]}){projectV2Field{... on ProjectV2SingleSelectField{id}}}}" \
+        >/dev/null
+fi
+
+# ── Custom fields: create-if-missing; existing fields are left untouched ──
+create_single_select() {
+    name="$1"
+    options_json="$2"
+    if [ -n "$(field_id "$name")" ]; then
+        echo "    Field '$name' already exists — leaving it as-is"
+        return 0
+    fi
+    echo "    Creating single-select field '$name'"
+    frag=$(printf '%s' "$options_json" | jq -r "$opts_to_graphql")
+    gh api graphql -f p="$project_id" \
+        -f query="mutation(\$p:ID!){createProjectV2Field(input:{projectId:\$p,dataType:SINGLE_SELECT,name:\"$name\",singleSelectOptions:[$frag]}){projectV2Field{... on ProjectV2SingleSelectField{id}}}}" \
+        >/dev/null
+}
+
+create_text() {
+    name="$1"
+    if [ -n "$(field_id "$name")" ]; then
+        echo "    Field '$name' already exists — leaving it as-is"
+        return 0
+    fi
+    echo "    Creating text field '$name'"
+    gh api graphql -f p="$project_id" \
+        -f query="mutation(\$p:ID!){createProjectV2Field(input:{projectId:\$p,dataType:TEXT,name:\"$name\"}){projectV2Field{... on ProjectV2FieldCommon{id}}}}" \
+        >/dev/null
+}
+
+create_number() {
+    name="$1"
+    if [ -n "$(field_id "$name")" ]; then
+        echo "    Field '$name' already exists — leaving it as-is"
+        return 0
+    fi
+    echo "    Creating number field '$name'"
+    gh api graphql -f p="$project_id" \
+        -f query="mutation(\$p:ID!){createProjectV2Field(input:{projectId:\$p,dataType:NUMBER,name:\"$name\"}){projectV2Field{... on ProjectV2FieldCommon{id}}}}" \
+        >/dev/null
+}
+
+# Metadata fields: on an ORGANIZATION these are org-level ISSUE fields (durable —
+# the value is on the issue, shared across every project; see
+# docs/project-management.md). Priority + Effort are GitHub built-ins;
+# setup-github-issue-fields.sh adds Product + Agent. A personal account has no org
+# issue fields, so fall back to creating them as project fields here.
+if [ "$owner_type" = "Organization" ]; then
+    echo "==> Metadata are org issue fields (Priority/Effort built-in; run setup-github-issue-fields.sh for Product/Agent)"
+    echo "==> Done — project #$project_number: $title"
+    exit 0
+fi
+
+echo "==> Custom project fields (personal account; starters — re-runs won't clobber them)"
+create_single_select "Priority" '[
+  {"name":"Urgent","color":"RED","description":""},
+  {"name":"High","color":"ORANGE","description":""},
+  {"name":"Medium","color":"YELLOW","description":""},
+  {"name":"Low","color":"GRAY","description":""}
+]'
+# Effort is story points on the Fibonacci ladder (1/2/3/5/8/13/21) — a NUMBER
+# field so views can sum it per group (single-selects can't be summed). The
+# ladder is a convention; a number field takes free numeric entry.
+create_number "Effort"
+create_text "Product"
+create_single_select "Agent" '[
+  {"name":"Claude Code","color":"ORANGE","description":""},
+  {"name":"Codex","color":"BLUE","description":""},
+  {"name":"Gemini CLI","color":"PURPLE","description":""},
+  {"name":"Qwen Code","color":"GREEN","description":""},
+  {"name":"DeepSeek","color":"RED","description":""},
+  {"name":"Kimi K2","color":"YELLOW","description":""},
+  {"name":"GLM","color":"PINK","description":""},
+  {"name":"GitHub Copilot","color":"GRAY","description":""}
+]'
+
+echo "==> Done — project #$project_number: $title"


### PR DESCRIPTION
harmon-init's root dogfooded `project_management: github` only partially — it carried `docs/project-management.md` + `close-milestone-on-release.yml` but not the setup scripts/tasks/checklist items the template generates. This completes the render (personal-account variant):

- **Scripts:** `scripts/setup-github-project.sh`, `scripts/setup-github-labels.sh` (copied from the template — static bash, values come via runtime args; `+x`).
- **Taskfile:** `setup:github-project` + `setup:github-labels` tasks (org-only `setup:github-issue-fields`/`issue-types` correctly stay absent for a personal repo).
- **CHECKLIST:** the GitHub Project / Labels / Project-views / Auto-add items (personal branch; block extracted from a faithful render, not hand-typed).

Root-only — no `template/` changes, so no consumer impact. Once #192 (the status.sh checks) also lands, `task status:setup` on harmon-init will exercise the new label check (this branch is off main, so its `status.sh` is still the old one — expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)