### PR TITLE
feat(template): extend axe-core a11y checks to web-astro (mirror web-app)

### DIFF
--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -282,7 +282,7 @@ jobs:
               })
             }
 [% endif %]
-[% if project_type == 'web-app' %]
+[% if project_type in ['web-astro', 'web-app'] %]
 
   a11y:
     # Accessibility (axe-core via Playwright). NON-BLOCKING for now: intentionally

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -441,7 +441,7 @@ tasks:
     desc: "Playwright PDF export (usage: task test:e2e:pdf -- <url> <output.pdf>)"
     cmds:
       - npx playwright pdf {{.CLI_ARGS}}
-[% if project_type == 'web-app' %]
+[% if project_type in ['web-astro', 'web-app'] %]
 
   test:a11y:
     # Accessibility (axe-core) assertions run through Playwright — catches

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -147,6 +147,16 @@ config, toolchain, devcontainer, and dev environment — against the items below
 - [ ] Enable mobile device projects in `playwright.config.ts` (e.g. Pixel +
       iPhone) — the Playwright scaffold ships them commented out, and
       mobile-first is the convention
+- [ ] Accessibility (axe-core): `pnpm add -D @axe-core/playwright`, then add a
+      `playwright.config.ts` with a `webServer` (starts `astro dev`/preview) +
+      `baseURL` so `tests/a11y.spec.ts` can run — this complements the Lighthouse
+      a11y gate (static pages) by covering interactive states (nav, cookie
+      banner, forms). `task test:a11y` skips until that config exists; once it
+      does, the non-blocking `a11y` CI job runs automatically.
+- [ ] Once real routes exist and pass axe, promote the `a11y` CI job to a
+      required check: add `a11y` to `verify.needs` + a `check a11y` line in
+      `.github/workflows/build.yml`, and add it to the ruleset's
+      `required_status_checks`.
 [% elif project_type == 'web-app' %]
 - [ ] Scaffold the app: `pnpm create @tanstack/start@latest` (TanStack Start) or vite + react
 - [ ] Add the standard stack: Tailwind v4, shadcn/ui, zod, vitest, lucide

--- a/template/docs/architecture/branch-protection.md.jinja
+++ b/template/docs/architecture/branch-protection.md.jinja
@@ -295,8 +295,9 @@ For an organization with many repos, consider creating an **org-level ruleset** 
 
 - **GitHub App for the devcontainer agent**: CI **workflows** already authenticate as the `[[ github_org ]]-ci` GitHub App (short-lived 1h tokens, no seat cost — see [security.md](security.md)). The remaining machine-user PAT documented above is the **devcontainer agent's** push token; it could likewise move to an App if rotation becomes burdensome. The ruleset protects `main` identically for App tokens, the bot PAT, or any actor.
 - **Terraform management**: The GitHub Terraform provider supports `github_repository_ruleset` resources. Codifying the ruleset in Terraform ensures consistency as repos multiply.
-- **Additional status checks**: For `web-app`, the `a11y` job (axe-core via
-  Playwright) already ships **non-blocking** — promote it to the required list
+- **Additional status checks**: For `web-app` and `web-astro`, the `a11y` job
+  (axe-core via Playwright) already ships **non-blocking** — promote it to the
+  required list
   once real routes pass (add `a11y` to `verify.needs` + a `check a11y` line in
   `build.yml`, and to `required_status_checks`). As the pipeline matures,
   likewise add E2E (Playwright) and, where not already gating, Lighthouse CI.

--- a/template/docs/architecture/tests.md.jinja
+++ b/template/docs/architecture/tests.md.jinja
@@ -10,7 +10,7 @@ How testing works in [[ project_name ]].
 [% if use_node %]
 | Unit / component tests | vitest | `task test` |
 | End-to-end | Playwright | `task test:e2e` |
-[% if project_type == 'web-app' %]
+[% if project_type in ['web-astro', 'web-app'] %]
 | Accessibility | axe-core (via Playwright) | `task test:a11y` |
 [% endif %]
 [% else %]
@@ -27,7 +27,7 @@ How testing works in [[ project_name ]].
   projects** (e.g. Pixel + iPhone). The scaffold ships the mobile projects
   commented out — enable them; mobile-first is the convention.
 [% endif %]
-[% if project_type == 'web-app' %]
+[% if project_type in ['web-astro', 'web-app'] %]
 - Accessibility: axe-core assertions live in Playwright specs tagged `@a11y`
   (run via `task test:a11y`). This is the automated **floor** (WCAG 2.x A/AA
   rules axe can detect) — keyboard + screen-reader testing still required.

