### PR TITLE
feat(template): direnv secrets via .envrc.tpl + op inject

### DIFF
--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -87,6 +87,11 @@ __pycache__/
 .ruff_cache/
 .coverage
 htmlcov/
+
+# direnv: resolved secret exports, generated from .envrc.tpl via `op inject`
+# (never committed). .envrc itself is committed and only activates the venv and
+# sources this file when present.
+.envrc.local
 [% endif %]
 [% if include_terraform %]
 

--- a/template/[% if use_python %].envrc.tpl[% endif %]
+++ b/template/[% if use_python %].envrc.tpl[% endif %]
@@ -1,0 +1,15 @@
+# op inject source — resolve the op:// references below into the gitignored
+# .envrc.local (which .envrc sources), so secrets never touch git:
+#
+#   op inject -i .envrc.tpl -o .envrc.local
+#
+# op:// references are pointers, not secrets, so THIS file is safe to commit; the
+# resolved .envrc.local is gitignored — never commit it. Re-run the command above
+# whenever you change a reference. Setup steps are in docs/CHECKLIST.md.
+#
+# Examples (uncomment and point each at your own 1Password item):
+#
+# export CLOUDFLARE_API_TOKEN="op://Vault/item/CLOUDFLARE_API_TOKEN"
+# export AWS_ACCESS_KEY_ID="op://Vault/item/Access Key ID"
+# export AWS_SECRET_ACCESS_KEY="op://Vault/item/Secret Access Key"
+# export TF_VAR_example="op://Vault/item/example"

--- a/template/[% if use_python %].envrc[% endif %]
+++ b/template/[% if use_python %].envrc[% endif %]
@@ -1,4 +1,10 @@
-# direnv: auto-activate the uv-managed virtualenv when you cd into the project.
-# Run `direnv allow` once to trust this file (the devcontainer does it in
-# post-create). Create the venv first with `uv sync` / `task install`.
+# direnv config for this project. Run `direnv allow` once to trust it (the
+# devcontainer does this in post-create).
+
+# Auto-activate the uv-managed virtualenv (create it with `uv sync` / `task install`).
 [ -f .venv/bin/activate ] && source .venv/bin/activate
+
+# Secret env vars (cloud creds, TF_VAR_*, ...) must NOT live in this committed
+# file. Put op:// references in .envrc.tpl, resolve them into the gitignored
+# .envrc.local with `op inject -i .envrc.tpl -o .envrc.local`, and they load here:
+[ -f .envrc.local ] && source .envrc.local

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -130,6 +130,13 @@ config, toolchain, devcontainer, and dev environment — against the items below
 - [ ] For local `.env` needs, use **1Password Environments** (mounts a virtual
       `.env`; secrets never hit disk or git) or `op run`/`op inject`. Commit only
       `.env.example`-style files
+[% if use_python %]
+- [ ] For direnv env vars that include secrets (cloud creds, `TF_VAR_*`), put
+      `op://` references in `.envrc.tpl`, then run
+      `op inject -i .envrc.tpl -o .envrc.local`. `.envrc` (committed, activates the
+      venv) sources the resolved `.envrc.local` (gitignored) — never commit resolved
+      secrets. `direnv allow` once to trust it
+[% endif %]
 [% if devcontainer %]
 - [ ] Devcontainer secrets: create a **1Password environment** that mounts
       `.devcontainer/devcontainer.env` (and `.devcontainer/dev/devcontainer.env`)


### PR DESCRIPTION
## Context
When auditing the platform repos against v3.14.0, sommerlawn-infra had evolved a safer direnv-secrets pattern than the template ships: instead of a committed `.envrc`, it keeps `op://` references in a committed `.envrc.tpl`, resolves them with `op inject` into a **gitignored** file, so resolved secrets never touch git. This upstreams that idea as the default for `use_python` repos.

## What changed (template/, `use_python`-gated)
- **`.envrc`** (still committed) now sources `.envrc.local` when present — it keeps activating the uv venv out of the box (no fresh-clone regression; the devcontainer's existing `[ -f .envrc ]` guard is unchanged).
- **`.envrc.tpl`** (new, committed) — the `op inject -i .envrc.tpl -o .envrc.local` source, with `op://` examples + instructions. `op://` refs are pointers, safe to commit.
- **`.gitignore`** ignores `.envrc.local` (resolved secrets), but not `.envrc`/`.envrc.tpl`.
- **CHECKLIST** documents the `op inject` step.

## Design note
I kept `.envrc` committed and put resolved secrets in a gitignored **`.envrc.local`** (sourced by `.envrc`), rather than gitignoring `.envrc` itself as sommerlawn-infra does. Same security guarantee (resolved secrets never committed), but no loss of out-of-the-box venv activation and no devcontainer change. sommerlawn-infra can align to `.envrc.local` on its next `copier update`, or keep its equivalent variant.

## Verification
- `task test:template:all` ✅ (iac render has `.envrc` + `.envrc.tpl`, gitignores `.envrc.local`; general/`use_python=false` render has no `.envrc*`)
- `task verify` ✅
- Template-only; harmon-init root is `use_python: false`, so no dogfood counterpart

🤖 Generated with [Claude Code](https://claude.com/claude-code)