### PR TITLE
fix(ci): remove paid Harden Runner dependency

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -34,35 +34,6 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      # Egress firewall (must be the first step). Claude runs with Bash on a
-      # throwaway runner, so bound where that runner can talk: block all
-      # outbound traffic except the endpoints the toolchain + Claude genuinely
-      # need. This is the real exfiltration/callback boundary behind the scoped
-      # Bash allowlist. Targets GitHub-hosted ubuntu runners; if CI_RUNS_ON
-      # points at a self-hosted runner, harden-runner degrades to best-effort.
-      # STARTER LIST: the first real run logs any blocked endpoint in its run
-      # summary — add legitimate ones. Telemetry is off, so nothing leaves for
-      # StepSecurity.
-      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: block
-          disable-telemetry: true
-          allowed-endpoints: >
-            github.com:443
-            api.github.com:443
-            codeload.github.com:443
-            objects.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            raw.githubusercontent.com:443
-            uploads.github.com:443
-            pipelines.actions.githubusercontent.com:443
-            registry.npmjs.org:443
-            nodejs.org:443
-            get.pnpm.io:443
-            pypi.org:443
-            files.pythonhosted.org:443
-            api.anthropic.com:443
-            statsig.anthropic.com:443
       # Defense in depth behind the job-level `if:` sender gate: an explicit
       # step (runs on the runner, unlike the GitHub-evaluated `if:`) that
       # re-asserts the authorized-sender allowlist BEFORE anything privileged
@@ -72,7 +43,7 @@ jobs:
         env:
           SENDER: ${{ github.event.sender.login }}
         run: |
-          case "$SENDER" in
+          case "$(printf '%s' "$SENDER" | tr '[:upper:]' '[:lower:]')" in
             "evanharmon1") echo "$SENDER is authorized"; exit 0 ;;
           esac
           echo "::error::$SENDER is not an authorized sender"
@@ -138,13 +109,12 @@ jobs:
           # settings reference): the project runners, git, gh, and read-only
           # inspection utilities — enough to implement a change, run
           # `task verify`, commit, push, and open a PR. Deliberately NOT allowed:
-          # curl/wget (exfiltration; also covered by the egress firewall),
+          # curl/wget (not needed; removing easy callback/exfiltration paths),
           # rm/chmod/sudo, and arbitrary `bash -c`/`eval`. Claude edits files via
           # the Edit/Write tools or `task` targets. Prefix matching is coarse and
           # shell can compose, so this is defense-in-depth, not a hard sandbox —
-          # the real boundaries are the narrow token, the egress firewall, branch
-          # protection, and the ephemeral runner. Widen if a real run stalls on a
-          # denied command.
+          # the real boundaries are the narrow token, branch protection, and the
+          # ephemeral runner. Widen if a real run stalls on a denied command.
           claude_args: >-
             --model opus --effort high --max-budget-usd 25 --max-turns 200
             --allowedTools "Edit,MultiEdit,Write,Read,NotebookEdit,Glob,Grep,LS,TodoWrite,Bash(task *),Bash(pnpm *),Bash(npx *),Bash(node *),Bash(git *),Bash(gh *),Bash(cd *),Bash(ls *),Bash(cat *),Bash(head *),Bash(tail *),Bash(grep *),Bash(rg *),Bash(find *),Bash(sed *),Bash(awk *),Bash(jq *),Bash(wc *),Bash(sort *),Bash(diff *),Bash(echo *),Bash(mkdir *),Bash(cp *),Bash(mv *),Bash(which *),Bash(pwd)"

--- a/.github/workflows/claude-plan.yml
+++ b/.github/workflows/claude-plan.yml
@@ -34,29 +34,6 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      # Egress firewall (must be the first step): bound where the runner can
-      # talk. Claude runs read-only here (Bash disallowed via claude_args
-      # below), so this is defense in depth for the action's own supply chain
-      # rather than a Claude sandbox. Targets GitHub-hosted ubuntu runners. STARTER LIST — the first
-      # real run logs any blocked endpoint in its run summary; telemetry is off,
-      # so nothing leaves for StepSecurity.
-      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: block
-          disable-telemetry: true
-          allowed-endpoints: >
-            github.com:443
-            api.github.com:443
-            codeload.github.com:443
-            objects.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            raw.githubusercontent.com:443
-            uploads.github.com:443
-            pipelines.actions.githubusercontent.com:443
-            registry.npmjs.org:443
-            nodejs.org:443
-            api.anthropic.com:443
-            statsig.anthropic.com:443
       # Defense in depth behind the job-level `if:` sender gate: an explicit
       # step that re-asserts the authorized-sender allowlist BEFORE minting any
       # token, so a spoof-shaped gap in the `if:` expression can never mint
