### PR TITLE
feat(template): security scanning strategy (SAST/SCA/secrets/audits) + Snyk optional/local

### DIFF
--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -445,12 +445,12 @@ tasks:
 [% endif %]
 
   security:sast:
-    desc: Static application security testing (Snyk)
+    desc: "Static application security testing (Snyk) — optional/local, needs SNYK_TOKEN (not in CI or `task security`)"
     cmds:
       - snyk code test --exclude=.worktrees --severity-threshold=high
 
   security:sca:
-    desc: Software composition analysis (Snyk)
+    desc: "Software composition analysis (Snyk) — optional/local, needs SNYK_TOKEN (not in CI or `task security`)"
     cmds:
 [% if use_node %]
       - snyk test --file=pnpm-lock.yaml --severity-threshold=high --show-vulnerable-paths=all

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -34,6 +34,14 @@ config, toolchain, devcontainer, and dev environment — against the items below
       **Snyk GitHub App** is installed it posts `code/snyk`/`security/snyk` PR checks,
       which the branch ruleset does **not** require; remove the app (or this repo from
       it) to drop them.
+[% if project_type == 'web-app' %]
+- [ ] **Product security** (this is a web-app — likely a customer-facing product):
+      the default CodeQL + Dependabot + gitleaks stack is the floor; for a real SaaS
+      also weigh a **paid Snyk tier** (licence compliance + reachability +
+      defense-in-depth; removes the Snyk-Code free limit), **DAST** against the
+      running app, and a **multi-tenant isolation** review before onboarding
+      customers. See [architecture/security.md](architecture/security.md).
+[% endif %]
 - [ ] CI GitHub App `[[ github_org ]]-ci`: create it by hand for this org (one App
       per org; **Settings → Developer settings → GitHub Apps**), or reuse the
       org's existing one;

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -27,8 +27,13 @@ config, toolchain, devcontainer, and dev environment — against the items below
 
 - [ ] Install the [Renovate app](https://github.com/apps/renovate) on the repo
 - [ ] Install the [CodeRabbit app](https://github.com/apps/coderabbitai) on the repo (`.coderabbit.yaml` is pre-configured)
-- [ ] Actions secrets: `CLAUDE_CODE_OAUTH_TOKEN` (claude-* workflows),
-      `SNYK_TOKEN` (snyk tasks)
+- [ ] Actions secret: `CLAUDE_CODE_OAUTH_TOKEN` (claude-* workflows)
+- [ ] Snyk is **optional and local-only**: `task security:sast`/`security:sca` are
+      opt-in — they are NOT in CI or `task security`, so run them by hand with
+      `SNYK_TOKEN` in your local env / 1Password (no Actions secret needed). If the
+      **Snyk GitHub App** is installed it posts `code/snyk`/`security/snyk` PR checks,
+      which the branch ruleset does **not** require; remove the app (or this repo from
+      it) to drop them.
 - [ ] CI GitHub App `[[ github_org ]]-ci`: create it by hand for this org (one App
       per org; **Settings → Developer settings → GitHub Apps**), or reuse the
       org's existing one;

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -20,6 +20,63 @@ current — it is the reference for "where do secrets live and who can do what".
   TODO: list the 1Password vault/items this project uses.
 - **Auditable changes.** `main` is protected; changes land via reviewed PRs
   (see [branch-protection.md](branch-protection.md)).
+
+## Security scanning: SAST, SCA, secrets & audits
+
+Scanning is layered across a few axes. Each check runs at a defined place — a
+`task` target, a CI job, a git hook, or a GitHub-native setting — so local runs,
+git hooks, and CI stay identical. **The default stack is GitHub-native + CI-local
+and needs no paid service.**
+
+| Axis | Catches | Default tool | Where it runs |
+|---|---|---|---|
+| **SAST** — flaws in *your own code* | injection, XSS, SSRF, path traversal, crypto/auth misuse | **CodeQL** (`codeql.yml`; JS/TS + Python) | CI, opt-in via the `FULL_SECURITY_SCAN=true` repo variable; results land in the GitHub Security tab |
+| **SCA** — CVEs in *dependencies* | vulnerable third-party packages | **Dependabot alerts** + **`task security:audit`** (`pnpm audit` / `pip-audit`) | Dependabot continuous (GitHub-native); audit in the CI `security` job + `task security` locally |
+| **Secrets** — committed credentials | keys, tokens, certs, `.env` | **gitleaks** (`task security:secrets`) | pre-push git hook + CI `security` job |
+| **IaC** — insecure infrastructure | open security groups, public buckets, … | **checkov** (`task lint:terraform:security`) | CI `lint` job + `task check` locally (Terraform repos) |
+| **Freshness** — stale dependencies | a widening exposure window | **Renovate** (`minimumReleaseAge: 3 days`) | continuous, grouped update PRs |
+
+- **`task security`** (the CI `security` job) is `security:secrets` (gitleaks) +
+  `security:audit` (dependency audit). It does **not** run Snyk.
+- **CodeQL is opt-in** — its analyze jobs skip unless `FULL_SECURITY_SCAN=true`,
+  which `task setup:github` sets. If CodeQL is your only SAST, confirm it is on.
+- **`task setup:github`** turns on the GitHub-native layers: Dependabot alerts,
+  Private Vulnerability Reporting, and the `FULL_SECURITY_SCAN` variable; the branch
+  ruleset makes `verify` + `security` required checks. See
+  [../CHECKLIST.md](../CHECKLIST.md).
+- Which tools apply depends on the stack: SAST/SCA need code + a manifest (web/app,
+  or Python for iac); IaC scanning is Terraform-only. A `general`/`docs` repo leans
+  mainly on secrets + audit.
+
+### Snyk is optional and redundant by default
+
+The template ships Snyk targets — `task security:sast` (`snyk code test`, SAST) and
+`task security:sca` (`snyk test`, SCA) — but they are **opt-in, local-only, and not
+in CI**, because the default stack already covers both axes: **CodeQL** for SAST and
+**Dependabot + `security:audit`** for SCA. On a normal repo Snyk is redundant — leave
+it off. (`SNYK_TOKEN` is a local credential, not a CI secret; and if the Snyk GitHub
+App is installed, its `code/snyk`/`security/snyk` PR checks are **not** required by
+the branch ruleset — remove the app to drop them.)
+
+### Exception: a shipped product (e.g. a B2B SaaS web app)
+
+For a product that holds customer data, revisit the above — the redundancy stops
+being waste and a **paid Snyk tier** is worth weighing:
+
+- **Defense in depth** — a second SAST/SCA opinion matters when a miss means a
+  customer-data breach, not a broken marketing page.
+- **License compliance** — you are distributing a product, and **Dependabot does not
+  scan dependency licences**; Snyk (or FOSSA) does.
+- **Reachability** — Snyk can rank which dependency CVEs are actually reachable in
+  your code, cutting noise.
+- **Sales & compliance** — B2B customers send security questionnaires and may require
+  SOC 2 / a vendor review, where a recognised commercial scanner is a checkbox. A
+  paid tier also removes the free Snyk-Code monthly test limit.
+
+A web app also needs layers this stack does **not** cover: **DAST** (scanning the
+running app for auth bypass / IDOR / injection on live endpoints), **multi-tenant
+isolation** (the top B2B web-app risk), and **container/image scanning** if it ships
+images.
 [% if devcontainer %]
 
 ## Two identities: the bot vs the operator

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -163,7 +163,7 @@ TODO: enumerate the tokens/secrets this repo depends on and where each lives:
 |---|---|---|---|
 | `CI_APP_CLIENT_ID` (var) + `CI_APP_PRIVATE_KEY` (secret) | [% if use_release_please %]release-please, [% endif %]claude-*[% if github_org != author_git_provider_username %], project-automation[% endif %] | repo or org Actions variable + secret | rotate App key per policy |
 | `CLAUDE_CODE_OAUTH_TOKEN` | claude-* workflows | repo Actions secret | TODO |
-| `SNYK_TOKEN` | `task security:sast`/`sca` | repo Actions secret | TODO |
+| `SNYK_TOKEN` | `task security:sast`/`sca` (optional, local-only — not in CI) | local env / 1Password | TODO |
 | TODO | TODO | TODO | TODO |
 [% if include_terraform or include_ansible %]
 


### PR DESCRIPTION
## Context
Grew out of the Snyk-quota noise + a discussion of the overall security posture. Two related pieces: document the whole scanning strategy, and formalize that Snyk is optional/local (redundant with the default GitHub-native + CI stack).

## 1. New: security scanning strategy (`docs/architecture/security.md`)
Adds a **"Security scanning: SAST, SCA, secrets & audits"** section — a table of the layered posture with, for each axis, what it catches, the default tool, and where it runs:

| Axis | Default tool | Runs |
|---|---|---|
| SAST (your code) | **CodeQL** | CI, opt-in via `FULL_SECURITY_SCAN` |
| SCA (dependencies) | **Dependabot alerts** + `task security:audit` (`pnpm`/`pip-audit`) | native + CI `security` |
| Secrets | **gitleaks** (`security:secrets`) | pre-push hook + CI |
| IaC | **checkov** (`lint:terraform:security`) | CI + local (Terraform) |
| Freshness | **Renovate** (3-day gate) | continuous PRs |

Plus the default position (**Snyk is redundant/optional** — the native + CI-local stack covers both SAST and SCA) and the **exception**: a shipped product (B2B SaaS web app) should weigh a **paid Snyk tier** (licence compliance, reachability, defense-in-depth, SOC2/questionnaire credibility) + **DAST** + **multi-tenant isolation**. A web-app-gated CHECKLIST item points at it.

## 2. Snyk framing (docs only — no behavior change)
Snyk never ran in CI (`security:sast`/`sca` are standalone local targets; the `code/snyk` red X is the external Snyk App). So:
- **CHECKLIST**: drop `SNYK_TOKEN` from Actions secrets; note Snyk is optional/local and the App's PR checks aren't ruleset-required.
- **security.md** token table: `SNYK_TOKEN` → local env / 1Password.
- **Taskfile**: `security:sast`/`sca` descs marked optional/local.

## Verification
`test:template:all` ✅ (scanning section renders for every profile; the product-security item renders only for `web-app`) · `task verify` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)