### PR TITLE
fix(template): review-findings batch — checkout hardening, secret-helper guards, a11y 2.2 tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # renovate: datasource=node-version
@@ -73,6 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           fetch-depth: 0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -106,6 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           fetch-depth: 0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,25 +39,35 @@ jobs:
         run: |
           # renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.+)$
           SHELLCHECK_VERSION=0.10.0
-          curl -sSL -o /tmp/shellcheck.tar.xz \
+          curl -fsSL --retry 3 -o /tmp/shellcheck.tar.xz \
             "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
           tar -xJf /tmp/shellcheck.tar.xz -C /tmp
           sudo install -m 0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
           # renovate: datasource=github-releases depName=mvdan/sh extractVersion=^v?(?<version>.+)$
           SHFMT_VERSION=3.13.1
-          sudo curl -sSL -o /usr/local/bin/shfmt \
+          # Raw-binary download: fail closed on a checksum mismatch (a version
+          # bump must update the pinned hash). Archive downloads (shellcheck,
+          # actionlint) already fail loudly at extract time on corruption; a
+          # hash-pinned toolchain image is the follow-on refactor.
+          SHFMT_SHA256=fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1
+          curl -fsSL --retry 3 -o /tmp/shfmt \
             "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
-          sudo chmod +x /usr/local/bin/shfmt
+          echo "${SHFMT_SHA256}  /tmp/shfmt" | sha256sum -c -
+          sudo install -m 0755 /tmp/shfmt /usr/local/bin/shfmt
           # renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v?(?<version>.+)$
           ACTIONLINT_VERSION=1.7.12
-          curl -sSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+          curl -fsSL --retry 3 "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
             | tar -xz -C /tmp actionlint
           sudo mv /tmp/actionlint /usr/local/bin/
           # renovate: datasource=github-releases depName=mikefarah/yq extractVersion=^v?(?<version>.+)$
           YQ_VERSION=4.44.3
-          sudo curl -sSL -o /usr/local/bin/yq \
+          # Raw-binary download: fail closed on a checksum mismatch (a version
+          # bump must update the pinned hash).
+          YQ_SHA256=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7
+          curl -fsSL --retry 3 -o /tmp/yq \
             "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
-          sudo chmod +x /usr/local/bin/yq
+          echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
+          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
           pip install yamllint
       - run: task check
       - run: task test:tasks

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -64,6 +64,10 @@ jobs:
             echo "::error::$SENDER is not authorized"
             exit 1
           fi
+      # Exception to the repo-wide `persist-credentials: false` hardening:
+      # this checkout deliberately persists the short-lived CI App token so
+      # Claude's `git push` of the working branch can authenticate. The token
+      # is least-privilege (minted above) and expires with the job.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0

--- a/.github/workflows/claude-plan.yml
+++ b/.github/workflows/claude-plan.yml
@@ -62,6 +62,8 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1.0.148
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -61,6 +61,8 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1.0.148
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -40,6 +40,8 @@ jobs:
             image_name: ghcr.io/evanharmon1/harmon-init-devcontainer-dev
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # renovate: datasource=node-version

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -106,15 +106,12 @@ tasks:
     # Check-only (no --fix) so this is a read-only gate like lint:prettier /
     # lint:shell: CI and the pre-commit hook fail loudly instead of silently
     # mutating the tree (and, in CI, discarding the fix while reporting green).
-    # Auto-fix lives in `task format` / `task format:file`.
+    # Auto-fix lives in `task format` / `task format:file`. The bin-vs-npx
+    # dispatch + default glob set (template/ excluded — jinja markdown) live in
+    # scripts/markdownlint.sh.
     desc: markdownlint-cli2, check mode (template/ excluded — jinja markdown)
     cmds:
-      - |
-        if [ -n "{{.CLI_ARGS}}" ]; then
-          npx --yes markdownlint-cli2 {{.CLI_ARGS}}
-        else
-          npx --yes markdownlint-cli2 '**/*.md' '#template/**' '#.claude/**' '#**/node_modules/**' '#.worktrees/**'
-        fi
+      - ./scripts/markdownlint.sh check {{.CLI_ARGS}}
 
   lint:actions:
     desc: actionlint on GitHub workflows
@@ -156,10 +153,10 @@ tasks:
       - |
         files=$(git ls-files '*.sh' '*.bash')
         [ -n "$files" ] && shfmt -w $files || true
-      # Best-effort: markdownlint --fix auto-fixes what it can but must NOT abort
-      # `format` on un-auto-fixable rule violations (e.g. MD024 duplicate heading,
-      # MD040 missing fence language) — `lint:markdown` (check-only) is the gate.
-      - npx --yes markdownlint-cli2 --fix '**/*.md' '#template/**' '#.claude/**' '#**/node_modules/**' '#.worktrees/**' || true
+      # Best-effort markdown auto-fix (bin-vs-npx dispatch + default globs in the
+      # helper; template/ excluded — jinja markdown); must NOT abort `format` on
+      # un-auto-fixable rule violations — `lint:markdown` (check-only) is the gate.
+      - ./scripts/markdownlint.sh fix
 
   format:file:
     desc: "Format a single file by extension (usage: task format:file -- <path>)"
