### PR TITLE
docs: stop overclaiming what the bot profile denies

### DIFF
--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -46,9 +46,15 @@ creating one is [guides/bot-account.md](../guides/bot-account.md).
   consequence: reading a ruleset's bypass actors needs a permission the bot does
   not have, so a preflight check that wants it must use a different identity or
   be dropped.
-- **Tailscale and production credentials** — the bot profile installs no
-  Tailscale and no 1Password CLI, so the container holds no path to production
-  secrets (see [guides/devcontainers.md](../guides/devcontainers.md)).
+- **Tailscale and on-demand secret fetch** — the bot profile installs no
+  1Password CLI, so there is **no path to pull arbitrary secrets on demand**, and
+  no Tailscale, so no tailnet reach (see
+  [guides/devcontainers.md](../guides/devcontainers.md)). Note what this does
+  *not* say: the container is not secret-free. It holds whatever the env-file
+  carries. That set is a **property of the 1Password Environment behind the
+  env-file** — a convention you maintain, not a guarantee the profile enforces.
+  Put a production credential in that Environment and it lands in the container,
+  next to the agent.
 
 ### Effective access = min(collaborator grant, PAT permissions)
 
@@ -66,7 +72,12 @@ back a mix of read-only and writable repos.
 
 Two practical consequences:
 
-- **To narrow the bot on a repo, change the collaborator grant, not the PAT.**
+- **Two levers, different jobs** — picking the wrong one is why this gets
+  confusing. To change the *level* on a repo the bot still works (write → read),
+  change the **collaborator grant**; a PAT cannot express per-repo levels. To stop
+  *this token* reaching a repo while the bot keeps access, remove it from the PAT's
+  **selected-repo list**. To revoke the bot entirely, drop the grant — and the list
+  entry too, so the token stops carrying reach it cannot use.
 - **Both layers, in order.** Adding a repo to the PAT's list does nothing if the
   bot has no access to it; granting access does nothing if the repo is not in the
   list.

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -106,9 +106,15 @@ creating one is [guides/bot-account.md](../guides/bot-account.md).
   consequence: reading a ruleset's bypass actors needs a permission the bot does
   not have, so a preflight check that wants it must use a different identity or
   be dropped.
-- **Tailscale and production credentials** — the bot profile installs no
-  Tailscale and no 1Password CLI, so the container holds no path to production
-  secrets (see [guides/devcontainers.md](../guides/devcontainers.md)).
+- **Tailscale and on-demand secret fetch** — the bot profile installs no
+  1Password CLI, so there is **no path to pull arbitrary secrets on demand**, and
+  no Tailscale, so no tailnet reach (see
+  [guides/devcontainers.md](../guides/devcontainers.md)). Note what this does
+  *not* say: the container is not secret-free. It holds whatever the env-file
+  carries. That set is a **property of the 1Password Environment behind the
+  env-file** — a convention you maintain, not a guarantee the profile enforces.
+  Put a production credential in that Environment and it lands in the container,
+  next to the agent.
 
 ### Effective access = min(collaborator grant, PAT permissions)
 
@@ -126,7 +132,12 @@ back a mix of read-only and writable repos.
 
 Two practical consequences:
 
-- **To narrow the bot on a repo, change the collaborator grant, not the PAT.**
+- **Two levers, different jobs** — picking the wrong one is why this gets
+  confusing. To change the *level* on a repo the bot still works (write → read),
+  change the **collaborator grant**; a PAT cannot express per-repo levels. To stop
+  *this token* reaching a repo while the bot keeps access, remove it from the PAT's
+  **selected-repo list**. To revoke the bot entirely, drop the grant — and the list
+  entry too, so the token stops carrying reach it cannot use.
 - **Adding a repo to the PAT's list is not enough** if the bot has no access to
   it; and granting access is not enough if the repo is not in the list. Both, in
   that order.


### PR DESCRIPTION
## Description

Ports two fixes from CodeRabbit's review of [ponderousdev/foreman#43](https://github.com/ponderousdev/foreman/pull/43), where this text landed as scaffold output. Fixing the template so it stops emitting them. Follows #296.

Both are the same defect class this doc exists to catch — **a claim stronger than the design delivers**.

### "the container holds no path to production secrets"

Presented a *mechanism* as a *guarantee*. Omitting the 1Password CLI removes the path to pull arbitrary secrets **on demand** — real, and worth stating. It does not make the container secret-free: it holds whatever the env-file carries (`GH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `AGENT_DECK_TELEGRAM_KEY`). That set is a property of the **1Password Environment behind the env-file** — a convention you maintain, not something the profile enforces. Put a production credential in that Environment and it lands in the container, next to the agent.

### "to narrow the bot on a repo, change the collaborator grant, not the PAT"

Correct for changing a *level*, wrong as a universal rule — the selected-repo list is what controls whether the token reaches a repo **at all**, so full revocation wants both levers. Replaced with goal-to-lever guidance, since picking the wrong lever is exactly what makes this confusing:

| Goal | Lever |
|---|---|
| Change the level on a repo the bot still works | the collaborator grant — a PAT can't express per-repo levels |
| Stop *this token* reaching a repo | remove it from the PAT's selected-repo list |
| Revoke the bot entirely | drop the grant, and the list entry too |

## Note on a third comment I did not take

CodeRabbit also claimed *"this repo does not set up a Git credential helper... private `uvx` dependencies still need an explicit `gh auth setup-git` step."* That premise is false — `post-create-common.sh:36` runs `gh auth setup-git` on the headless path (the `elif`), which is exactly how Foreman's existing `git push` works today. And uv's own docs confirm the mechanism: *"If there are no credentials present in the URL and authentication is needed, the Git credential helper will be queried"*, with a `gh`-backed helper named as the recommended approach. `UV_GITHUB_TOKEN` isn't a documented uv variable for this. Reasoning is on the foreman thread.

## Type of change
- [x] Documentation update

## How Has This Been Tested?
- [x] `task verify` passes
- [x] Old phrasing confirmed gone (newline-insensitive check — it wraps across lines, which is why a naive grep reports a false negative)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Tests — n/a, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
