### PR TITLE
feat(ci): fold the review-phase hardening back into the template

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,83 @@
+name: Setup toolchain
+description: >-
+  Install the shared toolchain (Node, Task), project
+  dependencies, and — behind inputs — the lint + security CLIs. Single source of
+  truth for the CI jobs and the Claude automation workflows so local, CI, and
+  agent runs all execute the same Taskfile targets. Callers must run
+  actions/checkout first.
+
+inputs:
+  install-deps:
+    description: Install project dependencies () when present.
+    default: "true"
+  lint-tools:
+    description: >-
+      Install shellcheck, shfmt, actionlint, yamllint, yq — required by
+      `task check` / `task verify`.
+    default: "false"
+  gitleaks:
+    description: Install gitleaks — required by `task security`.
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        # renovate: datasource=node-version
+        node-version: "24"
+    # uv provides uvx for foreman:lint's pinned ruff/black (see taskfiles/foreman.yml)
+    - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+    - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+      with:
+        # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
+        version: 3.51.1
+        repo-token: ${{ github.token }}
+    - name: Install lint tools (shellcheck, shfmt, actionlint, yamllint, yq)
+      if: inputs.lint-tools == 'true'
+      shell: bash
+      run: |
+        # renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.+)$
+        SHELLCHECK_VERSION=0.10.0
+        curl -fsSL --retry 3 -o /tmp/shellcheck.tar.xz \
+          "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+        tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+        sudo install -m 0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+        # renovate: datasource=github-releases depName=mvdan/sh extractVersion=^v?(?<version>.+)$
+        SHFMT_VERSION=3.13.1
+        # Raw-binary download: fail closed on a checksum mismatch (a version
+        # bump must update the pinned hash). Archive downloads (shellcheck,
+        # actionlint) already fail loudly at extract time on corruption; a
+        # hash-pinned toolchain image is the follow-on refactor.
+        SHFMT_SHA256=fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1
+        curl -fsSL --retry 3 -o /tmp/shfmt \
+          "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
+        echo "${SHFMT_SHA256}  /tmp/shfmt" | sha256sum -c -
+        sudo install -m 0755 /tmp/shfmt /usr/local/bin/shfmt
+        # renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v?(?<version>.+)$
+        ACTIONLINT_VERSION=1.7.12
+        curl -fsSL --retry 3 "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+          | tar -xz -C /tmp actionlint
+        sudo mv /tmp/actionlint /usr/local/bin/
+        # renovate: datasource=github-releases depName=mikefarah/yq extractVersion=^v?(?<version>.+)$
+        YQ_VERSION=4.44.3
+        # Raw-binary download: fail closed on a checksum mismatch (a version
+        # bump must update the pinned hash).
+        YQ_SHA256=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7
+        curl -fsSL --retry 3 -o /tmp/yq \
+          "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+        echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
+        sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+        # renovate: datasource=pypi depName=yamllint
+        YAMLLINT_VERSION=1.38.0
+        python3 -m pip install "yamllint==${YAMLLINT_VERSION}"
+    - name: Install gitleaks
+      if: inputs.gitleaks == 'true'
+      shell: bash
+      run: |
+        # renovate: datasource=github-releases depName=gitleaks/gitleaks extractVersion=^v?(?<version>.+)$
+        GITLEAKS_VERSION=8.24.3
+        curl -fsSL --retry 3 -o /tmp/gitleaks.tgz \
+          "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+        tar -xzf /tmp/gitleaks.tgz -C /tmp
+        sudo mv /tmp/gitleaks /usr/local/bin/gitleaks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,17 @@ concurrency:
 permissions:
   contents: read
 
+# Parallel jobs that all call into the Taskfile so local + CI run identical
+# commands. Toolchain setup goes through the shared ./.github/actions/setup
+# composite action (the same one the Claude automation workflows use). The
+# template-test job stays bespoke: it exercises copier renders, which need
+# copier + the devcontainer CLI the composite doesn't install.
+
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -26,52 +34,11 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: ./.github/actions/setup
         with:
