### PR TITLE
fix(template): guard build task on fresh scaffold + wrap long desc lines

### DIFF
--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -358,9 +358,18 @@ tasks:
 
   # ── Build ──────────────────────────────────────────────────────
   build:
+    # Skip cleanly before the app + deps exist (fresh scaffold), like lint:eslint
+    # and typecheck, so `task verify` (and CI's build step) stay green until the
+    # framework is scaffolded — see docs/CHECKLIST.md. Once package.json +
+    # node_modules exist this runs the real build unchanged.
     desc: Production build
     cmds:
-      - pnpm build
+      - |
+        if [ ! -f package.json ] || [ ! -d node_modules ]; then
+          echo "build: app/deps not set up yet -- skipping (scaffold the app + pnpm install)"
+        else
+          pnpm build
+        fi
 
   build:preview:
     desc: Preview production build locally
@@ -521,7 +530,10 @@ tasks:
   # credential and stay manual — see docs/CHECKLIST.md (branch ruleset import,
   # Renovate/CodeRabbit app installs, Actions secrets, the CI GitHub App).
   setup:github:
-    desc: Apply idempotent GitHub repo settings via gh (Dependabot alerts, private vulnerability reporting, CodeQL variable[% if github_org != author_git_provider_username %], bot collaborator[% endif %])
+    desc: >-
+      Apply idempotent GitHub repo settings via gh (Dependabot alerts, private
+      vulnerability reporting, CodeQL
+      variable[% if github_org != author_git_provider_username %], bot collaborator[% endif %])
     vars:
       REPO: "[[ github_org ]]/[[ project_slug ]]"
     cmds:
@@ -542,7 +554,10 @@ tasks:
 [% if project_management == 'github' %]
 
   setup:github-project:
-    desc: Idempotently create/sync the owner's GitHub Project V2 board + Status pipeline + Size number field (on a personal account also the other metadata fields). Requires `gh auth refresh -s project`.
+    desc: >-
+      Idempotently create/sync the owner's GitHub Project V2 board + Status
+      pipeline + Size number field (on a personal account also the other
+      metadata fields). Requires `gh auth refresh -s project`.
     cmds:
       - ./scripts/setup-github-project.sh --owner "[[ github_org ]]" --title "[[ github_org ]] Project"
 
@@ -555,7 +570,11 @@ tasks:
 [% if github_org != author_git_provider_username %]
 
   setup:github-issue-fields:
-    desc: Idempotently add the org's Product + Agent issue fields (Priority/Effort are GitHub built-ins, left at defaults; the numeric Size estimate is a project field via setup:github-project). Requires `gh` with the admin:org scope.
+    desc: >-
+      Idempotently add the org's Product + Agent issue fields (Priority/Effort
+      are GitHub built-ins, left at defaults; the numeric Size estimate is a
+      project field via setup:github-project). Requires `gh` with the admin:org
+      scope.
     cmds:
       - ./scripts/setup-github-issue-fields.sh --org "[[ github_org ]]"
 [% endif %]


### PR DESCRIPTION
## Summary

Surfaced while scaffolding a brand-new **web-app** repo (`ponderousdev/omator-app`) from this template.

The `build` task ran `pnpm build` **unconditionally**, unlike its siblings `lint:eslint` and `typecheck`, which deliberately skip cleanly before the app framework is scaffolded (*"so `task check` stays green before the app is set up"*). Because `verify` runs `check → build → validate`, a freshly-generated `web-app`/`web-astro` repo — which is conventions-only with **no `package.json` yet** (`docs/CHECKLIST.md` §3: scaffold the framework as a follow-up step) — failed in three places until you ran `pnpm create`:

1. **Local `task verify`** — red at the build step.
2. **CI `build.yml`** — the `task build` job step went red on the *first push*, before you'd had a chance to scaffold the framework.
3. **standardize-repo skill `verify-applied.sh`** — reported `FAILED` (it runs `task verify`), so the skill could never self-verify a correctly-generated web-app.

## Changes

- **Guard `build`** the same way `lint:eslint`/`typecheck` are guarded: skip when `package.json` or `node_modules` is absent, otherwise run the real `pnpm build` unchanged. Only the pre-framework window changes behavior.
- **Fold three `>200`-char `setup:github*` `desc:` lines** to `>-` block scalars so the rendered Taskfile is yamllint warning-clean. Rendered `desc` text is byte-identical.

## Verification

- `task test:template:all` — all profiles PASS (minimal, iac, meta, full, **webapp**, **web**, update).
- Fresh `web-app` render (no framework): `task build` now prints `build: app/deps not set up yet -- skipping` and exits 0; `task verify` no longer fails at build.
- No remaining `>200`-char lines in `template/Taskfile.yml.jinja`.

Template-only change — no dogfood-parity counterpart (root is not `use_node`; it has no `build` task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)