### PR TITLE
chore: configure devcontainer related repos

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,11 @@
 {
   "permissions": {
+    "additionalDirectories": [
+      "../harmon-devkit",
+      "../harmon-dotfiles",
+      "../harmon-ops",
+      "../evanharmon-site"
+    ],
     "allow": [
       "Bash(task:*)",
       "Bash(git status:*)",
@@ -16,5 +22,15 @@
       "Bash(git push -f:*)",
       "Bash(git push --force:*)"
     ]
+  },
+  "sandbox": {
+    "filesystem": {
+      "allowRead": [
+        "../harmon-devkit",
+        "../harmon-dotfiles",
+        "../harmon-ops",
+        "../evanharmon-site"
+      ]
+    }
   }
 }

--- a/.devcontainer/related-repos.txt
+++ b/.devcontainer/related-repos.txt
@@ -18,6 +18,9 @@
 # tools) AND sandbox.filesystem.allowRead (the Bash sandbox). See
 # docs/guides/devcontainers.md.
 #
-# Examples — uncomment and edit:
-#   your-org/shared-libs
-#   your-org/api@main
+# Harmon platform sibling repositories. These are cloned into /workspaces/
+# alongside harmon-init when the devcontainer is created.
+https://github.com/evanharmon1/harmon-devkit
+https://github.com/evanharmon1/harmon-dotfiles
+https://github.com/evanharmon1/harmon-ops
+https://github.com/evanharmon1/evanharmon-site

--- a/scripts/test-dogfood-parity.sh
+++ b/scripts/test-dogfood-parity.sh
@@ -14,7 +14,10 @@ cd "$(dirname "$0")/.."
 # Intentional root-only divergences (the template copy is what consumers get):
 #   .yamllint — root adds the template/ exclusion (jinja YAML is not valid YAML
 #               until rendered) and trims artifact dirs harmon-init never makes.
-ALLOW_DIVERGE=".yamllint"
+#   .devcontainer/related-repos.txt and .claude/settings.json — harmon-init's
+#               curated sibling-repo list and Claude read permissions; generated
+#               repositories begin with an empty, consumer-owned list instead.
+ALLOW_DIVERGE=".yamllint .devcontainer/related-repos.txt .claude/settings.json"
 
 fail=0
 checked=0


### PR DESCRIPTION
## Description

Configures harmon-init's existing devcontainer related-repository manifest to clone harmon-devkit, harmon-dotfiles, harmon-ops, and evanharmon-site. Grants Claude project and Bash-sandbox read access to those cloned siblings while retaining the template's empty consumer-owned default.

## Type of change

- [x] Task / chore (maintenance, tooling, no product change)

## How Has This Been Tested?

- [x] `task test:dogfood-parity`
- [x] `task check`
- [x] Pre-push: `task verify:skills:offline`, `task security:secrets`, and `task test:template:minimal`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes