### PR TITLE
feat(template): add axe-core a11y checks for web-app (Playwright, non-blocking)

### DIFF
--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -282,6 +282,49 @@ jobs:
               })
             }
 [% endif %]
+[% if project_type == 'web-app' %]
+
+  a11y:
+    # Accessibility (axe-core via Playwright). NON-BLOCKING for now: intentionally
+    # NOT in the `verify` needs list, so it reports but does not gate merges.
+    # Self-activates once the app ships a playwright.config.* (before then
+    # `task test:a11y` skips). To promote to a required check: add `a11y` to
+    # verify.needs + a `check a11y` line, and to the ruleset's required checks.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          # renovate: datasource=node-version
+          node-version: "24"
+          cache: pnpm
+      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        with:
+          # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
+          version: 3.51.1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: |
+          if [ -f package.json ]; then pnpm install --frozen-lockfile; fi
+      - name: Detect Playwright config
+        id: pw
+        run: |
+          if find . -maxdepth 1 -name 'playwright.config.*' 2>/dev/null | grep -q .; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Install Playwright browsers
+        if: steps.pw.outputs.present == 'true'
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Accessibility (axe) tests
+        run: task test:a11y
+[% endif %]
 
   verify:
     if: always()

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -441,6 +441,25 @@ tasks:
     desc: "Playwright PDF export (usage: task test:e2e:pdf -- <url> <output.pdf>)"
     cmds:
       - npx playwright pdf {{.CLI_ARGS}}
+[% if project_type == 'web-app' %]
+
+  test:a11y:
+    # Accessibility (axe-core) assertions run through Playwright — catches
+    # runtime a11y problems in real rendered/interactive states (what
+    # Lighthouse-on-static-URLs can't reach). Skips cleanly until Playwright +
+    # deps exist, like lint:eslint, so `task check`/CI stay green on a fresh
+    # scaffold. a11y tests are tagged `@a11y` (see tests/a11y.spec.ts).
+    desc: Accessibility tests (axe-core via Playwright)
+    cmds:
+      - |
+        if ! find . -maxdepth 1 -name 'playwright.config.*' 2>/dev/null | grep -q .; then
+          echo "test:a11y: no Playwright config yet -- skipping (add playwright.config.ts after scaffolding the app)"
+        elif [ ! -d node_modules ]; then
+          echo "test:a11y: deps not installed yet -- skipping (pnpm install + pnpm add -D @axe-core/playwright)"
+        else
+          pnpm exec playwright test --grep @a11y {{.CLI_ARGS}}
+        fi
+[% endif %]
 [% endif %]
 
   # ── Security ───────────────────────────────────────────────────

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -166,6 +166,14 @@ config, toolchain, devcontainer, and dev environment — against the items below
       and `workerd` if deploying to Cloudflare Workers — else `wrangler deploy`
       fails `ERR_PNPM_IGNORED_BUILDS`) via `allowBuilds` (pnpm 11+; the shipped
       `pnpm-workspace.yaml` uses it) or `pnpm approve-builds`
+- [ ] Accessibility (axe-core): `pnpm add -D @axe-core/playwright`, then add a
+      `playwright.config.ts` with a `webServer` (starts the app) + `baseURL` so
+      `tests/a11y.spec.ts` can run. `task test:a11y` skips until that config
+      exists; once it does, the non-blocking `a11y` CI job runs automatically.
+- [ ] Once real routes exist and pass axe, promote the `a11y` CI job to a
+      required check: add `a11y` to `verify.needs` + a `check a11y` line in
+      `.github/workflows/build.yml`, and add it to the ruleset's
+      `required_status_checks`.
 [% elif project_type == 'iac' %]
 - [ ] Lay out `terraform/` (main.tf, variables.tf, outputs.tf) and/or
       `ansible/` (site.yml, ansible.cfg, inventory/, roles/) — the lint tasks

--- a/template/docs/architecture/branch-protection.md.jinja
+++ b/template/docs/architecture/branch-protection.md.jinja
@@ -295,4 +295,8 @@ For an organization with many repos, consider creating an **org-level ruleset** 
 
 - **GitHub App for the devcontainer agent**: CI **workflows** already authenticate as the `[[ github_org ]]-ci` GitHub App (short-lived 1h tokens, no seat cost — see [security.md](security.md)). The remaining machine-user PAT documented above is the **devcontainer agent's** push token; it could likewise move to an App if rotation becomes burdensome. The ruleset protects `main` identically for App tokens, the bot PAT, or any actor.
 - **Terraform management**: The GitHub Terraform provider supports `github_repository_ruleset` resources. Codifying the ruleset in Terraform ensures consistency as repos multiply.
-- **Additional status checks**: As the CI pipeline matures, add checks for E2E tests (Playwright), accessibility (axe-core), and performance (Lighthouse CI) to the required list.
+- **Additional status checks**: For `web-app`, the `a11y` job (axe-core via
+  Playwright) already ships **non-blocking** — promote it to the required list
+  once real routes pass (add `a11y` to `verify.needs` + a `check a11y` line in
+  `build.yml`, and to `required_status_checks`). As the pipeline matures,
+  likewise add E2E (Playwright) and, where not already gating, Lighthouse CI.

--- a/template/docs/architecture/tests.md.jinja
+++ b/template/docs/architecture/tests.md.jinja
@@ -10,6 +10,9 @@ How testing works in [[ project_name ]].
 [% if use_node %]
 | Unit / component tests | vitest | `task test` |
 | End-to-end | Playwright | `task test:e2e` |
