### PR TITLE
feat(renovate): track harmon-devkit skill releases

### DIFF
--- a/.skills-sync.yaml
+++ b/.skills-sync.yaml
@@ -7,6 +7,7 @@
 # line) — any other directory in `dest` is a local skill it never touches.
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
+  # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
   ref: v0.5.0 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
   - repo

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,14 @@
   "customManagers": [
     {
       "customType": "regex",
+      "description": "Released harmon-devkit tag pinned by root and template skills-sync manifests",
+      "managerFilePatterns": ["/\\.skills-sync\\.ya?ml/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+ref:\\s*(?<currentValue>\\S+)"
+      ]
+    },
+    {
+      "customType": "regex",
       "description": "Devcontainer Dockerfile ARG pins — suffix-matched so the template's Dockerfile.jinja (inside a jinja-named directory) is managed too",
       "managerFilePatterns": ["/Dockerfile(\\.jinja)?$/"],
       "matchStrings": [
@@ -92,6 +100,17 @@
       "matchManagers": ["custom.regex"],
       "matchFileNames": ["template/.github/workflows/**"],
       "groupName": "GitHub Actions"
+    },
+    {
+      "description": "Surface harmon-devkit releases for deliberate pin-and-sync updates",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["evanharmon1/harmon-devkit"],
+      "groupName": "harmon-devkit skills",
+      "dependencyDashboardApproval": true,
+      "dependencyDashboardCategory": "Agent skills",
+      "prBodyNotes": [
+        "After approving this update, run `task sync:skills` and push the refreshed `.claude/skills/` as a separate commit; do not amend Renovate's commit."
+      ]
     },
     {
       "description": "Batch the web-astro test-fixture dependency bumps into one PR (the fixture validates the shipped ESLint config; its deps move together)",

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -430,12 +430,17 @@ minimal) # use_skills_sync=false -> none of the machinery renders
     [ ! -f .skills-sync.yaml ] || err ".skills-sync.yaml rendered but use_skills_sync=false"
     [ ! -f scripts/sync-skills.sh ] || err "scripts/sync-skills.sh rendered but use_skills_sync=false"
     ! grep -q 'sync:skills:' Taskfile.yml || err "sync:skills task rendered but use_skills_sync=false"
+    ! grep -q 'harmon-devkit skills' renovate.json || err "skills-sync Renovate rule rendered but use_skills_sync=false"
     ;;
 *) # use_skills_sync defaults on -> manifest, engine, and tasks all present
     [ -f .skills-sync.yaml ] || err ".skills-sync.yaml missing (use_skills_sync default on)"
     [ -x scripts/sync-skills.sh ] || err "scripts/sync-skills.sh missing or not executable"
     grep -q 'sync:skills:' Taskfile.yml || err "sync:skills task missing (use_skills_sync default on)"
     grep -q '^  - universal$' .skills-sync.yaml || err ".skills-sync.yaml categories missing 'universal' (skill_categories default)"
+    grep -q 'datasource=github-releases depName=evanharmon1/harmon-devkit' .skills-sync.yaml || err ".skills-sync.yaml missing Renovate annotation"
+    grep -q 'harmon-devkit skills' renovate.json || err "skills-sync Renovate rule missing"
+    grep -q 'dependencyDashboardApproval' renovate.json || err "skills-sync Renovate rule is not approval-gated"
+    grep -q 'task sync:skills' renovate.json || err "skills-sync Renovate PR instructions missing"
     ;;
 esac
 

--- a/template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja
+++ b/template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja
@@ -8,6 +8,7 @@
 # line) — any other directory in `dest` is a local skill it never touches.
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
+  # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
   ref: v0.5.0 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
 [% for cat in skill_categories %]

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -20,8 +20,11 @@ config, toolchain, devcontainer, and dev environment — against the items below
       `.claude/skills/`. Until then the `verify:skills*` drift checks skip
       cleanly (CI + pre-push). **Pin bumps are a two-step:** edit `ref` in
       `.skills-sync.yaml`, then run `task sync:skills` and commit the refreshed
-      `.claude/skills/` in the same PR — Renovate can bump the ref but can't do
-      the re-sync, so a ref-only commit fails the drift check.
+      `.claude/skills/` in the same PR. Renovate surfaces a new release in the
+      Dependency Dashboard; approve it there to open the pin PR, then run the
+      sync and push its output as a separate commit (do not amend Renovate's
+      commit). Renovate cannot do the re-sync, so a ref-only commit fails the
+      drift check.
 [% endif %]
 - [ ] Verify `[[ project_slug ]].code-workspace` opens the repo's folder in VS Code and has a unique VS Code Workspace color. Then add any other related repos (e.g. other org repos) to the `folders` list in the workspace file so you have quick access to those repos
 - [ ] Extend `.gitignore` for your stack — the template ships a base; add stack-specific entries via [gitignore.io](https://www.toptal.com/developers/gitignore)

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -10,6 +10,16 @@
     "enabled": true
   },
   "customManagers": [
+[% if use_skills_sync %]
+    {
+      "customType": "regex",
+      "description": "Released harmon-devkit tag pinned by the skills-sync manifest",
+      "managerFilePatterns": ["/\\.skills-sync\\.ya?ml/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+ref:\\s*(?<currentValue>\\S+)"
+      ]
+    },
+[% endif %]
 [% if devcontainer %]
     {
       "customType": "regex",
@@ -86,7 +96,18 @@
       "description": "Batch all Docker image updates into one PR",
       "matchDatasources": ["docker"],
       "groupName": "Docker images"
-    }[% if devcontainer %],
+    }[% if use_skills_sync %],
+    {
+      "description": "Surface harmon-devkit releases for deliberate pin-and-sync updates",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["evanharmon1/harmon-devkit"],
+      "groupName": "harmon-devkit skills",
+      "dependencyDashboardApproval": true,
+      "dependencyDashboardCategory": "Agent skills",
+      "prBodyNotes": [
+        "After approving this update, run `task sync:skills` and push the refreshed `.claude/skills/` as a separate commit; do not amend Renovate's commit."
+      ]
+    }[% endif %][% if devcontainer %],
     {
       "description": "Batch all devcontainer updates (base image + annotated tools) into one PR — must come after the Docker images rule so the base image lands here instead",
       "matchFileNames": [".devcontainer/**"],


### PR DESCRIPTION
## Summary

- add a Renovate regex manager for the harmon-devkit release tag pinned in .skills-sync.yaml
- keep updates deliberate with Dependency Dashboard approval
- tell each Renovate PR to run task sync:skills and add the vendored refresh as a separate commit
- render the manager only when skills sync is enabled and test both enabled and disabled profiles

## Validation

- task verify
- task test:template:all
- npx --yes --package renovate@latest renovate-config-validator --strict renovate.json
- pre-push skills drift, Gitleaks, and minimal rendered-template checks

## Operator flow

Approve the harmon-devkit release in the Renovate Dependency Dashboard. After Renovate opens the pin PR, run task sync:skills and push the refreshed .claude/skills/ as a second commit. A ref-only PR continues to fail the skills drift check.