-          # renovate: datasource=node-version
-          node-version: "24"
-      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
-        with:
-          # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
-          version: 3.51.1
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      # uv provides uvx for foreman:lint's pinned ruff/black (see taskfiles/foreman.yml)
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - name: Install lint tools (shellcheck, shfmt, actionlint, yamllint, yq)
-        run: |
-          # renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.+)$
-          SHELLCHECK_VERSION=0.10.0
-          curl -fsSL --retry 3 -o /tmp/shellcheck.tar.xz \
-            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
-          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
-          sudo install -m 0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
-          # renovate: datasource=github-releases depName=mvdan/sh extractVersion=^v?(?<version>.+)$
-          SHFMT_VERSION=3.13.1
-          # Raw-binary download: fail closed on a checksum mismatch (a version
-          # bump must update the pinned hash). Archive downloads (shellcheck,
-          # actionlint) already fail loudly at extract time on corruption; a
-          # hash-pinned toolchain image is the follow-on refactor.
-          SHFMT_SHA256=fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1
-          curl -fsSL --retry 3 -o /tmp/shfmt \
-            "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64"
-          echo "${SHFMT_SHA256}  /tmp/shfmt" | sha256sum -c -
-          sudo install -m 0755 /tmp/shfmt /usr/local/bin/shfmt
-          # renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v?(?<version>.+)$
-          ACTIONLINT_VERSION=1.7.12
-          curl -fsSL --retry 3 "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
-            | tar -xz -C /tmp actionlint
-          sudo mv /tmp/actionlint /usr/local/bin/
-          # renovate: datasource=github-releases depName=mikefarah/yq extractVersion=^v?(?<version>.+)$
-          YQ_VERSION=4.44.3
-          # Raw-binary download: fail closed on a checksum mismatch (a version
-          # bump must update the pinned hash).
-          YQ_SHA256=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7
-          curl -fsSL --retry 3 -o /tmp/yq \
-            "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
-          echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
-          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
-          pip install yamllint
-      - run: task check
+          lint-tools: "true"
+      - name: Lint
+        run: task check
       - run: task test:tasks
       - run: task foreman:test
       - name: Skills drift check (vendored skills vs pinned harmon-devkit ref)
@@ -80,7 +47,9 @@ jobs:
       - run: task test:devcontainer:permissions
 
   security:
-    runs-on: ubuntu-latest
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -90,27 +59,15 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: ./.github/actions/setup
         with:
-          # renovate: datasource=node-version
-          node-version: "24"
-      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
-        with:
-          # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
-          version: 3.51.1
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install gitleaks
-        run: |
-          # renovate: datasource=github-releases depName=gitleaks/gitleaks extractVersion=^v?(?<version>.+)$
-          GITLEAKS_VERSION=8.24.3
-          curl -sSL -o /tmp/gitleaks.tgz \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          tar -xzf /tmp/gitleaks.tgz -C /tmp
-          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks: "true"
       - run: task security:secrets
 
   template-test:
-    runs-on: ubuntu-latest
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -159,7 +116,9 @@ jobs:
   verify:
     if: always()
     needs: [lint, template-test]
-    runs-on: ubuntu-latest
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     steps:
       - name: Check job results
         run: |

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -14,15 +14,19 @@ on:
     types: [opened, assigned, labeled]
 jobs:
   implement:
+    # Authorized senders — an explicit allowlist (claude_authorized_members),
+    # not org membership. The `if:` gate and the Verify step below both derive
+    # from this list, so they stay in sync.
     if: >-
