### PR TITLE
feat(template): web-app retro from omator — secrets, e2e guard, ESLint 10, renovate jinja pins

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,8 +35,10 @@
       "dockerDashComposeVersion": "v2"
     },
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers-extra/features/go-task:1": {},
-    "ghcr.io/itsmechlark/features/1password:1.5.0": {}
+    // No 1Password CLI in the bot profile — this container must hold no path
+    // to production secrets (docs/guides/devcontainers.md). The human dev
+    // profile (.devcontainer/dev/) keeps its own op feature.
+    "ghcr.io/devcontainers-extra/features/go-task:1": {}
   },
   "mounts": [
     "source=claude-code-config-${localWorkspaceFolderBasename},target=/home/vscode/.claude,type=volume",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -321,6 +321,27 @@ tasks:
     cmds:
       - snyk test --severity-threshold=high --show-vulnerable-paths=all
 
+  # ── Secrets ────────────────────────────────────────────────────
+  # Destination-only helpers: the secret value stays on stdin — never in argv,
+  # env vars, Taskfile vars, or shell history (see docs/conventions.md).
+  secret:set:1p:
+    desc: "Set an existing 1Password field from stdin (usage: command | task secret:set:1p VAULT=... ITEM=... FIELD=... [SECTION=...])"
+    env:
+      VAULT: '{{.VAULT | default ""}}'
+      ITEM: '{{.ITEM | default ""}}'
+      FIELD: '{{.FIELD | default ""}}'
+      SECTION: '{{.SECTION | default ""}}'
+    cmds:
+      - ./scripts/secret-set-1p.sh
+
+  secret:set:gh:
+    desc: "Set a GitHub repo secret from stdin (usage: command | task secret:set:gh NAME=... REPO=owner/repo)"
+    env:
+      NAME: '{{.NAME | default ""}}'
+      REPO: '{{.REPO | default ""}}'
+    cmds:
+      - ./scripts/secret-set-gh.sh
+
   # ── Setup ─────────────────────────────────────────────────────
   bootstrap:
     desc: One-time machine setup (Homebrew)

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -79,6 +79,12 @@ it points here.
 
 - Local env comes from **1Password** (`op run` / `op inject`); CI reads GitHub
   Actions secrets. `gitleaks` runs on pre-push and in CI.
+- When generating or rotating secrets, keep the value **on stdin** and use the
+  destination-only helpers: `task secret:set:1p VAULT=… ITEM=… FIELD=…
+  [SECTION=…]` for existing 1Password fields, `task secret:set:gh NAME=…
+  REPO=owner/repo` for GitHub repo secrets. Never pass secret values as command
+  arguments, `--body` values, exported env vars, or Taskfile vars — they end up
+  in shell history and process listings.
 
 ## Docs & AI steering
 

--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,15 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+[A-Z_]+_VERSION=(?<currentValue>\\S+)"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "GitHub Action SHA pins (`uses: owner/repo@sha # vX.Y.Z`) in the template's .jinja workflows — the native github-actions manager can't parse the .jinja extension, so these pins rotted silently until the omator retro caught them",
+      "managerFilePatterns": ["/workflows/.*\\.ya?ml\\.jinja$/"],
+      "matchStrings": [
+        "uses: (?<depName>[^\\s@]+)@(?<currentDigest>[0-9a-f]{40}) # (?<currentValue>v[0-9][0-9.]*)"
+      ],
+      "datasourceTemplate": "github-tags"
     }
   ],
   "packageRules": [
@@ -55,12 +64,6 @@
       "groupName": "GitHub Actions"
     },
     {
-      "description": "Eject anthropics/claude-code-action from the batched GitHub Actions group and skip the 3-day release-age wait. It ships near-daily first-party releases, so grouping + minimumReleaseAge kept the whole Actions batch perpetually pending on the renovate/stability-days gate — each rebase pulled in a fresh release and reset the 3-day clock. It's a trusted first-party action and all updates are reviewed manually (automerge is off globally). Must come after the GitHub Actions group rules so this override wins.",
-      "matchPackageNames": ["anthropics/claude-code-action"],
-      "groupName": null,
-      "minimumReleaseAge": "0 days"
-    },
-    {
       "description": "Batch all Docker image updates into one PR",
       "matchDatasources": ["docker"],
       "groupName": "Docker images"
@@ -69,6 +72,12 @@
       "description": "Batch all devcontainer updates (base image + annotated tools) into one PR — must come after the Docker images rule so the base image lands here instead",
       "matchFileNames": [".devcontainer/**", "template/**"],
       "groupName": "Devcontainer"
+    },
+    {
+      "description": "Template workflow action pins belong with the GitHub Actions batch, not the Devcontainer batch — must come after the Devcontainer rule so this override wins",
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["template/.github/workflows/**"],
+      "groupName": "GitHub Actions"
     },
     {
       "description": "Batch the web-astro test-fixture dependency bumps into one PR (the fixture validates the shipped ESLint config; its deps move together)",
@@ -81,6 +90,12 @@
       "matchFileNames": ["tests/fixtures/web-app/package.json"],
       "groupName": "web-app fixture",
       "separateMajorMinor": false
+    },
+    {
+      "description": "Eject anthropics/claude-code-action from the batched GitHub Actions group and skip the 3-day release-age wait. It ships near-daily first-party releases, so grouping + minimumReleaseAge kept the whole Actions batch perpetually pending on the renovate/stability-days gate — each rebase pulled in a fresh release and reset the 3-day clock. It's a trusted first-party action and all updates are reviewed manually (automerge is off globally). Must come LAST so this override wins over every grouping rule (GitHub Actions, Devcontainer, template workflow pins).",
+      "matchPackageNames": ["anthropics/claude-code-action"],
+      "groupName": null,
+      "minimumReleaseAge": "0 days"
     }
   ]
 }

--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -116,11 +116,12 @@ assert_unit() {
 }
 
 # assert_config_invariants <repo_root> <config> <profile>
-# bot: NO tailscale feature, NO /dev/net/tun runArg, NO TS_AUTHKEY in
-#      initializeCommand. dev: all three present.
+# bot: NO tailscale feature, NO 1Password CLI feature, NO /dev/net/tun runArg,
+#      NO TS_AUTHKEY in initializeCommand — the bot container must hold no path
+#      to production secrets or the tailnet. dev: all four present.
 assert_config_invariants() {
     local repo_root="$1" config="$2" profile="$3"
-    local cfg has_ts_feature has_tun has_ts_init
+    local cfg has_ts_feature has_op_feature has_tun has_ts_init
 
     cfg="$(npx -y @devcontainers/cli read-configuration \
         --workspace-folder "$repo_root" \
@@ -129,6 +130,8 @@ assert_config_invariants() {
 
     has_ts_feature="$(printf '%s' "$cfg" |
         jq -r '[.configuration.features // {} | keys[] | select(test("tailscale";"i"))] | length')"
+    has_op_feature="$(printf '%s' "$cfg" |
+        jq -r '[.configuration.features // {} | keys[] | select(test("1password";"i"))] | length')"
     has_tun="$(printf '%s' "$cfg" |
         jq -r '[.configuration.runArgs // [] | .[] | select(test("/dev/net/tun"))] | length')"
     has_ts_init="$(printf '%s' "$cfg" |
@@ -136,10 +139,12 @@ assert_config_invariants() {
 
     if [ "$profile" = "bot" ]; then
         [ "$has_ts_feature" = "0" ] || fail "bot config has a tailscale feature"
+        [ "$has_op_feature" = "0" ] || fail "bot config has a 1Password CLI feature (no secret-store path in the bot container)"
         [ "$has_tun" = "0" ] || fail "bot config requests /dev/net/tun"
         [ "$has_ts_init" = "0" ] || fail "bot config references TS_AUTHKEY in initializeCommand"
     else
         [ "$has_ts_feature" != "0" ] || fail "dev config is missing the tailscale feature"
+        [ "$has_op_feature" != "0" ] || fail "dev config is missing the 1Password CLI feature"
         [ "$has_tun" != "0" ] || fail "dev config is missing the /dev/net/tun device"
         [ "$has_ts_init" = "1" ] || fail "dev config does not reference TS_AUTHKEY in initializeCommand"
     fi

--- a/scripts/lint-hygiene.sh
+++ b/scripts/lint-hygiene.sh
@@ -115,11 +115,11 @@ for f in "${files[@]}"; do
     # --- JSON syntax check ---
     case "$f" in
     *.json)
