### PR TITLE
docs(security): use provider-verbatim "Tailnet ID" field label

### DIFF
--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -305,7 +305,7 @@ org-level Actions **variable** (`CLOUDFLARE_ACCOUNT_ID`) shared by all repos.
 - **Tailscale is the standard network layer** for remote access — homelab
   hosts and remote sites join the tailnet rather than exposing ports. Its
   OAuth client lives in the org vault (fields: `Client ID`, `Client Secret`,
-  `tailnet ID`); scope OAuth clients narrowly (e.g. auth-key creation only)
+  `Tailnet ID`); scope OAuth clients narrowly (e.g. auth-key creation only)
   and prefer ephemeral/pre-authorized keys minted from them.
 - **SSH** keys are stored as 1Password SSH-key items (see conventions above)
   and served by the 1Password SSH agent where possible, so private keys never


### PR DESCRIPTION
## What
Fix a one-word casing inconsistency in `template/docs/architecture/security.md.jinja`: the Tailscale OAuth-client field label `tailnet ID` → `Tailnet ID`.

## Why
The conventions in the same file state:
> Field labels match the provider's own documentation, verbatim ... don't normalize to a house case style (kebab-case, Title Case) — the provider's spelling wins.

Tailscale's dashboard (Settings → General → Unique IDs) labels it **"Tailnet ID"** (Title Case) — confirmed against a live tailnet. So the verbatim label is `Tailnet ID`; the lowercase form violated the rule stated a few lines above it. `op://` references are label-exact, so this also prevents a real resolution mismatch.

One-word docs change.