### PR TITLE
feat(ci): shared setup composite action + hardened claude-implement; ADR for release-gated static-site deploys

### DIFF
--- a/docs/decisions/0003-release-gated-deploys-for-static-sites.md
+++ b/docs/decisions/0003-release-gated-deploys-for-static-sites.md
@@ -1,0 +1,98 @@
+# 3. Release-gated production deploys for static sites (not web apps)
+
+Date: 2026-07-14
+
+## Status
+
+Accepted
+
+## Context
+
+The template can scaffold two deploy-capable project types, and they want
+opposite things from the `main` → production relationship:
+
+- **`web-astro`** — a marketing/content site served as **static assets** from a
+  Cloudflare Worker. Stateless: no database, no schema, no auth, no payments.
+  A deploy is a content swap; rollback is "re-serve the previous bundle."
+- **`web-app`** — a stateful application (e.g. the TanStack/React + Convex +
+  Clerk + Stripe pattern in `omator`). Deploys carry **schema migrations,
+  auth, and money movement**; rollback can be lossy or impossible once a
+  migration has run or a charge has settled.
+
+Both are also scaffolded alongside automation that can land commits on `main`
+without a human writing them: the `claude-*` actions, GitHub Copilot's coding
+agent, Renovate, and foreman-driven agent PRs (see
+[0002](0002-foreman-deterministic-supervisor.md)). So "what does a merge to
+`main` do?" is a safety question, not just an ergonomics one.
+
+A single default (deploy-on-merge everywhere, or release-gate everywhere) is
+wrong for one of the two. This ADR records why the template splits them.
+
+## Decision
+
+**`web-astro` sites are release-gated. `web-app` projects are not.**
+
+- **`web-astro` → release-gated production.** A normal merge to `main` only
+  *stages*. Production ships when the **release-please release PR is merged** (a
+  deliberate human act that cuts the tag + CHANGELOG), and `release.yml`'s
+  `deploy-production` job deploys the **tagged commit**. `workflow_dispatch`
+  stays as the bootstrap/rollback escape hatch. This is wired via the
+  `deploy_cloudflare_workers` question, which defaults `true` for `web-astro`.
+- **`web-app` → deploy-on-merge.** Merging to `main` deploys production
+  directly (gated only by a one-time `DEPLOY_APP` enablement switch), then
+  smoke-tests the live URL. The release-please PR maintains the CHANGELOG but
+  does **not** trigger deploys. The template does not ship a `web-app` deploy
+  workflow yet; such projects hand-roll one (tracked as a follow-up).
+
+The rationale each way:
+
+**Why release-gate `web-astro`:**
+
+- **Intentional releases.** Decouple *integrated* (merged) from *shipped*
+  (deployed): batch several merges into one release, review the accumulated
+  CHANGELOG, and choose when to ship independently of when you merge.
+- **Automation-merge safety.** If `main` → prod were automatic, any
+  agent-merged or Renovate-merged PR would ship the instant it lands. The
+  release gate makes `main` a staging line that automation can reach but
+  **cannot ship from**; only a human merging the release PR ships.
+- **Staging for free.** Per-PR preview URLs (`deploy-preview.yml`) are the
+  validation surface and `main` is the soak buffer — no separate staging
+  environment or long-lived branch required.
+- **Versioned + revertable.** Prod deploys a **tag**, not a moving `main` HEAD,
+  so releases are versioned, changelog'd, and rollback is "redeploy the
+  previous tag." Cheap and safe *because the site is stateless*.
+
+**Why NOT release-gate `web-app` (the explicit "not"):**
+
+- **Small, frequent, attributable deploys are safer for stateful systems.**
+  Batching many merged PRs into one release means multiple schema/data changes
+  ship together — a bigger, harder-to-attribute, harder-to-roll-back blast
+  radius. Deploy-on-merge keeps each production change small and tied to one
+  PR, with an immediate post-deploy smoke test.
+- **The tag-rollback property doesn't hold.** With migrations, Stripe state,
+  and user data, "redeploy the old tag" can be lossy or impossible; the
+  discipline that actually protects a web app is expand/contract migrations and
+  forward-fix, not a release gate.
+- **The automation-safety concern is already covered elsewhere.** For web apps
+  the guard is the **human-merge-only** rule from
+  [0002](0002-foreman-deterministic-supervisor.md) — branch protection,
+  code-owner review, no auto-merge, and a bot token without bypass or
+  `workflows` write. `main` is human-gated even though it deploys, so
+  release-gating would trade away the frequent-deploy benefit **without adding
+  safety the app doesn't already have.**
+
+## Consequences
+
+- `web-astro`: `deploy_cloudflare_workers` defaults `true`, so `release.yml`
+  renders the `deploy-production` job (deploy the tag on release; dispatch for
+  bootstrap/rollback) and `deploy-preview.yml` provides per-PR previews. No
+  action needed to get the release-gated behavior.
+- `web-app`: opts out of the static Cloudflare deploy (`deploy_cloudflare_workers`
+  is offered but not defaulted on) and supplies its own deploy-on-merge
+  workflow. A first-class `web-app` deploy template (Convex + Cloudflare,
+  distilled from `omator`) is a deliberate follow-up, not shipped here.
+- Both keep `workflow_dispatch` so an emergency/manual deploy never depends on
+  the normal path — important for a stateful web app during an incident.
+- Revisit if a `web-astro` site ever grows server-side state (forms with
+  storage, edge KV, auth): at that point it has moved toward the `web-app`
+  profile and this ADR's split should be re-evaluated for it.

