### PR TITLE
fix(scripts): correct jq membership test in Status sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           # renovate: datasource=node-version
           node-version: "24"
-      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
           version: 3.51.1
@@ -71,7 +71,7 @@ jobs:
         with:
           # renovate: datasource=node-version
           node-version: "24"
-      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
           version: 3.51.1
@@ -104,7 +104,7 @@ jobs:
         with:
           # renovate: datasource=node-version
           node-version: "24"
-      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
           version: 3.51.1

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -165,7 +165,7 @@ else
         existing=$(printf '%s' "$fields_json" |
             jq -c '[.data.node.fields.nodes[] | select(.name=="Status") | .options[] | {name, color: (.color // "GRAY" | ascii_upcase), description: (.description // "")}]')
         desired=$(jq -cn --argjson ex "$existing" --argjson pl "$status_pipeline" \
-            '$ex + [ $pl[] | select( ([ $ex[].name ] | index(.name)) == null ) ]')
+            '$ex + [ $pl[] | select( .name as $n | ([ $ex[].name ] | index($n)) == null ) ]')
     fi
     frag=$(printf '%s' "$desired" | jq -r "$opts_to_graphql")
     gh api graphql -f f="$status_field_id" \


### PR DESCRIPTION
## Problem

`setup-github-project.sh` (copied verbatim into every repo scaffolded from this template) crashes on re-runs against an **existing** GitHub Project:

```
==> Syncing Status (keeping existing options, appending any missing)
jq: error (at <unknown>): Cannot index array with string ("name")
```

The existing project simply routes execution into the append/sync branch, which was broken — it is not a "project already exists" no-op.

## Root cause

The "append missing Status options" filter was:

```jq
$ex + [ $pl[] | select( ([ $ex[].name ] | index(.name)) == null ) ]
```

The `|` rebinds `.` to the names array `[ $ex[].name ]`, so `index(.name)` tried to index an **array** with the string `"name"` → the error above.

## Fix

Bind the pipeline item's name to `$n` **before** the pipe:

```jq
$ex + [ $pl[] | select( .name as $n | ([ $ex[].name ] | index($n)) == null ) ]
```

Only the re-run/append path was affected; a brand-new project takes the `desired="$status_pipeline"` branch, which never hit this filter.

## Verification

- Isolated `jq` repro: old filter errors, new filter returns the merged option list.
- shellcheck + shfmt clean (pre-commit hooks pass).
- Same fix validated live in a downstream repo against org project #2 — completes past `==> Syncing Status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)