### PR TITLE
fix(template): harden web-astro validators (lychee root-dir, JSON-LD origin check)

### DIFF
--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -271,7 +271,9 @@ tasks:
   validate:links:
     desc: Check the built site (dist/) for broken internal links (lychee, offline)
     cmds:
-      - lychee --offline --no-progress ./dist
+      # --root-dir is required to resolve root-relative links (/about, /rss.xml)
+      # against dist/ instead of failing with "provide a root dir".
+      - lychee --offline --no-progress --root-dir "{{.PWD}}/dist" ./dist
 [% endif %]
 
   guard:no-commit-to-main:

--- a/template/scripts/[% if project_type == 'web-astro' %]validate-jsonld.mjs[% endif %]
+++ b/template/scripts/[% if project_type == 'web-astro' %]validate-jsonld.mjs[% endif %]
@@ -49,7 +49,11 @@ for (const file of pages) {
     // Accept a single node, an array of nodes, or a @graph container.
     const nodes = Array.isArray(data) ? data : data['@graph'] || [data]
     const ctx = data['@context'] || nodes.find((n) => n && n['@context'])?.['@context']
-    if (!ctx || !String(ctx).includes('schema.org')) {
+    // @context may be a string or an array of strings/objects; anchor the match
+    // to the schema.org origin (a bare substring test would accept lookalike hosts
+    // — flagged by CodeQL as js/incomplete-url-substring-sanitization).
+    const ctxStrings = (Array.isArray(ctx) ? ctx : [ctx]).filter((s) => typeof s === 'string')
+    if (!ctxStrings.some((s) => /^https?:\/\/(www\.)?schema\.org([/#]|$)/i.test(s.trim()))) {
       console.error(`FAIL [${label}] JSON-LD missing a schema.org @context`)
       errors++
     }


### PR DESCRIPTION
## Summary

Upstreams two fixes pioneered downstream on the first CI shakedown of a freshly adopted web-astro repo ([evan-harmon#28](https://github.com/evanharmon1/evan-harmon/pull/28)):

1. **`validate:links` needs `--root-dir`** — `lychee --offline ./dist` fails on any site that uses root-relative links (`/about`, `/rss.xml`, `/#anchor`) with *"Cannot resolve root-relative link: provide a root dir"*. harmon-init's own render never hits it (no root-relative links), so `task test:template` couldn't catch it. Fix: `--root-dir "{{.PWD}}/dist"` so they resolve against the built site.

2. **`validate-jsonld.mjs` origin check** — CodeQL flags the bare `String(ctx).includes('schema.org')` as `js/incomplete-url-substring-sanitization` (it accepts lookalike hosts like `schema.org.evil.com`). Downstream this failed the PR's CodeQL check. Fix anchors the match to the schema.org origin (`/^https?:\/\/(www\.)?schema\.org([/#]|$)/i`) and handles the array form of `@context` while at it.

No root-layer twin edits needed: both files are web-astro-gated (harmon-init dogfoods the general profile), so dogfood parity is unaffected.

## Verification

- `task verify` — PASS (incl. the web profile's real-app toolchain smoke)
- `task test:template:all` — all 7 profiles PASS

Downstream evan-harmon already carries both fixes locally; the next `copier update` will converge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)