-        # Skip JSONC files (devcontainer.json, tsconfig*.json — TypeScript
-        # officially allows comments) and anything jinja-templated. tsc -b
-        # validates the tsconfigs loudly, so hygiene needn't parse them as JSON.
+        # Skip JSONC files (devcontainer.json, tsconfig*.json at any depth —
+        # TypeScript officially allows comments) and anything jinja-templated.
+        # tsc -b validates the tsconfigs loudly, so hygiene needn't parse them.
         case "$f" in
-        *devcontainer.json | */tsconfig.json | tsconfig.json | tsconfig.*.json | template/*) ;;
+        *devcontainer.json | tsconfig*.json | */tsconfig*.json | template/*) ;;
         *)
             if ! python3 -c "import json; json.load(open('$f'))" 2>/dev/null; then
                 warn "$f: invalid JSON"

--- a/scripts/lint-hygiene.sh
+++ b/scripts/lint-hygiene.sh
@@ -115,9 +115,11 @@ for f in "${files[@]}"; do
     # --- JSON syntax check ---
     case "$f" in
     *.json)
-        # Skip devcontainer.json (JSONC) and anything jinja-templated
+        # Skip JSONC files (devcontainer.json, tsconfig*.json — TypeScript
+        # officially allows comments) and anything jinja-templated. tsc -b
+        # validates the tsconfigs loudly, so hygiene needn't parse them as JSON.
         case "$f" in
-        *devcontainer.json | template/*) ;;
+        *devcontainer.json | */tsconfig.json | tsconfig.json | tsconfig.*.json | template/*) ;;
         *)
             if ! python3 -c "import json; json.load(open('$f'))" 2>/dev/null; then
                 warn "$f: invalid JSON"

--- a/scripts/secret-set-1p.sh
+++ b/scripts/secret-set-1p.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Update an existing 1Password item field from stdin without passing the secret
+# in shell history, environment variables, or process arguments.
+set -euo pipefail
+
+fail() {
+    echo "secret:set:1p: $*" >&2
+    exit 1
+}
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage:
+  secret-producing-command | task secret:set:1p VAULT=<vault> ITEM=<item> FIELD=<field> [SECTION=<section>]
+
+The secret is read from stdin. VAULT, ITEM, FIELD, and optional SECTION identify
+an existing 1Password field to update; the field is not created automatically.
+USAGE
+}
+
+vault="${VAULT:-}"
+item="${ITEM:-}"
+field="${FIELD:-}"
+section="${SECTION:-}"
+
+if [ -z "$vault" ] || [ -z "$item" ] || [ -z "$field" ]; then
+    usage
+    fail "VAULT, ITEM, and FIELD are required"
+fi
+
+if [ -t 0 ]; then
+    usage
+    fail "secret must be piped on stdin"
+fi
+
+command -v op >/dev/null 2>&1 || fail "op CLI is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+
+# Keep the caller's stdin available to jq as a raw file while jq reads the
+# 1Password item JSON from the pipeline.
+exec 3<&0
+
+op item get "$item" --vault "$vault" --format json --reveal |
+    jq \
+        --arg field "$field" \
+        --arg section "$section" \
+        --rawfile secret /dev/fd/3 \
+        '
+        def secret_value:
+          $secret | sub("\r?\n$"; "");
+
+        def field_matches:
+          .label == $field
+          and (
+            ($section | length) == 0
+            or (((.section? // {}) | .label? // "") == $section)
+          );
+
+        (secret_value) as $value
+        | if ($value | length) == 0 then
+            error("stdin secret is empty")
+          else
+            .
+          end
+        | ([.fields[] | select(field_matches)] | length) as $match_count
+        | if $match_count == 0 then
+            error("no matching 1Password field")
+          elif $match_count > 1 then
+            error("multiple matching 1Password fields; set SECTION")
+          else
+            (.fields[] |= if field_matches then .value = $value else . end)
+          end
+        ' |
+    op item edit "$item" --vault "$vault" >/dev/null
+
+echo "Updated 1Password item '$item' field '$field'."

--- a/scripts/secret-set-gh.sh
+++ b/scripts/secret-set-gh.sh
@@ -32,13 +32,26 @@ if [ -t 0 ]; then
 fi
 
 command -v gh >/dev/null 2>&1 || fail "gh CLI is required"
-command -v perl >/dev/null 2>&1 || fail "perl is required"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required"
 
-perl -0777 -e '
-    my $secret = <STDIN>;
-    $secret =~ s/\r?\n\z//;
-    die "stdin secret is empty\n" if $secret eq "";
-    print $secret;
-' | gh secret set "$name" --repo "$repo" >/dev/null
+# Read + validate stdin BEFORE gh runs: in a plain pipeline, `gh secret set`
+# starts consuming stdin before the producer's empty-check can fail, so an
+# empty pipe could write an empty secret and only error afterwards. python3 is
+# already the scripts' one interpreter dependency (lint-hygiene.sh). The value
+# stays out of argv and the environment: command substitution + the printf
+# builtin never surface it in a process listing.
+secret="$(python3 -c '
+import sys
+data = sys.stdin.buffer.read()
+if data.endswith(b"\r\n"):
+    data = data[:-2]
+elif data.endswith(b"\n"):
+    data = data[:-1]
+if not data:
+    sys.exit("stdin secret is empty")
+sys.stdout.buffer.write(data)
+')" || fail "stdin secret is empty"
+
+printf '%s' "$secret" | gh secret set "$name" --repo "$repo" >/dev/null
 
 echo "Updated GitHub secret '$name' in '$repo'."

--- a/scripts/secret-set-gh.sh
+++ b/scripts/secret-set-gh.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Set a GitHub repository secret from stdin without passing the secret in shell
+# history, environment variables, or process arguments.
+set -euo pipefail
+
+fail() {
+    echo "secret:set:gh: $*" >&2
+    exit 1
+}
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage:
+  secret-producing-command | task secret:set:gh NAME=<secret-name> REPO=<owner/repo>
+
+The secret value is read from stdin. NAME and REPO identify the GitHub
+repository secret to create or update.
+USAGE
+}
+
+name="${NAME:-}"
+repo="${REPO:-}"
+
+if [ -z "$name" ] || [ -z "$repo" ]; then
+    usage
+    fail "NAME and REPO are required"
+fi
+
+if [ -t 0 ]; then
+    usage
+    fail "secret must be piped on stdin"
+fi
+
+command -v gh >/dev/null 2>&1 || fail "gh CLI is required"
+command -v perl >/dev/null 2>&1 || fail "perl is required"
+
+perl -0777 -e '
+    my $secret = <STDIN>;
+    $secret =~ s/\r?\n\z//;
+    die "stdin secret is empty\n" if $secret eq "";
+    print $secret;
+' | gh secret set "$name" --repo "$repo" >/dev/null
+
+echo "Updated GitHub secret '$name' in '$repo'."

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -32,4 +32,12 @@ else
     echo "    (skipped: brew not on PATH)"
 fi
 
+echo "==> secret helper tasks reject missing destination metadata"
+if printf '%s' 'dummy-secret' | task secret:set:1p >/dev/null 2>&1; then
+    fail "task secret:set:1p succeeded without destination metadata"
+fi
+if printf '%s' 'dummy-secret' | task secret:set:gh >/dev/null 2>&1; then
+    fail "task secret:set:gh succeeded without destination metadata"
+fi
+
 echo "==> task targets OK (compile + bootstrap idempotency)"

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -416,12 +416,12 @@ fi
 
 # ── 12. web-app: the shipped ESLint config + tsc type-check a real React app ──
 # Same idea as the web-astro check above, for the web-app (React) project type.
-# eslint-plugin-react is not yet ESLint-10-ready, so the fixture pins ESLint 9.
-# The tsc step guards that the shipped tests/a11y.spec.ts type-checks once its
-# Playwright + axe devDeps exist — the web-astro astro-check caught that class of
-# bug; the eslint-only web-app check used to miss it. The fixture tsconfig
-# excludes src/routes (TanStack's createFileRoute needs a generated route tree to
-# type; ESLint still lints it) and includes tests/ so the a11y spec is checked.
+# The shipped config is ESLint 10 + type-aware linting (projectService), so the
+# fixture mirrors a real app: src/routeTree.gen.ts (a codegen stand-in) registers
+# the '/' route so createFileRoute type-checks, and convex/ carries its own
+# tsconfig + _generated stubs — under projectService every linted TS file must
+# belong to a project. The tsc steps guard that the shipped tests/a11y.spec.ts
+# and the convex/ functions type-check with their devDeps installed.
 if [ "$profile" = "webapp" ] && [ -f eslint.config.js ]; then
     if have pnpm; then
         cp -R "$repo_root/tests/fixtures/web-app/." .
@@ -435,8 +435,11 @@ if [ "$profile" = "webapp" ] && [ -f eslint.config.js ]; then
         elif ! "$bin/tsc" --noEmit >/dev/null 2>&1; then
             "$bin/tsc" --noEmit || true
             err "web-app fixture: tsc --noEmit failed — the shipped tests/a11y.spec.ts must type-check with @playwright/test + @axe-core/playwright installed"
+        elif ! "$bin/tsc" -p convex --noEmit >/dev/null 2>&1; then
+            "$bin/tsc" -p convex --noEmit || true
+            err "web-app fixture: tsc -p convex --noEmit failed — the convex/ functions must type-check under their own tsconfig"
         else
-            echo "web-app: shipped ESLint + tsc type-check clean on a real React app"
+            echo "web-app: shipped ESLint + tsc type-check (root + convex) clean on a real React app"
         fi
     else
         required pnpm "web-app toolchain validation" || fail=1

--- a/template/.coderabbit.yaml.jinja
+++ b/template/.coderabbit.yaml.jinja
@@ -21,6 +21,11 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    # Also auto-review stacked PRs — ones whose base is a feature branch rather
+    # than main — so each slice of a PR stack gets reviewed before the stack
+    # starts merging. Regex list; the default branch is always included.
+    base_branches:
+      - "feat/.*"
     ignore_usernames:
       - renovate[bot]
       - dependabot[bot]

--- a/template/.github/workflows/[% if deploy_cloudflare_workers %]deploy-preview.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if deploy_cloudflare_workers %]deploy-preview.yml[% endif %].jinja
@@ -61,13 +61,13 @@ jobs:
       url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # renovate: datasource=node-version
           node-version: "24"
           cache: pnpm
-      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
           version: 3.51.1

--- a/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
@@ -104,13 +104,13 @@ jobs:
           # Tag from release-please on release runs; the dispatched ref on
           # manual runs.
           ref: ${{ needs.release-please.outputs.tag_name || github.ref }}
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # renovate: datasource=node-version
           node-version: "24"
           cache: pnpm
-      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
           version: 3.51.1

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 [% if use_node %]
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 [% endif %]
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -51,7 +51,7 @@ jobs:
 [% if include_terraform %]
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 [% endif %]
-      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
           version: 3.51.1
@@ -113,13 +113,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # renovate: datasource=node-version
           node-version: "24"
           cache: pnpm
-      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
           version: 3.51.1
@@ -159,7 +159,7 @@ jobs:
           # renovate: datasource=node-version
           node-version: "24"
 [% if use_node %]
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 [% endif %]
 [% if use_python %]
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -167,7 +167,7 @@ jobs:
           python-version: "3.14"
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 [% endif %]
-      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
           version: 3.51.1
@@ -202,13 +202,13 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # renovate: datasource=node-version
           node-version: "24"
           cache: pnpm
-      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
           version: 3.51.1
@@ -308,13 +308,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # renovate: datasource=node-version
           node-version: "24"
           cache: pnpm
-      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
           version: 3.51.1

--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -81,6 +81,16 @@ coverage/
 
 # Lighthouse CI output
 .lighthouseci/
+[% if deploy_cloudflare_workers or project_type == 'web-app' %]
+
+# Wrangler local state (Cloudflare Workers)
+.wrangler/
+[% endif %]
+[% if project_type == 'web-app' %]
+
+# Convex anonymous/local dev deployment state (npx convex dev)
+.convex/
+[% endif %]
 [% endif %]
 [% if use_python %]
 
@@ -134,3 +144,5 @@ ansible/*.retry
 .env.*
 **/.env.*
 .env/
