### PR TITLE
docs(secrets): 1password conventions, remote-access standards, canonical envrc examples

### DIFF
--- a/template/[% if use_python %].envrc.tpl[% endif %]
+++ b/template/[% if use_python %].envrc.tpl[% endif %]
@@ -13,9 +13,11 @@
 # injection outright. The examples below escape the scheme with a backslash for
 # exactly that reason: when uncommenting, remove the backslash.
 #
-# Examples (uncomment, remove the backslash, point at your own 1Password item):
+# Examples (uncomment, remove the backslash, point at your org-vault item —
+# naming + canonical field labels per docs/architecture/security.md):
 #
-# export CLOUDFLARE_API_TOKEN="op\://Vault/item/CLOUDFLARE_API_TOKEN"
-# export AWS_ACCESS_KEY_ID="op\://Vault/item/Access Key ID"
-# export AWS_SECRET_ACCESS_KEY="op\://Vault/item/Secret Access Key"
-# export TF_VAR_example="op\://Vault/item/example"
+# export CLOUDFLARE_API_TOKEN="op\://<org-vault>/Cloudflare <repo>-terraform/API Token"
+# export CLOUDFLARE_ACCOUNT_ID="op\://<org-vault>/Cloudflare <org>/Account ID"
+# export AWS_ACCESS_KEY_ID="op\://<org-vault>/Cloudflare R2 <repo>-tfstate-rw/Access Key ID"
+# export AWS_SECRET_ACCESS_KEY="op\://<org-vault>/Cloudflare R2 <repo>-tfstate-rw/Secret Access Key"
+# export AWS_ENDPOINT_URL_S3="op\://<org-vault>/Cloudflare R2 <repo>-tfstate-rw/Default Endpoint"

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -236,8 +236,31 @@ TODO: enumerate the tokens/secrets this repo depends on and where each lives:
   1Password-provisioned secrets (and Ansible Vault where appropriate).
 [% endif %]
 [% endif %]
-[% if include_terraform %]
 
+### 1Password conventions (source of truth)
+
+1Password is the source of truth for every credential, consistent across orgs,
+provider accounts, and machines. The standard:
+
+- **One vault per org** (this repo: the `[[ github_org ]]` vault). No
+  credentials in personal/shared vaults.
+- **API credentials use the 1Password "API Credential" type**, named
+  `<Provider> <scope-descriptor>` — e.g. `Cloudflare [[ project_slug ]]-terraform`,
+  `Cloudflare R2 [[ project_slug ]]-tfstate-rw`. One item per credential;
+  related fields live on the item rather than as separate items.
+- **Canonical field labels** (references must match exactly): `API Token`,
+  `Access Key ID`, `Secret Access Key`, `Default Endpoint`, `Account ID`,
+  `App ID`, `Client ID`, `Client Secret`.
+- **Account-level identifiers** get a per-account item (e.g. `Cloudflare
+  <org>` holding `Account ID`) so identifiers have one home too.
+- **SSH keys use the 1Password SSH key type** (fields: `public key`,
+  `fingerprint`, `private key`, `passphrase`).
+- Repos consume credentials only through references[% if use_python %]
+  (`.envrc.tpl` → `op inject`, see
+  [../guides/local-secrets.md](../guides/local-secrets.md))[% endif %] or CI
+  secrets fed from these items (`op read "…" | gh secret set …`) — never by
+  copying values into other stores of record.
+[% if include_terraform %]
 ### Cloudflare credentials (creation click-paths)
 
 The two credential kinds are created in **different places** in the Cloudflare
@@ -270,6 +293,20 @@ dashboard — R2 tokens are not regular API tokens:
 The Cloudflare account ID is an identifier, not a secret — keep it as an
 org-level Actions **variable** (`CLOUDFLARE_ACCOUNT_ID`) shared by all repos.
 [% endif %]
+
+## Remote access (SSH, Tailscale, VNC)
+
+- **Tailscale is the standard network layer** for remote access — homelab
+  hosts and remote sites join the tailnet rather than exposing ports. Its
+  OAuth client lives in the org vault (fields: `Client ID`, `Client Secret`,
+  `tailnet ID`); scope OAuth clients narrowly (e.g. auth-key creation only)
+  and prefer ephemeral/pre-authorized keys minted from them.
+- **SSH** keys are stored as 1Password SSH-key items (see conventions above)
+  and served by the 1Password SSH agent where possible, so private keys never
+  sit loose on disk.
+- **VNC / screen sharing: Screens 5 is the standard client**, connecting over
+  the tailnet (never an exposed VNC port); any credential it needs lives on
+  the relevant 1Password item.
 
 ## Rotation & incident notes
 


### PR DESCRIPTION
Upstreams the org-wide secrets/credentials standard settled in sommerlawn (companion: sommerlawn/sommerlawn-infra#36, sommerlawn/sommerlawn-web#404). Two commits (originally aimed at #232/#233 which merged first — cherry-picked onto main; the orphaned recreated branches were deleted):

## `security.md` template — two new sections

**1Password conventions (source of truth)** — consistent across orgs (sommerlawn, harmonops, evanharmon, ponderousdev, …), provider accounts, and machines:
- one vault per org; API credentials as 1Password **API Credential** items named `<Provider> <scope-descriptor>`
- canonical field labels references must match exactly: `API Token`, `Access Key ID`, `Secret Access Key`, `Default Endpoint`, `Account ID`, `App ID`, `Client ID`, `Client Secret`
- per-account identifier items (e.g. `Cloudflare <org>` holding `Account ID`)
- SSH keys as 1Password **SSH key** items (`public key` / `fingerprint` / `private key` / `passphrase`)
- consumption only via references (`op inject`) or `op read … | gh secret set …` — never value-copying into other stores of record

**Remote access (SSH, Tailscale, VNC)** — Tailscale as the standard network layer (homelab + remote sites; OAuth client fields in the org vault, narrow scopes, ephemeral keys); SSH served by the 1Password agent; **Screens 5** as the standard VNC client, always over the tailnet.

## `.envrc.tpl` template

Example references now demonstrate the org-vault + canonical-field convention (still backslash-escaped so `op inject` never parses them; re-verified injectable).

`task verify` (incl. render tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)