### PR TITLE
fix(template): manifest freeze + nested eslint ignores + pnpm key fix

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -314,6 +314,14 @@ _skip_if_exists:
   # updating; only the list is per-repo). Ship an empty stub on first scaffold,
   # then freeze it so `copier update` never overwrites a populated list.
   - .devcontainer/related-repos.txt
+  # .release-please-manifest.json is release-please state (the repo's current
+  # released version), not template content. The template only seeds it (0.0.0)
+  # for a fresh scaffold; every repo that has cut a release carries a real
+  # version, so an unfrozen copy conflicts on EVERY `copier update` (seed vs
+  # real) and a careless resolution regresses release tracking. Same rationale
+  # as CHANGELOG.md above: freeze it — fresh scaffolds still get the seed; an
+  # existing manifest is never clobbered.
+  - .release-please-manifest.json
 
 # Keep CLAUDE.md/GEMINI.md as symlinks to AGENTS.md in generated projects
 # (without this, copier dereferences symlinks into duplicate files).

--- a/template/[% if project_type == 'web-app' %]eslint.config.js[% endif %]
+++ b/template/[% if project_type == 'web-app' %]eslint.config.js[% endif %]
@@ -8,7 +8,7 @@ import convex from '@convex-dev/eslint-plugin'
 
 export default [
   // specs/*/ holds vendored design-handoff bundles (deleted at sign-off).
-  { ignores: ['dist/', '.output/', '.nitro/', 'convex/_generated/', 'specs/'] },
+  { ignores: ['**/dist/', '**/.output/', '**/.nitro/', 'convex/_generated/', 'specs/'] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   { ...react.configs.flat.recommended, settings: { react: { version: 'detect' } } },

--- a/template/[% if project_type == 'web-astro' %]eslint.config.js[% endif %]
+++ b/template/[% if project_type == 'web-astro' %]eslint.config.js[% endif %]
@@ -5,7 +5,7 @@ import astro from 'eslint-plugin-astro'
 
 export default [
   // specs/*/ holds vendored design-handoff bundles (deleted at sign-off).
-  { ignores: ['dist/', '.astro/', 'specs/'] },
+  { ignores: ['**/dist/', '**/.astro/', 'specs/'] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   ...astro.configs.recommended,

--- a/template/[% if use_node %]pnpm-workspace.yaml[% endif %].jinja
+++ b/template/[% if use_node %]pnpm-workspace.yaml[% endif %].jinja
@@ -1,6 +1,8 @@
 # pnpm build-script approvals + version pins. pnpm 10+ blocks dependency build
-# scripts by default; list the ones that must run here (NOT the package.json
-# `pnpm` field — pnpm 10+ ignores that).
+# scripts by default. `allowBuilds` (a map) is the pnpm 11+ approval setting —
+# it replaced pnpm 10's `onlyBuiltDependencies` list, so this file requires
+# pnpm 11+. List the packages whose build scripts must run here (NOT the
+# package.json `pnpm` field — pnpm 10+ ignores that).
 allowBuilds:
   esbuild: true
   sharp: true

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -160,12 +160,12 @@ config, toolchain, devcontainer, and dev environment — against the items below
       `languageOptions.parserOptions.projectService: true`, to catch a missing
       `await` / floating promise that `tsc` won't. Makes ESLint type-check
       (slower) and needs your tsconfig wired up — skip to keep lint instant.
-- [ ] Put pnpm `overrides` / `auditConfig` / `onlyBuiltDependencies` in
+- [ ] Put pnpm `overrides` / `auditConfig` / `allowBuilds` in
       `pnpm-workspace.yaml`, **not** the `package.json` `pnpm` field — pnpm 10+
       ignores that field. Approve blocked build scripts (e.g. vite's `esbuild`,
       and `workerd` if deploying to Cloudflare Workers — else `wrangler deploy`
-      fails `ERR_PNPM_IGNORED_BUILDS`) via `onlyBuiltDependencies` or
-      `pnpm approve-builds`
+      fails `ERR_PNPM_IGNORED_BUILDS`) via `allowBuilds` (pnpm 11+; the shipped
+      `pnpm-workspace.yaml` uses it) or `pnpm approve-builds`
 [% elif project_type == 'iac' %]
 - [ ] Lay out `terraform/` (main.tf, variables.tf, outputs.tf) and/or
       `ansible/` (site.yml, ansible.cfg, inventory/, roles/) — the lint tasks


### PR DESCRIPTION
Follow-ups surfaced by the v3.20.1 → v3.21.0 fleet sync (all 10 repos hit these). Three independent template fixes.

## ① Freeze `.release-please-manifest.json` (`copier.yml` `_skip_if_exists`)

The manifest is release-please state (the repo's current released version), seeded at `0.0.0`. Every repo that has cut a release therefore conflicts on it on **every** `copier update` (seed vs real version), and a careless resolution silently regresses release tracking. **All 10 synced repos hit this.** Same rationale as `CHANGELOG.md`, which is already frozen. Fresh scaffolds still get the `0.0.0` seed; an existing manifest is never clobbered.

## ② Correct the pnpm build-approval key (`allowBuilds` = pnpm 11+)

`allowBuilds` (a map) was introduced in **pnpm 11**, replacing pnpm 10's `onlyBuiltDependencies` (a list, removed in v11). The shipped `pnpm-workspace.yaml` correctly uses `allowBuilds`, but its header comment said "pnpm 10+" and the **web-app** CHECKLIST section still referenced `onlyBuiltDependencies` — internally inconsistent. This corrects the comment and aligns the web-app checklist with the shipped file. No behavior change — `allowBuilds` is the right forward-looking key; repos consuming this file must be on pnpm 11+.

## ③ eslint `ignores` match nested generated dirs (flat config)

`{ ignores: ['dist/', '.astro/', …] }` matches only **top-level** dirs in ESLint flat config, so a nested generated `.astro/`/`dist/` (e.g. a leftover subdir after a rename) still gets linted and fails on generated `any` types — it bit local `task verify` in ponderous-site. Globbed to `'**/.astro/'`, `'**/dist/'`, `'**/.output/'`, `'**/.nitro/'` in both the web-astro and web-app variants (kept `convex/_generated/` and `specs/` as specific top-level paths).

## Verification

`task verify` green: dogfood parity OK (56 verbatim twins), all 7 template profiles + `test-template-update` PASS.

## Deliberately not included

- The minor Taskfile >200-char `desc:` yamllint **warnings** (non-blocking; wrapping churns every render for no functional gain).
- The pnpm 9/10 → 11 per-repo upgrades (separate, per-repo, need build + deploy testing).

Companion **skill** fixes (`diff-template.sh --show`, `mode-update.md` guidance) are in a separate harmon-devkit PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