+# ...but keep the committed example (documents required vars; contains no secrets).
+!/.env.example

--- a/template/.vscode/settings.json.jinja
+++ b/template/.vscode/settings.json.jinja
@@ -56,5 +56,6 @@
   },
   "search.smartCase": true,
   "terminal.integrated.defaultProfile.linux": "zsh",
-  "npm.packageManager": "[% if use_node %]pnpm[% else %]npm[% endif %]"
+  "npm.packageManager": "[% if use_node %]pnpm[% else %]npm[% endif %]",
+  "snyk.advanced.autoSelectOrganization": true
 }

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -82,6 +82,14 @@ Full reference: [docs/conventions.md](docs/conventions.md). Highlights:
   compiles and setup tasks are safe no-ops.
 - Indentation: 2 spaces default, 4 for Python/Terraform/Shell (`.editorconfig`).
 - Secrets never go in git; local env via 1Password (`op run` / `op inject`).
+- When generating or rotating secrets, keep secret values on stdin and use the
+  destination-only helpers:
+  `task secret:set:1p VAULT=... ITEM=... FIELD=... [SECTION=...]` for existing
+  1Password fields and `task secret:set:gh NAME=... REPO=owner/repo` for GitHub
+  repo secrets. Never pass secret values as command arguments, `--body` values,
+  exported env vars, or Taskfile vars. The hard rule above still applies:
+  agents must not run `secret:set:1p` or otherwise write to a password manager
+  without explicit user confirmation for that exact write.
 [% if include_terraform %]
 - Terraform: provider tokens are sensitive variables; use
   `lifecycle.ignore_changes` for mutable fields.

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -76,7 +76,7 @@ tasks:
     deps:
       - lint
 [% if use_node %]
-      - typecheck
+      - lint:typescript
 [% endif %]
 
   lint:
@@ -124,13 +124,20 @@ tasks:
     # lint:shell: CI and the pre-commit hook fail loudly instead of silently
     # mutating the tree (and, in CI, discarding the fix while reporting green).
     # Auto-fix lives in `task format` / `task format:file`.
+    # Prefer the repo-pinned markdownlint-cli2 (node_modules) so hooks/CI match
+    # the lockfile; fall back to npx for non-node repos and fresh scaffolds.
     desc: markdownlint-cli2 (check mode)
     cmds:
       - |
-        if [ -n "{{.CLI_ARGS}}" ]; then
-          npx --yes markdownlint-cli2 {{.CLI_ARGS}}
+        if [ -x node_modules/.bin/markdownlint-cli2 ]; then
+          run="pnpm exec markdownlint-cli2"
         else
-          npx --yes markdownlint-cli2 '**/*.md' '#.claude/**' '#specs/*/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' '#**/.terraform/**' '#**/.venv/**' '#**/.task/**'
+          run="npx --yes markdownlint-cli2"
+        fi
+        if [ -n "{{.CLI_ARGS}}" ]; then
+          $run {{.CLI_ARGS}}
+        else
+          $run '**/*.md' '#.claude/**' '#specs/*/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' '#**/.terraform/**' '#**/.venv/**' '#**/.task/**'
         fi
 
   lint:actions:
@@ -188,7 +195,10 @@ tasks:
           pnpm exec eslint {{.CLI_ARGS | default "."}}
         fi
 
-  typecheck:
+  lint:typescript:
+    # `lint:` group naming (a read-only gate like the other linters); the old
+    # bare name still works via the alias.
+    aliases: [typecheck]
     # Skip cleanly before the app + deps exist (fresh scaffold), like lint:eslint,
     # so `task check` / pre-push stay green — otherwise `astro check` prompts to
     # install @astrojs/check and hangs CI.
@@ -197,7 +207,7 @@ tasks:
     cmds:
       - |
         if [ ! -f package.json ] || [ ! -d node_modules ]; then
-          echo "typecheck: app/deps not set up yet -- skipping (scaffold Astro + pnpm install)"
+          echo "lint:typescript: app/deps not set up yet -- skipping (scaffold Astro + pnpm install)"
         else
           pnpm exec astro check
         fi
@@ -206,7 +216,11 @@ tasks:
     cmds:
       - |
         if [ ! -f package.json ] || [ ! -d node_modules ]; then
-          echo "typecheck: app/deps not set up yet -- skipping (pnpm install)"
+          echo "lint:typescript: app/deps not set up yet -- skipping (pnpm install)"
+        elif grep -q '"references"' tsconfig.json 2>/dev/null; then
+          # Solution-style root tsconfig (files: [] + project references): a plain
+          # `tsc --noEmit` against it type-checks NOTHING — build mode walks the refs.
+          pnpm exec tsc -b
         else
           pnpm exec tsc --noEmit
         fi
@@ -333,7 +347,14 @@ tasks:
     desc: Auto-format code
     cmds:
 [% if use_node %]
-      - npx --yes prettier --write .
+      # Repo-pinned prettier when installed (plugins in prettier.config.cjs need
+      # the local install anyway); npx fallback covers the fresh scaffold.
+      - |
+        if [ -x node_modules/.bin/prettier ]; then
+          pnpm exec prettier --write .
+        else
+          npx --yes prettier --write .
+        fi
 [% endif %]
 [% if use_python %]
       - uv run black .