--- a/template/.github/actions/setup/action.yml.jinja
+++ b/template/.github/actions/setup/action.yml.jinja
@@ -1,0 +1,119 @@
+name: Setup toolchain
+description: >-
+  Install the shared toolchain (Node/pnpm[% if use_python %], Python/uv[% endif %][% if include_terraform %], Terraform[% endif %], Task), project
+  dependencies, and — behind inputs — the lint + security CLIs. Single source of
+  truth for the CI jobs and the Claude automation workflows so local, CI, and
+  agent runs all execute the same Taskfile targets. Callers must run
+  actions/checkout first.
+
+inputs:
+  install-deps:
+    description: Install project dependencies ([% if use_node %]pnpm install[% if use_python %], [% endif %][% endif %][% if use_python %]uv sync[% endif %]) when present.
+    default: "true"
+  lint-tools:
+    description: >-
+      Install shellcheck, shfmt, actionlint, yamllint[% if use_skills_sync %], yq[% endif %] — required by
+      `task check` / `task verify`.
+    default: "false"
+  gitleaks:
+    description: Install gitleaks — required by `task security`.
+    default: "false"
+  cache:
+    description: >-
+      Enable the pnpm dependency cache. Turn OFF for credential-holding jobs —
+      the repo-wide Actions cache is writable from lower-trust PR runs, so a
+      job with push/deploy tokens takes the cold-install trade instead.
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+[% if use_node %]
+    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+[% endif %]
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        # renovate: datasource=node-version
+        node-version: "24"
+[% if use_node %]
+        cache: ${{ inputs.cache == 'true' && 'pnpm' || '' }}
+[% endif %]
+[% if use_python %]
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.14"
+    - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+[% endif %]
+[% if use_foreman and not use_python %]
+    # uv provides uvx for foreman:lint's pinned ruff/black (see taskfiles/foreman.yml)
+    - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+[% endif %]
+[% if include_terraform %]
+    - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+[% endif %]
+    - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+      with:
+        # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
+        version: 3.51.1
+        repo-token: ${{ github.token }}
+    - name: Install lint tools (shellcheck, shfmt, actionlint, yamllint[% if use_skills_sync %], yq[% endif %])
+      if: inputs.lint-tools == 'true'
+      shell: bash
+      run: |
+        # renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.+)$
+        SHELLCHECK_VERSION=0.10.0
+        curl -fsSL --retry 3 -o /tmp/shellcheck.tar.xz \
+          "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+        tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+        sudo install -m 0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+        # renovate: datasource=github-releases depName=mvdan/sh extractVersion=^v?(?<version>.+)$
+        SHFMT_VERSION=3.13.1
+        # Raw-binary download: fail closed on a checksum mismatch (a version
+        # bump must update the pinned hash). Archive downloads (shellcheck,
+        # actionlint) already fail loudly at extract time on corruption; a
+        # hash-pinned toolchain image is the follow-on refactor.
+        SHFMT_SHA256=fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1
+        curl -fsSL --retry 3 -o /tmp/shfmt \
+          "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
+        echo "${SHFMT_SHA256}  /tmp/shfmt" | sha256sum -c -
+        sudo install -m 0755 /tmp/shfmt /usr/local/bin/shfmt
+        # renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v?(?<version>.+)$
+        ACTIONLINT_VERSION=1.7.12
+        curl -fsSL --retry 3 "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+          | tar -xz -C /tmp actionlint
+        sudo mv /tmp/actionlint /usr/local/bin/
+[% if use_skills_sync %]
+        # renovate: datasource=github-releases depName=mikefarah/yq extractVersion=^v?(?<version>.+)$
+        YQ_VERSION=4.44.3
+        # Raw-binary download: fail closed on a checksum mismatch (a version
+        # bump must update the pinned hash).
+        YQ_SHA256=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7
+        curl -fsSL --retry 3 -o /tmp/yq \
+          "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+        echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
+        sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+[% endif %]
+        pip install yamllint
+    - name: Install gitleaks
+      if: inputs.gitleaks == 'true'
+      shell: bash
+      run: |
+        # renovate: datasource=github-releases depName=gitleaks/gitleaks extractVersion=^v?(?<version>.+)$
+        GITLEAKS_VERSION=8.24.3
+        curl -sSL -o /tmp/gitleaks.tgz \
+          "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+        tar -xzf /tmp/gitleaks.tgz -C /tmp
+        sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+[% if use_python %]
+    - name: Install Python dependencies
+      if: inputs.install-deps == 'true'
+      shell: bash
+      run: uv sync
+[% endif %]
+[% if use_node %]
+    - name: Install dependencies
+      if: inputs.install-deps == 'true'
+      shell: bash
+      run: |
+        if [ -f package.json ]; then pnpm install --frozen-lockfile; fi
+[% endif %]

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -12,7 +12,8 @@ on:
 
 # Parallel jobs that all call into the Taskfile so local + CI run identical commands.
 # A final `verify` job aggregates statuses for branch protection
