### PR TITLE
feat(template): upstream downstream-pioneered install + markdownlint hardening

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -11,5 +11,18 @@
   // rewrites a leading "+ " in prose to "- "), so exclude it everywhere. Without
   // this, the lefthook markdown hook (which passes staged files explicitly) would
   // still touch them even though `task lint:markdown` skips .claude via its glob.
-  "ignores": ["CHANGELOG.md", ".claude/**"]
+  //
+  // The remaining entries are gitignored artifact/cache dirs that can exist on
+  // disk (terraform provider cache, uv venv, go-task cache, npm deps) —
+  // markdownlint-cli2 does not read .gitignore, and while `task lint:markdown`
+  // excludes them via its glob, direct cli2 invocations (editor integrations,
+  // `format`) would otherwise scan them. Matching nothing is a no-op.
+  "ignores": [
+    "CHANGELOG.md",
+    ".claude/**",
+    "**/.terraform/**",
+    "**/.venv/**",
+    "**/.task/**",
+    "**/node_modules/**"
+  ]
 }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -321,7 +321,9 @@ tasks:
   install:
     desc: Install all project dependencies and tools
     cmds:
-      - brew bundle --file=Brewfile
+      # Use THIS repo's Brewfile by absolute path (never a user/global one), and
+      # don't cascade-upgrade unrelated already-installed brew dependents.
+      - HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew bundle --file={{.ROOT_DIR}}/Brewfile
       - task: install:hooks
 
   install:hooks:

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -474,7 +474,9 @@ tasks:
   install:
     desc: Install all project dependencies and tools
     cmds:
-      - brew bundle --file=Brewfile
+      # Use THIS repo's Brewfile by absolute path (never a user/global one), and
+      # don't cascade-upgrade unrelated already-installed brew dependents.
+      - HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew bundle --file={{.ROOT_DIR}}/Brewfile
 [% if use_python %]
       - uv sync
 [% endif %]

--- a/template/[% if use_release_please %].markdownlint-cli2.jsonc[% endif %].jinja
+++ b/template/[% if use_release_please %].markdownlint-cli2.jsonc[% endif %].jinja
@@ -11,5 +11,18 @@
   // rewrites a leading "+ " in prose to "- "), so exclude it everywhere. Without
   // this, the lefthook markdown hook (which passes staged files explicitly) would
   // still touch them even though `task lint:markdown` skips .claude via its glob.
-  "ignores": ["CHANGELOG.md", ".claude/**"]
+  //
+  // The remaining entries are gitignored artifact/cache dirs that can exist on
+  // disk (terraform provider cache, uv venv, go-task cache, npm deps) —
+  // markdownlint-cli2 does not read .gitignore, and while `task lint:markdown`
+  // excludes them via its glob, direct cli2 invocations (editor integrations,
+  // `format`) would otherwise scan them. Matching nothing is a no-op.
+  "ignores": [
+    "CHANGELOG.md",
+    ".claude/**",
+    "**/.terraform/**",
+    "**/.venv/**",
+    "**/.task/**",
+    "**/node_modules/**"
+  ]
 }


### PR DESCRIPTION
## Summary

Two improvements pioneered in downstream repos, generalized into the template during the 2026-07-03 standardize pass (companion to #209):

1. **`task install` hardening** (from sommerlawn-infra #14): `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew bundle --file={{.ROOT_DIR}}/Brewfile` — pins the repo's own Brewfile by absolute path and stops brew cascade-upgrading unrelated installed dependents. Root + template in lockstep.
2. **markdownlint-cli2 artifact-dir ignores** (from sommerlawn-infra): cli2 doesn't read `.gitignore`, so direct invocations (editor plugins, `task format`) scan on-disk artifact dirs (`.terraform/` provider caches, `.venv/`, `.task/`, `node_modules/`). Added unconditionally — patterns that match nothing are no-ops. Root + template in lockstep.

After this merges (and a release), sommerlawn-infra's remaining `diff-template.sh` DRIFTs round-trip to zero.

## Verification

- `task verify` ✅ · `task test:template:all` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)