-      (github.event.sender.login == 'evanharmon1' ||
-       github.event.sender.login == 'evanharmon1-bot') &&
+      (github.event.sender.login == 'evanharmon1') &&
       (contains(github.event.comment.body, '@claude implement') ||
        contains(github.event.review.body, '@claude implement') ||
        contains(github.event.issue.body, '@claude implement') ||
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-implement'))
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     timeout-minutes: 180
     permissions:
       contents: write
@@ -30,43 +34,65 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      # Egress firewall (must be the first step). Claude runs with Bash on a
+      # throwaway runner, so bound where that runner can talk: block all
+      # outbound traffic except the endpoints the toolchain + Claude genuinely
+      # need. This is the real exfiltration/callback boundary behind the scoped
+      # Bash allowlist. Targets GitHub-hosted ubuntu runners; if CI_RUNS_ON
+      # points at a self-hosted runner, harden-runner degrades to best-effort.
+      # STARTER LIST: the first real run logs any blocked endpoint in its run
+      # summary — add legitimate ones. Telemetry is off, so nothing leaves for
+      # StepSecurity.
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          disable-telemetry: true
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            uploads.github.com:443
+            pipelines.actions.githubusercontent.com:443
+            registry.npmjs.org:443
+            nodejs.org:443
+            get.pnpm.io:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            api.anthropic.com:443
+            statsig.anthropic.com:443
+      # Defense in depth behind the job-level `if:` sender gate: an explicit
+      # step (runs on the runner, unlike the GitHub-evaluated `if:`) that
+      # re-asserts the authorized-sender allowlist BEFORE anything privileged
+      # runs, so a spoof-shaped gap in the `if:` expression can never even mint
+      # a push-capable token, let alone use it. Token-free — mirrors the `if:`.
+      - name: Verify sender is authorized
+        env:
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          case "$SENDER" in
+            "evanharmon1") echo "$SENDER is authorized"; exit 0 ;;
+          esac
+          echo "::error::$SENDER is not an authorized sender"
+          exit 1
+      # The narrow token Claude reaches via git/gh: push commits (contents), open
+      # PRs (pull-requests), comment (issues) — nothing more, and minted only
+      # AFTER the sender is authorized. It lacks workflows:write, so a push that
+      # edits .github/workflows/ is rejected by GitHub, keeping a prompt-injected
+      # run from rewriting CI.
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
-          # Least-privilege token: implement pushes commits (contents), opens
-          # PRs (pull-requests), comments (issues), and may touch
-          # .github/workflows/ (workflows, write-only). org-projects (project
-          # Status updates) and members:read (the org-membership sender check)
-          # are gated to org repos only — an ungranted permission would fail
-          # token minting.
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
-          permission-workflows: write
-      # Defense in depth behind the job-level `if:` sender gate: re-verify the
-      # sender server-side (org membership / repo owner) BEFORE the privileged
-      # checkout, so a spoof-shaped gap in the expression can never reach a
-      # push-capable token.
-      - name: Verify sender is authorized
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          SENDER: ${{ github.event.sender.login }}
-        run: |
-          if [ "$SENDER" = "evanharmon1-bot" ]; then
-            echo "Bot $SENDER allowed"
-            exit 0
-          fi
-          if [ "$SENDER" = "evanharmon1" ]; then
-            echo "$SENDER is the repo owner"
-          else
-            echo "::error::$SENDER is not authorized"
-            exit 1
-          fi
       # Exception to the repo-wide `persist-credentials: false` hardening:
-      # this checkout deliberately persists the short-lived CI App token so
-      # Claude's `git push` of the working branch can authenticate. The token
+      # this checkout deliberately persists the short-lived narrow CI App token
+      # so Claude's `git push` of the working branch can authenticate. The token
       # is least-privilege (minted above) and expires with the job.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -81,7 +107,20 @@ jobs:
           bot_id=$(gh api "/users/${bot}" --jq .id)
           git config --global user.name "$bot"
           git config --global user.email "${bot_id}+${bot}@users.noreply.github.com"
+      # Provision the full toolchain Claude needs to run `task verify` (and the
+      # git hooks its push triggers): the shared setup action + the lint CLIs
+      # that back `task check` and gitleaks for the pre-push `task security`
+      # hook.
+      - uses: ./.github/actions/setup
+        with:
+          lint-tools: "true"
+          gitleaks: "true"
       - uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1.0.148
+        # GH_TOKEN lets Claude's own `gh` calls (e.g. `gh pr create`)
+        # authenticate as the CI app bot with the narrow token, matching the git
+        # identity above.
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
@@ -94,7 +133,21 @@ jobs:
           # --max-budget-usd caps API-key spend; likely a no-op under
           # CLAUDE_CODE_OAUTH_TOKEN (subscription) billing. Real runaway guards
           # are timeout-minutes (job-level) and --max-turns.
-          claude_args: "--model opus --effort high --max-budget-usd 25 --max-turns 200"
+          # --allowedTools grants the file-editing tools plus a SCOPED Bash
+          # allowlist (space-separated `Bash(cmd *)` form per the Claude Code
+          # settings reference): the project runners, git, gh, and read-only
+          # inspection utilities — enough to implement a change, run
+          # `task verify`, commit, push, and open a PR. Deliberately NOT allowed:
+          # curl/wget (exfiltration; also covered by the egress firewall),
+          # rm/chmod/sudo, and arbitrary `bash -c`/`eval`. Claude edits files via
+          # the Edit/Write tools or `task` targets. Prefix matching is coarse and
+          # shell can compose, so this is defense-in-depth, not a hard sandbox —
+          # the real boundaries are the narrow token, the egress firewall, branch
+          # protection, and the ephemeral runner. Widen if a real run stalls on a
+          # denied command.
+          claude_args: >-
+            --model opus --effort high --max-budget-usd 25 --max-turns 200
+            --allowedTools "Edit,MultiEdit,Write,Read,NotebookEdit,Glob,Grep,LS,TodoWrite,Bash(task *),Bash(pnpm *),Bash(npx *),Bash(node *),Bash(git *),Bash(gh *),Bash(cd *),Bash(ls *),Bash(cat *),Bash(head *),Bash(tail *),Bash(grep *),Bash(rg *),Bash(find *),Bash(sed *),Bash(awk *),Bash(jq *),Bash(wc *),Bash(sort *),Bash(diff *),Bash(echo *),Bash(mkdir *),Bash(cp *),Bash(mv *),Bash(which *),Bash(pwd)"
           prompt: |
             Implement the change requested in this issue or comment.
 

