### PR TITLE
feat(security): establish tiered repository scanning policy

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,8 +36,8 @@ ARG AGENT_DECK_VERSION=1.9.47
 ARG SESH_VERSION=2.26.2
 # renovate: datasource=npm depName=dmux
 ARG DMUX_VERSION=5.9.0
-# renovate: datasource=npm depName=snyk
-ARG SNYK_VERSION=1.1305.1
+# renovate: datasource=pypi depName=semgrep
+ARG SEMGREP_VERSION=1.170.0
 # renovate: datasource=npm depName=@playwright/test
 ARG PLAYWRIGHT_VERSION=1.60.0
 # renovate: datasource=npm depName=@playwright/cli
@@ -353,6 +353,13 @@ RUN npm install -g \
 # ---------- Python packages for agent-deck Telegram bridge ----------
 RUN uv pip install --system --break-system-packages --no-cache toml aiogram
 
+# ---------- Semgrep Community Edition ----------
+# Install the free SAST baseline independently of the project Python environment.
+RUN UV_TOOL_BIN_DIR=/usr/local/bin \
+    UV_TOOL_DIR=/opt/uv-tools \
+    uv tool install "semgrep==${SEMGREP_VERSION}" \
+    && rm -rf /root/.cache/uv
+
 # ---------- dotfile config ----------
 # /usr/local/share/devcontainer-config/ is kept (not cleaned up) so that
 # post-create scripts can seed persistent volumes that shadow the baked-in
@@ -403,7 +410,6 @@ RUN npm install -g \
         "@google/gemini-cli@${GEMINI_CLI_VERSION}" \
         "@openai/codex@${CODEX_VERSION}" \
         "dmux@${DMUX_VERSION}" \
-        "snyk@${SNYK_VERSION}" \
     && npm cache clean --force
 
 USER vscode

--- a/.github/Branch Protection Ruleset - Protect Main.json
+++ b/.github/Branch Protection Ruleset - Protect Main.json
@@ -48,6 +48,10 @@
           {
             "context": "security",
             "integration_id": 15368
+          },
+          {
+            "context": "codeql-verify",
+            "integration_id": 15368
           }
         ]
       }

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,7 +16,10 @@ inputs:
       `task check` / `task verify`.
     default: "false"
   gitleaks:
-    description: Install gitleaks — required by `task security`.
+    description: Install gitleaks — required by `task security:secrets`.
+    default: "false"
+  snyk:
+    description: Install the pinned Snyk CLI for an explicitly enabled scan.
     default: "false"
 
 runs:
@@ -26,7 +29,7 @@ runs:
       with:
         # renovate: datasource=node-version
         node-version: "24"
-    # uv provides uvx for foreman:lint's pinned ruff/black (see taskfiles/foreman.yml)
+    # uv provides uvx for pinned Semgrep CE and foreman:lint's ruff/black.
     - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
     - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
       with:
@@ -81,3 +84,10 @@ runs:
           "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
         tar -xzf /tmp/gitleaks.tgz -C /tmp
         sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+    - name: Install Snyk CLI
+      if: inputs.snyk == 'true'
+      shell: bash
+      run: |
+        # renovate: datasource=npm depName=snyk
+        SNYK_VERSION=1.1305.2
+        npm install --global "snyk@${SNYK_VERSION}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,13 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           gitleaks: "true"
-      - run: task security:secrets
+      - name: Secrets scan
+        run: task security:secrets
+      - name: Dependency audit
+        run: task security:audit
+      - name: Private-repo SAST fallback (Semgrep CE)
+        if: github.event.repository.private && vars.FULL_SECURITY_SCAN != 'true'
+        run: task security:sast
 
   template-test:
     # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,9 +9,9 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
-# Public repositories run CodeQL automatically. For a private/internal repo,
-# FULL_SECURITY_SCAN=true means the owner has deliberately enabled paid GitHub
-# Code Security. Free private repos use Semgrep CE in build.yml instead.
+# Harmon Init is public, so CodeQL runs for free. The private-repo condition is
+# retained for dogfood parity with the generated policy: private CodeQL requires
+# paid GitHub Code Security and an explicit FULL_SECURITY_SCAN=true opt-in.
 
 concurrency:
   group: codeql-${{ github.ref }}
@@ -23,9 +23,7 @@ jobs:
       (github.event.repository.private == false || vars.FULL_SECURITY_SCAN == 'true') &&
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
-    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
-    # default; set it to a JSON runner spec to override without a commit.
-    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     timeout-minutes: 30
     permissions:
       actions: read
@@ -35,12 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         language:
-[% if use_node %]
-          - javascript-typescript
-[% endif %]
-[% if use_python %]
           - python
-[% endif %]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -54,16 +47,10 @@ jobs:
         with:
           category: /language:${{ matrix.language }}
 
-  # Stable aggregate status (the matrixed analyze jobs have dynamic names).
-  # Named codeql-verify so it does not collide with the build workflow's
-  # required `verify` check. It always reports: public/paid scans must succeed;
-  # free private and fork-PR scans report a successful not-applicable gate.
   codeql-verify:
     if: always()
     needs: [analyze]
-    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
-    # default; set it to a JSON runner spec to override without a commit.
-    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     steps:
       - name: Check analyze result
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,8 @@ task check
 # Render the template into a temp dir and validate the output
 task test:template
 
-# Secrets scan
-task security:secrets
+# Free security baseline (Semgrep CE + gitleaks + dependency audit)
+task security
 
 # Foreman: dispatch ready issues to headless agents, shepherd their PRs
 task foreman:plan -- --milestone <n|title>   # dry-run the graph/waves
@@ -133,7 +133,7 @@ and ADR 0002. It ships to generated repos, so its files are two-layer twins.
 
 - No direct commits to main (enforced by lefthook `guard:no-commit-to-main` and the
   branch ruleset). Work on feature branches; PRs require code-owner review and the
-  `verify` + `security` status checks.
+  `verify` + `security` + `codeql-verify` status checks.
 - **Agents never merge to main** — no `gh pr merge`, `git merge`, or push to
   `main` without Evan's explicit, per-merge approval, even when CI is green and
   the ruleset would allow it. Open the PR, report that checks pass, then stop;

--- a/Brewfile
+++ b/Brewfile
@@ -21,8 +21,6 @@ brew "yamllint"
 
 # Security
 brew "gitleaks"
-tap "snyk/tap"
-brew "snyk/tap/snyk"
 
 # Devcontainer
 brew "hadolint"

