### PR TITLE
feat(template): add a summable Size project number field (Fibonacci points)

### DIFF
--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -498,10 +498,13 @@ artifacts; the prose rules are guidance, not lint):
   status; **no `Archived`** (native 90-day auto-archive); Canceled/Duplicate are
   close reasons; Blocked is the native blocked-by relationship or `blocked` label.
   `Agent Queue` is the AI-agent hand-off lane.
-- **Fields** — `Status` is a project field. **Priority + Effort are GitHub built-in
-  issue fields** (Effort must be a **Number** — story points, Fibonacci — so views
-  can sum it); **Product + Agent** are org issue fields from
-  `setup:github-issue-fields`. On a personal account all four are project fields.
+- **Fields** — `Status` is a project field. **Effort is ALWAYS a project Number
+  field** (story points, Fibonacci): only project number fields sum in view group
+  headers, so it stays on the project even for orgs — delete the org's built-in
+  single-select `Effort` ISSUE field (issue-field types can't be changed).
+  **Priority is a GitHub built-in issue field**; **Product + Agent** are org issue
+  fields from `setup:github-issue-fields`. On a personal account all four are
+  project fields.
 - **Issue types** — Bug/Feature/Task/Research (org). The Issue Forms set `type:` on
   org repos and a **default assignee**, and apply **no labels** (type is the Type
   field, not a label).

--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -498,13 +498,13 @@ artifacts; the prose rules are guidance, not lint):
   status; **no `Archived`** (native 90-day auto-archive); Canceled/Duplicate are
   close reasons; Blocked is the native blocked-by relationship or `blocked` label.
   `Agent Queue` is the AI-agent hand-off lane.
-- **Fields** — `Status` is a project field. **Effort is ALWAYS a project Number
-  field** (story points, Fibonacci): only project number fields sum in view group
-  headers, so it stays on the project even for orgs — delete the org's built-in
-  single-select `Effort` ISSUE field (issue-field types can't be changed).
-  **Priority is a GitHub built-in issue field**; **Product + Agent** are org issue
-  fields from `setup:github-issue-fields`. On a personal account all four are
-  project fields.
+- **Fields** — `Status` is a project field. **Size is ALWAYS a project Number
+  field** (estimation points, Fibonacci): only project number fields sum in view
+  group headers, so it lives on the project even for orgs. The GitHub built-in
+  issue fields (**Priority**, single-select **Effort**, Start/Target date) are
+  left at their defaults; **Product + Agent** are org issue fields from
+  `setup:github-issue-fields`. On a personal account (no issue fields)
+  `setup:github-project` creates Priority/Product/Agent/Size as project fields.
 - **Issue types** — Bug/Feature/Task/Research (org). The Issue Forms set `type:` on
   org repos and a **default assignee**, and apply **no labels** (type is the Type
   field, not a label).

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -42,9 +42,10 @@ config, toolchain, devcontainer, and dev environment — against the items below
       devcontainer prebuild populates `ghcr.io/evanharmon1/harmon-init-devcontainer` on merge to main
 - [ ] GitHub Project: run `task setup:github-project` (needs
       `gh auth refresh -s project`) to create the owner's default project (titled
-      `evanharmon1 Project`) and idempotently sync its `Status` pipeline — see
+      `evanharmon1 Project`) and idempotently sync its `Status` pipeline and
+      `Size` number field — see
       [project-management.md](project-management.md).
-      On a personal account it also creates Priority/Effort/Product/Agent as
+      On a personal account it also creates Priority/Product/Agent/Size as
       project fields (issue fields are org-only); status automation is a separate
       follow-up — the board is set up, but issue/PR status isn't auto-synced yet.
 - [ ] Labels: run `task setup:github-labels` to seed this repo's starter label

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -167,14 +167,14 @@ drive it.
 The work-metadata fields:
 
 - **Priority** — Urgent / High / Medium / Low
-- **Effort** — story points on the Fibonacci ladder (1 / 2 / 3 / 5 / 8 / 13 / 21),
+- **Size** — estimation points on the Fibonacci ladder (1 / 2 / 3 / 5 / 8 / 13 / 21),
   a project **number** field so a view can sum it per group
 - **Product** — which product/area it belongs to (free text)
 - **Agent** — which agent should implement it (Claude Code, Codex, Gemini CLI,
   Qwen Code, DeepSeek, Kimi K2, GLM, GitHub Copilot) and how (effort level, model)
 
-On a personal account all four are **project fields** (issue fields are
-org-only), created alongside the board by `task setup:github-project`.
+On a personal account there are no issue fields, so `task setup:github-project`
+creates **Priority, Product, Agent, and Size** as project fields.
 
 TODO: finalize each field's options/values.
 