@@ -170,7 +167,7 @@ tasks:
         [ -f "$f" ] || exit 0
         case "$f" in
         *.sh | *.bash) shfmt -w "$f" ;;
-        *.md | *.mdx) npx --yes markdownlint-cli2 --fix "$f" || true ;;
+        *.md | *.mdx) ./scripts/markdownlint.sh fix "$f" ;;
         esac
 
   fix:

--- a/scripts/lint-hygiene.sh
+++ b/scripts/lint-hygiene.sh
@@ -118,8 +118,12 @@ for f in "${files[@]}"; do
         # Skip JSONC files (devcontainer.json, tsconfig*.json at any depth —
         # TypeScript officially allows comments) and anything jinja-templated.
         # tsc -b validates the tsconfigs loudly, so hygiene needn't parse them.
+        # Match only conventional devcontainer filenames (devcontainer.json or
+        # .devcontainer.json, at the root or in a directory) — a suffix glob
+        # like *devcontainer.json would exempt e.g. mydevcontainer.json too.
         case "$f" in
-        *devcontainer.json | tsconfig*.json | */tsconfig*.json | template/*) ;;
+        devcontainer.json | */devcontainer.json | .devcontainer.json | */.devcontainer.json | \
+            tsconfig*.json | */tsconfig*.json | template/*) ;;
         *)
             if ! python3 -c "import json; json.load(open('$f'))" 2>/dev/null; then
                 warn "$f: invalid JSON"

--- a/scripts/markdownlint.sh
+++ b/scripts/markdownlint.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# markdownlint.sh — resolve markdownlint-cli2 and run it in check or fix mode.
+#
+# Prefer the repo-pinned binary (node_modules/.bin) so hooks/CI match the
+# lockfile; fall back to npx for non-node repos and fresh scaffolds. Invoking
+# the .bin shim directly is package-manager-agnostic (works under npm too,
+# where `pnpm exec` would break). Keeps this bin-vs-npx dispatch out of the
+# Taskfile per the "keep cmds trivial; non-trivial shell lives in scripts/*.sh"
+# rule.
+#
+# Usage:
+#   markdownlint.sh check [glob-or-file ...]   # read-only gate
+#   markdownlint.sh fix   [glob-or-file ...]   # best-effort auto-fix
+# With no glob/file args, a canonical repo-wide default set is used.
+set -euo pipefail
+
+mode="${1:-check}"
+if [ "$#" -gt 0 ]; then shift; fi
+
+# Canonical excludes: generated output (dist, .task, .terraform, .venv,
+# node_modules), vendored skills (.claude), scratch worktrees, spec fixtures,
+# and the template/ tree (jinja markdown — present only in the template repo
+# itself, an inert glob everywhere else).
+default_globs=(
+    '**/*.md'
+    '#template/**'
+    '#.claude/**'
+    '#specs/*/**'
+    '#**/node_modules/**'
+    '#dist/**'
+    '#.worktrees/**'
+    '#**/.terraform/**'
+    '#**/.venv/**'
+    '#**/.task/**'
+)
+
+if [ -x node_modules/.bin/markdownlint-cli2 ]; then
+    run=(node_modules/.bin/markdownlint-cli2)
+else
+    run=(npx --yes markdownlint-cli2)
+fi
+
+if [ "$#" -eq 0 ]; then
+    set -- "${default_globs[@]}"
+fi
+
+case "$mode" in
+check)
+    "${run[@]}" "$@"
+    ;;
+fix)
+    # Best-effort: --fix must not abort `task format` on un-auto-fixable rule
+    # violations (e.g. MD024 duplicate heading, MD040 missing fence language) —
+    # `markdownlint.sh check` is the gate.
+    "${run[@]}" --fix "$@" || true
+    ;;
+*)
+    echo "markdownlint.sh: unknown mode '$mode' (expected check|fix)" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/secret-set-1p.sh
+++ b/scripts/secret-set-1p.sh
@@ -15,6 +15,8 @@ Usage:
 
 The secret is read from stdin. VAULT, ITEM, FIELD, and optional SECTION identify
 an existing 1Password field to update; the field is not created automatically.
+The target field must be CONCEALED, and items holding a passkey or SSH key are
+rejected (op's full-item edit flow would clobber them).
 USAGE
 }
 
@@ -62,11 +64,29 @@ op item get "$item" --vault "$vault" --format json --reveal |
           else
             .
           end