-# (required checks: verify + security).
+# (required checks: verify + security). Every job's toolchain setup goes through
+# the shared ./.github/actions/setup composite action.
 
 concurrency:
   group: build-${{ github.ref }}
@@ -34,78 +35,9 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-[% if use_node %]
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-[% endif %]
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: ./.github/actions/setup
         with:
-          # renovate: datasource=node-version
-          node-version: "24"
-[% if use_node %]
-          cache: pnpm
-[% endif %]
-[% if use_python %]
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.14"
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-[% endif %]
-[% if use_foreman and not use_python %]
-      # uv provides uvx for foreman:lint's pinned ruff/black (see taskfiles/foreman.yml)
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-[% endif %]
-[% if include_terraform %]
-      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
-[% endif %]
-      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
-        with:
-          # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
-          version: 3.51.1
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install lint tools (shellcheck, shfmt, actionlint, yamllint[% if use_skills_sync %], yq[% endif %])
-        run: |
-          # renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.+)$
-          SHELLCHECK_VERSION=0.10.0
-          curl -fsSL --retry 3 -o /tmp/shellcheck.tar.xz \
-            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
-          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
-          sudo install -m 0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
-          # renovate: datasource=github-releases depName=mvdan/sh extractVersion=^v?(?<version>.+)$
-          SHFMT_VERSION=3.13.1
-          # Raw-binary download: fail closed on a checksum mismatch (a version
-          # bump must update the pinned hash). Archive downloads (shellcheck,
-          # actionlint) already fail loudly at extract time on corruption; a
-          # hash-pinned toolchain image is the follow-on refactor.
-          SHFMT_SHA256=fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1
-          curl -fsSL --retry 3 -o /tmp/shfmt \
-            "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
-          echo "${SHFMT_SHA256}  /tmp/shfmt" | sha256sum -c -
-          sudo install -m 0755 /tmp/shfmt /usr/local/bin/shfmt
-          # renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v?(?<version>.+)$
-          ACTIONLINT_VERSION=1.7.12
-          curl -fsSL --retry 3 "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
-            | tar -xz -C /tmp actionlint
-          sudo mv /tmp/actionlint /usr/local/bin/
-[% if use_skills_sync %]
-          # renovate: datasource=github-releases depName=mikefarah/yq extractVersion=^v?(?<version>.+)$
-          YQ_VERSION=4.44.3
-          # Raw-binary download: fail closed on a checksum mismatch (a version
-          # bump must update the pinned hash).
-          YQ_SHA256=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7
-          curl -fsSL --retry 3 -o /tmp/yq \
-            "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
-          echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
-          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
-[% endif %]
-          pip install yamllint
-[% if use_python %]
-      - run: uv sync
-[% endif %]
-[% if use_node %]
-      - name: Install dependencies
-        run: |
-          if [ -f package.json ]; then pnpm install --frozen-lockfile; fi
-[% endif %]
+          lint-tools: "true"
       - name: Lint[% if use_node %] + typecheck[% endif +%]
         run: task check
       - run: task test:tasks