@@ -334,7 +334,7 @@ explicit *not*-doing reasoning, and — since sub-issues auto-inherit it — the
 inherits; move the parent to `v1.1.0` and the whole tree moves with it. Never set
 the milestone per child.
 
-The **leaves** hold execution: the `Task` type and the **`Effort` points**. Put
+The **leaves** hold execution: the `Task` type and the **`Size` points**. Put
 the estimate on the mergeable one-PR slices, not the parent — estimating a slice is
 reliable, estimating a big parent isn't — and a view's field sums total the leaves
 for you.
@@ -402,10 +402,10 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   showing only the in-flight `Status` columns (**Ready, Agent Queue, In Progress,
   Verifying, In Review, Ready to Merge**), sorted by `Priority`.
 - **Planning** — table, grouped by **`Product`** (or `Type`), sorted by
-  `Priority`, with the **`Effort` field summed in each group header**. The "how
+  `Priority`, with the **`Size` field summed in each group header**. The "how
   big is the pile, and what's the plan" view, and a **dates-free roadmap
   substitute**: the per-group sum shows the weight behind each product without
-  maintaining a timeline. (`Effort` is a **number** field — GitHub sums number
+  maintaining a timeline. (`Size` is a **number** field — GitHub sums number
   fields in group headers, so this totals the points behind each group; a
   single-select can't be summed.)
 - **Mine** — table, `is:open assignee:@me`, sorted by `Priority`.

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -168,13 +168,13 @@ The work-metadata fields:
 
 - **Priority** — Urgent / High / Medium / Low
 - **Effort** — story points on the Fibonacci ladder (1 / 2 / 3 / 5 / 8 / 13 / 21),
-  a **number** field so a view can sum it per group
+  a project **number** field so a view can sum it per group
 - **Product** — which product/area it belongs to (free text)
 - **Agent** — which agent should implement it (Claude Code, Codex, Gemini CLI,
   Qwen Code, DeepSeek, Kimi K2, GLM, GitHub Copilot) and how (effort level, model)
 
-On a personal account these are **project fields** (issue fields are org-only),
-created alongside the board by `task setup:github-project`.
+On a personal account all four are **project fields** (issue fields are
+org-only), created alongside the board by `task setup:github-project`.
 
 TODO: finalize each field's options/values.
 

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 # setup-github-project.sh — idempotently create and sync a GitHub Project V2 for a
-# repo owner (an organization OR a personal user account): the board and its
-# Status pipeline (docs/project-management.md). On an ORGANIZATION, the metadata
-# fields are org-level ISSUE fields (Priority + Effort are GitHub built-ins;
+# repo owner (an organization OR a personal user account): the board, its
+# Status pipeline (docs/project-management.md), and the Effort project NUMBER
+# field — Effort stays a project field for BOTH owner types, because only
+# project number fields sum in view group headers (issue-field columns can
+# group/filter/sort, not sum). The other metadata on an ORGANIZATION are
+# org-level ISSUE fields (Priority is a GitHub built-in;
 # setup-github-issue-fields.sh adds Product + Agent); on a personal account (no
-# org issue fields) this script creates Priority/Effort/Product/Agent as project
-# fields instead.
+# org issue fields) this script creates Priority/Product/Agent as project
+# fields too.
 #
 # Safe to re-run and safe to run from every repo the owner controls: it looks the
 # project up by title, so the first run creates it and later runs just reconcile
@@ -212,13 +215,25 @@ create_number() {
         >/dev/null
 }
 
-# Metadata fields: on an ORGANIZATION these are org-level ISSUE fields (durable —
+# Effort: a project NUMBER field for BOTH owner types — story points on the
+# Fibonacci ladder (1/2/3/5/8/13/21; the ladder is a convention, the field takes
+# free numeric entry). Project views can group/filter/sort by org ISSUE-field
+# columns, but group-header SUMS only work for project NUMBER fields — and the
+# per-group sum is Effort's whole job (docs/project-management.md, Planning view).
+echo "==> Effort project field (number — views sum it per group)"
+create_number "Effort"
+
+# Other metadata: on an ORGANIZATION these are org-level ISSUE fields (durable —
 # the value is on the issue, shared across every project; see
-# docs/project-management.md). Priority + Effort are GitHub built-ins;
+# docs/project-management.md). Priority is a GitHub built-in;
 # setup-github-issue-fields.sh adds Product + Agent. A personal account has no org
 # issue fields, so fall back to creating them as project fields here.
 if [ "$owner_type" = "Organization" ]; then
-    echo "==> Metadata are org issue fields (Priority/Effort built-in; run setup-github-issue-fields.sh for Product/Agent)"
+    echo "==> Other metadata are org issue fields (Priority built-in; run setup-github-issue-fields.sh for Product/Agent)"
+    echo "    NOTE: delete the org's built-in single-select 'Effort' ISSUE field if it still"
+    echo "          exists — Effort lives on the project (issue-field types can't be changed):"
+    echo "          gh api orgs/$owner/issue-fields   # find the id, then"
+    echo "          gh api --method DELETE orgs/$owner/issue-fields/<id>"
     echo "==> Done — project #$project_number: $title"
     exit 0
 fi
@@ -230,10 +245,6 @@ create_single_select "Priority" '[
   {"name":"Medium","color":"YELLOW","description":""},
   {"name":"Low","color":"GRAY","description":""}
 ]'
-# Effort is story points on the Fibonacci ladder (1/2/3/5/8/13/21) — a NUMBER
-# field so views can sum it per group (single-selects can't be summed). The
-# ladder is a convention; a number field takes free numeric entry.
-create_number "Effort"
 create_text "Product"
 create_single_select "Agent" '[
   {"name":"Claude Code","color":"ORANGE","description":""},

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # setup-github-project.sh — idempotently create and sync a GitHub Project V2 for a
 # repo owner (an organization OR a personal user account): the board, its
-# Status pipeline (docs/project-management.md), and the Effort project NUMBER
-# field — Effort stays a project field for BOTH owner types, because only
-# project number fields sum in view group headers (issue-field columns can
-# group/filter/sort, not sum). The other metadata on an ORGANIZATION are
-# org-level ISSUE fields (Priority is a GitHub built-in;
-# setup-github-issue-fields.sh adds Product + Agent); on a personal account (no
-# org issue fields) this script creates Priority/Product/Agent as project
-# fields too.
+# Status pipeline (docs/project-management.md), and the Size project NUMBER
+# field — the numeric estimate stays a project field for BOTH owner types,
+# because only project number fields sum in view group headers (issue-field
+# columns can group/filter/sort, not sum). The other metadata on an ORGANIZATION
+# are org-level ISSUE fields (Priority/Effort are GitHub built-ins, left at
+# their defaults; setup-github-issue-fields.sh adds Product + Agent); on a
+# personal account (no org issue fields) this script creates
+# Priority/Product/Agent as project fields too.
 #
 # Safe to re-run and safe to run from every repo the owner controls: it looks the
 # project up by title, so the first run creates it and later runs just reconcile
@@ -215,13 +215,15 @@ create_number() {
         >/dev/null
 }
 
-# Effort: a project NUMBER field for BOTH owner types — story points on the
+# Size: a project NUMBER field for BOTH owner types — estimation points on the
 # Fibonacci ladder (1/2/3/5/8/13/21; the ladder is a convention, the field takes
 # free numeric entry). Project views can group/filter/sort by org ISSUE-field
 # columns, but group-header SUMS only work for project NUMBER fields — and the
-# per-group sum is Effort's whole job (docs/project-management.md, Planning view).
-echo "==> Effort project field (number — views sum it per group)"
-create_number "Effort"
+# per-group sum is Size's whole job (docs/project-management.md, Planning view).
+# GitHub's built-in Effort ISSUE field (single-select) is left at its default;
+# Size is the numeric, summable estimate.
+echo "==> Size project field (number — views sum it per group)"
+create_number "Size"
 
 # Other metadata: on an ORGANIZATION these are org-level ISSUE fields (durable —
 # the value is on the issue, shared across every project; see
@@ -229,11 +231,7 @@ create_number "Effort"
 # setup-github-issue-fields.sh adds Product + Agent. A personal account has no org
 # issue fields, so fall back to creating them as project fields here.
 if [ "$owner_type" = "Organization" ]; then
-    echo "==> Other metadata are org issue fields (Priority built-in; run setup-github-issue-fields.sh for Product/Agent)"
-    echo "    NOTE: delete the org's built-in single-select 'Effort' ISSUE field if it still"
-    echo "          exists — Effort lives on the project (issue-field types can't be changed):"
-    echo "          gh api orgs/$owner/issue-fields   # find the id, then"
-    echo "          gh api --method DELETE orgs/$owner/issue-fields/<id>"
+    echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product/Agent)"
     echo "==> Done — project #$project_number: $title"
     exit 0
 fi

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -531,7 +531,7 @@ tasks:
 [% if github_org != author_git_provider_username %]
 
   setup:github-issue-fields:
