### PR TITLE
fix(template): lefthook prettier hook excludes .meta/*.md vault symlinks

### DIFF
--- a/template/lefthook.yml.jinja
+++ b/template/lefthook.yml.jinja
@@ -16,13 +16,16 @@ pre-commit:
 [% if use_node %]
     prettier:
       glob: "*.{js,jsx,ts,tsx,astro,md,mdx,json,jsonc,yml,yaml,css,scss,html}"
-      # CLAUDE.md / GEMINI.md / copilot-instructions.md are symlinks to AGENTS.md;
-      # prettier errors when a symlink is passed explicitly (traversal during
-      # `--check .` skips them).
+      # CLAUDE.md / GEMINI.md / copilot-instructions.md are symlinks to AGENTS.md,
+      # and a v2-era `.meta/*.md` note may be a symlink into the Obsidian vault
+      # (obsidian_project_add moved the file and left a link); prettier errors
+      # when a symlink is passed explicitly (traversal during `--check .` skips
+      # them).
       exclude:
         - CLAUDE.md
         - GEMINI.md
         - .github/copilot-instructions.md
+        - ".meta/*.md"
       run: task lint:prettier -- {staged_files}
     eslint:
       glob: "*.{js,jsx,ts,tsx,astro,mdx}"


### PR DESCRIPTION
## Summary

One-line hardening from the evan-harmon v2→v3 re-adopt: v2's `obsidian_project_add` left `.meta/<name>.md` as a **symlink** into the Obsidian vault. v3 tracks `.meta/`, so the first commit after a re-adopt stages the symlink, lefthook's prettier hook passes it explicitly via `{staged_files}`, and prettier errors on explicitly-passed symlinks — blocking the commit. Same failure class as the existing `CLAUDE.md`/`GEMINI.md`/`copilot-instructions.md` excludes, so `.meta/*.md` joins that list (comment updated to explain why).

Any repo that ran v2's obsidian-add/bunch-add answers has these symlinks; evan-harmon carries this fix locally already and converges on its next `copier update`. No root twin: the root repo renders the general profile, which has no prettier hook.

## Verification

- `task verify` — PASS
- `task test:template:all` — all 7 profiles PASS

Skill context: documented as first-commit trap (d) in mode-adopt-existing.md (devkit #61).

🤖 Generated with [Claude Code](https://claude.com/claude-code)