@@ -134,20 +66,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          # renovate: datasource=node-version
-          node-version: "24"
-          cache: pnpm
-      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
-        with:
-          # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
-          version: 3.51.1
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install dependencies
-        run: |
-          if [ -f package.json ]; then pnpm install --frozen-lockfile; fi
+      - uses: ./.github/actions/setup
 [% if project_type == 'web-astro' %]
       - name: Install lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
@@ -176,37 +95,9 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: ./.github/actions/setup
         with:
-          # renovate: datasource=node-version
-          node-version: "24"
-[% if use_node %]
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-[% endif %]
-[% if use_python %]
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.14"
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-[% endif %]
-      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
-        with:
-          # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
-          version: 3.51.1
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install gitleaks
-        run: |
-          # renovate: datasource=github-releases depName=gitleaks/gitleaks extractVersion=^v?(?<version>.+)$
-          GITLEAKS_VERSION=8.24.3
-          curl -sSL -o /tmp/gitleaks.tgz \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          tar -xzf /tmp/gitleaks.tgz -C /tmp
-          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
-[% if use_node %]
-      - name: Install dependencies
-        run: |
-          if [ -f package.json ]; then pnpm install --frozen-lockfile; fi
-[% endif %]
+          gitleaks: "true"
       - name: Security scan
         run: task security
 [% if project_type == 'web-astro' %]
@@ -226,20 +117,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          # renovate: datasource=node-version
-          node-version: "24"
-          cache: pnpm
-      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
-        with:
-          # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
-          version: 3.51.1
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install dependencies
-        run: |
-          if [ -f package.json ]; then pnpm install --frozen-lockfile; fi
+      - uses: ./.github/actions/setup
       - name: Install Chrome (required for Lighthouse)
         uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1.7.3
         id: setup-chrome
@@ -334,20 +212,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          # renovate: datasource=node-version
-          node-version: "24"
-          cache: pnpm
-      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
-        with:
-          # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
-          version: 3.51.1
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install dependencies
-        run: |
-          if [ -f package.json ]; then pnpm install --frozen-lockfile; fi
+      - uses: ./.github/actions/setup
       - name: Detect Playwright config
         id: pw
         run: |