--- a/.github/workflows/claude-plan.yml
+++ b/.github/workflows/claude-plan.yml
@@ -14,15 +14,19 @@ on:
     types: [opened, assigned, labeled]
 jobs:
   plan:
+    # Authorized senders — an explicit allowlist (claude_authorized_members),
+    # not org membership. The `if:` gate and the Verify step below both derive
+    # from this list, so they stay in sync.
     if: >-
-      (github.event.sender.login == 'evanharmon1' ||
-       github.event.sender.login == 'evanharmon1-bot') &&
+      (github.event.sender.login == 'evanharmon1') &&
       (contains(github.event.comment.body, '@claude plan') ||
        contains(github.event.review.body, '@claude plan') ||
        contains(github.event.issue.body, '@claude plan') ||
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-plan'))
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     timeout-minutes: 120
     permissions:
       contents: read
@@ -30,37 +34,52 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      # Egress firewall (must be the first step): bound where the runner can
+      # talk. Claude runs read-only here (Bash disallowed via claude_args
+      # below), so this is defense in depth for the action's own supply chain
+      # rather than a Claude sandbox. Targets GitHub-hosted ubuntu runners. STARTER LIST — the first
+      # real run logs any blocked endpoint in its run summary; telemetry is off,
+      # so nothing leaves for StepSecurity.
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          disable-telemetry: true
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            uploads.github.com:443
+            pipelines.actions.githubusercontent.com:443
+            registry.npmjs.org:443
+            nodejs.org:443
+            api.anthropic.com:443
+            statsig.anthropic.com:443
+      # Defense in depth behind the job-level `if:` sender gate: an explicit
+      # step that re-asserts the authorized-sender allowlist BEFORE minting any
+      # token, so a spoof-shaped gap in the `if:` expression can never mint
+      # credentials. Token-free — mirrors the `if:` gate.
+      - name: Verify sender is authorized
+        env:
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          case "$SENDER" in
+            "evanharmon1") echo "$SENDER is authorized"; exit 0 ;;
+          esac
+          echo "::error::$SENDER is not an authorized sender"
+          exit 1
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: plan only comments (issues/pull-requests) and
-          # reads the repo (no push). org-projects (project Status updates) and
-          # members:read (the org-membership sender check) are gated to org
-          # repos — requesting a permission the installation lacks makes this
-          # step fail.
+          # reads the repo (no push).
           permission-contents: read
           permission-issues: write
           permission-pull-requests: write
-      # Defense in depth behind the job-level `if:` sender gate: re-verify the
-      # sender server-side (org membership / repo owner) so a spoof-shaped gap
-      # in the expression can never reach the Claude step.
-      - name: Verify sender is authorized
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          SENDER: ${{ github.event.sender.login }}
-        run: |
-          if [ "$SENDER" = "evanharmon1-bot" ]; then
-            echo "Bot $SENDER allowed"
-            exit 0
-          fi
-          if [ "$SENDER" = "evanharmon1" ]; then
-            echo "$SENDER is the repo owner"
-          else
-            echo "::error::$SENDER is not authorized"
-            exit 1
-          fi
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -14,52 +14,79 @@ on:
     types: [labeled]
 jobs:
   review:
+    # Authorized senders — the explicit claude_authorized_members allowlist plus
+    # the automation bots whose PRs review runs on. Used by both the `if:` gate
+    # (so unauthorized events never provision a runner) and the Verify step.
     if: >-
       (github.event.issue.pull_request != null ||
        github.event_name == 'pull_request_review_comment' ||
        github.event_name == 'pull_request_review' ||
        github.event_name == 'pull_request') &&
+      (github.event.sender.login == 'evanharmon1' || github.event.sender.login == 'renovate[bot]' || github.event.sender.login == 'coderabbitai[bot]' || github.event.sender.login == 'dependabot[bot]') &&
       (contains(github.event.comment.body, '@claude review') ||
        contains(github.event.review.body, '@claude review') ||
        (github.event.action == 'labeled' &&
         github.event.label.name == 'claude-review'))
-    runs-on: [ "ubuntu-latest" ]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: write
       id-token: write
     steps:
