### PR TITLE
feat(template): per-file lint-hygiene exemptions via .lint-hygiene-ignore

### DIFF
--- a/scripts/lint-hygiene.sh
+++ b/scripts/lint-hygiene.sh
@@ -8,6 +8,12 @@
 #
 # Usage: ./scripts/lint-hygiene.sh [file ...]
 #   If no files given, checks all tracked files.
+#
+# Per-file exemptions: an optional repo-root .lint-hygiene-ignore lists one
+# path or glob per line ('#' comments and blank lines allowed); matching files
+# are skipped entirely. Reserve it for app-managed configs the app rewrites on
+# its own terms (e.g. karabiner.json dropping the final newline) — it is not a
+# general lint escape hatch.
 set -euo pipefail
 
 errors=0
@@ -26,9 +32,36 @@ else
     done < <(git ls-files --cached --others --exclude-standard 2>/dev/null)
 fi
 
+# Load per-file exemption patterns (bash 3.2 compatible)
+ignore_patterns=()
+if [ -f .lint-hygiene-ignore ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+        '' | '#'*) continue ;;
+        esac
+        ignore_patterns+=("$line")
+    done <.lint-hygiene-ignore
+fi
+
+is_ignored() {
+    # Empty-array guard: "${arr[@]}" on an empty array is an unbound-variable
+    # error under `set -u` in bash 3.2.
+    [ "${#ignore_patterns[@]}" -eq 0 ] && return 1
+    local p pat
+    p="$1"
+    for pat in "${ignore_patterns[@]}"; do
+        # shellcheck disable=SC2254  # unquoted on purpose: glob match
+        case "$p" in
+        $pat) return 0 ;;
+        esac
+    done
+    return 1
+}
+
 for f in "${files[@]}"; do
     [ -f "$f" ] || continue
     [ -L "$f" ] && continue # skip symlinks (AGENTS.md aliases etc.)
+    if is_ignored "$f"; then continue; fi
 
     # Skip binary files and known binary extensions
     case "$f" in

--- a/template/scripts/lint-hygiene.sh
+++ b/template/scripts/lint-hygiene.sh
@@ -8,6 +8,12 @@
 #
 # Usage: ./scripts/lint-hygiene.sh [file ...]
 #   If no files given, checks all tracked files.
+#
+# Per-file exemptions: an optional repo-root .lint-hygiene-ignore lists one
+# path or glob per line ('#' comments and blank lines allowed); matching files
+# are skipped entirely. Reserve it for app-managed configs the app rewrites on
+# its own terms (e.g. karabiner.json dropping the final newline) — it is not a
+# general lint escape hatch.
 set -euo pipefail
 
 errors=0
@@ -26,9 +32,36 @@ else
     done < <(git ls-files --cached --others --exclude-standard 2>/dev/null)
 fi
 
+# Load per-file exemption patterns (bash 3.2 compatible)
+ignore_patterns=()
+if [ -f .lint-hygiene-ignore ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+        '' | '#'*) continue ;;
+        esac
+        ignore_patterns+=("$line")
+    done <.lint-hygiene-ignore
+fi
+
+is_ignored() {
+    # Empty-array guard: "${arr[@]}" on an empty array is an unbound-variable
+    # error under `set -u` in bash 3.2.
+    [ "${#ignore_patterns[@]}" -eq 0 ] && return 1
+    local p pat
+    p="$1"
+    for pat in "${ignore_patterns[@]}"; do
+        # shellcheck disable=SC2254  # unquoted on purpose: glob match
+        case "$p" in
+        $pat) return 0 ;;
+        esac
+    done
+    return 1
+}
+
 for f in "${files[@]}"; do
     [ -f "$f" ] || continue
     [ -L "$f" ] && continue # skip symlinks (AGENTS.md aliases etc.)
+    if is_ignored "$f"; then continue; fi
 
     # Skip binary files and known binary extensions
     case "$f" in


### PR DESCRIPTION
## Summary

Implements #213: `scripts/lint-hygiene.sh` now consults an optional repo-root **`.lint-hygiene-ignore`** — one path or glob per line, `#` comments and blank lines allowed — and skips matching files entirely. The template-owned script stays universal; a repo opts out its app-managed files without forking the script, and the file is deliberately documented as *not* a general lint escape hatch.

Motivating case (bit harmon-dotfiles twice): Karabiner and mackup rewrite their configs without a final newline, `chezmoi re-add` re-imports that byte-for-byte, and `lint:hygiene` fails on a file nobody deliberately touched. After this ships, harmon-dotfiles adds a two-line `.lint-hygiene-ignore` and the cycle ends.

## Implementation notes

- Glob matching via bash `case` patterns, so `dot_config/*`, `*.cfg`, and exact paths all work (`*` crosses `/`, keeping entries simple).
- macOS bash 3.2 portable: no `mapfile`; explicit empty-array guard (`"${arr[@]}"` on an empty array is an unbound-variable error under `set -u` in 3.2).
- No behavior change when the ignore file is absent.
- Root and template copies byte-identical (`test:dogfood-parity`).

## Verification

- Functional matrix (scratchpad): violation detected without ignore file; exact-path ignore; glob ignore; non-matching pattern still fails; subdir glob; empty ignore file — all as expected, run under both env bash and `/bin/bash` 3.2.57.
- `shellcheck --severity=error` + `shfmt -d` clean.
- `task verify` — PASS; `task test:template:all` — all 7 profiles PASS.

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)