### PR TITLE
docs(conventions): adopt `-site` repo suffix, retire `-web`

### DIFF
--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -8,7 +8,7 @@ should this repo have, and where does it come from?"**
 Ground-truth sources (read these, don't trust memory): `harmon-init/copier.yml`,
 `harmon-init/AGENTS.md`, the `harmon-init/template/` tree. Live reference repos
 that have been generated from the template: `harmonops/harmon-infra` (an `iac`
-project) and `sommerlawn/sommerlawn-web` (a `web-astro` project). The platform
+project) and `sommerlawn/sommerlawn-site` (a `web-astro` project). The platform
 and client repos are kept current via mode-update passes (all six were at
 v3.15.2 as of 2026-07-03), so their remaining divergences are **deliberate
 customizations** (Part 3.2), not lag — but they can drift between passes, so
@@ -62,7 +62,7 @@ Repo-root siblings of `docs/` (deliberately NOT under `docs/`):
 - **`.gitkeep`** keeps otherwise-empty dirs in git (`tests/.gitkeep`,
   `.claude/skills/.gitkeep`, and ansible `roles|playbooks|inventory/.gitkeep`
   for iac). Across the live repos, `docs/` subdirs are also kept with `.gitkeep`
-  (harmon-infra: `architecture/decisions/specs`; sommerlawn-web:
+  (harmon-infra: `architecture/decisions/specs`; sommerlawn-site:
   `decisions/runbooks/specs`).
 - **Filling content is [manual]:** most generated docs carry literal `TODO:`
   markers (e.g. `security.md`, `design-language.md`, `DESIGN.md`); the operator
@@ -538,6 +538,15 @@ Driven by the `project_type` copier answer: `general` / `web-astro` / `web-app` 
 `include_ansible`). `include_terraform` / `include_ansible` default to true for
 `iac`.
 
+**Repo naming (`<base>-<suffix>`).** Name a repo by what it contains:
+`-site` (websites / marketing / static sites — typically `web-astro`), `-app`
+(web/product applications — `web-app`), `-infra` (IaC — `iac`), `-docs`
+(documentation sites — `docs`), `-mobile` (mobile apps), `-hub`
+(umbrella / landing repos). Use **`-site`, never the older `-web`**: "web" is
+overloaded (every app is on the web) and collides with the natural name for a
+web client, whereas `-site` lines up cleanly with the other suffixes. So
+`sommerlawn-site` / `ponderous-site`, not `*-web`.
+
 **Important:** harmon-init is a **conventions-only** template — for web/app types
 it scaffolds the tooling/config but **not the framework itself**. Installing the
 actual framework + stack is a [manual] CHECKLIST step.
@@ -653,8 +662,8 @@ picks from this palette:
 - **Astro** (web-astro), **TanStack Start / vite + react** (web-app),
   **TypeScript**, **Vite**, **pnpm**, **Tailwind v4**, **zod**, **vitest**,
   **lucide** (icons), **shadcn/ui** (web-app components), **alpine** (some Astro
-  marketing sites — e.g. sommerlawn-web uses `@astrojs/alpinejs` + `alpinejs`).
-- A real web repo's `package.json` (sommerlawn-web) legitimately carries many
+  marketing sites — e.g. sommerlawn-site uses `@astrojs/alpinejs` + `alpinejs`).
+- A real web repo's `package.json` (sommerlawn-site) legitimately carries many
   extra deps (markdoc, mermaid, photoswipe, remark/rehype plugins, sitemap,
   astro-seo) and a large `pnpm.overrides` security-pin block + `auditConfig
   .ignoreCves`. **Do not flag** project-specific dependencies, overrides, or
@@ -686,7 +695,7 @@ them:
   lint+security+build-test into `build.yml`. NB: **harmon-infra retains** its
   split workflows, extra `deploy.yaml`/`mirror-devcontainer-base.yaml`, and
   self-hosted `contraption` runners as an **accepted permanent customization** —