+      # Egress firewall (must be the first step): bound where the runner can
+      # talk. Claude runs read-only here (Bash disallowed via claude_args
+      # below), so this is defense in depth for the action's own supply chain
+      # rather than a Claude sandbox. Targets GitHub-hosted ubuntu runners. STARTER LIST — the first
+      # real run logs any blocked endpoint in its run summary; telemetry is off,
+      # so nothing leaves for StepSecurity.
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          disable-telemetry: true
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            uploads.github.com:443
+            pipelines.actions.githubusercontent.com:443
+            registry.npmjs.org:443
+            nodejs.org:443
+            api.anthropic.com:443
+            statsig.anthropic.com:443
+      # Defense in depth behind the job-level `if:` sender gate (which now
+      # carries the same allowlist, so unauthorized events never provision a
+      # runner). Runs BEFORE minting the App token (the job GITHUB_TOKEN exists
+      # earlier for e.g. harden-runner, but no App token does yet) so a gap in
+      # that expression can't reach credential creation. Quoting makes `[bot]` a
+      # literal in the case pattern, not a glob class. Keep in sync with `if:`.
+      - name: Verify sender is authorized
+        env:
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          case "$SENDER" in
+            "evanharmon1") echo "$SENDER is authorized"; exit 0 ;;
+            "renovate[bot]") echo "$SENDER is authorized"; exit 0 ;;
+            "coderabbitai[bot]") echo "$SENDER is authorized"; exit 0 ;;
+            "dependabot[bot]") echo "$SENDER is authorized"; exit 0 ;;
+          esac
+          echo "::error::$SENDER is not an authorized sender"
+          exit 1
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           # Least-privilege token: review only comments (issues/pull-requests)
-          # and reads the repo (no push). members:read is gated to org repos —
-          # it backs the org-membership sender check; personal repos lack it
-          # and requesting it would fail token minting.
+          # and reads the repo (no push).
           permission-contents: read
           permission-pull-requests: write
           permission-issues: write
-      - name: Verify sender is authorized
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          SENDER: ${{ github.event.sender.login }}
-        run: |
-          if [ "$SENDER" = "evanharmon1-bot" ] || \
-             [ "$SENDER" = "renovate[bot]" ] || \
-             [ "$SENDER" = "coderabbitai[bot]" ] || \
-             [ "$SENDER" = "dependabot[bot]" ]; then
-            echo "Bot $SENDER allowed"
-            exit 0
-          fi
-          if [ "$SENDER" = "evanharmon1" ]; then
-            echo "$SENDER is the repo owner"
-          else
-            echo "::error::$SENDER is not authorized"
-            exit 1
-          fi
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false

--- a/template/.github/actions/setup/action.yml.jinja
+++ b/template/.github/actions/setup/action.yml.jinja
@@ -1,6 +1,6 @@
 name: Setup toolchain
 description: >-
-  Install the shared toolchain (Node/pnpm[% if use_python %], Python/uv[% endif %][% if include_terraform %], Terraform[% endif %], Task), project
+  Install the shared toolchain (Node[% if use_node %]/pnpm[% endif %][% if use_python %], Python/uv[% endif %][% if include_terraform %], Terraform[% endif %], Task), project
   dependencies, and — behind inputs — the lint + security CLIs. Single source of
   truth for the CI jobs and the Claude automation workflows so local, CI, and
   agent runs all execute the same Taskfile targets. Callers must run
@@ -18,12 +18,14 @@ inputs:
   gitleaks:
     description: Install gitleaks — required by `task security`.
     default: "false"
+[% if use_node %]
   cache:
     description: >-
       Enable the pnpm dependency cache. Turn OFF for credential-holding jobs —
       the repo-wide Actions cache is writable from lower-trust PR runs, so a
       job with push/deploy tokens takes the cold-install trade instead.
     default: "true"
+[% endif %]
 
 runs:
   using: composite
@@ -93,14 +95,16 @@ runs:
         echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
         sudo install -m 0755 /tmp/yq /usr/local/bin/yq
 [% endif %]
-        pip install yamllint
+        # renovate: datasource=pypi depName=yamllint
+        YAMLLINT_VERSION=1.38.0
+        python3 -m pip install "yamllint==${YAMLLINT_VERSION}"
     - name: Install gitleaks
       if: inputs.gitleaks == 'true'
       shell: bash
       run: |
         # renovate: datasource=github-releases depName=gitleaks/gitleaks extractVersion=^v?(?<version>.+)$
         GITLEAKS_VERSION=8.24.3
