### PR TITLE
feat(ci): explicit claude sender allowlist (configurable members) instead of org membership

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -66,6 +66,11 @@ code_owner:
   help: "CODE OWNER: GitHub user/team for CODEOWNERS (org repos may use org/team)"
   default: "[[ github_org ]]"
 
+claude_authorized_members:
+  type: str
+  help: "CLAUDE ACTIONS: comma-separated GitHub usernames allowed to trigger @claude plan/implement/review. An explicit allowlist (not org membership); the review workflow additionally allows the renovate/coderabbit/dependabot bots. Add more with `user-a,user-b`."
+  default: "[[ author_git_provider_username ]]"
+
 project_type:
   type: str
   help: "TYPE: What kind of project is this? (drives Taskfile, CI jobs, devcontainer tooling)"

--- a/template/.github/workflows/claude-implement.yml.jinja
+++ b/template/.github/workflows/claude-implement.yml.jinja
@@ -14,9 +14,12 @@ on:
     types: [opened, assigned, labeled]
 jobs:
   implement:
+    # Authorized senders — an explicit allowlist (claude_authorized_members),
+    # not org membership. The `if:` gate and the Verify step below both derive
+    # from this list, so they stay in sync.
+[% set _members = claude_authorized_members.split(',') | map('trim') | select | list %]
     if: >-
-      (github.event.sender.login == '[[ author_git_provider_username ]]' ||
-       github.event.sender.login == '[[ author_git_provider_username ]]-bot') &&
+      ([% for s in _members %]github.event.sender.login == '[[ s ]]'[% if not loop.last %] || [% endif %][% endfor %]) &&
       (contains(github.event.comment.body, '@claude implement') ||
        contains(github.event.review.body, '@claude implement') ||
        contains(github.event.issue.body, '@claude implement') ||
@@ -65,11 +68,26 @@ jobs:
             releases.hashicorp.com:443
             registry.terraform.io:443
 [% endif %]
-      # Two tokens by blast radius. Claude runs with Bash, so the token it can
-      # reach via git/gh is deliberately narrow: push commits (contents), open
-      # PRs (pull-requests), comment (issues) — nothing more. Notably it lacks
-      # workflows:write, so a push that edits .github/workflows/ is rejected by
-      # GitHub, keeping a prompt-injected run from rewriting CI.
+      # Defense in depth behind the job-level `if:` sender gate: re-assert the
+      # authorized-sender allowlist server-side BEFORE anything privileged runs,
+      # so a spoof-shaped gap in the `if:` expression can never even mint a
+      # push-capable token, let alone use it. Token-free — mirrors the `if:` gate.
+      - name: Verify sender is authorized
+        env:
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          case "$SENDER" in
+[% for s in _members %]
+            "[[ s ]]") echo "$SENDER is authorized"; exit 0 ;;
+[% endfor %]
+          esac
+          echo "::error::$SENDER is not an authorized sender"
+          exit 1
+      # The narrow token Claude reaches via git/gh: push commits (contents), open
+      # PRs (pull-requests), comment (issues) — nothing more, and minted only
+      # AFTER the sender is authorized. It lacks workflows:write, so a push that
+      # edits .github/workflows/ is rejected by GitHub, keeping a prompt-injected
+      # run from rewriting CI.
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
@@ -79,53 +97,19 @@ jobs:
           permission-pull-requests: write
           permission-issues: write
 [% if github_org != author_git_provider_username %]
-      # Privileged token for the sender check and the project-board update only:
-      # members:read backs the org-membership gate, organization-projects:write
-      # + issues:read move the Status card and resolve it by issue number.
-      # Claude must inherit none of these, so it is never wired into checkout,
-      # git identity, or the Claude step. Required (no continue-on-error): it is
-      # load-bearing for the sender gate below, and org-projects is gated to org
-      # repos so minting fails loudly on a personal fork.
+      # Separate token for the project-board update only — organization-projects
+      # to move the Status card plus issues:read to resolve it by issue number.
+      # Claude inherits neither, so it is never wired into checkout, git identity,
+      # or the Claude step. continue-on-error: a missing org grant (e.g. on a
+      # personal fork) skips the board update instead of aborting the job.
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token-privileged
+        id: app-token-projects
+        continue-on-error: true
         with:
           client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
-          permission-members: read
           permission-organization-projects: write
           permission-issues: read
