### PR TITLE
docs(secrets): local-secrets guide + fix self-breaking envrc template

### DIFF
--- a/template/[% if use_python %].envrc.tpl[% endif %]
+++ b/template/[% if use_python %].envrc.tpl[% endif %]
@@ -1,15 +1,21 @@
-# op inject source — resolve the op:// references below into the gitignored
-# .envrc.local (which .envrc sources), so secrets never touch git:
+# op inject source — resolves the 1Password secret references in this file into
+# the gitignored .envrc.local (which .envrc sources), so secrets never touch git:
 #
 #   op inject -i .envrc.tpl -o .envrc.local
 #
-# op:// references are pointers, not secrets, so THIS file is safe to commit; the
+# References are pointers, not secrets, so THIS file is safe to commit; the
 # resolved .envrc.local is gitignored — never commit it. Re-run the command above
-# whenever you change a reference. Setup steps are in docs/CHECKLIST.md.
+# whenever a reference or the underlying item changes. Setup steps are in
+# docs/CHECKLIST.md; mechanism + footguns in docs/guides/local-secrets.md.
 #
-# Examples (uncomment and point each at your own 1Password item):
+# NOTE: op inject parses secret references EVERYWHERE in this file, including
+# comments — a literal reference (or even the scheme prefix in prose) breaks
+# injection outright. The examples below escape the scheme with a backslash for
+# exactly that reason: when uncommenting, remove the backslash.
 #
-# export CLOUDFLARE_API_TOKEN="op://Vault/item/CLOUDFLARE_API_TOKEN"
-# export AWS_ACCESS_KEY_ID="op://Vault/item/Access Key ID"
-# export AWS_SECRET_ACCESS_KEY="op://Vault/item/Secret Access Key"
-# export TF_VAR_example="op://Vault/item/example"
+# Examples (uncomment, remove the backslash, point at your own 1Password item):
+#
+# export CLOUDFLARE_API_TOKEN="op\://Vault/item/CLOUDFLARE_API_TOKEN"
+# export AWS_ACCESS_KEY_ID="op\://Vault/item/Access Key ID"
+# export AWS_SECRET_ACCESS_KEY="op\://Vault/item/Secret Access Key"
+# export TF_VAR_example="op\://Vault/item/example"