-        curl -sSL -o /tmp/gitleaks.tgz \
+        curl -fsSL --retry 3 -o /tmp/gitleaks.tgz \
           "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
         tar -xzf /tmp/gitleaks.tgz -C /tmp
         sudo mv /tmp/gitleaks /usr/local/bin/gitleaks

--- a/template/.github/workflows/claude-implement.yml.jinja
+++ b/template/.github/workflows/claude-implement.yml.jinja
@@ -68,10 +68,11 @@ jobs:
             releases.hashicorp.com:443
             registry.terraform.io:443
 [% endif %]
-      # Defense in depth behind the job-level `if:` sender gate: re-assert the
-      # authorized-sender allowlist server-side BEFORE anything privileged runs,
-      # so a spoof-shaped gap in the `if:` expression can never even mint a
-      # push-capable token, let alone use it. Token-free — mirrors the `if:` gate.
+      # Defense in depth behind the job-level `if:` sender gate: an explicit
+      # step (runs on the runner, unlike the GitHub-evaluated `if:`) that
+      # re-asserts the authorized-sender allowlist BEFORE anything privileged
+      # runs, so a spoof-shaped gap in the `if:` expression can never even mint
+      # a push-capable token, let alone use it. Token-free — mirrors the `if:`.
       - name: Verify sender is authorized
         env:
           SENDER: ${{ github.event.sender.login }}
@@ -131,13 +132,18 @@ jobs:
       # Provision the full toolchain Claude needs to run `task verify` (and the
       # git hooks its push triggers): the shared setup action + the lint CLIs
       # that back `task check` and gitleaks for the pre-push `task security`
-      # hook. cache: false — this job holds a push-capable token, so it takes
-      # the cold-install trade rather than the PR-poisonable pnpm cache.
+      # hook.
+[% if use_node %]
+      # cache: false — this job holds a push-capable token, so it takes the
+      # cold-install trade rather than the PR-poisonable pnpm cache.
+[% endif %]
       - uses: ./.github/actions/setup
         with:
           lint-tools: "true"
           gitleaks: "true"
+[% if use_node %]
           cache: "false"
+[% endif %]
 [% if github_org != author_git_provider_username %]
       - name: Set issue status to In Progress
         if: steps.app-token-projects.outputs.token != ''
@@ -226,7 +232,7 @@ jobs:
           # denied command.
           claude_args: >-
             --model opus --effort high --max-budget-usd 25 --max-turns 200
-            --allowedTools "Edit,MultiEdit,Write,Read,NotebookEdit,Glob,Grep,LS,TodoWrite,WebFetch,Bash(task *),Bash(pnpm *),Bash(npx *),Bash(node *),Bash(git *),Bash(gh *),Bash(cd *),Bash(ls *),Bash(cat *),Bash(head *),Bash(tail *),Bash(grep *),Bash(rg *),Bash(find *),Bash(sed *),Bash(awk *),Bash(jq *),Bash(wc *),Bash(sort *),Bash(diff *),Bash(echo *),Bash(mkdir *),Bash(cp *),Bash(mv *),Bash(which *),Bash(pwd)"
+            --allowedTools "Edit,MultiEdit,Write,Read,NotebookEdit,Glob,Grep,LS,TodoWrite,Bash(task *),Bash(pnpm *),Bash(npx *),Bash(node *),Bash(git *),Bash(gh *),Bash(cd *),Bash(ls *),Bash(cat *),Bash(head *),Bash(tail *),Bash(grep *),Bash(rg *),Bash(find *),Bash(sed *),Bash(awk *),Bash(jq *),Bash(wc *),Bash(sort *),Bash(diff *),Bash(echo *),Bash(mkdir *),Bash(cp *),Bash(mv *),Bash(which *),Bash(pwd)"
           prompt: |
             Implement the change requested in this issue or comment.
 

--- a/template/.github/workflows/claude-plan.yml.jinja
+++ b/template/.github/workflows/claude-plan.yml.jinja
@@ -36,9 +36,9 @@ jobs:
       id-token: write
     steps:
       # Egress firewall (must be the first step): bound where the runner can
