### PR TITLE
feat: foreman v1 — deterministic supervisor for milestone-driven agent dispatch

### DIFF
--- a/.claude/agents/foreman-implementer.md
+++ b/.claude/agents/foreman-implementer.md
@@ -1,0 +1,18 @@
+---
+name: foreman-implementer
+description: Foreman's delivery loop for one dispatched unit — worktree discipline, full verification before finishing, AC→test mapping, self-review, BLOCKED.md escalation, never merge/push/open PRs. Foreman's claude backend injects the same rules automatically; use this agent manually only to continue work on a foreman unit inside its worktree.
+---
+
+You are foreman's implementer. Your operating rules are one-sourced in
+`scripts/foreman/prompts/implementer-preamble.md` — read that file FIRST and
+follow it exactly. Headless dispatches get it injected with the `%%TOKEN%%`
+placeholders filled; when invoked interactively, resolve them from context
+instead: the current worktree's branch (`git branch --show-current`), the unit
+number embedded in it (`<prefix>/<type>/<number>-<slug>`), the repo's
+`.foreman.toml` (`verify_command`), and the result file at
+`.foreman/units/<number>/result.json` under the main checkout.
+
+The non-negotiables, restated: never merge anything; never push; never open a
+PR (foreman verifies and opens it); never touch `.github/workflows/**`; never
+start background watchers; never bypass git hooks; escalate ambiguity via
+`BLOCKED.md` + a blocked result instead of inventing a decision.

--- a/.claude/agents/foreman-preflight.md
+++ b/.claude/agents/foreman-preflight.md
@@ -1,0 +1,17 @@
+---
+name: foreman-preflight
+description: Read-only critical analysis of a milestone/issue against the live repo before foreman dispatches agents at it — stale references, cross-issue contradictions, ambiguities, undeclared human-only tasks, file-collision risk. Produces findings + drafted correction comments for human approval. Never modifies anything.
+tools: Read, Grep, Glob, Bash
+---
+
+You are foreman's preflight analyst. Your contract is one-sourced in
+`scripts/foreman/prompts/preflight.md` — read it FIRST and follow it exactly,
+including the output format (`# Preflight findings` +
+`## DRAFT COMMENT FOR #<n>` sections). When invoked interactively, fetch the
+target units yourself with `gh issue view` instead of the injected
+`%%UNITS%%` block.
+
+You are strictly read-only: no file edits, no git mutations, no GitHub
+writes. Bash is for read-only inspection (`gh issue view`, `git log`, `rg`)
+only. Corrections you draft are posted by a HUMAN decision via
+`task foreman:preflight -- --post`, never by you.

--- a/.claude/agents/foreman-shepherd.md
+++ b/.claude/agents/foreman-shepherd.md
@@ -1,0 +1,18 @@
+---
+name: foreman-shepherd
+description: Foreman's post-PR runbooks — repair red CI (mechanical failures only), resolve conflicted rebases additively, and adjudicate review-bot findings (apply or decline-with-reasoning, resolve threads). Foreman resumes unit agents with these rules automatically; use this agent manually to shepherd a foreman PR by hand.
+---
+
+You are foreman's shepherd. The runbooks are one-sourced in
+`scripts/foreman/prompts/`: `shepherd-ci-fix.md` (red CI),
+`shepherd-rebase.md` (conflicts after a sibling merge), and
+`shepherd-adjudicate.md` (review-thread adjudication). Read the one matching
+your task FIRST and follow it exactly; fill its `%%TOKEN%%` placeholders from
+context (PR URL, branch, unit number, `.foreman.toml` verify_command).
+
+The non-negotiables, restated: never merge anything; rebase — never
+merge-main — as the one update mechanism; never weaken a test or the code to
+silence an infra failure (environmental failures go to the human queue);
+adjudicate every thread individually — blanket-accepting and
+blanket-dismissing are both prohibited; deterministic facts beat bot
+speculation.

--- a/.foreman.toml
+++ b/.foreman.toml
@@ -1,0 +1,32 @@
+# Foreman configuration for harmon-init (docs/architecture/foreman.md).
+#
+# harmon-init is a personal-account repo, so issue custom fields are
+# unavailable (org-only feature) — `inputs = "auto"` resolves to label mode
+# here (`foreman:claude`, `foreman:hold`, ...). Explicit approval is required
+# before any issue is dispatchable.
+
+backend = "claude"
+require_approval = true
+inputs = "auto"
+verify_command = ["task", "ci"]
+max_parallel = 3
+branch_prefix = "foreman"
+expected_login = "evanharmon1-bot"
+
+# subscription (default): adapters inherit CLAUDE_CODE_OAUTH_TOKEN; USD
+# budgets are inert (guardrails bind on timeout/turns). api: adapters export
+# FOREMAN_ANTHROPIC_API_KEY process-locally; USD budgets bind.
+billing = "subscription"
+
+# Set FOREMAN_SANDBOXED=1 (env) inside the egress-limited bot devcontainer to
+# let adapters run with a relaxed permission mode; the committed default stays
+# conservative for any other host.
+sandboxed = false
+
+[budgets]
+dispatch_usd = 20.0
+shepherd_usd = 10.0
+
+[timeouts]
+dispatch_min = 90
+shepherd_min = 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           version: 3.51.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       # uv provides uvx for foreman:lint's pinned ruff/black (see taskfiles/foreman.yml)
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install lint tools (shellcheck, shfmt, actionlint, yamllint, yq)
         run: |
           # renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.+)$

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
           # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
           version: 3.51.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      # uv provides uvx for foreman:lint's pinned ruff/black (see taskfiles/foreman.yml)
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Install lint tools (shellcheck, shfmt, actionlint, yamllint, yq)
         run: |
           # renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.+)$
@@ -59,6 +61,7 @@ jobs:
           pip install yamllint
       - run: task check
       - run: task test:tasks
+      - run: task foreman:test
       - name: Skills drift check (vendored skills vs pinned harmon-devkit ref)
         run: task verify:skills
       - run: task test:hooks

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,12 @@ Thumbs.db
 .worktrees/
 .lefthook-local.yml
 
+# Foreman runtime artifacts (logs, prompts, resume states — never state-of-record)
+.foreman/
+.foreman-stop
+__pycache__/
+*.pyc
+
 # Local editor/AI settings
 settings.local.json
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -10,4 +10,5 @@ paths = [
     '''\.git/''',
     '''\.task/''',
     '''\.worktrees/''',
+    '''\.foreman/''',
 ]

--- a/.yamllint
+++ b/.yamllint
@@ -8,6 +8,7 @@ ignore:
   - node_modules/
   - .task/
   - .worktrees/
+  - .foreman/
 
 rules:
   braces:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,9 +101,20 @@ task test:template
 # Secrets scan
 task security:secrets
 
+# Foreman: dispatch ready issues to headless agents, shepherd their PRs
+task foreman:plan -- --milestone <n|title>   # dry-run the graph/waves
+task foreman:dispatch -- --issue <n>         # worktree → agent → verify → PR
+task foreman:watch -- --milestone <n>        # unattended loop (humans merge)
+
 # Releases are INTENTIONAL — never automated on merge to main
 task release:patch   # or release:minor / release:major
 ```
+
+**Foreman** (`scripts/foreman/`, `taskfiles/foreman.yml`) is the deterministic
+supervisor for milestone-driven agent dispatch: explicit arming via
+`foreman:*` labels (issue fields on org repos), hardened doneness, a strict
+write contract, and **never a merge** — see `docs/architecture/foreman.md`
+and ADR 0002. It ships to generated repos, so its files are two-layer twins.
 
 ## Critical Copier Gotchas
 

--- a/Brewfile
+++ b/Brewfile
@@ -30,6 +30,9 @@ brew "hadolint"
 # Skills sync (scripts/sync-skills.sh reads .skills-sync.yaml)
 brew "yq"
 
+# Foreman python lint tooling (taskfiles/foreman.yml runs pinned ruff/black via uvx)
+brew "uv"
+
 # Runtime for npx-based tools (commitlint, markdownlint-cli2)
 brew "node"
 

--- a/Brewfile
+++ b/Brewfile
@@ -30,7 +30,7 @@ brew "hadolint"
 # Skills sync (scripts/sync-skills.sh reads .skills-sync.yaml)
 brew "yq"
 
-# Foreman python lint tooling (taskfiles/foreman.yml runs pinned ruff/black via uvx)
+# Python tooling (uv; foreman lint runs pinned ruff/black via uvx)
 brew "uv"
 
 # Runtime for npx-based tools (commitlint, markdownlint-cli2)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,6 +13,11 @@ output:
     begin: "::group::{{.TASK}}"
     end: "::endgroup::"
 
+includes:
+  # Foreman — deterministic supervisor for milestone-driven agent dispatch
+  # (task foreman:plan / dispatch / shepherd / watch ...; docs/architecture/foreman.md)
+  foreman: taskfiles/foreman.yml
+
 tasks:
   default:
     desc: Interactive task menu (tv)
@@ -52,6 +57,7 @@ tasks:
     cmds:
       - task: check
       - task: test:tasks
+      - task: foreman:test
       - task: test:hooks
       - task: test:devcontainer:permissions
       - task: test
@@ -67,6 +73,7 @@ tasks:
       - task: check
       - task: test:tasks
       - task: test:dogfood-parity
+      - task: foreman:test
       - task: test:hooks
       - task: test:template
 
@@ -83,6 +90,7 @@ tasks:
       - lint:markdown
       - lint:actions
       - lint:hygiene
+      - foreman:lint
 
   lint:yaml:
     desc: yamllint (template/ excluded via .yamllint ignore)
@@ -113,7 +121,7 @@ tasks:
         if [ -n "{{.CLI_ARGS}}" ]; then
           npx --yes markdownlint-cli2 {{.CLI_ARGS}}
         else
-          npx --yes markdownlint-cli2 '**/*.md' '#template/**' '#.claude/**' '#**/node_modules/**' '#.worktrees/**'
+          npx --yes markdownlint-cli2 '**/*.md' '#template/**' '#.claude/**' '#**/node_modules/**' '#.worktrees/**' '#.foreman/**'
         fi
 
   lint:actions:
@@ -159,7 +167,7 @@ tasks:
       # Best-effort: markdownlint --fix auto-fixes what it can but must NOT abort
       # `format` on un-auto-fixable rule violations (e.g. MD024 duplicate heading,
       # MD040 missing fence language) — `lint:markdown` (check-only) is the gate.
-      - npx --yes markdownlint-cli2 --fix '**/*.md' '#template/**' '#.claude/**' '#**/node_modules/**' '#.worktrees/**' || true
+      - npx --yes markdownlint-cli2 --fix '**/*.md' '#template/**' '#.claude/**' '#**/node_modules/**' '#.worktrees/**' '#.foreman/**' || true
 
   format:file:
     desc: "Format a single file by extension (usage: task format:file -- <path>)"
@@ -327,7 +335,7 @@ tasks:
   security:sast:
     desc: Static application security testing (source code)
     cmds:
-      - snyk code test --exclude=.worktrees --severity-threshold=high
+      - snyk code test --exclude=.worktrees,.foreman --severity-threshold=high
 
   security:sca:
     desc: Software composition analysis (Snyk)

--- a/copier.yml
+++ b/copier.yml
@@ -139,6 +139,11 @@ skill_categories:
     + (['infra'] if (include_terraform or include_ansible or project_type == 'iac') else []) ]]
   when: "[[ use_skills_sync ]]"
 
+use_foreman:
+  type: bool
+  help: "FOREMAN: Include foreman — deterministic supervisor that dispatches ready issues to headless agents, verifies, opens PRs, shepherds them (task foreman:*; Python 3.11+ at runtime)?"
+  default: yes
+
 devcontainer:
   type: bool
   help: "DEVCONTAINER: Add dual-profile .devcontainer (AI bot + human dev)?"

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -33,3 +33,4 @@ onward (diagrams and component deep-dives also live here):
 - [security.md](security.md) — the posture across config, secret state, and GitHub settings; holds the threat-model framing, not the config.
 - [branch-protection.md](branch-protection.md) — in-repo (CODEOWNERS) + out-of-repo (ruleset, Actions toggles, bot model) stitched into one picture (grep can't see GitHub settings).
 - [tests.md](tests.md) — the testing strategy holistically (shape, layers, what's tested where); routes to the testing decision and the guides.
+- [foreman.md](foreman.md) — the deterministic supervisor that dispatches armed issues to headless agents and shepherds their PRs to a human merge; state of record is GitHub + git.

--- a/docs/architecture/foreman.md
+++ b/docs/architecture/foreman.md
@@ -1,0 +1,235 @@
+# Foreman
+
+Foreman is a **deterministic supervisor** for milestone-driven agent work. It
+reads a milestone's (or a single issue's) dependency graph from GitHub,
+dispatches the currently-unblocked issues to isolated headless agents in git
+worktrees, verifies each result with the repo's own CI gate, opens PRs, and
+keeps those PRs healthy (CI repair, review adjudication, rebases) until a
+human merges them.
+
+Everything that can be a crisp pass/fail check is plain code; LLMs write code
+and adjudicate review findings, but they never judge "done" and never gate
+progression. Zero tokens are spent on coordination.
+
+## Non-negotiables
+
+- **No AI ever merges to main. Ever.** No auto-merge, no enabling flag. The
+  human merge is the only mechanism that advances the dependency graph;
+  foreman's job ends at "this PR is verified, adjudicated, and mergeable —
+  here is the suggested merge order." Server-side enforcement (branch
+  ruleset, code-owner review, bot token without bypass) is the boundary;
+  prompts are only a mitigation.
+- **Stateless in the repo.** Human inputs are stored (issue bodies, labels /
+  issue fields, comments); machine state is re-derived every tick from GitHub
+  - git and never stored. A stored status can lie after a crash; re-derived
+  state cannot. Worktrees and `.foreman/` logs are disposable operational
+  artifacts, never state-of-record.
+- **Foreman never edits human-authored content.** Issue titles/bodies,
+  milestone descriptions, and human/other-bot comments are read-only.
+  Corrections travel as comments (human-approved), never as edits.
+
+## The wave model
+
+Nodes are dispatch units (a parent issue; its sub-issues ride along as the
+internal task list — one unit, one PR). Edges are `blocked-by` dependencies
+(native GitHub dependencies primary; a `Depends-on: #n` body trailer is the
+fallback — both present and disagreeing fails loud).
+
+A **wave** is the set of open units whose dependencies are all satisfied.
+Because a satisfied dependency means *merged into the default branch by a
+human*, every agent branches off the default branch with complete,
+human-approved context — no stacked PRs, no cross-branch coordination. The
+human merge advances the graph; the next run (or watch tick) discovers the
+newly-unblocked wave. During a merge freeze foreman idles by design: PRs stay
+healthy, nothing new dispatches, and the log says it is waiting on merges.
+
+## Doneness (deterministic, hardened)
+
+A dependency is satisfied only when:
+
+- **Foreman-managed** (a closing PR carries the `foreman:unit=#N` marker):
+  the issue is closed **and** that PR is merged into the discovered default
+  branch, authored by the configured bot login, from a `foreman/...` attempt
+  branch. A marker PR that never merged fails loud.
+- **External** (no marker PR): the issue is closed as *completed*. Closed as
+  *not planned* blocks, with guidance — remove the edge, or apply the
+  explicit human override (`foreman=satisfied` field / `foreman:satisfied`
+  label). Every plan/status output prints *how* each dependency was
+  satisfied.
+
+## Inputs (humans write, foreman reads)
+
+Arming is **explicit by default**: only issues carrying the `foreman` input
+dispatch. The value names the backend (`claude`, `mock`) or `approved` (repo
+default backend); `hold` always wins; `satisfied` / `external` adjust
+dependency semantics. Per-repo config can relax to default-armed
+(`require_approval = false`), where invoking dispatch/watch is the arming
+act and `hold` excludes units.
+
+- **Org repos**: the org-level issue custom fields `foreman`,
+  `foreman-budget-usd`, `foreman-timeout-min` (issue fields are org-only).
+- **Personal-account repos**: `foreman:*` labels (boolean inputs only;
+  numeric overrides need fields).
+- `inputs = "auto"` probes availability once per run and prints the chosen
+  mode in every summary. In fields mode, a `foreman:*` label on the same
+  issue fails loud — two drifting sources of truth is a bug, not a feature.
+
+A unit must also satisfy the **spec contract**: an `## Acceptance Criteria`
+section with items tagged `[CI]` (must map to named automated tests) or
+`[HUMAN]` (surfaced, never attempted; the PR then `Refs` instead of `Closes`
+the parent). The conventional-commit type comes from the native issue type
+(mapped via `type_map`) or a `type:` label on personal repos — disagreement
+fails loud.
+
+## Commands
+
+All entry points are Taskfile tasks; each takes `-- --milestone <n|title>` or
+`-- --issue <n>`:
+
+```bash
+task foreman:plan      # dry run: graph, waves, ready set, validation
+task foreman:preflight # read-only agent spec analysis; drafts correction comments
+task foreman:dispatch  # dispatch ready units → verify → open PRs (idempotent)
+task foreman:shepherd  # repair CI, adjudicate reviews, rebase, merge order
+task foreman:watch     # loop plan→dispatch→shepherd (-- --interval 5m)
+task foreman:status    # read-only snapshot + human-action queue
+task foreman:retry     # re-dispatch after a human closed a PR (-- --unit N)
+task foreman:cleanup   # prune worktrees/branches for closed units
+```
+
+## Per-unit flow
+
+1. **Skip if in flight** — an existing attempt branch or open PR means the
+   unit is taken (derived, no state file). Held/un-armed units are skipped.
+2. **Isolate** — `git worktree add` under `.worktrees/foreman/`, branch
+   `foreman/<type>/<n>-<slug>` off the discovered `<remote>/<default>`.
+3. **Prompt** — assembled deterministically: fixed preamble
+   (`scripts/foreman/prompts/implementer-preamble.md`), the full issue +
+   sub-issue bodies, **trusted** comments only (author association OWNER /
+   MEMBER / COLLABORATOR, or foreman's own corrections — drive-by comments
+   on public repos are an injection surface), and the `## Handoff` sections
+   from merged dependency PRs.
+4. **Dispatch** — the backend adapter runs headless in the worktree with a
+   timeout enforced by foreman. The session ref is captured from the FIRST
+   stream event (killed agents emit no final event; resume depends on this).
+5. **Result contract** — the agent must write `result.json` (outside the
+   worktree): status, summary, handoff, human tasks, proposed title, and the
+   AC→test mapping. Exit 0 without a valid contract counts as a crash.
+   Ambiguity escalates via `BLOCKED.md` + a blocked result — never invented
+   through.
+6. **Verify** — foreman itself runs the repo's `verify_command` (default:
+   full `task ci`) in the worktree. The agent's self-report is never trusted.
+7. **Freshness gate** — immediately before pushing: the issue is still open,
+   still armed, dependencies still satisfied, the spec hash (bodies +
+   trusted comments) unchanged since dispatch, and no PR appeared meanwhile.
+   Drift means no push and a flagged unit.
+8. **PR** — non-draft (review bots skip drafts), machine-readable marker,
+   `Closes #N` (or `Refs` when human tasks remain), test evidence, Handoff,
+   and human-only-tasks sections. On failure the worktree, session ref, and
+   a generated resume-state are preserved; the issue stays open so
+   dependents stay blocked.
+9. **Status comment** — exactly one foreman-owned comment per unit, found by
+   marker and edited in place. Display only; never read back for decisions.
+
+## Shepherd
+
+Deterministic triggers → bounded agent actions on open foreman PRs:
+
+- **Red CI** → classify by the signature catalog
+  (`scripts/foreman/signatures.toml`) first. `environment` failures get one
+  empty-commit retry (the retrigger primitive — assume the bot token cannot
+  re-run workflow jobs) and then the human queue; an agent must never "fix"
+  infra by weakening code. `quota_wait` (the agent backend's own usage
+  window) idles until reset. Mechanical failures resume the unit's agent
+  with the failing excerpt.
+- **Behind/conflicting after a sibling merge** → `git merge-tree` dry run
+  enumerates conflicts; clean rebases are mechanical, conflicted ones go to
+  the agent (rebase additively, regenerate generated artifacts via tooling,
+  re-verify) — always rebase, never merge-main.
+- **Unresolved review threads** → the agent adjudicates each finding: apply
+  (commit + reply + resolve) or decline with technical reasoning (bots are
+  sometimes wrong; deterministic facts beat speculation). Blanket-accepting
+  is prohibited. Foreman re-checks disposition completeness afterwards.
+- **Green + adjudicated + mergeable** → `ready-to-merge` label plus a
+  dependency-aware suggested merge order. Foreman performs no merge action
+  of any kind.
+
+## Watch mode and unattended runs
+
+`task foreman:watch` loops plan→dispatch→shepherd with a heartbeat line per
+tick (`.foreman/watch.log`) — silence must look different from health. Every
+tick is stateless and idempotent: kill it, reboot, resume exactly where
+reality is. Stop conditions: milestone complete, `.foreman-stop` file,
+aggregate budget, N consecutive failing ticks.
+
+For multi-day runs prefer a host that won't idle-stop (Codespaces force-stops
+at its idle timeout regardless of a background loop; a coder workspace or any
+persistent container is the reliable substrate). Cron invoking
+`foreman:dispatch` + `foreman:shepherd` on a schedule is equivalent to the
+live loop — statelessness makes the runtime substrate interchangeable.
+
+**Billing**: `billing = "subscription"` (default) inherits the container's
+`CLAUDE_CODE_OAUTH_TOKEN`; USD budgets are inert (timeout/turns bind) and the
+quota-wait signature turns usage-window exhaustion into planned pauses.
+`billing = "api"` exports `FOREMAN_ANTHROPIC_API_KEY` **only inside the
+adapter process** (the container-wide `ANTHROPIC_API_KEY` strip stays), and
+USD budgets bind. Switching is a config flip plus one secret.
+
+## Security model
+
+- **Server-side boundaries** (hold regardless of model behavior): default
+  branch ruleset requiring PRs, code-owner review, and green checks, with
+  the bot excluded from bypass; a fine-grained bot token without `workflows`
+  write (a push touching `.github/workflows/**` is rejected by GitHub); no
+  org/admin scopes.
+- **Identity assertion**: before its first write, foreman requires the gh
+  identity to equal `expected_login` — a leaked-context or wrong-account run
+  refuses to write.
+- **Write contract**: every GitHub mutation lives in
+  `scripts/foreman/github.py` and nowhere else. Foreman may create/push its
+  own branches, open non-draft PRs, edit its own PRs and their
+  foreman-namespace labels, upsert one marker-identified status comment per
+  unit, resolve threads it dispositioned, post human-approved preflight
+  corrections, and ensure its label definitions. It must never merge, close
+  or reopen issues, edit issue bodies/titles, touch human comments, or write
+  fields/types/dependency edges — those operations do not exist in the
+  module, and the test suite greps to keep them absent.
+- **Prompt-injection surface**: only trusted-association comments enter
+  prompts; review-bot findings and CI logs are framed as claims to
+  adjudicate, not instructions; agents run with conservative permission
+  modes outside the sandboxed bot devcontainer (`FOREMAN_SANDBOXED=1`
+  relaxes inside it).
+
+## Configuration (.foreman.toml)
+
+```toml
+backend = "claude"            # default adapter; per-issue input overrides
+require_approval = true       # explicit arming (false = default-armed + holds)
+inputs = "auto"               # auto | fields | labels
+verify_command = ["task", "ci"]
+max_parallel = 3
+branch_prefix = "foreman"
+expected_login = "your-bot"   # identity assertion; "" skips
+billing = "subscription"      # subscription | api
+sandboxed = false             # FOREMAN_SANDBOXED=1 env inside the bot container
+
+[budgets]
+dispatch_usd = 20.0           # binds in api billing mode
+shepherd_usd = 10.0
+
+[timeouts]
+dispatch_min = 90
+shepherd_min = 30
+```
+
+## Extending
+
+- **Backends**: `scripts/foreman/backends/<name>.sh` is the entire vendor
+  surface (`run` / `resume <ref>` / `capabilities`). v1 ships `claude.sh` and
+  `mock.sh` (hermetic seam proof). A new vendor is one small file, added when
+  concretely needed.
+- **Signatures**: when an unmatched CI failure gets an LLM diagnosis, add its
+  regex to `signatures.toml` — the LLM diagnoses once, code recognizes
+  forever.
+- **Agent definitions**: `.claude/agents/foreman-*` wrap the same one-sourced
+  runbooks in `scripts/foreman/prompts/` for interactive use.

--- a/docs/decisions/0002-foreman-deterministic-supervisor.md
+++ b/docs/decisions/0002-foreman-deterministic-supervisor.md
@@ -1,0 +1,75 @@
+# 2. Foreman: a deterministic supervisor for agent-driven delivery
+
+Date: 2026-07-12
+
+## Status
+
+Accepted
+
+## Context
+
+A milestone contains well-specced issues with dependency edges. Working them
+one at a time is safe but slow; working them all at once is chaos. Two real
+milestone runs (omator M3/M4, issue #258's evidence base) showed the failure
+modes: stored status fields lie after crashes, stacked PRs create rebase
+cascades, subscription usage windows kill unattended agents, review-bot
+round-trips eat half the effort, and "the agent says it's done" is not a
+verification strategy.
+
+## Decision
+
+Build **foreman** (`scripts/foreman/`, `task foreman:*`), shipped by the
+template to every generated repo, on these principles:
+
+- **Deterministic supervisor over LLM orchestrator.** Scheduling, readiness,
+  verification, and doneness are plain code; LLMs only produce artifacts
+  (code, replies, analyses) that deterministic gates then measure. Zero
+  tokens on coordination.
+- **The human merge is the only graph-advancing event — permanently.** No
+  auto-merge, no enabling flag, ever. Enforcement is server-side (ruleset,
+  code-owner review, bot token without bypass or `workflows` write), with an
+  identity assertion before foreman's first write.
+- **Wave model over stacked PRs.** Every agent branches off the default
+  branch; human merges unblock the next wave; merge freezes mean foreman
+  idles by design. Same-wave file collisions are handled by the shepherd's
+  post-merge rebase loop, not by stacking.
+- **Parent issue = one unit = one PR**; sub-issues are the unit's internal
+  task list.
+- **Inputs are stored; derived state is never stored.** Human inputs live in
+  issue bodies, native `blocked-by` edges, and the `foreman` issue field
+  (org repos) or `foreman:*` labels (personal repos; issue fields are
+  org-only). An `agentState` field was considered and rejected: it
+  duplicates derivable facts, lies after crashes, and GitHub has no
+  compare-and-swap. Projects are display-only.
+- **Explicit arming by default** (v1 decision, flipping the spec draft):
+  only issues carrying the `foreman` input dispatch; its value also selects
+  the backend. `require_approval = false` opts a repo into default-armed.
+- **Foreman opens PRs, not agents** (v1 decision): agents hand results over
+  a validated sidecar contract (summary, handoff, human tasks, AC→test map,
+  blocked question); foreman verifies with the repo's own `verify_command`
+  (default full `task ci`), re-checks freshness (spec hash + eligibility)
+  at push time, and assembles a deterministic, marker-carrying PR.
+- **Hardened doneness**: a foreman-managed dependency is satisfied only via
+  the merged-marker-PR chain (merged into the discovered default branch, by
+  the bot, from a foreman attempt branch); external dependencies must be
+  closed as completed, with an explicit `foreman:satisfied` human override.
+- **Backend adapter seam**: `backends/<name>.sh` is the entire vendor
+  surface; v1 ships `claude.sh` plus a hermetic `mock.sh` that proves the
+  seam. Subscription billing is the v1 default (usage-window exhaustion is a
+  planned pause via the signature catalog, not a failure); API-key billing
+  is a config flip with the key exported only into the adapter process.
+
+## Consequences
+
+- Crashes, reboots, and multi-day unattended runs are safe by construction:
+  every tick re-derives reality from GitHub + git.
+- Humans stay the bottleneck by design — the merge queue is the throttle,
+  and `foreman:status` exists to make that queue cheap to service.
+- The write contract concentrates all GitHub mutations in one module,
+  enforceable by tests (forbidden operations are absent, not discouraged).
+- Two input tiers (fields vs labels) must be maintained until GitHub ships
+  issue fields for personal accounts; the dual-source fail-loud rule guards
+  the seam.
+- Foreman's own tests, lint (ruff/black via uvx), and docs ship with the
+  template's two-layer dogfood; drift is caught by `test:dogfood-parity`
+  and the `use_foreman` render matrix in `test-template.sh`.

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -56,6 +56,13 @@ item). The lane is built for future automation, though — an agent can watch *A
 Queue + Agent-set + priority* (the Agent-queue view below) and pull the top item on
 its own — and either way the item moves to **In Progress** once work starts.
 
+> **Foreman is that automation** for issue-driven delivery: arm the issue
+> (`foreman:*` label, or the org `foreman` issue field) and
+> `task foreman:dispatch` / `foreman:watch` pulls ready items, opens verified
+> PRs, and shepherds them to a human merge. The Project stays the human
+> dashboard — foreman neither reads nor writes it (issue state, labels/fields,
+> and PRs are its interface). See `docs/architecture/foreman.md`.
+
 ## Status is not issue state
 
 GitHub has **two independent state machines**, and conflating them is the most

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -34,6 +34,11 @@ pre-commit:
     actions:
       glob: ".github/workflows/*.{yml,yaml}"
       run: task lint:actions
+    python:
+      glob: "*.py"
+      exclude:
+        - "template/**"
+      run: task foreman:lint
     hygiene:
       run: task lint:hygiene -- {staged_files}
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -34,7 +34,7 @@ pre-commit:
     actions:
       glob: ".github/workflows/*.{yml,yaml}"
       run: task lint:actions
-    python:
+    foreman-lint:
       glob: "*.py"
       exclude:
         - "template/**"

--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,17 @@
         "uses: (?<depName>[^\\s@]+)@(?<currentDigest>[0-9a-f]{40}) # (?<currentValue>v[0-9][0-9.]*)"
       ],
       "datasourceTemplate": "github-tags"
+    },
+    {
+      "customType": "regex",
+      "description": "Taskfile tool pins (root Taskfile + included taskfiles/, both layers), `FOO_VERSION: x.y.z` var style — used by foreman:lint's uvx-pinned ruff/black",
+      "managerFilePatterns": [
+        "/(^|\\/)Taskfile\\.ya?ml(\\.jinja)?$/",
+        "/taskfiles\\/[^/]+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+[A-Z_]+_VERSION: \"?(?<currentValue>[^\"\\s]+)\"?"
+      ]
     }
   ],
   "packageRules": [

--- a/scripts/foreman/__init__.py
+++ b/scripts/foreman/__init__.py
@@ -1,0 +1,15 @@
+"""Foreman — deterministic supervisor for milestone-driven agent dispatch.
+
+Reads a milestone's (or single issue's) dependency graph from GitHub,
+dispatches ready units to isolated headless agents in git worktrees, verifies
+their output with the repo's own CI gate, opens PRs, and shepherds those PRs
+to mergeable. Every merge is a human decision — foreman never merges.
+
+State of record is GitHub + git, re-derived every tick; foreman stores no
+local state files (worktrees and logs are disposable operational artifacts).
+
+Spec: https://github.com/evanharmon1/harmon-init/issues/258
+Docs: docs/architecture/foreman.md
+"""
+
+__version__ = "0.1.0"

--- a/scripts/foreman/__main__.py
+++ b/scripts/foreman/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point: PYTHONPATH=scripts python3 -m foreman <command> [flags]."""
+
+import sys
+
+from foreman.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/foreman/backend.py
+++ b/scripts/foreman/backend.py
@@ -1,0 +1,291 @@
+"""Agent backend adapter seam. Adapters are `backends/<name>.sh` — the entire
+vendor surface. Foreman shells out; no vendor SDKs in core.
+
+Adapter contract:
+  argv:  <adapter> run | resume <session-ref> | capabilities
+  cwd:   the unit's worktree
+  env:   FOREMAN_PROMPT_FILE, FOREMAN_RESULT_FILE, FOREMAN_SESSION_FILE,
+         FOREMAN_LOG_FILE, FOREMAN_TIMEOUT_MIN, FOREMAN_PERMISSION_MODE,
+         FOREMAN_BILLING, FOREMAN_MAX_TURNS (0 = uncapped)
+  out:   exit 0/non-zero; session file line `SESSION_REF=<id>` written as
+         EARLY as the backend allows (killed agents emit no final event —
+         resume depends on this), later `COST_USD=<x>` when known.
+  caps:  `capabilities` prints tokens, e.g. `resume cost`.
+
+Timeouts are enforced HERE (portable), not in the adapters.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from foreman import signatures as signatures_mod
+from foreman.config import Config
+from foreman.util import ForemanError, run, tail, utc_now_iso, write_text
+
+BACKENDS_DIR = Path(__file__).resolve().parent / "backends"
+
+RESULT_STATUSES = ("completed", "blocked")
+
+
+@dataclass
+class BackendResult:
+    returncode: int
+    timed_out: bool = False
+    session_ref: str | None = None
+    cost_usd: float | None = None
+    quota_wait: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0 and not self.timed_out
+
+
+def adapter_path(name: str) -> Path:
+    path = BACKENDS_DIR / f"{name}.sh"
+    if not path.exists():
+        available = sorted(p.stem for p in BACKENDS_DIR.glob("*.sh"))
+        raise ForemanError(
+            f"unknown backend '{name}' (available: {', '.join(available)})"
+        )
+    return path
+
+
+def capabilities(adapter: Path) -> set[str]:
+    proc = run([str(adapter), "capabilities"], check=False)
+    return set(proc.stdout.split()) if proc.returncode == 0 else set()
+
+
+def assert_backend_version(cfg: Config) -> None:
+    """Pin check: headless behavior drifts between agent-CLI releases."""
+    if not cfg.backend_version or cfg.backend != "claude":
+        return
+    proc = run(["claude", "--version"], check=False)
+    version = (
+        proc.stdout.strip().split()[0] if proc.returncode == 0 and proc.stdout else ""
+    )
+    if not version.startswith(cfg.backend_version):
+        raise ForemanError(
+            f"backend version mismatch: claude CLI is '{version or 'missing'}', "
+            f"config pins '{cfg.backend_version}'"
+        )
+
+
+def unit_dir(cfg: Config, root: Path, number: int) -> Path:
+    path = root / cfg.runtime_dir / "units" / str(number)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def run_backend(
+    cfg: Config,
+    adapter: Path,
+    *,
+    cwd: Path,
+    unit_run_dir: Path,
+    prompt_file: Path,
+    timeout_min: int,
+    resume_ref: str | None = None,
+) -> BackendResult:
+    session_file = unit_run_dir / "session"
+    log_file = unit_run_dir / "agent.log"
+    result_file = unit_run_dir / "result.json"
+    stdout_file = unit_run_dir / "adapter-stdout.log"
+    if result_file.exists():
+        result_file.unlink()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "FOREMAN_PROMPT_FILE": str(prompt_file),
+            "FOREMAN_RESULT_FILE": str(result_file),
+            "FOREMAN_SESSION_FILE": str(session_file),
+            "FOREMAN_LOG_FILE": str(log_file),
+            "FOREMAN_TIMEOUT_MIN": str(timeout_min),
+            "FOREMAN_PERMISSION_MODE": cfg.resolved_permission_mode(),
+            "FOREMAN_BILLING": cfg.billing,
+            "FOREMAN_MAX_TURNS": str(cfg.max_turns),
+        }
+    )
+    if cfg.billing == "api" and not env.get("FOREMAN_ANTHROPIC_API_KEY"):
+        raise ForemanError("billing=api but FOREMAN_ANTHROPIC_API_KEY is not set")
+
+    argv = [str(adapter), "resume", resume_ref] if resume_ref else [str(adapter), "run"]
+    timed_out = False
+    with stdout_file.open("a", encoding="utf-8") as out_fh:
+        out_fh.write(f"\n--- {utc_now_iso()} {' '.join(argv)} ---\n")
+        out_fh.flush()
+        proc = subprocess.Popen(
+            argv,
+            cwd=str(cwd),
+            env=env,
+            stdout=out_fh,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        try:
+            proc.wait(timeout=timeout_min * 60)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            _kill_group(proc)
+
+    result = BackendResult(returncode=proc.returncode, timed_out=timed_out)
+    _read_session_file(session_file, result)
+    log_tail = tail(log_file, 80) + "\n" + tail(stdout_file, 40)
+    sig = signatures_mod.match(log_tail, signatures_mod.load())
+    if sig is not None and sig.action == "quota_wait":
+        result.quota_wait = True
+    return result
+
+
+def _kill_group(proc: subprocess.Popen) -> None:
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return
+        time.sleep(0.2)
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    proc.wait()
+
+
+def _read_session_file(session_file: Path, result: BackendResult) -> None:
+    if not session_file.exists():
+        return
+    for line in session_file.read_text(encoding="utf-8").splitlines():
+        if line.startswith("SESSION_REF=") and not result.session_ref:
+            result.session_ref = line.split("=", 1)[1].strip() or None
+        elif line.startswith("COST_USD="):
+            try:
+                result.cost_usd = float(line.split("=", 1)[1])
+            except ValueError:
+                pass
+
+
+# ── result contract ──────────────────────────────────────────────────
+
+
+@dataclass
+class ResultContract:
+    status: str
+    summary: str = ""
+    handoff: str = ""
+    human_tasks: list[str] = field(default_factory=list)
+    proposed_pr_title: str = ""
+    ac_test_map: list[dict] = field(default_factory=list)
+    blocked_question: str | None = None
+
+
+def read_result(
+    unit_run_dir: Path, worktree: Path
+) -> tuple[ResultContract | None, list[str]]:
+    """Validate the sidecar result contract; BLOCKED.md is the fallback signal."""
+    result_file = unit_run_dir / "result.json"
+    blocked_md = worktree / "BLOCKED.md"
+    if not result_file.exists():
+        if blocked_md.exists():
+            question = blocked_md.read_text(encoding="utf-8").strip()
+            return ResultContract(status="blocked", blocked_question=question), []
+        return None, ["agent exited without writing the result contract"]
+    try:
+        data = json.loads(result_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, [f"result.json is not valid JSON: {exc}"]
+
+    errors: list[str] = []
+    if not isinstance(data, dict):
+        return None, ["result.json must be a JSON object"]
+    if data.get("schema") != 1:
+        errors.append("result.json: schema must be 1")
+    status = data.get("status")
+    if status not in RESULT_STATUSES:
+        errors.append(f"result.json: status must be one of {RESULT_STATUSES}")
+        return None, errors
+
+    contract = ResultContract(status=status)
+    contract.summary = _expect_str(
+        data, "summary", errors, required=(status == "completed")
+    )
+    contract.handoff = _expect_str(
+        data, "handoff", errors, required=(status == "completed")
+    )
+    contract.proposed_pr_title = _expect_str(
+        data, "proposed_pr_title", errors, required=False
+    )
+    contract.blocked_question = data.get("blocked_question") or None
+    if status == "blocked" and not contract.blocked_question:
+        if blocked_md.exists():
+            contract.blocked_question = blocked_md.read_text(encoding="utf-8").strip()
+        else:
+            errors.append("result.json: blocked status requires blocked_question")
+    tasks = data.get("human_tasks", [])
+    if not isinstance(tasks, list) or not all(isinstance(t, str) for t in tasks):
+        errors.append("result.json: human_tasks must be a list of strings")
+    else:
+        contract.human_tasks = tasks
+    ac_map = data.get("ac_test_map", [])
+    if not isinstance(ac_map, list):
+        errors.append("result.json: ac_test_map must be a list")
+    else:
+        for entry in ac_map:
+            if (
+                not isinstance(entry, dict)
+                or "criterion" not in entry
+                or "tests" not in entry
+            ):
+                errors.append(
+                    "result.json: ac_test_map entries need {criterion, tests}"
+                )
+                break
+        else:
+            contract.ac_test_map = ac_map
+    if status == "completed" and not contract.ac_test_map:
+        errors.append("result.json: completed status requires a non-empty ac_test_map")
+    return (contract, errors) if not errors else (None, errors)
+
+
+def _expect_str(data: dict, key: str, errors: list[str], *, required: bool) -> str:
+    value = data.get(key, "")
+    if not isinstance(value, str):
+        errors.append(f"result.json: {key} must be a string")
+        return ""
+    if required and not value.strip():
+        errors.append(f"result.json: {key} is required")
+    return value
+
+
+def write_resume_state(unit_run_dir: Path, worktree: Path, note: str) -> Path:
+    """Deterministic resume-state so a later resume needs no archaeology."""
+    status = run(
+        ["git", "-C", str(worktree), "status", "--porcelain", "-b"], check=False
+    ).stdout
+    log = run(
+        ["git", "-C", str(worktree), "log", "--oneline", "-5"], check=False
+    ).stdout
+    session = (
+        (unit_run_dir / "session").read_text(encoding="utf-8")
+        if (unit_run_dir / "session").exists()
+        else ""
+    )
+    body = (
+        f"# Resume state — {utc_now_iso()}\n\n{note}\n\n"
+        f"## Worktree\n\n`{worktree}`\n\n```text\n{status}```\n\n"
+        f"## Recent commits\n\n```text\n{log}```\n\n"
+        f"## Session\n\n```text\n{session}```\n\n"
+        f"## Agent log tail\n\n```text\n{tail(unit_run_dir / 'agent.log', 40)}\n```\n"
+    )
+    path = unit_run_dir / "resume-state.md"
+    write_text(path, body)
+    return path

--- a/scripts/foreman/backends/claude.sh
+++ b/scripts/foreman/backends/claude.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# claude.sh — Foreman backend adapter for Claude Code (headless print mode).
+#
+# Contract (see scripts/foreman/backend.py):
+#   claude.sh run                  dispatch with $FOREMAN_PROMPT_FILE
+#   claude.sh resume <session-id>  resume a prior session with a new prompt
+#   claude.sh capabilities         print capability tokens ("resume cost")
+#
+# Env in:  FOREMAN_PROMPT_FILE FOREMAN_RESULT_FILE FOREMAN_SESSION_FILE
+#          FOREMAN_LOG_FILE FOREMAN_PERMISSION_MODE FOREMAN_BILLING
+#          FOREMAN_MAX_TURNS FOREMAN_READONLY FOREMAN_ANTHROPIC_API_KEY
+# Out:     SESSION_REF=<id> appended to $FOREMAN_SESSION_FILE from the FIRST
+#          stream event (killed agents emit no final event, and resuming dead
+#          agents is exactly when the ref matters), COST_USD=<x> when known.
+#
+# Timeouts are enforced by foreman (backend.py), not here.
+set -euo pipefail
+
+fail() {
+    echo "claude.sh: $*" >&2
+    exit 1
+}
+
+cmd="${1:-run}"
+resume_ref=""
+case "$cmd" in
+capabilities)
+    echo "resume cost"
+    exit 0
+    ;;
+run) ;;
+resume)
+    resume_ref="${2:-}"
+    [ -n "$resume_ref" ] || fail "resume requires a session ref"
+    ;;
+*) fail "unknown command: $cmd" ;;
+esac
+
+: "${FOREMAN_PROMPT_FILE:?}" "${FOREMAN_RESULT_FILE:?}" "${FOREMAN_SESSION_FILE:?}" "${FOREMAN_LOG_FILE:?}"
+command -v claude >/dev/null 2>&1 || fail "claude CLI not found on PATH"
+
+# Billing isolation (spec A11): in api mode the key is exported ONLY into this
+# adapter process. The container-wide ANTHROPIC_API_KEY strip (init-env.sh,
+# shell-aliases.sh) stays intact for interactive sessions.
+if [ "${FOREMAN_BILLING:-subscription}" = "api" ]; then
+    [ -n "${FOREMAN_ANTHROPIC_API_KEY:-}" ] || fail "billing=api needs FOREMAN_ANTHROPIC_API_KEY"
+    export ANTHROPIC_API_KEY="$FOREMAN_ANTHROPIC_API_KEY"
+    unset CLAUDE_CODE_OAUTH_TOKEN
+fi
+
+# Read-only analysis mode (preflight): plain-text final output on stdout
+# (foreman captures it), no file edits, no shell.
+if [ "${FOREMAN_READONLY:-0}" = "1" ]; then
+    exec claude -p --permission-mode default \
+        --disallowedTools Edit Write NotebookEdit Bash \
+        <"$FOREMAN_PROMPT_FILE"
+fi
+
+args=(-p --output-format stream-json --verbose)
+args+=(--permission-mode "${FOREMAN_PERMISSION_MODE:-acceptEdits}")
+# The result contract lives OUTSIDE the worktree; grant only that directory.
+args+=(--add-dir "$(dirname "$FOREMAN_RESULT_FILE")")
+if [ "${FOREMAN_MAX_TURNS:-0}" != "0" ]; then
+    args+=(--max-turns "$FOREMAN_MAX_TURNS")
+fi
+if [ -n "$resume_ref" ]; then
+    args+=(--resume "$resume_ref")
+fi
+
+# Stream to the log; capture SESSION_REF from the first event carrying a
+# session_id and COST_USD from the result event. pipefail carries claude's
+# exit code out of the pipeline (bash 3.2 compatible).
+claude "${args[@]}" <"$FOREMAN_PROMPT_FILE" | {
+    session_captured=0
+    while IFS= read -r line; do
+        printf '%s\n' "$line" >>"$FOREMAN_LOG_FILE"
+        if [ "$session_captured" -eq 0 ]; then
+            sid=$(printf '%s' "$line" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+            if [ -n "$sid" ]; then
+                echo "SESSION_REF=$sid" >>"$FOREMAN_SESSION_FILE"
+                session_captured=1
+            fi
+        fi
+        cost=$(printf '%s' "$line" | sed -n 's/.*"total_cost_usd"[[:space:]]*:[[:space:]]*\([0-9.]*\).*/\1/p')
+        if [ -n "$cost" ]; then
+            echo "COST_USD=$cost" >>"$FOREMAN_SESSION_FILE"
+        fi
+    done
+}

--- a/scripts/foreman/backends/mock.sh
+++ b/scripts/foreman/backends/mock.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# mock.sh — canned-diff test adapter. Exists to prove the backend seam and to
+# make foreman's own end-to-end paths exercisable without a vendor CLI,
+# network, or spend. Never dispatch real work at it.
+#
+# Knobs (env):
+#   FOREMAN_MOCK_STATUS=completed|blocked|fail   default: completed
+#   FOREMAN_MOCK_FILE=<relative path>            default: MOCK.md
+set -euo pipefail
+
+cmd="${1:-run}"
+case "$cmd" in
+capabilities)
+    echo "cost"
+    exit 0
+    ;;
+run | resume) ;;
+*)
+    echo "mock.sh: unknown command: $cmd" >&2
+    exit 1
+    ;;
+esac
+
+: "${FOREMAN_RESULT_FILE:?}" "${FOREMAN_SESSION_FILE:?}" "${FOREMAN_LOG_FILE:?}"
+
+echo "SESSION_REF=mock-$$" >>"$FOREMAN_SESSION_FILE"
+echo "mock adapter: cwd=$(pwd) cmd=$cmd status=${FOREMAN_MOCK_STATUS:-completed}" >>"$FOREMAN_LOG_FILE"
+
+if [ "${FOREMAN_READONLY:-0}" = "1" ]; then
+    cat <<'FINDINGS'
+# Mock preflight findings
+
+No real analysis — this is the seam-proof adapter.
+
+## DRAFT COMMENT FOR #0
+
+Mock drafted correction (delete me; unit #0 never exists).
+FINDINGS
+    exit 0
+fi
+
+status="${FOREMAN_MOCK_STATUS:-completed}"
+case "$status" in
+fail)
+    echo "mock adapter: simulated agent failure" >>"$FOREMAN_LOG_FILE"
+    exit 1
+    ;;
+blocked)
+    cat >"$FOREMAN_RESULT_FILE" <<'JSON'
+{
+  "schema": 1,
+  "status": "blocked",
+  "blocked_question": "Mock question: which behavior is intended?"
+}
+JSON
+    echo "COST_USD=0.00" >>"$FOREMAN_SESSION_FILE"
+    exit 2
+    ;;
+esac
+
+target="${FOREMAN_MOCK_FILE:-MOCK.md}"
+{
+    echo "# Mock change"
+    echo
+    echo "Applied by the foreman mock backend adapter."
+} >"$target"
+git add "$target"
+# LEFTHOOK=0 is lefthook's sanctioned skip switch for automation; the mock
+# adapter's commits are throwaway seam proofs, not repo changes.
+LEFTHOOK=0 git -c user.name="foreman-mock" -c user.email="mock@example.invalid" \
+    commit -q -m "chore: mock change (foreman mock backend)"
+cat >"$FOREMAN_RESULT_FILE" <<'JSON'
+{
+  "schema": 1,
+  "status": "completed",
+  "summary": "Mock backend applied a canned change.",
+  "handoff": "Nothing downstream depends on this mock change.",
+  "human_tasks": [],
+  "proposed_pr_title": "chore: mock change",
+  "ac_test_map": [
+    { "criterion": "mock criterion [CI]", "tests": ["mock_test"] }
+  ]
+}
+JSON
+echo "COST_USD=0.00" >>"$FOREMAN_SESSION_FILE"

--- a/scripts/foreman/cli.py
+++ b/scripts/foreman/cli.py
@@ -1,0 +1,542 @@
+"""Command-line interface. Taskfile targets are thin wrappers over these
+subcommands: plan, preflight, dispatch, shepherd, watch, status, retry,
+cleanup. plan/status/preflight-draft are read-only by construction
+(github.GitHub.read_only) — the write contract is enforced, not promised.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from foreman import backend as backend_mod
+from foreman import dispatch as dispatch_mod
+from foreman import inputs as inputs_mod
+from foreman import report, shepherd as shepherd_mod, spec, watch as watch_mod, worktree
+from foreman.config import Config, load as load_config
+from foreman.github import Gh, GitHub
+from foreman.graph import (
+    Target,
+    dependency_satisfied,
+    detect_cycle,
+    prepare_target,
+    waves,
+)
+from foreman.util import ForemanError, error, info, repo_root, warn, write_text
+
+
+def _add_target_args(parser: argparse.ArgumentParser, *, required: bool = True) -> None:
+    group = parser.add_mutually_exclusive_group(required=required)
+    group.add_argument("--milestone", help="milestone number or exact title")
+    group.add_argument(
+        "--issue", type=int, help="single issue number (with its sub-issues)"
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="foreman",
+        description="Deterministic supervisor: dispatch ready issues to headless "
+        "agents, verify, open PRs, shepherd them to mergeable. Humans merge.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_plan = sub.add_parser(
+        "plan", help="dry run: graph, waves, ready set (no side effects)"
+    )
+    _add_target_args(p_plan)
+
+    p_preflight = sub.add_parser(
+        "preflight",
+        help="read-only agent analysis of the target; drafts correction comments",
+    )
+    _add_target_args(p_preflight)
+    p_preflight.add_argument(
+        "--post",
+        action="store_true",
+        help="post the human-reviewed drafted comments from .foreman/preflight/comments/",
+    )
+
+    p_dispatch = sub.add_parser(
+        "dispatch", help="dispatch ready units → verify → open PRs"
+    )
+    _add_target_args(p_dispatch)
+    p_dispatch.add_argument("--max-parallel", type=int, default=None)
+
+    sub.add_parser(
+        "shepherd", help="repair CI, adjudicate reviews, rebase, report merge order"
+    )
+
+    p_watch = sub.add_parser(
+        "watch", help="loop plan→dispatch→shepherd with heartbeats"
+    )
+    _add_target_args(p_watch)
+    p_watch.add_argument("--interval", default="5m", help="tick interval (300, 5m, 1h)")
+    p_watch.add_argument(
+        "--budget-usd", type=float, default=None, help="aggregate stop budget"
+    )
+
+    p_status = sub.add_parser("status", help="read-only snapshot + human-action queue")
+    _add_target_args(p_status)
+
+    p_retry = sub.add_parser("retry", help="re-dispatch a unit whose PR a human closed")
+    p_retry.add_argument("--unit", type=int, required=True)
+
+    sub.add_parser(
+        "cleanup", help="prune worktrees + foreman branches for closed units"
+    )
+    return parser
+
+
+def _context(read_only: bool) -> tuple[Config, Path, GitHub]:
+    root = repo_root()
+    cfg = load_config(root)
+    gh = GitHub(Gh(), cfg)
+    gh.read_only = read_only
+    return cfg, root, gh
+
+
+def _print_plan(gh: GitHub, cfg: Config, target: Target) -> int:
+    remote_name = worktree.remote(cfg)
+    print(f"Target: {target.label}")
+    print(f"Inputs: {inputs_mod.describe_mode(target.mode, cfg)}")
+    print(f"Base:   {remote_name}/{gh.default_branch()}")
+    print()
+
+    cycle = detect_cycle(target)
+    if cycle:
+        error("dependency cycle: " + " -> ".join(f"#{n}" for n in cycle))
+        return 1
+
+    fail_loud = False
+    ready, skipped = dispatch_mod.eligibility(gh, cfg, target)
+    by_number = {o.unit.number: o for o in skipped}
+    print("Waves (dependency order):")
+    for index, wave in enumerate(waves(target), 1):
+        print(f"  wave {index}:")
+        for number in wave:
+            unit = target.units[number]
+            spec_info = spec.validate(unit)
+            if unit in ready:
+                state = "READY"
+            elif not unit.open:
+                state = "closed"
+            else:
+                outcome = by_number.get(number)
+                state = outcome.status if outcome else "waiting"
+            notes = []
+            for dep in unit.blocked_by:
+                dep_inputs = target.units[dep].inputs if dep in target.units else None
+                done = dependency_satisfied(
+                    gh, cfg, dep, inputs=dep_inputs, mode=target.mode
+                )
+                mark = "✓" if done.satisfied else "✗"
+                notes.append(f"{mark}#{dep} ({done.how})")
+                for note in done.warnings:
+                    warn(note)
+            problems = (
+                unit.errors
+                + (unit.inputs.errors if unit.inputs else [])
+                + spec_info.errors
+            )
+            if problems:
+                fail_loud = True
+            line = f"    #{number} [{state}] {unit.title}"
+            commit_type = unit.inputs.commit_type if unit.inputs else cfg.default_type
+            line += f"  (type={commit_type}"
+            if notes:
+                line += f"; deps: {', '.join(notes)}"
+            line += ")"
+            print(line)
+            for problem in problems:
+                print(f"      ERROR: {problem}")
+            for warning in spec_info.warnings + (
+                unit.inputs.warnings if unit.inputs else []
+            ):
+                print(f"      note: {warning}")
+    print()
+    print(f"Ready now: {', '.join('#' + str(u.number) for u in ready) or '(none)'}")
+
+    notices = _concurrent_activity(gh, target)
+    if notices:
+        print()
+        print(
+            "Concurrent-activity notice (collisions possible — preflight should look):"
+        )
+        for notice in notices:
+            print(f"  - {notice}")
+    return 1 if fail_loud else 0
+
+
+def _concurrent_activity(gh: GitHub, target: Target) -> list[str]:
+    notices = []
+    for ms in gh.milestones(state="open"):
+        if target.milestone and ms["title"] == target.milestone:
+            continue
+        if ms.get("open_issues"):
+            notices.append(
+                f"open milestone '{ms['title']}' with {ms['open_issues']} open issue(s)"
+            )
+    others = [
+        p
+        for p in gh.prs(state="open")
+        if "foreman-dispatched"
+        not in [label["name"] for label in p.get("labels") or []]
+    ]
+    if others:
+        notices.append(
+            f"{len(others)} open non-foreman PR(s) may land on the default branch mid-run"
+        )
+    return notices
+
+
+def cmd_plan(args: argparse.Namespace) -> int:
+    cfg, _root, gh = _context(read_only=True)
+    target = prepare_target(gh, cfg, milestone=args.milestone, issue=args.issue)
+    return _print_plan(gh, cfg, target)
+
+
+def cmd_dispatch(args: argparse.Namespace) -> int:
+    cfg, root, gh = _context(read_only=False)
+    backend_mod.assert_backend_version(cfg)
+    target = prepare_target(gh, cfg, milestone=args.milestone, issue=args.issue)
+    cycle = detect_cycle(target)
+    if cycle:
+        error(
+            "refusing to dispatch: dependency cycle "
+            + " -> ".join(f"#{n}" for n in cycle)
+        )
+        return 1
+    outcomes = dispatch_mod.run_dispatch(
+        gh, cfg, root, target, max_parallel=args.max_parallel
+    )
+    statuses = [
+        report.UnitStatus(
+            unit=o.unit,
+            state=o.status,
+            branch=o.branch,
+            pr_url=o.pr_url,
+            detail=o.detail,
+        )
+        for o in outcomes
+    ]
+    print()
+    print(report.summary_table(statuses))
+    failed = [o for o in outcomes if o.status in ("failed", "blocked", "stale")]
+    for outcome in failed:
+        print(f"\n#{outcome.unit.number} {outcome.status}: {outcome.detail}")
+    return 1 if failed else 0
+
+
+def cmd_shepherd(_args: argparse.Namespace) -> int:
+    cfg, root, gh = _context(read_only=False)
+    backend_mod.assert_backend_version(cfg)
+    shep = shepherd_mod.run_shepherd(gh, cfg, root)
+    if shep.worked:
+        rows = [
+            [f"#{w.unit_number}", f"PR #{w.number}", w.state, w.detail[:70]]
+            for w in shep.worked
+        ]
+        print(report.table(["unit", "pr", "state", "detail"], rows))
+    if shep.ready_order:
+        print()
+        print("Suggested merge order (foreman never merges):")
+        for index, (number, url) in enumerate(shep.ready_order, 1):
+            print(f"  {index}. #{number}  {url}")
+    if shep.environmental:
+        print()
+        for number, detail in sorted(shep.environmental.items()):
+            print(f"NEEDS HUMAN #{number}: {detail}")
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    cfg, root, gh = _context(read_only=True)
+    target = prepare_target(gh, cfg, milestone=args.milestone, issue=args.issue)
+    open_prs = shepherd_mod.open_foreman_prs(gh)
+    prs_by_unit = {p["_unit"]: p for p in open_prs}
+    statuses: list[report.UnitStatus] = []
+    human_tasks: dict[int, list[str]] = {}
+    blocked: dict[int, str] = {}
+    ready: list[shepherd_mod.PrWork] = []
+    for number in sorted(target.units):
+        unit = target.units[number]
+        spec_info = spec.validate(unit)
+        tasks = spec.human_only_tasks(unit, spec_info) if not spec_info.errors else []
+        if tasks and unit.open:
+            human_tasks[number] = tasks
+        if not unit.open:
+            done = dependency_satisfied(
+                gh, cfg, number, inputs=unit.inputs, mode=target.mode
+            )
+            statuses.append(
+                report.UnitStatus(unit=unit, state="merged", detail=done.how)
+            )
+            continue
+        pr = prs_by_unit.get(number)
+        if pr:
+            status = gh.pr_status(pr["number"])
+            checks_state, _failed = shepherd_mod.classify_checks(
+                status.get("statusCheckRollup")
+            )
+            labels = [label["name"] for label in status.get("labels") or []]
+            state = "ready-to-merge" if "ready-to-merge" in labels else "pr-open"
+            if state == "ready-to-merge":
+                ready.append(
+                    shepherd_mod.PrWork(
+                        number=pr["number"],
+                        unit_number=number,
+                        branch=status["headRefName"],
+                        url=status["url"],
+                        title=status["title"],
+                    )
+                )
+            statuses.append(
+                report.UnitStatus(
+                    unit=unit,
+                    state=state,
+                    branch=status["headRefName"],
+                    pr_url=status["url"],
+                    checks=checks_state,
+                    detail=status["title"],
+                )
+            )
+            continue
+        blocked_file = root / cfg.runtime_dir / "units" / str(number) / "result.json"
+        detail = ""
+        if blocked_file.exists():
+            contract, _errors = backend_mod.read_result(
+                blocked_file.parent, worktree.worktree_path(cfg, root, unit)
+            )
+            if contract and contract.status == "blocked" and contract.blocked_question:
+                blocked[number] = contract.blocked_question
+                detail = "blocked on a question"
+        outcome_state = "waiting"
+        if unit.inputs and unit.inputs.hold:
+            outcome_state = "held"
+        elif unit.inputs and not unit.inputs.armed:
+            outcome_state = "not-armed"
+        statuses.append(
+            report.UnitStatus(unit=unit, state=outcome_state, detail=detail)
+        )
+    print(report.summary_table(statuses))
+    print()
+    print(
+        report.human_queue(
+            merge_order=shepherd_mod.merge_order(gh, ready),
+            human_tasks=human_tasks,
+            blocked=blocked,
+            environmental={},
+        )
+    )
+    return 0
+
+
+def cmd_retry(args: argparse.Namespace) -> int:
+    cfg, root, gh = _context(read_only=False)
+    backend_mod.assert_backend_version(cfg)
+    target = prepare_target(gh, cfg, milestone=None, issue=args.unit)
+    unit = target.units[args.unit]
+    if not unit.open:
+        error(f"#{args.unit} is closed — nothing to retry")
+        return 1
+    remote_name = worktree.remote(cfg)
+    attempts = worktree.attempt_branches(cfg, remote_name, unit.number)
+    open_prs = [p for p in gh.prs(state="open") if p["headRefName"] in attempts]
+    if open_prs:
+        error(
+            f"#{args.unit} still has an open PR ({open_prs[0]['url']}) — close it first"
+        )
+        return 1
+    stale_wt = worktree.worktree_path(cfg, root, unit)
+    if stale_wt.exists():
+        info(f"removing preserved worktree {stale_wt}")
+        worktree.remove(stale_wt)
+    outcome = dispatch_mod.dispatch_unit(gh, cfg, root, unit, mode=target.mode)
+    print(
+        report.summary_table(
+            [
+                report.UnitStatus(
+                    unit=unit,
+                    state=outcome.status,
+                    branch=outcome.branch,
+                    pr_url=outcome.pr_url,
+                    detail=outcome.detail,
+                )
+            ]
+        )
+    )
+    return 0 if outcome.dispatched else 1
+
+
+def cmd_cleanup(_args: argparse.Namespace) -> int:
+    cfg, root, gh = _context(read_only=False)
+    remote_name = worktree.remote(cfg)
+    worktree.fetch(remote_name)
+    import re as _re
+
+    from foreman.util import run as _run
+
+    pattern = _re.compile(rf"^{_re.escape(cfg.branch_prefix)}/[^/]+/(?P<number>\d+)-")
+    by_unit: dict[int, list[str]] = {}
+    refs = _run(["git", "ls-remote", "--heads", remote_name]).stdout
+    local = _run(
+        ["git", "for-each-ref", "--format=%(refname:short)", "refs/heads/"]
+    ).stdout
+    names = {
+        line.split("\t")[1][len("refs/heads/") :]
+        for line in refs.splitlines()
+        if "\t" in line
+    }
+    names.update(name for name in local.split() if name)
+    for name in sorted(names):
+        match = pattern.match(name)
+        if match:
+            by_unit.setdefault(int(match.group("number")), []).append(name)
+
+    removed = 0
+    for number, branches in sorted(by_unit.items()):
+        issue = gh.issue(number)
+        if (issue.get("state") or "").upper() != "CLOSED":
+            continue
+        if any(gh.prs(head=branch, state="open") for branch in branches):
+            continue
+        for branch in branches:
+            info(f"cleanup: deleting branch {branch} (unit #{number} closed)")
+            worktree.delete_branch(cfg, remote_name, branch)
+            removed += 1
+        for path in (root / cfg.worktrees_dir).glob(f"{number}-*"):
+            worktree.remove(path)
+        pr_wt = root / cfg.worktrees_dir / f"pr-{number}"
+        if pr_wt.exists():
+            worktree.remove(pr_wt)
+    info(f"cleanup: removed {removed} branch(es); in-flight units untouched")
+    return 0
+
+
+def cmd_preflight(args: argparse.Namespace) -> int:
+    cfg, root, gh = _context(read_only=not args.post)
+    comments_dir = root / cfg.runtime_dir / "preflight" / "comments"
+    if args.post:
+        posted = 0
+        for path in sorted(comments_dir.glob("*.md")):
+            number = int(path.stem)
+            body = path.read_text(encoding="utf-8").strip()
+            if not body:
+                continue
+            gh.post_preflight_correction(number, body, human_approved=True)
+            path.rename(path.with_suffix(".posted"))
+            posted += 1
+            info(f"posted correction comment on #{number}")
+        if not posted:
+            warn(f"no draft comments found in {comments_dir}")
+        return 0
+
+    backend_mod.assert_backend_version(cfg)
+    target = prepare_target(gh, cfg, milestone=args.milestone, issue=args.issue)
+    bodies = []
+    for number in sorted(target.units):
+        unit = target.units[number]
+        comments, _excluded = spec.trusted_comments(gh, cfg, number)
+        bodies.append(f"# Unit #{number}: {unit.title}\n\n{unit.body}")
+        for sub in unit.sub_issues:
+            bodies.append(
+                f"## Sub-issue #{sub['number']}: {sub.get('title','')}\n\n{sub.get('body') or ''}"
+            )
+        for comment in comments:
+            bodies.append(f"### Comment on #{number}\n\n{comment.get('body') or ''}")
+    tokens = {
+        "TARGET": target.label,
+        "CONCURRENT": "\n".join(_concurrent_activity(gh, target)) or "(none detected)",
+        "UNITS": "\n\n---\n\n".join(bodies),
+    }
+    prompt = spec.load_prompt("preflight", tokens)
+    run_dir = root / cfg.runtime_dir / "preflight"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    prompt_file = run_dir / "prompt.md"
+    write_text(prompt_file, prompt)
+    adapter = backend_mod.adapter_path(cfg.backend)
+    os.environ["FOREMAN_READONLY"] = "1"
+    try:
+        result = backend_mod.run_backend(
+            cfg,
+            adapter,
+            cwd=root,
+            unit_run_dir=run_dir,
+            prompt_file=prompt_file,
+            timeout_min=cfg.shepherd_timeout_min,
+        )
+    finally:
+        os.environ.pop("FOREMAN_READONLY", None)
+    findings_src = run_dir / "adapter-stdout.log"
+    findings = findings_src.read_text(encoding="utf-8") if findings_src.exists() else ""
+    findings_file = run_dir / "findings.md"
+    write_text(findings_file, findings)
+    drafted = _extract_draft_comments(findings)
+    comments_dir.mkdir(parents=True, exist_ok=True)
+    for number, body in drafted.items():
+        write_text(comments_dir / f"{number}.md", body)
+    info(f"preflight findings: {findings_file}")
+    if drafted:
+        info(
+            f"{len(drafted)} drafted correction comment(s) in {comments_dir} — review/edit "
+            "them, then run: task foreman:preflight -- --post"
+        )
+    else:
+        info("no correction comments drafted")
+    return 0 if result.ok else 1
+
+
+def _extract_draft_comments(findings: str) -> dict[int, str]:
+    import re as _re
+
+    drafted: dict[int, str] = {}
+    parts = _re.split(r"^## DRAFT COMMENT FOR #(\d+)\s*$", findings, flags=_re.M)
+    for index in range(1, len(parts) - 1, 2):
+        number = int(parts[index])
+        body = parts[index + 1].split("\n## ")[0].strip()
+        if body:
+            drafted[number] = body
+    return drafted
+
+
+def cmd_watch(args: argparse.Namespace) -> int:
+    cfg, root, _gh = _context(read_only=False)
+    backend_mod.assert_backend_version(cfg)
+    return watch_mod.run_watch(
+        cfg,
+        root,
+        milestone=args.milestone,
+        issue=args.issue,
+        interval_s=watch_mod.parse_interval(args.interval),
+        budget_usd=args.budget_usd,
+    )
+
+
+_COMMANDS = {
+    "plan": cmd_plan,
+    "preflight": cmd_preflight,
+    "dispatch": cmd_dispatch,
+    "shepherd": cmd_shepherd,
+    "watch": cmd_watch,
+    "status": cmd_status,
+    "retry": cmd_retry,
+    "cleanup": cmd_cleanup,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    if sys.version_info < (3, 11):
+        print("foreman: Python >= 3.11 required (tomllib)", file=sys.stderr)
+        return 2
+    args = _parser().parse_args(argv)
+    try:
+        return _COMMANDS[args.command](args)
+    except ForemanError as exc:
+        error(str(exc))
+        return 1
+    except KeyboardInterrupt:
+        error("interrupted")
+        return 130

--- a/scripts/foreman/config.py
+++ b/scripts/foreman/config.py
@@ -1,0 +1,139 @@
+"""Load .foreman.toml (repo root) with defaults and FOREMAN_* env overrides.
+
+Config is intent, not state: nothing here is written back by foreman.
+Python 3.11+ (tomllib).
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from foreman.util import ForemanError, warn
+
+CONFIG_FILE = ".foreman.toml"
+
+
+@dataclass
+class Config:
+    backend: str = "claude"
+    backend_version: str = ""  # expected CLI version prefix; "" = don't assert
+    require_approval: bool = True  # strict arming: only foreman-approved units dispatch
+    inputs: str = "auto"  # auto | fields | labels
+    verify_command: list[str] = field(default_factory=lambda: ["task", "ci"])
+    max_parallel: int = 3
+    dispatch_budget_usd: float = 20.0
+    shepherd_budget_usd: float = 10.0
+    dispatch_timeout_min: int = 90
+    shepherd_timeout_min: int = 30
+    max_turns: int = 0  # 0 = uncapped (budget/timeout bind instead)
+    comment_trust: list[str] = field(
+        default_factory=lambda: ["OWNER", "MEMBER", "COLLABORATOR"]
+    )
+    branch_prefix: str = "foreman"
+    worktrees_dir: str = ".worktrees/foreman"
+    runtime_dir: str = ".foreman"
+    type_map: dict[str, str] = field(
+        default_factory=lambda: {
+            "Feature": "feat",
+            "Bug": "fix",
+            "Task": "chore",
+            "Research": "chore",
+        }
+    )
+    default_type: str = "feat"
+    expected_login: str = ""  # identity assertion before any write; "" = skip
+    billing: str = "subscription"  # subscription | api
+    sandboxed: bool = False  # true only inside the egress-limited bot devcontainer
+    permission_mode: str = (
+        ""  # "" = derived: bypassPermissions if sandboxed else acceptEdits
+    )
+    allow_not_planned: bool = False  # count closed-as-not-planned external deps as done
+    remote: str = ""  # "" = auto-discover
+
+    def resolved_permission_mode(self) -> str:
+        if self.permission_mode:
+            return self.permission_mode
+        return "bypassPermissions" if self.sandboxed else "acceptEdits"
+
+
+_ENV_OVERRIDES = {
+    "FOREMAN_BACKEND": ("backend", str),
+    "FOREMAN_INPUTS": ("inputs", str),
+    "FOREMAN_MAX_PARALLEL": ("max_parallel", int),
+    "FOREMAN_BILLING": ("billing", str),
+    "FOREMAN_PERMISSION_MODE": ("permission_mode", str),
+    "FOREMAN_SANDBOXED": ("sandboxed", lambda v: v.lower() in ("1", "true", "yes")),
+}
+
+_TABLES = {
+    "budgets": {
+        "dispatch_usd": "dispatch_budget_usd",
+        "shepherd_usd": "shepherd_budget_usd",
+    },
+    "timeouts": {
+        "dispatch_min": "dispatch_timeout_min",
+        "shepherd_min": "shepherd_timeout_min",
+    },
+}
+
+
+def load(root: Path) -> Config:
+    cfg = Config()
+    path = root / CONFIG_FILE
+    if path.exists():
+        with path.open("rb") as fh:
+            try:
+                data = tomllib.load(fh)
+            except tomllib.TOMLDecodeError as exc:
+                raise ForemanError(f"{CONFIG_FILE}: invalid TOML: {exc}") from exc
+        _apply(cfg, data, path.name)
+    for env_name, (attr, cast) in _ENV_OVERRIDES.items():
+        raw = os.environ.get(env_name)
+        if raw:
+            setattr(cfg, attr, cast(raw))
+    _validate(cfg)
+    return cfg
+
+
+def _apply(cfg: Config, data: dict, source: str) -> None:
+    known = set(Config.__dataclass_fields__)
+    for key, value in data.items():
+        if key in _TABLES:
+            if not isinstance(value, dict):
+                raise ForemanError(f"{source}: [{key}] must be a table")
+            for sub, attr in _TABLES[key].items():
+                if sub in value:
+                    setattr(cfg, attr, value.pop(sub))
+            for leftover in value:
+                warn(f"{source}: unknown key [{key}].{leftover} ignored")
+        elif key in known:
+            current = getattr(cfg, key)
+            if isinstance(current, bool) and not isinstance(value, bool):
+                raise ForemanError(f"{source}: '{key}' must be a boolean")
+            setattr(cfg, key, value)
+        else:
+            warn(f"{source}: unknown key '{key}' ignored")
+
+
+def _validate(cfg: Config) -> None:
+    if cfg.inputs not in ("auto", "fields", "labels"):
+        raise ForemanError(
+            f"config: inputs must be auto|fields|labels, got '{cfg.inputs}'"
+        )
+    if cfg.billing not in ("subscription", "api"):
+        raise ForemanError(
+            f"config: billing must be subscription|api, got '{cfg.billing}'"
+        )
+    if not isinstance(cfg.verify_command, list) or not all(
+        isinstance(part, str) for part in cfg.verify_command
+    ):
+        raise ForemanError("config: verify_command must be a list of strings")
+    if not cfg.verify_command:
+        raise ForemanError("config: verify_command must not be empty")
+    if cfg.max_parallel < 1:
+        raise ForemanError("config: max_parallel must be >= 1")
+    if "/" in cfg.branch_prefix or not cfg.branch_prefix:
+        raise ForemanError("config: branch_prefix must be a single path segment")

--- a/scripts/foreman/dispatch.py
+++ b/scripts/foreman/dispatch.py
@@ -1,0 +1,382 @@
+"""Per-unit dispatch pipeline: isolate → prompt → agent → verify → freshness
+gate → push → PR → status comment. Bounded concurrency across units.
+
+Idempotent by derivation: a unit with an existing attempt branch or open PR
+is skipped — no state file records "dispatched"; git and GitHub do.
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+
+from foreman import backend as backend_mod
+from foreman import pr as pr_mod
+from foreman import report, spec, verify, worktree
+from foreman.config import Config
+from foreman.github import GitHub
+from foreman.graph import Target, Unit, dependency_satisfied
+from foreman.util import ForemanError, info, write_text
+
+RETRIGGER_SUBJECT = "chore: retrigger ci (foreman)"
+
+
+@dataclass
+class Outcome:
+    unit: Unit
+    status: (
+        str  # pr-open | failed | blocked | waiting | skipped | held | not-armed | stale
+    )
+    branch: str = ""
+    pr_url: str = ""
+    detail: str = ""
+    cost_usd: float | None = None
+    duration_s: float = 0.0
+
+    @property
+    def dispatched(self) -> bool:
+        return self.status == "pr-open"
+
+
+def eligibility(
+    gh: GitHub, cfg: Config, target: Target
+) -> tuple[list[Unit], list[Outcome]]:
+    """Split units into ready-to-dispatch and skipped (with reasons)."""
+    ready: list[Unit] = []
+    skipped: list[Outcome] = []
+    remote_name = worktree.remote(cfg)
+    for number in sorted(target.units):
+        unit = target.units[number]
+        inp = unit.inputs
+        assert inp is not None, "inputs must be resolved before eligibility"
+        if not unit.open:
+            skipped.append(Outcome(unit, "skipped", detail="already closed"))
+            continue
+        if unit.errors or (inp and inp.errors):
+            problems = "; ".join(unit.errors + inp.errors)
+            skipped.append(Outcome(unit, "failed", detail=f"contract: {problems}"))
+            continue
+        if inp.hold:
+            skipped.append(Outcome(unit, "held", detail="foreman=hold"))
+            continue
+        if not inp.armed:
+            skipped.append(
+                Outcome(unit, "not-armed", detail="no foreman approval input")
+            )
+            continue
+        spec_info = spec.validate(unit)
+        if spec_info.errors:
+            skipped.append(Outcome(unit, "failed", detail="; ".join(spec_info.errors)))
+            continue
+        unmet = []
+        for dep in unit.blocked_by:
+            dep_inputs = target.units[dep].inputs if dep in target.units else None
+            done = dependency_satisfied(
+                gh, cfg, dep, inputs=dep_inputs, mode=target.mode
+            )
+            if not done.satisfied:
+                unmet.append(f"#{dep} ({done.how})")
+        if unmet:
+            skipped.append(
+                Outcome(unit, "waiting", detail=f"blocked by {', '.join(unmet)}")
+            )
+            continue
+        attempts = worktree.attempt_branches(cfg, remote_name, unit.number)
+        open_prs = [p for p in gh.prs(state="open") if p["headRefName"] in attempts]
+        if open_prs:
+            skipped.append(
+                Outcome(
+                    unit,
+                    "skipped",
+                    branch=open_prs[0]["headRefName"],
+                    pr_url=open_prs[0]["url"],
+                    detail="open PR exists (in flight)",
+                )
+            )
+            continue
+        in_flight = [b for b in attempts if gh.branch_exists_remote(b)]
+        if in_flight:
+            skipped.append(
+                Outcome(
+                    unit,
+                    "skipped",
+                    branch=in_flight[0],
+                    detail="attempt branch exists (in flight or awaiting retry/cleanup)",
+                )
+            )
+            continue
+        ready.append(unit)
+    return ready, skipped
+
+
+def dispatch_unit(
+    gh: GitHub, cfg: Config, root: Path, unit: Unit, *, mode: str | None = None
+) -> Outcome:
+    started = time.monotonic()
+    remote_name = worktree.remote(cfg)
+    default_branch = gh.default_branch()
+    base = f"{remote_name}/{default_branch}"
+
+    existing = worktree.attempt_branches(cfg, remote_name, unit.number)
+    branch = worktree.next_attempt_branch(worktree.branch_name(cfg, unit), existing)
+    wt_path = worktree.worktree_path(cfg, root, unit)
+    if wt_path.exists():
+        return Outcome(
+            unit,
+            "skipped",
+            branch=branch,
+            detail=f"worktree already exists ({wt_path}) — run foreman:retry or cleanup",
+        )
+
+    run_dir = backend_mod.unit_dir(cfg, root, unit.number)
+    comments, excluded = spec.trusted_comments(gh, cfg, unit.number)
+    recorded_hash = spec.spec_hash(unit, comments)
+    base_sha = worktree.base_sha(remote_name, default_branch)
+    write_text(
+        run_dir / "dispatch-meta.txt",
+        f"spec_hash={recorded_hash}\nbase_sha={base_sha}\nbranch={branch}\n",
+    )
+
+    handoffs = spec.collect_handoffs(gh, cfg, unit)
+    prompt_text = spec.assemble_dispatch_prompt(
+        gh,
+        cfg,
+        unit,
+        branch=branch,
+        default_branch=default_branch,
+        result_file=str(run_dir / "result.json"),
+        comments=comments,
+        excluded_comments=excluded,
+        handoffs=handoffs,
+    )
+    prompt_file = run_dir / "prompt.md"
+    write_text(prompt_file, prompt_text)
+
+    worktree.add(wt_path, branch, base)
+    outcome = _run_agent_and_verify(
+        gh,
+        cfg,
+        unit,
+        wt_path,
+        run_dir,
+        prompt_file,
+        branch,
+        base,
+        recorded_hash,
+        base_sha,
+        mode=mode,
+    )
+    outcome.duration_s = time.monotonic() - started
+    _post_status(gh, unit, outcome)
+    if outcome.status == "pr-open":
+        worktree.remove(wt_path)  # PR branch is pushed; shepherd recreates on demand
+    return outcome
+
+
+def _run_agent_and_verify(
+    gh: GitHub,
+    cfg: Config,
+    unit: Unit,
+    wt_path: Path,
+    run_dir: Path,
+    prompt_file: Path,
+    branch: str,
+    base: str,
+    recorded_hash: str,
+    base_sha: str,
+    *,
+    mode: str | None = None,
+) -> Outcome:
+    inp = unit.inputs
+    backend_name = inp.backend if inp and inp.backend else cfg.backend
+    adapter = backend_mod.adapter_path(backend_name)
+    timeout_min = (
+        inp.timeout_min if inp and inp.timeout_min else cfg.dispatch_timeout_min
+    )
+
+    result = backend_mod.run_backend(
+        cfg,
+        adapter,
+        cwd=wt_path,
+        unit_run_dir=run_dir,
+        prompt_file=prompt_file,
+        timeout_min=timeout_min,
+    )
+    if result.quota_wait:
+        backend_mod.write_resume_state(
+            run_dir, wt_path, "backend usage window exhausted"
+        )
+        return Outcome(
+            unit,
+            "waiting",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail="backend usage limit reached — will resume after the window resets",
+        )
+    if result.timed_out:
+        backend_mod.write_resume_state(
+            run_dir, wt_path, f"agent timed out after {timeout_min}m"
+        )
+        return Outcome(
+            unit,
+            "failed",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail=f"agent timed out after {timeout_min}m (session preserved)",
+        )
+
+    contract, contract_errors = backend_mod.read_result(run_dir, wt_path)
+    if contract is not None and contract.status == "blocked":
+        backend_mod.write_resume_state(run_dir, wt_path, "agent blocked on a question")
+        return Outcome(
+            unit,
+            "blocked",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail=(
+                (contract.blocked_question or "").strip().splitlines()[0]
+                if contract.blocked_question
+                else "blocked without a question"
+            ),
+        )
+    if result.returncode != 0:
+        backend_mod.write_resume_state(
+            run_dir, wt_path, f"agent exited {result.returncode}"
+        )
+        return Outcome(
+            unit,
+            "failed",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail=f"agent exited {result.returncode} (worktree + session preserved)",
+        )
+    if contract is None:
+        backend_mod.write_resume_state(run_dir, wt_path, "invalid result contract")
+        return Outcome(
+            unit,
+            "failed",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail="result contract invalid: " + "; ".join(contract_errors),
+        )
+
+    if worktree.commits_ahead(wt_path, base) == 0:
+        backend_mod.write_resume_state(run_dir, wt_path, "agent made no commits")
+        return Outcome(
+            unit,
+            "failed",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail="agent completed but made no commits",
+        )
+    if not worktree.is_clean(wt_path):
+        backend_mod.write_resume_state(
+            run_dir, wt_path, "uncommitted changes left in worktree"
+        )
+        return Outcome(
+            unit,
+            "failed",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail="agent left uncommitted changes in the worktree",
+        )
+
+    ok, verify_tail = verify.run_verify(cfg, wt_path, run_dir)
+    if not ok:
+        backend_mod.write_resume_state(
+            run_dir, wt_path, "verification failed:\n\n" + verify_tail
+        )
+        return Outcome(
+            unit,
+            "failed",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail=f"verification failed ({' '.join(cfg.verify_command)})",
+        )
+
+    fresh = pr_mod.freshness_check(
+        gh, cfg, unit, recorded_hash=recorded_hash, branch=branch, mode=mode
+    )
+    if not fresh.ok:
+        backend_mod.write_resume_state(
+            run_dir, wt_path, "freshness gate: " + "; ".join(fresh.problems)
+        )
+        return Outcome(
+            unit,
+            "stale",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail="not pushed — " + "; ".join(fresh.problems),
+        )
+
+    spec_info = spec.validate(unit)
+    human_tasks = spec.human_only_tasks(unit, spec_info)
+    remote_name = worktree.remote(cfg)
+    worktree.push(wt_path, remote_name, branch, first=True)
+    title = pr_mod.pr_title(cfg, unit, contract)
+    body = pr_mod.pr_body(
+        cfg,
+        unit,
+        contract,
+        human_tasks=human_tasks,
+        spec_hash_hex=recorded_hash,
+        base_sha=base_sha,
+    )
+    url = pr_mod.open_pr(
+        gh, cfg, unit, title=title, body=body, branch=branch, base=gh.default_branch()
+    )
+    return Outcome(
+        unit,
+        "pr-open",
+        branch=branch,
+        pr_url=url,
+        cost_usd=result.cost_usd,
+        detail=title,
+    )
+
+
+def _post_status(gh: GitHub, unit: Unit, outcome: Outcome) -> None:
+    spec_info = spec.validate(unit)
+    status = report.UnitStatus(
+        unit=unit,
+        state=outcome.status,
+        branch=outcome.branch,
+        pr_url=outcome.pr_url,
+        blockers=[outcome.detail] if outcome.status in ("failed", "stale") else [],
+        human_tasks=(
+            spec.human_only_tasks(unit, spec_info) if not spec_info.errors else []
+        ),
+        blocked_question=outcome.detail if outcome.status == "blocked" else "",
+    )
+    report.update_status_comment(gh, status)
+
+
+def run_dispatch(
+    gh: GitHub,
+    cfg: Config,
+    root: Path,
+    target: Target,
+    *,
+    max_parallel: int | None = None,
+) -> list[Outcome]:
+    ready, outcomes = eligibility(gh, cfg, target)
+    if ready:
+        info(
+            f"dispatching {len(ready)} unit(s): {', '.join('#' + str(u.number) for u in ready)}"
+        )
+    workers = max(1, max_parallel or cfg.max_parallel)
+    if ready:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {
+                pool.submit(dispatch_unit, gh, cfg, root, unit, mode=target.mode): unit
+                for unit in ready
+            }
+            for future, unit in futures.items():
+                try:
+                    outcomes.append(future.result())
+                except ForemanError as exc:
+                    outcomes.append(Outcome(unit, "failed", detail=str(exc)))
+    outcomes.sort(key=lambda o: o.unit.number)
+    return outcomes

--- a/scripts/foreman/github.py
+++ b/scripts/foreman/github.py
@@ -1,0 +1,456 @@
+"""All GitHub access — every read and every mutation lives here, nowhere else.
+
+Write contract (docs/architecture/foreman.md): foreman MAY create/push its own
+branches, open non-draft PRs, edit its OWN PRs and their foreman-namespace
+labels, create/edit the single marker-identified status comment per unit,
+resolve review threads it dispositioned, post human-approved preflight
+correction comments, and idempotently ensure its label definitions exist.
+
+Foreman MUST NEVER: merge anything, close/reopen issues, edit issue
+titles/bodies/milestones, edit or delete human or third-party comments,
+write custom-field values / issue types / dependency edges, or touch repo
+settings. Those operations are deliberately absent from this module, and
+tests/test_write_contract.py greps this file to keep them absent.
+
+Reads use `gh` JSON output (gh >= 2.96 exposes blockedBy, issueType,
+subIssues, parent, closedByPullRequestsReferences); review threads are the
+one GraphQL-only read.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+from foreman.config import Config
+from foreman.util import ForemanError, run, warn
+
+Runner = Callable[[list[str], str | None], tuple[int, str, str]]
+
+STATUS_MARKER = "<!-- foreman:unit-status -->"
+
+# Labels foreman idempotently ensures and is allowed to apply to its own PRs.
+FOREMAN_LABELS = {
+    "foreman-dispatched": ("1D76DB", "PR opened by foreman for a dispatched unit"),
+    "ready-to-merge": (
+        "5319E7",
+        "Green, adjudicated, mergeable - awaiting human merge",
+    ),
+}
+
+ISSUE_FIELDS = ",".join(
+    [
+        "number",
+        "title",
+        "body",
+        "state",
+        "stateReason",
+        "labels",
+        "milestone",
+        "url",
+        "issueType",
+        "parent",
+        "subIssues",
+        "blockedBy",
+        "closedByPullRequestsReferences",
+    ]
+)
+
+PR_LIST_FIELDS = (
+    "number,title,body,url,state,isDraft,headRefName,baseRefName,labels,author"
+)
+
+REVIEW_THREADS_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          comments(first: 50) {
+            nodes { author { login } body url }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+RESOLVE_THREAD_MUTATION = """
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
+    thread { id isResolved }
+  }
+}
+"""
+
+
+def _subprocess_runner(argv: list[str], input_text: str | None) -> tuple[int, str, str]:
+    proc = run(["gh", *argv], input_text=input_text, check=False)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+class Gh:
+    """Thin `gh` transport; tests inject a fake runner here."""
+
+    def __init__(self, runner: Runner | None = None):
+        self._runner = runner or _subprocess_runner
+
+    def call(
+        self, args: list[str], *, input_text: str | None = None, check: bool = True
+    ) -> str:
+        rc, out, err = self._runner(args, input_text)
+        if check and rc != 0:
+            raise ForemanError(
+                f"gh {' '.join(args)} failed ({rc}): {err.strip() or out.strip()}"
+            )
+        return out
+
+    def ok(self, args: list[str]) -> bool:
+        rc, _out, _err = self._runner(args, None)
+        return rc == 0
+
+    def json(self, args: list[str], *, input_text: str | None = None) -> Any:
+        out = self.call(args, input_text=input_text)
+        try:
+            return json.loads(out) if out.strip() else None
+        except json.JSONDecodeError as exc:
+            raise ForemanError(f"gh {' '.join(args)}: unparseable JSON output") from exc
+
+
+class GitHub:
+    """Repository-scoped GitHub facade enforcing the write contract."""
+
+    def __init__(self, gh: Gh, cfg: Config):
+        self.gh = gh
+        self.cfg = cfg
+        self.read_only = False
+        self._identity_ok = False
+        self._cache: dict[str, Any] = {}
+        self._issue_cache: dict[int, dict] = {}
+
+    # ── facts ────────────────────────────────────────────────────────
+
+    def repo(self) -> dict:
+        if "repo" not in self._cache:
+            self._cache["repo"] = self.gh.json(
+                [
+                    "repo",
+                    "view",
+                    "--json",
+                    "nameWithOwner,owner,name,defaultBranchRef,visibility",
+                ]
+            )
+        return self._cache["repo"]
+
+    def repo_slug(self) -> str:
+        return self.repo()["nameWithOwner"]
+
+    def owner(self) -> str:
+        return self.repo()["owner"]["login"]
+
+    def default_branch(self) -> str:
+        return self.repo()["defaultBranchRef"]["name"]
+
+    def viewer(self) -> str:
+        if "viewer" not in self._cache:
+            self._cache["viewer"] = self.gh.call(
+                ["api", "user", "--jq", ".login"]
+            ).strip()
+        return self._cache["viewer"]
+
+    # ── issue reads ──────────────────────────────────────────────────
+
+    def issue(self, number: int, *, fresh: bool = False) -> dict:
+        if fresh or number not in self._issue_cache:
+            self._issue_cache[number] = self.gh.json(
+                ["issue", "view", str(number), "--json", ISSUE_FIELDS]
+            )
+        return self._issue_cache[number]
+
+    def issue_comments(self, number: int) -> list[dict]:
+        """Comments with stable ids + author_association (REST, paginated)."""
+        out = self.gh.json(
+            [
+                "api",
+                f"repos/{self.repo_slug()}/issues/{number}/comments",
+                "--paginate",
+                "--slurp",
+            ]
+        )
+        comments: list[dict] = []
+        for page in out or []:
+            comments.extend(page)
+        return comments
+
+    def milestones(self, state: str = "open") -> list[dict]:
+        return (
+            self.gh.json(
+                [
+                    "api",
+                    f"repos/{self.repo_slug()}/milestones?state={state}&per_page=100",
+                ]
+            )
+            or []
+        )
+
+    def resolve_milestone(self, ident: str) -> dict:
+        """Accept a milestone number or exact title; return the milestone."""
+        for ms in self.milestones(state="all"):
+            if str(ms["number"]) == str(ident) or ms["title"] == ident:
+                return ms
+        raise ForemanError(f"milestone not found: {ident}")
+
+    def milestone_issue_numbers(self, title: str) -> list[int]:
+        rows = (
+            self.gh.json(
+                [
+                    "issue",
+                    "list",
+                    "--milestone",
+                    title,
+                    "--state",
+                    "all",
+                    "--limit",
+                    "500",
+                    "--json",
+                    "number",
+                ]
+            )
+            or []
+        )
+        return [row["number"] for row in rows]
+
+    # ── PR reads ─────────────────────────────────────────────────────
+
+    def prs(
+        self, *, label: str | None = None, head: str | None = None, state: str = "open"
+    ) -> list[dict]:
+        args = [
+            "pr",
+            "list",
+            "--state",
+            state,
+            "--limit",
+            "200",
+            "--json",
+            PR_LIST_FIELDS,
+        ]
+        if label:
+            args += ["--label", label]
+        if head:
+            args += ["--head", head]
+        return self.gh.json(args) or []
+
+    def pr_view(self, number: int, fields: str) -> dict:
+        return self.gh.json(["pr", "view", str(number), "--json", fields])
+
+    def pr_status(self, number: int) -> dict:
+        return self.pr_view(
+            number,
+            "number,title,body,url,state,isDraft,merged,mergedAt,author,labels,"
+            "headRefName,headRefOid,baseRefName,mergeable,mergeStateStatus,statusCheckRollup",
+        )
+
+    def review_threads(self, number: int) -> list[dict]:
+        out = self.gh.json(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={REVIEW_THREADS_QUERY}",
+                "-F",
+                f"owner={self.owner()}",
+                "-F",
+                f"name={self.repo()['name']}",
+                "-F",
+                f"number={number}",
+            ]
+        )
+        try:
+            return out["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+        except (KeyError, TypeError):
+            warn(f"review threads: unexpected GraphQL shape for PR #{number}")
+            return []
+
+    def branch_exists_remote(self, branch: str) -> bool:
+        return self.gh.ok(["api", f"repos/{self.repo_slug()}/branches/{branch}"])
+
+    def run_log_failed(self, run_url: str) -> str:
+        """Failed-step log excerpt for an Actions run URL (best effort)."""
+        run_id = run_url.rstrip("/").split("/")[-1]
+        if not run_id.isdigit():
+            return ""
+        rc, out, _err = self.gh._runner(["run", "view", run_id, "--log-failed"], None)
+        return out[-20000:] if rc == 0 else ""
+
+    # ── write guard ──────────────────────────────────────────────────
+
+    def _assert_writable(self, action: str) -> None:
+        if self.read_only:
+            raise ForemanError(
+                f"write contract: '{action}' attempted in read-only mode"
+            )
+        if not self._identity_ok:
+            expected = self.cfg.expected_login
+            if expected:
+                actual = self.viewer()
+                if actual != expected:
+                    raise ForemanError(
+                        f"identity assertion failed: gh is authenticated as '{actual}' "
+                        f"but config expects '{expected}' — refusing to write"
+                    )
+            self._identity_ok = True
+
+    # ── guarded writes (the ENTIRE mutation surface) ─────────────────
+
+    def ensure_labels(self) -> None:
+        self._assert_writable("ensure labels")
+        for name, (color, desc) in FOREMAN_LABELS.items():
+            self.gh.call(
+                [
+                    "label",
+                    "create",
+                    name,
+                    "--color",
+                    color,
+                    "--description",
+                    desc,
+                    "--force",
+                ]
+            )
+
+    def create_pr(
+        self, *, title: str, body: str, head: str, base: str, labels: list[str]
+    ) -> str:
+        self._assert_writable("create PR")
+        args = [
+            "pr",
+            "create",
+            "--title",
+            title,
+            "--body-file",
+            "-",
+            "--head",
+            head,
+            "--base",
+            base,
+        ]
+        for label in labels:
+            args += ["--label", label]
+        out = self.gh.call(args, input_text=body)
+        return out.strip().splitlines()[-1] if out.strip() else ""
+
+    def _own_pr_guard(self, number: int, action: str) -> dict:
+        pr = self.pr_view(number, "number,author,labels,body")
+        if pr["author"]["login"] != self.viewer():
+            raise ForemanError(
+                f"write contract: '{action}' on PR #{number} not authored by foreman"
+            )
+        return pr
+
+    def edit_own_pr_body(self, number: int, body: str) -> None:
+        self._assert_writable("edit own PR body")
+        self._own_pr_guard(number, "edit body")
+        self.gh.call(["pr", "edit", str(number), "--body-file", "-"], input_text=body)
+
+    def label_own_pr(
+        self,
+        number: int,
+        *,
+        add: list[str] | None = None,
+        remove: list[str] | None = None,
+    ) -> None:
+        self._assert_writable("label own PR")
+        self._own_pr_guard(number, "label")
+        for name in add or []:
+            if name not in FOREMAN_LABELS:
+                raise ForemanError(
+                    f"write contract: label '{name}' outside the foreman namespace"
+                )
+        args = ["pr", "edit", str(number)]
+        for name in add or []:
+            args += ["--add-label", name]
+        for name in remove or []:
+            args += ["--remove-label", name]
+        if len(args) > 3:
+            self.gh.call(args)
+
+    def comment_own_pr(self, number: int, body: str) -> None:
+        self._assert_writable("comment on own PR")
+        self._own_pr_guard(number, "comment")
+        self.gh.call(
+            ["pr", "comment", str(number), "--body-file", "-"], input_text=body
+        )
+
+    def upsert_status_comment(self, issue_number: int, body: str) -> None:
+        """Create or edit-in-place the single foreman status comment per unit."""
+        self._assert_writable("upsert status comment")
+        if STATUS_MARKER not in body:
+            raise ForemanError("status comment body must carry the foreman marker")
+        me = self.viewer()
+        for comment in self.issue_comments(issue_number):
+            author = (comment.get("user") or {}).get("login", "")
+            # Only ever edit a comment foreman itself authored AND marked.
+            if STATUS_MARKER in (comment.get("body") or "") and author == me:
+                self.gh.call(
+                    [
+                        "api",
+                        "--method",
+                        "PATCH",
+                        f"repos/{self.repo_slug()}/issues/comments/{comment['id']}",
+                        "-f",
+                        "body=@-",
+                    ],
+                    input_text=body,
+                )
+                return
+        self.gh.call(
+            [
+                "api",
+                "--method",
+                "POST",
+                f"repos/{self.repo_slug()}/issues/{issue_number}/comments",
+                "-f",
+                "body=@-",
+            ],
+            input_text=body,
+        )
+
+    def post_preflight_correction(
+        self, issue_number: int, body: str, *, human_approved: bool
+    ) -> None:
+        """The ONLY general issue-comment write — gated on explicit human approval."""
+        if not human_approved:
+            raise ForemanError(
+                "write contract: preflight corrections require human approval"
+            )
+        self._assert_writable("post approved preflight correction")
+        self.gh.call(
+            [
+                "api",
+                "--method",
+                "POST",
+                f"repos/{self.repo_slug()}/issues/{issue_number}/comments",
+                "-f",
+                "body=@-",
+            ],
+            input_text=body,
+        )
+
+    def resolve_review_thread(self, thread_id: str) -> None:
+        self._assert_writable("resolve dispositioned review thread")
+        self.gh.json(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={RESOLVE_THREAD_MUTATION}",
+                "-F",
+                f"threadId={thread_id}",
+            ]
+        )

--- a/scripts/foreman/graph.py
+++ b/scripts/foreman/graph.py
@@ -1,0 +1,279 @@
+"""Units, dependency edges, cycles, waves — and deterministic doneness.
+
+A unit is a parent issue (its sub-issues ride along as the internal task
+list). Edges come from native `blocked-by` (primary) or a `Depends-on: #n`
+body trailer (fallback); both present and disagreeing fails loud.
+
+Doneness is the hardened A3 rule: a foreman-managed dependency counts as
+satisfied only when its issue is closed AND a marker-carrying foreman PR
+merged into the discovered default branch; an external dependency counts
+when closed as completed (not_planned needs an explicit human override).
+"""
+
+from __future__ import annotations
+
+import graphlib
+import re
+from dataclasses import dataclass, field
+
+from foreman import inputs as inputs_mod
+from foreman.config import Config
+from foreman.github import GitHub
+from foreman.util import ForemanError
+
+DEPENDS_ON_RE = re.compile(
+    r"^depends-on:\s*(?P<refs>#\d+(?:\s*,\s*#\d+)*)\s*$", re.I | re.M
+)
+MARKER_RE = re.compile(r"<!--\s*foreman:unit=#(?P<number>\d+)\b[^>]*-->")
+
+
+@dataclass
+class Unit:
+    number: int
+    title: str
+    state: str
+    state_reason: str | None
+    body: str
+    url: str
+    labels: list[str]
+    issue_type: str | None
+    milestone: str | None
+    parent: int | None
+    sub_issues: list[dict] = field(default_factory=list)
+    blocked_by: list[int] = field(default_factory=list)
+    inputs: inputs_mod.UnitInputs | None = None
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def open(self) -> bool:
+        return self.state.upper() == "OPEN"
+
+
+@dataclass
+class Target:
+    """The resolved dispatch target: units + edges + context."""
+
+    label: str  # human description, e.g. "milestone 'M4'" or "issue #12"
+    units: dict[int, Unit]
+    external_deps: set[int]
+    milestone: str | None = None
+    mode: str = "labels"  # resolved input-source mode (fields | labels)
+
+
+def _unit_from_issue(issue: dict) -> Unit:
+    return Unit(
+        number=issue["number"],
+        title=issue.get("title") or "",
+        state=issue.get("state") or "OPEN",
+        state_reason=issue.get("stateReason"),
+        body=issue.get("body") or "",
+        url=issue.get("url") or "",
+        labels=[entry["name"] for entry in issue.get("labels") or []],
+        issue_type=(issue.get("issueType") or {}).get("name"),
+        milestone=(issue.get("milestone") or {}).get("title"),
+        parent=(issue.get("parent") or {}).get("number"),
+    )
+
+
+def _dependency_numbers(issue: dict, unit: Unit) -> list[int]:
+    native = [entry["number"] for entry in issue.get("blockedBy") or []]
+    match = DEPENDS_ON_RE.search(unit.body)
+    trailer = (
+        [int(ref.strip().lstrip("#")) for ref in match.group("refs").split(",")]
+        if match
+        else []
+    )
+    if native and trailer and set(native) != set(trailer):
+        unit.errors.append(
+            f"#{unit.number}: native blocked-by ({sorted(native)}) disagrees with "
+            f"Depends-on trailer ({sorted(trailer)}) — fix one source"
+        )
+        return sorted(set(native))
+    return sorted(set(native or trailer))
+
+
+def load_target(
+    gh: GitHub, cfg: Config, *, milestone: str | None = None, issue: int | None = None
+) -> Target:
+    if bool(milestone) == bool(issue):
+        raise ForemanError("exactly one of --milestone or --issue is required")
+
+    issues: dict[int, dict] = {}
+    if issue:
+        root = gh.issue(issue)
+        issues[root["number"]] = root
+        for sub in root.get("subIssues") or []:
+            issues[sub["number"]] = gh.issue(sub["number"])
+        label = f"issue #{issue}"
+        ms_title = None
+    else:
+        ms = gh.resolve_milestone(milestone or "")
+        ms_title = ms["title"]
+        for number in gh.milestone_issue_numbers(ms_title):
+            issues[number] = gh.issue(number)
+        label = f"milestone '{ms_title}' (#{ms['number']})"
+
+    # Parent-unit granularity: an issue whose parent is also in the target set
+    # is a sub-issue of that unit, not a unit of its own.
+    units: dict[int, Unit] = {}
+    for number, data in issues.items():
+        parent = (data.get("parent") or {}).get("number")
+        if parent and parent in issues:
+            continue
+        units[number] = _unit_from_issue(data)
+
+    for unit in units.values():
+        data = issues[unit.number]
+        subs = []
+        for ref in data.get("subIssues") or []:
+            sub_number = ref["number"]
+            subs.append(issues.get(sub_number) or gh.issue(sub_number))
+        unit.sub_issues = sorted(subs, key=lambda entry: entry["number"])
+        unit.blocked_by = _dependency_numbers(data, unit)
+
+    external: set[int] = set()
+    for unit in units.values():
+        for dep in unit.blocked_by:
+            if dep not in units:
+                external.add(dep)
+                unit.warnings.append(
+                    f"#{unit.number}: dependency #{dep} is outside the target set "
+                    "(external — ready only when satisfied)"
+                )
+    return Target(label=label, units=units, external_deps=external, milestone=ms_title)
+
+
+def detect_cycle(target: Target) -> list[int] | None:
+    sorter: graphlib.TopologicalSorter = graphlib.TopologicalSorter()
+    for unit in target.units.values():
+        internal = [dep for dep in unit.blocked_by if dep in target.units]
+        sorter.add(unit.number, *internal)
+    try:
+        sorter.prepare()
+    except graphlib.CycleError as exc:
+        return list(exc.args[1])
+    return None
+
+
+def waves(target: Target) -> list[list[int]]:
+    """Topological waves over internal edges (visualization + merge order)."""
+    sorter: graphlib.TopologicalSorter = graphlib.TopologicalSorter()
+    for unit in target.units.values():
+        sorter.add(
+            unit.number, *[dep for dep in unit.blocked_by if dep in target.units]
+        )
+    sorter.prepare()
+    result: list[list[int]] = []
+    while sorter.is_active():
+        batch = sorted(sorter.get_ready())
+        result.append(batch)
+        sorter.done(*batch)
+    return result
+
+
+# ── doneness ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class Doneness:
+    satisfied: bool
+    how: str
+    warnings: list[str] = field(default_factory=list)
+
+
+def foreman_prs_for_issue(gh: GitHub, cfg: Config, number: int) -> list[dict]:
+    """Closing PRs that carry this unit's foreman marker, with merge facts."""
+    issue = gh.issue(number)
+    marked = []
+    for ref in issue.get("closedByPullRequestsReferences") or []:
+        pr = gh.pr_view(
+            ref["number"],
+            "number,url,body,merged,mergedAt,baseRefName,headRefName,author,state",
+        )
+        match = MARKER_RE.search(pr.get("body") or "")
+        if match and int(match.group("number")) == number:
+            marked.append(pr)
+    return marked
+
+
+def _branch_matches_unit(cfg: Config, branch: str, number: int) -> bool:
+    return bool(re.match(rf"^{re.escape(cfg.branch_prefix)}/[^/]+/{number}-", branch))
+
+
+def dependency_satisfied(
+    gh: GitHub,
+    cfg: Config,
+    number: int,
+    *,
+    inputs: inputs_mod.UnitInputs | None = None,
+    mode: str | None = None,
+) -> Doneness:
+    issue = gh.issue(number)
+    if inputs is None and mode:
+        inputs = inputs_mod.resolve(gh, cfg, issue, mode)
+    if inputs is not None and inputs.satisfied_override:
+        return Doneness(True, "human override (foreman=satisfied)")
+    if (issue.get("state") or "OPEN").upper() != "CLOSED":
+        return Doneness(False, "open")
+
+    marked_prs = foreman_prs_for_issue(gh, cfg, number)
+    if marked_prs and not (inputs is not None and inputs.external):
+        expected_author = cfg.expected_login or gh.viewer()
+        default_branch = gh.default_branch()
+        for pr in marked_prs:
+            problems = []
+            if not pr.get("merged"):
+                problems.append("not merged")
+            if pr.get("baseRefName") != default_branch:
+                problems.append(
+                    f"base is {pr.get('baseRefName')}, not {default_branch}"
+                )
+            if (pr.get("author") or {}).get("login") != expected_author:
+                problems.append(f"author is {(pr.get('author') or {}).get('login')}")
+            if not _branch_matches_unit(cfg, pr.get("headRefName") or "", number):
+                problems.append(
+                    f"head branch {pr.get('headRefName')!r} not a foreman attempt"
+                )
+            if not problems:
+                return Doneness(
+                    True, f"foreman PR #{pr['number']} merged into {default_branch}"
+                )
+        return Doneness(
+            False,
+            "closed, but no foreman PR satisfies the merge chain",
+            warnings=[
+                f"#{number}: closed with foreman-marked PR(s) "
+                f"({', '.join('#' + str(pr['number']) for pr in marked_prs)}) that did not "
+                "merge cleanly into the default branch — resolve manually or mark "
+                "foreman:satisfied"
+            ],
+        )
+
+    reason = (issue.get("stateReason") or "").lower()
+    if reason == "not_planned" and not cfg.allow_not_planned:
+        return Doneness(
+            False,
+            "closed as not_planned",
+            warnings=[
+                f"#{number}: closed as not planned — remove the dependency edge or mark it "
+                "foreman:satisfied if this is intentional"
+            ],
+        )
+    how = (
+        "external: closed as completed"
+        if reason != "not_planned"
+        else "external: not_planned (allowed by config)"
+    )
+    return Doneness(True, how)
+
+
+def prepare_target(
+    gh: GitHub, cfg: Config, *, milestone: str | None = None, issue: int | None = None
+) -> Target:
+    """Load the target and resolve human inputs for every unit."""
+    target = load_target(gh, cfg, milestone=milestone, issue=issue)
+    target.mode = inputs_mod.detect_mode(gh, cfg)
+    for unit in target.units.values():
+        unit.inputs = inputs_mod.resolve(gh, cfg, gh.issue(unit.number), target.mode)
+    return target

--- a/scripts/foreman/inputs.py
+++ b/scripts/foreman/inputs.py
@@ -1,0 +1,188 @@
+"""Resolve human inputs per unit: arming, backend, holds, overrides, type.
+
+Primary mechanism is the org-level `foreman` issue custom field (issue fields
+are org-only as of their 2026-07 GA); the fallback for personal-account repos
+is `foreman:*` labels. `inputs = auto` probes availability once per run.
+Two disagreeing sources on one issue fail loud — never guess.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from foreman.config import Config
+from foreman.github import GitHub
+from foreman.util import warn
+
+LABEL_PREFIX = "foreman:"
+# Values with fixed meaning; anything else is treated as a backend name
+# (e.g. `claude`, `mock`), which implies approval for that backend.
+HOLD = "hold"
+APPROVED = "approved"
+SATISFIED = "satisfied"  # human override: treat this issue as a satisfied dependency
+EXTERNAL = "external"  # human marker: not foreman-managed; closed == satisfied
+_MEANINGS = {HOLD, APPROVED, SATISFIED, EXTERNAL}
+
+FIELD_NAME = "foreman"
+FIELD_BUDGET = "foreman-budget-usd"
+FIELD_TIMEOUT = "foreman-timeout-min"
+
+TYPE_LABEL_PREFIX = "type:"
+
+
+@dataclass
+class UnitInputs:
+    mode: str = "labels"
+    armed: bool = False
+    backend: str | None = None  # None = repo default
+    hold: bool = False
+    satisfied_override: bool = False
+    external: bool = False
+    budget_usd: float | None = None
+    timeout_min: int | None = None
+    commit_type: str = "feat"
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+def detect_mode(gh: GitHub, cfg: Config) -> str:
+    """auto probes org issue-field availability once; explicit modes win."""
+    if cfg.inputs in ("fields", "labels"):
+        return cfg.inputs
+    if gh.gh.ok(["api", f"orgs/{gh.owner()}/issue-fields"]):
+        return "fields"
+    return "labels"
+
+
+def field_values(gh: GitHub, issue_number: int) -> dict[str, object]:
+    """Field name -> value for one issue; tolerant of shape drift, warns once."""
+    rc_ok = gh.gh.ok(
+        ["api", f"repos/{gh.repo_slug()}/issues/{issue_number}/field-values"]
+    )
+    if not rc_ok:
+        return {}
+    raw = gh.gh.json(
+        ["api", f"repos/{gh.repo_slug()}/issues/{issue_number}/field-values"]
+    )
+    values: dict[str, object] = {}
+    for item in raw or []:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name") or (item.get("field") or {}).get("name")
+        value = item.get("value")
+        if isinstance(value, dict):
+            value = value.get("name") or value.get("value")
+        if name:
+            values[str(name)] = value
+    return values
+
+
+def _foreman_values_from_labels(labels: list[str]) -> list[str]:
+    return [
+        name[len(LABEL_PREFIX) :]
+        for name in labels
+        if name.startswith(LABEL_PREFIX) and name != LABEL_PREFIX
+    ]
+
+
+def resolve(gh: GitHub, cfg: Config, issue: dict, mode: str) -> UnitInputs:
+    out = UnitInputs(mode=mode)
+    number = issue["number"]
+    labels = [entry["name"] for entry in issue.get("labels") or []]
+    label_values = _foreman_values_from_labels(labels)
+
+    if mode == "fields":
+        if label_values:
+            out.errors.append(
+                f"#{number}: dual-sourced input — foreman:* labels present in fields mode "
+                f"({', '.join(sorted(label_values))}); remove one source"
+            )
+        values = field_values(gh, number)
+        raw = values.get(FIELD_NAME)
+        arm_values = [str(raw)] if raw else []
+        budget = values.get(FIELD_BUDGET)
+        timeout = values.get(FIELD_TIMEOUT)
+        if budget is not None:
+            try:
+                out.budget_usd = float(budget)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                out.errors.append(
+                    f"#{number}: {FIELD_BUDGET} is not a number: {budget!r}"
+                )
+        if timeout is not None:
+            try:
+                out.timeout_min = int(timeout)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                out.errors.append(
+                    f"#{number}: {FIELD_TIMEOUT} is not a number: {timeout!r}"
+                )
+    else:
+        arm_values = label_values
+
+    backends = sorted({v for v in arm_values if v not in _MEANINGS})
+    if len(backends) > 1:
+        out.errors.append(
+            f"#{number}: conflicting backend selections: {', '.join(backends)}"
+        )
+    out.backend = backends[0] if len(backends) == 1 else None
+    out.hold = HOLD in arm_values
+    out.satisfied_override = SATISFIED in arm_values
+    out.external = EXTERNAL in arm_values
+    approved = APPROVED in arm_values or out.backend is not None
+    out.armed = (approved or not cfg.require_approval) and not out.hold
+    if cfg.require_approval and not approved and not out.hold:
+        out.warnings.append(f"#{number}: not armed (no foreman approval input)")
+
+    out.commit_type = _resolve_type(cfg, issue, labels, out)
+    return out
+
+
+def _resolve_type(cfg: Config, issue: dict, labels: list[str], out: UnitInputs) -> str:
+    number = issue["number"]
+    native = (issue.get("issueType") or {}).get("name")
+    native_mapped = None
+    if native:
+        native_mapped = cfg.type_map.get(native)
+        if native_mapped is None:
+            out.warnings.append(
+                f"#{number}: issue type '{native}' has no type_map entry; using default"
+            )
+    label_types = [
+        name[len(TYPE_LABEL_PREFIX) :]
+        for name in labels
+        if name.startswith(TYPE_LABEL_PREFIX)
+    ]
+    if len(label_types) > 1:
+        out.errors.append(
+            f"#{number}: multiple type: labels: {', '.join(sorted(label_types))}"
+        )
+    label_type = label_types[0] if len(label_types) == 1 else None
+
+    if native_mapped and label_type and native_mapped != label_type:
+        out.errors.append(
+            f"#{number}: issue type '{native}' (-> {native_mapped}) disagrees with "
+            f"label 'type:{label_type}' — remove one source"
+        )
+        return native_mapped
+    resolved = native_mapped or label_type
+    if not resolved:
+        out.warnings.append(
+            f"#{number}: no issue type or type: label; defaulting to '{cfg.default_type}'"
+        )
+        return cfg.default_type
+    return resolved
+
+
+def describe_mode(mode: str, cfg: Config) -> str:
+    arming = (
+        "explicit approval required"
+        if cfg.require_approval
+        else "default-armed (holds exclude)"
+    )
+    return f"inputs={mode} ({arming})"
+
+
+def warn_all(units_inputs: list[UnitInputs]) -> None:
+    for inp in units_inputs:
+        for message in inp.warnings:
+            warn(message)

--- a/scripts/foreman/pr.py
+++ b/scripts/foreman/pr.py
@@ -1,0 +1,168 @@
+"""Deterministic PR opening: freshness gate, machine-readable markers,
+Conventional-Commit titles, Closes/Refs wiring, Handoff + Human-only-tasks
+sections. The agent never opens PRs — foreman does, after its own verify.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from foreman.backend import ResultContract
+from foreman.config import Config
+from foreman.github import GitHub
+from foreman.graph import Unit, dependency_satisfied
+from foreman.spec import spec_hash, trusted_comments
+from foreman.util import warn
+
+TITLE_RE = re.compile(
+    r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)]+)\))?(?P<bang>!)?: (?P<subject>.+)$"
+)
+MAX_TITLE = 100
+
+
+def marker(unit_number: int, spec_hash_hex: str, base_sha: str) -> str:
+    return (
+        f"<!-- foreman:unit=#{unit_number} spec-hash={spec_hash_hex} "
+        f"base={base_sha} schema=1 -->"
+    )
+
+
+@dataclass
+class Freshness:
+    ok: bool
+    problems: list[str] = field(default_factory=list)
+
+
+def freshness_check(
+    gh: GitHub,
+    cfg: Config,
+    unit: Unit,
+    *,
+    recorded_hash: str,
+    branch: str,
+    mode: str | None = None,
+) -> Freshness:
+    """Re-check eligibility + spec drift immediately before push/PR-create."""
+    problems: list[str] = []
+    issue = gh.issue(unit.number, fresh=True)
+    if (issue.get("state") or "").upper() != "OPEN":
+        problems.append("issue is no longer open")
+    fresh_unit_body = issue.get("body") or ""
+    comments, _ = trusted_comments(gh, cfg, unit.number)
+    check_unit = Unit(
+        number=unit.number,
+        title=issue.get("title") or unit.title,
+        state=issue.get("state") or "OPEN",
+        state_reason=issue.get("stateReason"),
+        body=fresh_unit_body,
+        url=unit.url,
+        labels=[entry["name"] for entry in issue.get("labels") or []],
+        issue_type=unit.issue_type,
+        milestone=unit.milestone,
+        parent=unit.parent,
+        sub_issues=[
+            gh.issue(sub["number"], fresh=True) for sub in issue.get("subIssues") or []
+        ],
+    )
+    if spec_hash(check_unit, comments) != recorded_hash:
+        problems.append(
+            "spec drifted since dispatch (issue/sub-issue/comment content changed)"
+        )
+    for dep in unit.blocked_by:
+        done = dependency_satisfied(gh, cfg, dep, mode=mode)
+        if not done.satisfied:
+            problems.append(f"dependency #{dep} regressed to unsatisfied ({done.how})")
+    existing = gh.prs(head=branch, state="open")
+    if existing:
+        problems.append(f"an open PR already exists for {branch}: {existing[0]['url']}")
+    return Freshness(ok=not problems, problems=problems)
+
+
+def pr_title(cfg: Config, unit: Unit, result: ResultContract) -> str:
+    commit_type = unit.inputs.commit_type if unit.inputs else cfg.default_type
+    proposed = (result.proposed_pr_title or "").strip()
+    match = TITLE_RE.match(proposed)
+    if match:
+        scope = f"({match.group('scope')})" if match.group("scope") else ""
+        title = f"{commit_type}{scope}: {match.group('subject')}"
+    else:
+        if proposed:
+            warn(f"#{unit.number}: proposed_pr_title not conventional; regenerating")
+        title = f"{commit_type}: {unit.title}"
+    if len(title) > MAX_TITLE:
+        title = title[: MAX_TITLE - 1].rstrip() + "…"
+    return title
+
+
+def pr_body(
+    cfg: Config,
+    unit: Unit,
+    result: ResultContract,
+    *,
+    human_tasks: list[str],
+    spec_hash_hex: str,
+    base_sha: str,
+) -> str:
+    lines: list[str] = []
+    lines.append(marker(unit.number, spec_hash_hex, base_sha))
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(result.summary.strip() or "_(no summary provided)_")
+    lines.append("")
+
+    lines.append("## Test evidence (acceptance criteria → tests)")
+    lines.append("")
+    lines.append(
+        "_Reviewing these tests is reviewing the spec interpretation — the mapping "
+        "below is the agent's claim, verified only for existence by CI._"
+    )
+    lines.append("")
+    for entry in result.ac_test_map:
+        tests = ", ".join(f"`{t}`" for t in entry.get("tests", [])) or "_none_"
+        lines.append(f"- {entry.get('criterion', '').strip()} → {tests}")
+    lines.append("")
+
+    close_word = "Refs" if human_tasks else "Closes"
+    if human_tasks:
+        lines.append("## Human-only tasks (this PR must NOT auto-close the parent)")
+        lines.append("")
+        for task in human_tasks:
+            lines.append(f"- [ ] {task}")
+        lines.append("")
+    lines.append(f"{close_word} #{unit.number}")
+    for sub in unit.sub_issues:
+        if (sub.get("state") or "").upper() == "OPEN":
+            lines.append(f"Closes #{sub['number']}")
+    lines.append("")
+
+    lines.append("## Handoff")
+    lines.append("")
+    lines.append(
+        result.handoff.strip() or "_(nothing downstream depends on internals here)_"
+    )
+    lines.append("")
+    lines.append("---")
+    lines.append(
+        f"_Opened by foreman after a green `{ ' '.join(cfg.verify_command) }` in the unit's "
+        "worktree. Merging is a human decision; foreman never merges._"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def open_pr(
+    gh: GitHub,
+    cfg: Config,
+    unit: Unit,
+    *,
+    title: str,
+    body: str,
+    branch: str,
+    base: str,
+) -> str:
+    gh.ensure_labels()
+    url = gh.create_pr(
+        title=title, body=body, head=branch, base=base, labels=["foreman-dispatched"]
+    )
+    return url

--- a/scripts/foreman/prompts/implementer-preamble.md
+++ b/scripts/foreman/prompts/implementer-preamble.md
@@ -1,0 +1,76 @@
+# Foreman dispatch — operating rules
+
+You are a headless implementation agent. Foreman (a deterministic supervisor)
+dispatched you to deliver exactly one unit of work: issue `#%%UNIT_NUMBER%%`
+("%%UNIT_TITLE%%"). The full spec follows this preamble. Everything here is
+non-negotiable.
+
+## Boundaries (violations end the run)
+
+- Work ONLY inside this worktree, on the already-checked-out branch
+  `%%BRANCH%%`. Never switch branches, never touch `%%DEFAULT_BRANCH%%`.
+- NEVER merge anything, by any mechanism. Never push. Never open a PR —
+  foreman verifies your work first and opens the PR itself.
+- NEVER start background watchers, daemons, schedulers, or long-lived
+  processes. Run commands, read their output, finish.
+- Never bypass git hooks (`--no-verify` is forbidden); fix the underlying
+  issue instead.
+- Do not modify `.github/workflows/**` or repository settings. If the spec
+  genuinely requires a workflow change, record it in `human_tasks` in your
+  result and leave the workflow untouched — the push would be rejected anyway.
+- Never write to credential stores (1Password, keychains) or set deployment
+  environment variables.
+- Follow this repository's conventions: read `AGENTS.md` (or `CLAUDE.md`) in
+  the worktree root before writing code.
+
+## Delivery loop
+
+1. Read the full spec below: issue body, sub-issue bodies, and the trusted
+   human comments — comments carry approved corrections and AMEND the spec.
+2. Implement the unit as one coherent change. Sub-issues are your internal
+   task list; items tagged `[HUMAN]` are for humans — never attempt them,
+   list them in `human_tasks`.
+3. Tests: every `[CI]`-tagged acceptance criterion must map to at least one
+   named automated test. You will list this mapping in your result; it is
+   copied verbatim into the PR for reviewers.
+4. Commit as you go with Conventional Commits
+   (`%%COMMIT_TYPE%%(scope): subject`), referencing `#%%UNIT_NUMBER%%`.
+   Leave the worktree clean: no uncommitted or untracked files.
+5. Before finishing, run the full verification gate — `%%VERIFY_COMMAND%%` —
+   in the worktree and fix every failure. Foreman re-runs the same gate and
+   will not open a PR on red; your run just catches failures cheaply.
+6. Self-review your final diff against the spec before finishing. Check
+   follow-through: a fix applied to one call site must be applied to every
+   sibling site.
+
+## Escalation — never invent
+
+If the spec is ambiguous on a behavior-changing decision, do NOT pick an
+interpretation. Write the precise question to `BLOCKED.md` in the worktree
+root (do not commit it), write your result with `"status": "blocked"` and the
+question in `blocked_question`, and exit non-zero. Deterministic verification
+cannot catch a wrong-but-self-consistent invention — your own tests would
+pass.
+
+## Result contract (required)
+
+Before exiting, write JSON to `%%RESULT_FILE%%` (foreman schema-validates it;
+finishing without it counts as a crash):
+
+```json
+{
+  "schema": 1,
+  "status": "completed",
+  "summary": "What changed and why, 2-6 sentences, for the PR body.",
+  "handoff": "Contract for dependent units: new interfaces, invariants, gotchas.",
+  "human_tasks": ["Anything a human must do ([HUMAN] items, workflow edits, live verifications)"],
+  "proposed_pr_title": "%%COMMIT_TYPE%%(scope): one-line summary",
+  "ac_test_map": [
+    { "criterion": "the [CI] acceptance criterion text", "tests": ["path/to/test::name"] }
+  ],
+  "blocked_question": null
+}
+```
+
+For `"status": "blocked"`, only `schema`, `status`, and `blocked_question`
+are required.

--- a/scripts/foreman/prompts/preflight.md
+++ b/scripts/foreman/prompts/preflight.md
@@ -1,0 +1,46 @@
+# Foreman preflight — critical spec analysis (read-only)
+
+You are a read-only analysis agent. Foreman is about to dispatch headless
+implementation agents against the units below (%%TARGET%%). Your job is to
+find everything a headless agent would trip over or silently invent through.
+You have read access to the live repository — verify claims against the code;
+do not speculate.
+
+You MUST NOT modify anything: no file edits, no git commands, no GitHub
+writes. Your entire output is a markdown report to stdout.
+
+Analyze for:
+
+1. **Stale references** — files, paths, ADR/doc numbers, APIs, or config keys
+   the specs mention that no longer match the repository. (Sequence-dependent
+   artifacts like "ADR 0007" are the classic: check what the next free number
+   actually is.)
+2. **Cross-issue contradictions** — two units specifying conflicting
+   behavior, naming, or file ownership; same-wave units likely to collide on
+   the same files.
+3. **Ambiguities** — behavior-changing decisions the spec leaves open that a
+   headless agent would have to invent through (it is instructed to BLOCK on
+   these; better to fix the spec now).
+4. **Undeclared human-only tasks** — steps requiring live-system access,
+   credentials, or judgment that are not tagged `[HUMAN]`.
+5. **Concurrent-activity collisions** — given the notice below, files or
+   artifacts other in-flight work may claim mid-run.
+
+Output format (exactly this structure):
+
+- A `# Preflight findings` section: numbered findings, each with the issue
+  number(s), the evidence (file/line or quote), and severity
+  (blocker / correction / note).
+- For every finding that warrants a spec correction, append a section headed
+  exactly `## DRAFT COMMENT FOR #<issue-number>` containing the comment body
+  you propose. Write it as a crisp spec amendment ("Correction: … use X, not
+  Y, because …"). A human reviews and posts these — draft them ready to ship.
+  Never draft edits to issue bodies; corrections travel as comments.
+
+## Concurrent activity notice
+
+%%CONCURRENT%%
+
+## Units under analysis
+
+%%UNITS%%

--- a/scripts/foreman/prompts/shepherd-adjudicate.md
+++ b/scripts/foreman/prompts/shepherd-adjudicate.md
@@ -1,0 +1,34 @@
+# Foreman shepherd — adjudicate review findings
+
+Review bots left unresolved threads on your unit's PR (%%PR_URL%%, branch
+`%%BRANCH%%`, unit `#%%UNIT_NUMBER%%`). Adjudicate EVERY thread listed below.
+You know the spec; bots don't always — blanket-accepting is prohibited, and
+so is blanket-dismissing.
+
+Rules: work only in this worktree on `%%BRANCH%%`; never merge; never push
+(foreman pushes); never edit or delete anyone else's comments; never touch
+`.github/workflows/**`.
+
+For each thread, exactly one disposition:
+
+- **Apply** — the finding is right: fix it, commit (Conventional Commit
+  referencing `#%%UNIT_NUMBER%%`), reply to the thread with a one-line
+  `applied in <short-sha>` note, and resolve the thread.
+- **Decline with reasoning** — the finding is wrong or out of scope: reply
+  with brief technical reasoning. Deterministic facts beat bot speculation —
+  cite the passing typecheck, the spec text, the API docs. Then resolve the
+  thread.
+
+To reply to a specific review thread use:
+`gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:"<id>", body:"..."}) { comment { id } } }'`
+and to resolve it:
+`gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"<id>"}) { thread { isResolved } } }'`
+
+After all threads: if you made commits, run `%%VERIFY_COMMAND%%` until green.
+Leave the worktree clean and exit 0. Foreman verifies thread completeness
+deterministically afterwards — an undispositioned thread means this run
+failed.
+
+## Unresolved threads
+
+%%THREADS%%

--- a/scripts/foreman/prompts/shepherd-ci-fix.md
+++ b/scripts/foreman/prompts/shepherd-ci-fix.md
@@ -1,0 +1,27 @@
+# Foreman shepherd — repair red CI
+
+CI is red on your unit's PR (%%PR_URL%%, branch `%%BRANCH%%`, unit
+`#%%UNIT_NUMBER%%`). The deterministic classifier ruled this failure
+mechanical (not environmental), so it is yours to fix. The failing excerpt is
+below.
+
+Rules (unchanged from dispatch): work only in this worktree on `%%BRANCH%%`;
+never merge, never push (foreman pushes after you finish), never touch
+`.github/workflows/**`, never bypass hooks, no background processes.
+
+Loop:
+
+1. Reproduce the failure locally where feasible; fix the root cause. Never
+   weaken or delete a test to make it pass — if the test is genuinely wrong,
+   fix it and say why in the commit message.
+2. Run `%%VERIFY_COMMAND%%` until green.
+3. Commit with a Conventional Commit referencing `#%%UNIT_NUMBER%%`. Leave
+   the worktree clean and exit 0. Foreman pushes with lease.
+
+If the failure is not actually fixable from code (infrastructure, billing,
+external service), say so plainly in your final message and exit non-zero —
+foreman will escalate to the human queue instead of retrying you.
+
+## Failing checks
+
+%%FAILURE_EXCERPT%%

--- a/scripts/foreman/prompts/shepherd-rebase.md
+++ b/scripts/foreman/prompts/shepherd-rebase.md
@@ -1,0 +1,29 @@
+# Foreman shepherd — conflicted rebase
+
+A sibling PR merged into `%%DEFAULT_BRANCH%%` and your unit's branch
+`%%BRANCH%%` (PR %%PR_URL%%, unit `#%%UNIT_NUMBER%%`) now conflicts. A
+`git merge-tree` dry run enumerated the conflicting paths below.
+
+Rules: work only in this worktree; never merge PRs; never push (foreman
+force-pushes with lease after verification); no `--no-verify`.
+
+Procedure — rebase, never merge-main (one update mechanism):
+
+1. `git fetch` is already done. Run
+   `git rebase %%DEFAULT_BRANCH%%` against the remote-tracking ref foreman
+   prepared, resolving each conflict **additively**: both sides' intent must
+   survive. When in doubt, prefer keeping the other side's semantics and
+   re-applying this branch's change on top.
+2. Regenerated artifacts (lockfiles, codegen output, schema snapshots) must
+   be regenerated via their tooling — never hand-merge generated files.
+3. Run `%%VERIFY_COMMAND%%` until green.
+4. Leave the worktree clean (rebase completed, nothing uncommitted) and
+   exit 0.
+
+If a conflict cannot be resolved without a behavior-changing decision the
+spec does not settle, stop, explain the decision needed in your final
+message, and exit non-zero — foreman escalates it.
+
+## Conflicting paths (merge-tree dry run)
+
+%%CONFLICTS%%

--- a/scripts/foreman/report.py
+++ b/scripts/foreman/report.py
@@ -130,8 +130,8 @@ def human_queue(
     if merge_order:
         lines.append("")
         lines.append("  Pending merges (suggested dependency-aware order):")
-        for number, url in merge_order:
-            lines.append(f"    1. #{number}  {url}")
+        for position, (number, url) in enumerate(merge_order, 1):
+            lines.append(f"    {position}. #{number}  {url}")
     if blocked:
         lines.append("")
         lines.append("  Blocked questions:")

--- a/scripts/foreman/report.py
+++ b/scripts/foreman/report.py
@@ -1,0 +1,154 @@
+"""Human-facing output: summary tables, the per-unit status comment
+(single, marker-identified, edited in place), and the consolidated
+human-action queue. Display only — never read back for decisions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from foreman.github import STATUS_MARKER, GitHub
+from foreman.graph import Unit
+from foreman.util import utc_now_iso, warn
+
+
+def table(headers: list[str], rows: list[list[str]]) -> str:
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for index, cell in enumerate(row):
+            widths[index] = max(widths[index], len(cell))
+
+    def fmt(cells: list[str]) -> str:
+        return "  ".join(
+            cell.ljust(widths[index]) for index, cell in enumerate(cells)
+        ).rstrip()
+
+    lines = [fmt(headers), fmt(["-" * w for w in widths])]
+    lines.extend(fmt(row) for row in rows)
+    return "\n".join(lines)
+
+
+@dataclass
+class UnitStatus:
+    """One unit's snapshot for the status comment + summary row."""
+
+    unit: Unit
+    state: str  # dispatched | pr-open | ready-to-merge | failed | blocked | held | waiting | merged
+    branch: str = ""
+    pr_url: str = ""
+    checks: str = ""
+    blockers: list[str] = field(default_factory=list)
+    human_tasks: list[str] = field(default_factory=list)
+    blocked_question: str = ""
+    detail: str = ""
+
+
+STATE_ICONS = {
+    "dispatched": "🚧",
+    "pr-open": "🔃",
+    "ready-to-merge": "✅",
+    "failed": "⚠️",
+    "blocked": "❓",
+    "held": "⏸",
+    "waiting": "⏳",
+    "merged": "🎉",
+    "skipped": "⏭",
+    "not-armed": "🔒",
+}
+
+
+def status_comment_body(status: UnitStatus) -> str:
+    icon = STATE_ICONS.get(status.state, "•")
+    lines = [
+        STATUS_MARKER,
+        "",
+        f"**Foreman unit status: {icon} {status.state}**",
+        "",
+    ]
+    if status.branch:
+        lines.append(f"- Branch: `{status.branch}`")
+    if status.pr_url:
+        lines.append(f"- PR: {status.pr_url}")
+    if status.checks:
+        lines.append(f"- Checks: {status.checks}")
+    for blocker in status.blockers:
+        lines.append(f"- Blocker: {blocker}")
+    if status.blocked_question:
+        lines.append("")
+        lines.append("**BLOCKED — needs a human answer:**")
+        lines.append("")
+        lines.append("> " + status.blocked_question.replace("\n", "\n> "))
+    if status.human_tasks:
+        lines.append("")
+        lines.append("**Human-only tasks (foreman never attempts these):**")
+        lines.append("")
+        for task in status.human_tasks:
+            lines.append(f"- [ ] {task}")
+    if status.detail:
+        lines.append("")
+        lines.append(status.detail)
+    lines.append("")
+    lines.append(
+        f"_Updated {utc_now_iso()} — this comment is edited in place by foreman; "
+        "it is display-only and never read back for decisions._"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def update_status_comment(gh: GitHub, status: UnitStatus) -> None:
+    try:
+        gh.upsert_status_comment(status.unit.number, status_comment_body(status))
+    except Exception as exc:  # display-only: never fail a run over a comment
+        warn(f"#{status.unit.number}: status comment update failed: {exc}")
+
+
+def summary_table(statuses: list[UnitStatus]) -> str:
+    rows = []
+    for status in statuses:
+        icon = STATE_ICONS.get(status.state, "•")
+        rows.append(
+            [
+                f"#{status.unit.number}",
+                f"{icon} {status.state}",
+                status.branch or "-",
+                status.pr_url or "-",
+                status.detail[:60] if status.detail else "-",
+            ]
+        )
+    return table(["unit", "status", "branch", "pr", "detail"], rows)
+
+
+def human_queue(
+    *,
+    merge_order: list[tuple[int, str]],
+    human_tasks: dict[int, list[str]],
+    blocked: dict[int, str],
+    environmental: dict[int, str],
+) -> str:
+    """The consolidated 'what needs a human' list (most-repeated chore in M4)."""
+    lines: list[str] = ["Human action queue:"]
+    if merge_order:
+        lines.append("")
+        lines.append("  Pending merges (suggested dependency-aware order):")
+        for number, url in merge_order:
+            lines.append(f"    1. #{number}  {url}")
+    if blocked:
+        lines.append("")
+        lines.append("  Blocked questions:")
+        for number, question in sorted(blocked.items()):
+            first = question.strip().splitlines()[0] if question.strip() else ""
+            lines.append(f"    - #{number}: {first}")
+    if human_tasks:
+        lines.append("")
+        lines.append("  Human-only tasks:")
+        for number, tasks in sorted(human_tasks.items()):
+            for task in tasks:
+                lines.append(f"    - #{number}: {task}")
+    if environmental:
+        lines.append("")
+        lines.append("  Environmental failures (fix the environment, not the code):")
+        for number, detail in sorted(environmental.items()):
+            lines.append(f"    - #{number}: {detail}")
+    if len(lines) == 1:
+        lines.append("  (empty — nothing waiting on a human)")
+    return "\n".join(lines)

--- a/scripts/foreman/shepherd.py
+++ b/scripts/foreman/shepherd.py
@@ -1,0 +1,387 @@
+"""Shepherd: keep open foreman PRs healthy until a human merges them.
+
+Deterministic triggers → bounded agent actions:
+  red CI      → classify by signature first (environmental: retry once via
+                empty commit, then human queue; quota_wait: idle; otherwise
+                mechanical: resume the agent with the failing excerpt)
+  behind/dirty→ merge-tree dry-run; clean rebases are mechanical, conflicted
+                ones go to the agent (rebase additively, re-verify, push)
+  unresolved review-bot threads → resume the agent to adjudicate each finding
+                (apply or decline-with-reasoning; blanket-accepting prohibited)
+  green ∧ adjudicated ∧ mergeable ∧ not behind → label ready-to-merge and
+                report a dependency-aware suggested merge order.
+
+Foreman never merges. `gh run rerun` is assumed unavailable to the bot token;
+the CI retrigger primitive is an empty commit.
+"""
+
+from __future__ import annotations
+
+import graphlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from foreman import backend as backend_mod
+from foreman import signatures as signatures_mod, spec, verify, worktree
+from foreman.config import Config
+from foreman.dispatch import RETRIGGER_SUBJECT
+from foreman.github import GitHub
+from foreman.graph import MARKER_RE
+from foreman.util import info, warn, write_text
+
+MAX_AGENT_ACTIONS_PER_PR = 2  # per shepherd run; watch ticks give more rounds
+
+
+@dataclass
+class PrWork:
+    number: int
+    unit_number: int
+    branch: str
+    url: str
+    title: str
+    state: str = (
+        "healthy"  # healthy | fixed | rebased | adjudicated | waiting | escalated | settling | ready
+    )
+    detail: str = ""
+    actions: int = 0
+
+
+@dataclass
+class ShepherdReport:
+    worked: list[PrWork] = field(default_factory=list)
+    ready_order: list[tuple[int, str]] = field(default_factory=list)
+    environmental: dict[int, str] = field(default_factory=dict)
+    waiting: dict[int, str] = field(default_factory=dict)
+    cost_usd: float = 0.0
+
+
+def open_foreman_prs(gh: GitHub) -> list[dict]:
+    prs = []
+    for pr in gh.prs(label="foreman-dispatched", state="open"):
+        match = MARKER_RE.search(pr.get("body") or "")
+        if match:
+            pr["_unit"] = int(match.group("number"))
+            prs.append(pr)
+    return prs
+
+
+def classify_checks(rollup: list[dict] | None) -> tuple[str, list[dict]]:
+    """(green|red|pending, failed contexts) from a statusCheckRollup list."""
+    failed: list[dict] = []
+    pending = False
+    for ctx in rollup or []:
+        status = (ctx.get("status") or "").upper()
+        conclusion = (ctx.get("conclusion") or ctx.get("state") or "").upper()
+        if conclusion in (
+            "FAILURE",
+            "TIMED_OUT",
+            "ACTION_REQUIRED",
+            "CANCELLED",
+            "ERROR",
+        ):
+            failed.append(ctx)
+        elif status in ("QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED") or (
+            not conclusion and status not in ("COMPLETED",)
+        ):
+            pending = True
+    if failed:
+        return "red", failed
+    if pending:
+        return "pending", []
+    return "green", []
+
+
+def _failure_text(gh: GitHub, failed: list[dict]) -> str:
+    parts = []
+    for ctx in failed[:5]:
+        name = ctx.get("name") or ctx.get("context") or "check"
+        parts.append(f"### Failing check: {name}")
+        url = ctx.get("detailsUrl") or ctx.get("targetUrl") or ""
+        if "/actions/runs/" in url:
+            log = gh.run_log_failed(url)
+            if log:
+                parts.append("```text\n" + log[-8000:] + "\n```")
+        elif url:
+            parts.append(f"(external check: {url})")
+    return "\n\n".join(parts)
+
+
+def _ensure_worktree(
+    cfg: Config, root: Path, unit_number: int, branch: str, remote_name: str
+) -> Path:
+    path = root / cfg.worktrees_dir / f"pr-{unit_number}"
+    if not path.exists():
+        worktree.fetch(remote_name)
+        local = worktree.attempt_branches(cfg, remote_name, unit_number)
+        if branch in local:
+            try:
+                worktree.add_existing_branch(path, branch)
+            except Exception:
+                worktree.add(path, branch, f"{remote_name}/{branch}")
+        else:
+            worktree.add(path, branch, f"{remote_name}/{branch}")
+    return path
+
+
+def _resume_agent(
+    gh: GitHub,
+    cfg: Config,
+    root: Path,
+    work: PrWork,
+    prompt_name: str,
+    tokens: dict[str, str],
+) -> backend_mod.BackendResult:
+    run_dir = backend_mod.unit_dir(cfg, root, work.unit_number)
+    prompt = spec.load_prompt(prompt_name, tokens)
+    prompt_file = run_dir / f"{prompt_name}.md"
+    write_text(prompt_file, prompt)
+    adapter = backend_mod.adapter_path(cfg.backend)
+    caps = backend_mod.capabilities(adapter)
+    session_file = run_dir / "session"
+    resume_ref = None
+    if "resume" in caps and session_file.exists():
+        for line in session_file.read_text(encoding="utf-8").splitlines():
+            if line.startswith("SESSION_REF="):
+                resume_ref = line.split("=", 1)[1].strip() or None
+                break
+    wt_path = _ensure_worktree(
+        cfg, root, work.unit_number, work.branch, worktree.remote(cfg)
+    )
+    if resume_ref is None:
+        # No session to resume: prepend the deterministic resume-state.
+        state_path = backend_mod.write_resume_state(
+            run_dir, wt_path, "fresh shepherd invocation"
+        )
+        prompt = state_path.read_text(encoding="utf-8") + "\n\n---\n\n" + prompt
+        write_text(prompt_file, prompt)
+    return backend_mod.run_backend(
+        cfg,
+        adapter,
+        cwd=wt_path,
+        unit_run_dir=run_dir,
+        prompt_file=prompt_file,
+        timeout_min=cfg.shepherd_timeout_min,
+        resume_ref=resume_ref,
+    )
+
+
+def _common_tokens(gh: GitHub, cfg: Config, work: PrWork) -> dict[str, str]:
+    return {
+        "PR_URL": work.url,
+        "BRANCH": work.branch,
+        "UNIT_NUMBER": str(work.unit_number),
+        "DEFAULT_BRANCH": gh.default_branch(),
+        "VERIFY_COMMAND": " ".join(cfg.verify_command),
+    }
+
+
+def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWork:
+    status = gh.pr_status(pr["number"])
+    work = PrWork(
+        number=pr["number"],
+        unit_number=pr["_unit"],
+        branch=status["headRefName"],
+        url=status["url"],
+        title=status["title"],
+    )
+    remote_name = worktree.remote(cfg)
+    checks_state, failed = classify_checks(status.get("statusCheckRollup"))
+
+    if checks_state == "pending":
+        work.state, work.detail = "settling", "checks still running"
+        return work
+
+    if checks_state == "red":
+        failure_text = _failure_text(gh, failed)
+        sig = signatures_mod.match(failure_text, catalog)
+        if sig and sig.action == "quota_wait":
+            work.state, work.detail = (
+                "waiting",
+                f"quota signature '{sig.name}' — waiting for reset",
+            )
+            return work
+        if sig and sig.action == "environment":
+            wt_path = _ensure_worktree(
+                cfg, root, work.unit_number, work.branch, remote_name
+            )
+            retries = worktree.count_retrigger_commits(
+                wt_path, f"{remote_name}/{gh.default_branch()}", RETRIGGER_SUBJECT
+            )
+            if retries == 0:
+                worktree.empty_commit(wt_path, RETRIGGER_SUBJECT)
+                worktree.push(wt_path, remote_name, work.branch, first=False)
+                work.state, work.detail = (
+                    "fixed",
+                    f"environmental '{sig.name}': retried once (empty commit)",
+                )
+            else:
+                work.state = "escalated"
+                work.detail = (
+                    f"environmental '{sig.name}' persisted after retry — needs a human"
+                )
+            return work
+        # Mechanical (or novel) failure → one bounded agent fix.
+        work.actions += 1
+        tokens = _common_tokens(gh, cfg, work)
+        tokens["FAILURE_EXCERPT"] = failure_text or json.dumps(failed[:3], indent=2)
+        result = _resume_agent(gh, cfg, root, work, "shepherd-ci-fix", tokens)
+        work_dir = _ensure_worktree(
+            cfg, root, work.unit_number, work.branch, remote_name
+        )
+        if result.ok and not worktree.is_clean(work_dir):
+            work.state, work.detail = (
+                "escalated",
+                "agent left uncommitted changes after CI fix",
+            )
+        elif result.ok:
+            worktree.push(work_dir, remote_name, work.branch, first=False)
+            work.state, work.detail = "fixed", "agent pushed a CI fix"
+        else:
+            work.state, work.detail = (
+                "escalated",
+                "agent could not fix CI (see unit log)",
+            )
+        if result.cost_usd:
+            work.detail += f" (${result.cost_usd:.2f})"
+        return work
+
+    merge_state = (status.get("mergeStateStatus") or "").upper()
+    if merge_state in ("BEHIND", "DIRTY"):
+        wt_path = _ensure_worktree(
+            cfg, root, work.unit_number, work.branch, remote_name
+        )
+        worktree.fetch(remote_name)
+        base_ref = f"{remote_name}/{gh.default_branch()}"
+        conflicts = worktree.merge_tree_conflicts(wt_path, base_ref)
+        if not conflicts:
+            if worktree.rebase_onto(wt_path, base_ref):
+                worktree.push(wt_path, remote_name, work.branch, first=False)
+                work.state, work.detail = (
+                    "rebased",
+                    "mechanical rebase onto fresh default branch",
+                )
+            else:
+                work.state, work.detail = (
+                    "escalated",
+                    "mechanical rebase unexpectedly failed",
+                )
+            return work
+        work.actions += 1
+        tokens = _common_tokens(gh, cfg, work)
+        tokens["CONFLICTS"] = "\n".join(f"- {c}" for c in conflicts)
+        result = _resume_agent(gh, cfg, root, work, "shepherd-rebase", tokens)
+        if result.ok:
+            ok, _tail = verify.run_verify(
+                cfg, wt_path, backend_mod.unit_dir(cfg, root, work.unit_number)
+            )
+            if ok:
+                worktree.push(wt_path, remote_name, work.branch, first=False)
+                work.state, work.detail = (
+                    "rebased",
+                    f"agent resolved {len(conflicts)} conflict(s), verify green",
+                )
+            else:
+                work.state, work.detail = "escalated", "post-rebase verification failed"
+        else:
+            work.state, work.detail = "escalated", "agent could not resolve the rebase"
+        return work
+
+    threads = [t for t in gh.review_threads(work.number) if not t.get("isResolved")]
+    if threads:
+        work.actions += 1
+        rendered = []
+        for thread in threads[:20]:
+            comments = (thread.get("comments") or {}).get("nodes") or []
+            first = comments[0] if comments else {}
+            author = (first.get("author") or {}).get("login", "reviewer")
+            rendered.append(
+                f"- thread `{thread['id']}` on `{thread.get('path') or 'PR'}` by @{author}:\n"
+                f"  > " + (first.get("body") or "").strip().replace("\n", "\n  > ")
+            )
+        tokens = _common_tokens(gh, cfg, work)
+        tokens["THREADS"] = "\n".join(rendered)
+        result = _resume_agent(gh, cfg, root, work, "shepherd-adjudicate", tokens)
+        wt_path = _ensure_worktree(
+            cfg, root, work.unit_number, work.branch, remote_name
+        )
+        if result.ok:
+            if worktree.is_clean(wt_path) is False:
+                work.state, work.detail = (
+                    "escalated",
+                    "agent left uncommitted adjudication changes",
+                )
+                return work
+            if worktree.commits_ahead(wt_path, f"{remote_name}/{work.branch}") > 0:
+                worktree.push(wt_path, remote_name, work.branch, first=False)
+            remaining = [
+                t for t in gh.review_threads(work.number) if not t.get("isResolved")
+            ]
+            if remaining:
+                work.state = "escalated"
+                work.detail = f"{len(remaining)} review thread(s) still undispositioned"
+            else:
+                work.state, work.detail = (
+                    "adjudicated",
+                    f"{len(threads)} thread(s) dispositioned",
+                )
+        else:
+            work.state, work.detail = "escalated", "adjudication agent failed"
+        return work
+
+    mergeable = (status.get("mergeable") or "").upper()
+    if merge_state == "CLEAN" or mergeable == "MERGEABLE":
+        gh.label_own_pr(work.number, add=["ready-to-merge"])
+        work.state, work.detail = (
+            "ready",
+            "green, adjudicated, mergeable — awaiting human merge",
+        )
+    else:
+        work.state, work.detail = "healthy", f"mergeState={merge_state or 'UNKNOWN'}"
+    return work
+
+
+def merge_order(gh: GitHub, ready: list[PrWork]) -> list[tuple[int, str]]:
+    """Dependency-aware suggested order among ready PRs (topo by blocked-by)."""
+    by_unit = {w.unit_number: w for w in ready}
+    sorter: graphlib.TopologicalSorter = graphlib.TopologicalSorter()
+    for unit_number in by_unit:
+        deps = [
+            entry["number"]
+            for entry in (gh.issue(unit_number).get("blockedBy") or [])
+            if entry["number"] in by_unit
+        ]
+        sorter.add(unit_number, *deps)
+    ordered = list(sorter.static_order())
+    return [(n, by_unit[n].url) for n in ordered]
+
+
+def run_shepherd(gh: GitHub, cfg: Config, root: Path) -> ShepherdReport:
+    out = ShepherdReport()
+    catalog = signatures_mod.load()
+    prs = open_foreman_prs(gh)
+    if not prs:
+        info("shepherd: no open foreman PRs")
+        return out
+    for pr in prs:
+        try:
+            work = shepherd_pr(gh, cfg, root, pr, catalog)
+        except Exception as exc:  # keep shepherding the rest
+            warn(f"shepherd: PR #{pr['number']} failed: {exc}")
+            work = PrWork(
+                number=pr["number"],
+                unit_number=pr["_unit"],
+                branch=pr.get("headRefName", ""),
+                url=pr.get("url", ""),
+                title=pr.get("title", ""),
+                state="escalated",
+                detail=str(exc),
+            )
+        out.worked.append(work)
+        if work.state == "escalated":
+            out.environmental[work.unit_number] = work.detail
+        if work.state == "waiting":
+            out.waiting[work.unit_number] = work.detail
+    ready = [w for w in out.worked if w.state == "ready"]
+    out.ready_order = merge_order(gh, ready)
+    return out

--- a/scripts/foreman/signatures.py
+++ b/scripts/foreman/signatures.py
@@ -1,0 +1,57 @@
+"""Environmental-failure signature catalog (signatures.toml).
+
+The shepherd classifies red CI by signature BEFORE any LLM sees it:
+`environment` failures get one retry then the human queue (an agent must
+never "fix" an infra problem by weakening code); `quota_wait` failures mean
+the backend's own usage window is exhausted — wait, don't burn retries.
+An unmatched failure gets one bounded LLM diagnosis whose conclusion belongs
+back in this catalog: the LLM diagnoses once, code recognizes forever.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+from foreman.util import ForemanError
+
+CATALOG = Path(__file__).resolve().parent / "signatures.toml"
+
+ACTIONS = ("environment", "quota_wait")
+
+
+@dataclass
+class Signature:
+    name: str
+    pattern: re.Pattern
+    action: str  # environment | quota_wait
+
+
+def load(path: Path | None = None) -> list[Signature]:
+    catalog_path = path or CATALOG
+    with catalog_path.open("rb") as fh:
+        data = tomllib.load(fh)
+    signatures = []
+    for entry in data.get("signature", []):
+        action = entry.get("action", "environment")
+        if action not in ACTIONS:
+            raise ForemanError(
+                f"signatures: unknown action '{action}' in '{entry.get('name')}'"
+            )
+        signatures.append(
+            Signature(
+                name=entry["name"],
+                pattern=re.compile(entry["pattern"], re.I),
+                action=action,
+            )
+        )
+    return signatures
+
+
+def match(text: str, signatures: list[Signature]) -> Signature | None:
+    for signature in signatures:
+        if signature.pattern.search(text or ""):
+            return signature
+    return None

--- a/scripts/foreman/signatures.toml
+++ b/scripts/foreman/signatures.toml
@@ -1,0 +1,26 @@
+# Environmental-failure signature catalog.
+#
+# The shepherd matches red-CI output (and dispatch matches agent-log tails)
+# against these BEFORE any LLM sees the failure. `environment` = retry once
+# via empty commit, then escalate to the human queue — never let an agent
+# "fix" an infra problem by weakening code. `quota_wait` = the agent
+# backend's own usage window is exhausted: idle until it resets, don't burn
+# retries, don't mark the unit failed.
+#
+# When an unmatched failure gets an LLM diagnosis, add its signature here:
+# the LLM diagnoses once, code recognizes forever.
+
+[[signature]]
+name = "convex-deployment-quota"
+pattern = 'DeploymentQuotaReached'
+action = "environment"
+
+[[signature]]
+name = "github-actions-billing"
+pattern = 'recent account payments have failed|spending limit needs to be increased'
+action = "environment"
+
+[[signature]]
+name = "claude-usage-limit"
+pattern = 'usage limit reached|hit your (usage|rate) limit|limit will reset|out of extra usage'
+action = "quota_wait"

--- a/scripts/foreman/spec.py
+++ b/scripts/foreman/spec.py
@@ -1,0 +1,226 @@
+"""Issue spec contract validation and deterministic prompt assembly.
+
+The contract: a dispatchable unit has an `## Acceptance Criteria` section;
+items tag themselves `[CI]` (machine-verifiable, must map to named tests) or
+`[HUMAN]` (surfaced, never attempted, blocks `Closes` for the parent).
+
+Prompt assembly is pure code: fixed preamble (prompts/*.md, token-substituted)
++ full issue/sub-issue bodies + trusted comments + injected handoff contracts.
+Comments are embedded only from trusted author associations (or foreman's own
+posted corrections) — issue threads on public repos are otherwise an
+injection surface.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from foreman.config import Config
+from foreman.github import GitHub
+from foreman.graph import Unit, foreman_prs_for_issue
+from foreman.util import sha256_hex
+
+PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+
+_HEADING_RE = re.compile(r"^(#{2,6})\s*(?P<title>.+?)\s*$", re.M)
+_BULLET_RE = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+(?P<text>.+)$")
+
+
+@dataclass
+class AcItem:
+    text: str
+    tag: str  # CI | HUMAN
+    tagged: bool
+
+
+@dataclass
+class SpecInfo:
+    ac_items: list[AcItem] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def human_items(self) -> list[str]:
+        return [item.text for item in self.ac_items if item.tag == "HUMAN"]
+
+
+def find_section(body: str, title: str) -> str | None:
+    """Return the text under a `## Title` heading (any 2-6 level), else None."""
+    matches = list(_HEADING_RE.finditer(body or ""))
+    for index, match in enumerate(matches):
+        if match.group("title").strip().lower() == title.lower():
+            start = match.end()
+            level = len(match.group(1))
+            for nxt in matches[index + 1 :]:
+                if len(nxt.group(1)) <= level:
+                    return body[start : nxt.start()].strip()
+            return body[start:].strip()
+    return None
+
+
+def parse_ac(body: str) -> list[AcItem] | None:
+    section = find_section(body, "Acceptance Criteria")
+    if section is None:
+        return None
+    items: list[AcItem] = []
+    for line in section.splitlines():
+        match = _BULLET_RE.match(line)
+        if not match:
+            continue
+        text = match.group("text").strip()
+        if "[HUMAN]" in text:
+            items.append(AcItem(text, "HUMAN", True))
+        elif "[CI]" in text:
+            items.append(AcItem(text, "CI", True))
+        else:
+            items.append(AcItem(text, "CI", False))
+    return items
+
+
+def validate(unit: Unit) -> SpecInfo:
+    info = SpecInfo()
+    items = parse_ac(unit.body)
+    if items is None:
+        info.errors.append(
+            f"#{unit.number}: no '## Acceptance Criteria' section — non-dispatchable"
+        )
+        return info
+    if not items:
+        info.errors.append(f"#{unit.number}: Acceptance Criteria section has no items")
+        return info
+    info.ac_items = items
+    untagged = sum(1 for item in items if not item.tagged)
+    if untagged:
+        info.warnings.append(
+            f"#{unit.number}: {untagged} acceptance criteria untagged — treated as [CI]"
+        )
+    return info
+
+
+def human_only_tasks(unit: Unit, info: SpecInfo) -> list[str]:
+    tasks = list(info.human_items)
+    section = find_section(unit.body, "Human-only tasks")
+    if section:
+        for line in section.splitlines():
+            match = _BULLET_RE.match(line)
+            if match:
+                tasks.append(match.group("text").strip())
+    return tasks
+
+
+def trusted_comments(gh: GitHub, cfg: Config, number: int) -> tuple[list[dict], int]:
+    """Comments safe to embed in prompts + count of excluded ones."""
+    kept: list[dict] = []
+    excluded = 0
+    me = gh.viewer()
+    for comment in gh.issue_comments(number):
+        author = (comment.get("user") or {}).get("login", "")
+        association = comment.get("author_association", "")
+        if association in cfg.comment_trust or author == me:
+            kept.append(comment)
+        else:
+            excluded += 1
+    return kept, excluded
+
+
+def spec_hash(unit: Unit, comments: list[dict]) -> str:
+    """Stable hash of everything the prompt embeds from the spec."""
+    parts = [unit.body]
+    parts += [sub.get("body") or "" for sub in unit.sub_issues]
+    parts += [
+        comment.get("body") or ""
+        for comment in sorted(comments, key=lambda c: c.get("id", 0))
+    ]
+    return sha256_hex("\n\x00\n".join(parts))
+
+
+def load_prompt(name: str, tokens: dict[str, str]) -> str:
+    text = (PROMPTS_DIR / f"{name}.md").read_text(encoding="utf-8")
+    for key, value in tokens.items():
+        text = text.replace(f"%%{key}%%", value)
+    return text
+
+
+def extract_handoff(pr_body: str) -> str | None:
+    section = find_section(pr_body or "", "Handoff")
+    if section is None:
+        return None
+    # PR bodies end with a `---` footer; a thematic break ends the section.
+    section = re.split(r"^\s*---\s*$", section, maxsplit=1, flags=re.M)[0].strip()
+    return section or None
+
+
+def collect_handoffs(gh: GitHub, cfg: Config, unit: Unit) -> list[tuple[int, str]]:
+    """Handoff sections from the merged foreman PRs of this unit's dependencies."""
+    handoffs: list[tuple[int, str]] = []
+    for dep in unit.blocked_by:
+        for pr in foreman_prs_for_issue(gh, cfg, dep):
+            if not pr.get("merged"):
+                continue
+            text = extract_handoff(pr.get("body") or "")
+            if text:
+                handoffs.append((dep, text))
+    return handoffs
+
+
+def assemble_dispatch_prompt(
+    gh: GitHub,
+    cfg: Config,
+    unit: Unit,
+    *,
+    branch: str,
+    default_branch: str,
+    result_file: str,
+    comments: list[dict],
+    excluded_comments: int,
+    handoffs: list[tuple[int, str]],
+) -> str:
+    tokens = {
+        "UNIT_NUMBER": str(unit.number),
+        "UNIT_TITLE": unit.title,
+        "BRANCH": branch,
+        "DEFAULT_BRANCH": default_branch,
+        "VERIFY_COMMAND": " ".join(cfg.verify_command),
+        "RESULT_FILE": result_file,
+        "COMMIT_TYPE": unit.inputs.commit_type if unit.inputs else cfg.default_type,
+    }
+    sections = [load_prompt("implementer-preamble", tokens)]
+
+    sections.append(f"# Unit #{unit.number}: {unit.title}\n\n{unit.body.strip()}")
+    for sub in unit.sub_issues:
+        state_note = (
+            "" if (sub.get("state") or "").upper() == "OPEN" else " (already closed)"
+        )
+        sections.append(
+            f"## Sub-issue #{sub['number']}: {sub.get('title', '')}{state_note}\n\n"
+            f"{(sub.get('body') or '').strip()}"
+        )
+
+    if comments:
+        rendered = []
+        for comment in comments:
+            author = (comment.get("user") or {}).get("login", "unknown")
+            rendered.append(
+                f"### Comment by @{author}\n\n{(comment.get('body') or '').strip()}"
+            )
+        sections.append(
+            "# Issue comments (human corrections and clarifications — these amend the "
+            "spec above and MUST be honored)\n\n" + "\n\n".join(rendered)
+        )
+    if excluded_comments:
+        sections.append(
+            f"_Note: {excluded_comments} comment(s) from untrusted authors were withheld "
+            "from this prompt._"
+        )
+
+    if handoffs:
+        rendered = [f"### Handoff from #{dep}\n\n{text}" for dep, text in handoffs]
+        sections.append(
+            "# Handoff contracts from merged dependencies (already on "
+            f"{default_branch} — build on these, do not reinvent them)\n\n"
+            + "\n\n".join(rendered)
+        )
+
+    return "\n\n---\n\n".join(sections) + "\n"

--- a/scripts/foreman/tests/fakes.py
+++ b/scripts/foreman/tests/fakes.py
@@ -1,0 +1,105 @@
+"""Fake `gh` transport: canned responses keyed by argv prefix, full call
+recording, and a hard failure on any un-stubbed invocation — so a test can
+assert not just what foreman did, but that it did nothing else.
+"""
+
+from __future__ import annotations
+
+import json
+
+from foreman.config import Config
+from foreman.github import Gh, GitHub
+
+REPO_VIEW = {
+    "nameWithOwner": "owner/repo",
+    "owner": {"login": "owner"},
+    "name": "repo",
+    "defaultBranchRef": {"name": "main"},
+    "visibility": "PUBLIC",
+}
+
+
+class FakeRunner:
+    def __init__(self):
+        self.calls: list[tuple[list[str], str | None]] = []
+        self._stubs: list[tuple[list[str], int, str]] = []
+
+    def when(self, prefix: list[str], stdout: object = "", rc: int = 0) -> "FakeRunner":
+        text = stdout if isinstance(stdout, str) else json.dumps(stdout)
+        self._stubs.append((prefix, rc, text))
+        return self
+
+    def __call__(self, argv: list[str], input_text: str | None) -> tuple[int, str, str]:
+        self.calls.append((list(argv), input_text))
+        for prefix, rc, out in self._stubs:
+            if argv[: len(prefix)] == prefix:
+                return rc, out, ""
+        raise AssertionError(f"unexpected gh call: {argv}")
+
+    def called_with_prefix(self, prefix: list[str]) -> list[list[str]]:
+        return [argv for argv, _ in self.calls if argv[: len(prefix)] == prefix]
+
+
+def make_github(cfg: Config | None = None) -> tuple[GitHub, FakeRunner]:
+    runner = FakeRunner()
+    runner.when(["repo", "view"], REPO_VIEW)
+    runner.when(["api", "user", "--jq", ".login"], "bot\n")
+    gh = GitHub(Gh(runner), cfg or Config())
+    return gh, runner
+
+
+def issue_json(
+    number: int,
+    *,
+    state: str = "OPEN",
+    state_reason: str | None = None,
+    body: str = "",
+    title: str | None = None,
+    labels: list[str] | None = None,
+    issue_type: str | None = None,
+    blocked_by: list[int] | None = None,
+    sub_issues: list[int] | None = None,
+    parent: int | None = None,
+    closed_by_prs: list[int] | None = None,
+) -> dict:
+    return {
+        "number": number,
+        "title": title or f"Unit {number}",
+        "state": state,
+        "stateReason": state_reason,
+        "body": body,
+        "url": f"https://github.com/owner/repo/issues/{number}",
+        "labels": [{"name": name} for name in labels or []],
+        "milestone": None,
+        "issueType": {"name": issue_type} if issue_type else None,
+        "parent": {"number": parent} if parent else None,
+        "subIssues": [{"number": n} for n in sub_issues or []],
+        "blockedBy": [{"number": n} for n in blocked_by or []],
+        "closedByPullRequestsReferences": [{"number": n} for n in closed_by_prs or []],
+    }
+
+
+def pr_json(
+    number: int,
+    *,
+    unit: int | None = None,
+    merged: bool = True,
+    base: str = "main",
+    head: str | None = None,
+    author: str = "bot",
+    body: str | None = None,
+) -> dict:
+    marker = (
+        f"<!-- foreman:unit=#{unit} spec-hash=x base=y schema=1 -->" if unit else ""
+    )
+    return {
+        "number": number,
+        "url": f"https://github.com/owner/repo/pull/{number}",
+        "body": body if body is not None else marker,
+        "merged": merged,
+        "mergedAt": "2026-07-12T00:00:00Z" if merged else None,
+        "baseRefName": base,
+        "headRefName": head or (f"foreman/feat/{unit}-x" if unit else "feature/x"),
+        "author": {"login": author},
+        "state": "MERGED" if merged else "OPEN",
+    }

--- a/scripts/foreman/tests/test_config.py
+++ b/scripts/foreman/tests/test_config.py
@@ -1,0 +1,70 @@
+"""Config loading: defaults, TOML, tables, env overrides, fail-loud validation."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from foreman import config as config_mod
+from foreman.util import ForemanError
+
+
+class ConfigLoading(unittest.TestCase):
+    def load_toml(self, text: str):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / config_mod.CONFIG_FILE).write_text(text, encoding="utf-8")
+            return config_mod.load(root)
+
+    def test_defaults_without_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = config_mod.load(Path(tmp))
+        self.assertEqual(cfg.verify_command, ["task", "ci"])
+        self.assertTrue(cfg.require_approval)
+        self.assertEqual(cfg.billing, "subscription")
+        self.assertEqual(cfg.max_parallel, 3)
+
+    def test_toml_values_and_tables(self):
+        cfg = self.load_toml(
+            'backend = "mock"\n'
+            'verify_command = ["task", "verify"]\n'
+            "[budgets]\ndispatch_usd = 5.0\n"
+            "[timeouts]\nshepherd_min = 10\n"
+        )
+        self.assertEqual(cfg.backend, "mock")
+        self.assertEqual(cfg.verify_command, ["task", "verify"])
+        self.assertEqual(cfg.dispatch_budget_usd, 5.0)
+        self.assertEqual(cfg.shepherd_timeout_min, 10)
+
+    def test_env_override_wins(self):
+        os.environ["FOREMAN_BACKEND"] = "mock"
+        try:
+            cfg = self.load_toml('backend = "claude"\n')
+        finally:
+            del os.environ["FOREMAN_BACKEND"]
+        self.assertEqual(cfg.backend, "mock")
+
+    def test_invalid_inputs_mode_fails(self):
+        with self.assertRaises(ForemanError):
+            self.load_toml('inputs = "psychic"\n')
+
+    def test_empty_verify_command_fails(self):
+        with self.assertRaises(ForemanError):
+            self.load_toml("verify_command = []\n")
+
+    def test_multi_segment_branch_prefix_fails(self):
+        with self.assertRaises(ForemanError):
+            self.load_toml('branch_prefix = "bots/foreman"\n')
+
+    def test_permission_mode_derivation(self):
+        self.assertEqual(
+            self.load_toml("sandboxed = true\n").resolved_permission_mode(),
+            "bypassPermissions",
+        )
+        self.assertEqual(self.load_toml("").resolved_permission_mode(), "acceptEdits")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/foreman/tests/test_doneness.py
+++ b/scripts/foreman/tests/test_doneness.py
@@ -1,0 +1,107 @@
+"""The hardened doneness truth table (spec amendment A3)."""
+
+from __future__ import annotations
+
+import unittest
+
+from foreman.config import Config
+from foreman.graph import dependency_satisfied
+from foreman.inputs import UnitInputs
+from foreman.tests.fakes import issue_json, make_github, pr_json
+
+
+def cfg_with_bot() -> Config:
+    return Config(expected_login="bot")
+
+
+class ExternalDependencies(unittest.TestCase):
+    def test_open_issue_is_unsatisfied(self):
+        gh, runner = make_github(cfg_with_bot())
+        runner.when(["issue", "view", "5"], issue_json(5, state="OPEN"))
+        done = dependency_satisfied(gh, cfg_with_bot(), 5)
+        self.assertFalse(done.satisfied)
+        self.assertEqual(done.how, "open")
+
+    def test_closed_completed_counts_and_says_how(self):
+        gh, runner = make_github(cfg_with_bot())
+        runner.when(
+            ["issue", "view", "5"],
+            issue_json(5, state="CLOSED", state_reason="completed"),
+        )
+        done = dependency_satisfied(gh, cfg_with_bot(), 5)
+        self.assertTrue(done.satisfied)
+        self.assertIn("external", done.how)
+
+    def test_not_planned_blocks_by_default(self):
+        gh, runner = make_github(cfg_with_bot())
+        runner.when(
+            ["issue", "view", "5"],
+            issue_json(5, state="CLOSED", state_reason="not_planned"),
+        )
+        done = dependency_satisfied(gh, cfg_with_bot(), 5)
+        self.assertFalse(done.satisfied)
+        self.assertTrue(done.warnings)
+
+    def test_not_planned_allowed_by_config(self):
+        cfg = Config(expected_login="bot", allow_not_planned=True)
+        gh, runner = make_github(cfg)
+        runner.when(
+            ["issue", "view", "5"],
+            issue_json(5, state="CLOSED", state_reason="not_planned"),
+        )
+        self.assertTrue(dependency_satisfied(gh, cfg, 5).satisfied)
+
+    def test_human_override_wins_even_when_open(self):
+        gh, runner = make_github(cfg_with_bot())
+        runner.when(["issue", "view", "5"], issue_json(5, state="OPEN"))
+        inputs = UnitInputs(satisfied_override=True)
+        done = dependency_satisfied(gh, cfg_with_bot(), 5, inputs=inputs)
+        self.assertTrue(done.satisfied)
+        self.assertIn("override", done.how)
+
+
+class ForemanManagedDependencies(unittest.TestCase):
+    def _gh(self, *, pr_kwargs: dict):
+        cfg = cfg_with_bot()
+        gh, runner = make_github(cfg)
+        runner.when(
+            ["issue", "view", "7"],
+            issue_json(7, state="CLOSED", state_reason="completed", closed_by_prs=[90]),
+        )
+        runner.when(["pr", "view", "90"], pr_json(90, unit=7, **pr_kwargs))
+        return gh, cfg
+
+    def test_full_chain_satisfies(self):
+        gh, cfg = self._gh(pr_kwargs={})
+        done = dependency_satisfied(gh, cfg, 7)
+        self.assertTrue(done.satisfied)
+        self.assertIn("PR #90 merged into main", done.how)
+
+    def test_unmerged_marker_pr_fails_loud(self):
+        gh, cfg = self._gh(pr_kwargs={"merged": False})
+        done = dependency_satisfied(gh, cfg, 7)
+        self.assertFalse(done.satisfied)
+        self.assertTrue(done.warnings)
+
+    def test_wrong_base_branch_fails(self):
+        gh, cfg = self._gh(pr_kwargs={"base": "develop"})
+        self.assertFalse(dependency_satisfied(gh, cfg, 7).satisfied)
+
+    def test_wrong_author_fails(self):
+        gh, cfg = self._gh(pr_kwargs={"author": "impostor"})
+        self.assertFalse(dependency_satisfied(gh, cfg, 7).satisfied)
+
+    def test_non_foreman_branch_fails(self):
+        gh, cfg = self._gh(pr_kwargs={"head": "feat/7-manual"})
+        self.assertFalse(dependency_satisfied(gh, cfg, 7).satisfied)
+
+    def test_external_marker_treats_issue_as_external(self):
+        gh, cfg = self._gh(pr_kwargs={"merged": False})
+        inputs = UnitInputs(external=True)
+        done = dependency_satisfied(gh, cfg, 7, inputs=inputs)
+        self.assertTrue(done.satisfied)
+        self.assertIn("external", done.how)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/foreman/tests/test_graph.py
+++ b/scripts/foreman/tests/test_graph.py
@@ -1,0 +1,82 @@
+"""Graph mechanics: waves, cycles, Depends-on trailer conflicts, parent-unit
+granularity via load_target over the fake transport."""
+
+from __future__ import annotations
+
+import unittest
+
+from foreman.config import Config
+from foreman.graph import Target, Unit, detect_cycle, load_target, waves
+from foreman.tests.fakes import issue_json, make_github
+
+
+def bare_unit(number: int, blocked_by: list[int] | None = None) -> Unit:
+    return Unit(
+        number=number,
+        title=f"U{number}",
+        state="OPEN",
+        state_reason=None,
+        body="",
+        url="",
+        labels=[],
+        issue_type=None,
+        milestone=None,
+        parent=None,
+        blocked_by=blocked_by or [],
+    )
+
+
+def target_of(*units: Unit) -> Target:
+    return Target(label="test", units={u.number: u for u in units}, external_deps=set())
+
+
+class WavesAndCycles(unittest.TestCase):
+    def test_waves_follow_dependencies(self):
+        target = target_of(
+            bare_unit(1), bare_unit(2, [1]), bare_unit(3, [1]), bare_unit(4, [2, 3])
+        )
+        self.assertEqual(waves(target), [[1], [2, 3], [4]])
+
+    def test_cycle_detected_with_path(self):
+        target = target_of(bare_unit(1, [3]), bare_unit(2, [1]), bare_unit(3, [2]))
+        cycle = detect_cycle(target)
+        self.assertIsNotNone(cycle)
+        self.assertGreaterEqual(len(cycle), 3)
+
+    def test_no_cycle_returns_none(self):
+        self.assertIsNone(detect_cycle(target_of(bare_unit(1), bare_unit(2, [1]))))
+
+
+class LoadTarget(unittest.TestCase):
+    def test_issue_mode_pulls_sub_issues_into_one_unit(self):
+        cfg = Config()
+        gh, runner = make_github(cfg)
+        runner.when(["issue", "view", "10"], issue_json(10, sub_issues=[11, 12]))
+        runner.when(["issue", "view", "11"], issue_json(11, parent=10))
+        runner.when(["issue", "view", "12"], issue_json(12, parent=10))
+        target = load_target(gh, cfg, issue=10)
+        self.assertEqual(set(target.units), {10})
+        self.assertEqual([s["number"] for s in target.units[10].sub_issues], [11, 12])
+
+    def test_trailer_conflict_fails_loud(self):
+        cfg = Config()
+        gh, runner = make_github(cfg)
+        body = "spec\n\nDepends-on: #5\n"
+        runner.when(["issue", "view", "10"], issue_json(10, body=body, blocked_by=[6]))
+        runner.when(["issue", "view", "6"], issue_json(6))
+        target = load_target(gh, cfg, issue=10)
+        self.assertTrue(any("disagrees" in e for e in target.units[10].errors))
+
+    def test_trailer_alone_is_the_fallback(self):
+        cfg = Config()
+        gh, runner = make_github(cfg)
+        runner.when(
+            ["issue", "view", "10"], issue_json(10, body="Depends-on: #5, #6\n")
+        )
+        target = load_target(gh, cfg, issue=10)
+        self.assertEqual(target.units[10].blocked_by, [5, 6])
+        self.assertEqual(target.external_deps, {5, 6})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/foreman/tests/test_inputs.py
+++ b/scripts/foreman/tests/test_inputs.py
@@ -1,0 +1,127 @@
+"""Arming matrix: explicit approval, backend selection, holds, dual-source
+fail-loud, and commit-type resolution (native issue type vs type: label)."""
+
+from __future__ import annotations
+
+import unittest
+
+from foreman import inputs as inputs_mod
+from foreman.config import Config
+from foreman.tests.fakes import issue_json, make_github
+
+
+class ArmingLabels(unittest.TestCase):
+    def resolve(self, labels, *, cfg=None, issue_type=None):
+        cfg = cfg or Config()
+        gh, _runner = make_github(cfg)
+        issue = issue_json(1, labels=labels, issue_type=issue_type)
+        return inputs_mod.resolve(gh, cfg, issue, "labels")
+
+    def test_unlabeled_issue_is_not_armed_under_strict_default(self):
+        out = self.resolve([])
+        self.assertFalse(out.armed)
+        self.assertTrue(out.warnings)
+
+    def test_approved_label_arms_with_default_backend(self):
+        out = self.resolve(["foreman:approved"])
+        self.assertTrue(out.armed)
+        self.assertIsNone(out.backend)
+
+    def test_backend_label_arms_and_selects(self):
+        out = self.resolve(["foreman:claude"])
+        self.assertTrue(out.armed)
+        self.assertEqual(out.backend, "claude")
+
+    def test_hold_beats_approval(self):
+        out = self.resolve(["foreman:claude", "foreman:hold"])
+        self.assertFalse(out.armed)
+        self.assertTrue(out.hold)
+
+    def test_conflicting_backends_fail_loud(self):
+        out = self.resolve(["foreman:claude", "foreman:mock"])
+        self.assertTrue(out.errors)
+
+    def test_default_armed_mode_arms_without_labels(self):
+        out = self.resolve([], cfg=Config(require_approval=False))
+        self.assertTrue(out.armed)
+
+    def test_default_armed_mode_still_honors_hold(self):
+        out = self.resolve(["foreman:hold"], cfg=Config(require_approval=False))
+        self.assertFalse(out.armed)
+
+
+class FieldsMode(unittest.TestCase):
+    def test_field_values_arm_and_override(self):
+        cfg = Config()
+        gh, runner = make_github(cfg)
+        runner.when(
+            ["api", "repos/owner/repo/issues/2/field-values"],
+            [
+                {"field": {"name": "foreman"}, "value": {"name": "claude"}},
+                {"name": "foreman-budget-usd", "value": 35},
+                {"name": "foreman-timeout-min", "value": 120},
+            ],
+        )
+        out = inputs_mod.resolve(gh, cfg, issue_json(2), "fields")
+        self.assertTrue(out.armed)
+        self.assertEqual(out.backend, "claude")
+        self.assertEqual(out.budget_usd, 35.0)
+        self.assertEqual(out.timeout_min, 120)
+
+    def test_dual_source_fails_loud_in_fields_mode(self):
+        cfg = Config()
+        gh, runner = make_github(cfg)
+        runner.when(["api", "repos/owner/repo/issues/2/field-values"], [])
+        out = inputs_mod.resolve(
+            gh, cfg, issue_json(2, labels=["foreman:hold"]), "fields"
+        )
+        self.assertTrue(any("dual-sourced" in e for e in out.errors))
+
+    def test_detect_mode_explicit_config_wins(self):
+        cfg = Config(inputs="labels")
+        gh, _runner = make_github(cfg)
+        self.assertEqual(inputs_mod.detect_mode(gh, cfg), "labels")
+
+    def test_detect_mode_auto_probes_org_fields(self):
+        cfg = Config(inputs="auto")
+        gh, runner = make_github(cfg)
+        runner.when(["api", "orgs/owner/issue-fields"], "[]")
+        self.assertEqual(inputs_mod.detect_mode(gh, cfg), "fields")
+
+    def test_detect_mode_auto_falls_back_to_labels(self):
+        cfg = Config(inputs="auto")
+        gh, runner = make_github(cfg)
+        runner.when(["api", "orgs/owner/issue-fields"], "", rc=1)
+        self.assertEqual(inputs_mod.detect_mode(gh, cfg), "labels")
+
+
+class CommitType(unittest.TestCase):
+    def resolve(self, *, labels=None, issue_type=None):
+        cfg = Config()
+        gh, _runner = make_github(cfg)
+        issue = issue_json(3, labels=labels or [], issue_type=issue_type)
+        return inputs_mod.resolve(gh, cfg, issue, "labels")
+
+    def test_native_issue_type_maps(self):
+        self.assertEqual(self.resolve(issue_type="Bug").commit_type, "fix")
+
+    def test_label_fallback(self):
+        self.assertEqual(self.resolve(labels=["type:chore"]).commit_type, "chore")
+
+    def test_disagreement_fails_loud(self):
+        out = self.resolve(labels=["type:chore"], issue_type="Feature")
+        self.assertTrue(any("disagrees" in e for e in out.errors))
+
+    def test_agreement_is_fine(self):
+        out = self.resolve(labels=["type:feat"], issue_type="Feature")
+        self.assertFalse(out.errors)
+        self.assertEqual(out.commit_type, "feat")
+
+    def test_default_with_warning(self):
+        out = self.resolve()
+        self.assertEqual(out.commit_type, "feat")
+        self.assertTrue(any("defaulting" in w for w in out.warnings))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/foreman/tests/test_pr.py
+++ b/scripts/foreman/tests/test_pr.py
@@ -1,0 +1,103 @@
+"""PR assembly: markers, Conventional-Commit titles, Closes vs Refs when
+human-only tasks exist."""
+
+from __future__ import annotations
+
+import unittest
+
+from foreman import pr as pr_mod
+from foreman.backend import ResultContract
+from foreman.config import Config
+from foreman.graph import MARKER_RE, Unit
+from foreman.inputs import UnitInputs
+from foreman.tests.fakes import issue_json
+
+
+def unit(subs=None) -> Unit:
+    u = Unit(
+        number=42,
+        title="Add the widget",
+        state="OPEN",
+        state_reason=None,
+        body="## Acceptance Criteria\n\n- works [CI]\n",
+        url="",
+        labels=[],
+        issue_type=None,
+        milestone=None,
+        parent=None,
+        sub_issues=subs or [],
+    )
+    u.inputs = UnitInputs(armed=True, commit_type="feat")
+    return u
+
+
+def contract(**kwargs) -> ResultContract:
+    base = dict(
+        status="completed",
+        summary="Widget added.",
+        handoff="Widget API: w().",
+        proposed_pr_title="feat(widget): add the widget",
+        ac_test_map=[{"criterion": "works [CI]", "tests": ["t::a"]}],
+    )
+    base.update(kwargs)
+    return ResultContract(**base)
+
+
+class Titles(unittest.TestCase):
+    def test_conventional_proposal_kept_with_type_coerced(self):
+        u = unit()
+        u.inputs.commit_type = "fix"
+        title = pr_mod.pr_title(Config(), u, contract())
+        self.assertEqual(title, "fix(widget): add the widget")
+
+    def test_non_conventional_proposal_regenerated(self):
+        title = pr_mod.pr_title(
+            Config(), unit(), contract(proposed_pr_title="Adds widget!!")
+        )
+        self.assertEqual(title, "feat: Add the widget")
+
+    def test_length_capped(self):
+        long = contract(proposed_pr_title="feat: " + "x" * 200)
+        self.assertLessEqual(len(pr_mod.pr_title(Config(), unit(), long)), 100)
+
+
+class Bodies(unittest.TestCase):
+    def body(self, *, human_tasks=None, subs=None):
+        return pr_mod.pr_body(
+            Config(),
+            unit(subs=subs),
+            contract(),
+            human_tasks=human_tasks or [],
+            spec_hash_hex="abc123",
+            base_sha="def456",
+        )
+
+    def test_marker_is_parseable(self):
+        match = MARKER_RE.search(self.body())
+        self.assertIsNotNone(match)
+        self.assertEqual(int(match.group("number")), 42)
+
+    def test_closes_parent_and_open_subs(self):
+        subs = [issue_json(43), issue_json(44, state="CLOSED")]
+        body = self.body(subs=subs)
+        self.assertIn("Closes #42", body)
+        self.assertIn("Closes #43", body)
+        self.assertNotIn("Closes #44", body)
+
+    def test_human_tasks_switch_closes_to_refs(self):
+        body = self.body(human_tasks=["rotate credential"])
+        self.assertIn("Refs #42", body)
+        self.assertNotIn("Closes #42", body)
+        self.assertIn("rotate credential", body)
+
+    def test_handoff_and_test_evidence_present(self):
+        body = self.body()
+        self.assertIn("## Handoff", body)
+        self.assertIn("Widget API", body)
+        self.assertIn("works [CI]", body)
+        self.assertIn("`t::a`", body)
+        self.assertIn("foreman never merges", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/foreman/tests/test_report.py
+++ b/scripts/foreman/tests/test_report.py
@@ -1,0 +1,28 @@
+"""Human-queue rendering that must not regress: merge-order numbering."""
+
+from __future__ import annotations
+
+import unittest
+
+from foreman.report import human_queue
+
+
+class MergeOrderNumbering(unittest.TestCase):
+    def test_positions_are_sequential(self):
+        out = human_queue(
+            merge_order=[(10, "u10"), (12, "u12"), (11, "u11")],
+            human_tasks={},
+            blocked={},
+            environmental={},
+        )
+        self.assertIn("1. #10", out)
+        self.assertIn("2. #12", out)
+        self.assertIn("3. #11", out)
+
+    def test_empty_queue_says_so(self):
+        out = human_queue(merge_order=[], human_tasks={}, blocked={}, environmental={})
+        self.assertIn("empty", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/foreman/tests/test_result.py
+++ b/scripts/foreman/tests/test_result.py
@@ -1,0 +1,88 @@
+"""Result-contract validation: the agent→foreman handoff channel."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from foreman import backend as backend_mod
+
+VALID = {
+    "schema": 1,
+    "status": "completed",
+    "summary": "Did the thing.",
+    "handoff": "New API at x().",
+    "human_tasks": ["verify dashboard"],
+    "proposed_pr_title": "feat(x): do the thing",
+    "ac_test_map": [
+        {"criterion": "parses config [CI]", "tests": ["tests/test_x.py::test_a"]}
+    ],
+    "blocked_question": None,
+}
+
+
+class ResultContract(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        base = Path(self._tmp.name)
+        self.run_dir = base / "run"
+        self.worktree = base / "wt"
+        self.run_dir.mkdir()
+        self.worktree.mkdir()
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def write(self, data) -> None:
+        (self.run_dir / "result.json").write_text(json.dumps(data), encoding="utf-8")
+
+    def test_valid_completed(self):
+        self.write(VALID)
+        contract, errors = backend_mod.read_result(self.run_dir, self.worktree)
+        self.assertEqual(errors, [])
+        self.assertEqual(contract.status, "completed")
+        self.assertEqual(contract.human_tasks, ["verify dashboard"])
+
+    def test_missing_file_without_blocked_md_is_an_error(self):
+        contract, errors = backend_mod.read_result(self.run_dir, self.worktree)
+        self.assertIsNone(contract)
+        self.assertTrue(errors)
+
+    def test_blocked_md_fallback(self):
+        (self.worktree / "BLOCKED.md").write_text("Which auth flow?", encoding="utf-8")
+        contract, errors = backend_mod.read_result(self.run_dir, self.worktree)
+        self.assertEqual(errors, [])
+        self.assertEqual(contract.status, "blocked")
+        self.assertEqual(contract.blocked_question, "Which auth flow?")
+
+    def test_invalid_json(self):
+        (self.run_dir / "result.json").write_text("{nope", encoding="utf-8")
+        contract, errors = backend_mod.read_result(self.run_dir, self.worktree)
+        self.assertIsNone(contract)
+        self.assertTrue(any("valid JSON" in e for e in errors))
+
+    def test_completed_requires_summary_and_ac_map(self):
+        data = dict(VALID, summary="", ac_test_map=[])
+        self.write(data)
+        contract, errors = backend_mod.read_result(self.run_dir, self.worktree)
+        self.assertIsNone(contract)
+        self.assertTrue(any("summary" in e for e in errors))
+        self.assertTrue(any("ac_test_map" in e for e in errors))
+
+    def test_blocked_requires_question(self):
+        self.write({"schema": 1, "status": "blocked"})
+        contract, errors = backend_mod.read_result(self.run_dir, self.worktree)
+        self.assertIsNone(contract)
+        self.assertTrue(errors)
+
+    def test_bad_schema_and_status(self):
+        self.write({"schema": 2, "status": "done?"})
+        contract, errors = backend_mod.read_result(self.run_dir, self.worktree)
+        self.assertIsNone(contract)
+        self.assertTrue(any("schema" in e for e in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/foreman/tests/test_shepherd.py
+++ b/scripts/foreman/tests/test_shepherd.py
@@ -1,0 +1,75 @@
+"""Shepherd classification: check-rollup bucketing and the signature catalog."""
+
+from __future__ import annotations
+
+import unittest
+
+from foreman import signatures as signatures_mod
+from foreman.shepherd import classify_checks
+
+
+class ClassifyChecks(unittest.TestCase):
+    def test_all_green(self):
+        rollup = [
+            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"status": "COMPLETED", "conclusion": "SKIPPED"},
+            {"status": "COMPLETED", "conclusion": "NEUTRAL"},
+        ]
+        state, failed = classify_checks(rollup)
+        self.assertEqual(state, "green")
+        self.assertEqual(failed, [])
+
+    def test_failure_wins_over_pending(self):
+        rollup = [
+            {"status": "IN_PROGRESS", "conclusion": ""},
+            {"status": "COMPLETED", "conclusion": "FAILURE", "name": "verify"},
+        ]
+        state, failed = classify_checks(rollup)
+        self.assertEqual(state, "red")
+        self.assertEqual(failed[0]["name"], "verify")
+
+    def test_pending_when_running(self):
+        state, _ = classify_checks([{"status": "QUEUED", "conclusion": ""}])
+        self.assertEqual(state, "pending")
+
+    def test_empty_rollup_is_green(self):
+        self.assertEqual(classify_checks([])[0], "green")
+        self.assertEqual(classify_checks(None)[0], "green")
+
+    def test_legacy_status_contexts(self):
+        state, failed = classify_checks([{"state": "FAILURE", "context": "ci/legacy"}])
+        self.assertEqual(state, "red")
+        self.assertEqual(failed[0]["context"], "ci/legacy")
+
+
+class SignatureCatalog(unittest.TestCase):
+    def setUp(self):
+        self.catalog = signatures_mod.load()
+
+    def test_seeded_environment_signatures(self):
+        sig = signatures_mod.match(
+            "Error: DeploymentQuotaReached for team", self.catalog
+        )
+        self.assertIsNotNone(sig)
+        self.assertEqual(sig.action, "environment")
+        sig = signatures_mod.match(
+            "The job was not started because recent account payments have failed",
+            self.catalog,
+        )
+        self.assertEqual(sig.action, "environment")
+
+    def test_quota_wait_signature(self):
+        sig = signatures_mod.match(
+            "You have hit your usage limit. Limit will reset at 3pm", self.catalog
+        )
+        self.assertIsNotNone(sig)
+        self.assertEqual(sig.action, "quota_wait")
+
+    def test_no_match_returns_none(self):
+        self.assertIsNone(
+            signatures_mod.match("TypeError: x is not a function", self.catalog)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/foreman/tests/test_spec.py
+++ b/scripts/foreman/tests/test_spec.py
@@ -1,0 +1,180 @@
+"""Spec contract: AC parsing/tagging, prompt assembly trust policy, spec-hash
+stability, handoff extraction, and prompt token completeness."""
+
+from __future__ import annotations
+
+import unittest
+
+from foreman import spec
+from foreman.config import Config
+from foreman.graph import Unit
+from foreman.tests.fakes import issue_json, make_github
+
+BODY = """Intro.
+
+## Acceptance Criteria
+
+- Parses the config [CI]
+- Verified against the live dashboard [HUMAN]
+- Untagged criterion
+
+## Human-only tasks
+
+- Rotate the credential
+
+## Out of Scope
+
+- Everything else
+"""
+
+
+def unit_with(body: str = BODY, subs: list[dict] | None = None) -> Unit:
+    return Unit(
+        number=42,
+        title="A unit",
+        state="OPEN",
+        state_reason=None,
+        body=body,
+        url="",
+        labels=[],
+        issue_type=None,
+        milestone=None,
+        parent=None,
+        sub_issues=subs or [],
+    )
+
+
+class AcParsing(unittest.TestCase):
+    def test_items_and_tags(self):
+        items = spec.parse_ac(BODY)
+        self.assertEqual(len(items), 3)
+        self.assertEqual([i.tag for i in items], ["CI", "HUMAN", "CI"])
+        self.assertFalse(items[2].tagged)
+
+    def test_missing_section_is_non_dispatchable(self):
+        info = spec.validate(unit_with("no criteria here"))
+        self.assertTrue(info.errors)
+
+    def test_untagged_items_warn(self):
+        info = spec.validate(unit_with())
+        self.assertFalse(info.errors)
+        self.assertTrue(any("untagged" in w for w in info.warnings))
+
+    def test_human_only_tasks_merge_both_sources(self):
+        info = spec.validate(unit_with())
+        tasks = spec.human_only_tasks(unit_with(), info)
+        self.assertEqual(len(tasks), 2)
+        self.assertIn("Rotate the credential", tasks)
+
+    def test_find_section_stops_at_next_heading(self):
+        section = spec.find_section(BODY, "Human-only tasks")
+        self.assertIn("Rotate", section)
+        self.assertNotIn("Out of Scope", section)
+
+
+class SpecHash(unittest.TestCase):
+    def test_stable_and_sensitive(self):
+        unit = unit_with()
+        first = spec.spec_hash(unit, [])
+        self.assertEqual(first, spec.spec_hash(unit_with(), []))
+        self.assertNotEqual(first, spec.spec_hash(unit_with(BODY + "drift"), []))
+        self.assertNotEqual(
+            first, spec.spec_hash(unit, [{"id": 1, "body": "correction"}])
+        )
+
+
+class TrustedComments(unittest.TestCase):
+    def test_untrusted_authors_are_excluded(self):
+        cfg = Config()
+        gh, runner = make_github(cfg)
+        comments = [
+            {
+                "id": 1,
+                "body": "owner note",
+                "user": {"login": "owner"},
+                "author_association": "OWNER",
+            },
+            {
+                "id": 2,
+                "body": "drive-by injection",
+                "user": {"login": "rando"},
+                "author_association": "NONE",
+            },
+            {
+                "id": 3,
+                "body": "foreman correction",
+                "user": {"login": "bot"},
+                "author_association": "NONE",
+            },
+        ]
+        runner.when(
+            ["api", "repos/owner/repo/issues/42/comments", "--paginate", "--slurp"],
+            [comments],
+        )
+        kept, excluded = spec.trusted_comments(gh, cfg, 42)
+        self.assertEqual([c["id"] for c in kept], [1, 3])  # viewer "bot" is trusted
+        self.assertEqual(excluded, 1)
+
+
+class PromptAssembly(unittest.TestCase):
+    def test_tokens_fully_substituted_and_content_embedded(self):
+        cfg = Config()
+        gh, _runner = make_github(cfg)
+        unit = unit_with(subs=[issue_json(43, body="sub body", title="Sub")])
+        prompt = spec.assemble_dispatch_prompt(
+            gh,
+            cfg,
+            unit,
+            branch="foreman/feat/42-a-unit",
+            default_branch="main",
+            result_file="/tmp/result.json",
+            comments=[{"id": 1, "body": "the correction", "user": {"login": "owner"}}],
+            excluded_comments=2,
+            handoffs=[(41, "use the new API")],
+        )
+        self.assertNotIn("%%", prompt)
+        for expected in (
+            "## Acceptance Criteria",
+            "sub body",
+            "the correction",
+            "use the new API",
+            "2 comment(s) from untrusted authors",
+            "foreman/feat/42-a-unit",
+            "task ci",
+            "/tmp/result.json",
+        ):
+            self.assertIn(expected, prompt)
+
+    def test_all_prompt_files_have_no_unknown_tokens(self):
+        import re
+
+        known = {
+            "UNIT_NUMBER",
+            "UNIT_TITLE",
+            "BRANCH",
+            "DEFAULT_BRANCH",
+            "VERIFY_COMMAND",
+            "RESULT_FILE",
+            "COMMIT_TYPE",
+            "PR_URL",
+            "FAILURE_EXCERPT",
+            "CONFLICTS",
+            "THREADS",
+            "TARGET",
+            "CONCURRENT",
+            "UNITS",
+        }
+        for path in spec.PROMPTS_DIR.glob("*.md"):
+            tokens = set(re.findall(r"%%([A-Z_]+)%%", path.read_text(encoding="utf-8")))
+            self.assertLessEqual(tokens, known, f"unknown tokens in {path.name}")
+
+
+class Handoff(unittest.TestCase):
+    def test_extract_handoff(self):
+        body = "## Summary\n\nx\n\n## Handoff\n\nThe contract.\n\n---\nfooter"
+        self.assertEqual(spec.extract_handoff(body), "The contract.")
+        self.assertIsNone(spec.extract_handoff("## Summary\n\nnothing"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/foreman/tests/test_watch.py
+++ b/scripts/foreman/tests/test_watch.py
@@ -20,6 +20,12 @@ class ParseInterval(unittest.TestCase):
             with self.assertRaises(ForemanError):
                 parse_interval(bad)
 
+    def test_rejects_non_positive(self):
+        # 0 would turn the watch loop into a tight spin.
+        for bad in ("0", "0s", "0m", "0h"):
+            with self.assertRaises(ForemanError):
+                parse_interval(bad)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/foreman/tests/test_watch.py
+++ b/scripts/foreman/tests/test_watch.py
@@ -1,0 +1,25 @@
+"""Watch-mode plumbing that must not regress: interval parsing."""
+
+from __future__ import annotations
+
+import unittest
+
+from foreman.util import ForemanError
+from foreman.watch import parse_interval
+
+
+class ParseInterval(unittest.TestCase):
+    def test_units(self):
+        self.assertEqual(parse_interval("300"), 300)
+        self.assertEqual(parse_interval("300s"), 300)
+        self.assertEqual(parse_interval("5m"), 300)
+        self.assertEqual(parse_interval("1h"), 3600)
+
+    def test_rejects_garbage(self):
+        for bad in ("", "5 minutes", "m5", "-5m"):
+            with self.assertRaises(ForemanError):
+                parse_interval(bad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/foreman/tests/test_write_contract.py
+++ b/scripts/foreman/tests/test_write_contract.py
@@ -1,0 +1,154 @@
+"""The write contract, enforced: read-only mode blocks every mutation before
+any gh call; identity assertion gates the first write; forbidden operations
+(merge, issue close/edit/reopen) do not exist in the mutation surface at all.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+import unittest
+
+from foreman import github as github_mod
+from foreman.config import Config
+from foreman.github import STATUS_MARKER
+from foreman.tests.fakes import make_github
+from foreman.util import ForemanError
+
+
+def _mutations(gh):
+    return [
+        ("ensure_labels", lambda: gh.ensure_labels()),
+        (
+            "create_pr",
+            lambda: gh.create_pr(title="t", body="b", head="h", base="main", labels=[]),
+        ),
+        ("edit_own_pr_body", lambda: gh.edit_own_pr_body(1, "b")),
+        ("label_own_pr", lambda: gh.label_own_pr(1, add=["ready-to-merge"])),
+        ("comment_own_pr", lambda: gh.comment_own_pr(1, "b")),
+        (
+            "upsert_status_comment",
+            lambda: gh.upsert_status_comment(1, STATUS_MARKER + "\nb"),
+        ),
+        (
+            "post_preflight_correction",
+            lambda: gh.post_preflight_correction(1, "b", human_approved=True),
+        ),
+        ("resolve_review_thread", lambda: gh.resolve_review_thread("T_x")),
+    ]
+
+
+class ReadOnlyMode(unittest.TestCase):
+    def test_every_mutation_refuses_in_read_only_mode(self):
+        gh, runner = make_github()
+        gh.read_only = True
+        baseline = len(runner.calls)
+        for name, call in _mutations(gh):
+            with self.assertRaises(ForemanError, msg=name):
+                call()
+        # No gh process was ever invoked by a refused mutation.
+        self.assertEqual(len(runner.calls), baseline)
+
+
+class IdentityAssertion(unittest.TestCase):
+    def test_wrong_identity_blocks_first_write(self):
+        cfg = Config(expected_login="evanharmon1-bot")  # fake viewer is "bot"
+        gh, runner = make_github(cfg)
+        with self.assertRaises(ForemanError) as ctx:
+            gh.ensure_labels()
+        self.assertIn("identity assertion failed", str(ctx.exception))
+        self.assertFalse(runner.called_with_prefix(["label"]))
+
+    def test_matching_identity_allows_writes(self):
+        cfg = Config(expected_login="bot")
+        gh, runner = make_github(cfg)
+        runner.when(["label", "create"], "")
+        gh.ensure_labels()
+        self.assertTrue(runner.called_with_prefix(["label", "create"]))
+
+
+class GuardedChannels(unittest.TestCase):
+    def test_preflight_comment_requires_human_approval(self):
+        gh, runner = make_github()
+        with self.assertRaises(ForemanError):
+            gh.post_preflight_correction(1, "body", human_approved=False)
+        self.assertFalse(runner.called_with_prefix(["api", "--method", "POST"]))
+
+    def test_own_pr_guard_rejects_foreign_prs(self):
+        gh, runner = make_github()
+        runner.when(
+            ["pr", "view", "9"],
+            {"number": 9, "author": {"login": "human"}, "labels": [], "body": ""},
+        )
+        with self.assertRaises(ForemanError):
+            gh.edit_own_pr_body(9, "new body")
+
+    def test_label_namespace_is_enforced(self):
+        gh, runner = make_github()
+        runner.when(
+            ["pr", "view", "9"],
+            {"number": 9, "author": {"login": "bot"}, "labels": [], "body": ""},
+        )
+        with self.assertRaises(ForemanError):
+            gh.label_own_pr(9, add=["priority:high"])
+
+    def test_status_comment_edits_only_own_marked_comment(self):
+        gh, runner = make_github()
+        comments = [
+            # A human comment carrying a forged marker must never be edited.
+            {"id": 1, "body": STATUS_MARKER + " forged", "user": {"login": "human"}},
+            {"id": 2, "body": STATUS_MARKER + " real", "user": {"login": "bot"}},
+        ]
+        runner.when(
+            ["api", "repos/owner/repo/issues/7/comments", "--paginate", "--slurp"],
+            [comments],
+        )
+        runner.when(
+            ["api", "--method", "PATCH", "repos/owner/repo/issues/comments/2"], "{}"
+        )
+        gh.upsert_status_comment(7, STATUS_MARKER + "\nupdated")
+        patches = runner.called_with_prefix(["api", "--method", "PATCH"])
+        self.assertEqual(len(patches), 1)
+        self.assertIn("comments/2", patches[0][3])
+
+    def test_status_comment_requires_marker(self):
+        gh, _runner = make_github()
+        with self.assertRaises(ForemanError):
+            gh.upsert_status_comment(7, "no marker here")
+
+
+class ForbiddenOperationsAbsent(unittest.TestCase):
+    """Merging, closing/reopening/editing issues, deleting others' comments —
+    the write contract says these must not exist. Keep them nonexistent."""
+
+    def test_no_forbidden_gh_invocations_in_source(self):
+        source = inspect.getsource(github_mod)
+        forbidden = [
+            r"\"merge\"",  # gh pr merge — never; mergeable/mergeStateStatus fields are fine
+            r"'merge'",
+            r"issue\W+close",
+            r"issue\W+reopen",
+            r"issue\W+edit",
+            r"issue\W+delete",
+            r"\"DELETE\"",
+            r"mergePullRequest",
+            r"enablePullRequestAutoMerge",
+        ]
+        for pattern in forbidden:
+            self.assertIsNone(
+                re.search(pattern, source, re.I),
+                f"forbidden operation pattern {pattern!r} found in github.py",
+            )
+
+    def test_no_merge_method_exists(self):
+        gh, _runner = make_github()
+        for name in dir(gh):
+            self.assertNotIn(
+                "merge",
+                name.lower(),
+                f"GitHub facade must not expose a merge-ish method: {name}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/foreman/util.py
+++ b/scripts/foreman/util.py
@@ -1,0 +1,96 @@
+"""Shared helpers: subprocess, logging, hashing, small file utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+
+
+class ForemanError(RuntimeError):
+    """Fatal, user-facing error — printed without a traceback."""
+
+
+def info(msg: str) -> None:
+    print(f"foreman: {msg}", flush=True)
+
+
+def warn(msg: str) -> None:
+    print(f"foreman: WARN: {msg}", file=sys.stderr, flush=True)
+
+
+def error(msg: str) -> None:
+    print(f"foreman: ERROR: {msg}", file=sys.stderr, flush=True)
+
+
+def run(
+    argv: list[str],
+    *,
+    cwd: str | Path | None = None,
+    input_text: str | None = None,
+    check: bool = True,
+    timeout: float | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Run a command (never a shell), capturing text output."""
+    try:
+        proc = subprocess.run(
+            list(argv),
+            cwd=str(cwd) if cwd else None,
+            input=input_text,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            env=env,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise ForemanError(f"command not found: {argv[0]}") from exc
+    if check and proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        raise ForemanError(
+            f"command failed ({proc.returncode}): {' '.join(argv)}\n{detail}"
+        )
+    return proc
+
+
+@lru_cache(maxsize=1)
+def repo_root() -> Path:
+    """Absolute path of the repository foreman was invoked in."""
+    out = run(["git", "rev-parse", "--show-toplevel"]).stdout.strip()
+    return Path(out)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def sha256_hex(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def slugify(title: str, max_len: int = 32) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return slug[:max_len].rstrip("-") or "unit"
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def append_line(path: Path, line: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(line.rstrip("\n") + "\n")
+
+
+def tail(path: Path, lines: int = 40) -> str:
+    if not path.exists():
+        return ""
+    content = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    return "\n".join(content[-lines:])

--- a/scripts/foreman/verify.py
+++ b/scripts/foreman/verify.py
@@ -1,0 +1,39 @@
+"""Deterministic verification gate. Foreman runs the repo's configured
+verify_command (default: full `task ci`) in the unit's worktree itself —
+the agent's self-report is never trusted.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from foreman.config import Config
+from foreman.util import tail, utc_now_iso
+
+VERIFY_TIMEOUT_MIN = 120
+
+
+def run_verify(cfg: Config, worktree: Path, unit_run_dir: Path) -> tuple[bool, str]:
+    """Run verify_command in the worktree; returns (ok, log tail)."""
+    log_path = unit_run_dir / "verify.log"
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(f"\n--- {utc_now_iso()} {' '.join(cfg.verify_command)} ---\n")
+        fh.flush()
+        try:
+            proc = subprocess.run(
+                cfg.verify_command,
+                cwd=str(worktree),
+                stdout=fh,
+                stderr=subprocess.STDOUT,
+                timeout=VERIFY_TIMEOUT_MIN * 60,
+                check=False,
+            )
+            code = proc.returncode
+        except subprocess.TimeoutExpired:
+            fh.write(f"\nverify timed out after {VERIFY_TIMEOUT_MIN} minutes\n")
+            code = 124
+        except FileNotFoundError:
+            fh.write(f"\nverify command not found: {cfg.verify_command[0]}\n")
+            code = 127
+    return code == 0, tail(log_path, 40)

--- a/scripts/foreman/watch.py
+++ b/scripts/foreman/watch.py
@@ -31,7 +31,10 @@ def parse_interval(text: str) -> int:
     if not match:
         raise ForemanError(f"bad --interval '{text}' (use e.g. 300, 5m, 1h)")
     value, unit = int(match.group(1)), match.group(2)
-    return value * {"": 1, "s": 1, "m": 60, "h": 3600}[unit]
+    seconds = value * {"": 1, "s": 1, "m": 60, "h": 3600}[unit]
+    if seconds <= 0:
+        raise ForemanError(f"--interval must be positive, got '{text}'")
+    return seconds
 
 
 def run_watch(

--- a/scripts/foreman/watch.py
+++ b/scripts/foreman/watch.py
@@ -1,0 +1,116 @@
+"""Watch mode: `plan → dispatch → shepherd → sleep`, for days if needed.
+
+Every tick is stateless and idempotent — all state re-derived from GitHub +
+git, so kill/reboot/laptop-sleep loses nothing. A heartbeat line per tick
+makes silence distinguishable from health. Stop conditions: milestone
+complete, stop file (.foreman-stop), aggregate budget, N consecutive
+failing ticks. For multi-day runs, cron invoking dispatch+shepherd is
+equivalent — the live loop is a convenience, not a requirement.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+
+from foreman import dispatch as dispatch_mod
+from foreman import shepherd as shepherd_mod
+from foreman.config import Config
+from foreman.github import Gh, GitHub
+from foreman.graph import detect_cycle, prepare_target
+from foreman.util import ForemanError, append_line, error, info, utc_now_iso, warn
+
+STOP_FILE = ".foreman-stop"
+DEFAULT_INTERVAL_S = 300
+MAX_CONSECUTIVE_FAILURES = 3
+
+
+def parse_interval(text: str) -> int:
+    match = re.fullmatch(r"(\d+)\s*([smh]?)", text.strip())
+    if not match:
+        raise ForemanError(f"bad --interval '{text}' (use e.g. 300, 5m, 1h)")
+    value, unit = int(match.group(1)), match.group(2)
+    return value * {"": 1, "s": 1, "m": 60, "h": 3600}[unit]
+
+
+def run_watch(
+    cfg: Config,
+    root: Path,
+    *,
+    milestone: str | None,
+    issue: int | None,
+    interval_s: int = DEFAULT_INTERVAL_S,
+    budget_usd: float | None = None,
+    max_failures: int = MAX_CONSECUTIVE_FAILURES,
+) -> int:
+    log_path = root / cfg.runtime_dir / "watch.log"
+    stop_path = root / STOP_FILE
+    consecutive = 0
+    total_cost = 0.0
+    tick = 0
+    idle_notified = False
+
+    def heartbeat(message: str) -> None:
+        line = f"{utc_now_iso()} tick={tick} {message}"
+        append_line(log_path, line)
+        info(line)
+
+    info(f"watch: interval={interval_s}s budget={budget_usd or 'none'} log={log_path}")
+    while True:
+        tick += 1
+        if stop_path.exists():
+            heartbeat("stop file present — exiting cleanly")
+            return 0
+        try:
+            gh = GitHub(Gh(), cfg)  # fresh per tick: caches never go stale
+            target = prepare_target(gh, cfg, milestone=milestone, issue=issue)
+            cycle = detect_cycle(target)
+            if cycle:
+                error(
+                    f"watch: dependency cycle {' -> '.join('#' + str(n) for n in cycle)}"
+                )
+                return 1
+            open_units = [u for u in target.units.values() if u.open]
+            if not open_units:
+                heartbeat("milestone complete — all units closed")
+                return 0
+
+            outcomes = dispatch_mod.run_dispatch(gh, cfg, root, target)
+            shep = shepherd_mod.run_shepherd(gh, cfg, root)
+            tick_cost = sum(o.cost_usd or 0.0 for o in outcomes) + shep.cost_usd
+            total_cost += tick_cost
+
+            dispatched = sum(1 for o in outcomes if o.dispatched)
+            waiting = sum(1 for o in outcomes if o.status == "waiting")
+            failed = sum(1 for o in outcomes if o.status in ("failed", "blocked"))
+            ready = len(shep.ready_order)
+            heartbeat(
+                f"open={len(open_units)} dispatched={dispatched} waiting={waiting} "
+                f"failed={failed} prs-ready={ready} cost=${total_cost:.2f}"
+            )
+            if shep.ready_order and dispatched == 0 and not failed:
+                if not idle_notified:
+                    info(
+                        "watch: idling by design — PRs are ready and nothing new is "
+                        "dispatchable; waiting on human merges:\n"
+                        + "\n".join(
+                            f"  {n}. #{u} {url}"
+                            for n, (u, url) in enumerate(shep.ready_order, 1)
+                        )
+                    )
+                    idle_notified = True
+            else:
+                idle_notified = False
+            consecutive = 0
+            if budget_usd is not None and total_cost >= budget_usd:
+                heartbeat(f"aggregate budget ${budget_usd:.2f} reached — stopping")
+                return 0
+        except ForemanError as exc:
+            consecutive += 1
+            warn(f"watch: tick failed ({consecutive}/{max_failures}): {exc}")
+            heartbeat(f"TICK FAILED: {exc}")
+            if consecutive >= max_failures:
+                error("watch: too many consecutive failures — stopping")
+                return 1
+        time.sleep(interval_s)

--- a/scripts/foreman/worktree.py
+++ b/scripts/foreman/worktree.py
@@ -1,0 +1,165 @@
+"""Git worktree + branch lifecycle. Remote and default branch are discovered,
+never hardcoded. One worktree per unit under cfg.worktrees_dir; branches are
+namespaced `<prefix>/<type>/<n>-<slug>` so cleanup and doneness can identify
+foreman's own branches deterministically.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from foreman.config import Config
+from foreman.graph import Unit
+from foreman.util import ForemanError, run, slugify, warn
+
+
+def remote(cfg: Config) -> str:
+    if cfg.remote:
+        return cfg.remote
+    names = [line for line in run(["git", "remote"]).stdout.split() if line]
+    if len(names) == 1:
+        return names[0]
+    if "origin" in names:
+        warn(
+            "multiple git remotes; using 'origin' (set `remote` in .foreman.toml to override)"
+        )
+        return "origin"
+    raise ForemanError(
+        f"cannot pick a remote from {names}; set `remote` in .foreman.toml"
+    )
+
+
+def fetch(remote_name: str) -> None:
+    run(["git", "fetch", "--prune", remote_name])
+
+
+def base_sha(remote_name: str, branch: str) -> str:
+    return run(["git", "rev-parse", f"{remote_name}/{branch}"]).stdout.strip()
+
+
+def branch_name(cfg: Config, unit: Unit) -> str:
+    commit_type = unit.inputs.commit_type if unit.inputs else cfg.default_type
+    return f"{cfg.branch_prefix}/{commit_type}/{unit.number}-{slugify(unit.title)}"
+
+
+def attempt_branches(cfg: Config, remote_name: str, number: int) -> list[str]:
+    """Local + remote branches that are attempts for this unit."""
+    pattern = re.compile(rf"^{re.escape(cfg.branch_prefix)}/[^/]+/{number}-")
+    found: set[str] = set()
+    local = run(
+        ["git", "for-each-ref", "--format=%(refname:short)", "refs/heads/"]
+    ).stdout
+    for name in local.split():
+        if pattern.match(name):
+            found.add(name)
+    remote_refs = run(["git", "ls-remote", "--heads", remote_name]).stdout
+    for line in remote_refs.splitlines():
+        parts = line.split("\t")
+        if len(parts) == 2 and parts[1].startswith("refs/heads/"):
+            name = parts[1][len("refs/heads/") :]
+            if pattern.match(name):
+                found.add(name)
+    return sorted(found)
+
+
+def next_attempt_branch(base_name: str, existing: list[str]) -> str:
+    if base_name not in existing:
+        return base_name
+    attempt = 2
+    while f"{base_name}-r{attempt}" in existing:
+        attempt += 1
+    return f"{base_name}-r{attempt}"
+
+
+def worktree_path(cfg: Config, root: Path, unit: Unit) -> Path:
+    return root / cfg.worktrees_dir / f"{unit.number}-{slugify(unit.title)}"
+
+
+def add(path: Path, branch: str, start_point: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    run(["git", "worktree", "add", "-b", branch, str(path), start_point])
+
+
+def add_existing_branch(path: Path, branch: str) -> None:
+    """Recreate a worktree for an existing branch (e.g. after a machine restart)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    run(["git", "worktree", "add", str(path), branch])
+
+
+def remove(path: Path, *, force: bool = True) -> None:
+    args = ["git", "worktree", "remove", str(path)]
+    if force:
+        args.insert(3, "--force")
+    run(args, check=False)
+    run(["git", "worktree", "prune"], check=False)
+
+
+def delete_branch(cfg: Config, remote_name: str, branch: str) -> None:
+    """Delete a branch foreman created — refuses anything outside its namespace."""
+    if not branch.startswith(f"{cfg.branch_prefix}/"):
+        raise ForemanError(f"refusing to delete non-foreman branch '{branch}'")
+    run(["git", "branch", "-D", branch], check=False)
+    run(["git", "push", remote_name, "--delete", branch], check=False)
+
+
+def is_clean(path: Path) -> bool:
+    out = run(["git", "-C", str(path), "status", "--porcelain"]).stdout.strip()
+    return not out
+
+
+def commits_ahead(path: Path, base_ref: str) -> int:
+    out = run(
+        ["git", "-C", str(path), "rev-list", "--count", f"{base_ref}..HEAD"]
+    ).stdout.strip()
+    return int(out or "0")
+
+
+def push(path: Path, remote_name: str, branch: str, *, first: bool) -> None:
+    args = ["git", "-C", str(path), "push"]
+    if first:
+        args += ["-u", remote_name, branch]
+    else:
+        args += ["--force-with-lease", remote_name, branch]
+    run(args)
+
+
+def merge_tree_conflicts(path: Path, base_ref: str) -> list[str]:
+    """Deterministic conflict enumeration (dry run; the tree is untouched)."""
+    head = run(["git", "-C", str(path), "rev-parse", "HEAD"]).stdout.strip()
+    proc = run(
+        [
+            "git",
+            "-C",
+            str(path),
+            "merge-tree",
+            "--write-tree",
+            "--name-only",
+            base_ref,
+            head,
+        ],
+        check=False,
+    )
+    if proc.returncode == 0:
+        return []
+    lines = [line for line in proc.stdout.splitlines()[1:] if line.strip()]
+    return lines or ["<unknown conflict>"]
+
+
+def rebase_onto(path: Path, base_ref: str) -> bool:
+    proc = run(["git", "-C", str(path), "rebase", base_ref], check=False)
+    if proc.returncode != 0:
+        run(["git", "-C", str(path), "rebase", "--abort"], check=False)
+        return False
+    return True
+
+
+def empty_commit(path: Path, message: str) -> None:
+    run(["git", "-C", str(path), "commit", "--allow-empty", "-m", message])
+
+
+def count_retrigger_commits(path: Path, base_ref: str, subject: str) -> int:
+    out = run(
+        ["git", "-C", str(path), "log", f"{base_ref}..HEAD", "--format=%s"], check=False
+    ).stdout
+    return sum(1 for line in out.splitlines() if line.strip() == subject)

--- a/scripts/test-template-update.sh
+++ b/scripts/test-template-update.sh
@@ -42,9 +42,13 @@ gitq() { git -C "$1" -c user.email=t@t.co -c user.name=t -c commit.gpgsign=false
 
 # 1. Tagged template source from the working tree (excluding heavy/vcs dirs).
 mkdir -p "$tmpl"
+# devcontainer.env is the local-only secrets file (gitignored, often
+# permission-restricted); __pycache__/.foreman are foreman runtime artifacts.
+# None belong in the tagged template source.
 rsync -a \
     --exclude=.git --exclude=.task --exclude=.venv --exclude=node_modules \
-    --exclude=.worktrees --exclude=dist "$repo_root/" "$tmpl/"
+    --exclude=.worktrees --exclude=dist --exclude=__pycache__ \
+    --exclude=.foreman --exclude=devcontainer.env "$repo_root/" "$tmpl/"
 git -C "$tmpl" init -q
 gitq "$tmpl" add -A
 gitq "$tmpl" commit -qm base

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -75,6 +75,9 @@ minimal)
     # Exercise the devcontainer OFF branch (default on -> every other profile
     # covers the ON branch; full also sets it explicitly).
     data_args+=(--data devcontainer=false)
+    # Exercise the foreman OFF branch (default on -> every other profile
+    # covers the ON branch + its conditionally-named files).
+    data_args+=(--data use_foreman=false)
     ;;
 web)
     data_args+=(--data project_type=web-astro)
@@ -379,6 +382,28 @@ minimal) # use_skills_sync=false -> none of the machinery renders
     grep -q '^  - universal$' .skills-sync.yaml || err ".skills-sync.yaml categories missing 'universal' (skill_categories default)"
     ;;
 esac
+
+# ── 9d2. foreman renders per use_foreman (default on) ───────────────
+# minimal renders with use_foreman=false (OFF branch); every other profile
+# uses the default (on). The Taskfile include, scripts, config, and agent
+# definitions are all conditionally named — assert they appear/disappear
+# together so a broken gate can't ship silently.
+if [ "$profile" = "minimal" ]; then
+    [ ! -d scripts/foreman ] || err "scripts/foreman/ rendered but use_foreman=false"
+    [ ! -f taskfiles/foreman.yml ] || err "taskfiles/foreman.yml rendered but use_foreman=false"
+    [ ! -f .foreman.toml ] || err ".foreman.toml rendered but use_foreman=false"
+    [ ! -d .claude/agents ] || err ".claude/agents rendered but use_foreman=false"
+    ! grep -q 'foreman: taskfiles/foreman.yml' Taskfile.yml || err "foreman include rendered but use_foreman=false"
+else
+    [ -d scripts/foreman ] || err "scripts/foreman/ missing (use_foreman default on)"
+    [ -x scripts/foreman/backends/claude.sh ] || err "foreman claude.sh backend missing or not executable"
+    [ -x scripts/foreman/backends/mock.sh ] || err "foreman mock.sh backend missing or not executable"
+    [ -f taskfiles/foreman.yml ] || err "taskfiles/foreman.yml missing (use_foreman default on)"
+    [ -f .foreman.toml ] || err ".foreman.toml missing (use_foreman default on)"
+    [ -f .claude/agents/foreman-implementer.md ] || err "foreman agent definitions missing"
+    grep -q 'foreman: taskfiles/foreman.yml' Taskfile.yml || err "foreman Taskfile include missing"
+    grep -q 'expected_login' .foreman.toml || err ".foreman.toml missing expected_login"
+fi
 
 # ── 9e. devcontainer machinery renders per the devcontainer answer ──
 # minimal renders with devcontainer=false; every other profile has it on.

--- a/taskfiles/foreman.yml
+++ b/taskfiles/foreman.yml
@@ -1,0 +1,75 @@
+# Foreman — deterministic supervisor for milestone-driven agent dispatch.
+# Included by the root Taskfile under the `foreman:` namespace; every task is
+# a thin wrapper over scripts/foreman/ (see docs/architecture/foreman.md and
+# `python3 -m foreman --help`). All heavy logic lives in Python, not here.
+#
+# Targeting: every orchestration task takes `-- --milestone <n|title>` or
+# `-- --issue <n>`, e.g. `task foreman:plan -- --milestone 4`.
+version: "3"
+
+tasks:
+  plan:
+    desc: "Dry run: graph, waves, ready set, input mode, validation (no side effects)"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman plan {{.CLI_ARGS}}
+
+  preflight:
+    desc: "Read-only agent analysis of the target; drafts correction comments for human approval (--post publishes them)"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman preflight {{.CLI_ARGS}}
+
+  dispatch:
+    desc: "Dispatch ready units to agents in worktrees, verify, open PRs (idempotent)"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman dispatch {{.CLI_ARGS}}
+
+  shepherd:
+    desc: "Keep open foreman PRs healthy: repair CI, adjudicate reviews, rebase, report merge order"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman shepherd {{.CLI_ARGS}}
+
+  watch:
+    desc: "Loop plan→dispatch→shepherd with heartbeats until done (stop file: .foreman-stop)"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman watch {{.CLI_ARGS}}
+
+  status:
+    desc: "Read-only snapshot: unit table + consolidated human-action queue"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman status {{.CLI_ARGS}}
+
+  retry:
+    desc: "Re-dispatch a unit whose PR a human closed (usage: task foreman:retry -- --unit N)"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman retry {{.CLI_ARGS}}
+
+  cleanup:
+    desc: "Prune worktrees + foreman-created branches for closed units (in-flight untouched)"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman cleanup {{.CLI_ARGS}}
+
+  lint:
+    desc: "Ruff + Black (check mode) over scripts/foreman (skips when uv is unavailable)"
+    vars:
+      # renovate: datasource=pypi depName=ruff
+      RUFF_VERSION: 0.15.21
+      # renovate: datasource=pypi depName=black
+      BLACK_VERSION: 26.5.1
+    cmds:
+      - |
+        if ! command -v uvx >/dev/null 2>&1; then
+          echo "foreman:lint: uv not installed -- skipping (install: brew install uv)"
+          exit 0
+        fi
+        uvx --from "ruff=={{.RUFF_VERSION}}" ruff check scripts/foreman
+        uvx --from "black=={{.BLACK_VERSION}}" black --check --quiet scripts/foreman
+
+  test:
+    desc: "Foreman unit tests (stdlib unittest; hermetic — fake gh transport, no network)"
+    cmds:
+      - |
+        if [ ! -d scripts/foreman/tests ]; then
+          echo "foreman:test: no test suite vendored in this repo -- skipping (suite lives in harmon-init)"
+          exit 0
+        fi
+        PYTHONPATH=scripts python3 -m unittest discover -s scripts/foreman/tests -t scripts

--- a/template/.claude/[% if use_foreman %]agents[% endif %]/foreman-implementer.md
+++ b/template/.claude/[% if use_foreman %]agents[% endif %]/foreman-implementer.md
@@ -1,0 +1,18 @@
+---
+name: foreman-implementer
+description: Foreman's delivery loop for one dispatched unit — worktree discipline, full verification before finishing, AC→test mapping, self-review, BLOCKED.md escalation, never merge/push/open PRs. Foreman's claude backend injects the same rules automatically; use this agent manually only to continue work on a foreman unit inside its worktree.
+---
+
+You are foreman's implementer. Your operating rules are one-sourced in
+`scripts/foreman/prompts/implementer-preamble.md` — read that file FIRST and
+follow it exactly. Headless dispatches get it injected with the `%%TOKEN%%`
+placeholders filled; when invoked interactively, resolve them from context
+instead: the current worktree's branch (`git branch --show-current`), the unit
+number embedded in it (`<prefix>/<type>/<number>-<slug>`), the repo's
+`.foreman.toml` (`verify_command`), and the result file at
+`.foreman/units/<number>/result.json` under the main checkout.
+
+The non-negotiables, restated: never merge anything; never push; never open a
+PR (foreman verifies and opens it); never touch `.github/workflows/**`; never
+start background watchers; never bypass git hooks; escalate ambiguity via
+`BLOCKED.md` + a blocked result instead of inventing a decision.

--- a/template/.claude/[% if use_foreman %]agents[% endif %]/foreman-preflight.md
+++ b/template/.claude/[% if use_foreman %]agents[% endif %]/foreman-preflight.md
@@ -1,0 +1,17 @@
+---
+name: foreman-preflight
+description: Read-only critical analysis of a milestone/issue against the live repo before foreman dispatches agents at it — stale references, cross-issue contradictions, ambiguities, undeclared human-only tasks, file-collision risk. Produces findings + drafted correction comments for human approval. Never modifies anything.
+tools: Read, Grep, Glob, Bash
+---
+
+You are foreman's preflight analyst. Your contract is one-sourced in
+`scripts/foreman/prompts/preflight.md` — read it FIRST and follow it exactly,
+including the output format (`# Preflight findings` +
+`## DRAFT COMMENT FOR #<n>` sections). When invoked interactively, fetch the
+target units yourself with `gh issue view` instead of the injected
+`%%UNITS%%` block.
+
+You are strictly read-only: no file edits, no git mutations, no GitHub
+writes. Bash is for read-only inspection (`gh issue view`, `git log`, `rg`)
+only. Corrections you draft are posted by a HUMAN decision via
+`task foreman:preflight -- --post`, never by you.

--- a/template/.claude/[% if use_foreman %]agents[% endif %]/foreman-shepherd.md
+++ b/template/.claude/[% if use_foreman %]agents[% endif %]/foreman-shepherd.md
@@ -1,0 +1,18 @@
+---
+name: foreman-shepherd
+description: Foreman's post-PR runbooks — repair red CI (mechanical failures only), resolve conflicted rebases additively, and adjudicate review-bot findings (apply or decline-with-reasoning, resolve threads). Foreman resumes unit agents with these rules automatically; use this agent manually to shepherd a foreman PR by hand.
+---
+
+You are foreman's shepherd. The runbooks are one-sourced in
+`scripts/foreman/prompts/`: `shepherd-ci-fix.md` (red CI),
+`shepherd-rebase.md` (conflicts after a sibling merge), and
+`shepherd-adjudicate.md` (review-thread adjudication). Read the one matching
+your task FIRST and follow it exactly; fill its `%%TOKEN%%` placeholders from
+context (PR URL, branch, unit number, `.foreman.toml` verify_command).
+
+The non-negotiables, restated: never merge anything; rebase — never
+merge-main — as the one update mechanism; never weaken a test or the code to
+silence an infra failure (environmental failures go to the human queue);
+adjudicate every thread individually — blanket-accepting and
+blanket-dismissing are both prohibited; deterministic facts beat bot
+speculation.

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -48,6 +48,10 @@ jobs:
           python-version: "3.14"
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 [% endif %]
+[% if use_foreman and not use_python %]
+      # uv provides uvx for foreman:lint's pinned ruff/black (see taskfiles/foreman.yml)
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+[% endif %]
 [% if include_terraform %]
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 [% endif %]
@@ -93,6 +97,9 @@ jobs:
       - name: Lint[% if use_node %] + typecheck[% endif +%]
         run: task check
       - run: task test:tasks
+[% if use_foreman %]
+      - run: task foreman:test
+[% endif %]
 [% if use_skills_sync %]
       - name: Skills drift check (vendored skills vs pinned harmon-devkit ref)
         run: task verify:skills

--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -111,6 +111,16 @@ htmlcov/
 # sources this file when present.
 .envrc.local
 [% endif %]
+[% if use_foreman %]
+
+# Foreman runtime artifacts (logs, prompts, resume states — never state-of-record)
+.foreman/
+.foreman-stop
+[% if not use_python %]
+__pycache__/
+*.pyc
+[% endif %]
+[% endif %]
 [% if include_terraform %]
 
 # Terraform

--- a/template/.gitleaks.toml.jinja
+++ b/template/.gitleaks.toml.jinja
@@ -9,6 +9,9 @@ paths = [
     '''\.git/''',
     '''\.task/''',
     '''\.worktrees/''',
+[% if use_foreman %]
+    '''\.foreman/''',
+[% endif %]
 [% if use_node %]
     '''node_modules/''',
     '''dist/''',

--- a/template/.yamllint
+++ b/template/.yamllint
@@ -8,6 +8,7 @@ ignore:
   - .astro/
   - .task/
   - .worktrees/
+  - .foreman/
   - .venv/
   - .terraform/
   - pnpm-lock.yaml

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -41,7 +41,17 @@ task check       # all linters
 task fix         # auto-format then lint
 task test        # tests
 task security    # gitleaks + dependency audit
+[% if use_foreman %]
+task foreman:plan -- --milestone <n>  # foreman: dry-run the dispatch graph
+[% endif %]
 ```
+[% if use_foreman %]
+
+**Foreman** (`task foreman:*`) is the deterministic supervisor that dispatches
+armed issues to headless agents, verifies their output with `task ci`, opens
+PRs, and shepherds them to mergeable — merging is always a human decision.
+See `docs/architecture/foreman.md`.
+[% endif %]
 
 `verify` is deliberately kept fast (lint[% if use_node %] + typecheck + build[% endif %] + the quick
 Taskfile/hook guards) so editors, git hooks, and AI agents can run it on every

--- a/template/Brewfile.jinja
+++ b/template/Brewfile.jinja
@@ -27,9 +27,9 @@ brew "node"
 brew "pnpm"
 brew "lychee"
 [% endif %]
-[% if use_python %]
+[% if use_python or use_foreman %]
 
-# Python tooling
+# Python tooling (uv[% if use_foreman %]; foreman lint runs pinned ruff/black via uvx[% endif %])
 brew "uv"
 [% endif %]
 [% if include_terraform %]

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -6,6 +6,13 @@ output:
   group:
     begin: "::group::{{.TASK}}"
     end: "::endgroup::"
+[% if use_foreman %]
+
+includes:
+  # Foreman — deterministic supervisor for milestone-driven agent dispatch
+  # (task foreman:plan / dispatch / shepherd / watch ...; docs/architecture/foreman.md)
+  foreman: taskfiles/foreman.yml
+[% endif %]
 
 # ── Entry Points ───────────────────────────────────────────────────
 tasks:
@@ -66,6 +73,9 @@ tasks:
 [% endif %]
       - task: validate
       - task: test:tasks
+[% if use_foreman %]
+      - task: foreman:test
+[% endif %]
 [% if devcontainer %]
       - task: test:hooks
 [% endif %]
@@ -93,6 +103,9 @@ tasks:
 [% endif %]
 [% if use_python %]
       - lint:python
+[% endif %]
+[% if use_foreman %]
+      - foreman:lint
 [% endif %]
 [% if include_terraform %]
       - lint:terraform

--- a/template/[% if use_foreman %].foreman.toml[% endif %].jinja
+++ b/template/[% if use_foreman %].foreman.toml[% endif %].jinja
@@ -1,0 +1,33 @@
+# Foreman configuration for [[ project_name ]] (docs/architecture/foreman.md).
+#
+# Issue custom fields are org-only: on an org-owned repo `inputs = "auto"`
+# resolves to fields mode (`foreman`, `foreman-budget-usd`,
+# `foreman-timeout-min`); on a personal-account repo it falls back to labels
+# (`foreman:claude`, `foreman:hold`, ...). Explicit approval is required
+# before any issue is dispatchable.
+
+backend = "claude"
+require_approval = true
+inputs = "auto"
+verify_command = ["task", "ci"]
+max_parallel = 3
+branch_prefix = "foreman"
+expected_login = "[[ author_git_provider_username ]]-bot"
+
+# subscription (default): adapters inherit CLAUDE_CODE_OAUTH_TOKEN; USD
+# budgets are inert (guardrails bind on timeout/turns). api: adapters export
+# FOREMAN_ANTHROPIC_API_KEY process-locally; USD budgets bind.
+billing = "subscription"
+
+# Set FOREMAN_SANDBOXED=1 (env) inside the egress-limited bot devcontainer to
+# let adapters run with a relaxed permission mode; the committed default stays
+# conservative for any other host.
+sandboxed = false
+
+[budgets]
+dispatch_usd = 20.0
+shepherd_usd = 10.0
+
+[timeouts]
+dispatch_min = 90
+shepherd_min = 30

--- a/template/[% if use_foreman %]taskfiles[% endif %]/foreman.yml
+++ b/template/[% if use_foreman %]taskfiles[% endif %]/foreman.yml
@@ -1,0 +1,75 @@
+# Foreman — deterministic supervisor for milestone-driven agent dispatch.
+# Included by the root Taskfile under the `foreman:` namespace; every task is
+# a thin wrapper over scripts/foreman/ (see docs/architecture/foreman.md and
+# `python3 -m foreman --help`). All heavy logic lives in Python, not here.
+#
+# Targeting: every orchestration task takes `-- --milestone <n|title>` or
+# `-- --issue <n>`, e.g. `task foreman:plan -- --milestone 4`.
+version: "3"
+
+tasks:
+  plan:
+    desc: "Dry run: graph, waves, ready set, input mode, validation (no side effects)"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman plan {{.CLI_ARGS}}
+
+  preflight:
+    desc: "Read-only agent analysis of the target; drafts correction comments for human approval (--post publishes them)"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman preflight {{.CLI_ARGS}}
+
+  dispatch:
+    desc: "Dispatch ready units to agents in worktrees, verify, open PRs (idempotent)"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman dispatch {{.CLI_ARGS}}
+
+  shepherd:
+    desc: "Keep open foreman PRs healthy: repair CI, adjudicate reviews, rebase, report merge order"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman shepherd {{.CLI_ARGS}}
+
+  watch:
+    desc: "Loop plan→dispatch→shepherd with heartbeats until done (stop file: .foreman-stop)"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman watch {{.CLI_ARGS}}
+
+  status:
+    desc: "Read-only snapshot: unit table + consolidated human-action queue"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman status {{.CLI_ARGS}}
+
+  retry:
+    desc: "Re-dispatch a unit whose PR a human closed (usage: task foreman:retry -- --unit N)"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman retry {{.CLI_ARGS}}
+
+  cleanup:
+    desc: "Prune worktrees + foreman-created branches for closed units (in-flight untouched)"
+    cmds:
+      - PYTHONPATH=scripts python3 -m foreman cleanup {{.CLI_ARGS}}
+
+  lint:
+    desc: "Ruff + Black (check mode) over scripts/foreman (skips when uv is unavailable)"
+    vars:
+      # renovate: datasource=pypi depName=ruff
+      RUFF_VERSION: 0.15.21
+      # renovate: datasource=pypi depName=black
+      BLACK_VERSION: 26.5.1
+    cmds:
+      - |
+        if ! command -v uvx >/dev/null 2>&1; then
+          echo "foreman:lint: uv not installed -- skipping (install: brew install uv)"
+          exit 0
+        fi
+        uvx --from "ruff=={{.RUFF_VERSION}}" ruff check scripts/foreman
+        uvx --from "black=={{.BLACK_VERSION}}" black --check --quiet scripts/foreman
+
+  test:
+    desc: "Foreman unit tests (stdlib unittest; hermetic — fake gh transport, no network)"
+    cmds:
+      - |
+        if [ ! -d scripts/foreman/tests ]; then
+          echo "foreman:test: no test suite vendored in this repo -- skipping (suite lives in harmon-init)"
+          exit 0
+        fi
+        PYTHONPATH=scripts python3 -m unittest discover -s scripts/foreman/tests -t scripts

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -55,6 +55,15 @@ assign the agent and trigger it (a `claude-*` workflow, or point Claude Code at 
 item). The lane is built for future automation, though — an agent can watch *Agent
 Queue + Agent-set + priority* (the Agent-queue view below) and pull the top item on
 its own — and either way the item moves to **In Progress** once work starts.
+[% if use_foreman %]
+
+> **Foreman is that automation** for issue-driven delivery: arm the issue
+> (`foreman:*` label, or the org `foreman` issue field) and
+> `task foreman:dispatch` / `foreman:watch` pulls ready items, opens verified
+> PRs, and shepherds them to a human merge. The Project stays the human
+> dashboard — foreman neither reads nor writes it (issue state, labels/fields,
+> and PRs are its interface). See `docs/architecture/foreman.md`.
+[% endif %]
 
 ## Status is not issue state
 

--- a/template/docs/architecture/README.md.jinja
+++ b/template/docs/architecture/README.md.jinja
@@ -33,6 +33,9 @@ onward (diagrams and component deep-dives also live here):
 - [security.md](security.md) — the posture across config, secret state, and GitHub settings; holds the threat-model framing, not the config.
 - [branch-protection.md](branch-protection.md) — in-repo (CODEOWNERS) + out-of-repo (ruleset, Actions toggles, bot model) stitched into one picture (grep can't see GitHub settings).
 - [tests.md](tests.md) — the testing strategy holistically (shape, layers, what's tested where); routes to the testing decision and the guides.
+[% if use_foreman %]
+- [foreman.md](foreman.md) — the deterministic supervisor that dispatches armed issues to headless agents and shepherds their PRs to a human merge; state of record is GitHub + git.
+[% endif %]
 [% if project_type in ['web-astro', 'web-app'] %]
 - [design-language.md](design-language.md) — the holistic visual/UX/brand language; philosophy here, with pointers to the live tokens, [DESIGN.md](../../DESIGN.md), and design ADRs.
 [% endif %]

--- a/template/docs/architecture/[% if use_foreman %]foreman.md[% endif %]
+++ b/template/docs/architecture/[% if use_foreman %]foreman.md[% endif %]
@@ -1,0 +1,235 @@
+# Foreman
+
+Foreman is a **deterministic supervisor** for milestone-driven agent work. It
+reads a milestone's (or a single issue's) dependency graph from GitHub,
+dispatches the currently-unblocked issues to isolated headless agents in git
+worktrees, verifies each result with the repo's own CI gate, opens PRs, and
+keeps those PRs healthy (CI repair, review adjudication, rebases) until a
+human merges them.
+
+Everything that can be a crisp pass/fail check is plain code; LLMs write code
+and adjudicate review findings, but they never judge "done" and never gate
+progression. Zero tokens are spent on coordination.
+
+## Non-negotiables
+
+- **No AI ever merges to main. Ever.** No auto-merge, no enabling flag. The
+  human merge is the only mechanism that advances the dependency graph;
+  foreman's job ends at "this PR is verified, adjudicated, and mergeable —
+  here is the suggested merge order." Server-side enforcement (branch
+  ruleset, code-owner review, bot token without bypass) is the boundary;
+  prompts are only a mitigation.
+- **Stateless in the repo.** Human inputs are stored (issue bodies, labels /
+  issue fields, comments); machine state is re-derived every tick from GitHub
+  - git and never stored. A stored status can lie after a crash; re-derived
+  state cannot. Worktrees and `.foreman/` logs are disposable operational
+  artifacts, never state-of-record.
+- **Foreman never edits human-authored content.** Issue titles/bodies,
+  milestone descriptions, and human/other-bot comments are read-only.
+  Corrections travel as comments (human-approved), never as edits.
+
+## The wave model
+
+Nodes are dispatch units (a parent issue; its sub-issues ride along as the
+internal task list — one unit, one PR). Edges are `blocked-by` dependencies
+(native GitHub dependencies primary; a `Depends-on: #n` body trailer is the
+fallback — both present and disagreeing fails loud).
+
+A **wave** is the set of open units whose dependencies are all satisfied.
+Because a satisfied dependency means *merged into the default branch by a
+human*, every agent branches off the default branch with complete,
+human-approved context — no stacked PRs, no cross-branch coordination. The
+human merge advances the graph; the next run (or watch tick) discovers the
+newly-unblocked wave. During a merge freeze foreman idles by design: PRs stay
+healthy, nothing new dispatches, and the log says it is waiting on merges.
+
+## Doneness (deterministic, hardened)
+
+A dependency is satisfied only when:
+
+- **Foreman-managed** (a closing PR carries the `foreman:unit=#N` marker):
+  the issue is closed **and** that PR is merged into the discovered default
+  branch, authored by the configured bot login, from a `foreman/...` attempt
+  branch. A marker PR that never merged fails loud.
+- **External** (no marker PR): the issue is closed as *completed*. Closed as
+  *not planned* blocks, with guidance — remove the edge, or apply the
+  explicit human override (`foreman=satisfied` field / `foreman:satisfied`
+  label). Every plan/status output prints *how* each dependency was
+  satisfied.
+
+## Inputs (humans write, foreman reads)
+
+Arming is **explicit by default**: only issues carrying the `foreman` input
+dispatch. The value names the backend (`claude`, `mock`) or `approved` (repo
+default backend); `hold` always wins; `satisfied` / `external` adjust
+dependency semantics. Per-repo config can relax to default-armed
+(`require_approval = false`), where invoking dispatch/watch is the arming
+act and `hold` excludes units.
+
+- **Org repos**: the org-level issue custom fields `foreman`,
+  `foreman-budget-usd`, `foreman-timeout-min` (issue fields are org-only).
+- **Personal-account repos**: `foreman:*` labels (boolean inputs only;
+  numeric overrides need fields).
+- `inputs = "auto"` probes availability once per run and prints the chosen
+  mode in every summary. In fields mode, a `foreman:*` label on the same
+  issue fails loud — two drifting sources of truth is a bug, not a feature.
+
+A unit must also satisfy the **spec contract**: an `## Acceptance Criteria`
+section with items tagged `[CI]` (must map to named automated tests) or
+`[HUMAN]` (surfaced, never attempted; the PR then `Refs` instead of `Closes`
+the parent). The conventional-commit type comes from the native issue type
+(mapped via `type_map`) or a `type:` label on personal repos — disagreement
+fails loud.
+
+## Commands
+
+All entry points are Taskfile tasks; each takes `-- --milestone <n|title>` or
+`-- --issue <n>`:
+
+```bash
+task foreman:plan      # dry run: graph, waves, ready set, validation
+task foreman:preflight # read-only agent spec analysis; drafts correction comments
+task foreman:dispatch  # dispatch ready units → verify → open PRs (idempotent)
+task foreman:shepherd  # repair CI, adjudicate reviews, rebase, merge order
+task foreman:watch     # loop plan→dispatch→shepherd (-- --interval 5m)
+task foreman:status    # read-only snapshot + human-action queue
+task foreman:retry     # re-dispatch after a human closed a PR (-- --unit N)
+task foreman:cleanup   # prune worktrees/branches for closed units
+```
+
+## Per-unit flow
+
+1. **Skip if in flight** — an existing attempt branch or open PR means the
+   unit is taken (derived, no state file). Held/un-armed units are skipped.
+2. **Isolate** — `git worktree add` under `.worktrees/foreman/`, branch
+   `foreman/<type>/<n>-<slug>` off the discovered `<remote>/<default>`.
+3. **Prompt** — assembled deterministically: fixed preamble
+   (`scripts/foreman/prompts/implementer-preamble.md`), the full issue +
+   sub-issue bodies, **trusted** comments only (author association OWNER /
+   MEMBER / COLLABORATOR, or foreman's own corrections — drive-by comments
+   on public repos are an injection surface), and the `## Handoff` sections
+   from merged dependency PRs.
+4. **Dispatch** — the backend adapter runs headless in the worktree with a
+   timeout enforced by foreman. The session ref is captured from the FIRST
+   stream event (killed agents emit no final event; resume depends on this).
+5. **Result contract** — the agent must write `result.json` (outside the
+   worktree): status, summary, handoff, human tasks, proposed title, and the
+   AC→test mapping. Exit 0 without a valid contract counts as a crash.
+   Ambiguity escalates via `BLOCKED.md` + a blocked result — never invented
+   through.
+6. **Verify** — foreman itself runs the repo's `verify_command` (default:
+   full `task ci`) in the worktree. The agent's self-report is never trusted.
+7. **Freshness gate** — immediately before pushing: the issue is still open,
+   still armed, dependencies still satisfied, the spec hash (bodies +
+   trusted comments) unchanged since dispatch, and no PR appeared meanwhile.
+   Drift means no push and a flagged unit.
+8. **PR** — non-draft (review bots skip drafts), machine-readable marker,
+   `Closes #N` (or `Refs` when human tasks remain), test evidence, Handoff,
+   and human-only-tasks sections. On failure the worktree, session ref, and
+   a generated resume-state are preserved; the issue stays open so
+   dependents stay blocked.
+9. **Status comment** — exactly one foreman-owned comment per unit, found by
+   marker and edited in place. Display only; never read back for decisions.
+
+## Shepherd
+
+Deterministic triggers → bounded agent actions on open foreman PRs:
+
+- **Red CI** → classify by the signature catalog
+  (`scripts/foreman/signatures.toml`) first. `environment` failures get one
+  empty-commit retry (the retrigger primitive — assume the bot token cannot
+  re-run workflow jobs) and then the human queue; an agent must never "fix"
+  infra by weakening code. `quota_wait` (the agent backend's own usage
+  window) idles until reset. Mechanical failures resume the unit's agent
+  with the failing excerpt.
+- **Behind/conflicting after a sibling merge** → `git merge-tree` dry run
+  enumerates conflicts; clean rebases are mechanical, conflicted ones go to
+  the agent (rebase additively, regenerate generated artifacts via tooling,
+  re-verify) — always rebase, never merge-main.
+- **Unresolved review threads** → the agent adjudicates each finding: apply
+  (commit + reply + resolve) or decline with technical reasoning (bots are
+  sometimes wrong; deterministic facts beat speculation). Blanket-accepting
+  is prohibited. Foreman re-checks disposition completeness afterwards.
+- **Green + adjudicated + mergeable** → `ready-to-merge` label plus a
+  dependency-aware suggested merge order. Foreman performs no merge action
+  of any kind.
+
+## Watch mode and unattended runs
+
+`task foreman:watch` loops plan→dispatch→shepherd with a heartbeat line per
+tick (`.foreman/watch.log`) — silence must look different from health. Every
+tick is stateless and idempotent: kill it, reboot, resume exactly where
+reality is. Stop conditions: milestone complete, `.foreman-stop` file,
+aggregate budget, N consecutive failing ticks.
+
+For multi-day runs prefer a host that won't idle-stop (Codespaces force-stops
+at its idle timeout regardless of a background loop; a coder workspace or any
+persistent container is the reliable substrate). Cron invoking
+`foreman:dispatch` + `foreman:shepherd` on a schedule is equivalent to the
+live loop — statelessness makes the runtime substrate interchangeable.
+
+**Billing**: `billing = "subscription"` (default) inherits the container's
+`CLAUDE_CODE_OAUTH_TOKEN`; USD budgets are inert (timeout/turns bind) and the
+quota-wait signature turns usage-window exhaustion into planned pauses.
+`billing = "api"` exports `FOREMAN_ANTHROPIC_API_KEY` **only inside the
+adapter process** (the container-wide `ANTHROPIC_API_KEY` strip stays), and
+USD budgets bind. Switching is a config flip plus one secret.
+
+## Security model
+
+- **Server-side boundaries** (hold regardless of model behavior): default
+  branch ruleset requiring PRs, code-owner review, and green checks, with
+  the bot excluded from bypass; a fine-grained bot token without `workflows`
+  write (a push touching `.github/workflows/**` is rejected by GitHub); no
+  org/admin scopes.
+- **Identity assertion**: before its first write, foreman requires the gh
+  identity to equal `expected_login` — a leaked-context or wrong-account run
+  refuses to write.
+- **Write contract**: every GitHub mutation lives in
+  `scripts/foreman/github.py` and nowhere else. Foreman may create/push its
+  own branches, open non-draft PRs, edit its own PRs and their
+  foreman-namespace labels, upsert one marker-identified status comment per
+  unit, resolve threads it dispositioned, post human-approved preflight
+  corrections, and ensure its label definitions. It must never merge, close
+  or reopen issues, edit issue bodies/titles, touch human comments, or write
+  fields/types/dependency edges — those operations do not exist in the
+  module, and the test suite greps to keep them absent.
+- **Prompt-injection surface**: only trusted-association comments enter
+  prompts; review-bot findings and CI logs are framed as claims to
+  adjudicate, not instructions; agents run with conservative permission
+  modes outside the sandboxed bot devcontainer (`FOREMAN_SANDBOXED=1`
+  relaxes inside it).
+
+## Configuration (.foreman.toml)
+
+```toml
+backend = "claude"            # default adapter; per-issue input overrides
+require_approval = true       # explicit arming (false = default-armed + holds)
+inputs = "auto"               # auto | fields | labels
+verify_command = ["task", "ci"]
+max_parallel = 3
+branch_prefix = "foreman"
+expected_login = "your-bot"   # identity assertion; "" skips
+billing = "subscription"      # subscription | api
+sandboxed = false             # FOREMAN_SANDBOXED=1 env inside the bot container
+
+[budgets]
+dispatch_usd = 20.0           # binds in api billing mode
+shepherd_usd = 10.0
+
+[timeouts]
+dispatch_min = 90
+shepherd_min = 30
+```
+
+## Extending
+
+- **Backends**: `scripts/foreman/backends/<name>.sh` is the entire vendor
+  surface (`run` / `resume <ref>` / `capabilities`). v1 ships `claude.sh` and
+  `mock.sh` (hermetic seam proof). A new vendor is one small file, added when
+  concretely needed.
+- **Signatures**: when an unmatched CI failure gets an LLM diagnosis, add its
+  regex to `signatures.toml` — the LLM diagnoses once, code recognizes
+  forever.
+- **Agent definitions**: `.claude/agents/foreman-*` wrap the same one-sourced
+  runbooks in `scripts/foreman/prompts/` for interactive use.

--- a/template/lefthook.yml.jinja
+++ b/template/lefthook.yml.jinja
@@ -51,6 +51,11 @@ pre-commit:
       glob: "*.py"
       run: task lint:python -- {staged_files}
 [% endif %]
+[% if use_foreman %]
+    foreman-lint:
+      glob: "*.py"
+      run: task foreman:lint
+[% endif %]
 [% if include_terraform %]
     terraform:
       glob: "*.{tf,tfvars}"

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/__init__.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/__init__.py
@@ -1,0 +1,15 @@
+"""Foreman — deterministic supervisor for milestone-driven agent dispatch.
+
+Reads a milestone's (or single issue's) dependency graph from GitHub,
+dispatches ready units to isolated headless agents in git worktrees, verifies
+their output with the repo's own CI gate, opens PRs, and shepherds those PRs
+to mergeable. Every merge is a human decision — foreman never merges.
+
+State of record is GitHub + git, re-derived every tick; foreman stores no
+local state files (worktrees and logs are disposable operational artifacts).
+
+Spec: https://github.com/evanharmon1/harmon-init/issues/258
+Docs: docs/architecture/foreman.md
+"""
+
+__version__ = "0.1.0"

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/__main__.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point: PYTHONPATH=scripts python3 -m foreman <command> [flags]."""
+
+import sys
+
+from foreman.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/backend.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/backend.py
@@ -1,0 +1,291 @@
+"""Agent backend adapter seam. Adapters are `backends/<name>.sh` — the entire
+vendor surface. Foreman shells out; no vendor SDKs in core.
+
+Adapter contract:
+  argv:  <adapter> run | resume <session-ref> | capabilities
+  cwd:   the unit's worktree
+  env:   FOREMAN_PROMPT_FILE, FOREMAN_RESULT_FILE, FOREMAN_SESSION_FILE,
+         FOREMAN_LOG_FILE, FOREMAN_TIMEOUT_MIN, FOREMAN_PERMISSION_MODE,
+         FOREMAN_BILLING, FOREMAN_MAX_TURNS (0 = uncapped)
+  out:   exit 0/non-zero; session file line `SESSION_REF=<id>` written as
+         EARLY as the backend allows (killed agents emit no final event —
+         resume depends on this), later `COST_USD=<x>` when known.
+  caps:  `capabilities` prints tokens, e.g. `resume cost`.
+
+Timeouts are enforced HERE (portable), not in the adapters.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from foreman import signatures as signatures_mod
+from foreman.config import Config
+from foreman.util import ForemanError, run, tail, utc_now_iso, write_text
+
+BACKENDS_DIR = Path(__file__).resolve().parent / "backends"
+
+RESULT_STATUSES = ("completed", "blocked")
+
+
+@dataclass
+class BackendResult:
+    returncode: int
+    timed_out: bool = False
+    session_ref: str | None = None
+    cost_usd: float | None = None
+    quota_wait: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0 and not self.timed_out
+
+
+def adapter_path(name: str) -> Path:
+    path = BACKENDS_DIR / f"{name}.sh"
+    if not path.exists():
+        available = sorted(p.stem for p in BACKENDS_DIR.glob("*.sh"))
+        raise ForemanError(
+            f"unknown backend '{name}' (available: {', '.join(available)})"
+        )
+    return path
+
+
+def capabilities(adapter: Path) -> set[str]:
+    proc = run([str(adapter), "capabilities"], check=False)
+    return set(proc.stdout.split()) if proc.returncode == 0 else set()
+
+
+def assert_backend_version(cfg: Config) -> None:
+    """Pin check: headless behavior drifts between agent-CLI releases."""
+    if not cfg.backend_version or cfg.backend != "claude":
+        return
+    proc = run(["claude", "--version"], check=False)
+    version = (
+        proc.stdout.strip().split()[0] if proc.returncode == 0 and proc.stdout else ""
+    )
+    if not version.startswith(cfg.backend_version):
+        raise ForemanError(
+            f"backend version mismatch: claude CLI is '{version or 'missing'}', "
+            f"config pins '{cfg.backend_version}'"
+        )
+
+
+def unit_dir(cfg: Config, root: Path, number: int) -> Path:
+    path = root / cfg.runtime_dir / "units" / str(number)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def run_backend(
+    cfg: Config,
+    adapter: Path,
+    *,
+    cwd: Path,
+    unit_run_dir: Path,
+    prompt_file: Path,
+    timeout_min: int,
+    resume_ref: str | None = None,
+) -> BackendResult:
+    session_file = unit_run_dir / "session"
+    log_file = unit_run_dir / "agent.log"
+    result_file = unit_run_dir / "result.json"
+    stdout_file = unit_run_dir / "adapter-stdout.log"
+    if result_file.exists():
+        result_file.unlink()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "FOREMAN_PROMPT_FILE": str(prompt_file),
+            "FOREMAN_RESULT_FILE": str(result_file),
+            "FOREMAN_SESSION_FILE": str(session_file),
+            "FOREMAN_LOG_FILE": str(log_file),
+            "FOREMAN_TIMEOUT_MIN": str(timeout_min),
+            "FOREMAN_PERMISSION_MODE": cfg.resolved_permission_mode(),
+            "FOREMAN_BILLING": cfg.billing,
+            "FOREMAN_MAX_TURNS": str(cfg.max_turns),
+        }
+    )
+    if cfg.billing == "api" and not env.get("FOREMAN_ANTHROPIC_API_KEY"):
+        raise ForemanError("billing=api but FOREMAN_ANTHROPIC_API_KEY is not set")
+
+    argv = [str(adapter), "resume", resume_ref] if resume_ref else [str(adapter), "run"]
+    timed_out = False
+    with stdout_file.open("a", encoding="utf-8") as out_fh:
+        out_fh.write(f"\n--- {utc_now_iso()} {' '.join(argv)} ---\n")
+        out_fh.flush()
+        proc = subprocess.Popen(
+            argv,
+            cwd=str(cwd),
+            env=env,
+            stdout=out_fh,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        try:
+            proc.wait(timeout=timeout_min * 60)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            _kill_group(proc)
+
+    result = BackendResult(returncode=proc.returncode, timed_out=timed_out)
+    _read_session_file(session_file, result)
+    log_tail = tail(log_file, 80) + "\n" + tail(stdout_file, 40)
+    sig = signatures_mod.match(log_tail, signatures_mod.load())
+    if sig is not None and sig.action == "quota_wait":
+        result.quota_wait = True
+    return result
+
+
+def _kill_group(proc: subprocess.Popen) -> None:
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return
+        time.sleep(0.2)
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    proc.wait()
+
+
+def _read_session_file(session_file: Path, result: BackendResult) -> None:
+    if not session_file.exists():
+        return
+    for line in session_file.read_text(encoding="utf-8").splitlines():
+        if line.startswith("SESSION_REF=") and not result.session_ref:
+            result.session_ref = line.split("=", 1)[1].strip() or None
+        elif line.startswith("COST_USD="):
+            try:
+                result.cost_usd = float(line.split("=", 1)[1])
+            except ValueError:
+                pass
+
+
+# ── result contract ──────────────────────────────────────────────────
+
+
+@dataclass
+class ResultContract:
+    status: str
+    summary: str = ""
+    handoff: str = ""
+    human_tasks: list[str] = field(default_factory=list)
+    proposed_pr_title: str = ""
+    ac_test_map: list[dict] = field(default_factory=list)
+    blocked_question: str | None = None
+
+
+def read_result(
+    unit_run_dir: Path, worktree: Path
+) -> tuple[ResultContract | None, list[str]]:
+    """Validate the sidecar result contract; BLOCKED.md is the fallback signal."""
+    result_file = unit_run_dir / "result.json"
+    blocked_md = worktree / "BLOCKED.md"
+    if not result_file.exists():
+        if blocked_md.exists():
+            question = blocked_md.read_text(encoding="utf-8").strip()
+            return ResultContract(status="blocked", blocked_question=question), []
+        return None, ["agent exited without writing the result contract"]
+    try:
+        data = json.loads(result_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, [f"result.json is not valid JSON: {exc}"]
+
+    errors: list[str] = []
+    if not isinstance(data, dict):
+        return None, ["result.json must be a JSON object"]
+    if data.get("schema") != 1:
+        errors.append("result.json: schema must be 1")
+    status = data.get("status")
+    if status not in RESULT_STATUSES:
+        errors.append(f"result.json: status must be one of {RESULT_STATUSES}")
+        return None, errors
+
+    contract = ResultContract(status=status)
+    contract.summary = _expect_str(
+        data, "summary", errors, required=(status == "completed")
+    )
+    contract.handoff = _expect_str(
+        data, "handoff", errors, required=(status == "completed")
+    )
+    contract.proposed_pr_title = _expect_str(
+        data, "proposed_pr_title", errors, required=False
+    )
+    contract.blocked_question = data.get("blocked_question") or None
+    if status == "blocked" and not contract.blocked_question:
+        if blocked_md.exists():
+            contract.blocked_question = blocked_md.read_text(encoding="utf-8").strip()
+        else:
+            errors.append("result.json: blocked status requires blocked_question")
+    tasks = data.get("human_tasks", [])
+    if not isinstance(tasks, list) or not all(isinstance(t, str) for t in tasks):
+        errors.append("result.json: human_tasks must be a list of strings")
+    else:
+        contract.human_tasks = tasks
+    ac_map = data.get("ac_test_map", [])
+    if not isinstance(ac_map, list):
+        errors.append("result.json: ac_test_map must be a list")
+    else:
+        for entry in ac_map:
+            if (
+                not isinstance(entry, dict)
+                or "criterion" not in entry
+                or "tests" not in entry
+            ):
+                errors.append(
+                    "result.json: ac_test_map entries need {criterion, tests}"
+                )
+                break
+        else:
+            contract.ac_test_map = ac_map
+    if status == "completed" and not contract.ac_test_map:
+        errors.append("result.json: completed status requires a non-empty ac_test_map")
+    return (contract, errors) if not errors else (None, errors)
+
+
+def _expect_str(data: dict, key: str, errors: list[str], *, required: bool) -> str:
+    value = data.get(key, "")
+    if not isinstance(value, str):
+        errors.append(f"result.json: {key} must be a string")
+        return ""
+    if required and not value.strip():
+        errors.append(f"result.json: {key} is required")
+    return value
+
+
+def write_resume_state(unit_run_dir: Path, worktree: Path, note: str) -> Path:
+    """Deterministic resume-state so a later resume needs no archaeology."""
+    status = run(
+        ["git", "-C", str(worktree), "status", "--porcelain", "-b"], check=False
+    ).stdout
+    log = run(
+        ["git", "-C", str(worktree), "log", "--oneline", "-5"], check=False
+    ).stdout
+    session = (
+        (unit_run_dir / "session").read_text(encoding="utf-8")
+        if (unit_run_dir / "session").exists()
+        else ""
+    )
+    body = (
+        f"# Resume state — {utc_now_iso()}\n\n{note}\n\n"
+        f"## Worktree\n\n`{worktree}`\n\n```text\n{status}```\n\n"
+        f"## Recent commits\n\n```text\n{log}```\n\n"
+        f"## Session\n\n```text\n{session}```\n\n"
+        f"## Agent log tail\n\n```text\n{tail(unit_run_dir / 'agent.log', 40)}\n```\n"
+    )
+    path = unit_run_dir / "resume-state.md"
+    write_text(path, body)
+    return path

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/backends/claude.sh
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/backends/claude.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# claude.sh — Foreman backend adapter for Claude Code (headless print mode).
+#
+# Contract (see scripts/foreman/backend.py):
+#   claude.sh run                  dispatch with $FOREMAN_PROMPT_FILE
+#   claude.sh resume <session-id>  resume a prior session with a new prompt
+#   claude.sh capabilities         print capability tokens ("resume cost")
+#
+# Env in:  FOREMAN_PROMPT_FILE FOREMAN_RESULT_FILE FOREMAN_SESSION_FILE
+#          FOREMAN_LOG_FILE FOREMAN_PERMISSION_MODE FOREMAN_BILLING
+#          FOREMAN_MAX_TURNS FOREMAN_READONLY FOREMAN_ANTHROPIC_API_KEY
+# Out:     SESSION_REF=<id> appended to $FOREMAN_SESSION_FILE from the FIRST
+#          stream event (killed agents emit no final event, and resuming dead
+#          agents is exactly when the ref matters), COST_USD=<x> when known.
+#
+# Timeouts are enforced by foreman (backend.py), not here.
+set -euo pipefail
+
+fail() {
+    echo "claude.sh: $*" >&2
+    exit 1
+}
+
+cmd="${1:-run}"
+resume_ref=""
+case "$cmd" in
+capabilities)
+    echo "resume cost"
+    exit 0
+    ;;
+run) ;;
+resume)
+    resume_ref="${2:-}"
+    [ -n "$resume_ref" ] || fail "resume requires a session ref"
+    ;;
+*) fail "unknown command: $cmd" ;;
+esac
+
+: "${FOREMAN_PROMPT_FILE:?}" "${FOREMAN_RESULT_FILE:?}" "${FOREMAN_SESSION_FILE:?}" "${FOREMAN_LOG_FILE:?}"
+command -v claude >/dev/null 2>&1 || fail "claude CLI not found on PATH"
+
+# Billing isolation (spec A11): in api mode the key is exported ONLY into this
+# adapter process. The container-wide ANTHROPIC_API_KEY strip (init-env.sh,
+# shell-aliases.sh) stays intact for interactive sessions.
+if [ "${FOREMAN_BILLING:-subscription}" = "api" ]; then
+    [ -n "${FOREMAN_ANTHROPIC_API_KEY:-}" ] || fail "billing=api needs FOREMAN_ANTHROPIC_API_KEY"
+    export ANTHROPIC_API_KEY="$FOREMAN_ANTHROPIC_API_KEY"
+    unset CLAUDE_CODE_OAUTH_TOKEN
+fi
+
+# Read-only analysis mode (preflight): plain-text final output on stdout
+# (foreman captures it), no file edits, no shell.
+if [ "${FOREMAN_READONLY:-0}" = "1" ]; then
+    exec claude -p --permission-mode default \
+        --disallowedTools Edit Write NotebookEdit Bash \
+        <"$FOREMAN_PROMPT_FILE"
+fi
+
+args=(-p --output-format stream-json --verbose)
+args+=(--permission-mode "${FOREMAN_PERMISSION_MODE:-acceptEdits}")
+# The result contract lives OUTSIDE the worktree; grant only that directory.
+args+=(--add-dir "$(dirname "$FOREMAN_RESULT_FILE")")
+if [ "${FOREMAN_MAX_TURNS:-0}" != "0" ]; then
+    args+=(--max-turns "$FOREMAN_MAX_TURNS")
+fi
+if [ -n "$resume_ref" ]; then
+    args+=(--resume "$resume_ref")
+fi
+
+# Stream to the log; capture SESSION_REF from the first event carrying a
+# session_id and COST_USD from the result event. pipefail carries claude's
+# exit code out of the pipeline (bash 3.2 compatible).
+claude "${args[@]}" <"$FOREMAN_PROMPT_FILE" | {
+    session_captured=0
+    while IFS= read -r line; do
+        printf '%s\n' "$line" >>"$FOREMAN_LOG_FILE"
+        if [ "$session_captured" -eq 0 ]; then
+            sid=$(printf '%s' "$line" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+            if [ -n "$sid" ]; then
+                echo "SESSION_REF=$sid" >>"$FOREMAN_SESSION_FILE"
+                session_captured=1
+            fi
+        fi
+        cost=$(printf '%s' "$line" | sed -n 's/.*"total_cost_usd"[[:space:]]*:[[:space:]]*\([0-9.]*\).*/\1/p')
+        if [ -n "$cost" ]; then
+            echo "COST_USD=$cost" >>"$FOREMAN_SESSION_FILE"
+        fi
+    done
+}

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/backends/mock.sh
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/backends/mock.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# mock.sh — canned-diff test adapter. Exists to prove the backend seam and to
+# make foreman's own end-to-end paths exercisable without a vendor CLI,
+# network, or spend. Never dispatch real work at it.
+#
+# Knobs (env):
+#   FOREMAN_MOCK_STATUS=completed|blocked|fail   default: completed
+#   FOREMAN_MOCK_FILE=<relative path>            default: MOCK.md
+set -euo pipefail
+
+cmd="${1:-run}"
+case "$cmd" in
+capabilities)
+    echo "cost"
+    exit 0
+    ;;
+run | resume) ;;
+*)
+    echo "mock.sh: unknown command: $cmd" >&2
+    exit 1
+    ;;
+esac
+
+: "${FOREMAN_RESULT_FILE:?}" "${FOREMAN_SESSION_FILE:?}" "${FOREMAN_LOG_FILE:?}"
+
+echo "SESSION_REF=mock-$$" >>"$FOREMAN_SESSION_FILE"
+echo "mock adapter: cwd=$(pwd) cmd=$cmd status=${FOREMAN_MOCK_STATUS:-completed}" >>"$FOREMAN_LOG_FILE"
+
+if [ "${FOREMAN_READONLY:-0}" = "1" ]; then
+    cat <<'FINDINGS'
+# Mock preflight findings
+
+No real analysis — this is the seam-proof adapter.
+
+## DRAFT COMMENT FOR #0
+
+Mock drafted correction (delete me; unit #0 never exists).
+FINDINGS
+    exit 0
+fi
+
+status="${FOREMAN_MOCK_STATUS:-completed}"
+case "$status" in
+fail)
+    echo "mock adapter: simulated agent failure" >>"$FOREMAN_LOG_FILE"
+    exit 1
+    ;;
+blocked)
+    cat >"$FOREMAN_RESULT_FILE" <<'JSON'
+{
+  "schema": 1,
+  "status": "blocked",
+  "blocked_question": "Mock question: which behavior is intended?"
+}
+JSON
+    echo "COST_USD=0.00" >>"$FOREMAN_SESSION_FILE"
+    exit 2
+    ;;
+esac
+
+target="${FOREMAN_MOCK_FILE:-MOCK.md}"
+{
+    echo "# Mock change"
+    echo
+    echo "Applied by the foreman mock backend adapter."
+} >"$target"
+git add "$target"
+# LEFTHOOK=0 is lefthook's sanctioned skip switch for automation; the mock
+# adapter's commits are throwaway seam proofs, not repo changes.
+LEFTHOOK=0 git -c user.name="foreman-mock" -c user.email="mock@example.invalid" \
+    commit -q -m "chore: mock change (foreman mock backend)"
+cat >"$FOREMAN_RESULT_FILE" <<'JSON'
+{
+  "schema": 1,
+  "status": "completed",
+  "summary": "Mock backend applied a canned change.",
+  "handoff": "Nothing downstream depends on this mock change.",
+  "human_tasks": [],
+  "proposed_pr_title": "chore: mock change",
+  "ac_test_map": [
+    { "criterion": "mock criterion [CI]", "tests": ["mock_test"] }
+  ]
+}
+JSON
+echo "COST_USD=0.00" >>"$FOREMAN_SESSION_FILE"

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/cli.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/cli.py
@@ -1,0 +1,542 @@
+"""Command-line interface. Taskfile targets are thin wrappers over these
+subcommands: plan, preflight, dispatch, shepherd, watch, status, retry,
+cleanup. plan/status/preflight-draft are read-only by construction
+(github.GitHub.read_only) — the write contract is enforced, not promised.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from foreman import backend as backend_mod
+from foreman import dispatch as dispatch_mod
+from foreman import inputs as inputs_mod
+from foreman import report, shepherd as shepherd_mod, spec, watch as watch_mod, worktree
+from foreman.config import Config, load as load_config
+from foreman.github import Gh, GitHub
+from foreman.graph import (
+    Target,
+    dependency_satisfied,
+    detect_cycle,
+    prepare_target,
+    waves,
+)
+from foreman.util import ForemanError, error, info, repo_root, warn, write_text
+
+
+def _add_target_args(parser: argparse.ArgumentParser, *, required: bool = True) -> None:
+    group = parser.add_mutually_exclusive_group(required=required)
+    group.add_argument("--milestone", help="milestone number or exact title")
+    group.add_argument(
+        "--issue", type=int, help="single issue number (with its sub-issues)"
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="foreman",
+        description="Deterministic supervisor: dispatch ready issues to headless "
+        "agents, verify, open PRs, shepherd them to mergeable. Humans merge.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_plan = sub.add_parser(
+        "plan", help="dry run: graph, waves, ready set (no side effects)"
+    )
+    _add_target_args(p_plan)
+
+    p_preflight = sub.add_parser(
+        "preflight",
+        help="read-only agent analysis of the target; drafts correction comments",
+    )
+    _add_target_args(p_preflight)
+    p_preflight.add_argument(
+        "--post",
+        action="store_true",
+        help="post the human-reviewed drafted comments from .foreman/preflight/comments/",
+    )
+
+    p_dispatch = sub.add_parser(
+        "dispatch", help="dispatch ready units → verify → open PRs"
+    )
+    _add_target_args(p_dispatch)
+    p_dispatch.add_argument("--max-parallel", type=int, default=None)
+
+    sub.add_parser(
+        "shepherd", help="repair CI, adjudicate reviews, rebase, report merge order"
+    )
+
+    p_watch = sub.add_parser(
+        "watch", help="loop plan→dispatch→shepherd with heartbeats"
+    )
+    _add_target_args(p_watch)
+    p_watch.add_argument("--interval", default="5m", help="tick interval (300, 5m, 1h)")
+    p_watch.add_argument(
+        "--budget-usd", type=float, default=None, help="aggregate stop budget"
+    )
+
+    p_status = sub.add_parser("status", help="read-only snapshot + human-action queue")
+    _add_target_args(p_status)
+
+    p_retry = sub.add_parser("retry", help="re-dispatch a unit whose PR a human closed")
+    p_retry.add_argument("--unit", type=int, required=True)
+
+    sub.add_parser(
+        "cleanup", help="prune worktrees + foreman branches for closed units"
+    )
+    return parser
+
+
+def _context(read_only: bool) -> tuple[Config, Path, GitHub]:
+    root = repo_root()
+    cfg = load_config(root)
+    gh = GitHub(Gh(), cfg)
+    gh.read_only = read_only
+    return cfg, root, gh
+
+
+def _print_plan(gh: GitHub, cfg: Config, target: Target) -> int:
+    remote_name = worktree.remote(cfg)
+    print(f"Target: {target.label}")
+    print(f"Inputs: {inputs_mod.describe_mode(target.mode, cfg)}")
+    print(f"Base:   {remote_name}/{gh.default_branch()}")
+    print()
+
+    cycle = detect_cycle(target)
+    if cycle:
+        error("dependency cycle: " + " -> ".join(f"#{n}" for n in cycle))
+        return 1
+
+    fail_loud = False
+    ready, skipped = dispatch_mod.eligibility(gh, cfg, target)
+    by_number = {o.unit.number: o for o in skipped}
+    print("Waves (dependency order):")
+    for index, wave in enumerate(waves(target), 1):
+        print(f"  wave {index}:")
+        for number in wave:
+            unit = target.units[number]
+            spec_info = spec.validate(unit)
+            if unit in ready:
+                state = "READY"
+            elif not unit.open:
+                state = "closed"
+            else:
+                outcome = by_number.get(number)
+                state = outcome.status if outcome else "waiting"
+            notes = []
+            for dep in unit.blocked_by:
+                dep_inputs = target.units[dep].inputs if dep in target.units else None
+                done = dependency_satisfied(
+                    gh, cfg, dep, inputs=dep_inputs, mode=target.mode
+                )
+                mark = "✓" if done.satisfied else "✗"
+                notes.append(f"{mark}#{dep} ({done.how})")
+                for note in done.warnings:
+                    warn(note)
+            problems = (
+                unit.errors
+                + (unit.inputs.errors if unit.inputs else [])
+                + spec_info.errors
+            )
+            if problems:
+                fail_loud = True
+            line = f"    #{number} [{state}] {unit.title}"
+            commit_type = unit.inputs.commit_type if unit.inputs else cfg.default_type
+            line += f"  (type={commit_type}"
+            if notes:
+                line += f"; deps: {', '.join(notes)}"
+            line += ")"
+            print(line)
+            for problem in problems:
+                print(f"      ERROR: {problem}")
+            for warning in spec_info.warnings + (
+                unit.inputs.warnings if unit.inputs else []
+            ):
+                print(f"      note: {warning}")
+    print()
+    print(f"Ready now: {', '.join('#' + str(u.number) for u in ready) or '(none)'}")
+
+    notices = _concurrent_activity(gh, target)
+    if notices:
+        print()
+        print(
+            "Concurrent-activity notice (collisions possible — preflight should look):"
+        )
+        for notice in notices:
+            print(f"  - {notice}")
+    return 1 if fail_loud else 0
+
+
+def _concurrent_activity(gh: GitHub, target: Target) -> list[str]:
+    notices = []
+    for ms in gh.milestones(state="open"):
+        if target.milestone and ms["title"] == target.milestone:
+            continue
+        if ms.get("open_issues"):
+            notices.append(
+                f"open milestone '{ms['title']}' with {ms['open_issues']} open issue(s)"
+            )
+    others = [
+        p
+        for p in gh.prs(state="open")
+        if "foreman-dispatched"
+        not in [label["name"] for label in p.get("labels") or []]
+    ]
+    if others:
+        notices.append(
+            f"{len(others)} open non-foreman PR(s) may land on the default branch mid-run"
+        )
+    return notices
+
+
+def cmd_plan(args: argparse.Namespace) -> int:
+    cfg, _root, gh = _context(read_only=True)
+    target = prepare_target(gh, cfg, milestone=args.milestone, issue=args.issue)
+    return _print_plan(gh, cfg, target)
+
+
+def cmd_dispatch(args: argparse.Namespace) -> int:
+    cfg, root, gh = _context(read_only=False)
+    backend_mod.assert_backend_version(cfg)
+    target = prepare_target(gh, cfg, milestone=args.milestone, issue=args.issue)
+    cycle = detect_cycle(target)
+    if cycle:
+        error(
+            "refusing to dispatch: dependency cycle "
+            + " -> ".join(f"#{n}" for n in cycle)
+        )
+        return 1
+    outcomes = dispatch_mod.run_dispatch(
+        gh, cfg, root, target, max_parallel=args.max_parallel
+    )
+    statuses = [
+        report.UnitStatus(
+            unit=o.unit,
+            state=o.status,
+            branch=o.branch,
+            pr_url=o.pr_url,
+            detail=o.detail,
+        )
+        for o in outcomes
+    ]
+    print()
+    print(report.summary_table(statuses))
+    failed = [o for o in outcomes if o.status in ("failed", "blocked", "stale")]
+    for outcome in failed:
+        print(f"\n#{outcome.unit.number} {outcome.status}: {outcome.detail}")
+    return 1 if failed else 0
+
+
+def cmd_shepherd(_args: argparse.Namespace) -> int:
+    cfg, root, gh = _context(read_only=False)
+    backend_mod.assert_backend_version(cfg)
+    shep = shepherd_mod.run_shepherd(gh, cfg, root)
+    if shep.worked:
+        rows = [
+            [f"#{w.unit_number}", f"PR #{w.number}", w.state, w.detail[:70]]
+            for w in shep.worked
+        ]
+        print(report.table(["unit", "pr", "state", "detail"], rows))
+    if shep.ready_order:
+        print()
+        print("Suggested merge order (foreman never merges):")
+        for index, (number, url) in enumerate(shep.ready_order, 1):
+            print(f"  {index}. #{number}  {url}")
+    if shep.environmental:
+        print()
+        for number, detail in sorted(shep.environmental.items()):
+            print(f"NEEDS HUMAN #{number}: {detail}")
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    cfg, root, gh = _context(read_only=True)
+    target = prepare_target(gh, cfg, milestone=args.milestone, issue=args.issue)
+    open_prs = shepherd_mod.open_foreman_prs(gh)
+    prs_by_unit = {p["_unit"]: p for p in open_prs}
+    statuses: list[report.UnitStatus] = []
+    human_tasks: dict[int, list[str]] = {}
+    blocked: dict[int, str] = {}
+    ready: list[shepherd_mod.PrWork] = []
+    for number in sorted(target.units):
+        unit = target.units[number]
+        spec_info = spec.validate(unit)
+        tasks = spec.human_only_tasks(unit, spec_info) if not spec_info.errors else []
+        if tasks and unit.open:
+            human_tasks[number] = tasks
+        if not unit.open:
+            done = dependency_satisfied(
+                gh, cfg, number, inputs=unit.inputs, mode=target.mode
+            )
+            statuses.append(
+                report.UnitStatus(unit=unit, state="merged", detail=done.how)
+            )
+            continue
+        pr = prs_by_unit.get(number)
+        if pr:
+            status = gh.pr_status(pr["number"])
+            checks_state, _failed = shepherd_mod.classify_checks(
+                status.get("statusCheckRollup")
+            )
+            labels = [label["name"] for label in status.get("labels") or []]
+            state = "ready-to-merge" if "ready-to-merge" in labels else "pr-open"
+            if state == "ready-to-merge":
+                ready.append(
+                    shepherd_mod.PrWork(
+                        number=pr["number"],
+                        unit_number=number,
+                        branch=status["headRefName"],
+                        url=status["url"],
+                        title=status["title"],
+                    )
+                )
+            statuses.append(
+                report.UnitStatus(
+                    unit=unit,
+                    state=state,
+                    branch=status["headRefName"],
+                    pr_url=status["url"],
+                    checks=checks_state,
+                    detail=status["title"],
+                )
+            )
+            continue
+        blocked_file = root / cfg.runtime_dir / "units" / str(number) / "result.json"
+        detail = ""
+        if blocked_file.exists():
+            contract, _errors = backend_mod.read_result(
+                blocked_file.parent, worktree.worktree_path(cfg, root, unit)
+            )
+            if contract and contract.status == "blocked" and contract.blocked_question:
+                blocked[number] = contract.blocked_question
+                detail = "blocked on a question"
+        outcome_state = "waiting"
+        if unit.inputs and unit.inputs.hold:
+            outcome_state = "held"
+        elif unit.inputs and not unit.inputs.armed:
+            outcome_state = "not-armed"
+        statuses.append(
+            report.UnitStatus(unit=unit, state=outcome_state, detail=detail)
+        )
+    print(report.summary_table(statuses))
+    print()
+    print(
+        report.human_queue(
+            merge_order=shepherd_mod.merge_order(gh, ready),
+            human_tasks=human_tasks,
+            blocked=blocked,
+            environmental={},
+        )
+    )
+    return 0
+
+
+def cmd_retry(args: argparse.Namespace) -> int:
+    cfg, root, gh = _context(read_only=False)
+    backend_mod.assert_backend_version(cfg)
+    target = prepare_target(gh, cfg, milestone=None, issue=args.unit)
+    unit = target.units[args.unit]
+    if not unit.open:
+        error(f"#{args.unit} is closed — nothing to retry")
+        return 1
+    remote_name = worktree.remote(cfg)
+    attempts = worktree.attempt_branches(cfg, remote_name, unit.number)
+    open_prs = [p for p in gh.prs(state="open") if p["headRefName"] in attempts]
+    if open_prs:
+        error(
+            f"#{args.unit} still has an open PR ({open_prs[0]['url']}) — close it first"
+        )
+        return 1
+    stale_wt = worktree.worktree_path(cfg, root, unit)
+    if stale_wt.exists():
+        info(f"removing preserved worktree {stale_wt}")
+        worktree.remove(stale_wt)
+    outcome = dispatch_mod.dispatch_unit(gh, cfg, root, unit, mode=target.mode)
+    print(
+        report.summary_table(
+            [
+                report.UnitStatus(
+                    unit=unit,
+                    state=outcome.status,
+                    branch=outcome.branch,
+                    pr_url=outcome.pr_url,
+                    detail=outcome.detail,
+                )
+            ]
+        )
+    )
+    return 0 if outcome.dispatched else 1
+
+
+def cmd_cleanup(_args: argparse.Namespace) -> int:
+    cfg, root, gh = _context(read_only=False)
+    remote_name = worktree.remote(cfg)
+    worktree.fetch(remote_name)
+    import re as _re
+
+    from foreman.util import run as _run
+
+    pattern = _re.compile(rf"^{_re.escape(cfg.branch_prefix)}/[^/]+/(?P<number>\d+)-")
+    by_unit: dict[int, list[str]] = {}
+    refs = _run(["git", "ls-remote", "--heads", remote_name]).stdout
+    local = _run(
+        ["git", "for-each-ref", "--format=%(refname:short)", "refs/heads/"]
+    ).stdout
+    names = {
+        line.split("\t")[1][len("refs/heads/") :]
+        for line in refs.splitlines()
+        if "\t" in line
+    }
+    names.update(name for name in local.split() if name)
+    for name in sorted(names):
+        match = pattern.match(name)
+        if match:
+            by_unit.setdefault(int(match.group("number")), []).append(name)
+
+    removed = 0
+    for number, branches in sorted(by_unit.items()):
+        issue = gh.issue(number)
+        if (issue.get("state") or "").upper() != "CLOSED":
+            continue
+        if any(gh.prs(head=branch, state="open") for branch in branches):
+            continue
+        for branch in branches:
+            info(f"cleanup: deleting branch {branch} (unit #{number} closed)")
+            worktree.delete_branch(cfg, remote_name, branch)
+            removed += 1
+        for path in (root / cfg.worktrees_dir).glob(f"{number}-*"):
+            worktree.remove(path)
+        pr_wt = root / cfg.worktrees_dir / f"pr-{number}"
+        if pr_wt.exists():
+            worktree.remove(pr_wt)
+    info(f"cleanup: removed {removed} branch(es); in-flight units untouched")
+    return 0
+
+
+def cmd_preflight(args: argparse.Namespace) -> int:
+    cfg, root, gh = _context(read_only=not args.post)
+    comments_dir = root / cfg.runtime_dir / "preflight" / "comments"
+    if args.post:
+        posted = 0
+        for path in sorted(comments_dir.glob("*.md")):
+            number = int(path.stem)
+            body = path.read_text(encoding="utf-8").strip()
+            if not body:
+                continue
+            gh.post_preflight_correction(number, body, human_approved=True)
+            path.rename(path.with_suffix(".posted"))
+            posted += 1
+            info(f"posted correction comment on #{number}")
+        if not posted:
+            warn(f"no draft comments found in {comments_dir}")
+        return 0
+
+    backend_mod.assert_backend_version(cfg)
+    target = prepare_target(gh, cfg, milestone=args.milestone, issue=args.issue)
+    bodies = []
+    for number in sorted(target.units):
+        unit = target.units[number]
+        comments, _excluded = spec.trusted_comments(gh, cfg, number)
+        bodies.append(f"# Unit #{number}: {unit.title}\n\n{unit.body}")
+        for sub in unit.sub_issues:
+            bodies.append(
+                f"## Sub-issue #{sub['number']}: {sub.get('title','')}\n\n{sub.get('body') or ''}"
+            )
+        for comment in comments:
+            bodies.append(f"### Comment on #{number}\n\n{comment.get('body') or ''}")
+    tokens = {
+        "TARGET": target.label,
+        "CONCURRENT": "\n".join(_concurrent_activity(gh, target)) or "(none detected)",
+        "UNITS": "\n\n---\n\n".join(bodies),
+    }
+    prompt = spec.load_prompt("preflight", tokens)
+    run_dir = root / cfg.runtime_dir / "preflight"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    prompt_file = run_dir / "prompt.md"
+    write_text(prompt_file, prompt)
+    adapter = backend_mod.adapter_path(cfg.backend)
+    os.environ["FOREMAN_READONLY"] = "1"
+    try:
+        result = backend_mod.run_backend(
+            cfg,
+            adapter,
+            cwd=root,
+            unit_run_dir=run_dir,
+            prompt_file=prompt_file,
+            timeout_min=cfg.shepherd_timeout_min,
+        )
+    finally:
+        os.environ.pop("FOREMAN_READONLY", None)
+    findings_src = run_dir / "adapter-stdout.log"
+    findings = findings_src.read_text(encoding="utf-8") if findings_src.exists() else ""
+    findings_file = run_dir / "findings.md"
+    write_text(findings_file, findings)
+    drafted = _extract_draft_comments(findings)
+    comments_dir.mkdir(parents=True, exist_ok=True)
+    for number, body in drafted.items():
+        write_text(comments_dir / f"{number}.md", body)
+    info(f"preflight findings: {findings_file}")
+    if drafted:
+        info(
+            f"{len(drafted)} drafted correction comment(s) in {comments_dir} — review/edit "
+            "them, then run: task foreman:preflight -- --post"
+        )
+    else:
+        info("no correction comments drafted")
+    return 0 if result.ok else 1
+
+
+def _extract_draft_comments(findings: str) -> dict[int, str]:
+    import re as _re
+
+    drafted: dict[int, str] = {}
+    parts = _re.split(r"^## DRAFT COMMENT FOR #(\d+)\s*$", findings, flags=_re.M)
+    for index in range(1, len(parts) - 1, 2):
+        number = int(parts[index])
+        body = parts[index + 1].split("\n## ")[0].strip()
+        if body:
+            drafted[number] = body
+    return drafted
+
+
+def cmd_watch(args: argparse.Namespace) -> int:
+    cfg, root, _gh = _context(read_only=False)
+    backend_mod.assert_backend_version(cfg)
+    return watch_mod.run_watch(
+        cfg,
+        root,
+        milestone=args.milestone,
+        issue=args.issue,
+        interval_s=watch_mod.parse_interval(args.interval),
+        budget_usd=args.budget_usd,
+    )
+
+
+_COMMANDS = {
+    "plan": cmd_plan,
+    "preflight": cmd_preflight,
+    "dispatch": cmd_dispatch,
+    "shepherd": cmd_shepherd,
+    "watch": cmd_watch,
+    "status": cmd_status,
+    "retry": cmd_retry,
+    "cleanup": cmd_cleanup,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    if sys.version_info < (3, 11):
+        print("foreman: Python >= 3.11 required (tomllib)", file=sys.stderr)
+        return 2
+    args = _parser().parse_args(argv)
+    try:
+        return _COMMANDS[args.command](args)
+    except ForemanError as exc:
+        error(str(exc))
+        return 1
+    except KeyboardInterrupt:
+        error("interrupted")
+        return 130

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/config.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/config.py
@@ -1,0 +1,139 @@
+"""Load .foreman.toml (repo root) with defaults and FOREMAN_* env overrides.
+
+Config is intent, not state: nothing here is written back by foreman.
+Python 3.11+ (tomllib).
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from foreman.util import ForemanError, warn
+
+CONFIG_FILE = ".foreman.toml"
+
+
+@dataclass
+class Config:
+    backend: str = "claude"
+    backend_version: str = ""  # expected CLI version prefix; "" = don't assert
+    require_approval: bool = True  # strict arming: only foreman-approved units dispatch
+    inputs: str = "auto"  # auto | fields | labels
+    verify_command: list[str] = field(default_factory=lambda: ["task", "ci"])
+    max_parallel: int = 3
+    dispatch_budget_usd: float = 20.0
+    shepherd_budget_usd: float = 10.0
+    dispatch_timeout_min: int = 90
+    shepherd_timeout_min: int = 30
+    max_turns: int = 0  # 0 = uncapped (budget/timeout bind instead)
+    comment_trust: list[str] = field(
+        default_factory=lambda: ["OWNER", "MEMBER", "COLLABORATOR"]
+    )
+    branch_prefix: str = "foreman"
+    worktrees_dir: str = ".worktrees/foreman"
+    runtime_dir: str = ".foreman"
+    type_map: dict[str, str] = field(
+        default_factory=lambda: {
+            "Feature": "feat",
+            "Bug": "fix",
+            "Task": "chore",
+            "Research": "chore",
+        }
+    )
+    default_type: str = "feat"
+    expected_login: str = ""  # identity assertion before any write; "" = skip
+    billing: str = "subscription"  # subscription | api
+    sandboxed: bool = False  # true only inside the egress-limited bot devcontainer
+    permission_mode: str = (
+        ""  # "" = derived: bypassPermissions if sandboxed else acceptEdits
+    )
+    allow_not_planned: bool = False  # count closed-as-not-planned external deps as done
+    remote: str = ""  # "" = auto-discover
+
+    def resolved_permission_mode(self) -> str:
+        if self.permission_mode:
+            return self.permission_mode
+        return "bypassPermissions" if self.sandboxed else "acceptEdits"
+
+
+_ENV_OVERRIDES = {
+    "FOREMAN_BACKEND": ("backend", str),
+    "FOREMAN_INPUTS": ("inputs", str),
+    "FOREMAN_MAX_PARALLEL": ("max_parallel", int),
+    "FOREMAN_BILLING": ("billing", str),
+    "FOREMAN_PERMISSION_MODE": ("permission_mode", str),
+    "FOREMAN_SANDBOXED": ("sandboxed", lambda v: v.lower() in ("1", "true", "yes")),
+}
+
+_TABLES = {
+    "budgets": {
+        "dispatch_usd": "dispatch_budget_usd",
+        "shepherd_usd": "shepherd_budget_usd",
+    },
+    "timeouts": {
+        "dispatch_min": "dispatch_timeout_min",
+        "shepherd_min": "shepherd_timeout_min",
+    },
+}
+
+
+def load(root: Path) -> Config:
+    cfg = Config()
+    path = root / CONFIG_FILE
+    if path.exists():
+        with path.open("rb") as fh:
+            try:
+                data = tomllib.load(fh)
+            except tomllib.TOMLDecodeError as exc:
+                raise ForemanError(f"{CONFIG_FILE}: invalid TOML: {exc}") from exc
+        _apply(cfg, data, path.name)
+    for env_name, (attr, cast) in _ENV_OVERRIDES.items():
+        raw = os.environ.get(env_name)
+        if raw:
+            setattr(cfg, attr, cast(raw))
+    _validate(cfg)
+    return cfg
+
+
+def _apply(cfg: Config, data: dict, source: str) -> None:
+    known = set(Config.__dataclass_fields__)
+    for key, value in data.items():
+        if key in _TABLES:
+            if not isinstance(value, dict):
+                raise ForemanError(f"{source}: [{key}] must be a table")
+            for sub, attr in _TABLES[key].items():
+                if sub in value:
+                    setattr(cfg, attr, value.pop(sub))
+            for leftover in value:
+                warn(f"{source}: unknown key [{key}].{leftover} ignored")
+        elif key in known:
+            current = getattr(cfg, key)
+            if isinstance(current, bool) and not isinstance(value, bool):
+                raise ForemanError(f"{source}: '{key}' must be a boolean")
+            setattr(cfg, key, value)
+        else:
+            warn(f"{source}: unknown key '{key}' ignored")
+
+
+def _validate(cfg: Config) -> None:
+    if cfg.inputs not in ("auto", "fields", "labels"):
+        raise ForemanError(
+            f"config: inputs must be auto|fields|labels, got '{cfg.inputs}'"
+        )
+    if cfg.billing not in ("subscription", "api"):
+        raise ForemanError(
+            f"config: billing must be subscription|api, got '{cfg.billing}'"
+        )
+    if not isinstance(cfg.verify_command, list) or not all(
+        isinstance(part, str) for part in cfg.verify_command
+    ):
+        raise ForemanError("config: verify_command must be a list of strings")
+    if not cfg.verify_command:
+        raise ForemanError("config: verify_command must not be empty")
+    if cfg.max_parallel < 1:
+        raise ForemanError("config: max_parallel must be >= 1")
+    if "/" in cfg.branch_prefix or not cfg.branch_prefix:
+        raise ForemanError("config: branch_prefix must be a single path segment")

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/dispatch.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/dispatch.py
@@ -1,0 +1,382 @@
+"""Per-unit dispatch pipeline: isolate → prompt → agent → verify → freshness
+gate → push → PR → status comment. Bounded concurrency across units.
+
+Idempotent by derivation: a unit with an existing attempt branch or open PR
+is skipped — no state file records "dispatched"; git and GitHub do.
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+
+from foreman import backend as backend_mod
+from foreman import pr as pr_mod
+from foreman import report, spec, verify, worktree
+from foreman.config import Config
+from foreman.github import GitHub
+from foreman.graph import Target, Unit, dependency_satisfied
+from foreman.util import ForemanError, info, write_text
+
+RETRIGGER_SUBJECT = "chore: retrigger ci (foreman)"
+
+
+@dataclass
+class Outcome:
+    unit: Unit
+    status: (
+        str  # pr-open | failed | blocked | waiting | skipped | held | not-armed | stale
+    )
+    branch: str = ""
+    pr_url: str = ""
+    detail: str = ""
+    cost_usd: float | None = None
+    duration_s: float = 0.0
+
+    @property
+    def dispatched(self) -> bool:
+        return self.status == "pr-open"
+
+
+def eligibility(
+    gh: GitHub, cfg: Config, target: Target
+) -> tuple[list[Unit], list[Outcome]]:
+    """Split units into ready-to-dispatch and skipped (with reasons)."""
+    ready: list[Unit] = []
+    skipped: list[Outcome] = []
+    remote_name = worktree.remote(cfg)
+    for number in sorted(target.units):
+        unit = target.units[number]
+        inp = unit.inputs
+        assert inp is not None, "inputs must be resolved before eligibility"
+        if not unit.open:
+            skipped.append(Outcome(unit, "skipped", detail="already closed"))
+            continue
+        if unit.errors or (inp and inp.errors):
+            problems = "; ".join(unit.errors + inp.errors)
+            skipped.append(Outcome(unit, "failed", detail=f"contract: {problems}"))
+            continue
+        if inp.hold:
+            skipped.append(Outcome(unit, "held", detail="foreman=hold"))
+            continue
+        if not inp.armed:
+            skipped.append(
+                Outcome(unit, "not-armed", detail="no foreman approval input")
+            )
+            continue
+        spec_info = spec.validate(unit)
+        if spec_info.errors:
+            skipped.append(Outcome(unit, "failed", detail="; ".join(spec_info.errors)))
+            continue
+        unmet = []
+        for dep in unit.blocked_by:
+            dep_inputs = target.units[dep].inputs if dep in target.units else None
+            done = dependency_satisfied(
+                gh, cfg, dep, inputs=dep_inputs, mode=target.mode
+            )
+            if not done.satisfied:
+                unmet.append(f"#{dep} ({done.how})")
+        if unmet:
+            skipped.append(
+                Outcome(unit, "waiting", detail=f"blocked by {', '.join(unmet)}")
+            )
+            continue
+        attempts = worktree.attempt_branches(cfg, remote_name, unit.number)
+        open_prs = [p for p in gh.prs(state="open") if p["headRefName"] in attempts]
+        if open_prs:
+            skipped.append(
+                Outcome(
+                    unit,
+                    "skipped",
+                    branch=open_prs[0]["headRefName"],
+                    pr_url=open_prs[0]["url"],
+                    detail="open PR exists (in flight)",
+                )
+            )
+            continue
+        in_flight = [b for b in attempts if gh.branch_exists_remote(b)]
+        if in_flight:
+            skipped.append(
+                Outcome(
+                    unit,
+                    "skipped",
+                    branch=in_flight[0],
+                    detail="attempt branch exists (in flight or awaiting retry/cleanup)",
+                )
+            )
+            continue
+        ready.append(unit)
+    return ready, skipped
+
+
+def dispatch_unit(
+    gh: GitHub, cfg: Config, root: Path, unit: Unit, *, mode: str | None = None
+) -> Outcome:
+    started = time.monotonic()
+    remote_name = worktree.remote(cfg)
+    default_branch = gh.default_branch()
+    base = f"{remote_name}/{default_branch}"
+
+    existing = worktree.attempt_branches(cfg, remote_name, unit.number)
+    branch = worktree.next_attempt_branch(worktree.branch_name(cfg, unit), existing)
+    wt_path = worktree.worktree_path(cfg, root, unit)
+    if wt_path.exists():
+        return Outcome(
+            unit,
+            "skipped",
+            branch=branch,
+            detail=f"worktree already exists ({wt_path}) — run foreman:retry or cleanup",
+        )
+
+    run_dir = backend_mod.unit_dir(cfg, root, unit.number)
+    comments, excluded = spec.trusted_comments(gh, cfg, unit.number)
+    recorded_hash = spec.spec_hash(unit, comments)
+    base_sha = worktree.base_sha(remote_name, default_branch)
+    write_text(
+        run_dir / "dispatch-meta.txt",
+        f"spec_hash={recorded_hash}\nbase_sha={base_sha}\nbranch={branch}\n",
+    )
+
+    handoffs = spec.collect_handoffs(gh, cfg, unit)
+    prompt_text = spec.assemble_dispatch_prompt(
+        gh,
+        cfg,
+        unit,
+        branch=branch,
+        default_branch=default_branch,
+        result_file=str(run_dir / "result.json"),
+        comments=comments,
+        excluded_comments=excluded,
+        handoffs=handoffs,
+    )
+    prompt_file = run_dir / "prompt.md"
+    write_text(prompt_file, prompt_text)
+
+    worktree.add(wt_path, branch, base)
+    outcome = _run_agent_and_verify(
+        gh,
+        cfg,
+        unit,
+        wt_path,
+        run_dir,
+        prompt_file,
+        branch,
+        base,
+        recorded_hash,
+        base_sha,
+        mode=mode,
+    )
+    outcome.duration_s = time.monotonic() - started
+    _post_status(gh, unit, outcome)
+    if outcome.status == "pr-open":
+        worktree.remove(wt_path)  # PR branch is pushed; shepherd recreates on demand
+    return outcome
+
+
+def _run_agent_and_verify(
+    gh: GitHub,
+    cfg: Config,
+    unit: Unit,
+    wt_path: Path,
+    run_dir: Path,
+    prompt_file: Path,
+    branch: str,
+    base: str,
+    recorded_hash: str,
+    base_sha: str,
+    *,
+    mode: str | None = None,
+) -> Outcome:
+    inp = unit.inputs
+    backend_name = inp.backend if inp and inp.backend else cfg.backend
+    adapter = backend_mod.adapter_path(backend_name)
+    timeout_min = (
+        inp.timeout_min if inp and inp.timeout_min else cfg.dispatch_timeout_min
+    )
+
+    result = backend_mod.run_backend(
+        cfg,
+        adapter,
+        cwd=wt_path,
+        unit_run_dir=run_dir,
+        prompt_file=prompt_file,
+        timeout_min=timeout_min,
+    )
+    if result.quota_wait:
+        backend_mod.write_resume_state(
+            run_dir, wt_path, "backend usage window exhausted"
+        )
+        return Outcome(
+            unit,
+            "waiting",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail="backend usage limit reached — will resume after the window resets",
+        )
+    if result.timed_out:
+        backend_mod.write_resume_state(
+            run_dir, wt_path, f"agent timed out after {timeout_min}m"
+        )
+        return Outcome(
+            unit,
+            "failed",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail=f"agent timed out after {timeout_min}m (session preserved)",
+        )
+
+    contract, contract_errors = backend_mod.read_result(run_dir, wt_path)
+    if contract is not None and contract.status == "blocked":
+        backend_mod.write_resume_state(run_dir, wt_path, "agent blocked on a question")
+        return Outcome(
+            unit,
+            "blocked",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail=(
+                (contract.blocked_question or "").strip().splitlines()[0]
+                if contract.blocked_question
+                else "blocked without a question"
+            ),
+        )
+    if result.returncode != 0:
+        backend_mod.write_resume_state(
+            run_dir, wt_path, f"agent exited {result.returncode}"
+        )
+        return Outcome(
+            unit,
+            "failed",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail=f"agent exited {result.returncode} (worktree + session preserved)",
+        )
+    if contract is None:
+        backend_mod.write_resume_state(run_dir, wt_path, "invalid result contract")
+        return Outcome(
+            unit,
+            "failed",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail="result contract invalid: " + "; ".join(contract_errors),
+        )
+
+    if worktree.commits_ahead(wt_path, base) == 0:
+        backend_mod.write_resume_state(run_dir, wt_path, "agent made no commits")
+        return Outcome(
+            unit,
+            "failed",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail="agent completed but made no commits",
+        )
+    if not worktree.is_clean(wt_path):
+        backend_mod.write_resume_state(
+            run_dir, wt_path, "uncommitted changes left in worktree"
+        )
+        return Outcome(
+            unit,
+            "failed",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail="agent left uncommitted changes in the worktree",
+        )
+
+    ok, verify_tail = verify.run_verify(cfg, wt_path, run_dir)
+    if not ok:
+        backend_mod.write_resume_state(
+            run_dir, wt_path, "verification failed:\n\n" + verify_tail
+        )
+        return Outcome(
+            unit,
+            "failed",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail=f"verification failed ({' '.join(cfg.verify_command)})",
+        )
+
+    fresh = pr_mod.freshness_check(
+        gh, cfg, unit, recorded_hash=recorded_hash, branch=branch, mode=mode
+    )
+    if not fresh.ok:
+        backend_mod.write_resume_state(
+            run_dir, wt_path, "freshness gate: " + "; ".join(fresh.problems)
+        )
+        return Outcome(
+            unit,
+            "stale",
+            branch=branch,
+            cost_usd=result.cost_usd,
+            detail="not pushed — " + "; ".join(fresh.problems),
+        )
+
+    spec_info = spec.validate(unit)
+    human_tasks = spec.human_only_tasks(unit, spec_info)
+    remote_name = worktree.remote(cfg)
+    worktree.push(wt_path, remote_name, branch, first=True)
+    title = pr_mod.pr_title(cfg, unit, contract)
+    body = pr_mod.pr_body(
+        cfg,
+        unit,
+        contract,
+        human_tasks=human_tasks,
+        spec_hash_hex=recorded_hash,
+        base_sha=base_sha,
+    )
+    url = pr_mod.open_pr(
+        gh, cfg, unit, title=title, body=body, branch=branch, base=gh.default_branch()
+    )
+    return Outcome(
+        unit,
+        "pr-open",
+        branch=branch,
+        pr_url=url,
+        cost_usd=result.cost_usd,
+        detail=title,
+    )
+
+
+def _post_status(gh: GitHub, unit: Unit, outcome: Outcome) -> None:
+    spec_info = spec.validate(unit)
+    status = report.UnitStatus(
+        unit=unit,
+        state=outcome.status,
+        branch=outcome.branch,
+        pr_url=outcome.pr_url,
+        blockers=[outcome.detail] if outcome.status in ("failed", "stale") else [],
+        human_tasks=(
+            spec.human_only_tasks(unit, spec_info) if not spec_info.errors else []
+        ),
+        blocked_question=outcome.detail if outcome.status == "blocked" else "",
+    )
+    report.update_status_comment(gh, status)
+
+
+def run_dispatch(
+    gh: GitHub,
+    cfg: Config,
+    root: Path,
+    target: Target,
+    *,
+    max_parallel: int | None = None,
+) -> list[Outcome]:
+    ready, outcomes = eligibility(gh, cfg, target)
+    if ready:
+        info(
+            f"dispatching {len(ready)} unit(s): {', '.join('#' + str(u.number) for u in ready)}"
+        )
+    workers = max(1, max_parallel or cfg.max_parallel)
+    if ready:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {
+                pool.submit(dispatch_unit, gh, cfg, root, unit, mode=target.mode): unit
+                for unit in ready
+            }
+            for future, unit in futures.items():
+                try:
+                    outcomes.append(future.result())
+                except ForemanError as exc:
+                    outcomes.append(Outcome(unit, "failed", detail=str(exc)))
+    outcomes.sort(key=lambda o: o.unit.number)
+    return outcomes

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/github.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/github.py
@@ -1,0 +1,456 @@
+"""All GitHub access — every read and every mutation lives here, nowhere else.
+
+Write contract (docs/architecture/foreman.md): foreman MAY create/push its own
+branches, open non-draft PRs, edit its OWN PRs and their foreman-namespace
+labels, create/edit the single marker-identified status comment per unit,
+resolve review threads it dispositioned, post human-approved preflight
+correction comments, and idempotently ensure its label definitions exist.
+
+Foreman MUST NEVER: merge anything, close/reopen issues, edit issue
+titles/bodies/milestones, edit or delete human or third-party comments,
+write custom-field values / issue types / dependency edges, or touch repo
+settings. Those operations are deliberately absent from this module, and
+tests/test_write_contract.py greps this file to keep them absent.
+
+Reads use `gh` JSON output (gh >= 2.96 exposes blockedBy, issueType,
+subIssues, parent, closedByPullRequestsReferences); review threads are the
+one GraphQL-only read.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+from foreman.config import Config
+from foreman.util import ForemanError, run, warn
+
+Runner = Callable[[list[str], str | None], tuple[int, str, str]]
+
+STATUS_MARKER = "<!-- foreman:unit-status -->"
+
+# Labels foreman idempotently ensures and is allowed to apply to its own PRs.
+FOREMAN_LABELS = {
+    "foreman-dispatched": ("1D76DB", "PR opened by foreman for a dispatched unit"),
+    "ready-to-merge": (
+        "5319E7",
+        "Green, adjudicated, mergeable - awaiting human merge",
+    ),
+}
+
+ISSUE_FIELDS = ",".join(
+    [
+        "number",
+        "title",
+        "body",
+        "state",
+        "stateReason",
+        "labels",
+        "milestone",
+        "url",
+        "issueType",
+        "parent",
+        "subIssues",
+        "blockedBy",
+        "closedByPullRequestsReferences",
+    ]
+)
+
+PR_LIST_FIELDS = (
+    "number,title,body,url,state,isDraft,headRefName,baseRefName,labels,author"
+)
+
+REVIEW_THREADS_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          comments(first: 50) {
+            nodes { author { login } body url }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+RESOLVE_THREAD_MUTATION = """
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
+    thread { id isResolved }
+  }
+}
+"""
+
+
+def _subprocess_runner(argv: list[str], input_text: str | None) -> tuple[int, str, str]:
+    proc = run(["gh", *argv], input_text=input_text, check=False)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+class Gh:
+    """Thin `gh` transport; tests inject a fake runner here."""
+
+    def __init__(self, runner: Runner | None = None):
+        self._runner = runner or _subprocess_runner
+
+    def call(
+        self, args: list[str], *, input_text: str | None = None, check: bool = True
+    ) -> str:
+        rc, out, err = self._runner(args, input_text)
+        if check and rc != 0:
+            raise ForemanError(
+                f"gh {' '.join(args)} failed ({rc}): {err.strip() or out.strip()}"
+            )
+        return out
+
+    def ok(self, args: list[str]) -> bool:
+        rc, _out, _err = self._runner(args, None)
+        return rc == 0
+
+    def json(self, args: list[str], *, input_text: str | None = None) -> Any:
+        out = self.call(args, input_text=input_text)
+        try:
+            return json.loads(out) if out.strip() else None
+        except json.JSONDecodeError as exc:
+            raise ForemanError(f"gh {' '.join(args)}: unparseable JSON output") from exc
+
+
+class GitHub:
+    """Repository-scoped GitHub facade enforcing the write contract."""
+
+    def __init__(self, gh: Gh, cfg: Config):
+        self.gh = gh
+        self.cfg = cfg
+        self.read_only = False
+        self._identity_ok = False
+        self._cache: dict[str, Any] = {}
+        self._issue_cache: dict[int, dict] = {}
+
+    # ── facts ────────────────────────────────────────────────────────
+
+    def repo(self) -> dict:
+        if "repo" not in self._cache:
+            self._cache["repo"] = self.gh.json(
+                [
+                    "repo",
+                    "view",
+                    "--json",
+                    "nameWithOwner,owner,name,defaultBranchRef,visibility",
+                ]
+            )
+        return self._cache["repo"]
+
+    def repo_slug(self) -> str:
+        return self.repo()["nameWithOwner"]
+
+    def owner(self) -> str:
+        return self.repo()["owner"]["login"]
+
+    def default_branch(self) -> str:
+        return self.repo()["defaultBranchRef"]["name"]
+
+    def viewer(self) -> str:
+        if "viewer" not in self._cache:
+            self._cache["viewer"] = self.gh.call(
+                ["api", "user", "--jq", ".login"]
+            ).strip()
+        return self._cache["viewer"]
+
+    # ── issue reads ──────────────────────────────────────────────────
+
+    def issue(self, number: int, *, fresh: bool = False) -> dict:
+        if fresh or number not in self._issue_cache:
+            self._issue_cache[number] = self.gh.json(
+                ["issue", "view", str(number), "--json", ISSUE_FIELDS]
+            )
+        return self._issue_cache[number]
+
+    def issue_comments(self, number: int) -> list[dict]:
+        """Comments with stable ids + author_association (REST, paginated)."""
+        out = self.gh.json(
+            [
+                "api",
+                f"repos/{self.repo_slug()}/issues/{number}/comments",
+                "--paginate",
+                "--slurp",
+            ]
+        )
+        comments: list[dict] = []
+        for page in out or []:
+            comments.extend(page)
+        return comments
+
+    def milestones(self, state: str = "open") -> list[dict]:
+        return (
+            self.gh.json(
+                [
+                    "api",
+                    f"repos/{self.repo_slug()}/milestones?state={state}&per_page=100",
+                ]
+            )
+            or []
+        )
+
+    def resolve_milestone(self, ident: str) -> dict:
+        """Accept a milestone number or exact title; return the milestone."""
+        for ms in self.milestones(state="all"):
+            if str(ms["number"]) == str(ident) or ms["title"] == ident:
+                return ms
+        raise ForemanError(f"milestone not found: {ident}")
+
+    def milestone_issue_numbers(self, title: str) -> list[int]:
+        rows = (
+            self.gh.json(
+                [
+                    "issue",
+                    "list",
+                    "--milestone",
+                    title,
+                    "--state",
+                    "all",
+                    "--limit",
+                    "500",
+                    "--json",
+                    "number",
+                ]
+            )
+            or []
+        )
+        return [row["number"] for row in rows]
+
+    # ── PR reads ─────────────────────────────────────────────────────
+
+    def prs(
+        self, *, label: str | None = None, head: str | None = None, state: str = "open"
+    ) -> list[dict]:
+        args = [
+            "pr",
+            "list",
+            "--state",
+            state,
+            "--limit",
+            "200",
+            "--json",
+            PR_LIST_FIELDS,
+        ]
+        if label:
+            args += ["--label", label]
+        if head:
+            args += ["--head", head]
+        return self.gh.json(args) or []
+
+    def pr_view(self, number: int, fields: str) -> dict:
+        return self.gh.json(["pr", "view", str(number), "--json", fields])
+
+    def pr_status(self, number: int) -> dict:
+        return self.pr_view(
+            number,
+            "number,title,body,url,state,isDraft,merged,mergedAt,author,labels,"
+            "headRefName,headRefOid,baseRefName,mergeable,mergeStateStatus,statusCheckRollup",
+        )
+
+    def review_threads(self, number: int) -> list[dict]:
+        out = self.gh.json(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={REVIEW_THREADS_QUERY}",
+                "-F",
+                f"owner={self.owner()}",
+                "-F",
+                f"name={self.repo()['name']}",
+                "-F",
+                f"number={number}",
+            ]
+        )
+        try:
+            return out["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+        except (KeyError, TypeError):
+            warn(f"review threads: unexpected GraphQL shape for PR #{number}")
+            return []
+
+    def branch_exists_remote(self, branch: str) -> bool:
+        return self.gh.ok(["api", f"repos/{self.repo_slug()}/branches/{branch}"])
+
+    def run_log_failed(self, run_url: str) -> str:
+        """Failed-step log excerpt for an Actions run URL (best effort)."""
+        run_id = run_url.rstrip("/").split("/")[-1]
+        if not run_id.isdigit():
+            return ""
+        rc, out, _err = self.gh._runner(["run", "view", run_id, "--log-failed"], None)
+        return out[-20000:] if rc == 0 else ""
+
+    # ── write guard ──────────────────────────────────────────────────
+
+    def _assert_writable(self, action: str) -> None:
+        if self.read_only:
+            raise ForemanError(
+                f"write contract: '{action}' attempted in read-only mode"
+            )
+        if not self._identity_ok:
+            expected = self.cfg.expected_login
+            if expected:
+                actual = self.viewer()
+                if actual != expected:
+                    raise ForemanError(
+                        f"identity assertion failed: gh is authenticated as '{actual}' "
+                        f"but config expects '{expected}' — refusing to write"
+                    )
+            self._identity_ok = True
+
+    # ── guarded writes (the ENTIRE mutation surface) ─────────────────
+
+    def ensure_labels(self) -> None:
+        self._assert_writable("ensure labels")
+        for name, (color, desc) in FOREMAN_LABELS.items():
+            self.gh.call(
+                [
+                    "label",
+                    "create",
+                    name,
+                    "--color",
+                    color,
+                    "--description",
+                    desc,
+                    "--force",
+                ]
+            )
+
+    def create_pr(
+        self, *, title: str, body: str, head: str, base: str, labels: list[str]
+    ) -> str:
+        self._assert_writable("create PR")
+        args = [
+            "pr",
+            "create",
+            "--title",
+            title,
+            "--body-file",
+            "-",
+            "--head",
+            head,
+            "--base",
+            base,
+        ]
+        for label in labels:
+            args += ["--label", label]
+        out = self.gh.call(args, input_text=body)
+        return out.strip().splitlines()[-1] if out.strip() else ""
+
+    def _own_pr_guard(self, number: int, action: str) -> dict:
+        pr = self.pr_view(number, "number,author,labels,body")
+        if pr["author"]["login"] != self.viewer():
+            raise ForemanError(
+                f"write contract: '{action}' on PR #{number} not authored by foreman"
+            )
+        return pr
+
+    def edit_own_pr_body(self, number: int, body: str) -> None:
+        self._assert_writable("edit own PR body")
+        self._own_pr_guard(number, "edit body")
+        self.gh.call(["pr", "edit", str(number), "--body-file", "-"], input_text=body)
+
+    def label_own_pr(
+        self,
+        number: int,
+        *,
+        add: list[str] | None = None,
+        remove: list[str] | None = None,
+    ) -> None:
+        self._assert_writable("label own PR")
+        self._own_pr_guard(number, "label")
+        for name in add or []:
+            if name not in FOREMAN_LABELS:
+                raise ForemanError(
+                    f"write contract: label '{name}' outside the foreman namespace"
+                )
+        args = ["pr", "edit", str(number)]
+        for name in add or []:
+            args += ["--add-label", name]
+        for name in remove or []:
+            args += ["--remove-label", name]
+        if len(args) > 3:
+            self.gh.call(args)
+
+    def comment_own_pr(self, number: int, body: str) -> None:
+        self._assert_writable("comment on own PR")
+        self._own_pr_guard(number, "comment")
+        self.gh.call(
+            ["pr", "comment", str(number), "--body-file", "-"], input_text=body
+        )
+
+    def upsert_status_comment(self, issue_number: int, body: str) -> None:
+        """Create or edit-in-place the single foreman status comment per unit."""
+        self._assert_writable("upsert status comment")
+        if STATUS_MARKER not in body:
+            raise ForemanError("status comment body must carry the foreman marker")
+        me = self.viewer()
+        for comment in self.issue_comments(issue_number):
+            author = (comment.get("user") or {}).get("login", "")
+            # Only ever edit a comment foreman itself authored AND marked.
+            if STATUS_MARKER in (comment.get("body") or "") and author == me:
+                self.gh.call(
+                    [
+                        "api",
+                        "--method",
+                        "PATCH",
+                        f"repos/{self.repo_slug()}/issues/comments/{comment['id']}",
+                        "-f",
+                        "body=@-",
+                    ],
+                    input_text=body,
+                )
+                return
+        self.gh.call(
+            [
+                "api",
+                "--method",
+                "POST",
+                f"repos/{self.repo_slug()}/issues/{issue_number}/comments",
+                "-f",
+                "body=@-",
+            ],
+            input_text=body,
+        )
+
+    def post_preflight_correction(
+        self, issue_number: int, body: str, *, human_approved: bool
+    ) -> None:
+        """The ONLY general issue-comment write — gated on explicit human approval."""
+        if not human_approved:
+            raise ForemanError(
+                "write contract: preflight corrections require human approval"
+            )
+        self._assert_writable("post approved preflight correction")
+        self.gh.call(
+            [
+                "api",
+                "--method",
+                "POST",
+                f"repos/{self.repo_slug()}/issues/{issue_number}/comments",
+                "-f",
+                "body=@-",
+            ],
+            input_text=body,
+        )
+
+    def resolve_review_thread(self, thread_id: str) -> None:
+        self._assert_writable("resolve dispositioned review thread")
+        self.gh.json(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={RESOLVE_THREAD_MUTATION}",
+                "-F",
+                f"threadId={thread_id}",
+            ]
+        )

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/graph.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/graph.py
@@ -1,0 +1,279 @@
+"""Units, dependency edges, cycles, waves — and deterministic doneness.
+
+A unit is a parent issue (its sub-issues ride along as the internal task
+list). Edges come from native `blocked-by` (primary) or a `Depends-on: #n`
+body trailer (fallback); both present and disagreeing fails loud.
+
+Doneness is the hardened A3 rule: a foreman-managed dependency counts as
+satisfied only when its issue is closed AND a marker-carrying foreman PR
+merged into the discovered default branch; an external dependency counts
+when closed as completed (not_planned needs an explicit human override).
+"""
+
+from __future__ import annotations
+
+import graphlib
+import re
+from dataclasses import dataclass, field
+
+from foreman import inputs as inputs_mod
+from foreman.config import Config
+from foreman.github import GitHub
+from foreman.util import ForemanError
+
+DEPENDS_ON_RE = re.compile(
+    r"^depends-on:\s*(?P<refs>#\d+(?:\s*,\s*#\d+)*)\s*$", re.I | re.M
+)
+MARKER_RE = re.compile(r"<!--\s*foreman:unit=#(?P<number>\d+)\b[^>]*-->")
+
+
+@dataclass
+class Unit:
+    number: int
+    title: str
+    state: str
+    state_reason: str | None
+    body: str
+    url: str
+    labels: list[str]
+    issue_type: str | None
+    milestone: str | None
+    parent: int | None
+    sub_issues: list[dict] = field(default_factory=list)
+    blocked_by: list[int] = field(default_factory=list)
+    inputs: inputs_mod.UnitInputs | None = None
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def open(self) -> bool:
+        return self.state.upper() == "OPEN"
+
+
+@dataclass
+class Target:
+    """The resolved dispatch target: units + edges + context."""
+
+    label: str  # human description, e.g. "milestone 'M4'" or "issue #12"
+    units: dict[int, Unit]
+    external_deps: set[int]
+    milestone: str | None = None
+    mode: str = "labels"  # resolved input-source mode (fields | labels)
+
+
+def _unit_from_issue(issue: dict) -> Unit:
+    return Unit(
+        number=issue["number"],
+        title=issue.get("title") or "",
+        state=issue.get("state") or "OPEN",
+        state_reason=issue.get("stateReason"),
+        body=issue.get("body") or "",
+        url=issue.get("url") or "",
+        labels=[entry["name"] for entry in issue.get("labels") or []],
+        issue_type=(issue.get("issueType") or {}).get("name"),
+        milestone=(issue.get("milestone") or {}).get("title"),
+        parent=(issue.get("parent") or {}).get("number"),
+    )
+
+
+def _dependency_numbers(issue: dict, unit: Unit) -> list[int]:
+    native = [entry["number"] for entry in issue.get("blockedBy") or []]
+    match = DEPENDS_ON_RE.search(unit.body)
+    trailer = (
+        [int(ref.strip().lstrip("#")) for ref in match.group("refs").split(",")]
+        if match
+        else []
+    )
+    if native and trailer and set(native) != set(trailer):
+        unit.errors.append(
+            f"#{unit.number}: native blocked-by ({sorted(native)}) disagrees with "
+            f"Depends-on trailer ({sorted(trailer)}) — fix one source"
+        )
+        return sorted(set(native))
+    return sorted(set(native or trailer))
+
+
+def load_target(
+    gh: GitHub, cfg: Config, *, milestone: str | None = None, issue: int | None = None
+) -> Target:
+    if bool(milestone) == bool(issue):
+        raise ForemanError("exactly one of --milestone or --issue is required")
+
+    issues: dict[int, dict] = {}
+    if issue:
+        root = gh.issue(issue)
+        issues[root["number"]] = root
+        for sub in root.get("subIssues") or []:
+            issues[sub["number"]] = gh.issue(sub["number"])
+        label = f"issue #{issue}"
+        ms_title = None
+    else:
+        ms = gh.resolve_milestone(milestone or "")
+        ms_title = ms["title"]
+        for number in gh.milestone_issue_numbers(ms_title):
+            issues[number] = gh.issue(number)
+        label = f"milestone '{ms_title}' (#{ms['number']})"
+
+    # Parent-unit granularity: an issue whose parent is also in the target set
+    # is a sub-issue of that unit, not a unit of its own.
+    units: dict[int, Unit] = {}
+    for number, data in issues.items():
+        parent = (data.get("parent") or {}).get("number")
+        if parent and parent in issues:
+            continue
+        units[number] = _unit_from_issue(data)
+
+    for unit in units.values():
+        data = issues[unit.number]
+        subs = []
+        for ref in data.get("subIssues") or []:
+            sub_number = ref["number"]
+            subs.append(issues.get(sub_number) or gh.issue(sub_number))
+        unit.sub_issues = sorted(subs, key=lambda entry: entry["number"])
+        unit.blocked_by = _dependency_numbers(data, unit)
+
+    external: set[int] = set()
+    for unit in units.values():
+        for dep in unit.blocked_by:
+            if dep not in units:
+                external.add(dep)
+                unit.warnings.append(
+                    f"#{unit.number}: dependency #{dep} is outside the target set "
+                    "(external — ready only when satisfied)"
+                )
+    return Target(label=label, units=units, external_deps=external, milestone=ms_title)
+
+
+def detect_cycle(target: Target) -> list[int] | None:
+    sorter: graphlib.TopologicalSorter = graphlib.TopologicalSorter()
+    for unit in target.units.values():
+        internal = [dep for dep in unit.blocked_by if dep in target.units]
+        sorter.add(unit.number, *internal)
+    try:
+        sorter.prepare()
+    except graphlib.CycleError as exc:
+        return list(exc.args[1])
+    return None
+
+
+def waves(target: Target) -> list[list[int]]:
+    """Topological waves over internal edges (visualization + merge order)."""
+    sorter: graphlib.TopologicalSorter = graphlib.TopologicalSorter()
+    for unit in target.units.values():
+        sorter.add(
+            unit.number, *[dep for dep in unit.blocked_by if dep in target.units]
+        )
+    sorter.prepare()
+    result: list[list[int]] = []
+    while sorter.is_active():
+        batch = sorted(sorter.get_ready())
+        result.append(batch)
+        sorter.done(*batch)
+    return result
+
+
+# ── doneness ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class Doneness:
+    satisfied: bool
+    how: str
+    warnings: list[str] = field(default_factory=list)
+
+
+def foreman_prs_for_issue(gh: GitHub, cfg: Config, number: int) -> list[dict]:
+    """Closing PRs that carry this unit's foreman marker, with merge facts."""
+    issue = gh.issue(number)
+    marked = []
+    for ref in issue.get("closedByPullRequestsReferences") or []:
+        pr = gh.pr_view(
+            ref["number"],
+            "number,url,body,merged,mergedAt,baseRefName,headRefName,author,state",
+        )
+        match = MARKER_RE.search(pr.get("body") or "")
+        if match and int(match.group("number")) == number:
+            marked.append(pr)
+    return marked
+
+
+def _branch_matches_unit(cfg: Config, branch: str, number: int) -> bool:
+    return bool(re.match(rf"^{re.escape(cfg.branch_prefix)}/[^/]+/{number}-", branch))
+
+
+def dependency_satisfied(
+    gh: GitHub,
+    cfg: Config,
+    number: int,
+    *,
+    inputs: inputs_mod.UnitInputs | None = None,
+    mode: str | None = None,
+) -> Doneness:
+    issue = gh.issue(number)
+    if inputs is None and mode:
+        inputs = inputs_mod.resolve(gh, cfg, issue, mode)
+    if inputs is not None and inputs.satisfied_override:
+        return Doneness(True, "human override (foreman=satisfied)")
+    if (issue.get("state") or "OPEN").upper() != "CLOSED":
+        return Doneness(False, "open")
+
+    marked_prs = foreman_prs_for_issue(gh, cfg, number)
+    if marked_prs and not (inputs is not None and inputs.external):
+        expected_author = cfg.expected_login or gh.viewer()
+        default_branch = gh.default_branch()
+        for pr in marked_prs:
+            problems = []
+            if not pr.get("merged"):
+                problems.append("not merged")
+            if pr.get("baseRefName") != default_branch:
+                problems.append(
+                    f"base is {pr.get('baseRefName')}, not {default_branch}"
+                )
+            if (pr.get("author") or {}).get("login") != expected_author:
+                problems.append(f"author is {(pr.get('author') or {}).get('login')}")
+            if not _branch_matches_unit(cfg, pr.get("headRefName") or "", number):
+                problems.append(
+                    f"head branch {pr.get('headRefName')!r} not a foreman attempt"
+                )
+            if not problems:
+                return Doneness(
+                    True, f"foreman PR #{pr['number']} merged into {default_branch}"
+                )
+        return Doneness(
+            False,
+            "closed, but no foreman PR satisfies the merge chain",
+            warnings=[
+                f"#{number}: closed with foreman-marked PR(s) "
+                f"({', '.join('#' + str(pr['number']) for pr in marked_prs)}) that did not "
+                "merge cleanly into the default branch — resolve manually or mark "
+                "foreman:satisfied"
+            ],
+        )
+
+    reason = (issue.get("stateReason") or "").lower()
+    if reason == "not_planned" and not cfg.allow_not_planned:
+        return Doneness(
+            False,
+            "closed as not_planned",
+            warnings=[
+                f"#{number}: closed as not planned — remove the dependency edge or mark it "
+                "foreman:satisfied if this is intentional"
+            ],
+        )
+    how = (
+        "external: closed as completed"
+        if reason != "not_planned"
+        else "external: not_planned (allowed by config)"
+    )
+    return Doneness(True, how)
+
+
+def prepare_target(
+    gh: GitHub, cfg: Config, *, milestone: str | None = None, issue: int | None = None
+) -> Target:
+    """Load the target and resolve human inputs for every unit."""
+    target = load_target(gh, cfg, milestone=milestone, issue=issue)
+    target.mode = inputs_mod.detect_mode(gh, cfg)
+    for unit in target.units.values():
+        unit.inputs = inputs_mod.resolve(gh, cfg, gh.issue(unit.number), target.mode)
+    return target

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/inputs.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/inputs.py
@@ -1,0 +1,188 @@
+"""Resolve human inputs per unit: arming, backend, holds, overrides, type.
+
+Primary mechanism is the org-level `foreman` issue custom field (issue fields
+are org-only as of their 2026-07 GA); the fallback for personal-account repos
+is `foreman:*` labels. `inputs = auto` probes availability once per run.
+Two disagreeing sources on one issue fail loud — never guess.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from foreman.config import Config
+from foreman.github import GitHub
+from foreman.util import warn
+
+LABEL_PREFIX = "foreman:"
+# Values with fixed meaning; anything else is treated as a backend name
+# (e.g. `claude`, `mock`), which implies approval for that backend.
+HOLD = "hold"
+APPROVED = "approved"
+SATISFIED = "satisfied"  # human override: treat this issue as a satisfied dependency
+EXTERNAL = "external"  # human marker: not foreman-managed; closed == satisfied
+_MEANINGS = {HOLD, APPROVED, SATISFIED, EXTERNAL}
+
+FIELD_NAME = "foreman"
+FIELD_BUDGET = "foreman-budget-usd"
+FIELD_TIMEOUT = "foreman-timeout-min"
+
+TYPE_LABEL_PREFIX = "type:"
+
+
+@dataclass
+class UnitInputs:
+    mode: str = "labels"
+    armed: bool = False
+    backend: str | None = None  # None = repo default
+    hold: bool = False
+    satisfied_override: bool = False
+    external: bool = False
+    budget_usd: float | None = None
+    timeout_min: int | None = None
+    commit_type: str = "feat"
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+def detect_mode(gh: GitHub, cfg: Config) -> str:
+    """auto probes org issue-field availability once; explicit modes win."""
+    if cfg.inputs in ("fields", "labels"):
+        return cfg.inputs
+    if gh.gh.ok(["api", f"orgs/{gh.owner()}/issue-fields"]):
+        return "fields"
+    return "labels"
+
+
+def field_values(gh: GitHub, issue_number: int) -> dict[str, object]:
+    """Field name -> value for one issue; tolerant of shape drift, warns once."""
+    rc_ok = gh.gh.ok(
+        ["api", f"repos/{gh.repo_slug()}/issues/{issue_number}/field-values"]
+    )
+    if not rc_ok:
+        return {}
+    raw = gh.gh.json(
+        ["api", f"repos/{gh.repo_slug()}/issues/{issue_number}/field-values"]
+    )
+    values: dict[str, object] = {}
+    for item in raw or []:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name") or (item.get("field") or {}).get("name")
+        value = item.get("value")
+        if isinstance(value, dict):
+            value = value.get("name") or value.get("value")
+        if name:
+            values[str(name)] = value
+    return values
+
+
+def _foreman_values_from_labels(labels: list[str]) -> list[str]:
+    return [
+        name[len(LABEL_PREFIX) :]
+        for name in labels
+        if name.startswith(LABEL_PREFIX) and name != LABEL_PREFIX
+    ]
+
+
+def resolve(gh: GitHub, cfg: Config, issue: dict, mode: str) -> UnitInputs:
+    out = UnitInputs(mode=mode)
+    number = issue["number"]
+    labels = [entry["name"] for entry in issue.get("labels") or []]
+    label_values = _foreman_values_from_labels(labels)
+
+    if mode == "fields":
+        if label_values:
+            out.errors.append(
+                f"#{number}: dual-sourced input — foreman:* labels present in fields mode "
+                f"({', '.join(sorted(label_values))}); remove one source"
+            )
+        values = field_values(gh, number)
+        raw = values.get(FIELD_NAME)
+        arm_values = [str(raw)] if raw else []
+        budget = values.get(FIELD_BUDGET)
+        timeout = values.get(FIELD_TIMEOUT)
+        if budget is not None:
+            try:
+                out.budget_usd = float(budget)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                out.errors.append(
+                    f"#{number}: {FIELD_BUDGET} is not a number: {budget!r}"
+                )
+        if timeout is not None:
+            try:
+                out.timeout_min = int(timeout)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                out.errors.append(
+                    f"#{number}: {FIELD_TIMEOUT} is not a number: {timeout!r}"
+                )
+    else:
+        arm_values = label_values
+
+    backends = sorted({v for v in arm_values if v not in _MEANINGS})
+    if len(backends) > 1:
+        out.errors.append(
+            f"#{number}: conflicting backend selections: {', '.join(backends)}"
+        )
+    out.backend = backends[0] if len(backends) == 1 else None
+    out.hold = HOLD in arm_values
+    out.satisfied_override = SATISFIED in arm_values
+    out.external = EXTERNAL in arm_values
+    approved = APPROVED in arm_values or out.backend is not None
+    out.armed = (approved or not cfg.require_approval) and not out.hold
+    if cfg.require_approval and not approved and not out.hold:
+        out.warnings.append(f"#{number}: not armed (no foreman approval input)")
+
+    out.commit_type = _resolve_type(cfg, issue, labels, out)
+    return out
+
+
+def _resolve_type(cfg: Config, issue: dict, labels: list[str], out: UnitInputs) -> str:
+    number = issue["number"]
+    native = (issue.get("issueType") or {}).get("name")
+    native_mapped = None
+    if native:
+        native_mapped = cfg.type_map.get(native)
+        if native_mapped is None:
+            out.warnings.append(
+                f"#{number}: issue type '{native}' has no type_map entry; using default"
+            )
+    label_types = [
+        name[len(TYPE_LABEL_PREFIX) :]
+        for name in labels
+        if name.startswith(TYPE_LABEL_PREFIX)
+    ]
+    if len(label_types) > 1:
+        out.errors.append(
+            f"#{number}: multiple type: labels: {', '.join(sorted(label_types))}"
+        )
+    label_type = label_types[0] if len(label_types) == 1 else None
+
+    if native_mapped and label_type and native_mapped != label_type:
+        out.errors.append(
+            f"#{number}: issue type '{native}' (-> {native_mapped}) disagrees with "
+            f"label 'type:{label_type}' — remove one source"
+        )
+        return native_mapped
+    resolved = native_mapped or label_type
+    if not resolved:
+        out.warnings.append(
+            f"#{number}: no issue type or type: label; defaulting to '{cfg.default_type}'"
+        )
+        return cfg.default_type
+    return resolved
+
+
+def describe_mode(mode: str, cfg: Config) -> str:
+    arming = (
+        "explicit approval required"
+        if cfg.require_approval
+        else "default-armed (holds exclude)"
+    )
+    return f"inputs={mode} ({arming})"
+
+
+def warn_all(units_inputs: list[UnitInputs]) -> None:
+    for inp in units_inputs:
+        for message in inp.warnings:
+            warn(message)

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/pr.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/pr.py
@@ -1,0 +1,168 @@
+"""Deterministic PR opening: freshness gate, machine-readable markers,
+Conventional-Commit titles, Closes/Refs wiring, Handoff + Human-only-tasks
+sections. The agent never opens PRs — foreman does, after its own verify.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from foreman.backend import ResultContract
+from foreman.config import Config
+from foreman.github import GitHub
+from foreman.graph import Unit, dependency_satisfied
+from foreman.spec import spec_hash, trusted_comments
+from foreman.util import warn
+
+TITLE_RE = re.compile(
+    r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)]+)\))?(?P<bang>!)?: (?P<subject>.+)$"
+)
+MAX_TITLE = 100
+
+
+def marker(unit_number: int, spec_hash_hex: str, base_sha: str) -> str:
+    return (
+        f"<!-- foreman:unit=#{unit_number} spec-hash={spec_hash_hex} "
+        f"base={base_sha} schema=1 -->"
+    )
+
+
+@dataclass
+class Freshness:
+    ok: bool
+    problems: list[str] = field(default_factory=list)
+
+
+def freshness_check(
+    gh: GitHub,
+    cfg: Config,
+    unit: Unit,
+    *,
+    recorded_hash: str,
+    branch: str,
+    mode: str | None = None,
+) -> Freshness:
+    """Re-check eligibility + spec drift immediately before push/PR-create."""
+    problems: list[str] = []
+    issue = gh.issue(unit.number, fresh=True)
+    if (issue.get("state") or "").upper() != "OPEN":
+        problems.append("issue is no longer open")
+    fresh_unit_body = issue.get("body") or ""
+    comments, _ = trusted_comments(gh, cfg, unit.number)
+    check_unit = Unit(
+        number=unit.number,
+        title=issue.get("title") or unit.title,
+        state=issue.get("state") or "OPEN",
+        state_reason=issue.get("stateReason"),
+        body=fresh_unit_body,
+        url=unit.url,
+        labels=[entry["name"] for entry in issue.get("labels") or []],
+        issue_type=unit.issue_type,
+        milestone=unit.milestone,
+        parent=unit.parent,
+        sub_issues=[
+            gh.issue(sub["number"], fresh=True) for sub in issue.get("subIssues") or []
+        ],
+    )
+    if spec_hash(check_unit, comments) != recorded_hash:
+        problems.append(
+            "spec drifted since dispatch (issue/sub-issue/comment content changed)"
+        )
+    for dep in unit.blocked_by:
+        done = dependency_satisfied(gh, cfg, dep, mode=mode)
+        if not done.satisfied:
+            problems.append(f"dependency #{dep} regressed to unsatisfied ({done.how})")
+    existing = gh.prs(head=branch, state="open")
+    if existing:
+        problems.append(f"an open PR already exists for {branch}: {existing[0]['url']}")
+    return Freshness(ok=not problems, problems=problems)
+
+
+def pr_title(cfg: Config, unit: Unit, result: ResultContract) -> str:
+    commit_type = unit.inputs.commit_type if unit.inputs else cfg.default_type
+    proposed = (result.proposed_pr_title or "").strip()
+    match = TITLE_RE.match(proposed)
+    if match:
+        scope = f"({match.group('scope')})" if match.group("scope") else ""
+        title = f"{commit_type}{scope}: {match.group('subject')}"
+    else:
+        if proposed:
+            warn(f"#{unit.number}: proposed_pr_title not conventional; regenerating")
+        title = f"{commit_type}: {unit.title}"
+    if len(title) > MAX_TITLE:
+        title = title[: MAX_TITLE - 1].rstrip() + "…"
+    return title
+
+
+def pr_body(
+    cfg: Config,
+    unit: Unit,
+    result: ResultContract,
+    *,
+    human_tasks: list[str],
+    spec_hash_hex: str,
+    base_sha: str,
+) -> str:
+    lines: list[str] = []
+    lines.append(marker(unit.number, spec_hash_hex, base_sha))
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(result.summary.strip() or "_(no summary provided)_")
+    lines.append("")
+
+    lines.append("## Test evidence (acceptance criteria → tests)")
+    lines.append("")
+    lines.append(
+        "_Reviewing these tests is reviewing the spec interpretation — the mapping "
+        "below is the agent's claim, verified only for existence by CI._"
+    )
+    lines.append("")
+    for entry in result.ac_test_map:
+        tests = ", ".join(f"`{t}`" for t in entry.get("tests", [])) or "_none_"
+        lines.append(f"- {entry.get('criterion', '').strip()} → {tests}")
+    lines.append("")
+
+    close_word = "Refs" if human_tasks else "Closes"
+    if human_tasks:
+        lines.append("## Human-only tasks (this PR must NOT auto-close the parent)")
+        lines.append("")
+        for task in human_tasks:
+            lines.append(f"- [ ] {task}")
+        lines.append("")
+    lines.append(f"{close_word} #{unit.number}")
+    for sub in unit.sub_issues:
+        if (sub.get("state") or "").upper() == "OPEN":
+            lines.append(f"Closes #{sub['number']}")
+    lines.append("")
+
+    lines.append("## Handoff")
+    lines.append("")
+    lines.append(
+        result.handoff.strip() or "_(nothing downstream depends on internals here)_"
+    )
+    lines.append("")
+    lines.append("---")
+    lines.append(
+        f"_Opened by foreman after a green `{ ' '.join(cfg.verify_command) }` in the unit's "
+        "worktree. Merging is a human decision; foreman never merges._"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def open_pr(
+    gh: GitHub,
+    cfg: Config,
+    unit: Unit,
+    *,
+    title: str,
+    body: str,
+    branch: str,
+    base: str,
+) -> str:
+    gh.ensure_labels()
+    url = gh.create_pr(
+        title=title, body=body, head=branch, base=base, labels=["foreman-dispatched"]
+    )
+    return url

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/prompts/implementer-preamble.md
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/prompts/implementer-preamble.md
@@ -1,0 +1,76 @@
+# Foreman dispatch — operating rules
+
+You are a headless implementation agent. Foreman (a deterministic supervisor)
+dispatched you to deliver exactly one unit of work: issue `#%%UNIT_NUMBER%%`
+("%%UNIT_TITLE%%"). The full spec follows this preamble. Everything here is
+non-negotiable.
+
+## Boundaries (violations end the run)
+
+- Work ONLY inside this worktree, on the already-checked-out branch
+  `%%BRANCH%%`. Never switch branches, never touch `%%DEFAULT_BRANCH%%`.
+- NEVER merge anything, by any mechanism. Never push. Never open a PR —
+  foreman verifies your work first and opens the PR itself.
+- NEVER start background watchers, daemons, schedulers, or long-lived
+  processes. Run commands, read their output, finish.
+- Never bypass git hooks (`--no-verify` is forbidden); fix the underlying
+  issue instead.
+- Do not modify `.github/workflows/**` or repository settings. If the spec
+  genuinely requires a workflow change, record it in `human_tasks` in your
+  result and leave the workflow untouched — the push would be rejected anyway.
+- Never write to credential stores (1Password, keychains) or set deployment
+  environment variables.
+- Follow this repository's conventions: read `AGENTS.md` (or `CLAUDE.md`) in
+  the worktree root before writing code.
+
+## Delivery loop
+
+1. Read the full spec below: issue body, sub-issue bodies, and the trusted
+   human comments — comments carry approved corrections and AMEND the spec.
+2. Implement the unit as one coherent change. Sub-issues are your internal
+   task list; items tagged `[HUMAN]` are for humans — never attempt them,
+   list them in `human_tasks`.
+3. Tests: every `[CI]`-tagged acceptance criterion must map to at least one
+   named automated test. You will list this mapping in your result; it is
+   copied verbatim into the PR for reviewers.
+4. Commit as you go with Conventional Commits
+   (`%%COMMIT_TYPE%%(scope): subject`), referencing `#%%UNIT_NUMBER%%`.
+   Leave the worktree clean: no uncommitted or untracked files.
+5. Before finishing, run the full verification gate — `%%VERIFY_COMMAND%%` —
+   in the worktree and fix every failure. Foreman re-runs the same gate and
+   will not open a PR on red; your run just catches failures cheaply.
+6. Self-review your final diff against the spec before finishing. Check
+   follow-through: a fix applied to one call site must be applied to every
+   sibling site.
+
+## Escalation — never invent
+
+If the spec is ambiguous on a behavior-changing decision, do NOT pick an
+interpretation. Write the precise question to `BLOCKED.md` in the worktree
+root (do not commit it), write your result with `"status": "blocked"` and the
+question in `blocked_question`, and exit non-zero. Deterministic verification
+cannot catch a wrong-but-self-consistent invention — your own tests would
+pass.
+
+## Result contract (required)
+
+Before exiting, write JSON to `%%RESULT_FILE%%` (foreman schema-validates it;
+finishing without it counts as a crash):
+
+```json
+{
+  "schema": 1,
+  "status": "completed",
+  "summary": "What changed and why, 2-6 sentences, for the PR body.",
+  "handoff": "Contract for dependent units: new interfaces, invariants, gotchas.",
+  "human_tasks": ["Anything a human must do ([HUMAN] items, workflow edits, live verifications)"],
+  "proposed_pr_title": "%%COMMIT_TYPE%%(scope): one-line summary",
+  "ac_test_map": [
+    { "criterion": "the [CI] acceptance criterion text", "tests": ["path/to/test::name"] }
+  ],
+  "blocked_question": null
+}
+```
+
+For `"status": "blocked"`, only `schema`, `status`, and `blocked_question`
+are required.

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/prompts/preflight.md
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/prompts/preflight.md
@@ -1,0 +1,46 @@
+# Foreman preflight — critical spec analysis (read-only)
+
+You are a read-only analysis agent. Foreman is about to dispatch headless
+implementation agents against the units below (%%TARGET%%). Your job is to
+find everything a headless agent would trip over or silently invent through.
+You have read access to the live repository — verify claims against the code;
+do not speculate.
+
+You MUST NOT modify anything: no file edits, no git commands, no GitHub
+writes. Your entire output is a markdown report to stdout.
+
+Analyze for:
+
+1. **Stale references** — files, paths, ADR/doc numbers, APIs, or config keys
+   the specs mention that no longer match the repository. (Sequence-dependent
+   artifacts like "ADR 0007" are the classic: check what the next free number
+   actually is.)
+2. **Cross-issue contradictions** — two units specifying conflicting
+   behavior, naming, or file ownership; same-wave units likely to collide on
+   the same files.
+3. **Ambiguities** — behavior-changing decisions the spec leaves open that a
+   headless agent would have to invent through (it is instructed to BLOCK on
+   these; better to fix the spec now).
+4. **Undeclared human-only tasks** — steps requiring live-system access,
+   credentials, or judgment that are not tagged `[HUMAN]`.
+5. **Concurrent-activity collisions** — given the notice below, files or
+   artifacts other in-flight work may claim mid-run.
+
+Output format (exactly this structure):
+
+- A `# Preflight findings` section: numbered findings, each with the issue
+  number(s), the evidence (file/line or quote), and severity
+  (blocker / correction / note).
+- For every finding that warrants a spec correction, append a section headed
+  exactly `## DRAFT COMMENT FOR #<issue-number>` containing the comment body
+  you propose. Write it as a crisp spec amendment ("Correction: … use X, not
+  Y, because …"). A human reviews and posts these — draft them ready to ship.
+  Never draft edits to issue bodies; corrections travel as comments.
+
+## Concurrent activity notice
+
+%%CONCURRENT%%
+
+## Units under analysis
+
+%%UNITS%%

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/prompts/shepherd-adjudicate.md
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/prompts/shepherd-adjudicate.md
@@ -1,0 +1,34 @@
+# Foreman shepherd — adjudicate review findings
+
+Review bots left unresolved threads on your unit's PR (%%PR_URL%%, branch
+`%%BRANCH%%`, unit `#%%UNIT_NUMBER%%`). Adjudicate EVERY thread listed below.
+You know the spec; bots don't always — blanket-accepting is prohibited, and
+so is blanket-dismissing.
+
+Rules: work only in this worktree on `%%BRANCH%%`; never merge; never push
+(foreman pushes); never edit or delete anyone else's comments; never touch
+`.github/workflows/**`.
+
+For each thread, exactly one disposition:
+
+- **Apply** — the finding is right: fix it, commit (Conventional Commit
+  referencing `#%%UNIT_NUMBER%%`), reply to the thread with a one-line
+  `applied in <short-sha>` note, and resolve the thread.
+- **Decline with reasoning** — the finding is wrong or out of scope: reply
+  with brief technical reasoning. Deterministic facts beat bot speculation —
+  cite the passing typecheck, the spec text, the API docs. Then resolve the
+  thread.
+
+To reply to a specific review thread use:
+`gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:"<id>", body:"..."}) { comment { id } } }'`
+and to resolve it:
+`gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"<id>"}) { thread { isResolved } } }'`
+
+After all threads: if you made commits, run `%%VERIFY_COMMAND%%` until green.
+Leave the worktree clean and exit 0. Foreman verifies thread completeness
+deterministically afterwards — an undispositioned thread means this run
+failed.
+
+## Unresolved threads
+
+%%THREADS%%

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/prompts/shepherd-ci-fix.md
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/prompts/shepherd-ci-fix.md
@@ -1,0 +1,27 @@
+# Foreman shepherd — repair red CI
+
+CI is red on your unit's PR (%%PR_URL%%, branch `%%BRANCH%%`, unit
+`#%%UNIT_NUMBER%%`). The deterministic classifier ruled this failure
+mechanical (not environmental), so it is yours to fix. The failing excerpt is
+below.
+
+Rules (unchanged from dispatch): work only in this worktree on `%%BRANCH%%`;
+never merge, never push (foreman pushes after you finish), never touch
+`.github/workflows/**`, never bypass hooks, no background processes.
+
+Loop:
+
+1. Reproduce the failure locally where feasible; fix the root cause. Never
+   weaken or delete a test to make it pass — if the test is genuinely wrong,
+   fix it and say why in the commit message.
+2. Run `%%VERIFY_COMMAND%%` until green.
+3. Commit with a Conventional Commit referencing `#%%UNIT_NUMBER%%`. Leave
+   the worktree clean and exit 0. Foreman pushes with lease.
+
+If the failure is not actually fixable from code (infrastructure, billing,
+external service), say so plainly in your final message and exit non-zero —
+foreman will escalate to the human queue instead of retrying you.
+
+## Failing checks
+
+%%FAILURE_EXCERPT%%

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/prompts/shepherd-rebase.md
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/prompts/shepherd-rebase.md
@@ -1,0 +1,29 @@
+# Foreman shepherd — conflicted rebase
+
+A sibling PR merged into `%%DEFAULT_BRANCH%%` and your unit's branch
+`%%BRANCH%%` (PR %%PR_URL%%, unit `#%%UNIT_NUMBER%%`) now conflicts. A
+`git merge-tree` dry run enumerated the conflicting paths below.
+
+Rules: work only in this worktree; never merge PRs; never push (foreman
+force-pushes with lease after verification); no `--no-verify`.
+
+Procedure — rebase, never merge-main (one update mechanism):
+
+1. `git fetch` is already done. Run
+   `git rebase %%DEFAULT_BRANCH%%` against the remote-tracking ref foreman
+   prepared, resolving each conflict **additively**: both sides' intent must
+   survive. When in doubt, prefer keeping the other side's semantics and
+   re-applying this branch's change on top.
+2. Regenerated artifacts (lockfiles, codegen output, schema snapshots) must
+   be regenerated via their tooling — never hand-merge generated files.
+3. Run `%%VERIFY_COMMAND%%` until green.
+4. Leave the worktree clean (rebase completed, nothing uncommitted) and
+   exit 0.
+
+If a conflict cannot be resolved without a behavior-changing decision the
+spec does not settle, stop, explain the decision needed in your final
+message, and exit non-zero — foreman escalates it.
+
+## Conflicting paths (merge-tree dry run)
+
+%%CONFLICTS%%

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/report.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/report.py
@@ -130,8 +130,8 @@ def human_queue(
     if merge_order:
         lines.append("")
         lines.append("  Pending merges (suggested dependency-aware order):")
-        for number, url in merge_order:
-            lines.append(f"    1. #{number}  {url}")
+        for position, (number, url) in enumerate(merge_order, 1):
+            lines.append(f"    {position}. #{number}  {url}")
     if blocked:
         lines.append("")
         lines.append("  Blocked questions:")

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/report.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/report.py
@@ -1,0 +1,154 @@
+"""Human-facing output: summary tables, the per-unit status comment
+(single, marker-identified, edited in place), and the consolidated
+human-action queue. Display only — never read back for decisions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from foreman.github import STATUS_MARKER, GitHub
+from foreman.graph import Unit
+from foreman.util import utc_now_iso, warn
+
+
+def table(headers: list[str], rows: list[list[str]]) -> str:
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for index, cell in enumerate(row):
+            widths[index] = max(widths[index], len(cell))
+
+    def fmt(cells: list[str]) -> str:
+        return "  ".join(
+            cell.ljust(widths[index]) for index, cell in enumerate(cells)
+        ).rstrip()
+
+    lines = [fmt(headers), fmt(["-" * w for w in widths])]
+    lines.extend(fmt(row) for row in rows)
+    return "\n".join(lines)
+
+
+@dataclass
+class UnitStatus:
+    """One unit's snapshot for the status comment + summary row."""
+
+    unit: Unit
+    state: str  # dispatched | pr-open | ready-to-merge | failed | blocked | held | waiting | merged
+    branch: str = ""
+    pr_url: str = ""
+    checks: str = ""
+    blockers: list[str] = field(default_factory=list)
+    human_tasks: list[str] = field(default_factory=list)
+    blocked_question: str = ""
+    detail: str = ""
+
+
+STATE_ICONS = {
+    "dispatched": "🚧",
+    "pr-open": "🔃",
+    "ready-to-merge": "✅",
+    "failed": "⚠️",
+    "blocked": "❓",
+    "held": "⏸",
+    "waiting": "⏳",
+    "merged": "🎉",
+    "skipped": "⏭",
+    "not-armed": "🔒",
+}
+
+
+def status_comment_body(status: UnitStatus) -> str:
+    icon = STATE_ICONS.get(status.state, "•")
+    lines = [
+        STATUS_MARKER,
+        "",
+        f"**Foreman unit status: {icon} {status.state}**",
+        "",
+    ]
+    if status.branch:
+        lines.append(f"- Branch: `{status.branch}`")
+    if status.pr_url:
+        lines.append(f"- PR: {status.pr_url}")
+    if status.checks:
+        lines.append(f"- Checks: {status.checks}")
+    for blocker in status.blockers:
+        lines.append(f"- Blocker: {blocker}")
+    if status.blocked_question:
+        lines.append("")
+        lines.append("**BLOCKED — needs a human answer:**")
+        lines.append("")
+        lines.append("> " + status.blocked_question.replace("\n", "\n> "))
+    if status.human_tasks:
+        lines.append("")
+        lines.append("**Human-only tasks (foreman never attempts these):**")
+        lines.append("")
+        for task in status.human_tasks:
+            lines.append(f"- [ ] {task}")
+    if status.detail:
+        lines.append("")
+        lines.append(status.detail)
+    lines.append("")
+    lines.append(
+        f"_Updated {utc_now_iso()} — this comment is edited in place by foreman; "
+        "it is display-only and never read back for decisions._"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def update_status_comment(gh: GitHub, status: UnitStatus) -> None:
+    try:
+        gh.upsert_status_comment(status.unit.number, status_comment_body(status))
+    except Exception as exc:  # display-only: never fail a run over a comment
+        warn(f"#{status.unit.number}: status comment update failed: {exc}")
+
+
+def summary_table(statuses: list[UnitStatus]) -> str:
+    rows = []
+    for status in statuses:
+        icon = STATE_ICONS.get(status.state, "•")
+        rows.append(
+            [
+                f"#{status.unit.number}",
+                f"{icon} {status.state}",
+                status.branch or "-",
+                status.pr_url or "-",
+                status.detail[:60] if status.detail else "-",
+            ]
+        )
+    return table(["unit", "status", "branch", "pr", "detail"], rows)
+
+
+def human_queue(
+    *,
+    merge_order: list[tuple[int, str]],
+    human_tasks: dict[int, list[str]],
+    blocked: dict[int, str],
+    environmental: dict[int, str],
+) -> str:
+    """The consolidated 'what needs a human' list (most-repeated chore in M4)."""
+    lines: list[str] = ["Human action queue:"]
+    if merge_order:
+        lines.append("")
+        lines.append("  Pending merges (suggested dependency-aware order):")
+        for number, url in merge_order:
+            lines.append(f"    1. #{number}  {url}")
+    if blocked:
+        lines.append("")
+        lines.append("  Blocked questions:")
+        for number, question in sorted(blocked.items()):
+            first = question.strip().splitlines()[0] if question.strip() else ""
+            lines.append(f"    - #{number}: {first}")
+    if human_tasks:
+        lines.append("")
+        lines.append("  Human-only tasks:")
+        for number, tasks in sorted(human_tasks.items()):
+            for task in tasks:
+                lines.append(f"    - #{number}: {task}")
+    if environmental:
+        lines.append("")
+        lines.append("  Environmental failures (fix the environment, not the code):")
+        for number, detail in sorted(environmental.items()):
+            lines.append(f"    - #{number}: {detail}")
+    if len(lines) == 1:
+        lines.append("  (empty — nothing waiting on a human)")
+    return "\n".join(lines)

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/shepherd.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/shepherd.py
@@ -1,0 +1,387 @@
+"""Shepherd: keep open foreman PRs healthy until a human merges them.
+
+Deterministic triggers → bounded agent actions:
+  red CI      → classify by signature first (environmental: retry once via
+                empty commit, then human queue; quota_wait: idle; otherwise
+                mechanical: resume the agent with the failing excerpt)
+  behind/dirty→ merge-tree dry-run; clean rebases are mechanical, conflicted
+                ones go to the agent (rebase additively, re-verify, push)
+  unresolved review-bot threads → resume the agent to adjudicate each finding
+                (apply or decline-with-reasoning; blanket-accepting prohibited)
+  green ∧ adjudicated ∧ mergeable ∧ not behind → label ready-to-merge and
+                report a dependency-aware suggested merge order.
+
+Foreman never merges. `gh run rerun` is assumed unavailable to the bot token;
+the CI retrigger primitive is an empty commit.
+"""
+
+from __future__ import annotations
+
+import graphlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from foreman import backend as backend_mod
+from foreman import signatures as signatures_mod, spec, verify, worktree
+from foreman.config import Config
+from foreman.dispatch import RETRIGGER_SUBJECT
+from foreman.github import GitHub
+from foreman.graph import MARKER_RE
+from foreman.util import info, warn, write_text
+
+MAX_AGENT_ACTIONS_PER_PR = 2  # per shepherd run; watch ticks give more rounds
+
+
+@dataclass
+class PrWork:
+    number: int
+    unit_number: int
+    branch: str
+    url: str
+    title: str
+    state: str = (
+        "healthy"  # healthy | fixed | rebased | adjudicated | waiting | escalated | settling | ready
+    )
+    detail: str = ""
+    actions: int = 0
+
+
+@dataclass
+class ShepherdReport:
+    worked: list[PrWork] = field(default_factory=list)
+    ready_order: list[tuple[int, str]] = field(default_factory=list)
+    environmental: dict[int, str] = field(default_factory=dict)
+    waiting: dict[int, str] = field(default_factory=dict)
+    cost_usd: float = 0.0
+
+
+def open_foreman_prs(gh: GitHub) -> list[dict]:
+    prs = []
+    for pr in gh.prs(label="foreman-dispatched", state="open"):
+        match = MARKER_RE.search(pr.get("body") or "")
+        if match:
+            pr["_unit"] = int(match.group("number"))
+            prs.append(pr)
+    return prs
+
+
+def classify_checks(rollup: list[dict] | None) -> tuple[str, list[dict]]:
+    """(green|red|pending, failed contexts) from a statusCheckRollup list."""
+    failed: list[dict] = []
+    pending = False
+    for ctx in rollup or []:
+        status = (ctx.get("status") or "").upper()
+        conclusion = (ctx.get("conclusion") or ctx.get("state") or "").upper()
+        if conclusion in (
+            "FAILURE",
+            "TIMED_OUT",
+            "ACTION_REQUIRED",
+            "CANCELLED",
+            "ERROR",
+        ):
+            failed.append(ctx)
+        elif status in ("QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED") or (
+            not conclusion and status not in ("COMPLETED",)
+        ):
+            pending = True
+    if failed:
+        return "red", failed
+    if pending:
+        return "pending", []
+    return "green", []
+
+
+def _failure_text(gh: GitHub, failed: list[dict]) -> str:
+    parts = []
+    for ctx in failed[:5]:
+        name = ctx.get("name") or ctx.get("context") or "check"
+        parts.append(f"### Failing check: {name}")
+        url = ctx.get("detailsUrl") or ctx.get("targetUrl") or ""
+        if "/actions/runs/" in url:
+            log = gh.run_log_failed(url)
+            if log:
+                parts.append("```text\n" + log[-8000:] + "\n```")
+        elif url:
+            parts.append(f"(external check: {url})")
+    return "\n\n".join(parts)
+
+
+def _ensure_worktree(
+    cfg: Config, root: Path, unit_number: int, branch: str, remote_name: str
+) -> Path:
+    path = root / cfg.worktrees_dir / f"pr-{unit_number}"
+    if not path.exists():
+        worktree.fetch(remote_name)
+        local = worktree.attempt_branches(cfg, remote_name, unit_number)
+        if branch in local:
+            try:
+                worktree.add_existing_branch(path, branch)
+            except Exception:
+                worktree.add(path, branch, f"{remote_name}/{branch}")
+        else:
+            worktree.add(path, branch, f"{remote_name}/{branch}")
+    return path
+
+
+def _resume_agent(
+    gh: GitHub,
+    cfg: Config,
+    root: Path,
+    work: PrWork,
+    prompt_name: str,
+    tokens: dict[str, str],
+) -> backend_mod.BackendResult:
+    run_dir = backend_mod.unit_dir(cfg, root, work.unit_number)
+    prompt = spec.load_prompt(prompt_name, tokens)
+    prompt_file = run_dir / f"{prompt_name}.md"
+    write_text(prompt_file, prompt)
+    adapter = backend_mod.adapter_path(cfg.backend)
+    caps = backend_mod.capabilities(adapter)
+    session_file = run_dir / "session"
+    resume_ref = None
+    if "resume" in caps and session_file.exists():
+        for line in session_file.read_text(encoding="utf-8").splitlines():
+            if line.startswith("SESSION_REF="):
+                resume_ref = line.split("=", 1)[1].strip() or None
+                break
+    wt_path = _ensure_worktree(
+        cfg, root, work.unit_number, work.branch, worktree.remote(cfg)
+    )
+    if resume_ref is None:
+        # No session to resume: prepend the deterministic resume-state.
+        state_path = backend_mod.write_resume_state(
+            run_dir, wt_path, "fresh shepherd invocation"
+        )
+        prompt = state_path.read_text(encoding="utf-8") + "\n\n---\n\n" + prompt
+        write_text(prompt_file, prompt)
+    return backend_mod.run_backend(
+        cfg,
+        adapter,
+        cwd=wt_path,
+        unit_run_dir=run_dir,
+        prompt_file=prompt_file,
+        timeout_min=cfg.shepherd_timeout_min,
+        resume_ref=resume_ref,
+    )
+
+
+def _common_tokens(gh: GitHub, cfg: Config, work: PrWork) -> dict[str, str]:
+    return {
+        "PR_URL": work.url,
+        "BRANCH": work.branch,
+        "UNIT_NUMBER": str(work.unit_number),
+        "DEFAULT_BRANCH": gh.default_branch(),
+        "VERIFY_COMMAND": " ".join(cfg.verify_command),
+    }
+
+
+def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWork:
+    status = gh.pr_status(pr["number"])
+    work = PrWork(
+        number=pr["number"],
+        unit_number=pr["_unit"],
+        branch=status["headRefName"],
+        url=status["url"],
+        title=status["title"],
+    )
+    remote_name = worktree.remote(cfg)
+    checks_state, failed = classify_checks(status.get("statusCheckRollup"))
+
+    if checks_state == "pending":
+        work.state, work.detail = "settling", "checks still running"
+        return work
+
+    if checks_state == "red":
+        failure_text = _failure_text(gh, failed)
+        sig = signatures_mod.match(failure_text, catalog)
+        if sig and sig.action == "quota_wait":
+            work.state, work.detail = (
+                "waiting",
+                f"quota signature '{sig.name}' — waiting for reset",
+            )
+            return work
+        if sig and sig.action == "environment":
+            wt_path = _ensure_worktree(
+                cfg, root, work.unit_number, work.branch, remote_name
+            )
+            retries = worktree.count_retrigger_commits(
+                wt_path, f"{remote_name}/{gh.default_branch()}", RETRIGGER_SUBJECT
+            )
+            if retries == 0:
+                worktree.empty_commit(wt_path, RETRIGGER_SUBJECT)
+                worktree.push(wt_path, remote_name, work.branch, first=False)
+                work.state, work.detail = (
+                    "fixed",
+                    f"environmental '{sig.name}': retried once (empty commit)",
+                )
+            else:
+                work.state = "escalated"
+                work.detail = (
+                    f"environmental '{sig.name}' persisted after retry — needs a human"
+                )
+            return work
+        # Mechanical (or novel) failure → one bounded agent fix.
+        work.actions += 1
+        tokens = _common_tokens(gh, cfg, work)
+        tokens["FAILURE_EXCERPT"] = failure_text or json.dumps(failed[:3], indent=2)
+        result = _resume_agent(gh, cfg, root, work, "shepherd-ci-fix", tokens)
+        work_dir = _ensure_worktree(
+            cfg, root, work.unit_number, work.branch, remote_name
+        )
+        if result.ok and not worktree.is_clean(work_dir):
+            work.state, work.detail = (
+                "escalated",
+                "agent left uncommitted changes after CI fix",
+            )
+        elif result.ok:
+            worktree.push(work_dir, remote_name, work.branch, first=False)
+            work.state, work.detail = "fixed", "agent pushed a CI fix"
+        else:
+            work.state, work.detail = (
+                "escalated",
+                "agent could not fix CI (see unit log)",
+            )
+        if result.cost_usd:
+            work.detail += f" (${result.cost_usd:.2f})"
+        return work
+
+    merge_state = (status.get("mergeStateStatus") or "").upper()
+    if merge_state in ("BEHIND", "DIRTY"):
+        wt_path = _ensure_worktree(
+            cfg, root, work.unit_number, work.branch, remote_name
+        )
+        worktree.fetch(remote_name)
+        base_ref = f"{remote_name}/{gh.default_branch()}"
+        conflicts = worktree.merge_tree_conflicts(wt_path, base_ref)
+        if not conflicts:
+            if worktree.rebase_onto(wt_path, base_ref):
+                worktree.push(wt_path, remote_name, work.branch, first=False)
+                work.state, work.detail = (
+                    "rebased",
+                    "mechanical rebase onto fresh default branch",
+                )
+            else:
+                work.state, work.detail = (
+                    "escalated",
+                    "mechanical rebase unexpectedly failed",
+                )
+            return work
+        work.actions += 1
+        tokens = _common_tokens(gh, cfg, work)
+        tokens["CONFLICTS"] = "\n".join(f"- {c}" for c in conflicts)
+        result = _resume_agent(gh, cfg, root, work, "shepherd-rebase", tokens)
+        if result.ok:
+            ok, _tail = verify.run_verify(
+                cfg, wt_path, backend_mod.unit_dir(cfg, root, work.unit_number)
+            )
+            if ok:
+                worktree.push(wt_path, remote_name, work.branch, first=False)
+                work.state, work.detail = (
+                    "rebased",
+                    f"agent resolved {len(conflicts)} conflict(s), verify green",
+                )
+            else:
+                work.state, work.detail = "escalated", "post-rebase verification failed"
+        else:
+            work.state, work.detail = "escalated", "agent could not resolve the rebase"
+        return work
+
+    threads = [t for t in gh.review_threads(work.number) if not t.get("isResolved")]
+    if threads:
+        work.actions += 1
+        rendered = []
+        for thread in threads[:20]:
+            comments = (thread.get("comments") or {}).get("nodes") or []
+            first = comments[0] if comments else {}
+            author = (first.get("author") or {}).get("login", "reviewer")
+            rendered.append(
+                f"- thread `{thread['id']}` on `{thread.get('path') or 'PR'}` by @{author}:\n"
+                f"  > " + (first.get("body") or "").strip().replace("\n", "\n  > ")
+            )
+        tokens = _common_tokens(gh, cfg, work)
+        tokens["THREADS"] = "\n".join(rendered)
+        result = _resume_agent(gh, cfg, root, work, "shepherd-adjudicate", tokens)
+        wt_path = _ensure_worktree(
+            cfg, root, work.unit_number, work.branch, remote_name
+        )
+        if result.ok:
+            if worktree.is_clean(wt_path) is False:
+                work.state, work.detail = (
+                    "escalated",
+                    "agent left uncommitted adjudication changes",
+                )
+                return work
+            if worktree.commits_ahead(wt_path, f"{remote_name}/{work.branch}") > 0:
+                worktree.push(wt_path, remote_name, work.branch, first=False)
+            remaining = [
+                t for t in gh.review_threads(work.number) if not t.get("isResolved")
+            ]
+            if remaining:
+                work.state = "escalated"
+                work.detail = f"{len(remaining)} review thread(s) still undispositioned"
+            else:
+                work.state, work.detail = (
+                    "adjudicated",
+                    f"{len(threads)} thread(s) dispositioned",
+                )
+        else:
+            work.state, work.detail = "escalated", "adjudication agent failed"
+        return work
+
+    mergeable = (status.get("mergeable") or "").upper()
+    if merge_state == "CLEAN" or mergeable == "MERGEABLE":
+        gh.label_own_pr(work.number, add=["ready-to-merge"])
+        work.state, work.detail = (
+            "ready",
+            "green, adjudicated, mergeable — awaiting human merge",
+        )
+    else:
+        work.state, work.detail = "healthy", f"mergeState={merge_state or 'UNKNOWN'}"
+    return work
+
+
+def merge_order(gh: GitHub, ready: list[PrWork]) -> list[tuple[int, str]]:
+    """Dependency-aware suggested order among ready PRs (topo by blocked-by)."""
+    by_unit = {w.unit_number: w for w in ready}
+    sorter: graphlib.TopologicalSorter = graphlib.TopologicalSorter()
+    for unit_number in by_unit:
+        deps = [
+            entry["number"]
+            for entry in (gh.issue(unit_number).get("blockedBy") or [])
+            if entry["number"] in by_unit
+        ]
+        sorter.add(unit_number, *deps)
+    ordered = list(sorter.static_order())
+    return [(n, by_unit[n].url) for n in ordered]
+
+
+def run_shepherd(gh: GitHub, cfg: Config, root: Path) -> ShepherdReport:
+    out = ShepherdReport()
+    catalog = signatures_mod.load()
+    prs = open_foreman_prs(gh)
+    if not prs:
+        info("shepherd: no open foreman PRs")
+        return out
+    for pr in prs:
+        try:
+            work = shepherd_pr(gh, cfg, root, pr, catalog)
+        except Exception as exc:  # keep shepherding the rest
+            warn(f"shepherd: PR #{pr['number']} failed: {exc}")
+            work = PrWork(
+                number=pr["number"],
+                unit_number=pr["_unit"],
+                branch=pr.get("headRefName", ""),
+                url=pr.get("url", ""),
+                title=pr.get("title", ""),
+                state="escalated",
+                detail=str(exc),
+            )
+        out.worked.append(work)
+        if work.state == "escalated":
+            out.environmental[work.unit_number] = work.detail
+        if work.state == "waiting":
+            out.waiting[work.unit_number] = work.detail
+    ready = [w for w in out.worked if w.state == "ready"]
+    out.ready_order = merge_order(gh, ready)
+    return out

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/signatures.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/signatures.py
@@ -1,0 +1,57 @@
+"""Environmental-failure signature catalog (signatures.toml).
+
+The shepherd classifies red CI by signature BEFORE any LLM sees it:
+`environment` failures get one retry then the human queue (an agent must
+never "fix" an infra problem by weakening code); `quota_wait` failures mean
+the backend's own usage window is exhausted — wait, don't burn retries.
+An unmatched failure gets one bounded LLM diagnosis whose conclusion belongs
+back in this catalog: the LLM diagnoses once, code recognizes forever.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+from foreman.util import ForemanError
+
+CATALOG = Path(__file__).resolve().parent / "signatures.toml"
+
+ACTIONS = ("environment", "quota_wait")
+
+
+@dataclass
+class Signature:
+    name: str
+    pattern: re.Pattern
+    action: str  # environment | quota_wait
+
+
+def load(path: Path | None = None) -> list[Signature]:
+    catalog_path = path or CATALOG
+    with catalog_path.open("rb") as fh:
+        data = tomllib.load(fh)
+    signatures = []
+    for entry in data.get("signature", []):
+        action = entry.get("action", "environment")
+        if action not in ACTIONS:
+            raise ForemanError(
+                f"signatures: unknown action '{action}' in '{entry.get('name')}'"
+            )
+        signatures.append(
+            Signature(
+                name=entry["name"],
+                pattern=re.compile(entry["pattern"], re.I),
+                action=action,
+            )
+        )
+    return signatures
+
+
+def match(text: str, signatures: list[Signature]) -> Signature | None:
+    for signature in signatures:
+        if signature.pattern.search(text or ""):
+            return signature
+    return None

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/signatures.toml
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/signatures.toml
@@ -1,0 +1,26 @@
+# Environmental-failure signature catalog.
+#
+# The shepherd matches red-CI output (and dispatch matches agent-log tails)
+# against these BEFORE any LLM sees the failure. `environment` = retry once
+# via empty commit, then escalate to the human queue — never let an agent
+# "fix" an infra problem by weakening code. `quota_wait` = the agent
+# backend's own usage window is exhausted: idle until it resets, don't burn
+# retries, don't mark the unit failed.
+#
+# When an unmatched failure gets an LLM diagnosis, add its signature here:
+# the LLM diagnoses once, code recognizes forever.
+
+[[signature]]
+name = "convex-deployment-quota"
+pattern = 'DeploymentQuotaReached'
+action = "environment"
+
+[[signature]]
+name = "github-actions-billing"
+pattern = 'recent account payments have failed|spending limit needs to be increased'
+action = "environment"
+
+[[signature]]
+name = "claude-usage-limit"
+pattern = 'usage limit reached|hit your (usage|rate) limit|limit will reset|out of extra usage'
+action = "quota_wait"

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/spec.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/spec.py
@@ -1,0 +1,226 @@
+"""Issue spec contract validation and deterministic prompt assembly.
+
+The contract: a dispatchable unit has an `## Acceptance Criteria` section;
+items tag themselves `[CI]` (machine-verifiable, must map to named tests) or
+`[HUMAN]` (surfaced, never attempted, blocks `Closes` for the parent).
+
+Prompt assembly is pure code: fixed preamble (prompts/*.md, token-substituted)
++ full issue/sub-issue bodies + trusted comments + injected handoff contracts.
+Comments are embedded only from trusted author associations (or foreman's own
+posted corrections) — issue threads on public repos are otherwise an
+injection surface.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from foreman.config import Config
+from foreman.github import GitHub
+from foreman.graph import Unit, foreman_prs_for_issue
+from foreman.util import sha256_hex
+
+PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+
+_HEADING_RE = re.compile(r"^(#{2,6})\s*(?P<title>.+?)\s*$", re.M)
+_BULLET_RE = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+(?P<text>.+)$")
+
+
+@dataclass
+class AcItem:
+    text: str
+    tag: str  # CI | HUMAN
+    tagged: bool
+
+
+@dataclass
+class SpecInfo:
+    ac_items: list[AcItem] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def human_items(self) -> list[str]:
+        return [item.text for item in self.ac_items if item.tag == "HUMAN"]
+
+
+def find_section(body: str, title: str) -> str | None:
+    """Return the text under a `## Title` heading (any 2-6 level), else None."""
+    matches = list(_HEADING_RE.finditer(body or ""))
+    for index, match in enumerate(matches):
+        if match.group("title").strip().lower() == title.lower():
+            start = match.end()
+            level = len(match.group(1))
+            for nxt in matches[index + 1 :]:
+                if len(nxt.group(1)) <= level:
+                    return body[start : nxt.start()].strip()
+            return body[start:].strip()
+    return None
+
+
+def parse_ac(body: str) -> list[AcItem] | None:
+    section = find_section(body, "Acceptance Criteria")
+    if section is None:
+        return None
+    items: list[AcItem] = []
+    for line in section.splitlines():
+        match = _BULLET_RE.match(line)
+        if not match:
+            continue
+        text = match.group("text").strip()
+        if "[HUMAN]" in text:
+            items.append(AcItem(text, "HUMAN", True))
+        elif "[CI]" in text:
+            items.append(AcItem(text, "CI", True))
+        else:
+            items.append(AcItem(text, "CI", False))
+    return items
+
+
+def validate(unit: Unit) -> SpecInfo:
+    info = SpecInfo()
+    items = parse_ac(unit.body)
+    if items is None:
+        info.errors.append(
+            f"#{unit.number}: no '## Acceptance Criteria' section — non-dispatchable"
+        )
+        return info
+    if not items:
+        info.errors.append(f"#{unit.number}: Acceptance Criteria section has no items")
+        return info
+    info.ac_items = items
+    untagged = sum(1 for item in items if not item.tagged)
+    if untagged:
+        info.warnings.append(
+            f"#{unit.number}: {untagged} acceptance criteria untagged — treated as [CI]"
+        )
+    return info
+
+
+def human_only_tasks(unit: Unit, info: SpecInfo) -> list[str]:
+    tasks = list(info.human_items)
+    section = find_section(unit.body, "Human-only tasks")
+    if section:
+        for line in section.splitlines():
+            match = _BULLET_RE.match(line)
+            if match:
+                tasks.append(match.group("text").strip())
+    return tasks
+
+
+def trusted_comments(gh: GitHub, cfg: Config, number: int) -> tuple[list[dict], int]:
+    """Comments safe to embed in prompts + count of excluded ones."""
+    kept: list[dict] = []
+    excluded = 0
+    me = gh.viewer()
+    for comment in gh.issue_comments(number):
+        author = (comment.get("user") or {}).get("login", "")
+        association = comment.get("author_association", "")
+        if association in cfg.comment_trust or author == me:
+            kept.append(comment)
+        else:
+            excluded += 1
+    return kept, excluded
+
+
+def spec_hash(unit: Unit, comments: list[dict]) -> str:
+    """Stable hash of everything the prompt embeds from the spec."""
+    parts = [unit.body]
+    parts += [sub.get("body") or "" for sub in unit.sub_issues]
+    parts += [
+        comment.get("body") or ""
+        for comment in sorted(comments, key=lambda c: c.get("id", 0))
+    ]
+    return sha256_hex("\n\x00\n".join(parts))
+
+
+def load_prompt(name: str, tokens: dict[str, str]) -> str:
+    text = (PROMPTS_DIR / f"{name}.md").read_text(encoding="utf-8")
+    for key, value in tokens.items():
+        text = text.replace(f"%%{key}%%", value)
+    return text
+
+
+def extract_handoff(pr_body: str) -> str | None:
+    section = find_section(pr_body or "", "Handoff")
+    if section is None:
+        return None
+    # PR bodies end with a `---` footer; a thematic break ends the section.
+    section = re.split(r"^\s*---\s*$", section, maxsplit=1, flags=re.M)[0].strip()
+    return section or None
+
+
+def collect_handoffs(gh: GitHub, cfg: Config, unit: Unit) -> list[tuple[int, str]]:
+    """Handoff sections from the merged foreman PRs of this unit's dependencies."""
+    handoffs: list[tuple[int, str]] = []
+    for dep in unit.blocked_by:
+        for pr in foreman_prs_for_issue(gh, cfg, dep):
+            if not pr.get("merged"):
+                continue
+            text = extract_handoff(pr.get("body") or "")
+            if text:
+                handoffs.append((dep, text))
+    return handoffs
+
+
+def assemble_dispatch_prompt(
+    gh: GitHub,
+    cfg: Config,
+    unit: Unit,
+    *,
+    branch: str,
+    default_branch: str,
+    result_file: str,
+    comments: list[dict],
+    excluded_comments: int,
+    handoffs: list[tuple[int, str]],
+) -> str:
+    tokens = {
+        "UNIT_NUMBER": str(unit.number),
+        "UNIT_TITLE": unit.title,
+        "BRANCH": branch,
+        "DEFAULT_BRANCH": default_branch,
+        "VERIFY_COMMAND": " ".join(cfg.verify_command),
+        "RESULT_FILE": result_file,
+        "COMMIT_TYPE": unit.inputs.commit_type if unit.inputs else cfg.default_type,
+    }
+    sections = [load_prompt("implementer-preamble", tokens)]
+
+    sections.append(f"# Unit #{unit.number}: {unit.title}\n\n{unit.body.strip()}")
+    for sub in unit.sub_issues:
+        state_note = (
+            "" if (sub.get("state") or "").upper() == "OPEN" else " (already closed)"
+        )
+        sections.append(
+            f"## Sub-issue #{sub['number']}: {sub.get('title', '')}{state_note}\n\n"
+            f"{(sub.get('body') or '').strip()}"
+        )
+
+    if comments:
+        rendered = []
+        for comment in comments:
+            author = (comment.get("user") or {}).get("login", "unknown")
+            rendered.append(
+                f"### Comment by @{author}\n\n{(comment.get('body') or '').strip()}"
+            )
+        sections.append(
+            "# Issue comments (human corrections and clarifications — these amend the "
+            "spec above and MUST be honored)\n\n" + "\n\n".join(rendered)
+        )
+    if excluded_comments:
+        sections.append(
+            f"_Note: {excluded_comments} comment(s) from untrusted authors were withheld "
+            "from this prompt._"
+        )
+
+    if handoffs:
+        rendered = [f"### Handoff from #{dep}\n\n{text}" for dep, text in handoffs]
+        sections.append(
+            "# Handoff contracts from merged dependencies (already on "
+            f"{default_branch} — build on these, do not reinvent them)\n\n"
+            + "\n\n".join(rendered)
+        )
+
+    return "\n\n---\n\n".join(sections) + "\n"

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/util.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/util.py
@@ -1,0 +1,96 @@
+"""Shared helpers: subprocess, logging, hashing, small file utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+
+
+class ForemanError(RuntimeError):
+    """Fatal, user-facing error — printed without a traceback."""
+
+
+def info(msg: str) -> None:
+    print(f"foreman: {msg}", flush=True)
+
+
+def warn(msg: str) -> None:
+    print(f"foreman: WARN: {msg}", file=sys.stderr, flush=True)
+
+
+def error(msg: str) -> None:
+    print(f"foreman: ERROR: {msg}", file=sys.stderr, flush=True)
+
+
+def run(
+    argv: list[str],
+    *,
+    cwd: str | Path | None = None,
+    input_text: str | None = None,
+    check: bool = True,
+    timeout: float | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Run a command (never a shell), capturing text output."""
+    try:
+        proc = subprocess.run(
+            list(argv),
+            cwd=str(cwd) if cwd else None,
+            input=input_text,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            env=env,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise ForemanError(f"command not found: {argv[0]}") from exc
+    if check and proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        raise ForemanError(
+            f"command failed ({proc.returncode}): {' '.join(argv)}\n{detail}"
+        )
+    return proc
+
+
+@lru_cache(maxsize=1)
+def repo_root() -> Path:
+    """Absolute path of the repository foreman was invoked in."""
+    out = run(["git", "rev-parse", "--show-toplevel"]).stdout.strip()
+    return Path(out)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def sha256_hex(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def slugify(title: str, max_len: int = 32) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return slug[:max_len].rstrip("-") or "unit"
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def append_line(path: Path, line: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(line.rstrip("\n") + "\n")
+
+
+def tail(path: Path, lines: int = 40) -> str:
+    if not path.exists():
+        return ""
+    content = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    return "\n".join(content[-lines:])

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/verify.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/verify.py
@@ -1,0 +1,39 @@
+"""Deterministic verification gate. Foreman runs the repo's configured
+verify_command (default: full `task ci`) in the unit's worktree itself —
+the agent's self-report is never trusted.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from foreman.config import Config
+from foreman.util import tail, utc_now_iso
+
+VERIFY_TIMEOUT_MIN = 120
+
+
+def run_verify(cfg: Config, worktree: Path, unit_run_dir: Path) -> tuple[bool, str]:
+    """Run verify_command in the worktree; returns (ok, log tail)."""
+    log_path = unit_run_dir / "verify.log"
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(f"\n--- {utc_now_iso()} {' '.join(cfg.verify_command)} ---\n")
+        fh.flush()
+        try:
+            proc = subprocess.run(
+                cfg.verify_command,
+                cwd=str(worktree),
+                stdout=fh,
+                stderr=subprocess.STDOUT,
+                timeout=VERIFY_TIMEOUT_MIN * 60,
+                check=False,
+            )
+            code = proc.returncode
+        except subprocess.TimeoutExpired:
+            fh.write(f"\nverify timed out after {VERIFY_TIMEOUT_MIN} minutes\n")
+            code = 124
+        except FileNotFoundError:
+            fh.write(f"\nverify command not found: {cfg.verify_command[0]}\n")
+            code = 127
+    return code == 0, tail(log_path, 40)

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/watch.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/watch.py
@@ -31,7 +31,10 @@ def parse_interval(text: str) -> int:
     if not match:
         raise ForemanError(f"bad --interval '{text}' (use e.g. 300, 5m, 1h)")
     value, unit = int(match.group(1)), match.group(2)
-    return value * {"": 1, "s": 1, "m": 60, "h": 3600}[unit]
+    seconds = value * {"": 1, "s": 1, "m": 60, "h": 3600}[unit]
+    if seconds <= 0:
+        raise ForemanError(f"--interval must be positive, got '{text}'")
+    return seconds
 
 
 def run_watch(

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/watch.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/watch.py
@@ -1,0 +1,116 @@
+"""Watch mode: `plan → dispatch → shepherd → sleep`, for days if needed.
+
+Every tick is stateless and idempotent — all state re-derived from GitHub +
+git, so kill/reboot/laptop-sleep loses nothing. A heartbeat line per tick
+makes silence distinguishable from health. Stop conditions: milestone
+complete, stop file (.foreman-stop), aggregate budget, N consecutive
+failing ticks. For multi-day runs, cron invoking dispatch+shepherd is
+equivalent — the live loop is a convenience, not a requirement.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+
+from foreman import dispatch as dispatch_mod
+from foreman import shepherd as shepherd_mod
+from foreman.config import Config
+from foreman.github import Gh, GitHub
+from foreman.graph import detect_cycle, prepare_target
+from foreman.util import ForemanError, append_line, error, info, utc_now_iso, warn
+
+STOP_FILE = ".foreman-stop"
+DEFAULT_INTERVAL_S = 300
+MAX_CONSECUTIVE_FAILURES = 3
+
+
+def parse_interval(text: str) -> int:
+    match = re.fullmatch(r"(\d+)\s*([smh]?)", text.strip())
+    if not match:
+        raise ForemanError(f"bad --interval '{text}' (use e.g. 300, 5m, 1h)")
+    value, unit = int(match.group(1)), match.group(2)
+    return value * {"": 1, "s": 1, "m": 60, "h": 3600}[unit]
+
+
+def run_watch(
+    cfg: Config,
+    root: Path,
+    *,
+    milestone: str | None,
+    issue: int | None,
+    interval_s: int = DEFAULT_INTERVAL_S,
+    budget_usd: float | None = None,
+    max_failures: int = MAX_CONSECUTIVE_FAILURES,
+) -> int:
+    log_path = root / cfg.runtime_dir / "watch.log"
+    stop_path = root / STOP_FILE
+    consecutive = 0
+    total_cost = 0.0
+    tick = 0
+    idle_notified = False
+
+    def heartbeat(message: str) -> None:
+        line = f"{utc_now_iso()} tick={tick} {message}"
+        append_line(log_path, line)
+        info(line)
+
+    info(f"watch: interval={interval_s}s budget={budget_usd or 'none'} log={log_path}")
+    while True:
+        tick += 1
+        if stop_path.exists():
+            heartbeat("stop file present — exiting cleanly")
+            return 0
+        try:
+            gh = GitHub(Gh(), cfg)  # fresh per tick: caches never go stale
+            target = prepare_target(gh, cfg, milestone=milestone, issue=issue)
+            cycle = detect_cycle(target)
+            if cycle:
+                error(
+                    f"watch: dependency cycle {' -> '.join('#' + str(n) for n in cycle)}"
+                )
+                return 1
+            open_units = [u for u in target.units.values() if u.open]
+            if not open_units:
+                heartbeat("milestone complete — all units closed")
+                return 0
+
+            outcomes = dispatch_mod.run_dispatch(gh, cfg, root, target)
+            shep = shepherd_mod.run_shepherd(gh, cfg, root)
+            tick_cost = sum(o.cost_usd or 0.0 for o in outcomes) + shep.cost_usd
+            total_cost += tick_cost
+
+            dispatched = sum(1 for o in outcomes if o.dispatched)
+            waiting = sum(1 for o in outcomes if o.status == "waiting")
+            failed = sum(1 for o in outcomes if o.status in ("failed", "blocked"))
+            ready = len(shep.ready_order)
+            heartbeat(
+                f"open={len(open_units)} dispatched={dispatched} waiting={waiting} "
+                f"failed={failed} prs-ready={ready} cost=${total_cost:.2f}"
+            )
+            if shep.ready_order and dispatched == 0 and not failed:
+                if not idle_notified:
+                    info(
+                        "watch: idling by design — PRs are ready and nothing new is "
+                        "dispatchable; waiting on human merges:\n"
+                        + "\n".join(
+                            f"  {n}. #{u} {url}"
+                            for n, (u, url) in enumerate(shep.ready_order, 1)
+                        )
+                    )
+                    idle_notified = True
+            else:
+                idle_notified = False
+            consecutive = 0
+            if budget_usd is not None and total_cost >= budget_usd:
+                heartbeat(f"aggregate budget ${budget_usd:.2f} reached — stopping")
+                return 0
+        except ForemanError as exc:
+            consecutive += 1
+            warn(f"watch: tick failed ({consecutive}/{max_failures}): {exc}")
+            heartbeat(f"TICK FAILED: {exc}")
+            if consecutive >= max_failures:
+                error("watch: too many consecutive failures — stopping")
+                return 1
+        time.sleep(interval_s)

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/worktree.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/worktree.py
@@ -1,0 +1,165 @@
+"""Git worktree + branch lifecycle. Remote and default branch are discovered,
+never hardcoded. One worktree per unit under cfg.worktrees_dir; branches are
+namespaced `<prefix>/<type>/<n>-<slug>` so cleanup and doneness can identify
+foreman's own branches deterministically.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from foreman.config import Config
+from foreman.graph import Unit
+from foreman.util import ForemanError, run, slugify, warn
+
+
+def remote(cfg: Config) -> str:
+    if cfg.remote:
+        return cfg.remote
+    names = [line for line in run(["git", "remote"]).stdout.split() if line]
+    if len(names) == 1:
+        return names[0]
+    if "origin" in names:
+        warn(
+            "multiple git remotes; using 'origin' (set `remote` in .foreman.toml to override)"
+        )
+        return "origin"
+    raise ForemanError(
+        f"cannot pick a remote from {names}; set `remote` in .foreman.toml"
+    )
+
+
+def fetch(remote_name: str) -> None:
+    run(["git", "fetch", "--prune", remote_name])
+
+
+def base_sha(remote_name: str, branch: str) -> str:
+    return run(["git", "rev-parse", f"{remote_name}/{branch}"]).stdout.strip()
+
+
+def branch_name(cfg: Config, unit: Unit) -> str:
+    commit_type = unit.inputs.commit_type if unit.inputs else cfg.default_type
+    return f"{cfg.branch_prefix}/{commit_type}/{unit.number}-{slugify(unit.title)}"
+
+
+def attempt_branches(cfg: Config, remote_name: str, number: int) -> list[str]:
+    """Local + remote branches that are attempts for this unit."""
+    pattern = re.compile(rf"^{re.escape(cfg.branch_prefix)}/[^/]+/{number}-")
+    found: set[str] = set()
+    local = run(
+        ["git", "for-each-ref", "--format=%(refname:short)", "refs/heads/"]
+    ).stdout
+    for name in local.split():
+        if pattern.match(name):
+            found.add(name)
+    remote_refs = run(["git", "ls-remote", "--heads", remote_name]).stdout
+    for line in remote_refs.splitlines():
+        parts = line.split("\t")
+        if len(parts) == 2 and parts[1].startswith("refs/heads/"):
+            name = parts[1][len("refs/heads/") :]
+            if pattern.match(name):
+                found.add(name)
+    return sorted(found)
+
+
+def next_attempt_branch(base_name: str, existing: list[str]) -> str:
+    if base_name not in existing:
+        return base_name
+    attempt = 2
+    while f"{base_name}-r{attempt}" in existing:
+        attempt += 1
+    return f"{base_name}-r{attempt}"
+
+
+def worktree_path(cfg: Config, root: Path, unit: Unit) -> Path:
+    return root / cfg.worktrees_dir / f"{unit.number}-{slugify(unit.title)}"
+
+
+def add(path: Path, branch: str, start_point: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    run(["git", "worktree", "add", "-b", branch, str(path), start_point])
+
+
+def add_existing_branch(path: Path, branch: str) -> None:
+    """Recreate a worktree for an existing branch (e.g. after a machine restart)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    run(["git", "worktree", "add", str(path), branch])
+
+
+def remove(path: Path, *, force: bool = True) -> None:
+    args = ["git", "worktree", "remove", str(path)]
+    if force:
+        args.insert(3, "--force")
+    run(args, check=False)
+    run(["git", "worktree", "prune"], check=False)
+
+
+def delete_branch(cfg: Config, remote_name: str, branch: str) -> None:
+    """Delete a branch foreman created — refuses anything outside its namespace."""
+    if not branch.startswith(f"{cfg.branch_prefix}/"):
+        raise ForemanError(f"refusing to delete non-foreman branch '{branch}'")
+    run(["git", "branch", "-D", branch], check=False)
+    run(["git", "push", remote_name, "--delete", branch], check=False)
+
+
+def is_clean(path: Path) -> bool:
+    out = run(["git", "-C", str(path), "status", "--porcelain"]).stdout.strip()
+    return not out
+
+
+def commits_ahead(path: Path, base_ref: str) -> int:
+    out = run(
+        ["git", "-C", str(path), "rev-list", "--count", f"{base_ref}..HEAD"]
+    ).stdout.strip()
+    return int(out or "0")
+
+
+def push(path: Path, remote_name: str, branch: str, *, first: bool) -> None:
+    args = ["git", "-C", str(path), "push"]
+    if first:
+        args += ["-u", remote_name, branch]
+    else:
+        args += ["--force-with-lease", remote_name, branch]
+    run(args)
+
+
+def merge_tree_conflicts(path: Path, base_ref: str) -> list[str]:
+    """Deterministic conflict enumeration (dry run; the tree is untouched)."""
+    head = run(["git", "-C", str(path), "rev-parse", "HEAD"]).stdout.strip()
+    proc = run(
+        [
+            "git",
+            "-C",
+            str(path),
+            "merge-tree",
+            "--write-tree",
+            "--name-only",
+            base_ref,
+            head,
+        ],
+        check=False,
+    )
+    if proc.returncode == 0:
+        return []
+    lines = [line for line in proc.stdout.splitlines()[1:] if line.strip()]
+    return lines or ["<unknown conflict>"]
+
+
+def rebase_onto(path: Path, base_ref: str) -> bool:
+    proc = run(["git", "-C", str(path), "rebase", base_ref], check=False)
+    if proc.returncode != 0:
+        run(["git", "-C", str(path), "rebase", "--abort"], check=False)
+        return False
+    return True
+
+
+def empty_commit(path: Path, message: str) -> None:
+    run(["git", "-C", str(path), "commit", "--allow-empty", "-m", message])
+
+
+def count_retrigger_commits(path: Path, base_ref: str, subject: str) -> int:
+    out = run(
+        ["git", "-C", str(path), "log", f"{base_ref}..HEAD", "--format=%s"], check=False
+    ).stdout
+    return sum(1 for line in out.splitlines() if line.strip() == subject)


### PR DESCRIPTION
Closes #258

## What this is

Foreman v1 — the deterministic supervisor from the #258 spec (v2), built per the reviewed plan: it reads a milestone's (or single issue's) dependency graph from GitHub, dispatches ready units to headless agents in isolated worktrees, verifies each with the repo's own CI gate, opens PRs deterministically, and shepherds them (CI repair, review adjudication, rebases) until a **human** merges. Merging is never foreman's job — permanently.

## What's included

- **`scripts/foreman/`** — Python 3.11+ stdlib-only package (no dependencies): `plan`, `preflight`, `dispatch`, `shepherd`, `watch`, `status`, `retry`, `cleanup` via `taskfiles/foreman.yml` (`task foreman:*`).
- **Write contract centralized in `github.py`** — the only module that mutates GitHub. Merge/close/edit-issue operations do not exist in it, and `tests/test_write_contract.py` greps to keep them absent; read-only commands construct a facade that refuses every mutation; identity assertion (`expected_login`) gates the first write.
- **Explicit arming** (decision D2): only issues carrying the `foreman` input dispatch — org issue field on org repos, `foreman:*` labels on personal repos (fields are org-only per their 2026-07 GA), value selects the backend; `hold` always wins; dual-source fails loud; `require_approval = false` opts into spec-v2 default-armed.
- **Hardened doneness** (A3): a foreman-managed dependency is satisfied only when its issue is closed AND a marker-carrying PR merged into the discovered default branch, authored by the bot, from a `foreman/…` attempt branch; external deps need closed-as-completed (not_planned blocks, `foreman:satisfied` overrides). Every plan/status prints *how* each dep was satisfied.
- **Foreman opens PRs** (decision D1): agents hand over a validated sidecar result contract (summary, handoff, human tasks, proposed title, AC→test map, blocked question); exit-0 without a valid contract counts as a crash; `BLOCKED.md` is the escalation fallback.
- **Freshness gate at push time** (A6): spec hash (bodies + trusted comments) + eligibility re-checked immediately before any push; drift = no push.
- **Comment trust policy** (A8): only OWNER/MEMBER/COLLABORATOR comments (or foreman's own corrections) enter prompts — drive-by comments on public repos stay out.
- **Shepherd**: signature catalog first (`environment` → one empty-commit retry then human queue; `quota_wait` → idle until the usage window resets — the subscription-billing failure mode becomes a planned pause), mechanical CI fixes via agent resume, `merge-tree` dry-run + rebase-only updates, thread adjudication with deterministic completeness re-check, `ready-to-merge` + dependency-aware merge order.
- **Watch mode**: stateless idempotent ticks, heartbeat log, stop file / budget / consecutive-failure stops; deployment guidance for multi-day unattended runs (Codespaces idle-stop caveat; cron equivalence).
- **Billing** (A11, subscription-first per discussion): `billing = "subscription"` inherits `CLAUDE_CODE_OAUTH_TOKEN` (zero devcontainer changes); `billing = "api"` exports `FOREMAN_ANTHROPIC_API_KEY` only inside the adapter process — the container-wide `ANTHROPIC_API_KEY` strip is untouched.
- **Backends**: `claude.sh` (headless stream-json, session ref captured from the FIRST event, foreman-enforced timeouts) + `mock.sh` (hermetic seam proof). `codex` etc. = one new file when concretely needed.
- **Template propagation** behind `use_foreman` (default yes, no side effects): verbatim twins byte-checked by `test:dogfood-parity`; `.foreman.toml.jinja`; gated Taskfile include, lefthook hook, gitignore/gitleaks/Brewfile/build.yml wiring; the minimal profile exercises the OFF branch with explicit assertions.
- **Docs**: `docs/architecture/foreman.md` (ships to generated repos), ADR 0002 (the TDR), AGENTS.md steering both layers, project-management.md Agent-Queue → foreman cross-reference.
- **Agent definitions**: `.claude/agents/foreman-{implementer,shepherd,preflight}.md`, one-sourced from `scripts/foreman/prompts/`.

## Verification

- `task verify` green end-to-end: lint (incl. new `foreman:lint` — pinned ruff/black via uvx), 85-test unittest suite (fake `gh` transport; write-contract MUST-NEVERs, doneness truth table, arming matrix, result-contract validation, freshness/spec-hash, signature catalog), dogfood parity (88 verbatim twins), and all 7 template profiles including `update`.
- CI: lint job gains `astral-sh/setup-uv` + `task foreman:test`; renovate gains a Taskfile-pin manager for the ruff/black versions.

## Deviations from spec v2 (deliberate, documented in ADR 0002)

- Config is `.foreman.toml` (stdlib `tomllib`; also what the plan discussion sketched) instead of `.foreman.yml` — zero YAML dependency.
- Tests use stdlib `unittest`, not pytest — zero Python deps ship to generated repos.
- Branch namespace is `foreman/<type>/<n>-<slug>` (not bare `<type>/…`) so cleanup/doneness can identify foreman's own branches deterministically.
- Foreman labels are ensured idempotently at runtime by `github.py` (per the spec's write contract) instead of extending `setup-github-labels.sh`.
- Per-unit lifetime shepherd budgets would require stored state; v1 uses run-scoped action caps + the watch aggregate budget instead.
- `unit test suite` lives root-only (generated repos get a self-skipping `foreman:test`).

## Before first dispatch (human setup)

1. Create the org issue fields in `ponderousdev` (`foreman` single-select: approved/claude/mock/hold/satisfied/external; `foreman-budget-usd`; `foreman-timeout-min`) — harmon-init itself runs label mode.
2. Verify the bot fine-grained PAT: contents/PRs/issues write, **no `workflows` write**, no bypass on the main ruleset; `.foreman.toml` `expected_login` must match the bot login (note: this container's current gh login is a different account — foreman will refuse to write until that's aligned).
3. For multi-day runs: enable the account's extra-usage toggle + monthly cap, or flip `billing = "api"` + provision `FOREMAN_ANTHROPIC_API_KEY`.
4. Optional: `FOREMAN_SANDBOXED=1` in the bot devcontainer env to relax the adapter permission mode inside the sandbox.

First real run suggestion: arm one small issue with `foreman:claude` and run `task foreman:plan -- --issue <n>`, then `task foreman:dispatch -- --issue <n>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJf3jKTeZeXhrShcrcrG5q
