### PR TITLE
fix(template): setup-github-project #205 parity + stale SNYK_TOKEN setup check

### DIFF
--- a/.claude/skills/standardize-repo/assets/verify-applied.sh
+++ b/.claude/skills/standardize-repo/assets/verify-applied.sh
@@ -33,9 +33,14 @@ cd "$target"
 have() { command -v "$1" >/dev/null 2>&1; }
 
 fail=0
+fail_msgs=""
 err() {
     echo "FAIL: $*" >&2
     fail=1
+    # accumulate a one-line summary of each failed check for the final verdict,
+    # so "FAILED" names what failed rather than trailing the advisory drift WARN
+    fail_msgs="${fail_msgs}    - $(printf '%s' "$*" | head -n 1)
+"
 }
 
 echo "Verifying applied conventions in: $(pwd)"
@@ -156,16 +161,20 @@ marker_re="\[\[-? ($varpfx)|\{\{-? ($varpfx)|\[%-? ($blockkw) "
 # Jinja ({{ x }} / {% x %}) — Ansible templates, nginx configs, etc. — and the
 # {{ <stem> }} branch of marker_re can't tell `{{ github_runner_image }}` (a real
 # Ansible var) from a copier leak. Copier's own delimiters are [[ ]] / [% %], so
-# dropping these files loses no real-leak coverage.
+# dropping these files loses no real-leak coverage. Likewise drop anything under
+# a `skills/` dir: agent-skill references/assets legitimately DOCUMENT copier's
+# [[ ]] / [% %] delimiters as examples (the standardize-repo skill itself does),
+# so they would false-positive on the repo that HOSTS the skill — cf. the
+# .claude/** exclude in the markdownlint config.
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     leaks=$(git ls-files --cached --others --exclude-standard -z 2>/dev/null |
         xargs -0 grep -IlE "$marker_re" 2>/dev/null |
-        grep -vE '\.(j2|jinja)$' || true)
+        grep -vE '\.(j2|jinja)$|(^|/)skills/' || true)
 else
     leaks=$(grep -rIlE "$marker_re" \
         --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=.venv \
         --exclude-dir=.terraform --exclude-dir=.task --exclude-dir=.worktrees \
-        --exclude-dir=dist --exclude='*.j2' --exclude='*.jinja' . 2>/dev/null || true)
+        --exclude-dir=dist --exclude-dir=skills --exclude='*.j2' --exclude='*.jinja' . 2>/dev/null || true)
 fi
 if [ -n "$leaks" ]; then
     err "unrendered template markers found in:"
@@ -199,9 +208,29 @@ if [ -f .copier-answers.yml ] && [ -x "$diff_tool" ] && have copier && have yq; 
     fi
 fi
 
+# ── 7. CODEOWNERS must not lose owners on adopt (access-control regression) ─
+# CODEOWNERS is rendered from the single `code_owner` answer (`* @owner`), so a
+# Path-B adopt over a repo with MORE owners (or a team) silently drops them — an
+# access-control change that must be surfaced and confirmed, never auto-applied.
+# harmon-init also freezes CODEOWNERS via _skip_if_exists; this is the belt to
+# that suspenders (and catches a hand-overwritten CODEOWNERS too). Compare the
+# @owners in the pre-adopt CODEOWNERS (on `main`) against the current one; skip
+# cleanly when there is no main, no CODEOWNERS, or not a git tree.
+co=".github/CODEOWNERS"
+if [ -f "$co" ] && git rev-parse --is-inside-work-tree >/dev/null 2>&1 &&
+    git cat-file -e "main:$co" 2>/dev/null; then
+    before="$(git show "main:$co" 2>/dev/null | grep -oE '@[A-Za-z0-9_/-]+' | sort -u)"
+    after="$(grep -oE '@[A-Za-z0-9_/-]+' "$co" 2>/dev/null | sort -u)"
+    dropped="$(comm -23 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep -v '^$' || true)"
+    if [ -n "$dropped" ]; then
+        err "CODEOWNERS dropped owner(s) present on main: $(printf '%s ' $dropped)— adopting must NOT silently reduce access. The template's single code_owner answer can't hold multiple owners/teams; restore the dropped owner(s) and confirm the change with the user."
+    fi
+fi
+
 # ── Result ──────────────────────────────────────────────────────────
 if [ "$fail" -ne 0 ]; then
-    echo "verify-applied: FAILED" >&2
+    echo "verify-applied: FAILED — checks that did not pass:" >&2
+    printf '%s' "$fail_msgs" >&2
     exit 1
 fi
 echo "verify-applied: PASS"

--- a/.claude/skills/standardize-repo/references/mode-adopt-existing.md
+++ b/.claude/skills/standardize-repo/references/mode-adopt-existing.md
@@ -79,8 +79,16 @@ Defaults worth knowing so you only override what's wrong (from `copier.yml`):
   `github_remote_create`, `github_release_init`, `bunch_add`,
   `obsidian_project_add`, `run_task_install`. The repo already exists and has a
   remote/history — let those run by hand later, not as a copier `_task`. Pass
