### PR TITLE
chore(ai): re-sync vendored standardize-repo skill (ponderousdev retro)

### DIFF
--- a/.claude/skills/standardize-repo/references/mode-new-repo.md
+++ b/.claude/skills/standardize-repo/references/mode-new-repo.md
@@ -128,6 +128,28 @@ If you left the side-effectful answers at their `no` defaults (the CI-safe,
 recommended path for unattended generation), only steps 1–2 run and you finish
 setup manually in the next section.
 
+## 4a. Normalize `_src_path` (local-path renders) — REQUIRED for updatability
+
+When you rendered from a **local checkout** (`copier copy ~/git/harmon-init …`),
+copier records that machine-local path as `_src_path` in the generated
+`.copier-answers.yml`, and the auto-run genesis commit (§4, task 2) captures it.
+A relative/local `_src_path` makes a later `copier update` abort with *"Updating
+is only supported in git-tracked templates"* (`copier-gotchas.md` §8) — the repo
+can pass every gate yet never accept a template update. Rewrite it to the
+canonical GitHub URL and fold the fix into the genesis commit **before the first
+push**:
+
+```bash
+cd <dest>
+yq -i '._src_path = "https://github.com/evanharmon1/harmon-init"' .copier-answers.yml
+git add .copier-answers.yml && git commit --amend --no-edit   # fold into the genesis scaffold commit
+```
+
+Skip this only if you rendered from the GitHub URL directly (then `_src_path` is
+already the URL). If the remote was **already** created/pushed (you set
+`github_remote_create=true`), don't amend — make it a normal follow-up commit
+instead. Always verify: `grep _src_path .copier-answers.yml` should show the URL.
+
 ## 5. After generation — local setup & self-check
 
 ```bash

--- a/.claude/skills/standardize-repo/references/post-generation-checklist.md
+++ b/.claude/skills/standardize-repo/references/post-generation-checklist.md
@@ -78,7 +78,10 @@ push so the remote exists.
 - [ ] **[human-only]** Set Actions **secret** `CLAUDE_CODE_OAUTH_TOKEN`
       (consumed by `claude-plan.yml`, `claude-implement.yml`,
       `claude-review.yml`). This is a real credential the agent must not invent;
-      a human pastes the token. Once you have it:
+      a human generates it with `claude setup-token` and pastes it. It **must**
+      start `sk-ant-oat01-` (an OAuth token billed to the Claude **subscription**)
+      — **not** `sk-ant-api03-` (a raw API key billed at pay-as-you-go **API
+      rates**, an easy and expensive mix-up). Once you have it:
 
   ```bash
   # human supplies the token value; do not fabricate it
@@ -122,6 +125,9 @@ push so the remote exists.
 
   - Generate a private key (`.pem`) and copy the **Client ID** (the Iv-style string on the App's settings page, not the numeric App ID).
   - **Install App** → on this org → **Only select repositories** (not "All").
+    **Creating the App is not enough:** an App with credentials set but *not
+    installed* on the repo makes `actions/create-github-app-token` fail at runtime
+    with a **404** (`Not Found`). This is the single easiest step to miss.
   - Set the variable + secret. **Scope the secret least-privilege** to the repos
     that use the App (`--visibility selected --repos`), not the whole org — the key
     can act as the App (commits, PRs, releases, workflow edits). **Pipe the `.pem`
@@ -142,6 +148,12 @@ push so the remote exists.
     Caveat: re-running `--repos` **replaces** the list (evicting repos not in it) —
     re-run with the full list to add a repo, or append one with `gh api --method PUT
     /orgs/<org>/actions/secrets/CI_APP_PRIVATE_KEY/repositories/{repo_id}`.
+
+  > **Free-org caveat:** org-level Actions variables/secrets only reach **private**
+  > repos on GitHub **Team/Enterprise**. On a **Free** org they read *empty* in a
+  > private repo's workflows — a silent failure (e.g. an empty `CLOUDFLARE_ACCOUNT_ID`
+  > made Terraform plan a resource *replacement*). On a Free org, set org-wide values
+  > (including `CI_APP_*`) **per-repo** instead. Public repos are unaffected.
 
   See `docs/architecture/security.md` for blast-radius and rotation notes.
 
@@ -197,17 +209,35 @@ The template ships conventions, not an application. Scaffold the framework that
 matches `<project_type>`:
 
 - [ ] **[scriptable via gh]** (`web-astro`) Scaffold Astro and add the standard