--- a/template/.github/workflows/claude-implement.yml.jinja
+++ b/template/.github/workflows/claude-implement.yml.jinja
@@ -32,24 +32,68 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      # Egress firewall (must be the first step). Claude runs with Bash on a
+      # throwaway runner, so bound where that runner can talk: block all
+      # outbound traffic except the endpoints the toolchain + Claude genuinely
+      # need. This is the real exfiltration/callback boundary behind the scoped
+      # Bash allowlist. Targets GitHub-hosted ubuntu runners; if CI_RUNS_ON
+      # points at a self-hosted runner, harden-runner degrades to best-effort.
+      # STARTER LIST: the first real run logs any blocked endpoint in its run
+      # summary — add legitimate ones. Telemetry is off, so nothing leaves for
+      # StepSecurity.
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          disable-telemetry: true
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            uploads.github.com:443
+            pipelines.actions.githubusercontent.com:443
+            registry.npmjs.org:443
+            nodejs.org:443
+            get.pnpm.io:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            api.anthropic.com:443
+            statsig.anthropic.com:443
+[% if include_terraform %]
+            releases.hashicorp.com:443
+            registry.terraform.io:443
+[% endif %]
+      # Two tokens by blast radius. Claude runs with Bash, so the token it can
+      # reach via git/gh is deliberately narrow: push commits (contents), open
+      # PRs (pull-requests), comment (issues) — nothing more. Notably it lacks
+      # workflows:write, so a push that edits .github/workflows/ is rejected by
+      # GitHub, keeping a prompt-injected run from rewriting CI.
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
-          # Least-privilege token: implement pushes commits (contents), opens
-          # PRs (pull-requests), comments (issues), and may touch
-          # .github/workflows/ (workflows, write-only). org-projects (project
-          # Status updates) and members:read (the org-membership sender check)
-          # are gated to org repos only — an ungranted permission would fail
-          # token minting.
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
-          permission-workflows: write
 [% if github_org != author_git_provider_username %]
-          permission-organization-projects: write
+      # Privileged token for the sender check and the project-board update only:
+      # members:read backs the org-membership gate, organization-projects:write
+      # + issues:read move the Status card and resolve it by issue number.
+      # Claude must inherit none of these, so it is never wired into checkout,
+      # git identity, or the Claude step. Required (no continue-on-error): it is
+      # load-bearing for the sender gate below, and org-projects is gated to org
+      # repos so minting fails loudly on a personal fork.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token-privileged
+        with:
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           permission-members: read
+          permission-organization-projects: write
+          permission-issues: read
 [% endif %]
       # Defense in depth behind the job-level `if:` sender gate: re-verify the
       # sender server-side (org membership / repo owner) BEFORE the privileged
@@ -57,7 +101,11 @@ jobs:
       # push-capable token.
       - name: Verify sender is authorized
         env:
+[% if github_org != author_git_provider_username %]
+          GH_TOKEN: ${{ steps.app-token-privileged.outputs.token }}
+[% else %]
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+[% endif %]
           SENDER: ${{ github.event.sender.login }}
         run: |
           if [ "$SENDER" = "[[ author_git_provider_username ]]-bot" ]; then
@@ -80,8 +128,8 @@ jobs:
           fi
 [% endif %]
       # Exception to the repo-wide `persist-credentials: false` hardening:
-      # this checkout deliberately persists the short-lived CI App token so
-      # Claude's `git push` of the working branch can authenticate. The token
+      # this checkout deliberately persists the short-lived narrow CI App token
+      # so Claude's `git push` of the working branch can authenticate. The token
       # is least-privilege (minted above) and expires with the job.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -96,11 +144,21 @@ jobs:
           bot_id=$(gh api "/users/${bot}" --jq .id)
           git config --global user.name "$bot"
           git config --global user.email "${bot_id}+${bot}@users.noreply.github.com"