-  `--defaults` (with the `--data` overrides above) to lock the rest down
-  non-interactively, or answer interactively and explicitly decline each one.
+  `--defaults` to avoid prompts **and explicitly pass each one `=false`** — do
+  NOT rely on copier.yml's `no` defaults. On a **re-adopt over an existing
+  `.copier-answers.yml`** (every v2 repo — see Path A's v2 note), copier seeds
+  defaults *from that answers file*, so a stale `true` there sails straight
+  through `--defaults` and **fires the side-effect `_task`** (observed: a v2
+  re-adopt's stale `github_remote_create: true` ran `gh repo create`; a stale
+  `github_release_init: true` would cut a bogus `release:init` v0.1.0).
+  harmon-init ≥ the side-effect-task hardening also gates these on `git_init`,
+  so `git_init=false` neutralizes them on a current template — but pass them all
+  `=false` to stay correct across template versions.
 
 ---
 
@@ -127,8 +135,11 @@ copier copy --trust ~/git/harmon-init . --vcs-ref=HEAD --defaults --overwrite \
   --data project_name="<Formal Project Name>" \
   --data project_slug="$(basename "$(pwd)")" \
   --data github_org="<org-or-user>" \
-  --data git_init=false        # ← REQUIRED: see note below
-  # ...remaining --data; all other side-effect answers already default = no
+  --data git_init=false \
+  --data github_remote_create=false --data github_release_init=false \
+  --data bunch_add=false --data obsidian_project_add=false --data run_task_install=false
+  # ↑ pass EVERY side effect =false (see §1). On a v2 RE-adopt copier seeds
+  #   defaults from the stale .copier-answers.yml, so they do NOT "default to no".
 ```
 
 `--vcs-ref=HEAD` is **mandatory** here when `~/git/harmon-init` is a local path:
@@ -158,6 +169,14 @@ from git rather than hand-merging conflict markers:
    `git checkout main -- <Taskfile.yml> <renovate.json> <.gitignore> …`. The repo
    was likely already close to current (hand-synced), so this loses little template
    improvement while preserving every customization.
+   - **`.github/CODEOWNERS` is access control — never silently reduce it.** The
+     template renders it from the single `code_owner` answer (`* @code_owner`),
+     which can't hold a second owner or a team, so the adopt render drops any
+     extras. `git checkout main -- .github/CODEOWNERS` (or merge the owners) and
+     **confirm any owner change with the user** — dropping a code owner is a
+     security regression, not a tooling sync. (harmon-init ≥ the CODEOWNERS-freeze
+     change keeps it via `_skip_if_exists`, and `verify-applied.sh` FAILS if an
+     owner present on `main` is missing post-adopt — but check it by hand too.)
    - **If you restore a customized `Taskfile.yml` but keep the template's
      workflows, reconcile the contract.** The template's `.github/workflows/*`
      delegate to `task` targets (e.g. `test:tasks`, `test:hooks`,
@@ -229,8 +248,12 @@ These are the recurring drifts harmon-init exists to fix (source:
    ln -sf ../AGENTS.md .github/copilot-instructions.md   # note: ../ from .github/
    ```
 
-   Merge any unique guidance from the old real file into `AGENTS.md` *before*
-   replacing it with a symlink. Then confirm the tool excludes are in place so
+   **Fold the old file's *substantive* guidance** — architecture, directory
+   structure, real commands, project-specific conventions — into `AGENTS.md`
+   *before* replacing it with a symlink. Don't settle for a thin fold that keeps
+   only the one-line project blurb (and a `TODO: run /init`): the old file's real
+   content is the whole point of the merge. Then confirm the tool excludes are
+   in place so
    linters don't choke on the symlinks: `lefthook.yml`'s prettier hook must
    `exclude` `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md`
    (these are explicit excludes in the template's `lefthook.yml`).
@@ -278,6 +301,94 @@ These are the recurring drifts harmon-init exists to fix (source:
    `Brewfile`; make scripts portable to macOS bash 3.2 (no `mapfile`, no
    `grep -P`).
 
+6. **v2→v3 re-adopt cleanup (the v2 question set predates lefthook/gitleaks).**
+   After the Path B render, **delete the superseded v2 artifacts** the template no
+   longer ships: `.pre-commit-config.yaml` (→ lefthook); `check_for_pattern.sh` +
+   any `test/whisperConfig.yml` (→ gitleaks); a v2 `package.json` (eslint/prettier
+   stubs) and `requirements.txt` (whispers/pre-commit deps) on a non-node repo;
+   `.ansible-lint` when ansible isn't in the pipeline; and the old `build.yaml` /
+   `security.yml` / `validate.yml` workflows the template's `build.yml` supersedes.
+   Untrack a now-gitignored root `todo.md` and drop a stale
+   `<old-slug>.code-workspace`. **`node_modules/` gotcha:** an older `general`
+   (`use_node=false`) `.gitignore` did NOT ignore `node_modules/`, so a v2 repo
+   carrying one needs it added (now fixed in harmon-init — present in every
+   profile). Restore the rich `README.md` from `main` and update its stale refs
+   (badges `validate.yml`/`build.yaml` → `build.yml`; `task validate` → `task
+   verify`; drop `.pre-commit-config.yaml`/`.ansible-lint` mentions). Fold the old
+   real `CLAUDE.md` into `AGENTS.md` per step 1.
+
+   **Three traps that block the first commit/push after a v2→v3 render:**
+   (a) **Stale pre-commit.com hook** — deleting `.pre-commit-config.yaml` leaves the
+   installed `.git/hooks/pre-commit` behind, which blocks *every* commit with
+   "No .pre-commit-config.yaml file was found"; run **`pre-commit uninstall`**,
+   then `task install:hooks` (lefthook) to wire the v3 hooks. Two things make this
+   recur: the stub is often **globally seeded** by git's `init.templateDir`
+   (`~/.git-template/hooks/pre-commit`, from a past `pre-commit init-templatedir`),
+   so it lands in *every* clone/`git init` — even repos with no
+   `.pre-commit-config.yaml`, where it **silently no-ops** (`--skip-on-missing-config`)
+   and hides next to lefthook's hooks; and `lefthook install` backs it up to
+   `pre-commit.old` while `lefthook uninstall` **restores** it, so a bare `rm` isn't
+   durable. Fix for good: `grep -rl 'generated by pre-commit' .git/hooks` → `rm` the
+   matches, then (if it holds only that stub) `git config --global --unset
+   init.templateDir` + `rm -rf ~/.git-template`. All local — `.git/hooks/*` is never
+   tracked, so there is nothing to commit or push. (b) **gitleaks
+   scans full history** — adopting it surfaces pre-existing leaks (a committed
+   key/cert/`.env`) that fail the pre-push hook *and* CI; for each KNOWN finding
+   add its fingerprint (`gitleaks detect --report-format json` → `.Fingerprint`)
+   to **`.gitleaksignore`** AND **rotate the secret** (urgent if the repo is
+   public — the allowlist stops re-flagging, it does not un-expose the key).
+   (c) **Mis-shebanged scripts** — a `#!/bin/sh` script that uses bash features
+   (`&>`, `function`, arrays) makes `shfmt` parse it as POSIX and fail; fix the
+   shebang to `#!/usr/bin/env bash`.
+
+   Path B's `--overwrite` also **resets `.gitignore`** to the template's —
+   re-merge the repo's custom ignores (binary/cache patterns like `*.dll`,
+   `.output/`) from `main`, but NOT what v3 now tracks (`*.code-workspace`,
+   `.vscode/settings.json`, `.meta/`).
+
+7. **Scope the repo's linters past reference/example content.** A repo that
+   *houses* example or vendored content — a boilerplate library (`templates/`,
+   `snippets/`), copy-paste Windows scripts, an agent-skill source — should not be
+   held to its own operational lint standard for that content (the same reason the
+   template excludes `.claude/**`). Patterns that worked: `lint:shell`'s
+   `SHELL_FILES` adds `':!:templates/' ':!:snippets/'`; `scripts/lint-hygiene.sh`
+   skips `*.cmd`/`*.bat` (Windows files use CRLF by convention). NB a `SHELL_FILES`
+   exclusion does **not** apply when lefthook passes `{staged_files}` via
+   `CLI_ARGS`, so add a matching lefthook `exclude:` if staged edits to that
+   content must skip too. A **chezmoi** dotfiles source is a special case: it is
+   **both** a chezmoi source directory **and** a harmon-init-templated repo, so its
+   repo-maintenance files sit at the root next to the dotfiles — and chezmoi must
+   not deploy any of them to `$HOME`. Handle it explicitly:
+   - **Root `Brewfile` for repo tooling, separate from the deployed one.** The repo
+     needs a root `Brewfile` (its own toolchain, for `task install` / `status.sh`),
+     kept distinct from the `private_Brewfile` chezmoi renders to `~/Brewfile` (the
+     full dev-machine set). `diff-template.sh` reports the root `Brewfile` as
+     `MISSING` because chezmoi names its copy `private_Brewfile` — a **false
+     MISSING**; add a root `Brewfile`, don't "restore" one.
+   - **`.chezmoiignore` every repo-maintenance file.** Files not starting with `.`
+     are NOT auto-ignored, so `AGENTS.md`, `GEMINI.md`, `DESIGN.md`, `CHANGELOG.md`,
+     `commitlint.config.mjs`, `lefthook.yml`, `Taskfile.yml`, `Brewfile`,
+     `renovate.json`, `release-please-config.json`, and the `scripts/`, `specs/`,
+     `tests/` dirs would otherwise be deployed to `$HOME` on the next
+     `chezmoi apply`. Add them all to `.chezmoiignore` and verify with
+     `chezmoi status` (an `A` line = would be added to `$HOME`) / `chezmoi managed`.
+   - The `.tmpl` files themselves are safe: they aren't `*.sh`/`*.yml` (so
+     `lint:shell`/`yamllint` skip them) and `{{ .chezmoi.* }}` Go-templates don't
+     match the copier marker scan. The one lint snag is app-managed configs missing
+     a trailing newline (e.g. `private_karabiner.json`) — append one.
+   - **If the source uses chezmoi `git.autoCommit`/`autoPush`, reconcile it with
+     lefthook.** A chezmoi source that auto-commits to `main` collides with the
+     template hooks head-on — the `no-commit-to-main` guard blocks the commit and
+     commitlint rejects chezmoi's non-Conventional message ("Update dot_zshrc"). To
+     keep the auto-push convenience, **trim `lefthook.yml` to the gitleaks `pre-push`
+     only** (drop `pre-commit` + `commit-msg`), so secrets are still caught before
+     they leave — an intentional, documented divergence (expect a future
+     copier-update conflict; keep the trimmed version). Also beware the **`git add .`
+     sweep**: chezmoi's `autoCommit` stages the *whole* source tree, so an uncommitted
+     repo-tooling edit sitting in the clone gets swept into a dotfile auto-commit and
+     pushed — keep the tree clean, or guard `chezmoi re-add` to skip when
+     `git status --porcelain` is non-empty.
+
 ---
 
 ## 5. Verify, then commit on the branch
@@ -294,6 +405,15 @@ assets/verify-applied.sh .
 `build` for node projects, then `validate`. `verify-applied.sh` confirms the
 adoption actually took (canonical AGENTS.md + symlinks, docs layout, `.yml`
 extensions, renovate annotations, no leaked copier vars). Fix everything they flag.
+
+**git-lfs repos: `lefthook install` shadows git-lfs's pre-push.** If the repo uses
+git-lfs, installing lefthook overwrites `.git/hooks/pre-push` with lefthook's
+(gitleaks) and moves git-lfs's aside to `pre-push.old` — so the git-lfs pre-push that
+uploads LFS objects on push **stops running, silently** (the push still succeeds, but
+LFS blobs may never upload). Detect with `grep -l git-lfs .git/hooks/*` after install;
+if git-lfs's pre-push was shadowed, make lefthook run it too (add a `pre-push` command
+that invokes `git lfs push`, or chain `pre-push.old`) and confirm with
+`git lfs push --dry-run origin HEAD` that objects still upload.
 
 Then stage, review the **full** diff one more time, and commit on the feature
 branch with a Conventional Commit message (types enforced by commitlint):

--- a/.claude/skills/standardize-repo/references/mode-audit.md
+++ b/.claude/skills/standardize-repo/references/mode-audit.md
@@ -276,19 +276,39 @@ assets/diff-template.sh "$TARGET"
 # --show to see the per-file diff
 ```
 
-It renders harmon-init from the repo's own `.copier-answers.yml` and reports both
-content **`DRIFT`** in the curated set and **`MISSING`** template files the repo
-lacks entirely (mapping `.yml`↔`.yaml`). The `MISSING` scan walks the whole render
-and is **manifest-independent**, so a file the template added after the curated list
-was last edited — or one a hand-reconciled update dropped — is still caught
-(`.gitkeep` dir-stubs show as benign `ABSENT`). Each `DRIFT` is either a
-**missed template improvement** or a **legitimate local customization** — read the
-diff to tell them apart. Fix the former with `copier update`
-([`mode-update.md`](./mode-update.md)) or by copying the template's version; leave
-the latter, reconciling **in place** (keep the customization in its normal file — do
-not extract it elsewhere). Severity: **should** (blocker if the drift breaks a
+It renders harmon-init **at the repo's own `_commit`** (from its
+`.copier-answers.yml`) and reports both content **`DRIFT`** in the curated set and
+**`MISSING`** template files the repo lacks entirely (mapping `.yml`↔`.yaml`). The
+`MISSING` scan walks the whole render and is **manifest-independent**, so a file the
+template added after the curated list was last edited — or one a hand-reconciled
+update dropped — is still caught (`.gitkeep` dir-stubs show as benign `ABSENT`).
+Because the render is at `_commit`, each **`DRIFT`** is the repo's **local
+customization** relative to its own baseline — or a **regression** where a past
+hand-reconcile dropped a same-baseline improvement (the status.sh / lint-hygiene /
+bootstrap class). It is **not** a newer-version improvement — those arrive via the
+`copier update` merge, not diff-template. Read the diff to tell them apart: restore
+a regression (copy the template's version), and leave a deliberate customization,
+reconciling **in place** (keep it in its normal file — do not extract it elsewhere). Severity: **should** (blocker if the drift breaks a
 required gate, e.g. a non-portable `lint-hygiene.sh`). Run this as a standard step of
 every audit.
+
+**Known false-`MISSING` categories — verify before "fixing".** Some `MISSING`
+findings are legitimate divergences, not gaps; re-adding the template's version is
+wrong. The recurring ones (nearly every iac/dotfiles repo hit ≥1):
+
+- **chezmoi `private_`/`dot_` prefix** — a dotfiles repo names the template's root
+  `Brewfile` `private_Brewfile` (→ `~/Brewfile`), so `Brewfile` reads `MISSING`. Add
+  a root `Brewfile` per [mode-adopt-existing.md](./mode-adopt-existing.md) §4.7, not
+  a "restored" copy.
+- **ADR renumbering** — the seed `docs/decisions/0001-record-architecture-decisions.md`
+  shows `MISSING` when the repo renumbered it (its `0001`/`0002` are real decisions).
+  Don't re-add — it would duplicate.
+- **Replaced terraform skeleton** — an iac repo with real infra (e.g.
+  `terraform/environments/…`) deleted the template's flat
+  `terraform/{main,variables,outputs}.tf` skeleton. `MISSING`, but correct — leave it.
+- **Gitignored `.envrc`** — a repo that resolves `.envrc`/`.envrc.local` from an
+  `.envrc.tpl` via `op inject` gitignores the resolved file, so it reads `MISSING`.
+  Leave it (it's the secure pattern the template now ships).
 
 **L. Workflow ↔ Taskfile contract.** Every `task <target>` referenced in
 `.github/workflows/*.yml` must exist in `Taskfile.yml`. CI's `lint`/`build` jobs
@@ -331,13 +351,17 @@ Apply fixes on a branch, prefer re-templating for files copier owns, then verify
    - **Templated bits — re-run copier.** For files the template owns, reconcile
      rather than hand-porting:
      - Generated from the template (has `.copier-answers.yml`):
+
        ```bash
        ( cd "$TARGET" && copier update --trust )
        ```
+
      - Never templated / adopting fresh:
+
        ```bash
        ( cd "$TARGET" && copier copy --trust ~/git/harmon-init . --vcs-ref=HEAD )
        ```
+
      `--vcs-ref=HEAD` is **load-bearing**: from a local path copier otherwise
      renders the latest git tag and silently ignores committed-but-untagged work;
      with it, copier includes dirty/untracked template changes via a throwaway

--- a/.claude/skills/standardize-repo/references/mode-new-repo.md
+++ b/.claude/skills/standardize-repo/references/mode-new-repo.md
@@ -121,10 +121,8 @@ project directory):
    plus `uv sync` / `pnpm install` if applicable).
 5. `task release:init` — when `github_release_init` (tags `v0.1.0`, pushes it,
    `gh release create`). Requires the remote to exist (step 3).
-6. `task util:bunch-install` — when `bunch_add` (macOS-only); moves the
-   generated `.meta/*.bunch` to iCloud and symlinks it back.
-7. `task util:obsidian-install` — when `obsidian_project_add` (macOS-only);
-   moves the generated `.meta/*.md` to the vault and symlinks it back.
+6. `task util:bunch-add` — when `bunch_add` (macOS-only).
+7. `task util:obsidian-add` — when `obsidian_project_add` (macOS-only).
 
 If you left the side-effectful answers at their `no` defaults (the CI-safe,
 recommended path for unattended generation), only steps 1–2 run and you finish

--- a/.claude/skills/standardize-repo/references/mode-update.md
+++ b/.claude/skills/standardize-repo/references/mode-update.md
@@ -41,10 +41,15 @@ assets/diff-template.sh .
 This renders harmon-init from the repo's own `.copier-answers.yml` and runs two
 checks (mapping `.yml`↔`.yaml`):
 
-- **`DRIFT`** — content differences in the curated file set. Each is either a
-  **template improvement the repo is missing** (the status.sh / lint-hygiene /
-  bootstrap class) or a **legitimate local customization** — the diff tells you
-  which.
+- **`DRIFT`** — a curated file differs from a render at the repo's **own recorded
+  `_commit`** (diff-template.sh renders at `_commit`, not the template's HEAD). So
+  DRIFT is the repo's **local customization** relative to its own baseline — or,
+  less often, a **regression** where a past hand-reconciled update dropped a
+  template improvement at/below that baseline (the status.sh / lint-hygiene /
+  bootstrap class). It is **not** "an improvement from a newer template version":
+  those arrive through the `copier update` three-way merge (§2), never via
+  diff-template. Read the diff to tell a deliberate customization from a regression
+  to restore.
 - **`MISSING`** — a template file the repo lacks entirely. This scan walks the
   whole render (it does **not** depend on the curated list), so a file the
   template added later, or one a previous hand-reconciled update dropped, can't
@@ -141,6 +146,19 @@ name and confirm your customization survived. Cross-check the §1 `diff-template
 worklist — any file that was `DRIFT` *before* the update but is now byte-identical to
 the template was silently reverted; restore the customization.
 
+**AGENTS.md is co-owned — always 3-way-merge it by hand; the safety net above does
+NOT cover it.** `AGENTS.md` is deliberately **not** in
+[`template-owned-files.txt`](../assets/template-owned-files.txt), so `diff-template.sh`
+never checks it and the silent-revert cross-check cannot catch an AGENTS.md clobber —
+yet it is usually the most heavily customized file in the repo (project overview,
+architecture, real commands, project-specific conventions). Treat every update as a
+genuine three-way merge on AGENTS.md, section by section: **keep the repo's
+substantive customizations**, but **do adopt the template's real improvements** —
+some template sections legitimately supersede the repo's (e.g. a corrected
+Conventional-Commits type enum, a reworded workflow rule). It is a judgment call, not
+a wholesale `--ours`/`--theirs`. Diff the merged result against the pre-update file
+(`git show HEAD:AGENTS.md`) and confirm both sides survived where each should.
+
 **Heavily-forked files: take `--ours` and re-apply the new bits.** When a file is
 *heavily* customized (a forked `Taskfile.yml`, a bespoke `status.sh`), copier's
 three-way merge can scramble it — a single conflict hunk spanning several unrelated
@@ -148,9 +166,19 @@ targets. Hand-resolving that is error-prone. Take the repo's complete version an
 cherry-pick only the genuinely-new pieces:
 
 ```bash
-git checkout --ours Taskfile.yml   # keep the repo's complete, working file
+git checkout main -- Taskfile.yml   # restore the repo's clean pre-update file
 # then add just what the update introduced (e.g. a new `status:setup` target)
 ```
+
+> **Don't hand-take a spanning "after" hunk — grep first.** The scrambled hunk's
+> "after" side often re-lists targets that ALSO live elsewhere in the file (copier
+> couldn't align them), so accepting it wholesale **duplicates keys** — a
+> `yamllint` `key-duplicates` error or a `task --list-all` parse failure catches it,
+> but only after the fact. Before taking any spanning "after" hunk, `grep -n '^  <target>:' <file>`
+> each target it defines; if one already appears outside the hunk, don't take it.
+> `git checkout main -- <file>` + re-applying only the genuinely-new targets is the
+> reliable path (prefer it over `git checkout --ours`, which needs a real merge
+> state a copier conflict may not have).
 
 **The template absorbed something this repo pioneered → add/add conflict; keep
 yours.** A canonical convention repo's innovations get *generalized* and upstreamed;
@@ -159,6 +187,20 @@ specific original (an add/add conflict on, e.g., `scripts/validate-*.mjs`). Keep
 repo's specific version (`git checkout --ours <file>`) — the generic one is for
 *other* repos. Recognise this when a file you know the repo authored shows up as a
 conflict against a near-identical-but-blander template version.
+
+**Bunch/Obsidian util targets — self-contained `bunch-add` vs. the template's
+add+install split.** The template splits the macOS-launcher helpers into
+`util:bunch-add` (scaffolds `.meta/*.bunch` via `scripts/meta-create.sh`) +
+`util:bunch-install` (moves it to iCloud) — same for `util:obsidian-*`. Older repos
+instead have a **self-contained `util:bunch-add`** that writes the launcher straight
+to iCloud with a hardcoded heredoc (no `.meta` step, no `install` target). On update,
+copier interleaves the two models — naively taking the "after" side leaves a new
+`util:bunch-install` whose input (`.meta/*.bunch`) the repo's direct-write `bunch-add`
+never produces, and the repo's real heredoc dangles as if it were the install cmds.
+These are low-stakes, macOS-only helpers, so pick ONE model cleanly: either adopt the
+template's full add+install pair (drop the heredoc) or keep the repo's self-contained
+`bunch-add` (and don't add a stray `install`) — do not mix. Keep the `docs/CHECKLIST.md`
+Bunch/Obsidian line consistent with whichever you chose.
 
 ## 4. Verify comprehensively
 
@@ -179,6 +221,15 @@ Re-run `diff-template.sh`: every remaining `DRIFT` should be an intentional loca
 customization you can explain, not a missed update. In particular, a `DRIFT` on a
 file the repo *renamed* (e.g. `.yaml`) may be an update copier skipped, not a
 customization — confirm against the §2 renamed-files note before dismissing it.
+
+**Check the git hooks aren't shadowed or stale, too.** Even in an already-templated
+repo two non-lefthook hook managers can lurk: a **pre-commit.com** stub in
+`.git/hooks/pre-commit` (globally seeded by `~/.git-template`, silently no-oping next
+to lefthook's hooks) and, in a **git-lfs** repo, a git-lfs `pre-push` that lefthook's
+install shadowed to `pre-push.old` (LFS objects then stop uploading on push). Both are
+covered under §5 / trap (a) of [`mode-adopt-existing.md`](./mode-adopt-existing.md) —
+audit with `grep -rl 'generated by pre-commit' .git/hooks` and
+`grep -l git-lfs .git/hooks/*`.
 
 ## 5. Hand off
 

--- a/.claude/skills/standardize-repo/references/post-generation-checklist.md
+++ b/.claude/skills/standardize-repo/references/post-generation-checklist.md
@@ -120,7 +120,7 @@ push so the remote exists.
     | Workflows | Read and write | claude may edit files under `.github/workflows/` |
     | Metadata | Read-only | required baseline |
 
-  - Generate a private key (`.pem`) and note the **App ID**.
+  - Generate a private key (`.pem`) and copy the **Client ID** (the Iv-style string on the App's settings page, not the numeric App ID).
   - **Install App** → on this org → **Only select repositories** (not "All").
   - Set the variable + secret. **Do this by hand and do not script org-scoped
     secret-setting** — the bulk `--repos` form *replaces* the secret's value and
@@ -129,7 +129,7 @@ push so the remote exists.
 
     ```bash
     # personal-account repo only; org-level should be set in the UI / non-destructively
-    gh variable set CI_APP_CLIENT_ID --repo "<org>/<repo>" --body "<app-id>"
+    gh variable set CI_APP_CLIENT_ID --repo "<org>/<repo>" --body "<client-id>"
     gh secret set CI_APP_PRIVATE_KEY --repo "<org>/<repo>" < path/to/app.pem
     ```
 
@@ -152,30 +152,23 @@ push so the remote exists.
 
 ### Org repos only (`github_org != author_git_provider_username`)
 
-- [ ] **[scriptable via gh]** Create a **Project V2** so that, after linking, it
-      is **project number 1** for the org, with a `Status` single-select field
-      (`project-automation.yml` and the `claude-*` workflows drive it). Use the
-      GraphQL API via `gh`:
+- [ ] **[scriptable via gh]** Create/sync the org **Project V2**. The generated
+      repo ships an idempotent task; run it (needs the `project` scope —
+      `gh auth refresh -s project`):
 
   ```bash
-  # 1. org node id
-  ORG_ID=$(gh api graphql -f query='query($l:String!){organization(login:$l){id}}' \
-    -f l="<org>" --jq '.data.organization.id')
-
-  # 2. create the project (note its number in the response)
-  gh api graphql -f query='mutation($o:ID!,$t:String!){createProjectV2(input:{ownerId:$o,title:$t}){projectV2{id number}}}' \
-    -f o="$ORG_ID" -f t="<repo>"
-
-  # 3. add the Status single-select field (capture PROJECT_ID from step 2)
-  gh api graphql -f query='mutation($p:ID!){createProjectV2Field(input:{projectId:$p,dataType:SINGLE_SELECT,name:"Status",singleSelectOptions:[{name:"Shaping",color:GRAY,description:""},{name:"In Progress",color:BLUE,description:""},{name:"Validating",color:YELLOW,description:""},{name:"In Review",color:PURPLE,description:""},{name:"Done",color:GREEN,description:""}]}){projectV2Field{... on ProjectV2SingleSelectField{id}}}}' \
-    -f p="<PROJECT_ID>"
+  task setup:github-project
   ```
 
-  > Note: "number 1" assumes this is the org's first Project V2. If other
-  > projects exist, the new project's number will differ — record the actual
-  > number and reconcile it with whatever the automation workflow references.
-  > TODO: confirm whether `project-automation.yml` hardcodes project number 1
-  > or reads it from a variable.
+  > It looks the project up by title, so it is safe to re-run and safe to run
+  > from any org repo (the first run creates it, later runs only reconcile). It
+  > seeds the full `Status` pipeline plus the Priority/Estimate/Product/Agent
+  > fields and never deletes existing options or fields.
+  > `project-automation.yml` and the `claude-*` workflows drive `Status`: the
+  > task records the project id in the `ORG_PROJECT_ID` org variable those
+  > workflows read (falling back to the project's title), so it no longer has to
+  > be the org's project number 1. For the exact GraphQL (or to run it by hand),
+  > see `scripts/setup-github-project.sh`.
 
 - [ ] **[scriptable via gh]** Add the bot machine account
       (`<author_git_provider_username>-bot`) as a **Write** collaborator (it does

--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -125,7 +125,20 @@ Universal task targets every repo has (from the template):
 (Snyk), `security:sca` (Snyk), `bootstrap`, `install`, `install:hooks`,
 `release:init`, `release:patch`, `release:minor`, `release:major`, `clean`,
 `status` (+ `status:git|gh|code|env`), `status:setup`, `util:bunch-add`,
-`util:bunch-install`, `util:obsidian-add`, `util:obsidian-install`.
+`util:obsidian-add`.
+
+**Lint vs. format discipline (read-only gates).** Every `lint:*` target and the
+`check`/`verify` aggregates are **read-only** — they report and fail, never
+modify files. All auto-fixing lives in `format`, `format:file`, and `fix` (=
+format then lint); **no `lint:*` body runs `--fix`/`--write`/`-w`/`-i`**.
+Pre-commit hooks call the read-only `lint:*` so a failing check blocks-and-tells
+instead of silently rewriting the tree. **Flag any `lint:*` that mutates** — the
+classic regression is `lint:markdown` carrying `markdownlint-cli2 --fix`, which
+makes CI report green while discarding the fix and makes the markdown hook commit
+the unfixed staged blob (no `stage_fixed`). Formatters (Prettier, Black, shfmt,
+`terraform fmt`, markdownlint) have a check side in `lint:*` + a write side in
+`format`; pure analyzers (shellcheck, actionlint, yamllint, ESLint, ansible-lint)
+are check-only by design.
 
 `status:setup` is a **setup-completeness audit** (run by hand, not part of the
 default dashboard): it checks the repo against `docs/CHECKLIST.md` and reports
@@ -138,7 +151,8 @@ quick first pass when auditing an already-standardized repo.
 Notable command bodies (for an auditor checking they match):
 
 - `lint:shell` → `shellcheck --severity=error` + `shfmt -d`
-- `lint:markdown` → `npx --yes markdownlint-cli2 --fix '**/*.md' '#.claude/**' …`
+- `lint:markdown` → `npx --yes markdownlint-cli2 '**/*.md' '#.claude/**' …`
+  (check-only; **no `--fix`** — auto-fix lives in `format`)
 - `lint:hygiene` → `./scripts/lint-hygiene.sh`
 - `security:secrets` → `gitleaks detect --no-banner --redact --source .`
 - `install` → `brew bundle --file=Brewfile` (+ `uv sync` / `pnpm install`) →
@@ -163,8 +177,8 @@ Notable command bodies (for an auditor checking they match):
   **type enum** (read from `commitlint.config.mjs`, identical in template and
   both live repos):
 
-  ```
-  build, change, chore, ci, docs, feat, fix, perf, refactor, remove, revert, style, test
+  ```text
+  build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
   ```
 
   Format `type(scope): subject`, imperative mood. Subject/body lines ≤ 100 chars
@@ -373,7 +387,7 @@ install the Renovate GitHub App on the repo. Conventions:
   Terraform providers each into one PR.
 - **`anthropics/claude-code-action` ejection:** removed from the Actions group
   (`groupName: null`) and `minimumReleaseAge: 0 days` (ships near-daily; grouping
-  + the 3-day gate kept the whole batch perpetually pending). Rule ordered AFTER
+  - the 3-day gate kept the whole batch perpetually pending). Rule ordered AFTER
   the group rules so the override wins.
 - npm `overrides` deptype disabled (avoids `EOVERRIDE`).
 - `dependencyDashboard: true`; weekly schedule `before 9am on Monday`,
@@ -448,8 +462,67 @@ install the Renovate GitHub App on the repo. Conventions:
 - Other root files: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE`
   (mit/private), `<slug>.code-workspace`, `.vscode/{settings,extensions}.json`,
   `.coderabbit.yaml` (CodeRabbit reviews — [manual] install the app),
-  `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/{bug,feature,task,research}.md`,
-  `.dockerignore`. **[copier]**
+  `.github/PULL_REQUEST_TEMPLATE.md`, the `.github/ISSUE_TEMPLATE/` YAML **Issue
+  Forms** (`{bug,feature,task,research}.yml` and `config.yml`, always generated —
+  see §1.13 for the `type:`/assignee behavior), `.dockerignore`. **[copier]**
+
+### 1.13 Project management (GitHub Projects) — when `project_management: github`
+
+The `project_management` copier answer (`github` / `linear` / `none`, default
+`none`) gates a GitHub-Projects playbook. **`github`** ships
+`docs/project-management.md` — the authoritative doc (statuses, fields, labels,
+milestones, hierarchy, cross-repo, views) — plus the setup tasks/scripts below.
+**`linear`** ships a `# Linear` TODO stub; **`none`** ships neither. **[copier]**
+for the doc/tasks/workflows; **[manual]** to run the setup (they hit the live
+GitHub API and are shellcheck/shfmt-gated only, never CI-tested).
+
+**One default Project (V2) per owner**, titled after the owner's GitHub login
+(`<owner> Project`); every repo feeds the one board. Slice it (by Product /
+`layer:` / Agent) instead of spinning up more projects.
+
+**Setup tasks** (idempotent + non-destructive; **[copier]** generates them, **[manual]** to run):
+
+| Task | Needs | Rendered when | Does |
+|---|---|---|---|
+| `setup:github-project` | `gh` + `project` scope | `project_management: github` | Create/sync the board + `Status` pipeline; write the `ORG_PROJECT_ID` org var (org only); on a **personal** account also create Priority/Effort/Product/Agent as project fields |
+| `setup:github-labels` | `gh` + repo write | `project_management: github` | `gh label create --force` for the five label families |
+| `setup:github-issue-fields` | `gh` + `admin:org` | `github` **and** org owner | Add the org **issue fields** Product + Agent (public preview) |
+| `setup:github-issue-types` | `gh` + `admin:org` | **org owner** (independent of `project_management`) | Ensure org issue types Bug/Feature/Task/Research (Task is GitHub's default; adds Research) |
+
+**Conventions the doc encodes** (audit the doc + the field/label/workflow
+artifacts; the prose rules are guidance, not lint):
+
+- **`Status`** — project single-select, one meaning ("where in delivery"):
+  Inbox/Icebox/Next · Todo/Shaping/Ready/Agent Queue · In Progress/Verifying/
+  In Review/Ready to Merge · Done/Deployed/Accepted. `Done` is the sole terminal
+  status; **no `Archived`** (native 90-day auto-archive); Canceled/Duplicate are
+  close reasons; Blocked is the native blocked-by relationship or `blocked` label.
+  `Agent Queue` is the AI-agent hand-off lane.
+- **Fields** — `Status` is a project field. **Priority + Effort are GitHub built-in
+  issue fields** (Effort must be a **Number** — story points, Fibonacci — so views
+  can sum it); **Product + Agent** are org issue fields from
+  `setup:github-issue-fields`. On a personal account all four are project fields.
+- **Issue types** — Bug/Feature/Task/Research (org). The Issue Forms set `type:` on
+  org repos and a **default assignee**, and apply **no labels** (type is the Type
+  field, not a label).
+- **Labels** — repo-level, five color families (Concerns / Source / Workflow /
+  Layer / Domain), orthogonal to Status and Type. There is no shared org label
+  pool; run `setup:github-labels` per repo.
+- **Milestones** — named after release versions (title == git tag), small +
+  rolling, preferred over iterations pre-launch.
+  `.github/workflows/close-milestone-on-release.yml` closes the matching milestone
+  on release publish — **[copier]** when `use_release_please` + `github`.
+- **Views** (Board / Triage / Agent queue / Planning / Mine) are **UI-only** —
+  Projects V2 has no view API. **[manual]**.
+- **Hierarchy** — sub-issues, no Epic type: the parent holds the spec +
+  milestone/project (children inherit both); leaves hold the `Task` type + `Effort`
+  points.
+
+**Org-only automation** (`github_org != author`):
+`.github/workflows/project-automation.yml` syncs `Status` from PR/CI events as the
+CI GitHub App, reading the `ORG_PROJECT_ID` org variable (title fallback).
+**[copier]**. The project's built-in **"Auto-add to project"** workflow
+(**[manual]**, UI, no API) puts every issue/PR on the board.
 
 ---
 
@@ -514,7 +587,7 @@ Adds (all [copier]):
 - **`include_terraform`** → `terraform/` skeleton (`main.tf`, `variables.tf`,
   `outputs.tf`, `tfvars.env.example`); tasks `lint:terraform` (`fmt -check`),
   `lint:terraform:validate`, `validate`→validate; lefthook terraform (pre-commit)
-  + terraform-validate (pre-push); terraform devcontainer feature; Renovate
+  - terraform-validate (pre-push); terraform devcontainer feature; Renovate
   Terraform-providers group; hashicorp/terraform extension.
 - **`include_ansible`** → `ansible/` skeleton (`ansible.cfg`, `requirements.yaml`,
   `inventory/ playbooks/ roles/` each `.gitkeep`); **`.ansible-lint`**; tasks
@@ -536,8 +609,7 @@ Like `general` (no `build`/framework). [copier]
 
 - **[manual] CHECKLIST:** decide the docs toolchain (plain markdown / Obsidian
   vault / static site generator).
-- `obsidian_project_add` (default no) generates a vault note and runs
-  `util:obsidian-install` post-gen; `util:obsidian-add` scaffolds one later.
+- `obsidian_project_add` (default no) wires `util:obsidian-add` + a vault note.
 
 ---
 
@@ -566,9 +638,8 @@ Legitimately repo- or type-specific differences. An auditor should treat these a
   repos (`github_org == author_git_provider_username`). Org repos get all three.
 - **`design-language.md` / DESIGN.md web section** only for web types; shadcn/ui
   named only for `web-app`.
-- **macOS-only meta** (`util:bunch-add`/`util:bunch-install` /
-  `util:obsidian-add`/`util:obsidian-install`, `.meta/`, Bunch cask) gated by
-  `bunch_add`/`obsidian_project_add` (default no).
+- **macOS-only meta** (`util:bunch-add`/`util:obsidian-add`, `.meta/`, Bunch
+  cask) gated by `bunch_add`/`obsidian_project_add` (default no).
 
 ### 3.2 Tech-stack preferences (web), expected to vary by repo
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,17 @@ itself, not against the root copy). The root form is the template rendered with
 harmon-init's own answers (e.g. `[[ ci_runner_labels ]]` → `[ "ubuntu-latest" ]`),
 and template-only logic (`[% if … %]`, `${VERSION}` arg substitution) collapses to
 its concrete value. When you touch a templated file, grep for the sibling and edit
-both.
+both. For **verbatim** twins — template files *without* a `.jinja` suffix, copied
+byte-for-byte into generated repos — `task test:dogfood-parity` (part of `task
+verify`) enforces byte-equality with the root copy, so a fix applied to only one
+side fails the gate instead of silently shipping stale content downstream
+(intentional root-only divergences are allowlisted in
+`scripts/test-dogfood-parity.sh`).
+
+The **standardize-repo skill** is vendored at `.claude/skills/standardize-repo`
+(so the devcontainer and cloud claude-* workflows can use it); the canonical copy
+lives in harmon-devkit (`ai/skills/repo/standardize-repo`). After the canonical
+copy changes, run `task ai:sync-skills` here and commit the refresh.
 
 ## Common Commands
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -66,6 +66,7 @@ tasks:
     cmds:
       - task: check
       - task: test:tasks
+      - task: test:dogfood-parity
       - task: test:hooks
       - task: test:template
 
@@ -272,6 +273,17 @@ tasks:
     desc: Guard the Taskfile itself (compiles; setup tasks are safe no-ops)
     cmds:
       - ./scripts/test-tasks.sh
+
+  test:dogfood-parity:
+    desc: Verbatim (non-jinja) template files must byte-match their root twins
+    cmds:
+      - ./scripts/test-dogfood-parity.sh
+
+  # ── AI assets ─────────────────────────────────────────────────
+  ai:sync-skills:
+    desc: Re-sync the vendored standardize-repo skill from harmon-devkit (canonical copy)
+    cmds:
+      - rsync -a --delete --exclude=.DS_Store ~/git/harmon-devkit/ai/skills/repo/standardize-repo/ .claude/skills/standardize-repo/
 
   # ── Security ──────────────────────────────────────────────────
   security:

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -471,10 +471,6 @@ if [[ "${SECTION}" == "setup" ]]; then
         has_release_wf=0
         find .github/workflows -maxdepth 1 \( -name 'release.yml' -o -name 'release.yaml' \) 2>/dev/null | grep -q . && has_release_wf=1
         uses_ci_app=$((has_claude_wf || has_release_wf))
-        uses_snyk=0
-        for tf in Taskfile.yml Taskfile.yaml; do
-            [ -f "$tf" ] && grep -qi 'snyk' "$tf" && uses_snyk=1
-        done
         uses_full_scan=0
         grep -rq 'FULL_SECURITY_SCAN' .github/workflows >/dev/null 2>&1 && uses_full_scan=1
 
@@ -682,15 +678,6 @@ if [[ "${SECTION}" == "setup" ]]; then
                     fi
                 else
                     checkline na "CI App credentials" "not used by this repo"
-                fi
-                if [ "${uses_snyk}" = 1 ]; then
-                    if has_cred "${d}/secrets.json" "SNYK_TOKEN"; then
-                        checkline ok "SNYK_TOKEN"
-                    else
-                        checkline no "SNYK_TOKEN" "gh secret set"
-                    fi
-                else
-                    checkline na "SNYK_TOKEN" "no snyk tasks"
                 fi
                 if [ "${uses_full_scan}" = 1 ]; then
                     if has_cred "${d}/vars.json" "FULL_SECURITY_SCAN"; then

--- a/scripts/test-dogfood-parity.sh
+++ b/scripts/test-dogfood-parity.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# test-dogfood-parity.sh — guard the root ↔ template dogfood for VERBATIM twins.
+#
+# Template files without a .jinja suffix are copied into generated repos byte-
+# for-byte, so the root dogfood copy of each must be identical to the template
+# copy. A fix applied to only one side ships stale content downstream (or stops
+# dogfooding it) — and `task test:template` cannot catch that, because it
+# validates the rendered template against itself, not against the root copy.
+# Jinja-templated files are exempt (the root copy is a render, not a copy);
+# ALLOW_DIVERGE lists intentional root-only divergences.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Intentional root-only divergences (the template copy is what consumers get):
+#   .yamllint — root adds the template/ exclusion (jinja YAML is not valid YAML
+#               until rendered) and trims artifact dirs harmon-init never makes.
+ALLOW_DIVERGE=".yamllint"
+
+fail=0
+checked=0
+while IFS= read -r tfile; do
+    # Map the template path to its root twin: strip jinja conditionals from
+    # path segments ("[% if … %]name[% endif %]" -> "name").
+    rel=$(printf '%s' "${tfile#template/}" | sed -E 's/\[% if [^%]*%\]//g; s/\[% endif %\]//g')
+    case " ${ALLOW_DIVERGE} " in *" ${rel} "*) continue ;; esac
+    # Root does not dogfood every profile's files (e.g. python/node-only ones).
+    [ -f "$rel" ] || continue
+    checked=$((checked + 1))
+    if ! diff -q "$tfile" "$rel" >/dev/null; then
+        echo "FAIL: ${rel} differs from its verbatim template twin (${tfile})" >&2
+        fail=1
+    fi
+done < <(find template -type f ! -name '*.jinja')
+
+if [ "$fail" -ne 0 ]; then
+    echo "dogfood parity: divergent verbatim twins — edit both copies in lockstep (see AGENTS.md)" >&2
+    exit 1
+fi
+echo "dogfood parity OK: ${checked} verbatim root<->template twins are identical"

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -165,7 +165,7 @@ else
         existing=$(printf '%s' "$fields_json" |
             jq -c '[.data.node.fields.nodes[] | select(.name=="Status") | .options[] | {name, color: (.color // "GRAY" | ascii_upcase), description: (.description // "")}]')
         desired=$(jq -cn --argjson ex "$existing" --argjson pl "$status_pipeline" \
-            '$ex + [ $pl[] | select( ([ $ex[].name ] | index(.name)) == null ) ]')
+            '$ex + [ $pl[] | select( .name as $n | ([ $ex[].name ] | index($n)) == null ) ]')
     fi
     frag=$(printf '%s' "$desired" | jq -r "$opts_to_graphql")
     gh api graphql -f f="$status_field_id" \

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -471,10 +471,6 @@ if [[ "${SECTION}" == "setup" ]]; then
         has_release_wf=0
         find .github/workflows -maxdepth 1 \( -name 'release.yml' -o -name 'release.yaml' \) 2>/dev/null | grep -q . && has_release_wf=1
         uses_ci_app=$((has_claude_wf || has_release_wf))