@@ -65,7 +42,7 @@ jobs:
         env:
           SENDER: ${{ github.event.sender.login }}
         run: |
-          case "$SENDER" in
+          case "$(printf '%s' "$SENDER" | tr '[:upper:]' '[:lower:]')" in
             "evanharmon1") echo "$SENDER is authorized"; exit 0 ;;
           esac
           echo "::error::$SENDER is not an authorized sender"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,40 +36,16 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      # Egress firewall (must be the first step): bound where the runner can
-      # talk. Claude runs read-only here (Bash disallowed via claude_args
-      # below), so this is defense in depth for the action's own supply chain
-      # rather than a Claude sandbox. Targets GitHub-hosted ubuntu runners. STARTER LIST — the first
-      # real run logs any blocked endpoint in its run summary; telemetry is off,
-      # so nothing leaves for StepSecurity.
-      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: block
-          disable-telemetry: true
-          allowed-endpoints: >
-            github.com:443
-            api.github.com:443
-            codeload.github.com:443
-            objects.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            raw.githubusercontent.com:443
-            uploads.github.com:443
-            pipelines.actions.githubusercontent.com:443
-            registry.npmjs.org:443
-            nodejs.org:443
-            api.anthropic.com:443
-            statsig.anthropic.com:443
       # Defense in depth behind the job-level `if:` sender gate (which now
       # carries the same allowlist, so unauthorized events never provision a
-      # runner). Runs BEFORE minting the App token (the job GITHUB_TOKEN exists
-      # earlier for e.g. harden-runner, but no App token does yet) so a gap in
-      # that expression can't reach credential creation. Quoting makes `[bot]` a
-      # literal in the case pattern, not a glob class. Keep in sync with `if:`.
+      # runner). Runs BEFORE minting the App token, so a gap in that expression
+      # cannot reach credential creation. Quoting makes `[bot]` a literal in the
+      # case pattern, not a glob class. Keep in sync with `if:`.
       - name: Verify sender is authorized
         env:
           SENDER: ${{ github.event.sender.login }}
         run: |
-          case "$SENDER" in
+          case "$(printf '%s' "$SENDER" | tr '[:upper:]' '[:lower:]')" in
             "evanharmon1") echo "$SENDER is authorized"; exit 0 ;;
             "renovate[bot]") echo "$SENDER is authorized"; exit 0 ;;
             "coderabbitai[bot]") echo "$SENDER is authorized"; exit 0 ;;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ Non-negotiable, regardless of any autonomy granted elsewhere in this file:
   and get confirmation before executing — announcing intent and proceeding in
   the same turn is not consent. Read operations (`op read`, `op item list`,
   `op inject` over existing references) are fine.
+- **Never make generated output depend on paid or trial-only SaaS by default.**
+  Any third-party service that requires an account, app installation, trial, or
+  payment must be an explicit Copier opt-in that defaults off, with its free-tier
+  and private-repository limitations documented next to the question.
 
 ## harmon-platform
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -71,6 +71,9 @@ it points here.
 - **Pin third-party actions by full commit SHA** with a trailing `# vX.Y.Z`
   comment, and annotate tool versions with `# renovate: datasource=…` so
   Renovate keeps them current.
+- Third-party CI/SaaS integrations that require an account, app installation,
+  trial, or payment must be explicit opt-ins that default off. Document free-tier
+  and private-repository limitations before adding them to generated output.
 - **Least-privilege `permissions:`** per job; never log secrets.
 - CI authenticates as the **`evanharmon1-ci` GitHub App** (short-lived
   tokens), not a PAT — see [architecture/security.md](architecture/security.md).

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -207,6 +207,17 @@ if [ -d .github/workflows ]; then
     else
         required actionlint "workflow lint" || fail=1
     fi
+
+    if grep -Rqs 'step-security/harden-runner' .github/workflows; then
+        err "rendered workflows include paid-only StepSecurity private-repo integration by default"
+    fi
+
+    for workflow in claude-plan.yml claude-implement.yml claude-review.yml; do
+        if [ -f ".github/workflows/$workflow" ] &&
+            ! grep -Fq "tr '[:upper:]' '[:lower:]'" ".github/workflows/$workflow"; then
+            err "$workflow does not normalize GitHub login case before sender authorization"
+        fi
+    done
 fi
 
 # ── 3b. Rendered JS/TS/JSON is Prettier-clean (node projects) ────────