-[% endif %]
-      # Defense in depth behind the job-level `if:` sender gate: re-verify the
-      # sender server-side (org membership / repo owner) BEFORE the privileged
-      # checkout, so a spoof-shaped gap in the expression can never reach a
-      # push-capable token.
-      - name: Verify sender is authorized
-        env:
-[% if github_org != author_git_provider_username %]
-          GH_TOKEN: ${{ steps.app-token-privileged.outputs.token }}
-[% else %]
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-[% endif %]
-          SENDER: ${{ github.event.sender.login }}
-        run: |
-          if [ "$SENDER" = "[[ author_git_provider_username ]]-bot" ]; then
-            echo "Bot $SENDER allowed"
-            exit 0
-          fi
-[% if github_org != author_git_provider_username %]
-          if gh api "orgs/[[ github_org ]]/members/$SENDER" --silent 2>/dev/null; then
-            echo "$SENDER is a [[ github_org ]] org member"
-          else
-            echo "::error::$SENDER is not authorized (not a [[ github_org ]] org member)"
-            exit 1
-          fi
-[% else %]
-          if [ "$SENDER" = "[[ author_git_provider_username ]]" ]; then
-            echo "$SENDER is the repo owner"
-          else
-            echo "::error::$SENDER is not authorized"
-            exit 1
-          fi
 [% endif %]
       # Exception to the repo-wide `persist-credentials: false` hardening:
       # this checkout deliberately persists the short-lived narrow CI App token
@@ -156,9 +140,10 @@ jobs:
           cache: "false"
 [% if github_org != author_git_provider_username %]
       - name: Set issue status to In Progress
+        if: steps.app-token-projects.outputs.token != ''
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.app-token-privileged.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token-projects.outputs.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ORG_PROJECT_ID: ${{ vars.ORG_PROJECT_ID }}
         run: |

--- a/template/.github/workflows/claude-plan.yml.jinja
+++ b/template/.github/workflows/claude-plan.yml.jinja
@@ -14,9 +14,12 @@ on:
     types: [opened, assigned, labeled]
 jobs:
   plan:
+    # Authorized senders — an explicit allowlist (claude_authorized_members),
+    # not org membership. The `if:` gate and the Verify step below both derive
+    # from this list, so they stay in sync.
+[% set _members = claude_authorized_members.split(',') | map('trim') | select | list %]
     if: >-
-      (github.event.sender.login == '[[ author_git_provider_username ]]' ||
-       github.event.sender.login == '[[ author_git_provider_username ]]-bot') &&
+      ([% for s in _members %]github.event.sender.login == '[[ s ]]'[% if not loop.last %] || [% endif %][% endfor %]) &&
       (contains(github.event.comment.body, '@claude plan') ||
        contains(github.event.review.body, '@claude plan') ||
        contains(github.event.issue.body, '@claude plan') ||
@@ -61,44 +64,30 @@ jobs:
           client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: plan only comments (issues/pull-requests) and
-          # reads the repo (no push). org-projects (project Status updates) and
-          # members:read (the org-membership sender check) are gated to org
-          # repos — requesting a permission the installation lacks makes this
-          # step fail.
+          # reads the repo (no push). org-projects (project Status updates) is
+          # gated to org repos — requesting a permission the installation lacks
+          # makes this step fail.
           permission-contents: read
           permission-issues: write
           permission-pull-requests: write
 [% if github_org != author_git_provider_username %]
           permission-organization-projects: write
-          permission-members: read
 [% endif %]
-      # Defense in depth behind the job-level `if:` sender gate: re-verify the
-      # sender server-side (org membership / repo owner) so a spoof-shaped gap
-      # in the expression can never reach the Claude step.
+      # Defense in depth behind the job-level `if:` sender gate: re-assert the
+      # authorized-sender allowlist server-side so a spoof-shaped gap in the
+      # `if:` expression can never reach the Claude step. Token-free — mirrors
+      # the `if:` gate.
       - name: Verify sender is authorized
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SENDER: ${{ github.event.sender.login }}
         run: |
-          if [ "$SENDER" = "[[ author_git_provider_username ]]-bot" ]; then
-            echo "Bot $SENDER allowed"
-            exit 0
-          fi
-[% if github_org != author_git_provider_username %]
-          if gh api "orgs/[[ github_org ]]/members/$SENDER" --silent 2>/dev/null; then
-            echo "$SENDER is a [[ github_org ]] org member"
-          else
-            echo "::error::$SENDER is not authorized (not a [[ github_org ]] org member)"
-            exit 1
-          fi
-[% else %]
-          if [ "$SENDER" = "[[ author_git_provider_username ]]" ]; then
-            echo "$SENDER is the repo owner"
-          else
-            echo "::error::$SENDER is not authorized"
-            exit 1
-          fi
-[% endif %]
+          case "$SENDER" in
+[% for s in _members %]
+            "[[ s ]]") echo "$SENDER is authorized"; exit 0 ;;
+[% endfor %]
+          esac
+          echo "::error::$SENDER is not an authorized sender"
+          exit 1
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false

--- a/template/.github/workflows/claude-review.yml.jinja
+++ b/template/.github/workflows/claude-review.yml.jinja
@@ -61,42 +61,24 @@ jobs:
           client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: review only comments (issues/pull-requests)
-          # and reads the repo (no push). members:read is gated to org repos —
-          # it backs the org-membership sender check; personal repos lack it
-          # and requesting it would fail token minting.
+          # and reads the repo (no push).
           permission-contents: read
           permission-pull-requests: write
           permission-issues: write
-[% if github_org != author_git_provider_username %]
-          permission-members: read
-[% endif %]
+      # Authorized senders — the explicit claude_authorized_members allowlist
+      # (not org membership) plus the automation bots whose PRs review runs on.
+[% set _review_senders = (claude_authorized_members.split(',') | map('trim') | select | list) + ['renovate[bot]', 'coderabbitai[bot]', 'dependabot[bot]'] %]
       - name: Verify sender is authorized
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SENDER: ${{ github.event.sender.login }}
         run: |
-          if [ "$SENDER" = "[[ author_git_provider_username ]]-bot" ] || \
-             [ "$SENDER" = "renovate[bot]" ] || \
-             [ "$SENDER" = "coderabbitai[bot]" ] || \
-             [ "$SENDER" = "dependabot[bot]" ]; then
-            echo "Bot $SENDER allowed"
-            exit 0
-          fi
-[% if github_org != author_git_provider_username %]
-          if gh api "orgs/[[ github_org ]]/members/$SENDER" --silent 2>/dev/null; then
-            echo "$SENDER is a [[ github_org ]] org member"
-          else
-            echo "::error::$SENDER is not authorized (not a [[ github_org ]] org member)"
-            exit 1
-          fi
-[% else %]
-          if [ "$SENDER" = "[[ author_git_provider_username ]]" ]; then
-            echo "$SENDER is the repo owner"
-          else
-            echo "::error::$SENDER is not authorized"
-            exit 1
-          fi
-[% endif %]
+          case "$SENDER" in
+[% for s in _review_senders %]
+            "[[ s ]]") echo "$SENDER is authorized"; exit 0 ;;
+[% endfor %]
+          esac
+          echo "::error::$SENDER is not an authorized sender"
+          exit 1
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false


### PR DESCRIPTION
Replaces the "any org member" sender check in the claude workflows with an **explicit, configurable allowlist** — and, because that makes the check token-free, folds in the sender-before-mint hardening and drops `members:read` everywhere.

## What changed
- **New copier var `claude_authorized_members`** — comma-separated GitHub usernames allowed to trigger `@claude plan/implement/review`. Default `[[ author_git_provider_username ]]` → **evanharmon1**. Add more with `user-a,user-b`.
- Both the job-level **`if:` gate** and the server-side **Verify step** render from that list (they stay in sync). `claude-review` additionally allows the `renovate`/`coderabbit`/`dependabot` bots (quoted `case` patterns so `[bot]` matches literally).
- The Verify step is now a **token-free `case`** over the allowlist. Since it no longer calls `gh api …/members/…`, **`members:read` is removed from every claude token**.
- **`claude-implement`**: with the check token-free, it now runs **first — before any token is minted** — so an unauthorized sender can't even mint the `contents:write` token (generalizes the CodeRabbit fix from lawnomator-site #24). The project-board token becomes a separate `continue-on-error` `app-token-projects` (`organization-projects:write` + `issues:read`); the status step is skipped when it's absent. This matches the lawnomator-site structure.

## Security note (calling out, per convention)
This **changes the authorization model** every future scaffold inherits: from "author/author-bot + any org member" to an **explicit member list** (default: the author only). It's *more* restrictive by default — org members are no longer implicitly authorized; you list them. The `<author>-bot` sender is no longer auto-allowed; add it to the list if you use it.

## Validation
`task verify` passes — source lint + guards + the full render matrix (`web`/`webapp`/`iac`/`minimal`/`full`/`meta`/`update`), including a rendered two-member allowlist and the `copier update` safety test. Spot-checked the generated `if:` gate and `case` arms for 1- and 2-member configs and the review bot list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)