### PR TITLE
feat(agents): hard rule — no unprompted password-manager writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,19 @@ runners — and can also be applied to existing repos to standardize them. This 
 an application; it is a template repository used via the
 [Copier](https://copier.readthedocs.io/en/stable/) templating tool.
 
+## Hard Rules
+
+Non-negotiable, regardless of any autonomy granted elsewhere in this file:
+
+- **Never write to a password manager or credential store unprompted.** Do not
+  create, modify, archive, or delete anything in 1Password (items, fields,
+  vaults — via the `op` CLI or any other means), OS keychains, or any other
+  secret store unless the user explicitly requested that specific write in the
+  current conversation. Even when asked, restate exactly what will be written
+  and get confirmation before executing — announcing intent and proceeding in
+  the same turn is not consent. Read operations (`op read`, `op item list`,
+  `op inject` over existing references) are fine.
+
 ## harmon-platform
 
 One of five repos in **harmon-platform** (Evan's developer & DevOps platform + homelab):

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -16,6 +16,19 @@ Repo: [[ repo_url ]] — see [docs/README.md](docs/README.md) for the
 documentation map, [docs/architecture/README.md](docs/architecture/README.md)
 for the architecture, and [DESIGN.md](DESIGN.md) for design/UX intent.
 
+## Hard Rules
+
+Non-negotiable, regardless of any autonomy granted elsewhere in this file:
+
+- **Never write to a password manager or credential store unprompted.** Do not
+  create, modify, archive, or delete anything in 1Password (items, fields,
+  vaults — via the `op` CLI or any other means), OS keychains, or any other
+  secret store unless the user explicitly requested that specific write in the
+  current conversation. Even when asked, restate exactly what will be written
+  and get confirmation before executing — announcing intent and proceeding in
+  the same turn is not consent. Read operations (`op read`, `op item list`,
+  `op inject` over existing references) are fine.
+
 ## Commands
 
 All commands go through the Taskfile (single source of truth — CI, git hooks,


### PR DESCRIPTION
Adds a **Hard Rules** section to the template `AGENTS.md.jinja` (top of the file, before Commands, so it reads constitution-first) and to this repo's own `AGENTS.md`:

> **Never write to a password manager or credential store unprompted.** Do not create, modify, archive, or delete anything in 1Password (items, fields, vaults — via the `op` CLI or any other means), OS keychains, or any other secret store unless the user explicitly requested that specific write in the current conversation. Even when asked, restate exactly what will be written and get confirmation before executing — announcing intent and proceeding in the same turn is not consent. Read operations are fine.

Prompted by a real incident today: an agent created two skeleton items in a 1Password vault while fixing sommerlawn-infra's `.envrc.tpl` references — useful intent, wrong authority model. The password manager is the root of trust; writes to it are never the agent's call, and "proceeding unless you object" in the same message gives no chance to object.

Propagates to downstream repos on their next `copier update`. Live repos can also be patched directly without waiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)