--- a/template/tests/[% if project_type in ['web-astro', 'web-app'] %]a11y.spec.ts[% endif %]
+++ b/template/tests/[% if project_type in ['web-astro', 'web-app'] %]a11y.spec.ts[% endif %]
@@ -4,8 +4,9 @@ import AxeBuilder from '@axe-core/playwright'
 // Automated accessibility checks — the WCAG 2.x A/AA rules axe can detect.
 // axe finds only ~a third to half of WCAG issues: this is the automated FLOOR,
 // not a substitute for keyboard / screen-reader testing. Tag a11y tests
-// `@a11y` so `task test:a11y` selects them. Requires (installed when you
-// scaffold the app): pnpm add -D @axe-core/playwright
+// `@a11y` so `task test:a11y` selects them. Requires (installed when you set up
+// Playwright): `pnpm add -D @playwright/test @axe-core/playwright` — until then
+// `tsc` / `astro check` can't type-check this file.
 test('homepage has no detectable accessibility violations @a11y', async ({ page }) => {
   await page.goto('/')
   const results = await new AxeBuilder({ page })

--- a/tests/fixtures/web-astro/package.json
+++ b/tests/fixtures/web-astro/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "devDependencies": {
     "@astrojs/check": "0.9.9",
+    "@axe-core/playwright": "^4.10.0",
     "@eslint/js": "10.0.1",
+    "@playwright/test": "^1.49.0",
     "astro": "7.0.3",
     "eslint": "10.6.0",
     "eslint-plugin-astro": "2.1.1",


### PR DESCRIPTION
## What

Implements **option B of #262**: extend the axe-core accessibility pattern from
#259 (v3.22.0) to **web-astro**, mirroring web-app. Closes the interactive-states
gap (nav drawer / cookie banner / forms) that Lighthouse-on-static-URLs can't
reach — web-astro's strict Lighthouse a11y gate stays; axe-in-Playwright
**complements** it.

## Changes

Mostly widening the existing `web-app` gates to `web-astro` too:

- **`Taskfile.yml.jinja`, `build.yml.jinja`, `tests.md.jinja`** — gate changed
  from `project_type == 'web-app'` to `project_type in ['web-astro', 'web-app']`
  (guarded `test:a11y` task, non-blocking `a11y` job, tests.md layer row +
  convention).
- **Spec** — filename condition widened; content is the shared verbatim file
  (renders for both web types).
- **`CHECKLIST.md.jinja`** — web-astro a11y setup + promotion items, noting axe
  **complements** the Lighthouse static gate by covering interactive states.
- **`branch-protection.md.jinja`** — the a11y promotion note now covers
  `web-app` **and** `web-astro`.

**Non-blocking preserved:** the `a11y` job is *not* in `verify.needs` for either
type; for web-astro, `lighthouse` still gates.

## Latent bug fixed along the way

web-astro's toolchain fixture runs `astro check` (a `tsc` typecheck); the web-app
fixture only runs ESLint, so **#259 never exercised this path**. The shipped
`tests/a11y.spec.ts` imports `@playwright/test` + `@axe-core/playwright`, which
`tsc` / `astro check` can't resolve until they're installed — so a scaffolded
(but pre-Playwright) repo would get a red typecheck.

- The web-astro toolchain fixture now installs both devDeps, modelling the
  "a11y is set up" state (a repo that *has* a Playwright a11y spec has Playwright
  installed). `astro check` (strict) passes on the spec.
- The spec comment now names **both** deps and notes the typecheck dependency.
- `@ts-nocheck` was rejected on purpose — the shipped ESLint config runs
  `tseslint.configs.recommended`, whose `ban-ts-comment` would then fail
  `lint:eslint`.
- **Fresh-scaffold-green still holds:** with no `package.json`, `typecheck`
  skips, so the spec is never processed until the app + deps exist.

## Verification

- `task verify` — **exit 0**; all profiles PASS (minimal, web, webapp, iac, full,
  meta) + `test:template:update`; dogfood-parity OK (56 twins); both web fixtures
  clean (web-astro ESLint+Prettier+astro check+build; web-app ESLint).
- Rendered **web-astro** spot-checks: `task test:a11y` prints the skip message and
  **exits 0**; `a11y:` job present; `verify.needs` unchanged
  (`[lint, security, build-test, lighthouse]` — no `a11y`, no `check a11y`);
  `tests/a11y.spec.ts` present; CHECKLIST/tests.md items render.
- **Exclusion** re-confirmed for `iac` / `general` / `docs` — none of the a11y
  artifacts appear.

## Note

The DESIGN.md web-section line added in #261 ("Automated floor: WCAG 2.2 AA via
axe-core (`task test:a11y`)") is already gated `web-astro`+`web-app`, so it
becomes **accurate** for web-astro with this change — no DESIGN.md edit needed.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)