+      # Provision the full toolchain Claude needs to run `task verify` (and the
+      # git hooks its push triggers): the shared setup action + the lint CLIs
+      # that back `task check` and gitleaks for the pre-push `task security`
+      # hook. cache: false — this job holds a push-capable token, so it takes
+      # the cold-install trade rather than the PR-poisonable pnpm cache.
+      - uses: ./.github/actions/setup
+        with:
+          lint-tools: "true"
+          gitleaks: "true"
+          cache: "false"
 [% if github_org != author_git_provider_username %]
       - name: Set issue status to In Progress
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token-privileged.outputs.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ORG_PROJECT_ID: ${{ vars.ORG_PROJECT_ID }}
         run: |
@@ -152,6 +210,11 @@ jobs:
           echo "Set issue #$ISSUE_NUMBER to In Progress"
 [% endif %]
       - uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1.0.148
+        # GH_TOKEN lets Claude's own `gh` calls (e.g. `gh pr create`)
+        # authenticate as the CI app bot with the narrow token, matching the git
+        # identity above.
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
@@ -164,7 +227,21 @@ jobs:
           # --max-budget-usd caps API-key spend; likely a no-op under
           # CLAUDE_CODE_OAUTH_TOKEN (subscription) billing. Real runaway guards
           # are timeout-minutes (job-level) and --max-turns.
-          claude_args: "--model opus --effort high --max-budget-usd 25 --max-turns 200"
+          # --allowedTools grants the file-editing tools plus a SCOPED Bash
+          # allowlist (space-separated `Bash(cmd *)` form per the Claude Code
+          # settings reference): the project runners, git, gh, and read-only
+          # inspection utilities — enough to implement a change, run
+          # `task verify`, commit, push, and open a PR. Deliberately NOT allowed:
+          # curl/wget (exfiltration; also covered by the egress firewall),
+          # rm/chmod/sudo, and arbitrary `bash -c`/`eval`. Claude edits files via
+          # the Edit/Write tools or `task` targets. Prefix matching is coarse and
+          # shell can compose, so this is defense-in-depth, not a hard sandbox —
+          # the real boundaries are the narrow token, the egress firewall, branch
+          # protection, and the ephemeral runner. Widen if a real run stalls on a
+          # denied command.
+          claude_args: >-
+            --model opus --effort high --max-budget-usd 25 --max-turns 200
+            --allowedTools "Edit,MultiEdit,Write,Read,NotebookEdit,Glob,Grep,LS,TodoWrite,WebFetch,Bash(task *),Bash(pnpm *),Bash(npx *),Bash(node *),Bash(git *),Bash(gh *),Bash(cd *),Bash(ls *),Bash(cat *),Bash(head *),Bash(tail *),Bash(grep *),Bash(rg *),Bash(find *),Bash(sed *),Bash(awk *),Bash(jq *),Bash(wc *),Bash(sort *),Bash(diff *),Bash(echo *),Bash(mkdir *),Bash(cp *),Bash(mv *),Bash(which *),Bash(pwd)"
           prompt: |
             Implement the change requested in this issue or comment.
 

--- a/template/.github/workflows/claude-plan.yml.jinja
+++ b/template/.github/workflows/claude-plan.yml.jinja
@@ -32,6 +32,29 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      # Egress firewall (must be the first step): bound where the runner can
+      # talk. This workflow is read-only (Bash is disallowed below), so this is
+      # defense in depth for the action's own supply chain rather than a Claude
+      # sandbox. Targets GitHub-hosted ubuntu runners. STARTER LIST — the first
+      # real run logs any blocked endpoint in its run summary; telemetry is off,
+      # so nothing leaves for StepSecurity.
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          disable-telemetry: true
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            uploads.github.com:443
+            pipelines.actions.githubusercontent.com:443
+            registry.npmjs.org:443
+            nodejs.org:443
+            api.anthropic.com:443
+            statsig.anthropic.com:443
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:

--- a/template/.github/workflows/claude-review.yml.jinja
+++ b/template/.github/workflows/claude-review.yml.jinja
@@ -32,6 +32,29 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      # Egress firewall (must be the first step): bound where the runner can
+      # talk. This workflow is read-only (Bash is disallowed below), so this is
+      # defense in depth for the action's own supply chain rather than a Claude
+      # sandbox. Targets GitHub-hosted ubuntu runners. STARTER LIST — the first
+      # real run logs any blocked endpoint in its run summary; telemetry is off,
+      # so nothing leaves for StepSecurity.
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          disable-telemetry: true
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            uploads.github.com:443
+            pipelines.actions.githubusercontent.com:443
+            registry.npmjs.org:443
+            nodejs.org:443
+            api.anthropic.com:443
+            statsig.anthropic.com:443
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:


### PR DESCRIPTION
Upstreams the CI pattern established in `ponderousdev/lawnomator-site` this session, and records the release-gating rationale as an ADR.

## Part 1 — ADR 0003: release-gated deploys for static sites

`docs/decisions/0003-release-gated-deploys-for-static-sites.md` records **why** the template release-gates `web-astro` production (deploy the tagged commit when the release-please PR merges) but leaves `web-app` on deploy-on-merge:

- **Static sites** are stateless → intentional, batched, tag-rollback releases are a clean win, and `main` never auto-ships (so agent/Renovate-merged commits only *stage*).
- **Web apps** are stateful (schema/auth/payments) → they want small, frequent, attributable deploys, can't cleanly tag-rollback, and get their automation-merge safety from the **human-merge-only** rule (ADR 0002) instead.

No workflow change here — the template *already* implements this via `deploy_cloudflare_workers` (defaults `true` for `web-astro`). This just records the reasoning, which was previously uncaptured (`ci-cd.md` even had a TODO).

## Part 2 — composite setup action + hardened `claude-implement`

**New `template/.github/actions/setup/action.yml.jinja`** — one source of truth for the toolchain (Node/pnpm, Python/uv, Terraform, Task — rendered per project type), deps, and behind inputs the lint CLIs (`task check`) + gitleaks (`task security`). `build.yml`'s five jobs now call it instead of duplicating ~6 setup blocks. A `cache` input lets credential-holding jobs skip the PR-poisonable pnpm cache.

**`claude-implement.yml.jinja` hardening** (mirrors the reviewed lawnomator-site setup):
- Provisions the toolchain via the composite action so Claude can actually run `task verify` (previously it had none — the bug that started this).
- **Egress firewall**: `step-security/harden-runner` (block, telemetry off) as the first step, with a starter allowlist.
- **Token split**: Claude's Bash reaches only a **narrow** token (contents/pull-requests/issues). A separate privileged token (org: `members:read` for the sender gate + `organization-projects:write`/`issues:read` for the board) is never wired into checkout, git identity, or the Claude step.
- **Scoped `--allowedTools`**: file tools + a documented space-form Bash allowlist; `curl`/`wget`, `rm`/`chmod`/`sudo`, and `bash -c`/`eval` omitted.

### ⚠️ Security-relevant changes (calling out explicitly, per convention)
Two intentional posture changes that affect **every future scaffold**:
1. **`claude-implement` drops `workflows:write` from the token Claude can reach.** A push that edits `.github/workflows/` will now be **rejected by GitHub** — so a prompt-injected run can't rewrite CI. Trade-off: legit "implement a change to a workflow" tasks will fail (by design). This reverses the template's prior "implement may touch `.github/workflows/`" stance.
2. **`harden-runner` (a third-party action) is now a default dependency** in every scaffolded repo's `claude-implement`, in `block` mode. The allowlist is a **starter** — a repo's first real `@claude implement` run logs any blocked endpoint in its run summary for tuning. Too-tight defaults could block a run until tuned.

### Scope notes
- `claude-plan` / `claude-review` are **unchanged** (read-only, no Bash, no toolchain) — a possible egress follow-up.
- A first-class `web-app` deploy-on-merge template (from `omator`) is a deliberate **follow-up**, not in this PR.

## Validation
`task verify` passes — source lint + guards + the **full render matrix** (`web`/`webapp`/`iac`/`minimal`/`full`/`meta`/`update`), which runs actionlint on the rendered workflows for both org and personal owners. Spot-checked the rendered `action.yml` and org-branch `claude-implement.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)