-  treat that as 3.2-class, not lag. (sommerlawn-web's old `-max` claude-workflow
+  treat that as 3.2-class, not lag. (sommerlawn-site's old `-max` claude-workflow
   variants are gone; its extra `links-online.yml` is a legit addition.)
 - **Older copier answer keys:** a pre-v3 `.copier-answers.yml` references
   now-renamed/removed questions (`github_collaboration_templates`,

--- a/copier.yml
+++ b/copier.yml
@@ -97,7 +97,7 @@ ci_runner:
 
 deploy_cloudflare_workers:
   type: bool
-  help: "DEPLOY: Deploy the site to Cloudflare Workers (static assets) from CI? (PR preview versions + release-gated production; the sommerlawn-web pattern)"
+  help: "DEPLOY: Deploy the site to Cloudflare Workers (static assets) from CI? (PR preview versions + release-gated production; the sommerlawn-site pattern)"
   default: "[[ project_type == 'web-astro' ]]"
   when: "[[ project_type in ['web-astro', 'web-app'] ]]"
 

--- a/docs/sourceRepoFollowUps.md
+++ b/docs/sourceRepoFollowUps.md
@@ -1,4 +1,4 @@
-# Follow-ups for harmon-infra and sommerlawn-web
+# Follow-ups for harmon-infra and sommerlawn-site
 
 Issues noticed while porting conventions into harmon-init v3. The plan is to
 fix these by applying the updated template to each repo (harmon-init is the
@@ -47,13 +47,13 @@ source of truth going forward), not by hand-editing them ad hoc.
 6. **validate.yml reinstalls lint tools inline every run** — candidates for
     the prebuilt devcontainer image or a composite action.
 
-## sommerlawn-web
+## sommerlawn-site
 
 1. **Duplicate claude workflows** — `claude-review-max.yml` /
     `claude-implement-max.yml` duplicate the base workflows; consolidate.
 2. **Missing codeql.yml** (infra has one).
 3. **Naming inconsistency** — workspace/bunch files say `sommer-lawn` while
-    the repo slug is `sommerlawn-web`; regenerating from the template
+    the repo slug is `sommerlawn-site`; regenerating from the template
     normalizes this.
 4. **lint-hygiene portability** — infra's `scripts/lint-hygiene.sh` uses
     `mapfile` and `grep -P` (Linux-only); the template version is portable to


### PR DESCRIPTION
## What

Rename the website / marketing-site repo suffix from `-web` to `-site`
(e.g. `sommerlawn-web` → `sommerlawn-site`) and document the full repo-naming
scheme explicitly.

`-web` is overloaded ("web" describes every app, and collides with the natural
name for a web client). `-site` distinguishes a website/marketing site from a
web **app** and lines up cleanly with the sibling suffixes (`-app`, `-infra`,
`-mobile`, `-docs`, `-hub`).

## Changes

- **`copier.yml`** — "the sommerlawn-**web** pattern" → "sommerlawn-**site** pattern".
- **`docs/sourceRepoFollowUps.md`** — `sommerlawn-web` → `sommerlawn-site` (3×).
- **`.claude/skills/…/standards-catalog.md`** — rename the live reference repo
  (5×) and add an explicit **Repo naming** convention note covering
  `-site` / `-app` / `-infra` / `-docs` / `-mobile` / `-hub`, calling out
  `-site` as the replacement for the older `-web`.

## Left intentionally

- `CHANGELOG.md` `sommerlawn-web` reference — accurate history at release time.
- `project_type` values `web-astro` / `web-app` — a separate convention (project
  type, not repo suffix); renaming them would break the template.
- "non-web repos" prose — common-noun usage, not a suffix.

## Note on the skill copy

`standards-catalog.md` is the **vendored** copy of the standardize-repo skill;
its canonical source is harmon-devkit. This PR mirrors the edit made canonically
in **harmon-devkit** (branch `docs/repo-naming-site-suffix`) — the two are kept
byte-identical for the changed region rather than running a full
`task ai:sync-skills`, which would have pulled unrelated pending drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)