--- a/README.md
+++ b/README.md
@@ -3,14 +3,18 @@
 A [Copier](https://copier.readthedocs.io/en/stable/) project template that
 bootstraps repos with a complete set of standardized conventions: go-task
 Taskfile, lefthook git hooks, conventional commits, GitHub Actions CI (with
-Claude Code plan/implement/review workflows), gitleaks/snyk/CodeQL security,
-Renovate, CodeRabbit, a dual-profile devcontainer (AI bot + human) with GHCR
+Claude Code plan/implement/review workflows), CodeQL for supported public
+repositories, Semgrep Community Edition as the free private-repository SAST
+fallback, gitleaks, Dependabot alerts, Renovate, optional Snyk Free scheduled or
+local second-opinion scans, paid security escalation, CodeRabbit, a dual-profile
+devcontainer (AI bot + human) with GHCR
 prebuilds, a docs tree, and AI steering docs (canonical `AGENTS.md`). It can
 also be applied to existing repos to standardize them.
 
 Author: Evan Harmon
 
 [![Build & Validate](https://github.com/evanharmon1/harmon-init/actions/workflows/build.yml/badge.svg)](https://github.com/evanharmon1/harmon-init/actions/workflows/build.yml)
+[![CodeQL](https://github.com/evanharmon1/harmon-init/actions/workflows/codeql.yml/badge.svg)](https://github.com/evanharmon1/harmon-init/actions/workflows/codeql.yml)
 [![Devcontainer Build](https://github.com/evanharmon1/harmon-init/actions/workflows/devcontainer-build.yml/badge.svg)](https://github.com/evanharmon1/harmon-init/actions/workflows/devcontainer-build.yml)
 [![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/evanharmon1/harmon-init)
 [![Latest Release](https://img.shields.io/github/v/release/evanharmon1/harmon-init?sort=semver)](https://github.com/evanharmon1/harmon-init/releases)
@@ -165,7 +169,9 @@ and canonical AGENTS.md. Projects generated from v2 should be re-templated
 |---|---|
 | `task verify` | Lint + template generation matrix (merge gate) |
 | `task check` | Root linters (template/ excluded — jinja isn't valid YAML) |
-| `task security:secrets` | gitleaks scan |
+| `task security` | Free local baseline: Semgrep CE + gitleaks + dependency audit |
+| `task security:sast` / `security:sca` | Semgrep CE / package-manager dependency audit |
+| `task security:sast:snyk` / `security:sca:snyk` | Optional Snyk second-opinion scans (manual or explicitly scheduled) |
 | `task install` | Brewfile deps + lefthook hooks |
 | `task release:patch` | Tag + GitHub release (also `:minor`/`:major`) |
 | `task status` | Project dashboard (also `status:git`/`:gh`/`:code`/`:env`) |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -305,8 +305,9 @@ tasks:
 
   # ── Security ──────────────────────────────────────────────────
   security:
-    desc: Run all security checks
+    desc: Run all free local security checks (Semgrep CE + gitleaks + dependency audit)
     deps:
+      - security:sast
       - security:secrets
       - security:audit
 
@@ -330,14 +331,24 @@ tasks:
       - echo "No package manifests to audit yet."
 
   security:sast:
-    desc: Static application security testing (source code)
+    desc: Static application security testing (Semgrep Community Edition)
     cmds:
-      - snyk code test --exclude=.worktrees,.foreman --severity-threshold=high
+      - ./scripts/run-semgrep.sh --exclude=.foreman --exclude=template {{.CLI_ARGS}}
 
   security:sca:
-    desc: Software composition analysis (Snyk)
+    desc: Software composition analysis (free package-manager audit)
+    deps:
+      - security:audit
+
+  security:sast:snyk:
+    desc: "Optional Snyk Code second-opinion scan (manual/local or explicitly scheduled); needs SNYK_TOKEN"
     cmds:
-      - snyk test --severity-threshold=high --show-vulnerable-paths=all
+      - snyk code test --exclude=.worktrees,.foreman,.claude,template --severity-threshold=high {{.CLI_ARGS}}
+
+  security:sca:snyk:
+    desc: "Optional Snyk Open Source second-opinion scan (manual/local or explicitly scheduled); needs SNYK_TOKEN"
+    cmds:
+      - snyk test --all-projects --exclude=.worktrees,.foreman,.claude,template --severity-threshold=high --show-vulnerable-paths=all {{.CLI_ARGS}}
 
   # ── Secrets ────────────────────────────────────────────────────
   # Destination-only helpers: the secret value stays on stdin — never in argv,
@@ -383,7 +394,7 @@ tasks:
       - lefthook install
 
   setup:github:
-    desc: Apply idempotent GitHub repo settings via gh (Dependabot alerts, private vulnerability reporting, CodeQL variable)
+    desc: Apply idempotent GitHub repo settings via gh (Dependabot alerts, private vulnerability reporting)
     vars:
       REPO: "evanharmon1/harmon-init"
     cmds:
@@ -397,8 +408,6 @@ tasks:
         else
           echo "Skipping private vulnerability reporting ({{.REPO}} is private; public-repo-only feature)."
         fi
-      - gh variable set FULL_SECURITY_SCAN --repo "{{.REPO}}" --body true
-
   setup:github-project:
     desc: Idempotently create/sync the owner's GitHub Project V2 board + Status pipeline (on a personal account also its metadata fields). Requires `gh auth refresh -s project`.
     cmds:

--- a/copier.yml
+++ b/copier.yml
@@ -82,6 +82,18 @@ project_type:
     docs (documentation/Obsidian): docs
   default: general
 
+snyk_scan_schedule:
+  type: str
+  help: >-
+    SNYK: Optional advisory SAST/SCA schedule. Off keeps Snyk manual/local;
+    weekly is the quota-aware opt-in; daily is intended for public repos or
+    accepted unlimited open-source projects.
+  choices:
+    "Off (manual/local only)": "off"
+    "Weekly (quota-aware)": weekly
+    "Daily (public or unlimited OSS)": daily
+  default: "off"
+
 include_terraform:
   type: bool
   help: "TERRAFORM: Include a terraform/ skeleton + terraform linting?"

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -20,18 +20,37 @@ config, toolchain, devcontainer, and dev environment — against the items below
 
 - [ ] **Automated settings** — run `task setup:github` (idempotent, safe to
       re-run): enables **Dependabot alerts** and **private vulnerability
-      reporting**, sets the `FULL_SECURITY_SCAN` variable (CodeQL). Do NOT add dependabot.yml — Renovate owns version updates.
+      reporting**. Do not add `dependabot.yml`: Renovate owns routine and
+      vulnerability-remediation PRs; Dependabot owns advisory alerts.
 - [ ] **Bot PAT** — the agent's `GH_TOKEN`. If a fine-grained PAT already covers
       `evanharmon1`, just add this repo to its **selected repositories**; a token is
       scoped to one resource owner, so a **new owner needs a new PAT**. Both layers
       are required — the collaborator grant sets the ceiling, the PAT's repo list
       reaches it. Procedure: [guides/bot-account.md](guides/bot-account.md).
-- [ ] Import the branch ruleset (see [architecture/branch-protection.md](architecture/branch-protection.md)) — do this once `build.yml` is on `main` so the required `verify`/`security` checks resolve. **Use the UI import:** Settings → Rules → Rulesets → **New ruleset ▸ Import a ruleset** → select `.github/Branch Protection Ruleset - Protect Main.json`. (Prefer the UI over `gh api … rulesets`: the API `POST` is not idempotent — re-running creates a duplicate ruleset — and currently rejects the `merge_queue` rule. To later change the ruleset, edit the existing one in the UI rather than re-importing.)
+- [ ] Import the branch ruleset (see [architecture/branch-protection.md](architecture/branch-protection.md)) — do this once `build.yml` and `codeql.yml` are on `main` so the required `verify`/`security`/`codeql-verify` checks resolve. **Use the UI import:** Settings → Rules → Rulesets → **New ruleset ▸ Import a ruleset** → select `.github/Branch Protection Ruleset - Protect Main.json`. (Prefer the UI over `gh api … rulesets`: the API `POST` is not idempotent — re-running creates a duplicate ruleset — and currently rejects the `merge_queue` rule. To later change the ruleset, edit the existing one in the UI rather than re-importing.)
 
 - [ ] Install the [Renovate app](https://github.com/apps/renovate) on the repo
 - [ ] Install the [CodeRabbit app](https://github.com/apps/coderabbitai) on the repo (`.coderabbit.yaml` is pre-configured)
-- [ ] Actions secrets: `CLAUDE_CODE_OAUTH_TOKEN` (claude-* workflows),
-      `SNYK_TOKEN` (snyk tasks)
+- [ ] Actions secret: `CLAUDE_CODE_OAUTH_TOKEN` (claude-* workflows)
+- [ ] **Free SAST coverage** — Harmon Init's public `codeql.yml` runs CodeQL
+      automatically and uploads results to the Security tab. Confirm a successful
+      run. Generated supported public stacks do the same; free private repos use
+      Semgrep CE in `build.yml` unless paid private CodeQL is explicitly enabled.
+- [ ] **Choose the Snyk posture** — Harmon Init currently uses the public-repo
+      default (CodeQL + Dependabot alerts/Renovate + gitleaks), so Snyk remains
+      off. Free private repos keep Snyk manual/local via
+      `task security:sast:snyk` and `task security:sca:snyk`; local tests consume
+      the same Snyk Organization quota. Do not install the Snyk GitHub App for
+      this posture; its PR checks are not required by the branch ruleset.
+- [ ] **Optional scheduled Snyk** — for a selected important public repository,
+      choose `snyk_scan_schedule=weekly` (conservative) or `daily` (public or
+      accepted unlimited OSS), commit the generated `snyk-scheduled.yml`, set the
+      Actions secret `SNYK_TOKEN`, and run it once with **Run workflow**. It runs
+      SAST + SCA only on its schedule/manual dispatch—never on PR or push—and
+      remains advisory. Confirm Snyk recognizes the public Git remote and does
+      not debit private-test usage; if it does, run `snyk monitor` once and set
+      the Project's Git remote URL in Snyk. Prefer weekly for any deliberately
+      budgeted private repo and check Organization Usage before enabling it.
 - [ ] CI GitHub App `evanharmon1-ci`: create it by hand for this org (one App
       per org; **Settings → Developer settings → GitHub Apps**), or reuse the
       org's existing one;

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -9,7 +9,7 @@ This document explains the branch protection ruleset applied to `main` and how i
 An importable copy of the ruleset ships in this repo at
 `.github/Branch Protection Ruleset - Protect Main.json`. Apply it through the
 GitHub **UI import** (do this once `build.yml` is on `main`, so the required
-`verify`/`security` checks resolve):
+`verify`/`security`/`codeql-verify` checks resolve):
 
 > Settings → Rules → Rulesets → **New ruleset ▸ Import a ruleset** → select
 > `.github/Branch Protection Ruleset - Protect Main.json`.
@@ -25,14 +25,12 @@ every rule type and is the GitHub-native way to apply an exported ruleset.
 
 ## Dependabot and Renovate
 
-Version updates are owned by **Renovate** (`renovate.json`) — do not add a
-`dependabot.yml`, it would duplicate Renovate's PRs. Dependabot still has a
-role as a GitHub-native security layer; enable these in
-Settings → Advanced Security:
+Routine updates and vulnerability-remediation PRs are owned by **Renovate**
+(`renovate.json`, with `vulnerabilityAlerts.enabled=true`) — do not add a
+`dependabot.yml`, which would create competing update PRs. Dependabot still owns
+the GitHub-native advisory feed; enable these in Settings → Advanced Security:
 
 - Dependabot alerts
-- Dependabot security updates (optional — alerts may be enough since Renovate
-  proposes the same bumps)
 - Private vulnerability reporting (used by `.github/SECURITY.md`)
 
 ## Security Model Overview
@@ -95,7 +93,7 @@ Every permission here is one a prompt-injected agent has.
 | --- | --- |
 | **Workflows** | The agent could rewrite `.github/workflows/`, then let CI run it with every Actions secret. The classic escalation. |
 | **Administration** | Rulesets, settings, bypass lists. The bot must not be able to unlock the door it is locked behind. |
-| **Variables — write** | Read is granted; write is not. Write lets the agent flip `FULL_SECURITY_SCAN` and silently stop CodeQL — a gate bypass that never appears in a PR diff. |
+| **Variables — write** | Read is granted; write is not. Write could opt a private repo into paid CodeQL or mutate another security/deploy switch without a PR diff. Public CodeQL cannot be disabled with `FULL_SECURITY_SCAN`. |
 | **Deployments** | Write lets the agent create deployments, colliding with release-gated deploys. Read buys nothing the agent's loop uses. |
 | **Secrets**, **Environments**, **Webhooks**, … | Never needed; each is one more thing a leaked token reaches. |
 
@@ -239,13 +237,22 @@ This is the core rule that prevents the AI agent from pushing directly to `main`
 
 All specified CI checks must pass before the PR can merge. The `strict_required_status_checks_policy: true` setting means the PR branch must be up-to-date with `main` before merging — if `main` advances after the checks ran, the checks must re-run. The `do_not_enforce_on_create: true` setting skips enforcement when the branch is first created (before any CI has had a chance to run).
 
-The required checks are the two aggregate jobs from `build.yml` (see
+The required checks are the build gates plus CodeQL's stable aggregate (see
 [ci-cd.md](ci-cd.md)):
 
 | Check      | Purpose                                                                                          |
 | ---------- | ----------------------------------------------------------------------------------------------- |
-| `verify`   | Aggregate gate — rolls up `lint`, and `security` so one check reports overall pass/fail |
-| `security` | Secret scanning (gitleaks) + dependency audit                                                    |
+| `verify`   | Aggregate build gate — rolls up root lint/template validation |
+| `security` | gitleaks + dependency audit; Semgrep CE when this job owns the visibility/profile SAST route |
+| `codeql-verify` | Requires CodeQL success on this public repo; reports not-applicable only on free private repos and fork PRs |
+
+Snyk PR/App checks are absent by default. An optional generated scheduled Snyk
+workflow is advisory and never a required check; it has no PR or push trigger.
+Only a high-consequence repository that deliberately adopts paid Snyk should
+consider per-PR scans and decide whether to make them merge requirements.
+Harmon Init's public CodeQL workflow is merge-gating through `codeql-verify`.
+Generated Node/Python repos receive the same stable gate and public/free,
+private/paid routing; see [security.md](security.md).
 
 Requiring the aggregate `verify` (rather than each leaf job) keeps the required-check
 list stable as jobs are added inside `build.yml`.

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -15,6 +15,14 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
 
 - `build.yml` — on push/PR to `main`: lint, security, then the aggregate **`verify`** job.
 - `claude-plan` / `claude-implement` / `claude-review` — `@claude …` on issues and PRs.
+- `codeql.yml` — Python CodeQL SAST. It runs automatically because Harmon Init is
+  public; the private-repository path requires paid GitHub Code Security and
+  `FULL_SECURITY_SCAN=true`.
+- The `build.yml` security job runs gitleaks + dependency audit and, when a
+  repository is private without the paid CodeQL opt-in, Semgrep CE.
+- Generated repositories may explicitly opt into `snyk-scheduled.yml` at a
+  weekly or daily cadence. It has only schedule/manual triggers, runs Snyk SAST
+  and SCA as advisory second-opinion scans, and is never a required PR check.
 - `devcontainer-build.yml` — prebuilds the devcontainer images to GHCR on `.devcontainer/**` changes.
 - `release.yml` — release-please maintains the rolling release PR.
 - `close-milestone-on-release.yml` — closes the milestone matching the tag on release publish.

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -19,6 +19,136 @@ current — it is the reference for "where do secrets live and who can do what".
 - **Auditable changes.** `main` is protected; changes land via reviewed PRs
   (see [branch-protection.md](branch-protection.md)).
 
+## Security scanning: SAST, SCA, secrets & audits
+
+Harmon Init's scanner policy separates a free baseline from optional commercial
+defense in depth. GitHub-hosted CodeQL is the preferred SAST engine where it is
+free: every public repository with a supported language. Semgrep Community
+Edition (CE) is the free CI fallback for private repositories and for generated
+profiles that do not have a CodeQL workflow.
+
+| Axis | Root status | Default for generated repos |
+|---|---|---|
+| **SAST** — flaws in first-party code | CodeQL in public CI; Semgrep CE via `task security:sast` locally | Public Node/Python: CodeQL; free private Node/Python: Semgrep CE; other profiles: Semgrep CE |
+| **SCA** — dependency CVEs | Dependabot alerts + `task security:audit` (no root manifests today) | Dependabot alerts + `pnpm audit` / `pip-audit` |
+| **Secrets** | gitleaks in pre-push and CI | gitleaks in pre-push and CI |
+| **IaC** | N/A at the root | checkov for Terraform profiles |
+| **Freshness/remediation** | Renovate, including Dependabot-alert remediation | Renovate, including Dependabot-alert remediation |
+
+The repository-class policy is:
+
+| Repository class | Standard |
+|---|---|
+| Public, CodeQL-supported | CodeQL + Dependabot alerts/Renovate + gitleaks; no Snyk by default |
+| Selected important public | Optionally add Snyk Free as a scheduled SAST/SCA second opinion; private-test quotas do not apply to public repositories |
+| Private | Semgrep CE is the dependable free CI SAST baseline; keep Snyk Free manual/local by default because its Organization-wide quotas can stop scans mid-month |
+| Important private | Consider paid GitHub Code Security/private CodeQL and/or paid Snyk, then decide whether per-PR scans should be merge-gating |
+| Qualifying public OSS | Consider Snyk's [Secure Developer Program](https://snyk.io/open-source/) for full entitlements without usage limits |
+
+`task security` is the portable free local baseline: Semgrep CE + gitleaks + the
+package-manager dependency audit. `security:sca` is an alias for that free
+audit. CI routes SAST by repository visibility instead of running two engines by
+default:
+
+- public repo + supported CodeQL workflow → CodeQL;
+- private repo + no paid private CodeQL opt-in → Semgrep CE;
+- profile without a CodeQL workflow → Semgrep CE at either visibility;
+- private repo + GitHub Code Security + `FULL_SECURITY_SCAN=true` → CodeQL.
+
+This avoids paying for the ordinary baseline or generating duplicate findings.
+Semgrep CE is useful, open-source, and runs without a hosted account, but it is
+not CodeQL-equivalent: its community analysis is principally intraprocedural
+and typically has shallower data-flow coverage than CodeQL or commercial
+engines. It is the private-repo floor, not a claim of full vulnerability
+coverage.
+
+### CodeQL eligibility
+
+CodeQL runs automatically for Harmon Init and every generated public Node/Python
+repository. GitHub code scanning and standard GitHub-hosted Actions runners are
+free for public repositories. CodeQL is preferred over Semgrep CE there because
+its supported-language queries include deeper interprocedural and data-flow
+analysis and integrate directly with GitHub's Security tab.
+
+For private/internal repositories, CodeQL code scanning requires an organization
+on GitHub Team or Enterprise with
+[GitHub Code Security enabled](https://docs.github.com/en/code-security/reference/code-scanning/troubleshoot-analysis-errors/private-repository-enablement).
+It is
+[billed by active committer](https://docs.github.com/en/billing/concepts/product-billing/github-advanced-security),
+and hosted Actions usage can also consume plan minutes.
+
+`FULL_SECURITY_SCAN=true` is only a workflow run switch. It does not grant the
+paid entitlement, create a missing workflow, or prove that analysis uploaded
+successfully. Confirm a successful run and results in the Security tab before
+counting private CodeQL as coverage. Leave it unset on free private repositories;
+the build workflow then runs Semgrep CE automatically. Public CodeQL cannot be
+disabled with this variable.
+
+### Dependency monitoring and update ownership
+
+Dependabot **alerts** are free for public and private repositories and are the
+continuous GitHub advisory feed. Renovate owns both routine dependency update PRs
+and alert-remediation PRs (`vulnerabilityAlerts.enabled=true`). Do not add a
+`dependabot.yml`: enabling Dependabot version/security update PRs alongside
+Renovate would create competing automation. Package-manager audits remain in CI
+as an immediate, provider-independent check.
+
+### Snyk second opinion and scheduling
+
+Snyk is not installed by default and is not part of `task security` or required
+PR CI. The explicit `task security:sast:snyk` and `task security:sca:snyk`
+targets provide manual/local second-opinion scans. `security:sca:snyk` uses
+`--all-projects`, so every detected manifest is scanned—and each manifest can
+consume a separate Snyk Open Source test on a private repository.
+
+The Copier answer `snyk_scan_schedule` controls the optional generated workflow:
+
+- `off` (default) — no workflow; keep `SNYK_TOKEN` local;
+- `weekly` — quota-aware advisory scans, appropriate for a selected repository;
+- `daily` — intended for public repositories or an accepted unlimited OSS
+  project, not the ordinary private Free-plan posture.
+
+When enabled, `snyk-scheduled.yml` installs a pinned CLI and runs Snyk Code
+(SAST) plus Snyk Open Source (SCA) as separate matrix jobs. It triggers only on
+its schedule or manual dispatch—not on pull requests or pushes—and is excluded
+from branch protection. Add the `SNYK_TOKEN` Actions secret only for this
+explicit scheduled opt-in. Run it manually once and watch the Snyk Organization
+Usage page. The workflow passes the public Git remote explicitly; if Snyk still
+debits private-test usage for a public repo, follow Snyk's
+[documented remedy](https://docs.snyk.io/developer-tools/snyk-cli/getting-started-with-the-snyk-cli#running-out-of-tests):
+run `snyk monitor` once and set the public Git remote URL in the Snyk Project.
+Scheduled and local CLI tests draw from the same private-repository allocation.
+Weekly is the conservative cadence. Daily Snyk Code alone is about 30 tests per
+repository per month, before manual tests, and SCA multiplies by the number of
+manifests.
+
+The scheduled workflow is intended primarily for selected important public
+repositories because Snyk's private-test limits do not apply there. A private
+repository may deliberately choose weekly after estimating Organization-wide
+usage, but the standard remains Semgrep CE in CI plus occasional local Snyk.
+Dependabot already monitors dependency advisories continuously, so weekly Snyk
+is normally enough for a second opinion.
+
+No Snyk GitHub App is needed for local or scheduled CLI scans. Leave it off on
+ordinary repositories. If installed, its PR checks are not required by the
+branch ruleset; remove the repository from the integration to eliminate them.
+
+### Paid escalation for a high-consequence product
+
+For a high-consequence product, choose paid controls based on the missing
+capability rather than enabling everything reflexively:
+
+- **GitHub Code Security** supplies private-repository CodeQL and keeps results
+  and remediation in GitHub.
+- **Paid Snyk** can be an alternative or a second SAST/SCA opinion, especially
+  when license policy, reachability prioritization, or vendor reporting matters.
+- **GitHub Secret Protection** adds server-side secret scanning, push protection,
+  and governance; gitleaks remains useful locally and in CI but does not block a
+  secret before it reaches GitHub in every client/path.
+- **DAST**, tenant-isolation tests, and container/image scanning are separate,
+  application-specific controls. A deployed web application should evaluate
+  them; a library or docs repository usually should not.
+
 ## Two identities: the bot vs the operator
 
 - **AI bot** (`evanharmon1-bot`) — runs in the primary
@@ -90,12 +220,13 @@ Write it down rather than re-derive it under pressure:
   the permission table. It can push branches, open PRs, and comment. It **cannot**
   merge `main` (ruleset + CODEOWNERS), edit workflows, or change settings.
 
-**Read is cheap; write is the line.** Variables are read-only deliberately: write
-would let an agent flip `FULL_SECURITY_SCAN` and silently stop CodeQL — a gate
-bypass that never appears in a PR diff, the same shape as the Workflows
-exclusion. The read grant is safe only because GitHub separates Secrets from
-Variables; if a variable ever holds something sensitive, read becomes
-exfiltration. Check when adding a variable, not forever.
+**Read is cheap; write is the line.** Variables are read-only deliberately:
+write could opt a private repository into paid CodeQL or mutate other
+security/deployment switches without a PR diff. Public CodeQL does not depend on
+`FULL_SECURITY_SCAN` and cannot be disabled through that variable. The read grant
+is safe only because GitHub separates Secrets from Variables; if a variable ever
+holds something sensitive, read becomes exfiltration. Check when adding a
+variable, not forever.
 
 ## CI automation identity (GitHub App)
 
@@ -221,7 +352,7 @@ TODO: enumerate the tokens/secrets this repo depends on and where each lives:
 |---|---|---|---|
 | `CI_APP_CLIENT_ID` (var) + `CI_APP_PRIVATE_KEY` (secret) | release-please, claude-* | repo or org Actions variable + secret | rotate App key per policy |
 | `CLAUDE_CODE_OAUTH_TOKEN` | claude-* workflows | repo Actions secret | TODO |
-| `SNYK_TOKEN` | `task security:sast`/`sca` | repo Actions secret | TODO |
+| `SNYK_TOKEN` | optional Snyk CLI scans; also `snyk-scheduled.yml` when explicitly generated | local env / 1Password by default; Actions secret only for scheduled/paid CI | manual |
 | `GH_TOKEN` (the bot's PAT) | the devcontainer agent's `gh`/git operations | 1Password Environment → devcontainer `--env-file` | manual; re-issue before expiry ([guides/bot-account.md](../guides/bot-account.md)) |
 | TODO | TODO | TODO | TODO |
 

--- a/docs/architecture/tests.md
+++ b/docs/architecture/tests.md
@@ -8,7 +8,10 @@ How testing works in Harmon Init.
 |---|---|---|
 | Lint / static analysis | shellcheck, yamllint, markdownlint, actionlint | `task check` |
 | Tests | TODO: pick a test runner | `task test` |
+| Application security | Semgrep CE locally; CodeQL in public CI | `task security:sast` |
+| Optional second opinion | Snyk Code + Open Source, manual or scheduled | `task security:sast:snyk` / `task security:sca:snyk` |
 | Secrets | gitleaks | `task security:secrets` |
+| Dependencies | package-manager audit | `task security:audit` |
 
 ## Conventions
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -17,7 +17,8 @@ it points here.
   major bump.
 - **Feature branches only.** Direct commits to `main` are blocked by the
   `guard:no-commit-to-main` pre-commit hook and the branch ruleset. Land changes
-  via a PR; code-owner review and the `verify` + `security` checks are required.
+  via a PR; code-owner review and the `verify` + `security` + `codeql-verify`
+  checks are required.
 - **Never bypass hooks** (`--no-verify` is forbidden) — fix the underlying issue.
   In the devcontainer a Claude Code hook actively blocks `--no-verify` and
   validates commit messages.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -11,7 +11,7 @@ project-specific (domain) terms as the model firms up.
 | Term | Meaning |
 |---|---|
 | `verify` | The aggregate CI job in `build.yml` that rolls up the other jobs into one required status check (the merge gate). See [architecture/ci-cd.md](architecture/ci-cd.md). |
-| `security` (check) | The CI job running secret scanning (gitleaks) + dependency audit; the second required status check. |
+| `security` (check) | The required CI job running gitleaks + dependency audit, plus Semgrep CE when this job owns the SAST route. |
 | `task` / Taskfile | go-task is the single source of truth for commands; lefthook hooks and CI both delegate to `task` targets so local and CI runs are identical. |
 | release-please | Bot that maintains a rolling "release" PR from Conventional Commits; merging it cuts the tag, GitHub release, and CHANGELOG. Releases are intentional, never automatic on merge. |
 | `evanharmon1-ci` (GitHub App) | The CI automation app that mints short-lived tokens for CI workflows (not a PAT). See [architecture/security.md](architecture/security.md). |

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -14,6 +14,7 @@ Common issues in Harmon Init and how to fix them.
 
 ## CI
 
-- **`verify` check missing on a PR** — ensure the Build & Validate workflow ran; required checks are `verify` and `security`.
+- **Required check missing on a PR** — ensure Build & Validate and CodeQL ran;
+  required checks are `verify`, `security`, and `codeql-verify`.
 
 TODO: add project-specific issues as they come up.

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,9 @@
   "prConcurrentLimit": 10,
   "automerge": false,
   "dependencyDashboard": true,
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -25,8 +28,8 @@
     },
     {
       "customType": "regex",
-      "description": "Workflow tool pins, `FOO_VERSION=x.y.z` shell-variable style",
-      "managerFilePatterns": ["/workflows/.*\\.ya?ml(\\.jinja)?$/"],
+      "description": "Workflow/composite-action and script tool pins, `FOO_VERSION=x.y.z` shell-variable style",
+      "managerFilePatterns": ["/(\\.github/(actions|workflows)/.*\\.ya?ml(\\.jinja)?|scripts/.*\\.sh)$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+[A-Z_]+_VERSION=(?<currentValue>\\S+)"
       ]

--- a/scripts/run-semgrep.sh
+++ b/scripts/run-semgrep.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep Semgrep on its PyPI/uv distribution. The Homebrew bottle has previously
+# failed during TLS-store initialization on macOS, and uv gives local + CI the
+# same explicitly pinned build.
+# renovate: datasource=pypi depName=semgrep
+SEMGREP_VERSION=1.170.0
+
+exec uvx --from "semgrep==${SEMGREP_VERSION}" semgrep scan \
+    --config p/default \
+    --metrics=off \
+    --error \
+    --severity ERROR \
+    --exclude=.worktrees \
+    "$@" \
+    .

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -471,6 +471,10 @@ if [[ "${SECTION}" == "setup" ]]; then
         has_release_wf=0
         find .github/workflows -maxdepth 1 \( -name 'release.yml' -o -name 'release.yaml' \) 2>/dev/null | grep -q . && has_release_wf=1
         uses_ci_app=$((has_claude_wf || has_release_wf))
+        has_codeql_wf=0
+        find .github/workflows -maxdepth 1 \( -name 'codeql.yml' -o -name 'codeql.yaml' \) 2>/dev/null | grep -q . && has_codeql_wf=1
+        has_semgrep_ci=0
+        grep -rq 'task security:sast' .github/workflows >/dev/null 2>&1 && has_semgrep_ci=1
         uses_full_scan=0
         grep -rq 'FULL_SECURITY_SCAN' .github/workflows >/dev/null 2>&1 && uses_full_scan=1
 
@@ -573,6 +577,21 @@ if [[ "${SECTION}" == "setup" ]]; then
                     checkline ok "Dependabot alerts"
                 else
                     checkline no "Dependabot alerts" "Settings → Advanced Security"
+                fi
+                if [ "${IS_PRIVATE}" = "true" ]; then
+                    if [ "${has_semgrep_ci}" = 1 ] && [ "${has_codeql_wf}" = 1 ]; then
+                        checkline ok "SAST route" "Semgrep CE default; paid CodeQL opt-in supported"
+                    elif [ "${has_semgrep_ci}" = 1 ]; then
+                        checkline ok "SAST route" "Semgrep CE (private)"
+                    else
+                        checkline no "SAST route" "add Semgrep CE or licensed private CodeQL"
+                    fi
+                elif [ "${has_codeql_wf}" = 1 ]; then
+                    checkline ok "SAST route" "CodeQL (public/free)"
+                elif [ "${has_semgrep_ci}" = 1 ]; then
+                    checkline ok "SAST route" "Semgrep CE"
+                else
+                    checkline no "SAST route" "add CodeQL or Semgrep CE"
                 fi
                 if [ "${IS_PRIVATE}" = "true" ]; then
                     checkline na "Private vuln reporting" "private repo"
@@ -680,13 +699,15 @@ if [[ "${SECTION}" == "setup" ]]; then
                     checkline na "CI App credentials" "not used by this repo"
                 fi
                 if [ "${uses_full_scan}" = 1 ]; then
-                    if has_cred "${d}/vars.json" "FULL_SECURITY_SCAN"; then
-                        checkline ok "FULL_SECURITY_SCAN (variable)"
+                    if [ "${IS_PRIVATE}" != "true" ]; then
+                        checkline na "Paid CodeQL opt-in" "CodeQL is public/free"
+                    elif has_cred "${d}/vars.json" "FULL_SECURITY_SCAN"; then
+                        checkline unknown "Paid CodeQL opt-in" "variable present; verify =true + entitlement"
                     else
-                        checkline no "FULL_SECURITY_SCAN (variable)" "set =true to enable CodeQL"
+                        checkline na "Paid CodeQL opt-in" "Semgrep CE free default"
                     fi
                 else
-                    checkline na "FULL_SECURITY_SCAN (variable)" "not referenced"
+                    checkline na "Paid CodeQL opt-in" "not supported by this profile"
                 fi
             fi
 

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -102,6 +102,7 @@ full)
         --data ci_runner=self-hosted
         --data github_org=test-org
         --data project_management=github
+        --data snyk_scan_schedule=weekly
     )
     ;;
 meta)
@@ -116,6 +117,7 @@ meta)
         --data bunch_add=true
         --data obsidian_project_add=true
         --data project_management=linear
+        --data snyk_scan_schedule=daily
     )
     copier_flags+=(--skip-tasks)
     ;;
@@ -179,6 +181,49 @@ if [ -f Taskfile.yml ]; then
     fi
 else
     err "no Taskfile.yml generated"
+fi
+
+# ── 1b. Free security policy renders as a coherent stack ───────────
+[ -x scripts/run-semgrep.sh ] || err "pinned Semgrep CE runner missing or not executable"
+grep -q 'brew "uv"' Brewfile || err "Brewfile must install uv for the Semgrep runner"
+! grep -qi 'snyk' Brewfile || err "Brewfile must not install optional Snyk"
+grep -q '^  security:sast:snyk:' Taskfile.yml || err "explicit optional Snyk SAST target missing"
+grep -q '^  security:sca:snyk:' Taskfile.yml || err "explicit optional Snyk SCA target missing"
+grep -q 'snyk test --all-projects' Taskfile.yml || err "Snyk SCA must scan every detected manifest"
+grep -q '^  snyk:' .github/actions/setup/action.yml || err "shared setup action is missing the opt-in Snyk installer"
+grep -q 'SNYK_VERSION=' .github/actions/setup/action.yml || err "Snyk CLI must be pinned and Renovate-manageable"
+grep -q 'task security:sast' .github/workflows/build.yml || err "build workflow is missing the Semgrep SAST route"
+jq -e '.vulnerabilityAlerts.enabled == true' renovate.json >/dev/null ||
+    err "Renovate vulnerability-alert remediation must be enabled"
+if [ -f .github/workflows/codeql.yml ]; then
+    grep -q 'github.event.repository.private == false' .github/workflows/codeql.yml ||
+        err "CodeQL must run automatically on public repositories"
+    grep -q '"context": "codeql-verify"' '.github/Branch Protection Ruleset - Protect Main.json' ||
+        err "supported-stack ruleset must require codeql-verify"
+else
+    ! grep -q '"context": "codeql-verify"' '.github/Branch Protection Ruleset - Protect Main.json' ||
+        err "ruleset requires codeql-verify but this profile has no CodeQL workflow"
+fi
+
+case "$profile" in
+full)
+    [ -f .github/workflows/snyk-scheduled.yml ] || err "weekly Snyk workflow did not render"
+    grep -q '23 6 \* \* 1' .github/workflows/snyk-scheduled.yml || err "weekly Snyk cron is incorrect"
+    ;;
+meta)
+    [ -f .github/workflows/snyk-scheduled.yml ] || err "daily Snyk workflow did not render"
+    grep -q '23 6 \* \* \*' .github/workflows/snyk-scheduled.yml || err "daily Snyk cron is incorrect"
+    ;;
+*)
+    [ ! -f .github/workflows/snyk-scheduled.yml ] || err "Snyk workflow rendered despite default schedule=off"
+    ;;
+esac
+if [ -f .github/workflows/snyk-scheduled.yml ]; then
+    grep -q 'workflow_dispatch:' .github/workflows/snyk-scheduled.yml || err "scheduled Snyk workflow needs manual dispatch"
+    ! grep -q '^  pull_request:\|^  push:' .github/workflows/snyk-scheduled.yml || err "scheduled Snyk workflow must not scan PRs or pushes"
+    grep -q 'SNYK_TOKEN' .github/workflows/snyk-scheduled.yml || err "scheduled Snyk workflow is missing token wiring"
+    grep -q 'remote-repo-url' .github/workflows/snyk-scheduled.yml || err "scheduled Snyk workflow must identify public repository context"
+    grep -q 'matrix.scan' .github/workflows/snyk-scheduled.yml || err "scheduled Snyk workflow must run SAST and SCA"
 fi
 
 # ── 2. No unrendered Copier variables leaked into output ────────────

--- a/template/.github/Branch Protection Ruleset - Protect Main.json.jinja
+++ b/template/.github/Branch Protection Ruleset - Protect Main.json.jinja
@@ -48,6 +48,12 @@
           {
             "context": "security",
             "integration_id": 15368
+[% if use_node or use_python %]
+          },
+          {
+            "context": "codeql-verify",
+            "integration_id": 15368
+[% endif %]
           }
         ]
       }

--- a/template/.github/actions/setup/action.yml.jinja
+++ b/template/.github/actions/setup/action.yml.jinja
@@ -1,6 +1,6 @@
 name: Setup toolchain
 description: >-
-  Install the shared toolchain (Node[% if use_node %]/pnpm[% endif %][% if use_python %], Python/uv[% endif %][% if include_terraform %], Terraform[% endif %], Task), project
+  Install the shared toolchain (Node[% if use_node %]/pnpm[% endif %], Python/uv[% if include_terraform %], Terraform[% endif %], Task), project
   dependencies, and — behind inputs — the lint + security CLIs. Single source of
   truth for the CI jobs and the Claude automation workflows so local, CI, and
   agent runs all execute the same Taskfile targets. Callers must run
@@ -16,7 +16,10 @@ inputs:
       `task check` / `task verify`.
     default: "false"
   gitleaks:
-    description: Install gitleaks — required by `task security`.
+    description: Install gitleaks — required by `task security:secrets`.
+    default: "false"
+  snyk:
+    description: Install the pinned Snyk CLI for an explicitly enabled scan.
     default: "false"
 [% if use_node %]
   cache:
@@ -40,16 +43,16 @@ runs:
 [% if use_node %]
         cache: ${{ inputs.cache == 'true' && 'pnpm' || '' }}
 [% endif %]
-[% if use_python %]
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
+[% if use_python %]
         python-version: "3.14"
-    - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+[% else %]
+        python-version: "3.13"
 [% endif %]
-[% if use_foreman and not use_python %]
-    # uv provides uvx for foreman:lint's pinned ruff/black (see taskfiles/foreman.yml)
+    # uv provides uvx for pinned Semgrep CE[% if use_foreman %] and foreman:lint's
+    # ruff/black (see taskfiles/foreman.yml)[% endif %].
     - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-[% endif %]
 [% if include_terraform %]
     - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 [% endif %]
@@ -108,6 +111,13 @@ runs:
           "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
         tar -xzf /tmp/gitleaks.tgz -C /tmp
         sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+    - name: Install Snyk CLI
+      if: inputs.snyk == 'true'
+      shell: bash
+      run: |
+        # renovate: datasource=npm depName=snyk
+        SNYK_VERSION=1.1305.2
+        npm install --global "snyk@${SNYK_VERSION}"
 [% if use_python %]
     - name: Install Python dependencies
       if: inputs.install-deps == 'true'

--- a/template/.github/workflows/[% if snyk_scan_schedule != 'off' %]snyk-scheduled.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if snyk_scan_schedule != 'off' %]snyk-scheduled.yml[% endif %].jinja
@@ -1,0 +1,61 @@
+name: Snyk Scheduled
+run-name: ${{ github.actor }} is running the optional Snyk second-opinion scan
+
+on:
+  workflow_dispatch:
+  schedule:
+[% if snyk_scan_schedule == 'daily' %]
+    - cron: "23 6 * * *"
+[% else %]
+    - cron: "23 6 * * 1"
+[% endif %]
+
+# Advisory defense in depth only: intentionally no pull_request/push trigger and
+# no required branch check. Public repositories do not consume private-test
+# quotas; private repositories should normally leave this workflow ungenerated.
+
+concurrency:
+  group: snyk-scheduled
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Snyk ${{ matrix.scan }}
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        scan:
+          - sast
+          - sca
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+        with:
+          snyk: "true"
+[% if use_node %]
+          # This job receives SNYK_TOKEN later. Do not restore a cache writable
+          # by lower-trust PR jobs into a credential-holding scheduled job.
+          cache: "false"
+[% endif %]
+      - name: Verify Snyk token is configured
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: test -n "${SNYK_TOKEN}"
+      - name: Run Snyk ${{ matrix.scan }} second-opinion scan
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_REMOTE_REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        # Explicit remote context helps Snyk classify a public repository as
+        # public so it does not debit the private-test allocation.
+        run: >-
+          task "security:${{ matrix.scan }}:snyk" --
+          "--remote-repo-url=${SNYK_REMOTE_REPO_URL}"

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -98,8 +98,15 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           gitleaks: "true"
-      - name: Security scan
-        run: task security
+      - name: Secrets scan
+        run: task security:secrets
+      - name: Dependency audit
+        run: task security:audit
+      - name: SAST (Semgrep Community Edition)
+[% if use_node or use_python %]
+        if: github.event.repository.private && vars.FULL_SECURITY_SCAN != 'true'
+[% endif %]
+        run: task security:sast
 [% if project_type == 'web-astro' %]
 
   lighthouse:

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -40,7 +40,7 @@ task ci          # FULL CI mirror — run before/instead of opening a PR
 task check       # all linters
 task fix         # auto-format then lint
 task test        # tests
-task security    # gitleaks + dependency audit
+task security    # Semgrep CE + gitleaks + dependency audit
 [% if use_foreman %]
 task foreman:plan -- --milestone <n>  # foreman: dry-run the dispatch graph
 [% endif %]

--- a/template/Brewfile.jinja
+++ b/template/Brewfile.jinja
@@ -18,8 +18,6 @@ brew "yamllint"
 
 # Security
 brew "gitleaks"
-tap "snyk/tap"
-brew "snyk/tap/snyk"
 
 # Runtime for npx-based tools (commitlint, markdownlint-cli2)
 brew "node"
@@ -27,11 +25,8 @@ brew "node"
 brew "pnpm"
 brew "lychee"
 [% endif %]
-[% if use_python or use_foreman %]
-
-# Python tooling (uv[% if use_foreman %]; foreman lint runs pinned ruff/black via uvx[% endif %])
+# Python tool runner (Semgrep CE[% if use_python %] + project dependencies[% endif %][% if use_foreman %] + foreman lint[% endif %] use uv/uvx)
 brew "uv"
-[% endif %]
 [% if include_terraform %]
 
 # Terraform

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -33,11 +33,12 @@ diagram that must stay in sync with reality) lives in
 ### Requirements
 
 - [Homebrew](https://brew.sh) and [go-task](https://taskfile.dev)
+- [uv](https://docs.astral.sh/uv/) (runs the pinned Semgrep CE baseline[% if use_python %] and manages Python dependencies[% endif %])
 [% if use_node %]
 - Node >= 22 and [pnpm](https://pnpm.io)
 [% endif %]
 [% if use_python %]
-- [uv](https://docs.astral.sh/uv/) (Python is pinned in `.python-version`)
+- Python is pinned in `.python-version`
 [% endif %]
 
 ### Install
@@ -114,7 +115,9 @@ See [DESIGN.md](DESIGN.md) for visual/UX direction.
 | `task build` | Production build |
 [% endif %]
 | `task test` | Run tests (see [docs/architecture/tests.md](docs/architecture/tests.md)) |
-| `task security` | gitleaks + dependency audit |
+| `task security` | Free local baseline: Semgrep CE + gitleaks + dependency audit |
+| `task security:sast` / `security:sca` | Semgrep CE / package-manager dependency audit |
+| `task security:sast:snyk` / `security:sca:snyk` | Optional Snyk second-opinion scans (manual or explicitly scheduled) |
 | `task release:patch` | Tag + GitHub release (also `:minor` / `:major`) |
 | `task status` | Project status dashboard (also `status:git`/`:gh`/`:code`/`:env`) |
 | `task status:setup` | Setup audit: GitHub config, toolchain, devcontainer, dev env |
@@ -130,7 +133,10 @@ same `task` targets as local hooks.
 |---|---|
 | `build.yml` | lint[% if use_node %], build-test[% endif %][% if project_type == 'web-astro' %], lighthouse[% endif %], security → aggregate `verify` gate |
 [% if use_node or use_python %]
-| `codeql.yml` | CodeQL analysis (opt-in via `FULL_SECURITY_SCAN` repo variable) |
+| `codeql.yml` | CodeQL SAST: automatic and free for public repos; private/internal repos require GitHub Code Security + `FULL_SECURITY_SCAN=true` |
+[% endif %]
+[% if snyk_scan_schedule != 'off' %]
+| `snyk-scheduled.yml` | Optional [[ snyk_scan_schedule ]] Snyk SAST/SCA second opinion; advisory and never a required PR check |
 [% endif %]
 [% if devcontainer %]
 | `devcontainer-build.yml` | Prebuilds devcontainer images to GHCR on merge to main |
@@ -141,7 +147,7 @@ same `task` targets as local hooks.
 [% endif %]
 
 Branch protection: `main` requires a PR with code-owner approval and the
-`verify` + `security` checks (importable ruleset in `.github/`; see
+`verify` + `security`[% if use_node or use_python %] + `codeql-verify`[% endif %] checks (importable ruleset in `.github/`; see
 [docs/architecture/branch-protection.md](docs/architecture/branch-protection.md)).
 [% if use_release_please %]
 **Releases are intentional** — release-please keeps a rolling release PR from

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -524,8 +524,9 @@ tasks:
 
   # ── Security ───────────────────────────────────────────────────
   security:
-    desc: Run all security checks (parallel)
+    desc: Run all free local security checks (Semgrep CE + gitleaks + dependency audit)
     deps:
+      - security:sast
       - security:secrets
       - security:audit
 
@@ -550,25 +551,31 @@ tasks:
       - pnpm audit --audit-level=high
 [% endif %]
 [% if use_python %]
-      - uvx pip-audit --desc --requirement <(uv pip compile pyproject.toml 2>/dev/null) || true
+      - uvx pip-audit --desc --requirement <(uv pip compile pyproject.toml 2>/dev/null)
 [% endif %]
 [% if not use_node and not use_python %]
       - echo "No package manifests to audit yet."
 [% endif %]
 
   security:sast:
-    desc: "Static application security testing (Snyk) — optional/local, needs SNYK_TOKEN (not in CI or `task security`)"
+    desc: Static application security testing (Semgrep Community Edition)
     cmds:
-      - snyk code test --exclude=.worktrees --severity-threshold=high
+      - ./scripts/run-semgrep.sh {{.CLI_ARGS}}
 
   security:sca:
-    desc: "Software composition analysis (Snyk) — optional/local, needs SNYK_TOKEN (not in CI or `task security`)"
+    desc: Software composition analysis (free package-manager audit)
+    deps:
+      - security:audit
+
+  security:sast:snyk:
+    desc: "Optional Snyk Code second-opinion scan (manual/local or explicitly scheduled); needs SNYK_TOKEN"
     cmds:
-[% if use_node %]
-      - snyk test --file=pnpm-lock.yaml --severity-threshold=high --show-vulnerable-paths=all
-[% else %]
-      - snyk test --severity-threshold=high --show-vulnerable-paths=all
-[% endif %]
+      - snyk code test --exclude=.worktrees,.foreman,.claude --severity-threshold=high {{.CLI_ARGS}}
+
+  security:sca:snyk:
+    desc: "Optional Snyk Open Source second-opinion scan (manual/local or explicitly scheduled); needs SNYK_TOKEN"
+    cmds:
+      - snyk test --all-projects --exclude=.worktrees,.foreman,.claude --severity-threshold=high --show-vulnerable-paths=all {{.CLI_ARGS}}
 
   # ── Secrets ────────────────────────────────────────────────────
   # Destination-only helpers: the secret value stays on stdin — never in argv,
@@ -632,8 +639,7 @@ tasks:
   setup:github:
     desc: >-
       Apply idempotent GitHub repo settings via gh (Dependabot alerts, private
-      vulnerability reporting, CodeQL
-      variable[% if github_org != author_git_provider_username %], bot collaborator[% endif %])
+      vulnerability reporting[% if github_org != author_git_provider_username %], bot collaborator[% endif %])
     vars:
       REPO: "[[ github_org ]]/[[ project_slug ]]"
     cmds:
@@ -647,7 +653,6 @@ tasks:
         else
           echo "Skipping private vulnerability reporting ({{.REPO}} is private; public-repo-only feature)."
         fi
-      - gh variable set FULL_SECURITY_SCAN --repo "{{.REPO}}" --body true
 [% if github_org != author_git_provider_username %]
       - gh api "repos/{{.REPO}}/collaborators/[[ author_git_provider_username ]]-bot" --method PUT -f permission=push
 [% endif %]

--- a/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile
@@ -36,8 +36,8 @@ ARG AGENT_DECK_VERSION=1.9.47
 ARG SESH_VERSION=2.26.2
 # renovate: datasource=npm depName=dmux
 ARG DMUX_VERSION=5.9.0
-# renovate: datasource=npm depName=snyk
-ARG SNYK_VERSION=1.1305.1
+# renovate: datasource=pypi depName=semgrep
+ARG SEMGREP_VERSION=1.170.0
 # renovate: datasource=npm depName=@playwright/test
 ARG PLAYWRIGHT_VERSION=1.60.0
 # renovate: datasource=npm depName=@playwright/cli
@@ -353,6 +353,13 @@ RUN npm install -g \
 # ---------- Python packages for agent-deck Telegram bridge ----------
 RUN uv pip install --system --break-system-packages --no-cache toml aiogram
 
+# ---------- Semgrep Community Edition ----------
+# Install the free SAST baseline independently of the project Python environment.
+RUN UV_TOOL_BIN_DIR=/usr/local/bin \
+    UV_TOOL_DIR=/opt/uv-tools \
+    uv tool install "semgrep==${SEMGREP_VERSION}" \
+    && rm -rf /root/.cache/uv
+
 # ---------- dotfile config ----------
 # /usr/local/share/devcontainer-config/ is kept (not cleaned up) so that
 # post-create scripts can seed persistent volumes that shadow the baked-in
@@ -403,7 +410,6 @@ RUN npm install -g \
         "@google/gemini-cli@${GEMINI_CLI_VERSION}" \
         "@openai/codex@${CODEX_VERSION}" \
         "dmux@${DMUX_VERSION}" \
-        "snyk@${SNYK_VERSION}" \
     && npm cache clean --force
 
 USER vscode

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -32,16 +32,17 @@ config, toolchain, devcontainer, and dev environment — against the items below
 
 - [ ] **Automated settings** — run `task setup:github` (idempotent, safe to
       re-run): enables **Dependabot alerts** and **private vulnerability
-      reporting**, sets the `FULL_SECURITY_SCAN` variable (CodeQL)[% if github_org != author_git_provider_username %], and adds
+      reporting** when public[% if github_org != author_git_provider_username %], and adds
       the `[[ author_git_provider_username ]]-bot` machine account as a Write
-      collaborator[% endif %]. Do NOT add dependabot.yml — Renovate owns version updates.[% if devcontainer %]
+      collaborator[% endif %]. Do not add `dependabot.yml`: Renovate owns routine
+      and vulnerability-remediation PRs; Dependabot owns advisory alerts.[% if devcontainer %]
 - [ ] **Bot PAT** — the agent's `GH_TOKEN`. If a fine-grained PAT already covers
       [% if github_org != author_git_provider_username %]`[[ github_org ]]`[% else %]`[[ author_git_provider_username ]]`[% endif %],
       just add this repo to its **selected repositories**; a token is scoped to one
       resource owner, so a **new owner needs a new PAT**. Both layers are required —
       the collaborator grant above sets the ceiling, the PAT's repo list reaches it.
       Procedure: [guides/bot-account.md](guides/bot-account.md).[% endif %]
-- [ ] Import the branch ruleset (see [architecture/branch-protection.md](architecture/branch-protection.md)) — do this once `build.yml` is on `main` so the required `verify`/`security` checks resolve. **Use the UI import:** Settings → Rules → Rulesets → **New ruleset ▸ Import a ruleset** → select `.github/Branch Protection Ruleset - Protect Main.json`. (Prefer the UI over `gh api … rulesets`: the API `POST` is not idempotent — re-running creates a duplicate ruleset — and currently rejects the `merge_queue` rule. To later change the ruleset, edit the existing one in the UI rather than re-importing.)
+- [ ] Import the branch ruleset (see [architecture/branch-protection.md](architecture/branch-protection.md)) — do this once `build.yml`[% if use_node or use_python %] and `codeql.yml`[% endif %] are on `main` so the required `verify`/`security`[% if use_node or use_python %]/`codeql-verify`[% endif %] checks resolve. **Use the UI import:** Settings → Rules → Rulesets → **New ruleset ▸ Import a ruleset** → select `.github/Branch Protection Ruleset - Protect Main.json`. (Prefer the UI over `gh api … rulesets`: the API `POST` is not idempotent — re-running creates a duplicate ruleset — and currently rejects the `merge_queue` rule. To later change the ruleset, edit the existing one in the UI rather than re-importing.)
 
 - [ ] Install the [Renovate app](https://github.com/apps/renovate) on the repo
 - [ ] Install the [CodeRabbit app](https://github.com/apps/coderabbitai) on the repo (`.coderabbit.yaml` is pre-configured)
@@ -49,19 +50,50 @@ config, toolchain, devcontainer, and dev environment — against the items below
       with `claude setup-token`; the value must start **`sk-ant-oat01-`** (an OAuth
       token, billed to your Claude subscription), **not** `sk-ant-api03-` (a raw API
       key, billed at pay-as-you-go API rates). Then `gh secret set CLAUDE_CODE_OAUTH_TOKEN`
-- [ ] Snyk is **optional and local-only**: `task security:sast`/`security:sca` are
-      opt-in — they are NOT in CI or `task security`, so run them by hand with
-      `SNYK_TOKEN` in your local env / 1Password (no Actions secret needed). If the
-      **Snyk GitHub App** is installed it posts `code/snyk`/`security/snyk` PR checks,
-      which the branch ruleset does **not** require; remove the app (or this repo from
-      it) to drop them.
+[% if use_node or use_python %]
+- [ ] **SAST coverage** — public repositories run CodeQL automatically and for
+      free; confirm a successful upload in the Security tab. Free private repos
+      run Semgrep CE in `build.yml`. Only set `FULL_SECURITY_SCAN=true` on a
+      private/internal repository after enabling paid GitHub Code Security; the
+      variable is a run switch, not an entitlement. It cannot disable public
+      CodeQL.
+[% else %]
+- [ ] **SAST coverage** — this profile has no CodeQL workflow, so Semgrep CE runs
+      in `build.yml` for public and private repositories. Add CodeQL later if the
+      repo gains a supported application stack and is public (free) or has paid
+      GitHub Code Security (private/internal).
+[% endif %]
+- [ ] **Choose the Snyk posture** — the default is manual/local only via
+      `task security:sast:snyk` and `task security:sca:snyk`; it is not part of
+      `task security` or required PR CI. Free private-repository tests share the
+      Snyk Organization's monthly quota, including local CLI tests. Leave the
+      Snyk GitHub App off unless deliberately adopting its PR integration; its
+      checks are not required by the default branch ruleset.
+[% if snyk_scan_schedule != 'off' %]
+- [ ] **Activate scheduled Snyk ([[ snyk_scan_schedule ]])** —
+      `snyk-scheduled.yml` was generated as an advisory SAST + SCA second
+      opinion. Set the Actions secret `SNYK_TOKEN`, use **Run workflow** once to
+      verify it, and check the Snyk Organization Usage page. It has schedule and
+      manual triggers only—never PR/push—and is not a required check. Daily is
+      intended for public or accepted unlimited OSS. Confirm Snyk recognizes the
+      public Git remote and does not debit private-test usage; if it does, run
+      `snyk monitor` once and set the Project's Git remote URL in Snyk. Reconsider
+      weekly private scans if the shared quota is too small.
+[% else %]
+- [ ] **Optional scheduled Snyk** — leave this off for ordinary and free private
+      repos. For a selected important public repo, re-render with
+      `snyk_scan_schedule=weekly` (conservative) or `daily` (public or accepted
+      unlimited OSS), set the generated workflow's `SNYK_TOKEN` Actions secret,
+      and verify one manual run. Confirm Snyk classifies the public Git remote
+      correctly. The workflow is advisory and never a required PR check.
+[% endif %]
 [% if project_type == 'web-app' %]
 - [ ] **Product security** (this is a web-app — likely a customer-facing product):
-      the default CodeQL + Dependabot + gitleaks stack is the floor; for a real SaaS
-      also weigh a **paid Snyk tier** (licence compliance + reachability +
-      defense-in-depth; removes the Snyk-Code free limit), **DAST** against the
-      running app, and a **multi-tenant isolation** review before onboarding
-      customers. See [architecture/security.md](architecture/security.md).
+      visibility-appropriate SAST + Dependabot alerts/Renovate + gitleaks is the
+      floor. For a real SaaS, evaluate paid GitHub Code Security and/or Snyk,
+      GitHub Secret Protection, DAST against the running app, and a multi-tenant
+      isolation review before onboarding customers. See
+      [architecture/security.md](architecture/security.md).
 [% endif %]
 - [ ] **Create** the CI GitHub App `[[ github_org ]]-ci` by hand (one App per org;
       **Settings → Developer settings → GitHub Apps**), or reuse the org's existing one.

--- a/template/docs/architecture/branch-protection.md.jinja
+++ b/template/docs/architecture/branch-protection.md.jinja
@@ -9,7 +9,7 @@ This document explains the branch protection ruleset applied to `main` and how i
 An importable copy of the ruleset ships in this repo at
 `.github/Branch Protection Ruleset - Protect Main.json`. Apply it through the
 GitHub **UI import** (do this once `build.yml` is on `main`, so the required
-`verify`/`security` checks resolve):
+`verify`/`security`[% if use_node or use_python %]/`codeql-verify`[% endif %] checks resolve):
 
 > Settings → Rules → Rulesets → **New ruleset ▸ Import a ruleset** → select
 > `.github/Branch Protection Ruleset - Protect Main.json`.
@@ -25,14 +25,12 @@ every rule type and is the GitHub-native way to apply an exported ruleset.
 
 ## Dependabot and Renovate
 
-Version updates are owned by **Renovate** (`renovate.json`) — do not add a
-`dependabot.yml`, it would duplicate Renovate's PRs. Dependabot still has a
-role as a GitHub-native security layer; enable these in
-Settings → Advanced Security:
+Routine updates and vulnerability-remediation PRs are owned by **Renovate**
+(`renovate.json`, with `vulnerabilityAlerts.enabled=true`) — do not add a
+`dependabot.yml`, which would create competing update PRs. Dependabot still owns
+the GitHub-native advisory feed; enable these in Settings → Advanced Security:
 
 - Dependabot alerts
-- Dependabot security updates (optional — alerts may be enough since Renovate
-  proposes the same bumps)
 - Private vulnerability reporting (used by `.github/SECURITY.md`)
 
 ## Security Model Overview
@@ -113,7 +111,7 @@ Every permission here is one a prompt-injected agent has.
 | --- | --- |
 | **Workflows** | The agent could rewrite `.github/workflows/`, then let CI run it with every Actions secret. The classic escalation. |
 | **Administration** | Rulesets, settings, bypass lists. The bot must not be able to unlock the door it is locked behind. |
-| **Variables — write** | Read is granted; write is not. Write lets the agent flip `FULL_SECURITY_SCAN` and silently stop CodeQL — a gate bypass that never appears in a PR diff. |
+| **Variables — write** | Read is granted; write is not. Write could opt a private repo into paid CodeQL or mutate another security/deploy switch without a PR diff. Public CodeQL cannot be disabled with `FULL_SECURITY_SCAN`. |
 | **Deployments** | Write lets the agent create deployments, colliding with release-gated deploys. Read buys nothing the agent's loop uses. |
 | **Secrets**, **Environments**, **Webhooks**, … | Never needed; each is one more thing a leaked token reaches. |
 
@@ -290,16 +288,31 @@ This is the core rule that prevents the AI agent from pushing directly to `main`
 
 All specified CI checks must pass before the PR can merge. The `strict_required_status_checks_policy: true` setting means the PR branch must be up-to-date with `main` before merging — if `main` advances after the checks ran, the checks must re-run. The `do_not_enforce_on_create: true` setting skips enforcement when the branch is first created (before any CI has had a chance to run).
 
-The required checks are the two aggregate jobs from `build.yml` (see
+The required checks are the build gates[% if use_node or use_python %] plus CodeQL's stable aggregate[% endif %] (see
 [ci-cd.md](ci-cd.md)):
 
 | Check      | Purpose                                                                                          |
 | ---------- | ----------------------------------------------------------------------------------------------- |
 | `verify`   | Aggregate gate — rolls up `lint`[% if use_node %], `build-test`[% endif %][% if project_type == 'web-astro' %], `lighthouse`[% endif %], and `security` so one check reports overall pass/fail |
-| `security` | Secret scanning (gitleaks) + dependency audit                                                    |
+| `security` | gitleaks + dependency audit; Semgrep CE when this job owns the visibility/profile SAST route |
+[% if use_node or use_python %]
+| `codeql-verify` | Requires CodeQL success on public and paid-private routes; reports not-applicable on free private repos and fork PRs |
+[% endif %]
 
 Requiring the aggregate `verify` (rather than each leaf job) keeps the required-check
 list stable as jobs are added inside `build.yml`.
+
+[% if use_node or use_python %]
+`codeql-verify` is stable across visibility: public and paid-private CodeQL must
+succeed; free private repositories and fork PRs get a successful not-applicable
+result while the required `security` job carries the Semgrep fallback. It runs
+on `merge_group`, so it is safe for the merge queue.
+[% endif %]
+Snyk PR/App checks are absent by default.[% if snyk_scan_schedule != 'off' %] The generated
+scheduled Snyk workflow is advisory and never a required check; it has no PR or
+push trigger.[% endif %] Only a high-consequence repository that deliberately adopts
+paid Snyk should consider per-PR scans and whether to make them merge
+requirements. See [security.md](security.md) for the scanner policy.
 
 [% if github_org != author_git_provider_username %]
 ### `merge_queue`

--- a/template/docs/architecture/ci-cd.md.jinja
+++ b/template/docs/architecture/ci-cd.md.jinja
@@ -13,10 +13,19 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
 
 ## Workflows
 
-- `build.yml` — on push/PR to `main`: lint[% if use_node %], build-test[% endif %][% if project_type == 'web-astro' %], lighthouse[% endif %], security, then the aggregate **`verify`** job.
+- `build.yml` — on push/PR to `main`: lint[% if use_node %], build-test[% endif %][% if project_type == 'web-astro' %], lighthouse[% endif %], security, then the aggregate **`verify`** job. Security always runs gitleaks + dependency audit[% if use_node or use_python %], and uses Semgrep CE as the free private-repo SAST fallback[% else %] + Semgrep CE SAST[% endif %].
 - `claude-plan` / `claude-implement` / `claude-review` — `@claude …` on issues and PRs.
 [% if use_node or use_python %]
-- `codeql.yml` — CodeQL analysis (opt-in via the `FULL_SECURITY_SCAN` variable).
+- `codeql.yml` — CodeQL SAST runs automatically and for free on public
+  repositories. Private/internal repositories require paid GitHub Code Security
+  plus `FULL_SECURITY_SCAN=true`; otherwise `build.yml` supplies Semgrep CE.
+  Confirm successful uploads in the Security tab.
+[% endif %]
+[% if snyk_scan_schedule != 'off' %]
+- `snyk-scheduled.yml` — optional [[ snyk_scan_schedule ]] Snyk Code + Open
+  Source second-opinion scans. It has schedule/manual triggers only, consumes no
+  PR checks, and is not part of branch protection. See
+  [security.md](security.md) for quota guidance.
 [% endif %]
 [% if devcontainer %]
 - `devcontainer-build.yml` — prebuilds the devcontainer images to GHCR on `.devcontainer/**` changes.

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -23,60 +23,154 @@ current — it is the reference for "where do secrets live and who can do what".
 
 ## Security scanning: SAST, SCA, secrets & audits
 
-Scanning is layered across a few axes. Each check runs at a defined place — a
-`task` target, a CI job, a git hook, or a GitHub-native setting — so local runs,
-git hooks, and CI stay identical. **The default stack is GitHub-native + CI-local
-and needs no paid service.**
+Scanning is layered across a few axes. GitHub-hosted CodeQL is the preferred SAST
+engine where it is free: public repositories with a supported generated
+workflow. Semgrep Community Edition (CE) is the free CI fallback for private
+repositories and for profiles without a CodeQL workflow.
 
 | Axis | Catches | Default tool | Where it runs |
 |---|---|---|---|
-| **SAST** — flaws in *your own code* | injection, XSS, SSRF, path traversal, crypto/auth misuse | **CodeQL** (`codeql.yml`; JS/TS + Python) | CI, opt-in via the `FULL_SECURITY_SCAN=true` repo variable; results land in the GitHub Security tab |
-| **SCA** — CVEs in *dependencies* | vulnerable third-party packages | **Dependabot alerts** + **`task security:audit`** (`pnpm audit` / `pip-audit`) | Dependabot continuous (GitHub-native); audit in the CI `security` job + `task security` locally |
+[% if use_node or use_python %]
+| **SAST** — flaws in *your own code* | injection, XSS, SSRF, path traversal, crypto/auth misuse | **CodeQL** for public repos; **Semgrep CE** for free private repos | CodeQL runs automatically in public CI. Private CI uses Semgrep unless paid GitHub Code Security + `FULL_SECURITY_SCAN=true` opts into CodeQL |
+[% else %]
+| **SAST** — flaws in *your own code* | injection, XSS, SSRF, path traversal, crypto/auth misuse | **Semgrep CE** | CI and `task security:sast`; this profile has no generated CodeQL workflow |
+[% endif %]
+| **SCA** — CVEs in *dependencies* | vulnerable third-party packages | **Dependabot alerts** + **`task security:audit`** (`pnpm audit` / `pip-audit`) | Dependabot continuous; audit in the CI `security` job + `task security` locally |
 | **Secrets** — committed credentials | keys, tokens, certs, `.env` | **gitleaks** (`task security:secrets`) | pre-push git hook + CI `security` job |
 | **IaC** — insecure infrastructure | open security groups, public buckets, … | **checkov** (`task lint:terraform:security`) | CI `lint` job + `task check` locally (Terraform repos) |
-| **Freshness** — stale dependencies | a widening exposure window | **Renovate** (`minimumReleaseAge: 3 days`) | continuous, grouped update PRs |
+| **Freshness/remediation** — stale or vulnerable dependencies | a widening exposure window | **Renovate** (`minimumReleaseAge: 3 days`, Dependabot-alert remediation enabled) | continuous update and vulnerability-fix PRs |
 
-- **`task security`** (the CI `security` job) is `security:secrets` (gitleaks) +
-  `security:audit` (dependency audit). It does **not** run Snyk.
-- **CodeQL is opt-in** — its analyze jobs skip unless `FULL_SECURITY_SCAN=true`,
-  which `task setup:github` sets. If CodeQL is your only SAST, confirm it is on.
+The repository-class policy is:
+
+| Repository class | Standard |
+|---|---|
+| Public, CodeQL-supported | CodeQL + Dependabot alerts/Renovate + gitleaks; no Snyk by default |
+| Selected important public | Optionally add Snyk Free as a scheduled SAST/SCA second opinion; private-test quotas do not apply to public repositories |
+| Private | Semgrep CE is the dependable free CI SAST baseline; keep Snyk Free manual/local by default because its Organization-wide quotas can stop scans mid-month |
+| Important private | Consider paid GitHub Code Security/private CodeQL and/or paid Snyk, then decide whether per-PR scans should be merge-gating |
+| Qualifying public OSS | Consider Snyk's [Secure Developer Program](https://snyk.io/open-source/) for full entitlements without usage limits |
+
+- **`task security`** is the portable free local baseline: `security:sast`
+  (Semgrep CE) + `security:secrets` (gitleaks) + `security:audit` (the
+  package-manager audit). It does **not** run Snyk.
+- **CI routes SAST by visibility** instead of running duplicate engines:
+[% if use_node or use_python %]
+  public → CodeQL; free private → Semgrep CE; private with GitHub Code Security +
+  `FULL_SECURITY_SCAN=true` → CodeQL.
+[% else %]
+  this profile has no CodeQL workflow, so Semgrep CE runs for both public and
+  private repositories.
+[% endif %]
 - **`task setup:github`** turns on the GitHub-native layers: Dependabot alerts,
-  Private Vulnerability Reporting, and the `FULL_SECURITY_SCAN` variable; the branch
-  ruleset makes `verify` + `security` required checks. See
+  and Private Vulnerability Reporting when the repository is public; the branch
+  ruleset makes `verify` + `security`[% if use_node or use_python %] + `codeql-verify`[% endif %] required checks. See
   [../CHECKLIST.md](../CHECKLIST.md).
 - Which tools apply depends on the stack: SAST/SCA need code + a manifest (web/app,
-  or Python for iac); IaC scanning is Terraform-only. A `general`/`docs` repo leans
-  mainly on secrets + audit.
+  or Python for iac); IaC scanning is Terraform-only.
 
-### Snyk is optional and redundant by default
+Semgrep CE is useful, open-source, and runs without a hosted account, but it is
+not CodeQL-equivalent: its community analysis is principally intraprocedural
+and normally has shallower data-flow coverage than CodeQL or commercial engines.
+It is the private-repository floor, not a claim of full vulnerability coverage.
 
-The template ships Snyk targets — `task security:sast` (`snyk code test`, SAST) and
-`task security:sca` (`snyk test`, SCA) — but they are **opt-in, local-only, and not
-in CI**, because the default stack already covers both axes: **CodeQL** for SAST and
-**Dependabot + `security:audit`** for SCA. On a normal repo Snyk is redundant — leave
-it off. (`SNYK_TOKEN` is a local credential, not a CI secret; and if the Snyk GitHub
-App is installed, its `code/snyk`/`security/snyk` PR checks are **not** required by
-the branch ruleset — remove the app to drop them.)
+[% if use_node or use_python %]
+### Enable CodeQL when the repository is eligible
 
-### Exception: a shipped product (e.g. a B2B SaaS web app)
+The template includes `codeql.yml` for Node and Python profiles. It runs
+automatically on every **public** repository: GitHub code scanning and standard
+GitHub-hosted Actions runners are free there. CodeQL is preferred over Semgrep CE
+for these stacks because its queries include deeper interprocedural and data-flow
+analysis and integrate directly with GitHub's Security tab.
 
-For a product that holds customer data, revisit the above — the redundancy stops
-being waste and a **paid Snyk tier** is worth weighing:
+For **private/internal** repositories, CodeQL code scanning requires an
+organization on GitHub Team or Enterprise with
+[GitHub Code Security enabled](https://docs.github.com/en/code-security/reference/code-scanning/troubleshoot-analysis-errors/private-repository-enablement).
+That product is
+[billed by active committer](https://docs.github.com/en/billing/concepts/product-billing/github-advanced-security),
+and GitHub-hosted Actions usage can also consume the plan's minutes. Leave
+`FULL_SECURITY_SCAN` unset when that entitlement is unavailable; the build
+workflow runs Semgrep CE instead. When the paid entitlement is enabled, set
+`FULL_SECURITY_SCAN=true`, confirm a successful upload in the Security tab, and
+then count private CodeQL as coverage. The variable cannot disable public
+CodeQL.
+[% else %]
+### Semgrep is the SAST baseline
 
-- **Defense in depth** — a second SAST/SCA opinion matters when a miss means a
-  customer-data breach, not a broken marketing page.
-- **License compliance** — you are distributing a product, and **Dependabot does not
-  scan dependency licences**; Snyk (or FOSSA) does.
-- **Reachability** — Snyk can rank which dependency CVEs are actually reachable in
-  your code, cutting noise.
-- **Sales & compliance** — B2B customers send security questionnaires and may require
-  SOC 2 / a vendor review, where a recognised commercial scanner is a checkbox. A
-  paid tier also removes the free Snyk-Code monthly test limit.
+This profile does not generate `codeql.yml`, so the build workflow runs Semgrep
+CE for public and private repositories. If the repository later gains a
+CodeQL-supported application stack, add a CodeQL workflow for public coverage or
+for paid private GitHub Code Security coverage.
+[% endif %]
 
-A web app also needs layers this stack does **not** cover: **DAST** (scanning the
-running app for auth bypass / IDOR / injection on live endpoints), **multi-tenant
-isolation** (the top B2B web-app risk), and **container/image scanning** if it ships
-images.
+### Dependency monitoring and update ownership
+
+Dependabot **alerts** are free for public and private repositories and are the
+continuous GitHub advisory feed. Renovate owns routine dependency update PRs and
+alert-remediation PRs (`vulnerabilityAlerts.enabled=true`). Do not add a
+`dependabot.yml`: Dependabot update PRs would compete with Renovate. The
+package-manager audit remains in CI as an immediate provider-independent check.
+
+### Snyk second opinion and scheduling
+
+Snyk is not installed by default and is not part of `task security` or required
+PR CI. The explicit `task security:sast:snyk` (`snyk code test`) and
+`task security:sca:snyk` (`snyk test --all-projects`) targets provide
+manual/local second-opinion scans. Every detected dependency manifest can
+consume a separate Snyk Open Source test on a private repository.
+
+The Copier answer `snyk_scan_schedule` controls the optional workflow:
+
+- `off` (default) — no workflow; keep `SNYK_TOKEN` local;
+- `weekly` — quota-aware advisory scans, appropriate for a selected repository;
+- `daily` — intended for public repositories or an accepted unlimited OSS
+  project, not the ordinary private Free-plan posture.
+
+[% if snyk_scan_schedule != 'off' %]
+This repository generated `snyk-scheduled.yml` with the **[[ snyk_scan_schedule ]]**
+cadence. It installs a pinned CLI and runs Snyk Code (SAST) plus Snyk Open
+Source (SCA) as separate matrix jobs. It triggers only on its schedule or manual
+dispatch—not on pull requests or pushes—and is excluded from branch protection.
+Add the `SNYK_TOKEN` Actions secret, run it manually once, and watch the Snyk
+Organization Usage page. The workflow passes the public Git remote explicitly;
+if Snyk still debits private-test usage for a public repo, follow Snyk's
+[documented remedy](https://docs.snyk.io/developer-tools/snyk-cli/getting-started-with-the-snyk-cli#running-out-of-tests):
+run `snyk monitor` once and set the public Git remote URL in the Snyk Project.
+[% else %]
+This repository kept the default `off`, so no Snyk workflow or Actions secret is
+needed. Re-render with `weekly` or `daily` only after deliberately selecting the
+repository for scheduled defense in depth.
+[% endif %]
+
+Scheduled and local CLI tests draw from the same private-repository allocation.
+Weekly is the conservative cadence. Daily Snyk Code alone is about 30 tests per
+repository per month, before manual tests, and SCA multiplies by the number of
+manifests. The scheduled workflow is intended primarily for selected important
+public repositories because Snyk's private-test limits do not apply there. A
+private repository may deliberately choose weekly after estimating
+Organization-wide usage, but the standard remains Semgrep CE in CI plus
+occasional local Snyk. Dependabot already monitors dependency advisories
+continuously, so weekly Snyk is normally enough for a second opinion.
+
+No Snyk GitHub App is needed for local or scheduled CLI scans. Leave it off on
+ordinary repositories. If installed, its PR checks (commonly
+`code/snyk`/`security/snyk`) are not required by the branch ruleset; remove the
+repository from the integration to eliminate them.
+
+### Paid escalation for a high-consequence product
+
+Choose paid controls based on the capability the product needs:
+
+- **GitHub Code Security** supplies private-repository CodeQL and keeps findings
+  and remediation in GitHub.
+- **Paid Snyk** can be an alternative or a second SAST/SCA opinion, especially
+  when dependency-license policy, reachability, or vendor reporting matters.
+- **GitHub Secret Protection** adds server-side secret scanning, push protection,
+  and governance. Gitleaks remains useful locally and in CI but does not block a
+  secret before it reaches GitHub in every client/path.
+
+DAST, tenant-isolation tests, and container/image scanning are separate,
+application-specific controls. A deployed web application should evaluate them;
+a library or docs repository usually should not.
 [% if devcontainer %]
 
 ## Two identities: the bot vs the operator
@@ -158,12 +252,13 @@ Write it down rather than re-derive it under pressure:
   repo the bot should not see.
 [% endif %]
 
-**Read is cheap; write is the line.** Variables are read-only deliberately: write
-would let an agent flip `FULL_SECURITY_SCAN` and silently stop CodeQL — a gate
-bypass that never appears in a PR diff, the same shape as the Workflows
-exclusion. The read grant is safe only because GitHub separates Secrets from
-Variables; if a variable ever holds something sensitive, read becomes
-exfiltration. Check when adding a variable, not forever.
+**Read is cheap; write is the line.** Variables are read-only deliberately:
+write could opt a private repository into paid CodeQL or mutate other
+security/deployment switches without a PR diff. Public CodeQL does not depend on
+`FULL_SECURITY_SCAN` and cannot be disabled through that variable. The read grant
+is safe only because GitHub separates Secrets from Variables; if a variable ever
+holds something sensitive, read becomes exfiltration. Check when adding a
+variable, not forever.
 [% endif %]
 
 ## CI automation identity (GitHub App)
@@ -301,7 +396,7 @@ even the in-org radius small:
 | `CI_APP_CLIENT_ID` (var) + `CI_APP_PRIVATE_KEY` (secret) | [% if use_release_please %]release-please, [% endif %]claude-*[% if github_org != author_git_provider_username %], project-automation[% endif %] | repo or org Actions variable + secret | rotate App key per policy |
 | `CLAUDE_CODE_OAUTH_TOKEN` | claude-* workflows | repo Actions secret | re-run `claude setup-token` |
 [% if devcontainer %]| `GH_TOKEN` (the bot's PAT) | the devcontainer agent's `gh`/git operations | 1Password Environment → devcontainer `--env-file` | manual; re-issue before expiry ([guides/bot-account.md](../guides/bot-account.md)) |
-[% endif %]| `SNYK_TOKEN` | `task security:sast`/`sca` (optional, local-only — not in CI) | local env / 1Password | manual |
+[% endif %]| `SNYK_TOKEN` | optional Snyk CLI scans[% if snyk_scan_schedule != 'off' %] + `snyk-scheduled.yml`[% endif %] | local env / 1Password by default[% if snyk_scan_schedule != 'off' %]; Actions secret for the generated schedule[% endif %] | manual |
 | TODO | TODO | TODO | TODO |
 
 > **`CLAUDE_CODE_OAUTH_TOKEN` must be an OAuth token, not an API key.** Generate

--- a/template/docs/architecture/tests.md.jinja
+++ b/template/docs/architecture/tests.md.jinja
@@ -16,7 +16,10 @@ How testing works in [[ project_name ]].
 [% else %]
 | Tests | TODO: pick a test runner | `task test` |
 [% endif %]
+| Application security | Semgrep CE locally[% if use_node or use_python %]; CodeQL in eligible CI[% endif %] | `task security:sast` |
+| Optional second opinion | Snyk Code + Open Source, manual[% if snyk_scan_schedule != 'off' %] or [[ snyk_scan_schedule ]] scheduled[% endif %] | `task security:sast:snyk` / `task security:sca:snyk` |
 | Secrets | gitleaks | `task security:secrets` |
+| Dependencies | package-manager audit | `task security:audit` |
 
 ## Conventions
 

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -17,7 +17,8 @@ it points here.
   major bump.
 - **Feature branches only.** Direct commits to `main` are blocked by the
   `guard:no-commit-to-main` pre-commit hook and the branch ruleset. Land changes
-  via a PR; code-owner review and the `verify` + `security` checks are required.
+  via a PR; code-owner review and the `verify` + `security`[% if use_node or use_python %] + `codeql-verify`[% endif %]
+  checks are required.
 - **Never bypass hooks** (`--no-verify` is forbidden) — fix the underlying issue.
 [% if devcontainer %]
   In the devcontainer a Claude Code hook actively blocks `--no-verify` and

--- a/template/docs/glossary.md.jinja
+++ b/template/docs/glossary.md.jinja
@@ -11,7 +11,7 @@ project-specific (domain) terms as the model firms up.
 | Term | Meaning |
 |---|---|
 | `verify` | The aggregate CI job in `build.yml` that rolls up the other jobs into one required status check (the merge gate). See [architecture/ci-cd.md](architecture/ci-cd.md). |
-| `security` (check) | The CI job running secret scanning (gitleaks) + dependency audit; the second required status check. |
+| `security` (check) | The required CI job running gitleaks + dependency audit, plus Semgrep CE when this job owns the SAST route. |
 | `task` / Taskfile | go-task is the single source of truth for commands; lefthook hooks and CI both delegate to `task` targets so local and CI runs are identical. |
 [% if use_release_please %]
 | release-please | Bot that maintains a rolling "release" PR from Conventional Commits; merging it cuts the tag, GitHub release, and CHANGELOG. Releases are intentional, never automatic on merge. |

--- a/template/docs/guides/troubleshooting.md.jinja
+++ b/template/docs/guides/troubleshooting.md.jinja
@@ -14,6 +14,7 @@ Common issues in [[ project_name ]] and how to fix them.
 
 ## CI
 
-- **`verify` check missing on a PR** — ensure the Build & Validate workflow ran; required checks are `verify` and `security`.
+- **Required check missing on a PR** — ensure Build & Validate[% if use_node or use_python %] and CodeQL[% endif %] ran;
+  required checks are `verify`, `security`[% if use_node or use_python %], and `codeql-verify`[% endif %].
 
 TODO: add project-specific issues as they come up.

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -6,6 +6,9 @@
   "prConcurrentLimit": 10,
   "automerge": false,
   "dependencyDashboard": true,
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
   "customManagers": [
 [% if devcontainer %]
     {
@@ -28,8 +31,8 @@
     },
     {
       "customType": "regex",
-      "description": "Workflow tool pins, `FOO_VERSION=x.y.z` shell-variable style",
-      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
+      "description": "Workflow/composite-action and script tool pins, `FOO_VERSION=x.y.z` shell-variable style",
+      "managerFilePatterns": ["/^(\\.github/(actions|workflows)/.*\\.ya?ml|scripts/.*\\.sh)$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+[A-Z_]+_VERSION=(?<currentValue>\\S+)"
       ]

--- a/template/scripts/run-semgrep.sh
+++ b/template/scripts/run-semgrep.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep Semgrep on its PyPI/uv distribution. The Homebrew bottle has previously
+# failed during TLS-store initialization on macOS, and uv gives local + CI the
+# same explicitly pinned build.
+# renovate: datasource=pypi depName=semgrep
+SEMGREP_VERSION=1.170.0
+
+exec uvx --from "semgrep==${SEMGREP_VERSION}" semgrep scan \
+    --config p/default \
+    --metrics=off \
+    --error \
+    --severity ERROR \
+    --exclude=.worktrees \
+    "$@" \
+    .

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -471,6 +471,10 @@ if [[ "${SECTION}" == "setup" ]]; then
         has_release_wf=0
         find .github/workflows -maxdepth 1 \( -name 'release.yml' -o -name 'release.yaml' \) 2>/dev/null | grep -q . && has_release_wf=1
         uses_ci_app=$((has_claude_wf || has_release_wf))
+        has_codeql_wf=0
+        find .github/workflows -maxdepth 1 \( -name 'codeql.yml' -o -name 'codeql.yaml' \) 2>/dev/null | grep -q . && has_codeql_wf=1
+        has_semgrep_ci=0
+        grep -rq 'task security:sast' .github/workflows >/dev/null 2>&1 && has_semgrep_ci=1
         uses_full_scan=0
         grep -rq 'FULL_SECURITY_SCAN' .github/workflows >/dev/null 2>&1 && uses_full_scan=1
 
@@ -573,6 +577,21 @@ if [[ "${SECTION}" == "setup" ]]; then
                     checkline ok "Dependabot alerts"
                 else
                     checkline no "Dependabot alerts" "Settings → Advanced Security"
+                fi
+                if [ "${IS_PRIVATE}" = "true" ]; then
+                    if [ "${has_semgrep_ci}" = 1 ] && [ "${has_codeql_wf}" = 1 ]; then
+                        checkline ok "SAST route" "Semgrep CE default; paid CodeQL opt-in supported"
+                    elif [ "${has_semgrep_ci}" = 1 ]; then
+                        checkline ok "SAST route" "Semgrep CE (private)"
+                    else
+                        checkline no "SAST route" "add Semgrep CE or licensed private CodeQL"
+                    fi
+                elif [ "${has_codeql_wf}" = 1 ]; then
+                    checkline ok "SAST route" "CodeQL (public/free)"
+                elif [ "${has_semgrep_ci}" = 1 ]; then
+                    checkline ok "SAST route" "Semgrep CE"
+                else
+                    checkline no "SAST route" "add CodeQL or Semgrep CE"
                 fi
                 if [ "${IS_PRIVATE}" = "true" ]; then
                     checkline na "Private vuln reporting" "private repo"
@@ -680,13 +699,15 @@ if [[ "${SECTION}" == "setup" ]]; then
                     checkline na "CI App credentials" "not used by this repo"
                 fi
                 if [ "${uses_full_scan}" = 1 ]; then
-                    if has_cred "${d}/vars.json" "FULL_SECURITY_SCAN"; then
-                        checkline ok "FULL_SECURITY_SCAN (variable)"
+                    if [ "${IS_PRIVATE}" != "true" ]; then
+                        checkline na "Paid CodeQL opt-in" "CodeQL is public/free"
+                    elif has_cred "${d}/vars.json" "FULL_SECURITY_SCAN"; then
+                        checkline unknown "Paid CodeQL opt-in" "variable present; verify =true + entitlement"
                     else
-                        checkline no "FULL_SECURITY_SCAN (variable)" "set =true to enable CodeQL"
+                        checkline na "Paid CodeQL opt-in" "Semgrep CE free default"
                     fi
                 else
-                    checkline na "FULL_SECURITY_SCAN (variable)" "not referenced"
+                    checkline na "Paid CodeQL opt-in" "not supported by this profile"
                 fi
             fi
 


### PR DESCRIPTION
## Summary

- make CodeQL the public-repository SAST default and Semgrep CE the private-repository free baseline
- retain Dependabot, Renovate, and Gitleaks across supported repositories
- add opt-in off, weekly, or daily Snyk scheduled SAST/SCA scans to the Copier template
- document free, paid, public OSS, quota, and branch-protection guidance in root and rendered-template docs
- update setup actions, task targets, status output, rulesets, and template assertions in dogfood parity

## Validation

- task verify
- pre-push skills drift, Gitleaks, and minimal rendered-template checks

## Follow-up

The pinned standardize-repo skill still needs the canonical Snyk guidance updated and released from harmon-devkit, after which harmon-init can bump its pin and sync the vendored copy.