-    desc: Idempotently add the org's Product + Agent issue fields (Priority + Effort are GitHub built-ins; public preview). Requires `gh` with the admin:org scope.
+    desc: Idempotently add the org's Product + Agent issue fields (Priority is a GitHub built-in; Effort is a project number field via setup:github-project). Requires `gh` with the admin:org scope.
     cmds:
       - ./scripts/setup-github-issue-fields.sh --org "[[ github_org ]]"
 [% endif %]

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -518,7 +518,7 @@ tasks:
 [% if project_management == 'github' %]
 
   setup:github-project:
-    desc: Idempotently create/sync the owner's GitHub Project V2 board + Status pipeline (on a personal account also its metadata fields). Requires `gh auth refresh -s project`.
+    desc: Idempotently create/sync the owner's GitHub Project V2 board + Status pipeline + Size number field (on a personal account also the other metadata fields). Requires `gh auth refresh -s project`.
     cmds:
       - ./scripts/setup-github-project.sh --owner "[[ github_org ]]" --title "[[ github_org ]] Project"
 
@@ -531,7 +531,7 @@ tasks:
 [% if github_org != author_git_provider_username %]
 
   setup:github-issue-fields:
-    desc: Idempotently add the org's Product + Agent issue fields (Priority is a GitHub built-in; Effort is a project number field via setup:github-project). Requires `gh` with the admin:org scope.
+    desc: Idempotently add the org's Product + Agent issue fields (Priority/Effort are GitHub built-ins, left at defaults; the numeric Size estimate is a project field via setup:github-project). Requires `gh` with the admin:org scope.
     cmds:
       - ./scripts/setup-github-issue-fields.sh --org "[[ github_org ]]"
 [% endif %]

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -60,7 +60,8 @@ config, toolchain, devcontainer, and dev environment — against the items below
 [% if project_management == 'github' %]
 - [ ] GitHub Project: run `task setup:github-project` (needs
       `gh auth refresh -s project`) to create the owner's default project (titled
