### PR TITLE
fix(template): web-astro .prettierignore ignores transient scratch files

### DIFF
--- a/template/[% if use_node %].prettierignore[% endif %]
+++ b/template/[% if use_node %].prettierignore[% endif %]
@@ -21,6 +21,15 @@ dist/
 .terraform/
 .venv/
 pnpm-lock.yaml
+
+# Transient scratch files that concurrent tooling (test harnesses, editors,
+# some CLIs) drops into the repo root can vanish mid-run and race
+# `prettier --check .` into an ENOENT crash (exit 2) — failing the format gate
+# on a file that was never ours. Ignore the common temp/backup patterns so a
+# stray file can't break the gate.
+_tmp_*
+*.tmp
+*~
 # Design-handoff bundles under specs/ (vendored Claude Design exports).
 specs/*/
 


### PR DESCRIPTION
## Problem

The generated web-astro `.prettierignore` doesn't shield the format gate from transient files. `task lint:prettier` runs `prettier --check .` over the whole repo root, so if concurrent tooling (a test harness, an editor, some CLI) drops a scratch file into the root and then deletes it, prettier can race into:

```
[error] Unable to read file "_tmp_<pid>_<md5>":
[error] ENOENT: no such file or directory
```

— exit 2, failing the format gate on a file that was never part of the repo. Observed during the harmon-init v3.20.0 standardize run of a web-astro repo: `task verify` was green standalone 3× and the check PASSED on immediate re-run, confirming a race rather than a real defect.

## Fix

Add common transient/backup patterns to the web-astro `.prettierignore` so a stray root file can't break the gate:

```
_tmp_*
*.tmp
*~
```

Template-only file (`[% if use_node %].prettierignore[% endif %]`); harmon-init root isn't `use_node`, so there's no dogfood twin.

## Verification

- `task verify` ✅ (includes the web-astro render test, which runs the shipped Prettier/ESLint/astro toolchain over a real app — clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
