### PR TITLE
feat(taskfile)!: verify becomes the definition-of-done gate; check is the fast gate

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -64,10 +64,10 @@ tasks:
       - task: security
 
   verify:
-    # Local gate for this template repo. Unlike a generated repo's `verify` (which
-    # is tuned to stay under a minute for agents/hooks), this one renders the whole
-    # template via test:template, so it is inherently heavier — but it still runs
-    # the same fast Taskfile/hook guards a generated repo's verify does.
+    # Local gate for this template repo. Like a generated repo's `verify` (the
+    # Foreman v2 vocabulary: the definition-of-done gate — check + build +
+    # test), it runs check, the quick guards, and its test tier — which here
+    # renders the whole template via test:template, so it is inherently heavier.
     desc: Local verification gate (check → guards → test:template)
     cmds:
       - task: check

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -36,7 +36,7 @@ and humans run the same targets):
 
 ```bash
 task check       # FAST gate (<~1 min) — run constantly; safe for hooks/agents
-task verify      # definition-of-done gate — check + build + test; run before finishing
+task verify      # definition-of-done gate — check[% if use_node %] + build[% endif %] + validate + test; run before finishing
 task ci          # FULL CI mirror — run before/instead of opening a PR
 task fix         # auto-format then lint
 task test        # tests

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -35,9 +35,9 @@ All commands go through the Taskfile (single source of truth — CI, git hooks,
 and humans run the same targets):
 
 ```bash
-task verify      # FAST local gate (<~1 min) — run constantly; safe for hooks/agents
+task check       # FAST gate (<~1 min) — run constantly; safe for hooks/agents
+task verify      # definition-of-done gate — check + build + test; run before finishing
 task ci          # FULL CI mirror — run before/instead of opening a PR
-task check       # all linters
 task fix         # auto-format then lint
 task test        # tests
 task security    # Semgrep CE + gitleaks + dependency audit
@@ -53,11 +53,13 @@ PRs, and shepherds them to mergeable — merging is always a human decision.
 See `docs/architecture/foreman.md`.
 [% endif %]
 
-`verify` is deliberately kept fast (lint[% if use_node %] + typecheck + build[% endif %] + the quick
-Taskfile/hook guards) so editors, git hooks, and AI agents can run it on every
-change without getting bogged down. `ci` is the full pipeline — everything CI
-runs (`verify` + `test` + `security`[% if devcontainer %] + the devcontainer permission assert[% endif %]) — so you
-can reproduce a CI run locally on demand instead of waiting on a PR.
+`check` is deliberately kept fast (lint[% if use_node %] + typecheck[% endif %]) so editors, git hooks, and
+AI agents can run it on every change without getting bogged down. `verify` is
+the definition-of-done gate — check[% if use_node %] + build[% endif %] + validate + test plus the quick
+Taskfile/hook guards (the Foreman v2 vocabulary: verify = check + build +
+test). `ci` is the full pipeline — everything CI runs (`verify` +
+`security`[% if devcontainer %] + the devcontainer permission assert[% endif %]) — so you can reproduce a CI
+run locally on demand instead of waiting on a PR.
 
 ## Definition of Done
 

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -107,8 +107,8 @@ See [DESIGN.md](DESIGN.md) for visual/UX direction.
 
 | Command | What it does |
 |---|---|
-| `task verify` | Local merge gate: lint[% if use_node %] + typecheck + build[% endif %] |
-| `task check` | All linters in parallel |
+| `task check` | Fast gate: all linters[% if use_node %] + typecheck[% endif %], in parallel |
+| `task verify` | Definition-of-done gate: check[% if use_node %] + build[% endif %] + validate + tests |
 | `task fix` | Auto-format, then lint |
 [% if use_node %]
 | `task dev` | Dev server with hot reload |

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -51,21 +51,20 @@ tasks:
     # a PR to catch everything CI would, on demand, without waiting on a PR run.
     # Builds on `verify` and adds the heavier / environment-dependent checks
     # (the devcontainer permission assert needs a Docker daemon, like CI has).
-    desc: Full CI mirror (verify → [test:devcontainer:permissions →] test → security)
+    desc: Full CI mirror (verify → [test:devcontainer:permissions →] security)
     cmds:
       - task: verify
 [% if devcontainer %]
       - task: test:devcontainer:permissions
 [% endif %]
-      - task: test
       - task: security
 
   verify:
-    # Fast local gate (target: well under a minute) — safe for editors, git
-    # hooks, and AI agents to run on every change without getting bogged down.
-    # Add a check here ONLY if it stays fast; heavier or environment-dependent
-    # checks (test, security, the devcontainer permission assert) live in `ci`.
-    desc: Fast local gate (check[% if use_node %] → build[% endif %] → validate → guards)
+    # The definition-of-done gate — everything that must pass before a change
+    # is done (Foreman v2 task vocabulary: verify = check + build + test).
+    # For the fast inner loop use `check`; heavier environment-dependent
+    # checks (security, the devcontainer permission assert) stay in `ci`.
+    desc: Definition-of-done gate (check[% if use_node %] → build[% endif %] → validate → guards → test)
     cmds:
       - task: check
 [% if use_node %]