+        # Fail closed on items op cannot safely round-trip via a full-item JSON
+        # edit: passkeys are unsupported in the template flow (a get -> edit
+        # round-trip silently overwrites/destroys them), and SSH-key items are
+        # likewise not template-editable. Signals: the item category, or any
+        # field carrying a structured (object) value — plain STRING/CONCEALED
+        # fields are scalars, so an object value marks a passkey/SSH-key/document
+        # credential we must not touch.
+        | if (.category == "SSHKEY" or .category == "PASSKEY")
+             or (([.fields[] | select((.value | type) == "object")] | length) > 0) then
+            error("item holds a passkey or SSH key; refusing full-item edit (op would clobber it)")
+          else
+            .
+          end
         | ([.fields[] | select(field_matches)] | length) as $match_count
         | if $match_count == 0 then
             error("no matching 1Password field")
           elif $match_count > 1 then
             error("multiple matching 1Password fields; set SECTION")
+          # Require the target to be a CONCEALED field: field_matches keys only
+          # on label/section, so without this a STRING (plaintext) field with the
+          # same label would receive the secret in the clear.
+          elif ([.fields[] | select(field_matches and .type == "CONCEALED")] | length) == 0 then
+            error("matching field is not CONCEALED; refusing to write a secret to a non-concealed field")
           else
             (.fields[] |= if field_matches then .value = $value else . end)
           end

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -33,11 +33,27 @@ else
 fi
 
 echo "==> secret helper tasks reject missing destination metadata"
-if printf '%s' 'dummy-secret' | task secret:set:1p >/dev/null 2>&1; then
+# Assert the stable missing-destination diagnostic, not just a nonzero exit:
+# a bare `if ! task ...` would also be satisfied by an unrelated failure
+# (missing op/gh, a Taskfile parse error). Clear any inherited destination
+# metadata first so the tests actually exercise the missing-metadata path.
+out=$(printf '%s' 'dummy-secret' |
+    env -u VAULT -u ITEM -u FIELD -u SECTION task secret:set:1p 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 0 ]; then
     fail "task secret:set:1p succeeded without destination metadata"
 fi
-if printf '%s' 'dummy-secret' | task secret:set:gh >/dev/null 2>&1; then
+case "$out" in
+*"VAULT, ITEM, and FIELD are required"*) ;;
+*) fail "task secret:set:1p failed for the wrong reason: $out" ;;
+esac
+out=$(printf '%s' 'dummy-secret' |
+    env -u NAME -u REPO task secret:set:gh 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 0 ]; then
     fail "task secret:set:gh succeeded without destination metadata"
 fi
+case "$out" in
+*"NAME and REPO are required"*) ;;
+*) fail "task secret:set:gh failed for the wrong reason: $out" ;;
+esac
 
 echo "==> task targets OK (compile + bootstrap idempotency)"

--- a/template/.github/workflows/[% if deploy_cloudflare_workers %]deploy-preview.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if deploy_cloudflare_workers %]deploy-preview.yml[% endif %].jinja
@@ -61,6 +61,8 @@ jobs:
       url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/template/.github/workflows/[% if devcontainer %]devcontainer-build.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if devcontainer %]devcontainer-build.yml[% endif %].jinja
@@ -42,6 +42,8 @@ jobs:
             image_name: [[ devcontainer_image ]]-dev
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # renovate: datasource=node-version

--- a/template/.github/workflows/[% if include_terraform %]terraform.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if include_terraform %]terraform.yml[% endif %].jinja
@@ -40,6 +40,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       - name: terraform fmt
         run: terraform fmt -check -recursive terraform/
@@ -67,6 +69,8 @@ jobs:
       # TF_VAR_cloudflare_account_id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       - name: terraform plan
         run: |

--- a/template/.github/workflows/[% if use_node or use_python %]codeql.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_node or use_python %]codeql.yml[% endif %].jinja
@@ -40,6 +40,8 @@ jobs:
 [% endif %]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:

--- a/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
@@ -106,11 +106,15 @@ jobs:
           # manual runs.
           ref: ${{ needs.release-please.outputs.tag_name || github.ref }}
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      # No `cache: pnpm` here on purpose: the repo-wide Actions cache is
+      # writable from lower-trust PR runs, and this job holds production
+      # deploy credentials -- a cold install is the safe trade. deploy-preview
+      # keeps its cache: that job builds the PR's own code, so poisoning it
+      # grants nothing the PR does not already have.
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           # renovate: datasource=node-version
           node-version: "24"
-          cache: pnpm
       - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$

--- a/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_release_please %]release.yml[% endif %].jinja
@@ -101,6 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           # Tag from release-please on release runs; the dispatched ref on
           # manual runs.
           ref: ${{ needs.release-please.outputs.tag_name || github.ref }}

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -32,6 +32,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 [% if use_node %]
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 [% endif %]
@@ -113,6 +115,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -153,6 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           fetch-depth: 0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -202,6 +207,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -308,6 +315,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -62,26 +62,36 @@ jobs:
         run: |
           # renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.+)$
           SHELLCHECK_VERSION=0.10.0
-          curl -sSL -o /tmp/shellcheck.tar.xz \
+          curl -fsSL --retry 3 -o /tmp/shellcheck.tar.xz \
             "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
           tar -xJf /tmp/shellcheck.tar.xz -C /tmp
           sudo install -m 0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
           # renovate: datasource=github-releases depName=mvdan/sh extractVersion=^v?(?<version>.+)$
           SHFMT_VERSION=3.13.1