-      `[[ github_org ]] Project`) and idempotently sync its `Status` pipeline — see
+      `[[ github_org ]] Project`) and idempotently sync its `Status` pipeline and
+      `Size` number field — see
       [project-management.md](project-management.md).
 [% if github_org != author_git_provider_username %]
       It also writes the project id to the `ORG_PROJECT_ID` org variable that
@@ -68,14 +69,13 @@ config, toolchain, devcontainer, and dev environment — against the items below
       the project title).
 - [ ] Org issue fields: run `task setup:github-issue-fields` (needs `gh` with the
       `admin:org` scope) to add the org's **Product** and **Agent** issue fields.
-      Priority is a GitHub built-in issue field — tune its options in the org's
-      issue-field settings. **Effort is deliberately a project number field**, not
-      an issue field (only project number fields sum in view group headers;
-      `task setup:github-project` creates it) — delete the org's built-in
-      single-select `Effort` issue field (the setup scripts print the command).
-      Idempotent and non-destructive.
+      Priority/Effort (and the date fields) are GitHub built-in issue fields, left
+      at their defaults — tune options in the org's issue-field settings if you
+      like. **The numeric estimate is the `Size` project number field** (created
+      by `task setup:github-project`; only project number fields sum in view
+      group headers). Idempotent and non-destructive.
 [% else %]
-      On a personal account it also creates Priority/Effort/Product/Agent as
+      On a personal account it also creates Priority/Product/Agent/Size as
       project fields (issue fields are org-only); status automation is a separate
       follow-up — the board is set up, but issue/PR status isn't auto-synced yet.
 [% endif %]

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -67,10 +67,13 @@ config, toolchain, devcontainer, and dev environment — against the items below
       project-automation.yml and the claude-* workflows read (they fall back to
       the project title).
 - [ ] Org issue fields: run `task setup:github-issue-fields` (needs `gh` with the
-      `admin:org` scope) to add the org's **Product** and **Agent** issue fields
-      (GitHub public preview). Priority + Effort are GitHub built-in issue fields,
-      so they aren't recreated — tune their options in the org's issue-field
-      settings. Idempotent and non-destructive.
+      `admin:org` scope) to add the org's **Product** and **Agent** issue fields.
+      Priority is a GitHub built-in issue field — tune its options in the org's
+      issue-field settings. **Effort is deliberately a project number field**, not
+      an issue field (only project number fields sum in view group headers;
+      `task setup:github-project` creates it) — delete the org's built-in
+      single-select `Effort` issue field (the setup scripts print the command).
+      Idempotent and non-destructive.
 [% else %]
       On a personal account it also creates Priority/Effort/Product/Agent as
       project fields (issue fields are org-only); status automation is a separate

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -171,7 +171,7 @@ drive it.
 The work-metadata fields:
 
 - **Priority** — Urgent / High / Medium / Low