-        uses_snyk=0
-        for tf in Taskfile.yml Taskfile.yaml; do
-            [ -f "$tf" ] && grep -qi 'snyk' "$tf" && uses_snyk=1
-        done
         uses_full_scan=0
         grep -rq 'FULL_SECURITY_SCAN' .github/workflows >/dev/null 2>&1 && uses_full_scan=1
 
@@ -682,15 +678,6 @@ if [[ "${SECTION}" == "setup" ]]; then
                     fi
                 else
                     checkline na "CI App credentials" "not used by this repo"
-                fi
-                if [ "${uses_snyk}" = 1 ]; then
-                    if has_cred "${d}/secrets.json" "SNYK_TOKEN"; then
-                        checkline ok "SNYK_TOKEN"
-                    else
-                        checkline no "SNYK_TOKEN" "gh secret set"
-                    fi
-                else
-                    checkline na "SNYK_TOKEN" "no snyk tasks"
                 fi
                 if [ "${uses_full_scan}" = 1 ]; then
                     if has_cred "${d}/vars.json" "FULL_SECURITY_SCAN"; then


### PR DESCRIPTION
## Summary

Fixes found during the 2026-07-03 standardize pass (all six downstream repos → v3.15.2). **Needs a release** so downstream `copier update` can pick these up — both fixes change template output.

1. **`fix(template)`: ship the #205 jq fix in the template `setup-github-project.sh`** — #205 fixed the Status-sync membership test in the ROOT script only; the verbatim template twin kept shipping the buggy filter. (sommerlawn-infra #25 / sommerlawn-web #397 hand-port it meanwhile; harmon-infra already had it.)
2. **`fix(template)`: drop the `SNYK_TOKEN` Actions-secret check from `status:setup`** — Snyk is optional/local since #197, so the check flagged a false ✗ on every repo audited today (both status.sh twins).
3. **`ci`: new `task test:dogfood-parity`** — byte-compares all 56 verbatim (non-jinja) root↔template twins so a one-sided fix like #205 fails `task verify` instead of shipping stale content. `.yamllint` allowlisted (intentional root-only divergence).
4. **`chore`: re-sync the vendored standardize-repo skill** (7 files were stale vs harmon-devkit) + new `task ai:sync-skills` to make the refresh repeatable; AGENTS.md documents both new mechanisms.

## Verification

- `task verify` ✅ (now includes the parity guard) · `task test:template:all` ✅ (devcontainer config check SKIPped locally — no docker daemon; CI covers it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)