-          sudo curl -sSL -o /usr/local/bin/shfmt \
+          # Raw-binary download: fail closed on a checksum mismatch (a version
+          # bump must update the pinned hash). Archive downloads (shellcheck,
+          # actionlint) already fail loudly at extract time on corruption; a
+          # hash-pinned toolchain image is the follow-on refactor.
+          SHFMT_SHA256=fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1
+          curl -fsSL --retry 3 -o /tmp/shfmt \
             "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
-          sudo chmod +x /usr/local/bin/shfmt
+          echo "${SHFMT_SHA256}  /tmp/shfmt" | sha256sum -c -
+          sudo install -m 0755 /tmp/shfmt /usr/local/bin/shfmt
           # renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v?(?<version>.+)$
           ACTIONLINT_VERSION=1.7.12
-          curl -sSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+          curl -fsSL --retry 3 "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
             | tar -xz -C /tmp actionlint
           sudo mv /tmp/actionlint /usr/local/bin/
 [% if use_skills_sync %]
           # renovate: datasource=github-releases depName=mikefarah/yq extractVersion=^v?(?<version>.+)$
           YQ_VERSION=4.44.3
-          sudo curl -sSL -o /usr/local/bin/yq \
+          # Raw-binary download: fail closed on a checksum mismatch (a version
+          # bump must update the pinned hash).
+          YQ_SHA256=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7
+          curl -fsSL --retry 3 -o /tmp/yq \
             "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
-          sudo chmod +x /usr/local/bin/yq
+          echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
+          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
 [% endif %]
           pip install yamllint
 [% if use_python %]

--- a/template/.github/workflows/claude-implement.yml.jinja
+++ b/template/.github/workflows/claude-implement.yml.jinja
@@ -79,6 +79,10 @@ jobs:
             exit 1
           fi
 [% endif %]
+      # Exception to the repo-wide `persist-credentials: false` hardening:
+      # this checkout deliberately persists the short-lived CI App token so
+      # Claude's `git push` of the working branch can authenticate. The token
+      # is least-privilege (minted above) and expires with the job.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0

--- a/template/.github/workflows/claude-plan.yml.jinja
+++ b/template/.github/workflows/claude-plan.yml.jinja
@@ -77,6 +77,8 @@ jobs:
           fi
 [% endif %]
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 [% if github_org != author_git_provider_username %]
       - name: Set issue status to Shaping
         continue-on-error: true

--- a/template/.github/workflows/claude-review.yml.jinja
+++ b/template/.github/workflows/claude-review.yml.jinja
@@ -75,6 +75,8 @@ jobs:
           fi
 [% endif %]
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1.0.148
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -123,24 +123,11 @@ tasks:
     # Check-only (no --fix) so this is a read-only gate like lint:prettier /
     # lint:shell: CI and the pre-commit hook fail loudly instead of silently
     # mutating the tree (and, in CI, discarding the fix while reporting green).
-    # Auto-fix lives in `task format` / `task format:file`.
-    # Prefer the repo-pinned markdownlint-cli2 (node_modules) so hooks/CI match
-    # the lockfile; fall back to npx for non-node repos and fresh scaffolds.
-    # Invoke the .bin shim directly — package-manager-agnostic (works in
-    # npm-managed repos too, where `pnpm exec` would break).
+    # Auto-fix lives in `task format` / `task format:file`. The bin-vs-npx
+    # dispatch + default glob set live in scripts/markdownlint.sh.
     desc: markdownlint-cli2 (check mode)
     cmds:
-      - |
-        if [ -x node_modules/.bin/markdownlint-cli2 ]; then
-          run="node_modules/.bin/markdownlint-cli2"
-        else
-          run="npx --yes markdownlint-cli2"
-        fi
-        if [ -n "{{.CLI_ARGS}}" ]; then
-          $run {{.CLI_ARGS}}
-        else
-          $run '**/*.md' '#.claude/**' '#specs/*/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' '#**/.terraform/**' '#**/.venv/**' '#**/.task/**'
-        fi
+      - ./scripts/markdownlint.sh check {{.CLI_ARGS}}
 
   lint:actions:
     desc: actionlint on GitHub workflows
@@ -368,16 +355,10 @@ tasks:
       - |
         files=$(git ls-files '*.sh' '*.bash')
         [ -n "$files" ] && shfmt -w $files || true