-- **Effort** — story points on the Fibonacci ladder (1 / 2 / 3 / 5 / 8 / 13 / 21),
+- **Size** — estimation points on the Fibonacci ladder (1 / 2 / 3 / 5 / 8 / 13 / 21),
   a project **number** field so a view can sum it per group
 - **Product** — which product/area it belongs to (free text)
 - **Agent** — which agent should implement it (Claude Code, Codex, Gemini CLI,
@@ -181,22 +181,21 @@ The work-metadata fields:
 **Priority, Product, and Agent are org issue fields**: org-level, defined once,
 and — unlike a project field — the value lives on the **issue**, stays consistent
 across every project the issue belongs to, and shows in the issue timeline. GitHub
-ships **Priority** (plus **Start date** / **Target date**) built in, so
-`task setup:github-issue-fields` only adds **Product** and **Agent**; tune
-Priority's options in the org's issue-field settings.
+ships **Priority** and **Effort** (plus **Start date** / **Target date**) built
+in, left at their defaults, so `task setup:github-issue-fields` only adds
+**Product** and **Agent**.
 
-**Effort is the exception — a project number field** (created by
+**Size is the exception — a project number field** (created by
 `task setup:github-project`): project views can group, filter, and sort by
 issue-field columns, but group-header **sums** only work for project **number**
-fields, and the per-group sum is Effort's whole job (see the Planning view). An
-issue field's type can't be changed after creation, so **delete the org's
-built-in single-select `Effort` issue field** to avoid two Efforts
-(`gh api orgs/<org>/issue-fields` for the id, then
-`gh api --method DELETE orgs/<org>/issue-fields/<id>`).
+fields, and the per-group sum is Size's whole job (see the Planning view). An
+issue field's type also can't be changed after creation, so the built-in
+single-select `Effort` issue field can't hold the numeric estimate — leave it at
+its default (a coarse gut-check) and put points in `Size`.
 
 [% else %]
-On a personal account all four are **project fields** (issue fields are
-org-only), created alongside the board by `task setup:github-project`.
+On a personal account there are no issue fields, so `task setup:github-project`
+creates **Priority, Product, Agent, and Size** as project fields.
 
 [% endif %]
 TODO: finalize each field's options/values.
@@ -378,7 +377,7 @@ explicit *not*-doing reasoning, and — since sub-issues auto-inherit it — the
 inherits; move the parent to `v1.1.0` and the whole tree moves with it. Never set
 the milestone per child.
 
-The **leaves** hold execution: the `Task` type and the **`Effort` points**. Put
+The **leaves** hold execution: the `Task` type and the **`Size` points**. Put
 the estimate on the mergeable one-PR slices, not the parent — estimating a slice is
 reliable, estimating a big parent isn't — and a view's field sums total the leaves
 for you.
@@ -446,10 +445,10 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   showing only the in-flight `Status` columns (**Ready, Agent Queue, In Progress,
   Verifying, In Review, Ready to Merge**), sorted by `Priority`.
 - **Planning** — table, grouped by **`Product`** (or `Type`), sorted by
-  `Priority`, with the **`Effort` field summed in each group header**. The "how
+  `Priority`, with the **`Size` field summed in each group header**. The "how
   big is the pile, and what's the plan" view, and a **dates-free roadmap
   substitute**: the per-group sum shows the weight behind each product without
-  maintaining a timeline. (`Effort` is a **number** field — GitHub sums number
+  maintaining a timeline. (`Size` is a **number** field — GitHub sums number
   fields in group headers, so this totals the points behind each group; a
   single-select can't be summed.)
 - **Mine** — table, `is:open assignee:@me`, sorted by `Priority`.

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -172,24 +172,31 @@ The work-metadata fields:
 
 - **Priority** — Urgent / High / Medium / Low
 - **Effort** — story points on the Fibonacci ladder (1 / 2 / 3 / 5 / 8 / 13 / 21),
-  a **number** field so a view can sum it per group
+  a project **number** field so a view can sum it per group
 - **Product** — which product/area it belongs to (free text)
 - **Agent** — which agent should implement it (Claude Code, Codex, Gemini CLI,
   Qwen Code, DeepSeek, Kimi K2, GLM, GitHub Copilot) and how (effort level, model)
 
 [% if github_org != author_git_provider_username %]
-These are **org issue fields** (GitHub public preview): org-level, defined once,
+**Priority, Product, and Agent are org issue fields**: org-level, defined once,
 and — unlike a project field — the value lives on the **issue**, stays consistent
 across every project the issue belongs to, and shows in the issue timeline. GitHub
-ships **Priority** and **Effort** (plus **Start date** / **Target date**) as
-built-in issue fields, so `task setup:github-issue-fields` only adds the two that
-aren't built in — **Product** and **Agent**. Tune Priority's options and make
-**Effort a number** (story points) in the org's issue-field settings, so the
-Planning view can sum it.
+ships **Priority** (plus **Start date** / **Target date**) built in, so
+`task setup:github-issue-fields` only adds **Product** and **Agent**; tune
+Priority's options in the org's issue-field settings.
+
+**Effort is the exception — a project number field** (created by
+`task setup:github-project`): project views can group, filter, and sort by
+issue-field columns, but group-header **sums** only work for project **number**
+fields, and the per-group sum is Effort's whole job (see the Planning view). An
+issue field's type can't be changed after creation, so **delete the org's
+built-in single-select `Effort` issue field** to avoid two Efforts
+(`gh api orgs/<org>/issue-fields` for the id, then
+`gh api --method DELETE orgs/<org>/issue-fields/<id>`).
 
 [% else %]
-On a personal account these are **project fields** (issue fields are org-only),
-created alongside the board by `task setup:github-project`.
+On a personal account all four are **project fields** (issue fields are
+org-only), created alongside the board by `task setup:github-project`.
 
 [% endif %]
 TODO: finalize each field's options/values.

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 # setup-github-project.sh — idempotently create and sync a GitHub Project V2 for a
-# repo owner (an organization OR a personal user account): the board and its
-# Status pipeline (docs/project-management.md). On an ORGANIZATION, the metadata
-# fields are org-level ISSUE fields (Priority + Effort are GitHub built-ins;
+# repo owner (an organization OR a personal user account): the board, its
+# Status pipeline (docs/project-management.md), and the Effort project NUMBER
+# field — Effort stays a project field for BOTH owner types, because only
+# project number fields sum in view group headers (issue-field columns can
+# group/filter/sort, not sum). The other metadata on an ORGANIZATION are
+# org-level ISSUE fields (Priority is a GitHub built-in;
 # setup-github-issue-fields.sh adds Product + Agent); on a personal account (no
-# org issue fields) this script creates Priority/Effort/Product/Agent as project
-# fields instead.
+# org issue fields) this script creates Priority/Product/Agent as project
+# fields too.
 #
 # Safe to re-run and safe to run from every repo the owner controls: it looks the
 # project up by title, so the first run creates it and later runs just reconcile
@@ -212,13 +215,25 @@ create_number() {
         >/dev/null
 }
 
-# Metadata fields: on an ORGANIZATION these are org-level ISSUE fields (durable —
+# Effort: a project NUMBER field for BOTH owner types — story points on the
+# Fibonacci ladder (1/2/3/5/8/13/21; the ladder is a convention, the field takes
+# free numeric entry). Project views can group/filter/sort by org ISSUE-field
+# columns, but group-header SUMS only work for project NUMBER fields — and the
+# per-group sum is Effort's whole job (docs/project-management.md, Planning view).
+echo "==> Effort project field (number — views sum it per group)"
+create_number "Effort"
+
+# Other metadata: on an ORGANIZATION these are org-level ISSUE fields (durable —
 # the value is on the issue, shared across every project; see
-# docs/project-management.md). Priority + Effort are GitHub built-ins;
+# docs/project-management.md). Priority is a GitHub built-in;
 # setup-github-issue-fields.sh adds Product + Agent. A personal account has no org
 # issue fields, so fall back to creating them as project fields here.
 if [ "$owner_type" = "Organization" ]; then
-    echo "==> Metadata are org issue fields (Priority/Effort built-in; run setup-github-issue-fields.sh for Product/Agent)"
+    echo "==> Other metadata are org issue fields (Priority built-in; run setup-github-issue-fields.sh for Product/Agent)"
+    echo "    NOTE: delete the org's built-in single-select 'Effort' ISSUE field if it still"
+    echo "          exists — Effort lives on the project (issue-field types can't be changed):"
+    echo "          gh api orgs/$owner/issue-fields   # find the id, then"
+    echo "          gh api --method DELETE orgs/$owner/issue-fields/<id>"
     echo "==> Done — project #$project_number: $title"
     exit 0
 fi
@@ -230,10 +245,6 @@ create_single_select "Priority" '[
   {"name":"Medium","color":"YELLOW","description":""},
   {"name":"Low","color":"GRAY","description":""}
 ]'
-# Effort is story points on the Fibonacci ladder (1/2/3/5/8/13/21) — a NUMBER
-# field so views can sum it per group (single-selects can't be summed). The
-# ladder is a convention; a number field takes free numeric entry.
-create_number "Effort"
 create_text "Product"
 create_single_select "Agent" '[
   {"name":"Claude Code","color":"ORANGE","description":""},

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # setup-github-project.sh — idempotently create and sync a GitHub Project V2 for a
 # repo owner (an organization OR a personal user account): the board, its
-# Status pipeline (docs/project-management.md), and the Effort project NUMBER
-# field — Effort stays a project field for BOTH owner types, because only
-# project number fields sum in view group headers (issue-field columns can
-# group/filter/sort, not sum). The other metadata on an ORGANIZATION are
-# org-level ISSUE fields (Priority is a GitHub built-in;
-# setup-github-issue-fields.sh adds Product + Agent); on a personal account (no
-# org issue fields) this script creates Priority/Product/Agent as project
-# fields too.
+# Status pipeline (docs/project-management.md), and the Size project NUMBER
+# field — the numeric estimate stays a project field for BOTH owner types,
+# because only project number fields sum in view group headers (issue-field
+# columns can group/filter/sort, not sum). The other metadata on an ORGANIZATION
+# are org-level ISSUE fields (Priority/Effort are GitHub built-ins, left at
+# their defaults; setup-github-issue-fields.sh adds Product + Agent); on a
+# personal account (no org issue fields) this script creates
+# Priority/Product/Agent as project fields too.
 #
 # Safe to re-run and safe to run from every repo the owner controls: it looks the
 # project up by title, so the first run creates it and later runs just reconcile
@@ -215,13 +215,15 @@ create_number() {
         >/dev/null
 }
 
-# Effort: a project NUMBER field for BOTH owner types — story points on the
+# Size: a project NUMBER field for BOTH owner types — estimation points on the
 # Fibonacci ladder (1/2/3/5/8/13/21; the ladder is a convention, the field takes
 # free numeric entry). Project views can group/filter/sort by org ISSUE-field
 # columns, but group-header SUMS only work for project NUMBER fields — and the
-# per-group sum is Effort's whole job (docs/project-management.md, Planning view).
-echo "==> Effort project field (number — views sum it per group)"
-create_number "Effort"
+# per-group sum is Size's whole job (docs/project-management.md, Planning view).
+# GitHub's built-in Effort ISSUE field (single-select) is left at its default;
+# Size is the numeric, summable estimate.
+echo "==> Size project field (number — views sum it per group)"
+create_number "Size"
 
 # Other metadata: on an ORGANIZATION these are org-level ISSUE fields (durable —
 # the value is on the issue, shared across every project; see
@@ -229,11 +231,7 @@ create_number "Effort"
 # setup-github-issue-fields.sh adds Product + Agent. A personal account has no org
 # issue fields, so fall back to creating them as project fields here.
 if [ "$owner_type" = "Organization" ]; then
-    echo "==> Other metadata are org issue fields (Priority built-in; run setup-github-issue-fields.sh for Product/Agent)"
-    echo "    NOTE: delete the org's built-in single-select 'Effort' ISSUE field if it still"
-    echo "          exists — Effort lives on the project (issue-field types can't be changed):"
-    echo "          gh api orgs/$owner/issue-fields   # find the id, then"
-    echo "          gh api --method DELETE orgs/$owner/issue-fields/<id>"
+    echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product/Agent)"
     echo "==> Done — project #$project_number: $title"
     exit 0
 fi

--- a/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # setup-github-issue-fields.sh — idempotently add the org ISSUE FIELDS that are
-# NOT GitHub built-ins: Product and Agent. GitHub already ships Priority, Effort,
-# Start date, and Target date as built-in issue fields (Priority's options are
-# Urgent/High/Medium/Low; Effort is the size/estimate field), so we never recreate
-# those. Create-if-missing only; it never edits or deletes a field.
+# NOT GitHub built-ins: Product and Agent. GitHub already ships Priority,
+# Start date, and Target date as useful built-in issue fields (Priority's options
+# are Urgent/High/Medium/Low), so we never recreate those. Create-if-missing
+# only; it never edits or deletes a field.
+#
+# NB: Effort is deliberately NOT an issue field — it is a project NUMBER field
+# (setup-github-project.sh) because only project number fields sum in view group
+# headers, and the per-group sum is Effort's whole job. The org's built-in
+# single-select Effort ISSUE field should be DELETED (issue-field types can't be
+# changed after creation); this script prints the command when it sees one.
 #
 # Issue fields are org-level, durable metadata: the value lives on the *issue*
 # (not a project item), is the same across every project the issue belongs to,
@@ -104,4 +110,16 @@ create_field() {
 create_field "Product" "text" "Which product/area it belongs to"
 create_field "Agent" "single_select" "Which agent should implement it" "$agent_opts"
 
-echo "==> Done — added issue fields on '$org': Product, Agent (Priority + Effort are GitHub built-ins)"
+# Advisory: Effort must live on the PROJECT (number field, so views can sum it).
+# If the org still has its built-in single-select Effort ISSUE field, say how to
+# remove it — never delete automatically (this script is non-destructive).
+effort_id=$(printf '%s' "$existing" |
+    jq -r '.[] | select(.name == "Effort" and .data_type == "single_select") | .id' | head -n1)
+if [ -n "$effort_id" ]; then
+    echo "==> NOTE: this org has the built-in single-select 'Effort' ISSUE field (id $effort_id)."
+    echo "          Effort belongs on the project as a NUMBER field (views sum it; see"
+    echo "          setup-github-project.sh). Issue-field types can't be changed — delete it with:"
+    echo "          gh api --method DELETE orgs/$org/issue-fields/$effort_id"
+fi
+
+echo "==> Done — added issue fields on '$org': Product, Agent (Priority is a GitHub built-in)"

--- a/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 # setup-github-issue-fields.sh — idempotently add the org ISSUE FIELDS that are
-# NOT GitHub built-ins: Product and Agent. GitHub already ships Priority,
-# Start date, and Target date as useful built-in issue fields (Priority's options
-# are Urgent/High/Medium/Low), so we never recreate those. Create-if-missing
-# only; it never edits or deletes a field.
+# NOT GitHub built-ins: Product and Agent. GitHub already ships Priority, Effort,
+# Start date, and Target date as built-in issue fields, and we never recreate or
+# modify those (leave them at their defaults). Create-if-missing only; it never
+# edits or deletes a field.
 #
-# NB: Effort is deliberately NOT an issue field — it is a project NUMBER field
-# (setup-github-project.sh) because only project number fields sum in view group
-# headers, and the per-group sum is Effort's whole job. The org's built-in
-# single-select Effort ISSUE field should be DELETED (issue-field types can't be
-# changed after creation); this script prints the command when it sees one.
+# NB: the numeric, summable estimate is NOT an issue field — it is the Size
+# project NUMBER field (setup-github-project.sh), because only project number
+# fields sum in view group headers. The built-in single-select Effort issue
+# field stays as GitHub ships it (a coarse gut-check, not the estimate).
 #
 # Issue fields are org-level, durable metadata: the value lives on the *issue*
 # (not a project item), is the same across every project the issue belongs to,
@@ -110,16 +109,4 @@ create_field() {
 create_field "Product" "text" "Which product/area it belongs to"
 create_field "Agent" "single_select" "Which agent should implement it" "$agent_opts"
 
-# Advisory: Effort must live on the PROJECT (number field, so views can sum it).
-# If the org still has its built-in single-select Effort ISSUE field, say how to
-# remove it — never delete automatically (this script is non-destructive).
-effort_id=$(printf '%s' "$existing" |
-    jq -r '.[] | select(.name == "Effort" and .data_type == "single_select") | .id' | head -n1)
-if [ -n "$effort_id" ]; then
-    echo "==> NOTE: this org has the built-in single-select 'Effort' ISSUE field (id $effort_id)."
-    echo "          Effort belongs on the project as a NUMBER field (views sum it; see"
-    echo "          setup-github-project.sh). Issue-field types can't be changed — delete it with:"
-    echo "          gh api --method DELETE orgs/$org/issue-fields/$effort_id"
-fi
-
-echo "==> Done — added issue fields on '$org': Product, Agent (Priority is a GitHub built-in)"
+echo "==> Done — added issue fields on '$org': Product, Agent (Priority/Effort/dates are GitHub built-ins)"


### PR DESCRIPTION
## Problem

The PM design needs a numeric estimation field on the Fibonacci ladder (1/2/3/5/8/13/21) that **sums in project-view group headers** (the Planning view depends on it). GitHub's built-in `Effort` **issue field** can't be that field: it ships as a single-select, an issue field's `data_type` can't be changed after creation, and the Projects integration for issue fields supports **group/filter/sort only** — group-header **sums** are documented only for project **number** fields.

## Design (v2 of this PR — don't fight GitHub's defaults)

- **GitHub's four built-in issue fields stay exactly as shipped** — Priority, single-select Effort (a coarse gut-check), Start date, Target date. Nothing deletes or modifies them.
- **The numeric estimate is a new `Size` project NUMBER field**, created by `setup-github-project.sh` for **both** owner types. Fibonacci by convention (free numeric entry); sums appear in table/board/roadmap group headers.
- `setup-github-issue-fields.sh` stays Product+Agent only, fully non-destructive.
- `project-management.md`, CHECKLIST, Taskfile descs, vendored skill catalog updated; "public preview" labels dropped (issue fields went GA 2026-07-02).

## Already applied live (both orgs)

- `Size` NUMBER field on `harmonops Project` + `sommerlawn Project` (renamed from the interim Effort project field — values preserved)
- Built-in-style `Effort` issue field **restored** (High/Medium/Low, original colors/order; it had been deleted in this PR's first iteration)

## Verification

- `task verify` ✅ (dogfood-parity: 56 twins identical) · `task test:template:all` ✅
- Companion: harmon-devkit #59 (same catalog correction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)