--- a/template/.github/workflows/claude-implement.yml.jinja
+++ b/template/.github/workflows/claude-implement.yml.jinja
@@ -35,39 +35,6 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      # Egress firewall (must be the first step). Claude runs with Bash on a
-      # throwaway runner, so bound where that runner can talk: block all
-      # outbound traffic except the endpoints the toolchain + Claude genuinely
-      # need. This is the real exfiltration/callback boundary behind the scoped
-      # Bash allowlist. Targets GitHub-hosted ubuntu runners; if CI_RUNS_ON
-      # points at a self-hosted runner, harden-runner degrades to best-effort.
-      # STARTER LIST: the first real run logs any blocked endpoint in its run
-      # summary — add legitimate ones. Telemetry is off, so nothing leaves for
-      # StepSecurity.
-      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: block
-          disable-telemetry: true
-          allowed-endpoints: >
-            github.com:443
-            api.github.com:443
-            codeload.github.com:443
-            objects.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            raw.githubusercontent.com:443
-            uploads.github.com:443
-            pipelines.actions.githubusercontent.com:443
-            registry.npmjs.org:443
-            nodejs.org:443
-            get.pnpm.io:443
-            pypi.org:443
-            files.pythonhosted.org:443
-            api.anthropic.com:443
-            statsig.anthropic.com:443
-[% if include_terraform %]
-            releases.hashicorp.com:443
-            registry.terraform.io:443
-[% endif %]
       # Defense in depth behind the job-level `if:` sender gate: an explicit
       # step (runs on the runner, unlike the GitHub-evaluated `if:`) that
       # re-asserts the authorized-sender allowlist BEFORE anything privileged
@@ -77,9 +44,9 @@ jobs:
         env:
           SENDER: ${{ github.event.sender.login }}
         run: |
-          case "$SENDER" in
+          case "$(printf '%s' "$SENDER" | tr '[:upper:]' '[:lower:]')" in
 [% for s in _members %]
-            "[[ s ]]") echo "$SENDER is authorized"; exit 0 ;;
+            "[[ s | lower ]]") echo "$SENDER is authorized"; exit 0 ;;
 [% endfor %]
           esac
           echo "::error::$SENDER is not an authorized sender"
@@ -223,13 +190,12 @@ jobs:
           # settings reference): the project runners, git, gh, and read-only
           # inspection utilities — enough to implement a change, run
           # `task verify`, commit, push, and open a PR. Deliberately NOT allowed:
-          # curl/wget (exfiltration; also covered by the egress firewall),
+          # curl/wget (not needed; removing easy callback/exfiltration paths),
           # rm/chmod/sudo, and arbitrary `bash -c`/`eval`. Claude edits files via
           # the Edit/Write tools or `task` targets. Prefix matching is coarse and
           # shell can compose, so this is defense-in-depth, not a hard sandbox —
-          # the real boundaries are the narrow token, the egress firewall, branch
-          # protection, and the ephemeral runner. Widen if a real run stalls on a
-          # denied command.
+          # the real boundaries are the narrow token, branch protection, and the
+          # ephemeral runner. Widen if a real run stalls on a denied command.
           claude_args: >-
             --model opus --effort high --max-budget-usd 25 --max-turns 200
             --allowedTools "Edit,MultiEdit,Write,Read,NotebookEdit,Glob,Grep,LS,TodoWrite,Bash(task *),Bash(pnpm *),Bash(npx *),Bash(node *),Bash(git *),Bash(gh *),Bash(cd *),Bash(ls *),Bash(cat *),Bash(head *),Bash(tail *),Bash(grep *),Bash(rg *),Bash(find *),Bash(sed *),Bash(awk *),Bash(jq *),Bash(wc *),Bash(sort *),Bash(diff *),Bash(echo *),Bash(mkdir *),Bash(cp *),Bash(mv *),Bash(which *),Bash(pwd)"