-      # Best-effort: markdownlint --fix auto-fixes what it can but must NOT abort
-      # `format` on un-auto-fixable rule violations (e.g. MD024 duplicate heading,
-      # MD040 missing fence language) — `lint:markdown` (check-only) is the gate.
-      - |
-        if [ -x node_modules/.bin/markdownlint-cli2 ]; then
-          run="node_modules/.bin/markdownlint-cli2"
-        else
-          run="npx --yes markdownlint-cli2"
-        fi
-        $run --fix '**/*.md' '#.claude/**' '#**/node_modules/**' '#dist/**' '#.worktrees/**' '#**/.terraform/**' '#**/.venv/**' || true
+      # Best-effort markdown auto-fix (bin-vs-npx dispatch in the helper); must
+      # NOT abort `format` on un-auto-fixable rule violations — `lint:markdown`
+      # (check-only) is the gate.
+      - ./scripts/markdownlint.sh fix
 
   format:file:
     desc: "Format a single file by extension (usage: task format:file -- <path>)"
@@ -403,13 +384,7 @@ tasks:
         *.tf | *.tfvars) terraform fmt "$f" ;;
 [% endif %]
         *.sh | *.bash) shfmt -w "$f" ;;
-        *.md | *.mdx)
-          if [ -x node_modules/.bin/markdownlint-cli2 ]; then
-            node_modules/.bin/markdownlint-cli2 --fix "$f" || true
-          else
-            npx --yes markdownlint-cli2 --fix "$f" || true
-          fi
-          ;;
+        *.md | *.mdx) ./scripts/markdownlint.sh fix "$f" ;;
         esac
 
   fix:

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -171,17 +171,18 @@ tasks:
   lint:eslint:
     # Skip cleanly when ESLint can't run yet -- no config (fresh scaffold) or deps
     # not installed -- so `task check` stays green before the app is set up. Runs
-    # the project's own ESLint via `pnpm exec` so a plugin-based flat config (e.g.
-    # the web-astro eslint.config.js) resolves its plugins.
+    # the project's own ESLint via the node_modules/.bin shim (package-manager-
+    # agnostic — works under npm too, where `pnpm exec` would break) so a
+    # plugin-based flat config (e.g. the web-astro eslint.config.js) resolves.
     desc: ESLint
     cmds:
       - |
         if ! find . -maxdepth 1 \( -name 'eslint.config.*' -o -name '.eslintrc.*' \) 2>/dev/null | grep -q .; then
           echo "lint:eslint: no ESLint config yet -- skipping (add one after scaffolding the app)"
-        elif [ ! -d node_modules ]; then
-          echo "lint:eslint: deps not installed yet -- skipping (run pnpm install)"
+        elif [ ! -x node_modules/.bin/eslint ]; then
+          echo "lint:eslint: deps not installed yet -- skipping (install dependencies first)"
         else
-          pnpm exec eslint {{.CLI_ARGS | default "."}}
+          node_modules/.bin/eslint {{.CLI_ARGS | default "."}}
         fi
 
   lint:typescript:
@@ -195,23 +196,23 @@ tasks:
     desc: TypeScript / Astro type checking
     cmds:
       - |
-        if [ ! -f package.json ] || [ ! -d node_modules ]; then
-          echo "lint:typescript: app/deps not set up yet -- skipping (scaffold Astro + pnpm install)"
+        if [ ! -f package.json ] || [ ! -x node_modules/.bin/astro ]; then
+          echo "lint:typescript: app/deps not set up yet -- skipping (scaffold Astro + install deps)"
         else
-          pnpm exec astro check
+          node_modules/.bin/astro check
         fi
 [% else %]
     desc: TypeScript type checking
     cmds:
       - |
-        if [ ! -f package.json ] || [ ! -d node_modules ]; then
-          echo "lint:typescript: app/deps not set up yet -- skipping (pnpm install)"
+        if [ ! -f package.json ] || [ ! -x node_modules/.bin/tsc ]; then
+          echo "lint:typescript: app/deps not set up yet -- skipping (install dependencies)"
         elif grep -q '"references"' tsconfig.json 2>/dev/null; then
           # Solution-style root tsconfig (files: [] + project references): a plain
           # `tsc --noEmit` against it type-checks NOTHING — build mode walks the refs.
-          pnpm exec tsc -b
+          node_modules/.bin/tsc -b
         else
-          pnpm exec tsc --noEmit
+          node_modules/.bin/tsc --noEmit
         fi
 [% endif %]
 [% endif %]
@@ -500,10 +501,10 @@ tasks:
       - |
         if ! find . -maxdepth 1 -name 'playwright.config.*' 2>/dev/null | grep -q .; then
           echo "test:a11y: no Playwright config yet -- skipping (add playwright.config.ts after scaffolding the app)"
-        elif [ ! -d node_modules ]; then
-          echo "test:a11y: deps not installed yet -- skipping (pnpm install + pnpm add -D @axe-core/playwright)"
+        elif [ ! -x node_modules/.bin/playwright ]; then
+          echo "test:a11y: deps not installed yet -- skipping (install deps; add @playwright/test + @axe-core/playwright as devDependencies if missing)"
         else
-          pnpm exec playwright test --grep @a11y {{.CLI_ARGS}}
+          node_modules/.bin/playwright test --grep @a11y {{.CLI_ARGS}}
         fi
 [% endif %]
 [% endif %]