+[% if project_type == 'web-app' %]
+| Accessibility | axe-core (via Playwright) | `task test:a11y` |
+[% endif %]
 [% else %]
 | Tests | TODO: pick a test runner | `task test` |
 [% endif %]
@@ -23,5 +26,10 @@ How testing works in [[ project_name ]].
 - Playwright runs desktop Chromium/Firefox/WebKit **and mobile device
   projects** (e.g. Pixel + iPhone). The scaffold ships the mobile projects
   commented out — enable them; mobile-first is the convention.
+[% endif %]
+[% if project_type == 'web-app' %]
+- Accessibility: axe-core assertions live in Playwright specs tagged `@a11y`
+  (run via `task test:a11y`). This is the automated **floor** (WCAG 2.x A/AA
+  rules axe can detect) — keyboard + screen-reader testing still required.
 [% endif %]
 - TODO: document coverage expectations and fixtures as the suite grows.

--- a/template/tests/[% if project_type == 'web-app' %]a11y.spec.ts[% endif %]
+++ b/template/tests/[% if project_type == 'web-app' %]a11y.spec.ts[% endif %]
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+
+// Automated accessibility checks — the WCAG 2.x A/AA rules axe can detect.
+// axe finds only ~a third to half of WCAG issues: this is the automated FLOOR,
+// not a substitute for keyboard / screen-reader testing. Tag a11y tests
+// `@a11y` so `task test:a11y` selects them. Requires (installed when you
+// scaffold the app): pnpm add -D @axe-core/playwright
+test('homepage has no detectable accessibility violations @a11y', async ({ page }) => {
+  await page.goto('/')
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .analyze()
+  expect(results.violations).toEqual([])
+})
+
+// The reason axe-in-Playwright beats Lighthouse: test INTERACTIVE states too.
+// Uncomment and adapt once the app has real UI:
+// test('nav menu (open) has no violations @a11y', async ({ page }) => {
+//   await page.goto('/')
+//   await page.getByRole('button', { name: /menu/i }).click()
+//   const results = await new AxeBuilder({ page }).analyze()
+//   expect(results.violations).toEqual([])
+// })


### PR DESCRIPTION
## What

Adds **axe-core accessibility checks as a standard for `web-app` projects**
(TanStack/React): `@axe-core/playwright` assertions run through Playwright, plus
a dedicated **non-blocking `a11y` CI job**. Implements #199.

Everything is gated on `[% if project_type == 'web-app' %]` — nothing lands for
`web-astro`, `iac`, `docs`, or `general`.

## Changes

- **`template/Taskfile.yml.jinja`** — guarded `test:a11y` task (after
  `test:e2e:pdf`) that self-skips until a `playwright.config.*` + `node_modules`
  exist, exactly like `lint:eslint`/`typecheck`. **Not** wired into `verify` or
  `test` — it runs in its own CI job and on demand only.
- **`template/tests/[% if project_type == 'web-app' %]a11y.spec.ts[% endif %]`**
  — new example spec, tagged `@a11y`. No `.jinja` suffix (condition carried in
  the filename, copied verbatim) — mirrors the `validate-jsonld.mjs` precedent.
- **`template/.github/workflows/build.yml.jinja`** — non-blocking `a11y` job
  (after `lighthouse`, before `verify`). Deliberately **left out of
  `verify.needs`** so it reports but does not gate merges; self-activates once
  the app ships a `playwright.config.*`. Reuses the already-pinned action SHAs.
- **Docs** — `CHECKLIST.md` (install `@axe-core/playwright` + add
  `playwright.config.ts`; how to promote to required), `tests.md` (Layers row +
  Conventions bullet framing axe as the automated *floor*), `branch-protection.md`
  (refreshed the axe mention).

## Design (per the issue)

- **Guarded** so a fresh scaffold stays green (the #255 lesson) — the template
  ships no `package.json`/`playwright.config.*`/app.
- **Non-blocking first** so a flaky/empty a11y gate never forces a `--no-verify`.
  Promotion to a required check is a documented one-liner.
- **No dependency pre-declared** — the user installs `@axe-core/playwright` when
  scaffolding; CHECKLIST covers it.
- **axe is the automated floor**, not "accessible = done" — documented as such.

## Verification

- `task verify` — **exit 0**; all template profiles PASS (minimal, web, webapp,
  iac, full, meta) + `test:template:update`; dogfood-parity OK (56 twins).
- Rendered **web-app** spot-checks: `task test:a11y` prints the skip message and
  **exits 0**; `a11y:` job present; `verify.needs` **unchanged**
  (`[lint, security, build-test]` — no `a11y`, no `check a11y` call);
  `tests/a11y.spec.ts` present; CHECKLIST/tests.md items render.
- **Exclusion** confirmed by rendering web-astro/iac/general: none of
  `test:a11y`, `tests/a11y.spec.ts`, or the `a11y:` job appear.
- Spec file is Prettier-clean under the shipped config flags; rendered workflow
  passes actionlint/yamllint; markdown passes markdownlint.

## Not included (Part B — optional)

The issue's **Part B** (resolve the `DESIGN.md` accessibility-bar TODO, a
root↔template dogfood-lockstep edit) is labelled *"do only if explicitly asked"*,
so it's left out of this PR. Happy to add it in a follow-up (or here) on request.

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)