-      stack:
+      stack. **Scaffold BEFORE the first push** when the repo deploys to Cloudflare
+      Workers: the pre-push hook runs `astro check`, which fails on a bare repo with
+      no app — so scaffold on a branch, fast-forward it into `main`, *then*
+      `gh repo create --push` (never `--no-verify`).
 
   ```bash
   pnpm create astro@latest . --template minimal
   pnpm add -D @tailwindcss/vite vitest
+  pnpm add @astrojs/react react react-dom   # if using React islands (the standard stack)
   pnpm add zod lucide
+  # install the plugins the shipped eslint.config.js + prettier config expect:
+  pnpm add -D eslint @eslint/js typescript-eslint eslint-plugin-astro globals
+  pnpm add -D prettier prettier-config-standard prettier-plugin-astro prettier-plugin-tailwindcss
   ```
 
   Then move lint tooling (prettier, eslint, markdownlint-cli2, @commitlint/cli)
   into `devDependencies` and switch the generated `Taskfile.yml`'s `npx --yes`
   calls to `pnpm exec`. Review `lighthouserc.json` URLs once routes exist.
+
+  Build-script approvals + the esbuild security floor already ship in
+  `pnpm-workspace.yaml` (`allowBuilds: esbuild, sharp`, plus `workerd` when
+  deploying to Workers; `overrides: esbuild >=0.28.1`) — add any other packages
+  your deps need to `allowBuilds`, not the `package.json` `pnpm` field (pnpm 10+
+  ignores it).
+
+  > **Cloudflare Workers deploy:** bootstrap the Worker **once** before PR
+  > previews work. A preview (`wrangler versions upload`) requires the Worker to
+  > already exist, so run the production deploy first (Actions → *Release Please*
+  > → *Run workflow* on `main`). See the generated `docs/guides/deploying.md`.
 
 - [ ] **[scriptable via gh]** (`web-app`) Scaffold a TanStack Start app (or
       vite + react) and add the standard stack:

--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -381,6 +381,22 @@ Required secrets/variables (**[manual]**, in CHECKLIST): `CLAUDE_CODE_OAUTH_TOKE
 - **Secrets via 1Password** locally (`op run`/`op inject`); CI reads Actions
   secrets. **`.env` is fully gitignored** (`.env`, `**/.env`, `.env.*`); commit
   only `.env.example`-style files. **[copier]** gitignore; **[manual]** wiring.
+- **1Password credential naming (source of truth).** Authoritative convention is
+  in the generated repo's `docs/architecture/security.md` ("1Password
+  conventions"); when creating a repo's credentials, follow it verbatim:
+  - **One vault per org** (the `<org>` vault) — nothing in personal/shared vaults.
+  - **API credentials** use 1Password's **API Credential** type, named
+    `<Provider> <scope-descriptor>` — e.g. `Cloudflare <slug>-terraform`,
+    `Cloudflare R2 <slug>-tfstate` (Terraform state backend), and **`Cloudflare
+    <slug>-github-actions`** for a per-site Workers-deploy token
+    (`CLOUDFLARE_API_TOKEN`). One token per site/purpose (least privilege), one
+    1Password item per credential.
+  - **Account-level identifiers** get their own per-account item — e.g. `Cloudflare
+    <org>` holding `Account ID` (drives the `CLOUDFLARE_ACCOUNT_ID` Actions var).
+  - **Field labels match the provider's docs verbatim** (`Account ID`, `API Token`,
+    `Access Key ID`, `Secret Access Key`, `Default Endpoint`) — don't invent
+    generic labels (`key`, `secret`) or re-case them; references must match exactly.
+  **[manual]** — a human creates credentials; the agent never fabricates them.
 
 ### 1.9 Dependency management (Renovate)
 


### PR DESCRIPTION
Mechanical re-sync of the vendored `standardize-repo` skill from harmon-devkit after evanharmon1/harmon-devkit#69 merged (the canonical copy changed). Produced by `task ai:sync-skills`; the vendored copy now byte-matches the canonical (`diff -r` clean).

## Refreshed reference docs
- `mode-new-repo.md` — new §4a: `_src_path` local→GitHub-URL normalization step (so a locally-rendered repo stays `copier update`-able).
- `post-generation-checklist.md` — fuller web-astro scaffold automation + the "scaffold before first push / pre-push `astro check`" ordering gotcha + bootstrap-the-Worker-before-preview; `CLAUDE_CODE_OAUTH_TOKEN` oat01-vs-api03; CI-App "not installed → `create-github-app-token` 404"; free-org caveat.
- `standards-catalog.md` — 1Password/Cloudflare credential-naming convention (per-org vault; `<Provider> <scope>` item names incl. per-site `<slug>-github-actions` Workers tokens; provider-verbatim field labels).

## Scope
Vendored skill copy only (`.claude/skills/standardize-repo/`), under the `.claude/**` markdownlint ignore. No behavior/config/security-setting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)