### PR TITLE
feat(template): agents must ask before merging to main (convention + settings backstop)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,16 @@
       "Bash(git status:*)",
       "Bash(git diff:*)",
       "Bash(git log:*)"
+    ],
+    "ask": [
+      "Bash(gh pr merge)",
+      "Bash(gh pr merge:*)",
+      "Bash(git merge)",
+      "Bash(git merge:*)",
+      "Bash(git push origin main)",
+      "Bash(git push origin main:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push --force:*)"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,11 @@ task release:patch   # or release:minor / release:major
 - No direct commits to main (enforced by lefthook `guard:no-commit-to-main` and the
   branch ruleset). Work on feature branches; PRs require code-owner review and the
   `verify` + `security` status checks.
+- **Agents never merge to main** — no `gh pr merge`, `git merge`, or push to
+  `main` without Evan's explicit, per-merge approval, even when CI is green and
+  the ruleset would allow it. Open the PR, report that checks pass, then stop;
+  merging is always a human decision. (`.claude/settings.json` backstops this
+  with `permissions.ask` rules on merge commands.)
 - Git hooks are managed by **lefthook** (`task install:hooks`); every hook delegates
   to a Taskfile target so local hooks, CI, and manual runs execute identical
   commands. Never bypass hooks with `--no-verify`.

--- a/template/.claude/settings.json
+++ b/template/.claude/settings.json
@@ -5,6 +5,16 @@
       "Bash(git status:*)",
       "Bash(git diff:*)",
       "Bash(git log:*)"
+    ],
+    "ask": [
+      "Bash(gh pr merge)",
+      "Bash(gh pr merge:*)",
+      "Bash(git merge)",
+      "Bash(git merge:*)",
+      "Bash(git push origin main)",
+      "Bash(git push origin main:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push --force:*)"
     ]
   }
 }

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -43,6 +43,10 @@ can reproduce a CI run locally on demand instead of waiting on a PR.
   refactor, revert, style, test).
 - Never bypass git hooks (`--no-verify` is forbidden); fix the underlying issue.
 - Work on a feature branch; direct commits to `main` are blocked.
+- **Never merge to main yourself** — no `gh pr merge`, `git merge`, or push to
+  `main` without the maintainer's explicit, per-merge approval, even when CI is
+  green and the ruleset would allow it. Open the PR, report that checks pass,
+  then stop; merging is always a human decision.
 [% if use_release_please %]
 - Releases are intentional: release-please keeps a rolling release PR from
   conventional commits; merging it cuts the tag/release. Nothing bumps on a


### PR DESCRIPTION
## Summary

Encodes the "always ask before merging to main" rule into the template's conventions, two layers:

1. **Instruction layer — AGENTS.md**: new Definition of Done bullet in `template/AGENTS.md.jinja` (and the equivalent in root `AGENTS.md` Development Workflow): agents never `gh pr merge` / `git merge` / push to `main` without the maintainer's explicit per-merge approval, even with green CI and a permissive ruleset — open the PR, report status, stop.
2. **Harness layer — `.claude/settings.json`** (root + template verbatim twin, kept byte-identical): `permissions.ask` rules for `gh pr merge` (all variants incl. `--auto`/`--admin`), `git merge`, `git push origin main`, and force pushes — Claude Code prompts before any of these run in a generated repo.

Caveat noted for the record: `ask` rules are skipped in `bypassPermissions` contexts (e.g. the devcontainer bot profile); the AGENTS.md instruction covers that behaviorally, and switching to `deny` remains an option if a hard block is preferred.

## Verification

- `task verify` — PASS
- `task test:template:all` — all 7 profiles PASS
- Root and template `settings.json` remain byte-identical (dogfood parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)