### PR TITLE
docs(template): harden deploy + CI-App onboarding guidance

### DIFF
--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -27,7 +27,10 @@ config, toolchain, devcontainer, and dev environment — against the items below
 
 - [ ] Install the [Renovate app](https://github.com/apps/renovate) on the repo
 - [ ] Install the [CodeRabbit app](https://github.com/apps/coderabbitai) on the repo (`.coderabbit.yaml` is pre-configured)
-- [ ] Actions secret: `CLAUDE_CODE_OAUTH_TOKEN` (claude-* workflows)
+- [ ] Actions secret: `CLAUDE_CODE_OAUTH_TOKEN` (claude-* workflows) — generate
+      with `claude setup-token`; the value must start **`sk-ant-oat01-`** (an OAuth
+      token, billed to your Claude subscription), **not** `sk-ant-api03-` (a raw API
+      key, billed at pay-as-you-go API rates). Then `gh secret set CLAUDE_CODE_OAUTH_TOKEN`
 - [ ] Snyk is **optional and local-only**: `task security:sast`/`security:sca` are
       opt-in — they are NOT in CI or `task security`, so run them by hand with
       `SNYK_TOKEN` in your local env / 1Password (no Actions secret needed). If the
@@ -42,14 +45,19 @@ config, toolchain, devcontainer, and dev environment — against the items below
       running app, and a **multi-tenant isolation** review before onboarding
       customers. See [architecture/security.md](architecture/security.md).
 [% endif %]
-- [ ] CI GitHub App `[[ github_org ]]-ci`: create it by hand (one App per org;
-      **Settings → Developer settings → GitHub Apps**), or reuse the org's existing
-      one; **install it on only the repos that use it** (the harmon-init repos —
-      they run release-please / claude-* / project-automation), not "All". Then set
-      `CI_APP_CLIENT_ID` (Actions **variable**) + `CI_APP_PRIVATE_KEY` (Actions
+- [ ] **Create** the CI GitHub App `[[ github_org ]]-ci` by hand (one App per org;
+      **Settings → Developer settings → GitHub Apps**), or reuse the org's existing one.
+- [ ] **Install** the App on this repo — **Install App → Only select repositories**
+      (the harmon-init repos that run release-please / claude-* / project-automation),
+      **not "All"**. **Creating the App is not enough:** an App whose credentials are
+      set but which is *not installed* on the repo makes
+      `actions/create-github-app-token` fail at runtime with a **404**
+      (`Not Found` — "not installed on this repository"). This is the single
+      easiest step to miss.
+- [ ] Set `CI_APP_CLIENT_ID` (Actions **variable**) + `CI_APP_PRIVATE_KEY` (Actions
       **secret**) — **pipe the `.pem` in** (never paste it; flattened newlines break
-      the key), and **scope the secret to those same repos** (least privilege — the
-      key can act as the App: commits, PRs, releases, workflow edits):
+      the key), and **scope both to those same repos** (least privilege — the key can
+      act as the App: commits, PRs, releases, workflow edits):
 
       ```bash
       gh secret set CI_APP_PRIVATE_KEY --org [[ github_org ]] \
@@ -125,16 +133,16 @@ config, toolchain, devcontainer, and dev environment — against the items below
       `pnpm add -D eslint @eslint/js typescript-eslint eslint-plugin-astro globals`
 - [ ] Install the shipped prettier config's plugins:
       `pnpm add -D prettier prettier-config-standard prettier-plugin-astro prettier-plugin-tailwindcss`
-- [ ] Approve build scripts so `astro build` (and, when deploying to Cloudflare
-      Workers, `wrangler deploy`) work — pnpm 10+ blocks dependency build scripts
-      by default. Add the blocked packages to `pnpm-workspace.yaml` (`esbuild`,
-      `sharp`, `lefthook` if it is a pnpm dep, and **`workerd`** — wrangler pulls
-      it in at deploy time, so without it the Cloudflare deploy fails
-      `ERR_PNPM_IGNORED_BUILDS`), or run `pnpm approve-builds`
-- [ ] Put pnpm `overrides` and `auditConfig` (security version floors, audit CVE
-      ignores) in `pnpm-workspace.yaml`, **not** the `package.json` `pnpm` field —
-      pnpm 10+ silently ignores that field, so overrides declared there vanish on
-      the next lockfile resolve
+- [ ] Build-script approvals + version pins already ship in
+      **`pnpm-workspace.yaml`** — the template pre-approves `esbuild` + `sharp`
+      (and **`workerd`** when deploying to Cloudflare Workers, so `wrangler deploy`
+      doesn't fail `ERR_PNPM_IGNORED_BUILDS`) under `allowBuilds`, and floors
+      `esbuild` at the patched `>=0.28.1` under `overrides` (pnpm 10+ blocks
+      dependency build scripts by default). Add any other packages whose build
+      scripts your deps need to `allowBuilds` (or run `pnpm approve-builds`); keep
+      all pnpm `overrides` / `auditConfig` there too, **not** in the `package.json`
+      `pnpm` field — pnpm 10+ silently ignores that field, so entries there vanish
+      on the next lockfile resolve
 - [ ] Review `lighthouserc.json` URLs once routes exist
 - [ ] Enable mobile device projects in `playwright.config.ts` (e.g. Pixel +
       iPhone) — the Playwright scaffold ships them commented out, and

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -110,6 +110,13 @@ Each job mints a short-lived (1h) installation token at runtime via
 Set both once as **org-level** Actions variable + secret (every repo in the org
 inherits them); for a personal-account repo, set them per-repo.
 
+> **Free-org caveat:** org-level Actions variables/secrets only reach **private**
+> repos on GitHub **Team/Enterprise**. On a **Free** org they resolve to *empty*
+> in a private repo's workflows — a silent failure (e.g. an empty
+> `TF_VAR_cloudflare_account_id` makes Terraform plan a resource *replacement*).
+> On a Free org, set org-wide values **per-repo** instead. Public repos are
+> unaffected.
+
 ### Creating the `[[ github_org ]]-ci` App (once per org)
 
 Create the App **by hand.** GitHub's app-manifest ("one-click") flow only
@@ -219,9 +226,15 @@ TODO: enumerate the tokens/secrets this repo depends on and where each lives:
 | Secret / variable | Used by | Stored in | Rotation |
 |---|---|---|---|
 | `CI_APP_CLIENT_ID` (var) + `CI_APP_PRIVATE_KEY` (secret) | [% if use_release_please %]release-please, [% endif %]claude-*[% if github_org != author_git_provider_username %], project-automation[% endif %] | repo or org Actions variable + secret | rotate App key per policy |
-| `CLAUDE_CODE_OAUTH_TOKEN` | claude-* workflows | repo Actions secret | TODO |
+| `CLAUDE_CODE_OAUTH_TOKEN` | claude-* workflows | repo Actions secret | re-run `claude setup-token` |
 | `SNYK_TOKEN` | `task security:sast`/`sca` (optional, local-only — not in CI) | local env / 1Password | TODO |
 | TODO | TODO | TODO | TODO |
+
+> **`CLAUDE_CODE_OAUTH_TOKEN` must be an OAuth token, not an API key.** Generate
+> it with `claude setup-token`; the value starts **`sk-ant-oat01-`** and bills the
+> claude-* workflows to your Claude **subscription**. A raw API key
+> (**`sk-ant-api03-`**) also authenticates but bills at pay-as-you-go **API
+> rates** — an easy, expensive mix-up. Check the prefix before saving the secret.
 [% if include_terraform or include_ansible %]
 
 ## Infrastructure secrets

--- a/template/docs/guides/deploying.md.jinja
+++ b/template/docs/guides/deploying.md.jinja
@@ -22,6 +22,12 @@ dashboard).
   branch or tag deploys that ref directly — used once to create the Worker,
   and to redeploy the previous release tag.
 
+> **Bootstrap before the first preview.** A preview (`wrangler versions upload`)
+> **requires the Worker to already exist** — the very first preview otherwise
+> fails with *"cannot upload a new version of a Worker that does not yet exist."*
+> On a brand-new repo, run the Bootstrap dispatch (a production `wrangler deploy`)
+> **once** to create the Worker; preview deploys work from then on.
+
 Credentials: `CLOUDFLARE_ACCOUNT_ID` is an org-level Actions **variable** (an
 identifier, not a secret); `CLOUDFLARE_API_TOKEN` is a repo **secret** — an
 Account API Token scoped to **Account → Workers Scripts → Edit** only, 1-year


### PR DESCRIPTION
Documentation improvements distilled from the **ponderousdev greenfield build** — two new repos (`ponderous-infra`, `lawnomator-site`) scaffolded from harmon-init and taken all the way to live Cloudflare Workers deploys. Each item below is a papercut that cost real time during that run.

## Changes

**`docs/guides/deploying.md.jinja`** — deploy chicken-and-egg
- A preview (`wrangler versions upload`) requires the Worker to **already exist**; on a brand-new repo the first preview fails with *"cannot upload a new version of a Worker that does not yet exist."* Added a callout to run the Bootstrap dispatch (a production `wrangler deploy`) once first.

**`docs/CHECKLIST.md.jinja`**
- Split the single CI-GitHub-App item into distinct **Create / Install / Set-credentials** checkboxes. Calls out that *creating the App is not enough* — an App with credentials set but **not installed** on the repo makes `actions/create-github-app-token` fail at runtime with a **404**. This was the easiest step to miss.
- `CLAUDE_CODE_OAUTH_TOKEN`: must start `sk-ant-oat01-` (OAuth, billed to the Claude subscription), **not** `sk-ant-api03-` (raw API key, billed at API rates).
- Reconciled the web-astro build-approve step with the now-shipped `pnpm-workspace.yaml` (#248): `esbuild`/`sharp`/`workerd` under `allowBuilds`, `esbuild` floor under `overrides` — collapsing two stale "add these yourself" items into one "already ships, add extras if needed."

**`docs/architecture/security.md.jinja`**
- **Free-org caveat**: org-level Actions vars/secrets only reach **private** repos on Team/Enterprise; on a **Free** org they read *empty* in private workflows (a silent failure — e.g. an empty `CLOUDFLARE_ACCOUNT_ID` made Terraform plan a resource replacement). Set them per-repo on a Free org.
- `CLAUDE_CODE_OAUTH_TOKEN` inventory row + note (oat01 vs api03 billing), rotation = re-run `claude setup-token`.

## Verification
`task verify` passes locally (lint + template render + rendered-output lint).

## Scope
Docs-only, template layer. No behavior/config changes; no security-relevant setting changes. Companion skill-side updates (naming convention, `_src_path` fix, web-astro scaffold automation, mirrored doc notes) will follow in a harmon-devkit PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)