--- a/template/scripts/lint-hygiene.sh
+++ b/template/scripts/lint-hygiene.sh
@@ -118,8 +118,12 @@ for f in "${files[@]}"; do
         # Skip JSONC files (devcontainer.json, tsconfig*.json at any depth —
         # TypeScript officially allows comments) and anything jinja-templated.
         # tsc -b validates the tsconfigs loudly, so hygiene needn't parse them.
+        # Match only conventional devcontainer filenames (devcontainer.json or
+        # .devcontainer.json, at the root or in a directory) — a suffix glob
+        # like *devcontainer.json would exempt e.g. mydevcontainer.json too.
         case "$f" in
-        *devcontainer.json | tsconfig*.json | */tsconfig*.json | template/*) ;;
+        devcontainer.json | */devcontainer.json | .devcontainer.json | */.devcontainer.json | \
+            tsconfig*.json | */tsconfig*.json | template/*) ;;
         *)
             if ! python3 -c "import json; json.load(open('$f'))" 2>/dev/null; then
                 warn "$f: invalid JSON"

--- a/template/scripts/markdownlint.sh
+++ b/template/scripts/markdownlint.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# markdownlint.sh — resolve markdownlint-cli2 and run it in check or fix mode.
+#
+# Prefer the repo-pinned binary (node_modules/.bin) so hooks/CI match the
+# lockfile; fall back to npx for non-node repos and fresh scaffolds. Invoking
+# the .bin shim directly is package-manager-agnostic (works under npm too,
+# where `pnpm exec` would break). Keeps this bin-vs-npx dispatch out of the
+# Taskfile per the "keep cmds trivial; non-trivial shell lives in scripts/*.sh"
+# rule.
+#
+# Usage:
+#   markdownlint.sh check [glob-or-file ...]   # read-only gate
+#   markdownlint.sh fix   [glob-or-file ...]   # best-effort auto-fix
+# With no glob/file args, a canonical repo-wide default set is used.
+set -euo pipefail
+
+mode="${1:-check}"
+if [ "$#" -gt 0 ]; then shift; fi
+
+# Canonical excludes: generated output (dist, .task, .terraform, .venv,
+# node_modules), vendored skills (.claude), scratch worktrees, spec fixtures,
+# and the template/ tree (jinja markdown — present only in the template repo
+# itself, an inert glob everywhere else).
+default_globs=(
+    '**/*.md'
+    '#template/**'
+    '#.claude/**'
+    '#specs/*/**'
+    '#**/node_modules/**'
+    '#dist/**'
+    '#.worktrees/**'
+    '#**/.terraform/**'
+    '#**/.venv/**'
+    '#**/.task/**'
+)
+
+if [ -x node_modules/.bin/markdownlint-cli2 ]; then
+    run=(node_modules/.bin/markdownlint-cli2)
+else
+    run=(npx --yes markdownlint-cli2)
+fi
+
+if [ "$#" -eq 0 ]; then
+    set -- "${default_globs[@]}"
+fi
+
+case "$mode" in
+check)
+    "${run[@]}" "$@"
+    ;;
+fix)
+    # Best-effort: --fix must not abort `task format` on un-auto-fixable rule
+    # violations (e.g. MD024 duplicate heading, MD040 missing fence language) —
+    # `markdownlint.sh check` is the gate.
+    "${run[@]}" --fix "$@" || true
+    ;;
+*)
+    echo "markdownlint.sh: unknown mode '$mode' (expected check|fix)" >&2
+    exit 2
+    ;;
+esac

--- a/template/scripts/secret-set-1p.sh
+++ b/template/scripts/secret-set-1p.sh
@@ -15,6 +15,8 @@ Usage:
 
 The secret is read from stdin. VAULT, ITEM, FIELD, and optional SECTION identify
 an existing 1Password field to update; the field is not created automatically.
+The target field must be CONCEALED, and items holding a passkey or SSH key are
+rejected (op's full-item edit flow would clobber them).
 USAGE
 }
 
@@ -62,11 +64,29 @@ op item get "$item" --vault "$vault" --format json --reveal |
           else
             .
           end
+        # Fail closed on items op cannot safely round-trip via a full-item JSON
+        # edit: passkeys are unsupported in the template flow (a get -> edit
+        # round-trip silently overwrites/destroys them), and SSH-key items are
+        # likewise not template-editable. Signals: the item category, or any
+        # field carrying a structured (object) value — plain STRING/CONCEALED
+        # fields are scalars, so an object value marks a passkey/SSH-key/document
+        # credential we must not touch.
+        | if (.category == "SSHKEY" or .category == "PASSKEY")
+             or (([.fields[] | select((.value | type) == "object")] | length) > 0) then
+            error("item holds a passkey or SSH key; refusing full-item edit (op would clobber it)")
+          else
+            .
+          end
         | ([.fields[] | select(field_matches)] | length) as $match_count
         | if $match_count == 0 then
             error("no matching 1Password field")
           elif $match_count > 1 then
             error("multiple matching 1Password fields; set SECTION")
