### PR TITLE
fix(template): ignore terraform state and tfvars (can contain secrets)

### DIFF
--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -106,9 +106,14 @@ htmlcov/
 # Terraform
 .terraform/
 *.tfplan
-*.tfstate.backup
 override.tf
 crash.log
+# State and tfvars can hold secrets — never commit them (only *.tfvars.example).
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json
+!*.tfvars.example
 [% endif %]
 [% if include_ansible %]
 


### PR DESCRIPTION
## What

The template `.gitignore` only ignored `*.tfstate.backup` — leaving the primary
state file (`*.tfstate`) and `*.tfvars` trackable in **every generated `iac`
repo**. Both routinely contain secrets (API tokens/keys pulled into Terraform
state; credentials in tfvars). This adds the full protection.

## Change

`template/.gitignore.jinja` (the `[% if include_terraform %]` block):

```diff
-*.tfstate.backup
+# State and tfvars can hold secrets — never commit them (only *.tfvars.example).
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json
+!*.tfvars.example
```

`*.tfstate.*` subsumes the old `*.tfstate.backup`, so that line is dropped.
`!*.tfvars.example` keeps example files committed.

## Why

This is the exact leak class harmonops/harmon-infra ADR-0001 exists to prevent
(state committed with no ignore rule). sommerlawn-infra already **hand-added**
these same lines — so the template has been shipping the gap and downstream repos
have been patching around it. Found while scaffolding `ponderousdev/ponderous-infra`
(a new Cloudflare iac repo), where I added the same lines locally.

## Dogfood parity

The block is `include_terraform`-gated and harmon-init dogfoods with
`include_terraform=false`, so there is **no root `.gitignore` counterpart** to keep
in sync. Verified by rendering an `iac` profile (the new lines appear correctly);
`task verify` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
