### PR TITLE
feat(template): shield design-handoff bundles under specs/ + mobile Playwright convention

### DIFF
--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -16,6 +16,12 @@
 #     (DirtyLocalWarning). The real working tree is never touched.
 set -euo pipefail
 
+# Git hooks export GIT_DIR/GIT_WORK_TREE (in a linked worktree GIT_DIR points at
+# .git/worktrees/<name>). Left set, the rendered project's `git init` re-targets
+# the CALLING repo instead of the temp dir and the render never becomes a repo
+# (actionlint then fails with "no project was found"). Sanitize unconditionally.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 profile="${1:-minimal}"
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 dest="$(mktemp -d -t harmon-init-test-XXXXXX)"

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,3 +14,11 @@ against. (Specs cover *what* and *why*; `docs/architecture/` covers *how*, and
    acceptance criteria.
 3. Keep one spec per feature/change; link it from the implementing PR, and
    update or supersede it as the work evolves.
+
+## Design-handoff bundles
+
+Claude Design exports (the `design-handoff` skill's input) are unpacked into
+**subdirectories** here — `specs/handoff-<feature>/`. They are vendored,
+temporary reference material: ignored by git and every linter (`specs/*/` in
+the ignore configs) and **deleted at sign-off**, never committed. Top-level
+`specs/*.md` spec files stay tracked and linted as usual.

--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -40,6 +40,11 @@ node_modules/
 # Git worktrees
 .worktrees/
 
+# Design-handoff bundles (Claude Design exports) live as specs/ subdirectories
+# while being implemented and are deleted at sign-off — never committed.
+# Top-level specs/*.md (README, _template, feature specs) stay tracked.
+specs/*/
+
 # Lefthook local overrides (not committed)
 .lefthook-local.yml
 

--- a/template/.yamllint
+++ b/template/.yamllint
@@ -4,6 +4,7 @@ extends: default
 ignore:
   - node_modules/
   - dist/
+  - specs/*/
   - .astro/
   - .task/
   - .worktrees/

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -130,7 +130,7 @@ tasks:
         if [ -n "{{.CLI_ARGS}}" ]; then
           npx --yes markdownlint-cli2 {{.CLI_ARGS}}
         else
-          npx --yes markdownlint-cli2 '**/*.md' '#.claude/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' '#**/.terraform/**' '#**/.venv/**' '#**/.task/**'
+          npx --yes markdownlint-cli2 '**/*.md' '#.claude/**' '#specs/*/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' '#**/.terraform/**' '#**/.venv/**' '#**/.task/**'
         fi
 
   lint:actions:

--- a/template/[% if project_type == 'web-app' %]eslint.config.js[% endif %]
+++ b/template/[% if project_type == 'web-app' %]eslint.config.js[% endif %]
@@ -7,7 +7,8 @@ import router from '@tanstack/eslint-plugin-router'
 import convex from '@convex-dev/eslint-plugin'
 
 export default [
-  { ignores: ['dist/', '.output/', '.nitro/', 'convex/_generated/'] },
+  // specs/*/ holds vendored design-handoff bundles (deleted at sign-off).
+  { ignores: ['dist/', '.output/', '.nitro/', 'convex/_generated/', 'specs/'] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   { ...react.configs.flat.recommended, settings: { react: { version: 'detect' } } },

--- a/template/[% if project_type == 'web-astro' %]eslint.config.js[% endif %]
+++ b/template/[% if project_type == 'web-astro' %]eslint.config.js[% endif %]
@@ -4,7 +4,8 @@ import tseslint from 'typescript-eslint'
 import astro from 'eslint-plugin-astro'
 
 export default [
-  { ignores: ['dist/', '.astro/'] },
+  // specs/*/ holds vendored design-handoff bundles (deleted at sign-off).
+  { ignores: ['dist/', '.astro/', 'specs/'] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   ...astro.configs.recommended,

--- a/template/[% if use_node %].prettierignore[% endif %]
+++ b/template/[% if use_node %].prettierignore[% endif %]
@@ -21,6 +21,8 @@ dist/
 .terraform/
 .venv/
 pnpm-lock.yaml
+# Design-handoff bundles under specs/ (vendored Claude Design exports).
+specs/*/
 
 # release-please owns CHANGELOG.md (writes double blanks Prettier would strip).
 CHANGELOG.md

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -124,6 +124,9 @@ config, toolchain, devcontainer, and dev environment — against the items below
       pnpm 10+ silently ignores that field, so overrides declared there vanish on
       the next lockfile resolve
 - [ ] Review `lighthouserc.json` URLs once routes exist
+- [ ] Enable mobile device projects in `playwright.config.ts` (e.g. Pixel +
+      iPhone) — the Playwright scaffold ships them commented out, and
+      mobile-first is the convention
 [% elif project_type == 'web-app' %]
 - [ ] Scaffold the app: `pnpm create @tanstack/start@latest` (TanStack Start) or vite + react
 - [ ] Add the standard stack: Tailwind v4, shadcn/ui, zod, vitest, lucide

--- a/template/docs/architecture/tests.md.jinja
+++ b/template/docs/architecture/tests.md.jinja
@@ -19,4 +19,9 @@ How testing works in [[ project_name ]].
 
 - Test files live in `tests/` at the repo root (or co-located per framework convention).
 - `task verify` is the local merge gate; CI runs the same task targets.
+[% if project_type in ['web-astro', 'web-app'] %]
+- Playwright runs desktop Chromium/Firefox/WebKit **and mobile device
+  projects** (e.g. Pixel + iPhone). The scaffold ships the mobile projects
+  commented out — enable them; mobile-first is the convention.
+[% endif %]
 - TODO: document coverage expectations and fixtures as the suite grows.

--- a/template/specs/README.md
+++ b/template/specs/README.md
@@ -14,3 +14,11 @@ against. (Specs cover *what* and *why*; `docs/architecture/` covers *how*, and
    acceptance criteria.
 3. Keep one spec per feature/change; link it from the implementing PR, and
    update or supersede it as the work evolves.
+
+## Design-handoff bundles
+
+Claude Design exports (the `design-handoff` skill's input) are unpacked into
+**subdirectories** here — `specs/handoff-<feature>/`. They are vendored,
+temporary reference material: ignored by git and every linter (`specs/*/` in
+the ignore configs) and **deleted at sign-off**, never committed. Top-level
+`specs/*.md` spec files stay tracked and linted as usual.


### PR DESCRIPTION
## What

Makes every generated repo **design-handoff-ready**: `specs/*/` subdirectories (vendored Claude Design bundles — temporary, deleted at sign-off, never committed) are excluded from git and every linter, and the mobile-first testing convention gets teeth.

In the ponderous-web run (ponderousdev/ponderous-web#22) the bundle broke `verify` on six surfaces the moment it landed — prettier tried to *reformat the sign-off reference*, eslint/markdownlint/yamllint attacked its files, and the untracked-file hygiene scan choked on its empty manifest JSON. This ships the shield by default:

- **`.gitignore.jinja`** — `specs/*/` (top-level `specs/*.md` stay tracked)
- **`.prettierignore`** (use_node) — `specs/*/`
- **`.yamllint`** — `specs/*/`
- **Taskfile markdownlint glob** — `'#specs/*/**'`
- **web-astro + web-app `eslint.config.js`** — `'specs/'`
- **`specs/README.md`** — documents the bundle flow (dogfood twin synced)

Not covered by design (scaffolded files the template doesn't own): `tsconfig.json` `exclude` — the design-handoff skill's new "shield the bundle" step handles that (evanharmon1/harmon-devkit#60).

Also:

- **`tests.md` + web-astro CHECKLIST** — enable Playwright's **mobile device projects** (Pixel/iPhone): the scaffold ships them commented out while AGENTS.md declares mobile-first; ponderous-web's mobile sweep projects were what caught two real layout bugs.
- **`fix(scripts)`** ride-along: `test-template.sh` sanitizes `GIT_DIR`/`GIT_WORK_TREE` — git hooks export them, and from a linked worktree the rendered project's `git init` re-targeted the calling repo, making pre-push impossible from any worktree.

## Pairing

- evanharmon1/harmon-devkit#60 updates the design-handoff skill (bundle-shield step referencing this default) and the standardize-repo catalog (audit mode now flags repos missing these ignores).
- Existing repos pick this up via the normal `copier update` / mode-update pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)