@@ -347,7 +368,13 @@ tasks:
       # Best-effort: markdownlint --fix auto-fixes what it can but must NOT abort
       # `format` on un-auto-fixable rule violations (e.g. MD024 duplicate heading,
       # MD040 missing fence language) — `lint:markdown` (check-only) is the gate.
-      - npx --yes markdownlint-cli2 --fix '**/*.md' '#.claude/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' || true
+      - |
+        if [ -x node_modules/.bin/markdownlint-cli2 ]; then
+          run="pnpm exec markdownlint-cli2"
+        else
+          run="npx --yes markdownlint-cli2"
+        fi
+        $run --fix '**/*.md' '#.claude/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' || true
 
   format:file:
     desc: "Format a single file by extension (usage: task format:file -- <path>)"
@@ -358,7 +385,13 @@ tasks:
         [ -f "$f" ] || exit 0
         case "$f" in
 [% if use_node %]
-        *.js | *.jsx | *.ts | *.tsx | *.json | *.css | *.astro) npx --yes prettier --write "$f" ;;
+        *.js | *.jsx | *.ts | *.tsx | *.json | *.css | *.astro)
+          if [ -x node_modules/.bin/prettier ]; then
+            pnpm exec prettier --write "$f"
+          else
+            npx --yes prettier --write "$f"
+          fi
+          ;;
 [% endif %]
 [% if use_python %]
         *.py) uv run black "$f" ;;
@@ -367,7 +400,13 @@ tasks:
         *.tf | *.tfvars) terraform fmt "$f" ;;
 [% endif %]
         *.sh | *.bash) shfmt -w "$f" ;;
-        *.md | *.mdx) npx --yes markdownlint-cli2 --fix "$f" || true ;;
+        *.md | *.mdx)
+          if [ -x node_modules/.bin/markdownlint-cli2 ]; then
+            pnpm exec markdownlint-cli2 --fix "$f" || true
+          else
+            npx --yes markdownlint-cli2 --fix "$f" || true
+          fi
+          ;;
         esac
 
   fix:
@@ -450,7 +489,15 @@ tasks:
 
   test:e2e:
     desc: Run Playwright end-to-end tests
+    # Local dev secrets (if any) come from .env.local; CI passes env via the
+    # workflow instead. A missing file is ignored.
+    dotenv:
+      - .env.local
     cmds:
+      # Fail closed: refuse to run e2e with production-capable credentials or
+      # targets in the environment. The guard fails until configured for this
+      # app's providers — see scripts/e2e-env-guard.sh.
+      - ./scripts/e2e-env-guard.sh
       - npx playwright test {{.CLI_ARGS}}
 
   test:e2e:screenshot:
@@ -530,6 +577,27 @@ tasks:
 [% else %]
       - snyk test --severity-threshold=high --show-vulnerable-paths=all
 [% endif %]
+
+  # ── Secrets ────────────────────────────────────────────────────
+  # Destination-only helpers: the secret value stays on stdin — never in argv,
+  # env vars, Taskfile vars, or shell history (see docs/conventions.md).
+  secret:set:1p:
+    desc: "Set an existing 1Password field from stdin (usage: command | task secret:set:1p VAULT=... ITEM=... FIELD=... [SECTION=...])"
+    env:
+      VAULT: '{{.VAULT | default ""}}'
+      ITEM: '{{.ITEM | default ""}}'
+      FIELD: '{{.FIELD | default ""}}'
+      SECTION: '{{.SECTION | default ""}}'
+    cmds:
+      - ./scripts/secret-set-1p.sh
+
+  secret:set:gh:
+    desc: "Set a GitHub repo secret from stdin (usage: command | task secret:set:gh NAME=... REPO=owner/repo)"
+    env:
+      NAME: '{{.NAME | default ""}}'
+      REPO: '{{.REPO | default ""}}'
+    cmds:
+      - ./scripts/secret-set-gh.sh
 
   # ── Setup ──────────────────────────────────────────────────────
   bootstrap:

--- a/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
@@ -41,8 +41,10 @@
       "dockerDashComposeVersion": "v2"
     },
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers-extra/features/go-task:1": {},
-    "ghcr.io/itsmechlark/features/1password:1.5.0": {}
+    // No 1Password CLI in the bot profile — this container must hold no path
+    // to production secrets (docs/guides/devcontainers.md). The human dev
+    // profile (.devcontainer/dev/) keeps its own op feature.
+    "ghcr.io/devcontainers-extra/features/go-task:1": {}
   },
   "mounts": [
     "source=claude-code-config-${localWorkspaceFolderBasename},target=/home/vscode/.claude,type=volume",

--- a/template/[% if project_type == 'web-app' %]eslint.config.js[% endif %]
+++ b/template/[% if project_type == 'web-app' %]eslint.config.js[% endif %]
@@ -1,28 +1,56 @@
 import js from '@eslint/js'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
-import react from 'eslint-plugin-react'
 import reactHooks from 'eslint-plugin-react-hooks'
 import router from '@tanstack/eslint-plugin-router'
 import convex from '@convex-dev/eslint-plugin'
+import prettier from 'eslint-config-prettier'
 
-export default [
-  // specs/*/ holds vendored design-handoff bundles (deleted at sign-off).
-  { ignores: ['**/dist/', '**/.output/', '**/.nitro/', 'convex/_generated/', 'specs/'] },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
-  { ...react.configs.flat.recommended, settings: { react: { version: 'detect' } } },
-  react.configs.flat['jsx-runtime'],
+// ESLint 10 flat config. ESLint 10 tracks JSX natively, so eslint-plugin-react
+// is dropped (it isn't v10-ready and is no longer needed for the jsx-runtime).
+// Type-aware linting (projectService) catches floating promises — which matter
+// with async backend APIs (e.g. Convex's ctx). eslint-config-prettier is last
+// so formatting rules never fight Prettier.
+export default tseslint.config(
   {
-    plugins: { 'react-hooks': reactHooks },
-    rules: reactHooks.configs['recommended-latest'].rules
+    // specs/*/ holds vendored design-handoff bundles (deleted at sign-off);
+    // routeTree.gen.ts + convex/_generated/ are generated (committed but not linted).
+    ignores: [
+      '**/dist/',
+      '**/.output/',
+      '**/.nitro/',
+      'convex/_generated/',
+      'src/routeTree.gen.ts',
+      'specs/'
+    ]
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname
+      }
+    }
   },
   // TanStack Router (route property order, param names) + Convex (args
   // validators, table-id types, query patterns). Drop a block if a given
   // web-app doesn't use that library.
   ...router.configs['flat/recommended'],
   ...convex.configs.recommended,
+  {
+    plugins: { 'react-hooks': reactHooks },
+    rules: reactHooks.configs['recommended-latest'].rules
+  },
   { languageOptions: { globals: { ...globals.node, ...globals.browser } } },
-  // CommonJS config files (e.g. prettier.config.cjs) legitimately use require().
-  { files: ['**/*.cjs'], rules: { '@typescript-eslint/no-require-imports': 'off' } }
-]
+  // Plain JS/CJS config files (eslint.config.js, prettier.config.cjs, etc.) are
+  // not part of a tsconfig — turn off type-aware rules for them.
+  {
+    files: ['**/*.{js,cjs,mjs}'],
+    extends: [tseslint.configs.disableTypeChecked]
+  },
+  // CommonJS config files legitimately use require().
+  { files: ['**/*.cjs'], rules: { '@typescript-eslint/no-require-imports': 'off' } },
+  prettier
+)

--- a/template/[% if use_node %].env.example[% endif %]
+++ b/template/[% if use_node %].env.example[% endif %]
@@ -1,0 +1,7 @@
+# Required environment variables — names and placeholders only, never real
+# values. Copy to .env.local (gitignored) and fill in; secrets come from
+# 1Password (`op run` / `op inject`). This file is the one committed exception
+# to the .env* ignore (see .gitignore's `!/.env.example`).
+#
+# TODO: document this app's variables as they appear, e.g.:
+# VITE_PUBLIC_API_URL=http://localhost:3000

--- a/template/[% if use_node %].prettierignore[% endif %]
+++ b/template/[% if use_node %].prettierignore[% endif %]
@@ -16,6 +16,11 @@
 .claude/
 node_modules/
 dist/
+# Generated (committed but tool-owned): TanStack route tree + Convex codegen.
+src/routeTree.gen.ts
+convex/_generated/
+# Convex local dev runtime state
+.convex/
 .task/
 .worktrees/
 .terraform/

