### PR TITLE
fix(template): honor use_release_please in CHANGELOG, ignore .lighthouseci/, a11y gate to 1.0

### DIFF
--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -78,6 +78,9 @@ playwright-report/
 # coverage / test output
 coverage/
 .nyc_output/
+
+# Lighthouse CI output
+.lighthouseci/
 [% endif %]
 [% if use_python %]
 

--- a/template/CHANGELOG.md.jinja
+++ b/template/CHANGELOG.md.jinja
@@ -4,9 +4,12 @@ All notable changes to [[ project_name ]] are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-Releases are cut manually with `task release:patch|minor|major` (never
+[% if use_release_please %]Releases are intentional: release-please maintains a rolling release PR from
+conventional commits, and merging it cuts the tag, GitHub release, and this
+changelog (`task release:*` remains as a manual override).
+[% else %]Releases are cut manually with `task release:patch|minor|major` (never
 automatically on merge).
-
+[% endif %]
 ## [Unreleased]
 
 ### Added

--- a/template/[% if project_type == 'web-astro' %]lighthouserc.json[% endif %]
+++ b/template/[% if project_type == 'web-astro' %]lighthouserc.json[% endif %]
@@ -11,7 +11,7 @@
     "assert": {
       "assertions": {
         "categories:performance": ["warn", { "minScore": 0.7 }],
-        "categories:accessibility": ["error", { "minScore": 0.85 }],
+        "categories:accessibility": ["error", { "minScore": 1 }],
         "categories:best-practices": ["error", { "minScore": 0.7 }],
         "categories:seo": ["error", { "minScore": 0.9 }]
       }


### PR DESCRIPTION
Closes out the three template gaps logged during the ponderous-web adopt-existing run (ponderousdev/ponderous-web#19, 2026-07-03) and carried there since as intentional local divergences.

## Changes

1. **`CHANGELOG.md.jinja`** — the release blurb said releases *"are cut manually with `task release:*`"* unconditionally, which is wrong for `use_release_please` repos. Now conditional; the release-please wording is copied verbatim from ponderous-web's field-tested local fix so its next `copier update` three-way-merges cleanly instead of conflicting.

2. **`.gitignore.jinja`** (node profile) — ignore **`.lighthouseci/`**: the web-astro lighthouse CI job and any local `lhci autorun` write it as scratch output; today it risks being committed from fresh template repos.

3. **web-astro `lighthouserc.json`** — accessibility assert **0.85 → 1**. ⚠️ Intentionally stricter default: a11y is the one Lighthouse category where 100 is realistically achievable and worth hard-enforcing — the 1.0 gate is exactly what caught real WCAG contrast failures (status-badge text on tinted surfaces, low-contrast index numerals) in ponderousdev/ponderous-web#22 that a 0.85 gate would have shipped. Existing repos wanting a looser bar can keep their own value; the default should be the safe one.

## Verification

`task verify` green; all template profiles render (minimal/web/webapp/iac/full/meta PASS — including the release-please **off** branch of the new conditional).

Once merged, ponderous-web's matching local divergences dissolve on its next `copier update` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)