### PR TITLE
docs(security): concrete Cloudflare DNS token permission recipe

### DIFF
--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -281,9 +281,15 @@ dashboard — R2 tokens are not regular API tokens:
    the account, not a user.)
 2. Name it for the audit log, e.g. `[[ project_slug ]]-terraform`.
 3. Permissions: least privilege for what this repo's Terraform actually
-   manages (verify against a `terraform plan` after creating). Account
-   Resources: this account only. TTL: end date 1 year out + a renewal
-   reminder.
+   manages (verify against a `terraform plan` after creating). For DNS-only
+   management — the common case — that is two rows: `Zone · DNS · Edit` **and**
+   `Zone · Zone · Read` (the built-in **"Edit zone DNS"** template sets exactly
+   these). `Edit` is full CRUDL, so it already includes read — don't add a
+   separate DNS Read; the second row is needed because the `cloudflare_zone`
+   resource reads zone metadata that `DNS · Edit` alone doesn't cover. Do
+   **not** grant "Zone DNS Settings" — despite the name it is DNSSEC/zone
+   settings, not records. Account Resources: this account only. TTL: end date
+   1 year out + a renewal reminder.
 4. Copy the value once → 1Password item → `gh secret set` for CI[% if use_python %] → locally
    `op inject -i .envrc.tpl -o .envrc.local && direnv reload` (see
    [../guides/local-secrets.md](../guides/local-secrets.md))[% endif %].


### PR DESCRIPTION
## What
The Account API Token section (`template/docs/architecture/security.md.jinja`) tells you to grant *"least privilege for what this repo's Terraform manages (verify against a plan)"* — right principle, but every repo has to rediscover the exact permissions for the common Cloudflare-DNS case.

This adds the concrete recipe:
- **`Zone · DNS · Edit` + `Zone · Zone · Read`** (the built-in "Edit zone DNS" template sets exactly these).
- `Edit` is full CRUDL → already includes read (don't add a separate DNS Read).
- The second row (`Zone · Zone · Read`) is required because the `cloudflare_zone` resource reads zone metadata that `DNS · Edit` doesn't cover.
- Don't grant **"Zone DNS Settings"** — despite the name it's DNSSEC/zone settings, not records.

## Why
This came out of adopting the standard in a downstream repo. A token created with only DNS·Edit authenticated fine but had **zero zone access** (couldn't read the zone), and "Zone DNS Settings" nearly got checked instead of DNS. The generic guidance was correct but cost several dashboard round-trips to get right. Verified end-to-end: the recipe above produces a token that passes `terraform plan` for a DNS-managing root.

Docs-only, no template logic changed.