### PR TITLE
feat(deploy): upstream the proven deployment strategies into the template

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -95,6 +95,12 @@ ci_runner:
     - self-hosted
   default: ubuntu-latest
 
+deploy_cloudflare_workers:
+  type: bool
+  help: "DEPLOY: Deploy the site to Cloudflare Workers (static assets) from CI? (PR preview versions + release-gated production; the sommerlawn-web pattern)"
+  default: "[[ project_type == 'web-astro' ]]"
+  when: "[[ project_type in ['web-astro', 'web-app'] ]]"
+
 license:
   type: str
   help: "LICENSE: Add license?"

--- a/template/.github/workflows/[% if deploy_cloudflare_workers %]deploy-preview.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if deploy_cloudflare_workers %]deploy-preview.yml[% endif %].jinja
@@ -1,0 +1,158 @@
+name: Deploy Preview
+run-name: deploy preview for PR #${{ github.event.pull_request.number }}
+
+# Cloudflare deploys run from GitHub Actions via wrangler-action against the
+# [[ project_slug ]] Worker (static assets — wrangler.jsonc). Every same-repo
+# PR uploads a non-production Worker *version* bound to the `preview` GitHub
+# Environment: a unique versioned preview URL plus a stable branch-alias URL,
+# both on workers.dev. Versions never receive live traffic; production
+# deploys happen in release.yml when a release-please release PR merges.
+#
+# Requires the Worker to exist (first created by the bootstrap/production
+# deploy in release.yml — see that file's workflow_dispatch trigger).
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: deploy-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Fork PRs have no secrets, and until CLOUDFLARE_API_TOKEN is configured the
+  # deploy should skip rather than fail. Secrets are not readable in job-level
+  # `if:` expressions, so a tiny preflight job exposes the check as an output.
+  preflight:
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    timeout-minutes: 5
+    outputs:
+      configured: ${{ steps.check.outputs.configured }}
+    steps:
+      - name: Check Cloudflare credentials
+        id: check
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -n "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "CLOUDFLARE_API_TOKEN is not available (fork PR or secret not yet configured) — skipping preview deploy." \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  deploy:
+    needs: preflight
+    if: needs.preflight.outputs.configured == 'true'
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    environment:
+      name: preview
+      url: ${{ steps.deploy.outputs.deployment-url }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          # renovate: datasource=node-version
+          node-version: "24"
+          cache: pnpm
+      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        with:
+          # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
+          version: 3.51.1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: task build
+      # github.head_ref is attacker-influenced (branch names may contain `;`,
+      # `$`, backticks) and the wrangler-action command runs through a shell,
+      # so reduce it to a safe preview alias: lowercase [a-z0-9-], no
+      # leading/trailing dash, short enough that alias + "-[[ project_slug ]]"
+      # fits in a 63-char DNS label.
+      - name: Derive preview alias from branch name
+        id: branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          alias=$(printf '%s' "$HEAD_REF" \
+            | tr '[:upper:]' '[:lower:]' \
+            | tr -c 'a-z0-9-' '-' \
+            | tr -s '-' \
+            | sed -e 's/^-//' -e 's/-$//' \
+            | cut -c1-[[ [40, 62 - (project_slug | length)] | min ]])
+          echo "alias=$alias" >> "$GITHUB_OUTPUT"
+      - name: Upload preview version to Cloudflare Workers
+        id: deploy
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: pnpm
+          # renovate: datasource=npm depName=wrangler
+          wranglerVersion: "4.107.0"
+          command: >-
+            versions upload
+            --preview-alias=${{ steps.branch.outputs.alias }}
+            --message=pr-${{ github.event.pull_request.number }}
+      - name: Comment preview URLs on PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
+          COMMAND_OUTPUT: ${{ steps.deploy.outputs.command-output }}
+          PREVIEW_ALIAS: ${{ steps.branch.outputs.alias }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const deployUrl = process.env.DEPLOY_URL
+            // wrangler-action only surfaces the versioned preview URL as an
+            // output; fish the stable branch-alias URL out of wrangler's
+            // stdout.
+            const alias = process.env.PREVIEW_ALIAS
+            const aliasUrl = (process.env.COMMAND_OUTPUT || '')
+              .match(/https:\/\/[a-z0-9.-]+\.workers\.dev/g)
+              ?.find(u => u.includes(`//${alias}-`)) ?? null
+            const body = [
+              '## Cloudflare Workers Preview',
+              '',
+              '| | URL |',
+              '|---|---|',
+              `| **Preview (this version)** | ${deployUrl} |`,
+              aliasUrl ? `| **Branch alias** | ${aliasUrl} |` : null,
+              '',
+              `_Deployed commit: ${process.env.HEAD_SHA}_`,
+            ].filter(l => l !== null).join('\n')
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.startsWith('## Cloudflare Workers Preview')
+            )
+            if (existing) {
+              await github.rest.issues.updateComment({
+                comment_id: existing.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              })
+            }

--- a/template/.github/workflows/[% if include_terraform %]terraform.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if include_terraform %]terraform.yml[% endif %].jinja
@@ -1,0 +1,123 @@
+name: Terraform
+# GitOps deploy-on-merge (harmonops/harmon-infra ADR-0006, the shared infra
+# standard): PRs produce a plan (the review gate), pushes to main apply, and a
+# post-apply re-plan asserts the state converged.
+#
+# The plan/apply job is dormant until remote state exists: configure an
+# S3-compatible backend with native locking (use_lockfile, Terraform >= 1.10 —
+# Cloudflare R2 supports it), add the R2_* backend credentials and provider
+# TF_VAR_* secrets, then set the TERRAFORM_CI_ENABLED repo variable to 'true'.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "terraform/**"
+      - ".github/workflows/terraform.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "terraform/**"
+      - ".github/workflows/terraform.yml"
+  workflow_dispatch:
+
+# Never cancel an in-flight apply on main — a killed apply can strand
+# half-created resources; PR runs are plan-only and safe to cancel.
+concurrency:
+  group: terraform-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  terraform-validate:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+      - name: terraform fmt
+        run: terraform fmt -check -recursive terraform/
+      - name: terraform validate
+        run: |
+          terraform -chdir=terraform init -backend=false -input=false
+          terraform -chdir=terraform validate -no-color
+
+  terraform-plan-apply:
+    # Dormant until TERRAFORM_CI_ENABLED=true (repo variable) — needs remote
+    # state + credentials, see the header comment.
+    if: >-
+      vars.TERRAFORM_CI_ENABLED == 'true' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    timeout-minutes: 15
+    env:
+      # The S3-compatible backend (Cloudflare R2) reads AWS-style env vars.
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      TF_IN_AUTOMATION: "true"
+      # Add provider credentials as TF_VAR_* secrets here, e.g.:
+      # TF_VAR_cloudflare_api_token: ${{ secrets.TF_VAR_CLOUDFLARE_API_TOKEN }}
+      # TF_VAR_cloudflare_account_id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+      - name: terraform plan
+        run: |
+          terraform -chdir=terraform init -input=false
+          terraform -chdir=terraform plan -no-color -input=false -lock=false \
+            | tee /tmp/tfplan.txt
+      - name: Plan summary
+        if: always()
+        run: |
+          {
+            echo "## Terraform plan"
+            echo '```'
+            tail -n 100 /tmp/tfplan.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      # Deploy-on-merge: merging the reviewed plan is the approval. Applies
+      # take the state lock (no -lock=false here). workflow_dispatch on main
+      # re-applies — useful to reconcile drift without an empty commit.
+      - name: terraform apply
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: terraform -chdir=terraform apply -auto-approve -input=false -no-color
+      # Post-apply smoke: a clean re-plan proves the applied state converged
+      # (exit 2 = unexpected residual diff, exit 1 = plan error).
+      - name: converge check (post-apply re-plan)
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: |
+          terraform -chdir=terraform plan -detailed-exitcode -no-color -input=false -lock=false \
+            > /tmp/tfconverge.txt 2>&1 || {
+              echo "Post-apply plan is not clean — state did not converge:"
+              tail -n 60 /tmp/tfconverge.txt
+              exit 1
+            }
+          echo "Converged: post-apply plan reports no changes."
+
+  terraform-verify:
+    if: always()
+    needs: [terraform-validate, terraform-plan-apply]
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    steps:
+      - name: Check job results
+        # POSIX single-bracket tests on purpose: bash's double-bracket test
+        # syntax collides with this template's jinja delimiters.
+        run: |
+          fail=0
+          check() {
+            [ "$2" = "success" ] || [ "$2" = "skipped" ] || { echo "Job $1 result: $2"; fail=1; }
+          }
+          check terraform-validate "${{ needs.terraform-validate.result }}"
+          check terraform-plan-apply "${{ needs.terraform-plan-apply.result }}"
+          if [ "$fail" -ne 0 ]; then
+            echo "One or more required jobs failed."
+            exit 1
+          fi
+          echo "All required jobs passed."

--- a/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
@@ -1,16 +1,40 @@
 name: Release Please
+[% if deploy_cloudflare_workers %]
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch'
+    && format('manual production deploy of {0}', github.ref_name)
+    || 'release-please maintaining the release PR' }}
+[% else %]
 run-name: release-please maintaining the release PR
+[% endif %]
 
 # Releases stay intentional: release-please maintains a rolling release PR from
 # conventional commits (feat -> minor, fix -> patch; pre-1.0 feat bumps minor;
 # chore/docs/ci produce no release). Merging that PR — a deliberate act — is
 # what creates the tag, GitHub release, and CHANGELOG entry. Nothing is bumped
 # automatically on a normal merge to main.
+[% if deploy_cloudflare_workers %]
+#
+# Production deploys are release-first: when release-please cuts a release,
+# the deploy-production job builds the tagged commit and runs `wrangler
+# deploy` against the [[ project_slug ]] Worker (static assets —
+# wrangler.jsonc). Gating on the step output — instead of chaining
+# `on: release` / `on: deployment_status` — avoids the GitHub limitation that
+# events created by GITHUB_TOKEN never trigger workflows.
+#
+# workflow_dispatch deploys the selected ref directly (release-please is
+# skipped). Two uses: the one-time bootstrap deploy that creates the Worker
+# before any release exists, and rollback — dispatch the workflow from the
+# previous release tag to redeploy it.
+[% endif %]
 
 on:
   push:
     branches:
       - main
+[% if deploy_cloudflare_workers %]
+  workflow_dispatch:
+[% endif %]
 
 concurrency:
   group: release-please
@@ -21,6 +45,9 @@ permissions:
 
 jobs:
   release-please:
+[% if deploy_cloudflare_workers %]
+    if: github.event_name == 'push'
+[% endif %]
     # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
     # default; set it to a JSON runner spec to override without a commit.
     runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
@@ -28,6 +55,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+[% if deploy_cloudflare_workers %]
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+[% endif %]
     steps:
       # CI GitHub App token, not GITHUB_TOKEN: PRs opened by GITHUB_TOKEN never
       # trigger CI, and branch protection requires those checks to pass before
@@ -44,5 +76,66 @@ jobs:
           permission-pull-requests: write
           permission-issues: write
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
+[% if deploy_cloudflare_workers %]
+
+  deploy-production:
+    needs: release-please
+    # Runs when release-please created a release, or on manual dispatch
+    # (bootstrap/rollback) where release-please is skipped — hence
+    # !cancelled() so the skipped `needs` doesn't auto-skip this job.
+    if: >-
+      !cancelled() && (
+        github.event_name == 'workflow_dispatch' ||
+        needs.release-please.outputs.release_created == 'true'
+      )
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    environment:
+      name: production
+      # TODO: add `url: https://<your-domain>` once the custom domain exists.
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Tag from release-please on release runs; the dispatched ref on
+          # manual runs.
+          ref: ${{ needs.release-please.outputs.tag_name || github.ref }}
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          # renovate: datasource=node-version
+          node-version: "24"
+          cache: pnpm
+      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        with:
+          # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
+          version: 3.51.1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: task build
+      - name: Deploy to Cloudflare Workers (production)
+        id: deploy
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: pnpm
+          # renovate: datasource=npm depName=wrangler
+          wranglerVersion: "4.107.0"
+          command: deploy
+      - name: Summarize deployment
+        env:
+          DEPLOYED_REF: ${{ needs.release-please.outputs.tag_name || github.ref_name }}
+        run: |
+          {
+            echo "## Production deployment"
+            echo ""
+            echo "- Ref: \`$DEPLOYED_REF\` (${{ github.event_name }})"
+          } >> "$GITHUB_STEP_SUMMARY"
+[% endif %]

--- a/template/[% if deploy_cloudflare_workers %]wrangler.jsonc[% endif %].jinja
+++ b/template/[% if deploy_cloudflare_workers %]wrangler.jsonc[% endif %].jinja
@@ -1,0 +1,23 @@
+// Cloudflare Workers (static assets) configuration. The worker is assets-only
+// (no script): it serves the build output from dist/, including any _headers
+// and _redirects files copied from public/.
+//
+// Deploys run from GitHub Actions (deploy-preview.yml uploads preview
+// versions, release.yml runs `wrangler deploy` on releases). Manage custom
+// domains outside this file (Terraform cloudflare_workers_custom_domain, or
+// the dashboard) so wrangler owns only the Worker itself.
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "[[ project_slug ]]",
+  // Bump deliberately when adopting new runtime behavior.
+  "compatibility_date": "2026-07-01",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "404-page"
+  },
+  // No workers.dev production URL (the site lives on its custom domain), but
+  // keep per-version preview URLs for PR deploys — workers_dev: false would
+  // otherwise disable them by default.
+  "workers_dev": false,
+  "preview_urls": true
+}

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -155,6 +155,18 @@ config, toolchain, devcontainer, and dev environment — against the items below
 [% endif %]
 
 ## 4. Secrets & environment
+[% if deploy_cloudflare_workers %]
+
+- [ ] Cloudflare Workers deploys: create an **Account API Token** scoped to
+      **Account → Workers Scripts → Edit** only (1-year TTL + renewal
+      reminder) and add it: `gh secret set CLOUDFLARE_API_TOKEN`. The
+      `CLOUDFLARE_ACCOUNT_ID` org-level Actions variable is shared org-wide —
+      set it once per org if missing.
+- [ ] Create the `preview` and `production` GitHub Environments (production:
+      restrict to protected branches). Then bootstrap the Worker: Actions →
+      *Release Please* → *Run workflow* (main) — the first `wrangler deploy`
+      creates it; PR preview uploads work from that point.
+[% endif %]
 
 - [ ] For local `.env` needs, use **1Password Environments** (mounts a virtual
       `.env`; secrets never hit disk or git) or `op run`/`op inject`. Commit only

--- a/template/docs/guides/deploying.md.jinja
+++ b/template/docs/guides/deploying.md.jinja
@@ -4,7 +4,33 @@ How to deploy [[ project_name ]]. For the shape of the CI/CD pipeline see
 [../architecture/ci-cd.md](../architecture/ci-cd.md); for production operational
 procedures and rollback runbooks see [../runbooks/](../runbooks/).
 
+[% if deploy_cloudflare_workers %]
+The site is served by the `[[ project_slug ]]` **Cloudflare Worker** (static
+assets, configured in [`wrangler.jsonc`](../../wrangler.jsonc)). All deploys
+run from GitHub Actions via `cloudflare/wrangler-action`. Custom domains are
+managed outside wrangler (Terraform `cloudflare_workers_custom_domain`, or the
+dashboard).
+
+- **Preview**: every same-repo PR uploads a non-production Worker *version*
+  (`deploy-preview.yml`) — versioned + branch-alias URLs on workers.dev,
+  posted as a sticky PR comment. Preview versions never receive production
+  traffic. Skips gracefully when `CLOUDFLARE_API_TOKEN` is unavailable.
+- **Production**: merging the release-please release PR makes `release.yml`
+  build the tagged commit and run `wrangler deploy`. Normal merges to `main`
+  do **not** deploy production.
+- **Bootstrap / rollback**: Actions → *Release Please* → *Run workflow* with a
+  branch or tag deploys that ref directly — used once to create the Worker,
+  and to redeploy the previous release tag.
+
+Credentials: `CLOUDFLARE_ACCOUNT_ID` is an org-level Actions **variable** (an
+identifier, not a secret); `CLOUDFLARE_API_TOKEN` is a repo **secret** — an
+Account API Token scoped to **Account → Workers Scripts → Edit** only, 1-year
+TTL with a renewal reminder (rotate via the token's Roll button + re-run
+`gh secret set CLOUDFLARE_API_TOKEN`). Also create `preview` and `production`
+GitHub Environments (see the post-generation CHECKLIST).
+[% else %]
 > TODO: no deployment is configured yet — fill in the sections below.
+[% endif %]
 
 ## Environments
 

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -22,7 +22,8 @@
       "description": "Workflow tool pins, `version:` style",
       "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+version:\\s*(?<currentValue>\\S+)"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+version:\\s*(?<currentValue>\\S+)",
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+wranglerVersion:\\s*\"(?<currentValue>[^\"]+)\""
       ]
     },
     {


### PR DESCRIPTION
Upstreams both deployment patterns settled and battle-tested this week, so downstream repos get them on generation / `copier update`.

## iac repos — Terraform GitOps CD (`include_terraform`)

New `terraform.yml` template implementing [harmon-infra ADR-0006](https://github.com/harmonops/harmon-infra/blob/main/docs/decisions/0006-terraform-deploy-on-merge.md):

- `terraform-validate` always (fmt + validate, no credentials)
- `terraform-plan-apply` gated behind `TERRAFORM_CI_ENABLED`: plan on PR (posted to the step summary — the review gate), `apply -auto-approve` on push/dispatch to main, **post-apply converge check** (`plan -detailed-exitcode` must be clean)
- concurrency never cancels an in-flight apply on main; PR runs cancel freely
- `terraform-verify` aggregate for branch protection
- R2/S3 backend credentials via `R2_*` secrets; provider `TF_VAR_*`s left as commented examples

Note for reviewers: the verify step deliberately uses POSIX `[ ]` tests — bash's double-bracket syntax collides with this template's jinja delimiters (found the fun way).

## web-astro repos — Cloudflare Workers deploys (new `deploy_cloudflare_workers` question)

Defaults **true for web-astro**, asked for web-app, false otherwise. Emits the [sommerlawn-web](https://github.com/sommerlawn/sommerlawn-web) pattern:

- `wrangler.jsonc` — assets-only Worker named after the project slug; preview URLs on, workers.dev production URL off; custom domains managed outside wrangler
- `deploy-preview.yml` — per-PR `wrangler versions upload --preview-alias=<branch>` with preflight skip (fork PRs / pre-setup), branch-name sanitization (rendered `cut` length computed from the slug so alias + name fits the 63-char DNS label), sticky PR comment with versioned + alias URLs
- `release.yml` gains a release-first `deploy-production` job (`release_created`-gated `wrangler deploy`) plus `workflow_dispatch` for the one-time Worker bootstrap and tag rollbacks
- renovate manages the pinned `wranglerVersion`; the deploying guide and post-gen CHECKLIST document the credential model (Account API Token scoped to Workers Scripts Edit only, org-level `CLOUDFLARE_ACCOUNT_ID` **variable**, `preview`/`production` Environments, bootstrap step)

Everything uses the `CI_RUNS_ON` runtime runner switch from #227.

## Verified

- `task verify` (includes template render tests) green
- Manual renders across **web-astro** (full deploy pack emitted), **iac** (terraform.yml emitted, no wrangler), **general** (neither) — all actionlint-clean (only pre-existing SC2016 info notices in untouched claude-*/project-automation templates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)