--- a/template/[% if use_node %]pnpm-workspace.yaml[% endif %].jinja
+++ b/template/[% if use_node %]pnpm-workspace.yaml[% endif %].jinja
@@ -25,3 +25,10 @@ allowBuilds:
 # the patched line until they catch up.
 overrides:
   esbuild: '>=0.28.1'
+
+# pnpm 11 defaults minimumReleaseAge to 1440 (1 day) — freshly published
+# versions won't resolve until they age. To install a pinned release younger
+# than that, add version-pinned entries here (they become harmless no-ops once
+# the version ages past the cooldown):
+# minimumReleaseAgeExclude:
+#   - some-package@1.2.3

--- a/template/[% if use_node %]pnpm-workspace.yaml[% endif %].jinja
+++ b/template/[% if use_node %]pnpm-workspace.yaml[% endif %].jinja
@@ -5,7 +5,15 @@
 # package.json `pnpm` field — pnpm 10+ ignores that).
 allowBuilds:
   esbuild: true
+[% if project_type == 'web-app' %]
+  # sharp is an optional transitive dep of tooling (e.g. wrangler) that web-app
+  # code never imports; its from-source build fails on current Node and is
+  # unnecessary (prebuilt binaries ship as optional deps). Explicit false =
+  # "do not run its build script".
+  sharp: false
+[% else %]
   sharp: true
+[% endif %]
 [% if deploy_cloudflare_workers %]
   # workerd (the Cloudflare Workers runtime) is pulled in by wrangler at deploy
   # time; approve its build or `wrangler deploy` fails ERR_PNPM_IGNORED_BUILDS.

