### PR TITLE
test(template): type-check the web-app fixture (guard the a11y spec's tsc path)

### DIFF
--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -393,23 +393,32 @@ if [ "$profile" = "web" ] && [ -f eslint.config.js ]; then
     fi
 fi
 
-# ── 12. web-app: the shipped ESLint config lints a real React app ────
+# ── 12. web-app: the shipped ESLint config + tsc type-check a real React app ──
 # Same idea as the web-astro check above, for the web-app (React) project type.
 # eslint-plugin-react is not yet ESLint-10-ready, so the fixture pins ESLint 9.
+# The tsc step guards that the shipped tests/a11y.spec.ts type-checks once its
+# Playwright + axe devDeps exist — the web-astro astro-check caught that class of
+# bug; the eslint-only web-app check used to miss it. The fixture tsconfig
+# excludes src/routes (TanStack's createFileRoute needs a generated route tree to
+# type; ESLint still lints it) and includes tests/ so the a11y spec is checked.
 if [ "$profile" = "webapp" ] && [ -f eslint.config.js ]; then
     if have pnpm; then
         cp -R "$repo_root/tests/fixtures/web-app/." .
         pnpm install --silent >/dev/null 2>&1 || true
-        if [ ! -x node_modules/.bin/eslint ]; then
-            err "web-app fixture: install did not provide eslint (see tests/fixtures/web-app/package.json)"
-        elif ! node_modules/.bin/eslint . >/dev/null 2>&1; then
-            node_modules/.bin/eslint . || true
+        bin="node_modules/.bin"
+        if [ ! -x "$bin/eslint" ] || [ ! -x "$bin/tsc" ]; then
+            err "web-app fixture: install did not provide the toolchain (see tests/fixtures/web-app/package.json)"
+        elif ! "$bin/eslint" . >/dev/null 2>&1; then
+            "$bin/eslint" . || true
             err "web-app fixture: shipped eslint.config.js failed to lint a real React app"
+        elif ! "$bin/tsc" --noEmit >/dev/null 2>&1; then
+            "$bin/tsc" --noEmit || true
+            err "web-app fixture: tsc --noEmit failed — the shipped tests/a11y.spec.ts must type-check with @playwright/test + @axe-core/playwright installed"
         else
-            echo "web-app: shipped ESLint config lints a real React app cleanly"
+            echo "web-app: shipped ESLint + tsc type-check clean on a real React app"
         fi
     else
-        required pnpm "web-app ESLint validation" || fail=1
+        required pnpm "web-app toolchain validation" || fail=1
     fi
 fi
 

--- a/tests/fixtures/web-app/package.json
+++ b/tests/fixtures/web-app/package.json
@@ -3,8 +3,10 @@
   "type": "module",
   "private": true,
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.0",
     "@convex-dev/eslint-plugin": "2.0.0",
     "@eslint/js": "9.39.4",
+    "@playwright/test": "^1.49.0",
     "@tanstack/eslint-plugin-router": "1.162.0",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/tests/fixtures/web-app/tsconfig.json
+++ b/tests/fixtures/web-app/tsconfig.json
@@ -8,5 +8,6 @@
     "skipLibCheck": true,
     "noEmit": true
   },
-  "include": ["src"]
+  "include": ["src", "tests"],
+  "exclude": ["src/routes"]
 }


### PR DESCRIPTION
## What

Closes the test-quality gap flagged during #263: the **web-app toolchain fixture
only ran ESLint**, so it never exercised the `tsc` path that caught the latent
typecheck bug on web-astro. The shipped `tests/a11y.spec.ts` imports
`@playwright/test` + `@axe-core/playwright`, which `tsc` / `astro check` can't
resolve until they're installed — web-astro's fixture caught that (it runs
`astro check`); web-app's didn't.

This adds an equivalent `tsc --noEmit` step to the web-app fixture.

## Changes (test-infra only — no template output changes)

- **`tests/fixtures/web-app/package.json`** — add `@playwright/test` +
  `@axe-core/playwright` so `tsc` can resolve the a11y spec's imports (models the
  set-up state, mirroring the web-astro fixture).
- **`tests/fixtures/web-app/tsconfig.json`** — `include` now covers `tests/` (so
  the a11y spec is type-checked) and `exclude`s `src/routes` (TanStack's
  `createFileRoute('/')` needs a generated route tree to type — `TS2345` without
  it; ESLint still lints the file).
- **`scripts/test-template.sh`** (step 12) — run `tsc --noEmit` after ESLint,
  mirroring the web-astro block's style.

## Why exclude `src/routes`

Empirically, whole-project `tsc` fails only on `src/routes/index.tsx`:
`error TS2345: Argument of type '"/"' is not assignable to parameter of type
'undefined'` — `createFileRoute` is typed against a generated route tree the
fixture can't produce. Excluding it keeps `src/App.tsx` + the a11y spec in scope;
ESLint (via `@tanstack/eslint-plugin-router`) still covers the route file.

## Verification

- Confirmed the tsc step **actually checks the spec**: injecting a deliberate
  type error into `a11y.spec.ts` makes `tsc` fail (`TS2322` at that line). So this
  genuinely guards the regression, not just a green no-op.
- `task verify` — **exit 0**; all profiles PASS; dogfood-parity OK; both web
  fixtures clean (`web-app: shipped ESLint + tsc type-check clean on a real React
  app`; web-astro unchanged).
- `shellcheck --severity=error` + `shfmt -d` clean on the edited harness.

Follow-up to #263 (no template behavior change — purely strengthens the test
that guards the shipped a11y spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