--- a/template/docs/guides/README.md.jinja
+++ b/template/docs/guides/README.md.jinja
@@ -10,6 +10,12 @@ Calm, repeatable how-tos read *in advance* (the crisis counterpart is
 - [troubleshooting.md](troubleshooting.md) — symptom → cause → fix for **dev**
   problems (broken build, failing local setup). Distinct from runbooks, which
   cover prod incidents.
+[% if use_python %]
+- [local-secrets.md](local-secrets.md) — how credentials reach a local shell:
+  1Password references in `.envrc.tpl`, `op inject` into the gitignored
+  `.envrc.local`, direnv sourcing, the uv/venv non-relationship, footguns,
+  and repair.
+[% endif %]
 [% if devcontainer %]
 - [devcontainers.md](devcontainers.md) — the dual-profile devcontainer (bot vs
   dev), local secrets via **1Password Environments**, GHCR prebuilds, and

--- a/template/docs/guides/[% if use_python %]local-secrets.md[% endif %].jinja
+++ b/template/docs/guides/[% if use_python %]local-secrets.md[% endif %].jinja
@@ -1,0 +1,86 @@
+# Local secrets (1Password + direnv)
+
+How credentials reach your shell when working in this repo locally. CI is a
+separate system (GitHub Actions secrets/variables) and is unaffected by
+everything on this page. For *which* credentials exist, see
+[../architecture/security.md](../architecture/security.md); this page covers
+the *mechanism*.
+
+## The flow
+
+```text
+.envrc.tpl ── committed; 1Password secret references (pointers, not secrets)
+    │
+    │  op inject -i .envrc.tpl -o .envrc.local     (run manually, re-run after
+    ▼                                               rotations/reference changes)
+.envrc.local ── gitignored; the resolved plaintext exports
+    ▲
+    │  sourced, if present, by…
+.envrc ── committed and secret-free; executed by direnv on `cd` (after
+          `direnv allow`)
+```
+
+Three files, three different trust levels:
+
+- **`.envrc`** (committed) — deliberately inert. It only (1) activates the
+  Python venv and (2) sources `.envrc.local` if it exists. Because it holds no
+  secrets it can live in git, so the stable logic is shared instead of
+  regenerated per machine.
+- **`.envrc.tpl`** (committed) — the inject *source*: secret references like
+  `op://<vault>/<item>/<field>` plus any non-secret exports (identifiers such
+  as account IDs can be literals). References are safe to commit — they're
+  pointers into 1Password, not values.
+- **`.envrc.local`** (gitignored, per-machine) — the generated output with
+  real values. Treat it as a disposable cache of 1Password: never commit it,
+  never edit it by hand, regenerate at will.
+
+## Where uv and the venv fit (they don't, really)
+
+`.envrc` also runs `source .venv/bin/activate` — the uv-managed virtualenv
+(`uv sync` / `task install`) holding this repo's Python tooling. It shares the
+direnv hook with the secrets flow but is otherwise unrelated: no venv, no
+problem for secrets, and vice versa.
+
+## First-time setup on a machine
+
+```bash
+op inject -i .envrc.tpl -o .envrc.local   # 1Password auth prompt on first use
+direnv allow                              # trust .envrc once
+```
+
+`cd` out and back in (or `direnv reload`) and the vars are live.
+
+## After rotating a secret
+
+`.envrc.local` goes **stale silently** — nothing warns you that 1Password has
+a newer value. After any rotation: re-run the `op inject` command, then
+`direnv reload`.
+
+## Footguns
+
+- **`op inject` parses secret references everywhere in the file — including
+  comments.** A literal reference (or even the scheme prefix followed by
+  text) in a comment makes injection fail outright. Keep prose in
+  `.envrc.tpl` free of literal reference syntax.
+- **References break when 1Password items move.** Renaming an item, changing
+  a field label, or reorganizing vaults silently orphans the pointer;
+  injection then fails with "item deleted or archived" or "isn't an item".
+  When reorganizing vaults, grep your repos for the old vault/item names.
+- **`.envrc.local` is plaintext on disk.** Gitignored is not encrypted. If
+  that bothers you, skip the file entirely and run commands on demand with
+  zero standing secrets:
+
+  ```bash
+  op run --env-file=.envrc.tpl -- <command>
+  ```
+
+## When `op inject` fails (repair)
+
+1. Read the error — it names the reference it choked on.
+2. `op item list --vault <vault>` (or `op item list | grep -i <name>`) to find
+   where the item actually lives now.
+3. Fix the reference in `.envrc.tpl`, commit that (it's pointer-only), re-run
+   `op inject`, `direnv reload`.
+4. If the item is truly gone (deleted items are unrecoverable via `op`),
+   recreate the credential at its source and store the new value in a fresh
+   1Password item.


### PR DESCRIPTION
Companion to sommerlawn/sommerlawn-infra#28 (which now carries the repo-specific version of this guide). Two parts:

## 1. New guide: `docs/guides/local-secrets.md` (rendered for `use_python` repos, same gate as the envrc files)

Documents the full local-credentials mechanism that previously lived nowhere: the three envrc files and their trust levels (`.envrc` committed+inert, `.envrc.tpl` committed pointers, `.envrc.local` gitignored plaintext cache), the `op inject` flow, how direnv drives it, the **uv/venv non-relationship** (same hook, unrelated concern), silent staleness after rotation, footguns, the repair procedure when references break, and the `op run --env-file` zero-standing-secrets alternative. Indexed in the guides README.

## 2. Bug fix: the shipped `.envrc.tpl` broke `op inject` out of the box

`op inject` parses secret references **everywhere in the file, comments included**. The template's tpl contained both the scheme prefix in prose and valid-shaped `op://Vault/item/...` example references in comments — so a freshly generated repo's very first `op inject` failed before reaching any real reference. (This exact failure bit sommerlawn-infra today, inherited from here.) Fixed: prose reworded, examples backslash-escaped (`op\://…`) with an uncomment-and-remove-the-backslash instruction, and an explicit warning comment so the footgun stays documented at the point of use.

Verified: `op inject` now succeeds against both the raw template file and a rendered iac output; `task verify` (incl. render tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)