+          # Require the target to be a CONCEALED field: field_matches keys only
+          # on label/section, so without this a STRING (plaintext) field with the
+          # same label would receive the secret in the clear.
+          elif ([.fields[] | select(field_matches and .type == "CONCEALED")] | length) == 0 then
+            error("matching field is not CONCEALED; refusing to write a secret to a non-concealed field")
           else
             (.fields[] |= if field_matches then .value = $value else . end)
           end

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -33,11 +33,27 @@ else
 fi
 
 echo "==> secret helper tasks reject missing destination metadata"
-if printf '%s' 'dummy-secret' | task secret:set:1p >/dev/null 2>&1; then
+# Assert the stable missing-destination diagnostic, not just a nonzero exit:
+# a bare `if ! task ...` would also be satisfied by an unrelated failure
+# (missing op/gh, a Taskfile parse error). Clear any inherited destination
+# metadata first so the tests actually exercise the missing-metadata path.
+out=$(printf '%s' 'dummy-secret' |
+    env -u VAULT -u ITEM -u FIELD -u SECTION task secret:set:1p 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 0 ]; then
     fail "task secret:set:1p succeeded without destination metadata"
 fi
-if printf '%s' 'dummy-secret' | task secret:set:gh >/dev/null 2>&1; then
+case "$out" in
+*"VAULT, ITEM, and FIELD are required"*) ;;
+*) fail "task secret:set:1p failed for the wrong reason: $out" ;;
+esac
+out=$(printf '%s' 'dummy-secret' |
+    env -u NAME -u REPO task secret:set:gh 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 0 ]; then
     fail "task secret:set:gh succeeded without destination metadata"
 fi
+case "$out" in
+*"NAME and REPO are required"*) ;;
+*) fail "task secret:set:gh failed for the wrong reason: $out" ;;
+esac
 
 echo "==> task targets OK (compile + bootstrap idempotency)"

--- a/template/tests/[% if project_type in ['web-astro', 'web-app'] %]a11y.spec.ts[% endif %]
+++ b/template/tests/[% if project_type in ['web-astro', 'web-app'] %]a11y.spec.ts[% endif %]
@@ -4,10 +4,10 @@ import AxeBuilder from '@axe-core/playwright'
 // Automated accessibility checks — the WCAG 2.x A/AA rules axe can detect.
 // axe finds only ~a third to half of WCAG issues: this is the automated FLOOR,
 // not a substitute for keyboard / screen-reader testing. Tag a11y tests
-// `@a11y` so `task test:a11y` selects them. Requires (installed when you set up
-// Playwright): `pnpm add -D @playwright/test @axe-core/playwright` — until then
-// `tsc` / `astro check` can't type-check this file, so pair adding this spec
-// with that dep install. If your playwright config sets a custom testDir,
+// `@a11y` so `task test:a11y` selects them. Requires @playwright/test and
+// @axe-core/playwright as devDependencies (add them if missing) plus an
+// install run with your package manager — until then `tsc` / `astro check`
+// can't type-check this file. If your playwright config sets a custom testDir,
 // move this spec there or Playwright will never pick it up.
 
 // Chromium only: axe analyzes the DOM, so results don't vary by engine, and
@@ -26,7 +26,9 @@ test.use({ contextOptions: { reducedMotion: 'reduce' } })
 test('homepage has no detectable accessibility violations @a11y', async ({ page }) => {
   await page.goto('/')
   const results = await new AxeBuilder({ page })
-    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    // Tags are not cumulative — the 2.2 tags must be listed alongside 2.0/2.1
+    // to actually assert the WCAG 2.2 AA floor the docs commit to.
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa'])
     .analyze()
   expect(results.violations).toEqual([])
 })


### PR DESCRIPTION
## Summary