-      # talk. This workflow is read-only (Bash is disallowed below), so this is
-      # defense in depth for the action's own supply chain rather than a Claude
-      # sandbox. Targets GitHub-hosted ubuntu runners. STARTER LIST — the first
+      # talk. Claude runs read-only here (Bash disallowed via claude_args
+      # below), so this is defense in depth for the action's own supply chain
+      # rather than a Claude sandbox. Targets GitHub-hosted ubuntu runners. STARTER LIST — the first
       # real run logs any blocked endpoint in its run summary; telemetry is off,
       # so nothing leaves for StepSecurity.
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -58,25 +58,10 @@ jobs:
             nodejs.org:443
             api.anthropic.com:443
             statsig.anthropic.com:443
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
-        with:
-          client-id: ${{ vars.CI_APP_CLIENT_ID }}
-          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
-          # Least-privilege token: plan only comments (issues/pull-requests) and
-          # reads the repo (no push). org-projects (project Status updates) is
-          # gated to org repos — requesting a permission the installation lacks
-          # makes this step fail.
-          permission-contents: read
-          permission-issues: write
-          permission-pull-requests: write
-[% if github_org != author_git_provider_username %]
-          permission-organization-projects: write
-[% endif %]
-      # Defense in depth behind the job-level `if:` sender gate: re-assert the
-      # authorized-sender allowlist server-side so a spoof-shaped gap in the
-      # `if:` expression can never reach the Claude step. Token-free — mirrors
-      # the `if:` gate.
+      # Defense in depth behind the job-level `if:` sender gate: an explicit
+      # step that re-asserts the authorized-sender allowlist BEFORE minting any
+      # token, so a spoof-shaped gap in the `if:` expression can never mint
+      # credentials. Token-free — mirrors the `if:` gate.
       - name: Verify sender is authorized
         env:
           SENDER: ${{ github.event.sender.login }}
@@ -88,14 +73,39 @@ jobs:
           esac
           echo "::error::$SENDER is not an authorized sender"
           exit 1
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          # Least-privilege token: plan only comments (issues/pull-requests) and
+          # reads the repo (no push).
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: write
+[% if github_org != author_git_provider_username %]
+      # Separate token for the project-board update only. continue-on-error so a
+      # missing organization-projects grant (e.g. a personal fork) skips the
+      # status update instead of failing the whole plan job. issues:read lets
+      # the board lookup resolve items by issue number (`...on Issue { number }`).
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token-projects
+        continue-on-error: true
+        with:
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          permission-organization-projects: write
+          permission-issues: read
+[% endif %]
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 [% if github_org != author_git_provider_username %]
       - name: Set issue status to Shaping
+        if: steps.app-token-projects.outputs.token != ''
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token-projects.outputs.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ORG_PROJECT_ID: ${{ vars.ORG_PROJECT_ID }}
         run: |

--- a/template/.github/workflows/claude-review.yml.jinja
+++ b/template/.github/workflows/claude-review.yml.jinja
@@ -14,11 +14,16 @@ on:
     types: [labeled]
 jobs:
   review:
+    # Authorized senders — the explicit claude_authorized_members allowlist plus
+    # the automation bots whose PRs review runs on. Used by both the `if:` gate
+    # (so unauthorized events never provision a runner) and the Verify step.
+[% set _review_senders = (claude_authorized_members.split(',') | map('trim') | select | list) + ['renovate[bot]', 'coderabbitai[bot]', 'dependabot[bot]'] %]
     if: >-
       (github.event.issue.pull_request != null ||
        github.event_name == 'pull_request_review_comment' ||
        github.event_name == 'pull_request_review' ||
        github.event_name == 'pull_request') &&
