### PR TITLE
docs(template): state the accessibility bar in DESIGN.md (WCAG 2.2 AA)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -22,7 +22,7 @@ clearly *worse* if changed? State the single most important quality (e.g.
 - **Clarity over cleverness.** Optimize for the next reader (often an AI agent).
 - **Consistency is a feature.** Reuse existing patterns before inventing new ones.
 - **Simple by default.** Add structure only when complexity demands it.
-- **Accessible by default.** TODO: state the bar (e.g. WCAG 2.2 AA) where it applies.
+- **Accessible by default (WCAG 2.2 AA where a UI applies).**
 
 ## Non-negotiables
 

--- a/template/DESIGN.md.jinja
+++ b/template/DESIGN.md.jinja
@@ -22,7 +22,7 @@ clearly *worse* if changed? State the single most important quality (e.g.
 - **Clarity over cleverness.** Optimize for the next reader (often an AI agent).
 - **Consistency is a feature.** Reuse existing patterns before inventing new ones.
 - **Simple by default.** Add structure only when complexity demands it.
-- **Accessible by default.** TODO: state the bar (e.g. WCAG 2.2 AA) where it applies.
+- **Accessible by default (WCAG 2.2 AA where a UI applies).**
 
 ## Non-negotiables
 
@@ -48,6 +48,8 @@ file wins if they disagree.
   `prefers-reduced-motion`.
 - **Accessibility.** Keyboard-navigable, semantic HTML, visible focus, labelled
   controls, sufficient contrast. Treat this as non-negotiable, not polish.
+  Automated floor: **WCAG 2.2 AA** via axe-core (`task test:a11y`); manual
+  keyboard / screen-reader testing covers the rest.
 - **Voice & tone.** TODO: how copy should read (terse/warm/technical).
 [% endif %]
 


### PR DESCRIPTION
## What

Resolves the `DESIGN.md` **accessibility-bar TODO** — this is **Part B of #199**,
deferred out of #259 (the axe-core wiring, now merged) because it's a judgment
call about product intent. Now that `web-app` ships an axe-core floor, DESIGN.md
can state the bar.

## Changes

Two small text edits, no code:

- **Principles bullet** (`## Principles`, renders for *every* project type):
  `- **Accessible by default.** TODO: state the bar (e.g. WCAG 2.2 AA) where it applies.`
  → `- **Accessible by default (WCAG 2.2 AA where a UI applies).**`
  Applied to **both** `DESIGN.md` (root) and `template/DESIGN.md.jinja` — see
  lockstep note below.
- **Web UX section** (`## Visual & UX direction (web)`, template only —
  `web-astro`/`web-app`): append to the Accessibility bullet that the automated
  floor is **WCAG 2.2 AA via axe-core** (`task test:a11y`), with manual keyboard
  / screen-reader testing covering the rest.

## Dogfood lockstep

`DESIGN.md.jinja` has a `.jinja` suffix, so `task test:dogfood-parity` (verbatim
twins only) does **not** guard it — the root `DESIGN.md` is a hand-maintained
*render* of the template with harmon-init's own (`general`) answers. The
Principles line renders identically for all types, so it's edited in both files
and kept byte-identical by hand; the web-section sentence only exists in the
template (it doesn't render for the `general` root).

## Verification

- `task verify` — **exit 0**; all template profiles PASS (minimal, web, webapp,
  iac, full, meta) + `test:template:update`; dogfood-parity OK (56 twins).
- Root `DESIGN.md` passes `lint:markdown` (0 errors); rendered DESIGN.md is
  markdown-clean in every profile (`test:template` step 3c).
- Confirmed the Principles line is byte-identical across both files.

Part B of #199 · follow-up to #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)