@@ -79,10 +78,13 @@ tasks:
 [% if devcontainer %]
       - task: test:hooks
 [% endif %]
+      - task: test
 
   # ── Quality Checks ────────────────────────────────────────────
   check:
-    desc: Run all linters[% if use_node %] + typecheck[% endif %] (parallel)
+    # Fast local gate (target: well under a minute) — safe for editors, git
+    # hooks, and AI agents to run on every change without getting bogged down.
+    desc: Fast local gate — all linters[% if use_node %] + typecheck[% endif %] (parallel)
     deps:
       - lint
 [% if use_node %]

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -61,9 +61,10 @@ tasks:
 
   verify:
     # The definition-of-done gate — everything that must pass before a change
-    # is done (Foreman v2 task vocabulary: verify = check + build + test).
-    # For the fast inner loop use `check`; heavier environment-dependent
-    # checks (security, the devcontainer permission assert) stay in `ci`.
+    # is done. Foreman v2 calls this the "check + build + test" tier; the desc
+    # below lists this repo's exact steps. For the fast inner loop use `check`;
+    # heavier environment-dependent checks (security, the devcontainer
+    # permission assert) stay in `ci`.
     desc: Definition-of-done gate (check[% if use_node %] → build[% endif %] → validate → guards → test)
     cmds:
       - task: check

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -34,7 +34,9 @@ it points here.
   `install:hooks`, `status:git`. **Never action-first** (`typescript:lint`,
   `yaml:lint`).
 - Pipeline order is **`check → build → validate → test → security`**, with
-  `verify` (local gate) and `ci` (full) as the aggregates.
+  `verify` (the definition-of-done gate — check + build + validate + test) and
+  `ci` (full — verify + security) as the aggregates. `check` is the fast
+  inner-loop/hook gate.
 - **`lint:*` and `check` are read-only gates** — they report and fail, never
   modify files. All auto-fixing lives in **`task format`**, **`task format:file
   -- <path>`**, and **`task fix`** (= format then lint). Pre-commit hooks run the

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -34,7 +34,7 @@ it points here.
   `install:hooks`, `status:git`. **Never action-first** (`typescript:lint`,
   `yaml:lint`).
 - Pipeline order is **`check → build → validate → test → security`**, with
-  `verify` (the definition-of-done gate — check + build + validate + test) and
+  `verify` (the definition-of-done gate — check[% if use_node %] + build[% endif %] + validate + test) and
   `ci` (full — verify + security) as the aggregates. `check` is the fast
   inner-loop/hook gate.
 - **`lint:*` and `check` are read-only gates** — they report and fail, never


### PR DESCRIPTION
## Summary

Adopts the **Foreman v2 task vocabulary** (ponderousdev/foreman#16): `verify` becomes the **definition-of-done gate** (`check + build + test`), and the fast hook/inner-loop role moves to **`check`**.

Previously `verify` was the sub-minute fast gate (no tests) and `ci` added `test`. Under Foreman v2 a consumer wired with `[verify] default = ["task", "verify"]` would run a **test-free** in-unit gate — this fixes that.

## Changes

- **`template/Taskfile.yml.jinja`**: `verify` gains `test` (slowest, last); `ci` drops its now-redundant `test` step; `check` picks up the fast-gate comment/framing.
- **`Taskfile.yml`** (root dogfood): `verify` comment updated to the new vocabulary (its test tier is `test:template`; command list unchanged).
- **`AGENTS.md` / `README` / `docs/conventions.md`** (template): describe the new `check` = fast gate / `verify` = definition-of-done roles.

No wiring changes were needed in lefthook or `build.yml`: hooks already call granular targets, and CI runs each tier as its own step.

## Why e2e stays out of `ci`

`test:e2e` fails closed until an app configures `scripts/e2e-env-guard.sh`, so wiring it into `ci` would break fresh scaffolds. The `test` task itself is a safe no-op on fresh scaffolds (echoes a TODO when there's no vitest config) and does **not** call `test:e2e`, so adding it to `verify` is safe. Foreman's composed gate keys e2e to the `ports` capability instead.

## Verification

`task verify` passes locally — all six template profiles (minimal, iac, meta, full, webapp, web), `test:dogfood-parity`, `check`, `test:tasks`, `foreman:test`, and `test:hooks` green.

## Breaking change

`task verify` now runs the test suite — it is the definition-of-done gate, not the <1-minute fast gate. Use `task check` for the fast inner loop; hooks are unaffected (they already call granular targets). Consumers pick this up via `copier update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
