### PR TITLE
feat(ci): runtime CI_RUNS_ON runner switch in generated workflows

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -89,7 +89,7 @@ include_ansible:
 
 ci_runner:
   type: str
-  help: "CI RUNNER: GitHub Actions runner for this repo's workflows"
+  help: "CI RUNNER: default GitHub Actions runner (the CI_RUNS_ON repo/org variable overrides at runtime)"
   choices:
     - ubuntu-latest
     - self-hosted
@@ -174,11 +174,13 @@ repo_url:
   default: "https://github.com/[[ github_org ]]/[[ project_slug ]]"
   when: false
 
-# Rendered inside `runs-on: [...]` in generated workflows — one place to
-# extend self-hosted labels.
-ci_runner_labels:
+# Render-time fallback for `runs-on:` in generated workflows. At runtime the
+# CI_RUNS_ON GitHub Actions variable (repo or org level, JSON: '"ubuntu-latest"'
+# or '["self-hosted","linux",...]') overrides this without a re-render — so a
+# downed self-hosted runner box is a variable flip, not a template update.
+ci_runs_on_default:
   type: str
-  default: "[% if ci_runner == 'self-hosted' %]\"self-hosted\", \"linux\"[% else %]\"ubuntu-latest\"[% endif %]"
+  default: "[% if ci_runner == 'self-hosted' %][\"self-hosted\", \"linux\"][% else %]\"ubuntu-latest\"[% endif %]"
   when: false
 
 use_node:

--- a/template/.github/workflows/[% if devcontainer %]devcontainer-build.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if devcontainer %]devcontainer-build.yml[% endif %].jinja
@@ -20,7 +20,9 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -95,7 +97,9 @@ jobs:
   devcontainer-verify:
     if: always()
     needs: [build]
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     steps:
       - name: Check job results
         run: |

--- a/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
@@ -20,7 +20,9 @@ jobs:
       ((github.event_name == 'pull_request') ||
        (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
        (github.event_name == 'workflow_run'))
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -147,7 +149,9 @@ jobs:
   project-automation-verify:
     if: always()
     needs: [sync-status]
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     steps:
       - name: Check job results
         run: |

--- a/template/.github/workflows/[% if use_node or use_python %]codeql.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_node or use_python %]codeql.yml[% endif %].jinja
@@ -20,7 +20,9 @@ jobs:
       vars.FULL_SECURITY_SCAN == 'true' &&
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     timeout-minutes: 30
     permissions:
       actions: read
@@ -56,7 +58,9 @@ jobs:
   codeql-verify:
     if: always()
     needs: [analyze]
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     steps:
       - name: Check analyze result
         run: |

--- a/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
@@ -21,7 +21,9 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     timeout-minutes: 10
     permissions:
       contents: write

--- a/template/.github/workflows/[% if use_release_please and project_management == 'github' %]close-milestone-on-release.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_release_please and project_management == 'github' %]close-milestone-on-release.yml[% endif %].jinja
@@ -13,7 +13,9 @@ permissions:
 jobs:
   close-milestone:
     name: Close matching milestone
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     timeout-minutes: 10
     steps:
       - name: Close the milestone named after the tag

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -23,7 +23,9 @@ permissions:
 
 jobs:
   lint:
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -91,7 +93,9 @@ jobs:
 [% if use_node %]
 
   build-test:
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -128,7 +132,9 @@ jobs:
 [% endif %]
 
   security:
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -173,7 +179,9 @@ jobs:
 [% if project_type == 'web-astro' %]
 
   lighthouse:
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -278,7 +286,9 @@ jobs:
   verify:
     if: always()
     needs: [lint, security[% if use_node %], build-test[% endif %][% if project_type == 'web-astro' %], lighthouse[% endif %]]
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     steps:
       - name: Check job results
         run: |

--- a/template/.github/workflows/claude-implement.yml.jinja
+++ b/template/.github/workflows/claude-implement.yml.jinja
@@ -22,7 +22,9 @@ jobs:
        contains(github.event.issue.body, '@claude implement') ||
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-implement'))
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     timeout-minutes: 180
     permissions:
       contents: write

--- a/template/.github/workflows/claude-plan.yml.jinja
+++ b/template/.github/workflows/claude-plan.yml.jinja
@@ -22,7 +22,9 @@ jobs:
        contains(github.event.issue.body, '@claude plan') ||
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-plan'))
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     timeout-minutes: 120
     permissions:
       contents: read

--- a/template/.github/workflows/claude-review.yml.jinja
+++ b/template/.github/workflows/claude-review.yml.jinja
@@ -23,7 +23,9 @@ jobs:
        contains(github.event.review.body, '@claude review') ||
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-review'))
-    runs-on: [ [[ ci_runner_labels ]] ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
     timeout-minutes: 60
     permissions:
       contents: read


### PR DESCRIPTION
Upstreams the runner-switch pattern proven in [harmonops/harmon-infra#362](https://github.com/harmonops/harmon-infra/pull/362) (created when the contraption runner host went down and every pinned job stranded).

## What changed

All 16 `runs-on:` sites in the template workflows go from render-time labels to a runtime switch:

```yaml
# before (render-time only — changing runners = re-render + commit)
runs-on: [ [[ ci_runner_labels ]] ]

# after (runtime override, rendered fallback)
runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
```

- **`CI_RUNS_ON`** is a GitHub Actions **variable** (repo or org level) holding a JSON runner spec — `'"ubuntu-latest"'` or `'["self-hosted","linux","contraption"]'`. Set/unset it to move a repo's CI between runner fleets with zero commits — exactly what you want when a self-hosted box dies.
- The `ci_runner` copier question stays and now only picks the rendered **fallback**: `'"ubuntu-latest"'` (default) or `'["self-hosted", "linux"]'`. The derived `ci_runner_labels` var is replaced by `ci_runs_on_default` (JSON-shaped).

## Verified

- `task verify` (includes the template render tests) passes.
- Both variants rendered and actionlint-clean:
  - hosted: `runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}`
  - self-hosted: `runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '["self-hosted", "linux"]') }}`
- The hosted-rendered form is byte-identical to what harmon-infra#362 shipped by hand, so the next `copier update` there reconciles cleanly for template-owned workflows.

## Downstream propagation

Copier-wired repos (harmon-infra, sommerlawn-web, sommerlawn-infra, sommerlawn-zoho, …) pick this up on their next `copier update` for **template-owned** workflows. Repo-specific workflows (e.g. harmon-infra's terraform/deploy/security/validate — already converted in #362) and unwired repos (sommerlawn-hub) need direct edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)