### PR TITLE
fix: add required priority key to Agent issue-field options

### DIFF
--- a/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
@@ -52,16 +52,17 @@ done
 api_version="2026-03-10"
 
 # Agent single-select options. Colors are GitHub's palette: gray, blue, green,
-# yellow, orange, red, pink, purple.
+# yellow, orange, red, pink, purple. `priority` (1-based) is REQUIRED per option
+# on this preview endpoint and sets the display order (1 shows first).
 agent_opts='[
-  {"name":"Claude Code","color":"orange","description":""},
-  {"name":"Codex","color":"blue","description":""},
-  {"name":"Gemini CLI","color":"purple","description":""},
-  {"name":"Qwen Code","color":"green","description":""},
-  {"name":"DeepSeek","color":"red","description":""},
-  {"name":"Kimi K2","color":"yellow","description":""},
-  {"name":"GLM","color":"pink","description":""},
-  {"name":"GitHub Copilot","color":"gray","description":""}
+  {"name":"Claude Code","color":"orange","description":"","priority":1},
+  {"name":"Codex","color":"blue","description":"","priority":2},
+  {"name":"Gemini CLI","color":"purple","description":"","priority":3},
+  {"name":"Qwen Code","color":"green","description":"","priority":4},
+  {"name":"DeepSeek","color":"red","description":"","priority":5},
+  {"name":"Kimi K2","color":"yellow","description":"","priority":6},
+  {"name":"GLM","color":"pink","description":"","priority":7},
+  {"name":"GitHub Copilot","color":"gray","description":"","priority":8}
 ]'
 
 echo "==> Reading existing issue fields for '$org'"


### PR DESCRIPTION
## Problem

`scripts/setup-github-issue-fields.sh` (templated) fails when creating the **Agent** single_select issue field:

```
gh: Invalid request.
Invalid property /options/0: object is missing required key: priority.
... (one per option) ... (HTTP 422)
```

GitHub's issue-fields **public-preview** REST API now requires a `priority` integer on **every** `single_select` option (it sets the display order — the built-in `Priority`/`Effort` fields show the same shape). The script's `agent_opts` only sent `name`/`color`/`description`, so all 8 options failed validation.

This is exactly the "API is subject to change" caveat in the script's own header — `priority` became required sometime after this script was written.

## Fix

Add `"priority":1…8` to each `agent_opts` entry (1-based, sets display order — Claude Code first).

## Verification

Reproduced and fixed in a downstream repo (`harmon-infra`): re-running the task after the change created the Agent field cleanly with all 8 options. `lint:shell` (shellcheck + shfmt) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)