### PR TITLE
fix(template): harden sync-skills dest against absolute/traversal paths

### DIFF
--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -189,8 +189,12 @@ cmd_sync() {
     require_tools
     WORKDIR="$(mktemp -d)"
     dest="$(manifest_get '.dest')"
+    # dest is committed config (.skills-sync.yaml), but sync deletes paths under
+    # it — so refuse anything that could reach outside the repo before any rm.
     case "$dest" in
     "" | "/" | "." | "..") die "refusing to vendor into unsafe dest '$dest'" ;;
+    /*) die "refusing absolute dest '$dest' — .skills-sync.yaml dest must be repo-relative" ;;
+    ../* | */../* | */..) die "refusing dest with a '..' traversal component: '$dest'" ;;
     esac
     ref="$(manifest_get '.source.ref')"
     [ -n "$ref" ] && [ "$ref" != "null" ] || die "manifest: .source.ref is required"

--- a/template/scripts/[% if use_skills_sync %]sync-skills.sh[% endif %]
+++ b/template/scripts/[% if use_skills_sync %]sync-skills.sh[% endif %]
@@ -189,8 +189,12 @@ cmd_sync() {
     require_tools
     WORKDIR="$(mktemp -d)"
     dest="$(manifest_get '.dest')"
+    # dest is committed config (.skills-sync.yaml), but sync deletes paths under
+    # it — so refuse anything that could reach outside the repo before any rm.
     case "$dest" in
     "" | "/" | "." | "..") die "refusing to vendor into unsafe dest '$dest'" ;;
+    /*) die "refusing absolute dest '$dest' — .skills-sync.yaml dest must be repo-relative" ;;
+    ../* | */../* | */..) die "refusing dest with a '..' traversal component: '$dest'" ;;
     esac
     ref="$(manifest_get '.source.ref')"
     [ -n "$ref" ] && [ "$ref" != "null" ] || die "manifest: .source.ref is required"


### PR DESCRIPTION
The managed-set sync engine deletes paths under the manifest's `dest` (the
`.skills-sync.yaml` destination). `dest` is committed, reviewed config — but a
mis-edit to an **absolute path** (`dest: /some/dir`) or a **`..` traversal
component** (`dest: ../../x`) could make the `rm -rf` of managed subdirs reach
outside the repo. This adds those two rejections to the existing
empty/`/`/`.`/`..` guard, before any deletion runs.

Context: the managed-set rewrite (#271) already removed the old engine's
whole-directory `rm -rf "$dest"`; sync now only deletes specific,
`assert_sane_name`-guarded managed subdirs. So the blast radius was already
small — this closes the residual gap where `dest` itself was unguarded.

Engine kept byte-identical across the root dogfood copy, the template copy, and
harmon-devkit's canonical copy (a matching PR harden's devkit's engine +
`test-skills.sh`). A new `test-engine` case covers absolute + traversal
rejection and confirms a normal relative dest still works.

From Copilot review on harmon-ops#58 (a v3.24.0 update PR whose template-owned
`sync-skills.sh` predates the managed-set rewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)