--- a/template/[% if use_node %]prettier.config.cjs[% endif %].jinja
+++ b/template/[% if use_node %]prettier.config.cjs[% endif %].jinja
@@ -7,6 +7,12 @@ module.exports = {
   trailingComma: 'none',
   semi: false,
   printWidth: 100,
+[% if project_type == 'web-app' %]
+  // Required for prettier-plugin-tailwindcss on Tailwind v4 (no tailwind.config
+  // file to discover). Uncomment once the app's main stylesheet exists — the
+  // plugin hard-fails (ENOENT) if the path doesn't exist yet. See docs/CHECKLIST.md.
+  // tailwindStylesheet: './src/styles/globals.css',
+[% endif %]
   // pluginSearchDirs: [__dirname],
 [% if project_type == 'web-astro' %]
   plugins: [

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -169,22 +169,44 @@ config, toolchain, devcontainer, and dev environment — against the items below
 [% elif project_type == 'web-app' %]
 - [ ] Scaffold the app: `pnpm create @tanstack/start@latest` (TanStack Start) or vite + react
 - [ ] Add the standard stack: Tailwind v4, shadcn/ui, zod, vitest, lucide
-- [ ] Move lint tooling into devDependencies and switch Taskfile `npx --yes` calls to `pnpm exec`
-- [ ] Install the shipped `eslint.config.js`'s plugins (ESLint 9 — eslint-plugin-react
-      isn't ESLint 10-ready yet): `pnpm add -D eslint@9 @eslint/js@9 typescript-eslint
-      eslint-plugin-react eslint-plugin-react-hooks globals @tanstack/eslint-plugin-router
-      @convex-dev/eslint-plugin` (drop the TanStack Router / Convex plugins if a given app doesn't use them)
-- [ ] (optional) Type-aware async safety: add `@typescript-eslint/no-floating-promises`
-      and `no-misused-promises` to `eslint.config.js`, scoped to `src/**` with
-      `languageOptions.parserOptions.projectService: true`, to catch a missing
-      `await` / floating promise that `tsc` won't. Makes ESLint type-check
-      (slower) and needs your tsconfig wired up — skip to keep lint instant.
+- [ ] Move lint tooling into devDependencies (`pnpm add -D prettier
+      prettier-config-standard prettier-plugin-tailwindcss markdownlint-cli2`) —
+      the Taskfile auto-prefers the repo-pinned `node_modules` bins over
+      `npx --yes` once they're installed
+- [ ] Install the shipped `eslint.config.js`'s plugins (ESLint 10; no
+      eslint-plugin-react — ESLint 10 tracks JSX natively): `pnpm add -D eslint
+      @eslint/js typescript-eslint eslint-config-prettier eslint-plugin-react-hooks
+      globals @tanstack/eslint-plugin-router @convex-dev/eslint-plugin` (drop the
+      TanStack Router / Convex plugins if a given app doesn't use them)
+- [ ] The shipped config runs **type-aware linting** (`projectService`), so every
+      linted `.ts`/`.tsx` file must belong to a tsconfig project: give `convex/`
+      its own `convex/tsconfig.json` (Convex runtime: `"types": []`, exclude
+      `./_generated`) and keep generated files (`src/routeTree.gen.ts`,
+      `convex/_generated/`) in the config's `ignores` — commit them, never lint
+      them. Directories of one-off scripts either get a tsconfig or an
+      `ignores` entry.
+- [ ] If the root `tsconfig.json` becomes solution-style (`files: []` +
+      `references`), nothing to do — `task lint:typescript` detects it and runs
+      `tsc -b` instead of `tsc --noEmit` (which would silently check nothing).
+- [ ] Tailwind v4 has no `tailwind.config`: once the main stylesheet exists
+      (e.g. `src/styles/globals.css`), uncomment `tailwindStylesheet` in
+      `prettier.config.cjs` so prettier-plugin-tailwindcss can sort classes
+      (it hard-fails if the path doesn't exist yet)
+- [ ] Vitest: split `vitest.config.ts` into **projects** when the backend needs
+      a different runtime — e.g. a `react` project (jsdom, `src/**/*.test.{ts,tsx}`)
+      and a `convex` project (edge-runtime + `convex-test`, `convex/**/*.test.ts`,
+      no deployment needed). `task test` picks the config up automatically.
 - [ ] Put pnpm `overrides` / `auditConfig` / `allowBuilds` in
       `pnpm-workspace.yaml`, **not** the `package.json` `pnpm` field — pnpm 10+
       ignores that field. Approve blocked build scripts (e.g. vite's `esbuild`,
       and `workerd` if deploying to Cloudflare Workers — else `wrangler deploy`
       fails `ERR_PNPM_IGNORED_BUILDS`) via `allowBuilds` (pnpm 11+; the shipped
       `pnpm-workspace.yaml` uses it) or `pnpm approve-builds`
+- [ ] When adding Playwright e2e: configure `scripts/e2e-env-guard.sh` with this
+      app's auth providers, deploy credentials, and production domains —
+      `task test:e2e` runs it first and it **fails until configured** (fail
+      closed; see the script header). Document required env vars in
+      `.env.example` (names only, never values).
 - [ ] Accessibility (axe-core): `pnpm add -D @axe-core/playwright`, then add a
       `playwright.config.ts` with a `webServer` (starts the app) + `baseURL` so
       `tests/a11y.spec.ts` can run. `task test:a11y` skips until that config

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -97,6 +97,12 @@ it points here.
 
 - Local env comes from **1Password** (`op run` / `op inject`); CI reads GitHub
   Actions secrets. `gitleaks` runs on pre-push and in CI.
+- When generating or rotating secrets, keep the value **on stdin** and use the
+  destination-only helpers: `task secret:set:1p VAULT=… ITEM=… FIELD=…
+  [SECTION=…]` for existing 1Password fields, `task secret:set:gh NAME=…
+  REPO=owner/repo` for GitHub repo secrets. Never pass secret values as command
+  arguments, `--body` values, exported env vars, or Taskfile vars — they end up
+  in shell history and process listings.
 
 ## Docs & AI steering
 

--- a/template/lefthook.yml.jinja
+++ b/template/lefthook.yml.jinja
@@ -32,7 +32,7 @@ pre-commit:
       run: task lint:eslint -- {staged_files}
     typecheck:
       glob: "*.{ts,tsx,astro}"
-      run: task typecheck
+      run: task lint:typescript
 [% endif %]
     yaml:
       glob: "*.{yml,yaml}"
@@ -77,7 +77,7 @@ pre-push:
 [% endif %]
 [% if use_node %]
     typecheck:
-      run: task typecheck
+      run: task lint:typescript
 [% endif %]
 [% if include_terraform %]
     terraform-validate:

--- a/template/scripts/[% if use_node %]e2e-env-guard.sh[% endif %]
+++ b/template/scripts/[% if use_node %]e2e-env-guard.sh[% endif %]
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Fail-closed environment guard for the e2e suite: refuse to run when any
+# production-capable credential or target is present in the environment.
+# `task test:e2e` runs this before Playwright, loading .env.local first.
+#
+# CONFIGURE ME (when the app grows an e2e suite): replace the TODO examples
+# below with this app's real auth providers, deploy credentials, and production
+# domains, then delete the "not configured" failure at the end. The guard must
+# fail closed — when in doubt, refuse to run. Reference implementation: the
+# omator repo's scripts/e2e-env-guard.sh.
+set -euo pipefail
+
+fail() {
+    echo "e2e-env-guard: $*" >&2
+    echo "e2e-env-guard: refusing to run" >&2
+    exit 1
+}
+
+# ── 1. Auth-provider keys must be test/dev-instance keys ──────────────
+# TODO example (Clerk): only sk_test_/pk_test_ keys may ever be present.
+# for var in CLERK_SECRET_KEY CLERK_SECRET_KEY_TEST; do
+#     val="${!var:-}"
+#     if [ -n "$val" ] && [[ "$val" != sk_test_* ]]; then
+#         fail "$var is not an sk_test_ key — live keys are forbidden in e2e environments"
+#     fi
+# done
+
+# ── 2. Production domains are never a valid e2e target ────────────────
+# TODO: list this app's production domains (a post-deploy smoke test against
+# prod belongs in a separate task, not the e2e suite).
+# if [ -n "${PLAYWRIGHT_BASE_URL:-}" ]; then
+#     host="$(printf '%s' "$PLAYWRIGHT_BASE_URL" | sed -E 's|^[a-z]+://([^/:]+).*|\1|')"
+#     case "$host" in
+#     example.com | *.example.com)
+#         fail "PLAYWRIGHT_BASE_URL targets a production domain ($host)"
+#         ;;
+#     esac
+# fi
+
+# ── 3. Provider/deploy credentials must never be present for e2e ──────
+# They belong in CI secrets or the backend's env store — never in an
+# environment that runs browser tests.
+# for var in CLOUDFLARE_API_TOKEN STRIPE_SECRET_KEY STRIPE_WEBHOOK_SECRET; do
+#     if [ -n "${!var:-}" ]; then
+#         fail "$var must never be present for e2e (it belongs in CI secrets)"
+#     fi
+# done
+
+# Fail closed until the checks above are configured for this app.
+fail "not configured yet — add this app's provider/domain checks above, then remove this line (see the header comment)"
+
+# echo "e2e-env-guard: OK — no production-capable credentials detected"

--- a/template/scripts/devcontainer-assert.sh
+++ b/template/scripts/devcontainer-assert.sh
@@ -116,11 +116,12 @@ assert_unit() {
 }
 
 # assert_config_invariants <repo_root> <config> <profile>
-# bot: NO tailscale feature, NO /dev/net/tun runArg, NO TS_AUTHKEY in
-#      initializeCommand. dev: all three present.
+# bot: NO tailscale feature, NO 1Password CLI feature, NO /dev/net/tun runArg,
+#      NO TS_AUTHKEY in initializeCommand — the bot container must hold no path
+#      to production secrets or the tailnet. dev: all four present.
 assert_config_invariants() {
     local repo_root="$1" config="$2" profile="$3"
-    local cfg has_ts_feature has_tun has_ts_init
+    local cfg has_ts_feature has_op_feature has_tun has_ts_init
 
     cfg="$(npx -y @devcontainers/cli read-configuration \
         --workspace-folder "$repo_root" \
@@ -129,6 +130,8 @@ assert_config_invariants() {
 
     has_ts_feature="$(printf '%s' "$cfg" |
         jq -r '[.configuration.features // {} | keys[] | select(test("tailscale";"i"))] | length')"
+    has_op_feature="$(printf '%s' "$cfg" |
+        jq -r '[.configuration.features // {} | keys[] | select(test("1password";"i"))] | length')"
     has_tun="$(printf '%s' "$cfg" |
         jq -r '[.configuration.runArgs // [] | .[] | select(test("/dev/net/tun"))] | length')"
     has_ts_init="$(printf '%s' "$cfg" |
@@ -136,10 +139,12 @@ assert_config_invariants() {
 
     if [ "$profile" = "bot" ]; then
         [ "$has_ts_feature" = "0" ] || fail "bot config has a tailscale feature"
+        [ "$has_op_feature" = "0" ] || fail "bot config has a 1Password CLI feature (no secret-store path in the bot container)"
         [ "$has_tun" = "0" ] || fail "bot config requests /dev/net/tun"
         [ "$has_ts_init" = "0" ] || fail "bot config references TS_AUTHKEY in initializeCommand"
     else
         [ "$has_ts_feature" != "0" ] || fail "dev config is missing the tailscale feature"
+        [ "$has_op_feature" != "0" ] || fail "dev config is missing the 1Password CLI feature"
         [ "$has_tun" != "0" ] || fail "dev config is missing the /dev/net/tun device"
         [ "$has_ts_init" = "1" ] || fail "dev config does not reference TS_AUTHKEY in initializeCommand"
     fi

--- a/template/scripts/lint-hygiene.sh
+++ b/template/scripts/lint-hygiene.sh
@@ -115,11 +115,11 @@ for f in "${files[@]}"; do
     # --- JSON syntax check ---
     case "$f" in
     *.json)
-        # Skip JSONC files (devcontainer.json, tsconfig*.json — TypeScript
-        # officially allows comments) and anything jinja-templated. tsc -b
-        # validates the tsconfigs loudly, so hygiene needn't parse them as JSON.
+        # Skip JSONC files (devcontainer.json, tsconfig*.json at any depth —
+        # TypeScript officially allows comments) and anything jinja-templated.
+        # tsc -b validates the tsconfigs loudly, so hygiene needn't parse them.
         case "$f" in
-        *devcontainer.json | */tsconfig.json | tsconfig.json | tsconfig.*.json | template/*) ;;
+        *devcontainer.json | tsconfig*.json | */tsconfig*.json | template/*) ;;
         *)
             if ! python3 -c "import json; json.load(open('$f'))" 2>/dev/null; then
                 warn "$f: invalid JSON"

--- a/template/scripts/lint-hygiene.sh
+++ b/template/scripts/lint-hygiene.sh
@@ -115,9 +115,11 @@ for f in "${files[@]}"; do
     # --- JSON syntax check ---
     case "$f" in
     *.json)
-        # Skip devcontainer.json (JSONC) and anything jinja-templated
+        # Skip JSONC files (devcontainer.json, tsconfig*.json — TypeScript
+        # officially allows comments) and anything jinja-templated. tsc -b
+        # validates the tsconfigs loudly, so hygiene needn't parse them as JSON.
         case "$f" in
-        *devcontainer.json | template/*) ;;
+        *devcontainer.json | */tsconfig.json | tsconfig.json | tsconfig.*.json | template/*) ;;
         *)
             if ! python3 -c "import json; json.load(open('$f'))" 2>/dev/null; then
                 warn "$f: invalid JSON"

--- a/template/scripts/secret-set-1p.sh
+++ b/template/scripts/secret-set-1p.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Update an existing 1Password item field from stdin without passing the secret
+# in shell history, environment variables, or process arguments.
+set -euo pipefail
+
+fail() {
+    echo "secret:set:1p: $*" >&2
+    exit 1
+}
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage:
+  secret-producing-command | task secret:set:1p VAULT=<vault> ITEM=<item> FIELD=<field> [SECTION=<section>]
+
+The secret is read from stdin. VAULT, ITEM, FIELD, and optional SECTION identify
+an existing 1Password field to update; the field is not created automatically.
+USAGE
+}
+
+vault="${VAULT:-}"
+item="${ITEM:-}"
+field="${FIELD:-}"
+section="${SECTION:-}"
+
+if [ -z "$vault" ] || [ -z "$item" ] || [ -z "$field" ]; then
+    usage
+    fail "VAULT, ITEM, and FIELD are required"
+fi
+
+if [ -t 0 ]; then
+    usage
+    fail "secret must be piped on stdin"
+fi
+
+command -v op >/dev/null 2>&1 || fail "op CLI is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+
+# Keep the caller's stdin available to jq as a raw file while jq reads the
+# 1Password item JSON from the pipeline.
+exec 3<&0
+
+op item get "$item" --vault "$vault" --format json --reveal |
+    jq \
+        --arg field "$field" \
+        --arg section "$section" \
+        --rawfile secret /dev/fd/3 \
+        '
+        def secret_value:
+          $secret | sub("\r?\n$"; "");
+
+        def field_matches:
+          .label == $field
+          and (
+            ($section | length) == 0
+            or (((.section? // {}) | .label? // "") == $section)
+          );
+
+        (secret_value) as $value
+        | if ($value | length) == 0 then
+            error("stdin secret is empty")
+          else
+            .
+          end
+        | ([.fields[] | select(field_matches)] | length) as $match_count
+        | if $match_count == 0 then
+            error("no matching 1Password field")
+          elif $match_count > 1 then
+            error("multiple matching 1Password fields; set SECTION")
+          else
+            (.fields[] |= if field_matches then .value = $value else . end)
+          end
+        ' |
+    op item edit "$item" --vault "$vault" >/dev/null
+
+echo "Updated 1Password item '$item' field '$field'."

--- a/template/scripts/secret-set-gh.sh
+++ b/template/scripts/secret-set-gh.sh
@@ -32,13 +32,26 @@ if [ -t 0 ]; then
 fi
 
 command -v gh >/dev/null 2>&1 || fail "gh CLI is required"
-command -v perl >/dev/null 2>&1 || fail "perl is required"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required"
 
-perl -0777 -e '
-    my $secret = <STDIN>;
-    $secret =~ s/\r?\n\z//;
-    die "stdin secret is empty\n" if $secret eq "";
-    print $secret;
-' | gh secret set "$name" --repo "$repo" >/dev/null
+# Read + validate stdin BEFORE gh runs: in a plain pipeline, `gh secret set`
+# starts consuming stdin before the producer's empty-check can fail, so an
+# empty pipe could write an empty secret and only error afterwards. python3 is
+# already the scripts' one interpreter dependency (lint-hygiene.sh). The value
+# stays out of argv and the environment: command substitution + the printf
+# builtin never surface it in a process listing.
+secret="$(python3 -c '
+import sys
+data = sys.stdin.buffer.read()
+if data.endswith(b"\r\n"):
+    data = data[:-2]
+elif data.endswith(b"\n"):
+    data = data[:-1]
+if not data:
+    sys.exit("stdin secret is empty")
+sys.stdout.buffer.write(data)
+')" || fail "stdin secret is empty"
+
+printf '%s' "$secret" | gh secret set "$name" --repo "$repo" >/dev/null
 
 echo "Updated GitHub secret '$name' in '$repo'."

--- a/template/scripts/secret-set-gh.sh
+++ b/template/scripts/secret-set-gh.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Set a GitHub repository secret from stdin without passing the secret in shell
+# history, environment variables, or process arguments.
+set -euo pipefail
+
+fail() {
+    echo "secret:set:gh: $*" >&2
+    exit 1
+}
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage:
+  secret-producing-command | task secret:set:gh NAME=<secret-name> REPO=<owner/repo>
+
+The secret value is read from stdin. NAME and REPO identify the GitHub
+repository secret to create or update.
+USAGE
+}
+
+name="${NAME:-}"
+repo="${REPO:-}"
+
+if [ -z "$name" ] || [ -z "$repo" ]; then
+    usage
+    fail "NAME and REPO are required"
+fi
+
+if [ -t 0 ]; then
+    usage
+    fail "secret must be piped on stdin"
+fi
+
+command -v gh >/dev/null 2>&1 || fail "gh CLI is required"
+command -v perl >/dev/null 2>&1 || fail "perl is required"
+
+perl -0777 -e '
+    my $secret = <STDIN>;
+    $secret =~ s/\r?\n\z//;
+    die "stdin secret is empty\n" if $secret eq "";
+    print $secret;
+' | gh secret set "$name" --repo "$repo" >/dev/null
+
+echo "Updated GitHub secret '$name' in '$repo'."

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -32,4 +32,12 @@ else
     echo "    (skipped: brew not on PATH)"
 fi
 
+echo "==> secret helper tasks reject missing destination metadata"
+if printf '%s' 'dummy-secret' | task secret:set:1p >/dev/null 2>&1; then
+    fail "task secret:set:1p succeeded without destination metadata"
+fi
+if printf '%s' 'dummy-secret' | task secret:set:gh >/dev/null 2>&1; then
+    fail "task secret:set:gh succeeded without destination metadata"
+fi
+
 echo "==> task targets OK (compile + bootstrap idempotency)"

--- a/tests/fixtures/web-app/convex/_generated/server.d.ts
+++ b/tests/fixtures/web-app/convex/_generated/server.d.ts
@@ -1,0 +1,7 @@
+/* Minimal stand-in for Convex codegen output (convex/_generated/): real apps
+   commit the full generated .js + .d.ts and exclude the directory from lint.
+   This stub is just enough for the fixture's imports to resolve with types. */
+import { queryGeneric, mutationGeneric } from 'convex/server'
+
+export declare const query: typeof queryGeneric
+export declare const mutation: typeof mutationGeneric

--- a/tests/fixtures/web-app/convex/myFunctions.ts
+++ b/tests/fixtures/web-app/convex/myFunctions.ts
@@ -3,7 +3,5 @@ import { v } from 'convex/values'
 
 export const get = query({
   args: { id: v.string() },
-  handler: async (ctx, args) => {
-    return await ctx.db.get(args.id)
-  }
+  handler: (_ctx, args) => args.id
 })

--- a/tests/fixtures/web-app/convex/tsconfig.json
+++ b/tests/fixtures/web-app/convex/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "lib": ["ES2023", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    // Match Convex's runtime: don't auto-include @types/node (most of Node
+    // isn't available in Convex functions).
+    "types": [],
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  // _generated ships its own .js + .d.ts; imports still resolve, we just don't
+  // re-typecheck the generated files.
+  "exclude": ["./_generated"]
+}

--- a/tests/fixtures/web-app/package.json
+++ b/tests/fixtures/web-app/package.json
@@ -5,18 +5,20 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.10.0",
     "@convex-dev/eslint-plugin": "2.0.0",
-    "@eslint/js": "9.39.4",
+    "@eslint/js": "10.0.1",
     "@playwright/test": "^1.49.0",
     "@tanstack/eslint-plugin-router": "1.162.0",
+    "@tanstack/react-router": "1.170.17",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
-    "eslint": "9.39.4",
-    "eslint-plugin-react": "7.37.5",
+    "convex": "1.42.1",
+    "eslint": "10.6.0",
+    "eslint-config-prettier": "10.1.8",
     "eslint-plugin-react-hooks": "7.1.1",
     "globals": "17.7.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.62.0"
+    "typescript-eslint": "8.63.0"
   }
 }

--- a/tests/fixtures/web-app/src/routeTree.gen.ts
+++ b/tests/fixtures/web-app/src/routeTree.gen.ts
@@ -1,0 +1,33 @@
+/* eslint-disable */
+
+// @ts-nocheck
+
+// Minimal stand-in for TanStack Router codegen (src/routeTree.gen.ts): real
+// apps commit the generated file, exclude it from lint/format, and its module
+// augmentation is what makes `createFileRoute('/')` type-check. This fixture
+// copy registers just the '/' route so the fixture behaves like a real app.
+
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as IndexRouteImport } from './routes/index'
+
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+
+declare module '@tanstack/react-router' {
+  interface FileRoutesByPath {
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+  }
+}
+
+export const routeTree = rootRouteImport._addFileChildren({
+  IndexRoute,
+})

--- a/tests/fixtures/web-app/src/routes/__root.tsx
+++ b/tests/fixtures/web-app/src/routes/__root.tsx
@@ -1,0 +1,5 @@
+import { createRootRoute, Outlet } from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  component: () => <Outlet />
+})

--- a/tests/fixtures/web-app/tsconfig.json
+++ b/tests/fixtures/web-app/tsconfig.json
@@ -8,6 +8,5 @@
     "skipLibCheck": true,
     "noEmit": true
   },
-  "include": ["src", "tests"],
-  "exclude": ["src/routes"]
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
## Why

Omator is the first real `web-app` repo generated from this template (rendered at v3.21.1) and has ~7 weeks of production evolution on top of it. This PR is the retro: I re-rendered the template at HEAD with omator's exact copier answers, diffed the trees, attributed every drift hunk to "omator moved forward" vs "template moved forward" (v3.21.1 → v3.23.0 changes were excluded as noise), and upstreamed the forward drift that generalizes. Everything here is proven in omator; nothing is speculative.

## Adopted

### Security

- **Destination-only secret helpers** (`task secret:set:1p`, `task secret:set:gh` + `scripts/secret-set-{1p,gh}.sh`): the secret value stays on stdin — never argv, env vars, Taskfile vars, or shell history. Shipped to all project types (root + template twins, dogfood parity). `test-tasks.sh` now asserts both helpers reject when destination metadata is missing. Documented in `conventions.md` and `AGENTS.md` (with the existing "agents never write to a password manager unprompted" hard rule cross-referenced).
- **Bot devcontainer holds no path to production secrets**: the 1Password CLI feature is removed from the bot profile (root + template; the human `dev/` profile keeps it) — omator established this invariant for its e2e security model and it generalizes: the agent container should never be able to read a credential store. `devcontainer-assert.sh` now enforces it structurally (bot: no `1password` feature; dev: must have it), alongside the existing tailscale/`TS_AUTHKEY` invariants.
- **Fail-closed e2e env guard** (`scripts/e2e-env-guard.sh`, node types): `task test:e2e` now loads `.env.local` and runs the guard first. The shipped stub carries omator's proven check patterns (test-key prefixes, prod-domain rejection, forbidden provider credentials) as commented examples and **fails until configured** — you cannot start running e2e without deciding what production-capable looks like for your app. CHECKLIST wires it into the scaffold flow.
- **`.env.example` convention** (node types): committed, names-only env documentation with a `!/.env.example` gitignore escape hatch (everything else `.env*` stays ignored).

### Web-app toolchain

- **ESLint 10 + type-aware linting is now the shipped default** (`eslint.config.js` for `web-app`): `recommendedTypeChecked` + `projectService`, `eslint-plugin-react` dropped (not v10-ready; ESLint 10 tracks JSX natively — omator's answer to the blocker the old fixture comment documented), react-hooks kept, `eslint-config-prettier` last, typed rules disabled for plain `js/cjs/mjs` config files, and generated files (`src/routeTree.gen.ts`, `convex/_generated/`, `dist/`) ignored. The type-aware upgrade is what catches floating promises against async backend APIs (Convex ctx) — previously a manual opt-in note in the CHECKLIST.
- **The web-app fixture now mirrors a real app** so the shipped config is actually exercised under `projectService` (every linted TS file must belong to a tsconfig project): a `src/routeTree.gen.ts` codegen stand-in registers the `/` route so `createFileRoute` type-checks (the old fixture had to exclude `src/routes` from tsc entirely), and `convex/` carries its own runtime-accurate `tsconfig.json` (`"types": []`) + `_generated` stubs. `test-template.sh` (webapp profile) additionally runs `tsc -p convex --noEmit`. Fixture deps bumped to omator's proven versions (eslint 10.6.0, typescript-eslint 8.63.0, + `@tanstack/react-router`, `convex`, `eslint-config-prettier`).
- **`typecheck` → `lint:typescript`** (alias `typecheck` kept, so nothing breaks): `docs/conventions.md` already used `lint:typescript` in its `group:action` examples — the Taskfile just never matched its own convention. omator renamed it in practice; this converges template and reference repo. The task body is also now **solution-tsconfig aware**: if the root `tsconfig.json` has `references`, it runs `tsc -b` — a plain `tsc --noEmit` against a solution file type-checks *nothing* and reports green (the silent-false-green omator hit when it adopted project references).
- **Prefer repo-pinned bins over `npx --yes`** in `lint:markdown` / `format` / `format:file`: when `node_modules/.bin/<tool>` exists, run it via `pnpm exec` (lockfile-pinned, no on-demand latest download); fall back to npx for non-node repos and fresh scaffolds. This is omator's `pnpm exec` convention made scaffold-safe.
- **`pnpm-workspace.yaml`**: `sharp: false` for web-app (optional transitive dep of tooling that web-app code never imports; its from-source build fails on current Node — explicit false silences it). web-astro keeps `sharp: true` (Astro's image pipeline actually uses it).
- **Tailwind v4 class sorting**: `tailwindStylesheet` documented in `prettier.config.cjs` (web-app) as a commented line + CHECKLIST step — verified empirically that prettier-plugin-tailwindcss **hard-fails (ENOENT)** when the path doesn't exist, so it can't ship enabled on a pre-scaffold render.
- **Generated-file hygiene**: `.prettierignore` gets the "committed but tool-owned" block (`src/routeTree.gen.ts`, `convex/_generated/`, `.convex/`); `.gitignore` gets `.wrangler/` (CF or web-app) and `.convex/` (web-app); `lint-hygiene.sh` skips `tsconfig*.json` in its JSON-parse gate (JSONC is legal there; `tsc` validates them loudly anyway).

### CI/CD & repo automation

- **Renovate now manages action SHA pins in the template's `.jinja` workflows.** Root-cause fix for real rot found in the diff: the native `github-actions` manager can't parse `*.yml.jinja`, so shipped pins aged silently while root/omator pins moved (pnpm/action-setup was **two majors behind**: v4.3.0 vs v6.0.9). New regex manager (`uses: owner/repo@sha # vX.Y.Z`, `github-tags` datasource) + a grouping rule so these land in the "GitHub Actions" batch instead of "Devcontainer" (the claude-code-action ejection rule moved last so it still wins). One-time catch-up included: `pnpm/action-setup` → v6.0.9, `arduino/setup-task` → v3.0.0 (SHAs byte-verified against omator/root).
- **CodeRabbit reviews stacked PRs**: `auto_review.base_branches: ["feat/.*"]` so each slice of a PR stack gets reviewed before the stack merges.
- `.vscode/settings.json`: `snyk.advanced.autoSelectOrganization: true` (kills a recurring first-run prompt).

### Docs

- CHECKLIST web-app §3 rewritten to match reality: the stale "ESLint 9 because eslint-plugin-react" install line and the "optional type-aware linting" bullet are replaced by the new defaults; added omator-proven scaffold notes (convex tsconfig pattern, solution-tsconfig behavior, Vitest `projects` split for mixed runtimes, tailwindStylesheet activation, e2e-guard configuration, `.env.example`).

## Considered and NOT adopted (deliberately)

- **Convex deploy pipeline** (omator's `deploy.yml`, `preview.yml` per-PR full-stack previews, `deploy:convex*` tasks, post-deploy smoke job): omator is the only Convex repo and answered `deploy_cloudflare_workers: false`, then built its own deploy model. Templatizing a one-repo deploy pipeline is speculation; future *omator apps live in the same repo. Revisit if a second Convex repo appears.
- **`test:e2e:local` anonymous-sandbox flow + convex-codegen-sandbox guide**: Convex-specific operational docs; stays app-side.
- **Design-system gates** (`lint:design`, contrast/off-palette/brand-asset scripts, brand screenshot projects): per-brand tooling coupled to omator's token system, not a repo convention.
- **omator's extra per-project typecheck list** (`tsc -p convex/workers/tests-e2e`): app-specific project layout; the CHECKLIST documents the pattern instead of the Taskfile hardcoding paths.
- **`validate` as `wrangler deploy --dry-run`**: coupled to omator's CF-assets deploy model (which it built outside the template's CF support).
- **omator's `minimumReleaseAgeExclude` entries in `pnpm-workspace.yaml`**: version-pinned operational state, not a convention. Root cause understood: **pnpm 11 defaults `minimumReleaseAge` to 1 day**, and typescript-eslint 8.63.0 was younger than that when omator adopted typed linting — the excludes carved it out of the default cooldown. They're vestigial now that the version has aged (omator can drop them whenever). The shipped `pnpm-workspace.yaml` now documents the pattern in a comment so the next repo doesn't have to rediscover it.
- **`screenshots/` gitignore, project-scoped Playwright invocation, shortened CodeRabbit tone line**: app-local.

## Follow-ups (not this PR)

- **omator should `copier update`** (v3.21.1 → next release): it's missing skills-sync, the a11y job/task, the fresh-scaffold build guard, and after this PR would reconcile the shared files cleanly (its local versions of most of these hunks are what's being upstreamed, so the three-way merge should be quiet).
- **harmon-devkit `standards-catalog.md` §2.3 (web-app)** should be updated to mention: secret helpers, e2e env guard, ESLint 10 typed linting, `lint:typescript`, bot-container 1Password invariant — then `task ai:sync-skills` re-vendored here. (Vendored skill copy deliberately untouched in this PR; canonical lives in harmon-devkit.)
- **omator cleanup (optional)**: its `minimumReleaseAgeExclude` list (typescript-eslint@8.63.0 set) is now vestigial — it excluded those versions from pnpm 11's default 1-day release-age cooldown at scaffold time, and the versions have long since aged past it. Safe to delete.

## Verification

- `task verify` (full local gate): check + build + validate + test:tasks + test:dogfood-parity (58 verbatim twins identical) + test:hooks + the full `test:template:*` matrix (minimal / web / webapp / iac / full / meta / update), including the webapp fixture toolchain run — shipped ESLint 10 config + `tsc --noEmit` + `tsc -p convex --noEmit` clean on the realistic fixture.
- `prettier-plugin-tailwindcss` missing-stylesheet behavior verified empirically (hard ENOENT crash → shipped commented).
- New/changed shell ships shellcheck/shfmt-clean in renders; renovate.json parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