Batch of template + root-dogfood fixes derived from CodeRabbit/Copilot reviews
of the 10 downstream v3.24.0 update PRs. Each finding was re-verified against
current `main` (post #271/#273/#275) before fixing. Template and root layers
edited in lockstep; consumer-affecting changes are `feat:`/`fix:`.

Downstreams receive these on their next release + `copier update`.

## A. Security (dedicated section per repo convention)

### A1 — `persist-credentials: false` on workflow checkouts (zizmor "artipacked")

Added to every `actions/checkout` step in the shipped template workflows and the
root dogfood workflows. The persisted git credential is never used by later
steps in any of these jobs (none do a credentialed `git push`), so it is removed
from the on-disk git config.

**Per-job verification — every checkout hardened except one documented exception:**

| Workflow | Job | Hardened? |
|---|---|---|
| build.yml | lint, build-test, security, lighthouse, a11y | yes |
| codeql.yml | analyze | yes |
| terraform.yml | validate, plan | yes (both) |
| deploy-preview.yml | deploy-preview | yes |
| devcontainer-build.yml | build | yes |
| release.yml | deploy-production | yes |
| claude-plan.yml | plan | yes |
| claude-review.yml | review | yes |
| **claude-implement.yml** | **implement** | **EXCEPTION — persists token on purpose** |

**Exception (documented inline):** `claude-implement`'s checkout deliberately
persists the short-lived, least-privilege CI App token so Claude's `git push` of
the working branch (the job's deliverable) can authenticate. It uses
`token: ${{ steps.app-token.outputs.token }}` and the token expires with the
job. `release.yml`'s `release-please` job has no checkout at all (the action
uses the API), so nothing to harden there; its `deploy-production` checkout does
not need credentials and is hardened.

### A2 — drop `cache: pnpm` from the production deploy job

`release.yml`'s `deploy-production` job holds the Cloudflare deploy credentials,
and the repo-wide Actions cache is writable from lower-trust PR runs — so a
poisonable dependency cache there is an unnecessary trust edge. Switched to a
cold install. `deploy-preview` **deliberately keeps** its cache (documented in a
comment): that job only builds the PR's own code, so cache poisoning grants
nothing the PR cannot already do. Root lockstep N/A — harmon-init's own
`release.yml` has no deploy job.

## B. a11y

- **B1** — added `wcag22a`/`wcag22aa` to the axe `withTags` list in the shipped
  `a11y.spec.ts`. Tags are not cumulative, so without them the spec never
  asserted the WCAG 2.2 AA floor the docs advertise. One-line comment added.
- **B2** — reworded the `test:a11y` skip message and the spec header dep guidance
  to be true in both dependency states and package-manager-agnostic ("install
  deps; add `@playwright/test` + `@axe-core/playwright` as devDependencies if
  missing") instead of an unconditional `pnpm add -D`.

## C. ponderous-infra#13 CodeRabbit findings — verdicts

- **C1 — accepted (pragmatic).** shfmt and yq are raw-binary downloads where a
  truncated/tampered file installs silently. Pinned their sha256 next to the
  version pin, download to a temp file with `curl --fail --retry`, verify, then
  install — failing closed (a Renovate bump must update the hash). Archive
  downloads (shellcheck, actionlint) keep no hash — they already fail loudly at
  extract time on corruption — but gained `--fail`/`--retry`. A hash-pinned
  toolchain image is the noted follow-on refactor, out of scope.
- **C2 — accepted.** `lint-hygiene.sh` used `*devcontainer.json`, which exempted
  any file merely ending in that suffix (e.g. `maliciousdevcontainer.json`) from
  the strict-JSON check. Now matches only `devcontainer.json`/`.devcontainer.json`
  at the root or under a directory. Verbatim twin — dogfood parity enforces.
- **C3 — accepted.** `secret-set-1p.sh` gains two fail-closed guards: reject
  items op can't safely round-trip via a full-item JSON edit (passkeys — which
  the flow silently destroys — and SSH keys, detected by item category or any
  structured/object field value), and require the matched field to be `CONCEALED`
  before writing (previously a same-labelled `STRING` field could receive the
  secret in the clear). Stdin-only semantics unchanged. Verified against sample
  item JSON: CONCEALED writes, STRING rejects, passkey-present rejects.
- **C4 — accepted.** `test-tasks.sh`'s secret-helper negative tests discarded
  output and keyed only on exit code, so an unrelated failure would falsely
  satisfy them. Now captures combined stdout+stderr, asserts each helper's stable
  missing-destination diagnostic, and clears inherited destination env
  (`VAULT/ITEM/FIELD`, `NAME/REPO`) so the missing-metadata path is actually
  exercised.
- **C5 — accepted.** The markdownlint bin-vs-npx dispatch (multi-line inline
  shell across `lint:markdown`/`format`/`format:file`) violated the "keep cmds
  trivial; non-trivial shell lives in scripts/*.sh" rule (only `scripts/*.sh` is
  shellcheck/shfmt-linted). Extracted to `scripts/markdownlint.sh` (`check`/`fix`
  modes, canonical default glob set, `-x` guard preserved). Targets are now thin
  delegates. New verbatim twin, identical in both layers, enforced by dogfood
  parity. Root Taskfile targets converted in lockstep.

## D. Finish the deferred #271 follow-up

Converted the remaining `pnpm exec` call sites in the template Taskfile
(`lint:eslint`, `lint:typescript` = `astro check`/`tsc -b`/`tsc --noEmit`,
`test:a11y` = `playwright`) to the direct `node_modules/.bin/<tool>` + `-x`
guard pattern, completing the package-manager-agnostic conversion (works under
npm too; skips cleanly on a fresh scaffold). The `npx`-based sites
(`test:e2e`, `test`, commitlint) were already package-manager-agnostic and left
as-is. Root lockstep N/A — these targets are node-only, absent from the non-node
root Taskfile.

## Gates

- `task verify` (lint + guards + `test:template:all` + dogfood-parity): **green**
- `task test:template:all` (minimal, web, webapp, iac, full, meta, update): **green**
- `task security:secrets` (gitleaks): **no leaks**

Do not merge — opening for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
