### PR TITLE
feat(template): default project_management to github for org repos

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -115,12 +115,16 @@ devcontainer:
 
 project_management:
   type: str
-  help: "PROJECT MGMT: Add a project-management doc (docs/project-management.md)?"
+  help: "PROJECT MGMT: GitHub Projects playbook (docs/project-management.md + setup tasks)? Org repos default to GitHub (shared org board); personal to none."
   choices:
     none: none
     GitHub Projects: github
     Linear (TODO stub): linear
-  default: none
+  # Org repos (github_org != the author's own account) default to GitHub Projects,
+  # since every org repo feeds the one shared org board; personal repos default to
+  # none. Override either way at generation. Existing repos keep their recorded
+  # answer on `copier update` — this only affects new generation.
+  default: "[% if github_org != author_git_provider_username %]github[% else %]none[% endif %]"
 
 git_init:
   type: bool


### PR DESCRIPTION
## Context
Standardizing the platform repos, all three **org** repos (harmonops, sommerlawn ×2) generated with `project_management: none` and had to be hand-flipped to `github` afterward — the `standardize-repo --defaults` path always takes the default, and the default was `none`. This makes org repos default to GitHub Projects instead.

## Change
`project_management`'s default becomes conditional (matching the existing `ci_runner_labels` pattern):

```yaml
default: "[% if github_org != author_git_provider_username %]github[% else %]none[% endif %]"
```

- **Org repos** (`github_org != author`) → default **`github`** — every org repo feeds the one shared org board.
- **Personal repos** → default **`none`** (unchanged).
- Both overridable at generation; the help text now says so.

## Blast radius
- **Existing repos keep their recorded answer on `copier update`** — only new generation is affected.
- `test:template:all` passes: the only org profile (`full`) already sets `project_management=github` explicitly, and all personal profiles keep `github_org=author` → `none`, so **no rendered profile output changes**.
- Verified by spot-render: `--data github_org=some-org` (no explicit PM) → `github` + `docs/project-management.md`; a personal render → `none`, no PM artifacts.

## Verification
`task test:template:all` ✅ · `task verify` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)