### PR TITLE
chore: re-sync vendored standardize-repo skill (devkit #57)

### DIFF
--- a/.claude/skills/standardize-repo/assets/diff-template.sh
+++ b/.claude/skills/standardize-repo/assets/diff-template.sh
@@ -115,6 +115,8 @@ repo_variant() {
 
 drift=0
 checked=0
+drift_count=0
+missing_count=0
 while IFS= read -r f; do
     case "$f" in '' | \#*) continue ;; esac
     [ -f "$render/$f" ] || continue # conditional file not in this profile
@@ -123,11 +125,13 @@ while IFS= read -r f; do
     if [ -z "$rv" ]; then
         echo "MISSING  $f  (template ships it; repo doesn't)"
         drift=1
+        missing_count=$((missing_count + 1))
         continue
     fi
     if ! diff -q "$render/$f" "$rv" >/dev/null 2>&1; then
         echo "DRIFT    ${rv#"$target"/}"
         drift=1
+        drift_count=$((drift_count + 1))
         [ "$show" -eq 1 ] && diff -u "$rv" "$render/$f" | sed 's/^/    /'
     fi
 done <"$manifest"
@@ -151,14 +155,17 @@ while IFS= read -r abs; do
     *)
         echo "MISSING  $g  (template ships it; repo lacks it — review)"
         drift=1
+        missing_count=$((missing_count + 1))
         ;;
     esac
 done < <(find "$render" -type f | sort)
 
 echo ""
 if [ "$drift" -ne 0 ]; then
-    echo "diff-template: $checked curated files checked for drift; whole render"
-    echo "  scanned for missing files. Findings above (DRIFT/MISSING). For each,"
+    # The counts make truncated output self-evident: if you can't see
+    # $drift_count DRIFT + $missing_count MISSING lines above, you cut them off.
+    echo "diff-template: ${drift_count} DRIFT + ${missing_count} MISSING across $checked curated files"
+    echo "  checked and a whole-render missing-file scan. Findings above. For each,"
     echo "  review the diff (\`diff-template.sh --show\`): pull missed template"
     echo "  improvements in with \`copier update\`, keep legit local customizations."
     exit 1

--- a/.claude/skills/standardize-repo/references/mode-adopt-existing.md
+++ b/.claude/skills/standardize-repo/references/mode-adopt-existing.md
@@ -375,7 +375,11 @@ These are the recurring drifts harmon-init exists to fix (source:
    - The `.tmpl` files themselves are safe: they aren't `*.sh`/`*.yml` (so
      `lint:shell`/`yamllint` skip them) and `{{ .chezmoi.* }}` Go-templates don't
      match the copier marker scan. The one lint snag is app-managed configs missing
-     a trailing newline (e.g. `private_karabiner.json`) — append one.
+     a trailing newline (e.g. `private_karabiner.json`, `private_dot_mackup.cfg`) —
+     append one, and expect it to **recur**: the app rewrites its config without a
+     newline and the next `chezmoi re-add` re-imports it, failing `lint:hygiene`
+     again (bit harmon-dotfiles twice, 2026-06/07). Re-append on each occurrence;
+     a durable per-file lint-hygiene ignore is a harmon-init backlog item.
    - **If the source uses chezmoi `git.autoCommit`/`autoPush`, reconcile it with
      lefthook.** A chezmoi source that auto-commits to `main` collides with the
      template hooks head-on — the `no-commit-to-main` guard blocks the commit and

--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -8,13 +8,14 @@ should this repo have, and where does it come from?"**
 Ground-truth sources (read these, don't trust memory): `harmon-init/copier.yml`,
 `harmon-init/AGENTS.md`, the `harmon-init/template/` tree. Live reference repos
 that have been generated from the template: `harmonops/harmon-infra` (an `iac`
-project) and `sommerlawn/sommerlawn-web` (a `web-astro` project). Note: the live
-repos are pinned to **older template commits** (e.g. harmon-infra `_commit:
-v2.3.1`) and predate several current conventions (release-please, the
-AGENTS.md-canonical symlink flip, the dual-profile devcontainer, the
-`docs/product|architecture|decisions|guides|runbooks` layout). Treat the
-**template** as canonical; treat divergences in the live repos as either legit
-project-type specifics (Part 3) or as drift the repo itself would need to update.
+project) and `sommerlawn/sommerlawn-web` (a `web-astro` project). The platform
+and client repos are kept current via mode-update passes (all six were at
+v3.15.2 as of 2026-07-03), so their remaining divergences are **deliberate
+customizations** (Part 3.2), not lag — but they can drift between passes, so
+read the repo's actual `_commit` in `.copier-answers.yml` rather than assuming
+either way. Treat the **template** as canonical; treat divergences in a live
+repo as legit project-type/stack specifics (Part 3), deliberate customizations,
+or — in a repo that hasn't been updated recently — template-version lag (3.3).
 
 Every item is tagged:
 
@@ -656,11 +657,14 @@ picks from this palette:
   .ignoreCves`. **Do not flag** project-specific dependencies, overrides, or
   CVE-ignore entries — those are app decisions.
 
-### 3.3 Drift from older template commits (live repos lag the template)
+### 3.3 Drift from older template commits (recognition patterns for un-reconciled repos)
 
-The live reference repos were generated from older harmon-init commits and have
-since diverged. These are **template-version lag**, not violations of intent — but
-a repo being *brought up to current standard* would update them:
+Repos generated from **pre-v3** harmon-init that haven't been reconciled show
+these patterns. The platform/client reference repos were reconciled in 2026-06/07
+and no longer do — keep the list for **other** older repos (pre-v3 personal or
+client projects) an audit may target. These are **template-version lag**, not
+violations of intent — a repo being *brought up to current standard* would update
+them:
 
 - **Symlink direction flipped:** live repos have `AGENTS.md -> CLAUDE.md` (and
   `GEMINI.md -> CLAUDE.md`), keeping the real content in `CLAUDE.md`. The current
@@ -674,16 +678,19 @@ a repo being *brought up to current standard* would update them:
   current `product/ architecture/{ci-cd,security,branch-protection,tests} guides/
   runbooks/` + kebab-case filenames. They lack `docs/product/`, `docs/guides/`,
   `docs/glossary.md`, `docs/conventions.md`.
-- **Split CI workflows:** harmon-infra splits `build`/`security`/`validate`/
-  `terraform` into separate workflow files and has extra ones (`deploy.yaml`,
-  `mirror-devcontainer-base.yaml`); sommerlawn-web has `-max` variants of the
-  claude workflows and `links-online.yml`. The current template consolidates
-  lint+security+build-test into `build.yml`.
-- **Older copier answer keys:** harmon-infra's `.copier-answers.yml` references
+- **Split CI workflows:** an older repo may split `build`/`security`/`validate`
+  into separate workflow files where the current template consolidates
+  lint+security+build-test into `build.yml`. NB: **harmon-infra retains** its
+  split workflows, extra `deploy.yaml`/`mirror-devcontainer-base.yaml`, and
+  self-hosted `contraption` runners as an **accepted permanent customization** —
+  treat that as 3.2-class, not lag. (sommerlawn-web's old `-max` claude-workflow
+  variants are gone; its extra `links-online.yml` is a legit addition.)
+- **Older copier answer keys:** a pre-v3 `.copier-answers.yml` references
   now-renamed/removed questions (`github_collaboration_templates`,
-  `run_task_bootstrap`, `project_url`) — expected for a `_commit: v2.3.1` repo.
-- **Stale `requirements.txt`** in harmon-infra alongside `pyproject.toml`/`uv.lock`
-  — the current template is uv/pyproject-only.
+  `run_task_bootstrap`, `project_url`).
+- **Stale `requirements.txt`** alongside `pyproject.toml`/`uv.lock` — the current
+  template is uv/pyproject-only. (Removed from harmon-infra 2026-07-03 once its
+  last consumer, a legacy Snyk CI step, was dropped.)
 
 When auditing: distinguish "**legit conditional/stack difference**" (3.1, 3.2 —
 leave alone) from "**template-version lag**" (3.3 — candidate for an update toward


### PR DESCRIPTION
First use of `task ai:sync-skills` (added in #209): refreshes the vendored `.claude/skills/standardize-repo` with harmon-devkit #57's changes (diff-template counts footer, standards-catalog live-repos note, chezmoi newline recurrence). No template output changes — root-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)