### PR TITLE
docs(checklist): steer pnpm config to pnpm-workspace.yaml

### DIFF
--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -112,8 +112,14 @@ config, toolchain, devcontainer, and dev environment — against the items below
       `pnpm add -D eslint @eslint/js typescript-eslint eslint-plugin-astro globals`
 - [ ] Install the shipped prettier config's plugins:
       `pnpm add -D prettier prettier-config-standard prettier-plugin-astro prettier-plugin-tailwindcss`
-- [ ] Approve Astro's native build scripts so `astro build` works:
-      `pnpm approve-builds` (esbuild, sharp) — or add them to `onlyBuiltDependencies`
+- [ ] Approve build scripts so `astro build` works — pnpm 10+ blocks dependency
+      build scripts by default. Add an `onlyBuiltDependencies` list to
+      `pnpm-workspace.yaml` (e.g. `esbuild`, `sharp`, plus `lefthook` if it is a
+      pnpm dep), or run `pnpm approve-builds`
+- [ ] Put pnpm `overrides` and `auditConfig` (security version floors, audit CVE
+      ignores) in `pnpm-workspace.yaml`, **not** the `package.json` `pnpm` field —
+      pnpm 10+ silently ignores that field, so overrides declared there vanish on
+      the next lockfile resolve
 - [ ] Review `lighthouserc.json` URLs once routes exist
 [% elif project_type == 'web-app' %]
 - [ ] Scaffold the app: `pnpm create @tanstack/start@latest` (TanStack Start) or vite + react
@@ -128,6 +134,10 @@ config, toolchain, devcontainer, and dev environment — against the items below
       `languageOptions.parserOptions.projectService: true`, to catch a missing
       `await` / floating promise that `tsc` won't. Makes ESLint type-check
       (slower) and needs your tsconfig wired up — skip to keep lint instant.
+- [ ] Put pnpm `overrides` / `auditConfig` / `onlyBuiltDependencies` in
+      `pnpm-workspace.yaml`, **not** the `package.json` `pnpm` field — pnpm 10+
+      ignores that field. Approve blocked build scripts (e.g. vite's `esbuild`)
+      via `onlyBuiltDependencies` or `pnpm approve-builds`
 [% elif project_type == 'iac' %]
 - [ ] Lay out `terraform/` (main.tf, variables.tf, outputs.tf) and/or
       `ansible/` (site.yml, ansible.cfg, inventory/, roles/) — the lint tasks


### PR DESCRIPTION
## Summary

Downstream discovery from a generated repo (sommerlawn-web): **pnpm 10+ no longer reads the `pnpm` field from `package.json`**. Any repo that declares security `overrides` / `auditConfig` the old way has them **silently ignored** — they still work via the committed lockfile but vanish on the next lockfile resolve. pnpm 10 also **blocks dependency build scripts by default**.

harmon-init is a conventions-only template (it ships no `package.json` / `pnpm-workspace.yaml`), so there's no generated file to fix — but the **scaffolding checklist** is exactly where to steer people. This updates both web sections of `docs/CHECKLIST.md.jinja`:

- **web-astro**: reword the build-scripts step around `onlyBuiltDependencies` in `pnpm-workspace.yaml` (pnpm 10 blocks scripts by default), and add a step to keep `overrides`/`auditConfig` in `pnpm-workspace.yaml` rather than the `package.json` `pnpm` field.
- **web-app**: add the parallel guidance (vite pulls `esbuild`).

## Verification

- `task verify` passes (exit 0) — template renders and the generated markdown lints clean; `test-template (web): PASS`.
- Docs-only; no change to generated config files.

## Context

Companion to sommerlawn/sommerlawn-web#393, which migrated that repo's actual config to `pnpm-workspace.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)