+      ([% for s in _review_senders %]github.event.sender.login == '[[ s ]]'[% if not loop.last %] || [% endif %][% endfor %]) &&
       (contains(github.event.comment.body, '@claude review') ||
        contains(github.event.review.body, '@claude review') ||
        (github.event.action == 'labeled' &&
@@ -33,9 +38,9 @@ jobs:
       id-token: write
     steps:
       # Egress firewall (must be the first step): bound where the runner can
-      # talk. This workflow is read-only (Bash is disallowed below), so this is
-      # defense in depth for the action's own supply chain rather than a Claude
-      # sandbox. Targets GitHub-hosted ubuntu runners. STARTER LIST — the first
+      # talk. Claude runs read-only here (Bash disallowed via claude_args
+      # below), so this is defense in depth for the action's own supply chain
+      # rather than a Claude sandbox. Targets GitHub-hosted ubuntu runners. STARTER LIST — the first
       # real run logs any blocked endpoint in its run summary; telemetry is off,
       # so nothing leaves for StepSecurity.
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -55,19 +60,12 @@ jobs:
             nodejs.org:443
             api.anthropic.com:443
             statsig.anthropic.com:443
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
-        with:
-          client-id: ${{ vars.CI_APP_CLIENT_ID }}
-          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
-          # Least-privilege token: review only comments (issues/pull-requests)
-          # and reads the repo (no push).
-          permission-contents: read
-          permission-pull-requests: write
-          permission-issues: write
-      # Authorized senders — the explicit claude_authorized_members allowlist
-      # (not org membership) plus the automation bots whose PRs review runs on.
-[% set _review_senders = (claude_authorized_members.split(',') | map('trim') | select | list) + ['renovate[bot]', 'coderabbitai[bot]', 'dependabot[bot]'] %]
+      # Defense in depth behind the job-level `if:` sender gate (which now
+      # carries the same allowlist, so unauthorized events never provision a
+      # runner). Runs BEFORE minting the App token (the job GITHUB_TOKEN exists
+      # earlier for e.g. harden-runner, but no App token does yet) so a gap in
+      # that expression can't reach credential creation. Quoting makes `[bot]` a
+      # literal in the case pattern, not a glob class. Keep in sync with `if:`.
       - name: Verify sender is authorized
         env:
           SENDER: ${{ github.event.sender.login }}
@@ -79,6 +77,16 @@ jobs:
           esac
           echo "::error::$SENDER is not an authorized sender"
           exit 1
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          # Least-privilege token: review only comments (issues/pull-requests)
+          # and reads the repo (no push).
+          permission-contents: read
+          permission-pull-requests: write
+          permission-issues: write
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false


### PR DESCRIPTION
Consolidates every fix and insight that CodeRabbit + Copilot surfaced during review of the downstream CI-hardening PRs (lawnomator-site #24/#25, ponderous-site #34, ponderous-infra #15, omator #274) back into the harmon-init template — so it stops emitting versions that keep getting re-flagged, and the next scaffold / `copier update` is clean.

## Composite action (`.github/actions/setup`)
- **Pin `yamllint`** (Renovate-managed) and install via **`python3 -m pip`** instead of bare `pip` (reliable interpreter/PATH on runners).
- **gitleaks download** → `curl -fsSL --retry 3` (fail on HTTP errors + retry), matching every other download.
- **`cache` input only declared when `use_node`** (it's pnpm-specific — dead on iac/python-only repos); pnpm dropped from the description unless `use_node`.

## `claude-implement`
- **Drop `WebFetch`** from `--allowedTools` (Claude reaches GitHub via allowed `gh`; don't let arbitrary fetch undercut the egress firewall).
- `cache: "false"` passed to the setup action **only when `use_node`**.
- Reword the sender-check comment — it's an explicit **runner** step, not "server-side" (that fits the GitHub-evaluated `if:`).

## `claude-plan`
- **Sender check runs before minting any token.**
- **Split `organization-projects` into a separate `continue-on-error` token** (with **`issues: read`** so the status GraphQL resolves items via `...on Issue { number }`); main token stays contents/issues/pull-requests; status step skipped when the projects token is absent.

## `claude-review`
- **Add the sender allowlist (members + renovate/coderabbit/dependabot) to the job-level `if:` gate** so unauthorized events never provision a runner.
- **Sender check runs before the App token;** comment clarifies `[bot]` is literal when quoted, and that the job `GITHUB_TOKEN` exists earlier.

## Both plan/review
- Egress comment reworded — it's **Claude** that runs read-only (Bash disallowed via `claude_args`), not the workflow.

## Deliberately NOT changed (reviewed + declined in the downstream threads)
- `claude.ai:443` in the egress list — verified the action installs via Bun + npm Agent SDK, **not** `claude.ai/install.sh`.
- Pinning runners off `CI_RUNS_ON` — breaks self-hosted-only setups.
- Per-archive checksums (shellcheck/actionlint/gitleaks) — archives fail loudly at extract; a hash-pinned toolchain image is the tracked follow-on.
- `node`/`npx`/`pnpm` in the Bash allowlist — contained by the egress firewall + needed for builds.
- Dropping `id-token: write` — harmless if unused; confirm no OIDC path (harden-runner/action) before removing everywhere.

## Validation
`task verify` passes — source lint + guards + the full render matrix (`web`/`webapp`/`iac`/`minimal`/`full`/`meta`/`update`, org + personal owners) with actionlint on the rendered workflows. Spot-checked rendered iac (no `cache` input, `python3 -m pip`, `-fsSL --retry`, no WebFetch) and an org web-astro config (review `if:` sender allowlist, plan token split with `issues: read` + guarded status, sender-verify before token).

## Follow-up (not in this PR)
Once merged + released, the downstream repos can `copier update` to pick these up and drop the per-repo patches. A `task`-target extraction of the sender check (to dedupe the allowlist across the three workflows) was raised by CodeRabbit and is a reasonable separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)