--- a/template/.github/workflows/claude-plan.yml.jinja
+++ b/template/.github/workflows/claude-plan.yml.jinja
@@ -35,29 +35,6 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      # Egress firewall (must be the first step): bound where the runner can
-      # talk. Claude runs read-only here (Bash disallowed via claude_args
-      # below), so this is defense in depth for the action's own supply chain
-      # rather than a Claude sandbox. Targets GitHub-hosted ubuntu runners. STARTER LIST — the first
-      # real run logs any blocked endpoint in its run summary; telemetry is off,
-      # so nothing leaves for StepSecurity.
-      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: block
-          disable-telemetry: true
-          allowed-endpoints: >
-            github.com:443
-            api.github.com:443
-            codeload.github.com:443
-            objects.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            raw.githubusercontent.com:443
-            uploads.github.com:443
-            pipelines.actions.githubusercontent.com:443
-            registry.npmjs.org:443
-            nodejs.org:443
-            api.anthropic.com:443
-            statsig.anthropic.com:443
       # Defense in depth behind the job-level `if:` sender gate: an explicit
       # step that re-asserts the authorized-sender allowlist BEFORE minting any
       # token, so a spoof-shaped gap in the `if:` expression can never mint
@@ -66,9 +43,9 @@ jobs:
         env:
           SENDER: ${{ github.event.sender.login }}
         run: |
-          case "$SENDER" in
+          case "$(printf '%s' "$SENDER" | tr '[:upper:]' '[:lower:]')" in
 [% for s in _members %]
-            "[[ s ]]") echo "$SENDER is authorized"; exit 0 ;;
+            "[[ s | lower ]]") echo "$SENDER is authorized"; exit 0 ;;
 [% endfor %]
           esac
           echo "::error::$SENDER is not an authorized sender"

--- a/template/.github/workflows/claude-review.yml.jinja
+++ b/template/.github/workflows/claude-review.yml.jinja
@@ -37,42 +37,18 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      # Egress firewall (must be the first step): bound where the runner can
-      # talk. Claude runs read-only here (Bash disallowed via claude_args
-      # below), so this is defense in depth for the action's own supply chain
-      # rather than a Claude sandbox. Targets GitHub-hosted ubuntu runners. STARTER LIST — the first
-      # real run logs any blocked endpoint in its run summary; telemetry is off,
-      # so nothing leaves for StepSecurity.
-      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: block
-          disable-telemetry: true
-          allowed-endpoints: >
-            github.com:443
-            api.github.com:443
-            codeload.github.com:443
-            objects.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            raw.githubusercontent.com:443
-            uploads.github.com:443
-            pipelines.actions.githubusercontent.com:443
-            registry.npmjs.org:443
-            nodejs.org:443
-            api.anthropic.com:443
-            statsig.anthropic.com:443
       # Defense in depth behind the job-level `if:` sender gate (which now
       # carries the same allowlist, so unauthorized events never provision a
-      # runner). Runs BEFORE minting the App token (the job GITHUB_TOKEN exists
-      # earlier for e.g. harden-runner, but no App token does yet) so a gap in
-      # that expression can't reach credential creation. Quoting makes `[bot]` a
-      # literal in the case pattern, not a glob class. Keep in sync with `if:`.
+      # runner). Runs BEFORE minting the App token, so a gap in that expression
+      # cannot reach credential creation. Quoting makes `[bot]` a literal in the
+      # case pattern, not a glob class. Keep in sync with `if:`.
       - name: Verify sender is authorized
         env:
           SENDER: ${{ github.event.sender.login }}
         run: |
-          case "$SENDER" in
+          case "$(printf '%s' "$SENDER" | tr '[:upper:]' '[:lower:]')" in
 [% for s in _review_senders %]
-            "[[ s ]]") echo "$SENDER is authorized"; exit 0 ;;
+            "[[ s | lower ]]") echo "$SENDER is authorized"; exit 0 ;;
 [% endfor %]
           esac
           echo "::error::$SENDER is not an authorized sender"

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -94,6 +94,9 @@ it points here.
 - **Pin third-party actions by full commit SHA** with a trailing `# vX.Y.Z`
   comment, and annotate tool versions with `# renovate: datasource=…` so
   Renovate keeps them current.
+- Third-party CI/SaaS integrations that require an account, app installation,
+  trial, or payment must be explicit opt-ins that default off. Document free-tier
+  and private-repository limitations before adding them to generated output.
 - **Least-privilege `permissions:`** per job; never log secrets.
 - CI authenticates as the **`[[ github_org ]]-ci` GitHub App** (short-lived
   tokens), not a PAT — see [architecture/security.md](architecture/security.md).


### PR DESCRIPTION
## Summary

- remove Harden Runner from the default Claude workflows and Copier templates because private-repository enforcement requires a StepSecurity trial or subscription
- normalize authorized sender logins before shell comparisons
- add rendered-template regression coverage and a policy preventing paid or trial SaaS dependencies from being enabled by default

## Verification

- `task verify`