### PR TITLE
fix(ci): harden shared setup and Semgrep wrapper

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,15 +1,11 @@
 name: Setup toolchain
 description: >-
-  Install the shared toolchain (Node, Task), project
-  dependencies, and — behind inputs — the lint + security CLIs. Single source of
-  truth for the CI jobs and the Claude automation workflows so local, CI, and
-  agent runs all execute the same Taskfile targets. Callers must run
-  actions/checkout first.
+  Install the shared toolchain (Node, Task) and — behind inputs — the lint +
+  security CLIs. Single source of truth for the CI jobs and the Claude
+  automation workflows so local, CI, and agent runs all execute the same
+  Taskfile targets. Callers must run actions/checkout first.
 
 inputs:
-  install-deps:
-    description: Install project dependencies () when present.
-    default: "true"
   lint-tools:
     description: >-
       Install shellcheck, shfmt, actionlint, yamllint, yq — required by

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,7 +52,8 @@ tasks:
   ci:
     # Full local mirror of this repo's CI — run on demand to catch everything CI
     # would (the lint job's guards, the template render matrix, security) without
-    # waiting on a PR. test:devcontainer:permissions needs a Docker daemon.
+    # waiting on a PR. The devcontainer permission assertion is a unit check and
+    # does not build or start a container.
     desc: Full CI mirror (check → guards → test → security)
     cmds:
       - task: check

--- a/scripts/run-semgrep.sh
+++ b/scripts/run-semgrep.sh
@@ -7,11 +7,12 @@ set -euo pipefail
 # renovate: datasource=pypi depName=semgrep
 SEMGREP_VERSION=1.170.0
 
+# Semgrep defaults to the current directory when no target is provided. Do not
+# append one here: callers can scope local scans with `task security:sast -- <path>`.
 exec uvx --from "semgrep==${SEMGREP_VERSION}" semgrep scan \
     --config p/default \
     --metrics=off \
     --error \
     --severity ERROR \
     --exclude=.worktrees \
-    "$@" \
-    .
+    "$@"

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -18,6 +18,9 @@ fail() {
     exit 1
 }
 
+test_tmp="$(mktemp -d)"
+trap 'rm -rf "$test_tmp"' EXIT
+
 echo "==> Taskfile compiles (every task parses)"
 if ! task --list-all >/dev/null 2>&1; then
     fail "task --list-all failed — the Taskfile does not compile"
@@ -30,6 +33,23 @@ if command -v brew >/dev/null 2>&1; then
     fi
 else
     echo "    (skipped: brew not on PATH)"
+fi
+
+echo "==> Semgrep wrapper preserves explicit scan targets"
+semgrep_bin="${test_tmp}/semgrep-bin"
+semgrep_args="${test_tmp}/semgrep-args"
+mkdir -p "$semgrep_bin"
+cat >"${semgrep_bin}/uvx" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"${SEMGREP_ARGS:?}"
+EOF
+chmod +x "${semgrep_bin}/uvx"
+PATH="${semgrep_bin}:${PATH}" SEMGREP_ARGS="$semgrep_args" \
+    ./scripts/run-semgrep.sh scripts
+[ "$(tail -n 1 "$semgrep_args")" = "scripts" ] ||
+    fail "Semgrep wrapper did not preserve the explicit target"
+if grep -Fxq . "$semgrep_args"; then
+    fail "Semgrep wrapper appended a repository-wide target"
 fi
 
 echo "==> secret helper tasks reject missing destination metadata"

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -487,11 +487,12 @@ if [ "$profile" = "minimal" ]; then
     [ ! -d .devcontainer ] || err ".devcontainer/ rendered but devcontainer=false"
     [ ! -f scripts/devcontainer-assert.sh ] || err "scripts/devcontainer-assert.sh rendered but devcontainer=false"
     [ ! -f scripts/devcontainer-smoke.sh ] || err "scripts/devcontainer-smoke.sh rendered but devcontainer=false"
-    ! grep -q 'test:devcontainer:permissions:' Taskfile.yml || err "test:devcontainer tasks rendered but devcontainer=false"
+    ! grep -q 'test:devcontainer:permissions' Taskfile.yml || err "test:devcontainer references rendered but devcontainer=false"
 else
     [ -d .devcontainer ] || err ".devcontainer/ missing (devcontainer on for profile '$profile')"
     [ -x scripts/devcontainer-assert.sh ] || err "scripts/devcontainer-assert.sh missing or not executable"
     [ -x scripts/devcontainer-smoke.sh ] || err "scripts/devcontainer-smoke.sh missing or not executable"
+    grep -q -- '- task: test:devcontainer:permissions' Taskfile.yml || err "ci task is missing the devcontainer permission assertion"
 fi
 
 # ── 9f. .prettierignore: web-app-only entries are gated by project type ──

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -192,6 +192,19 @@ grep -q '^  security:sca:snyk:' Taskfile.yml || err "explicit optional Snyk SCA 
 grep -q 'snyk test --all-projects' Taskfile.yml || err "Snyk SCA must scan every detected manifest"
 grep -q '^  snyk:' .github/actions/setup/action.yml || err "shared setup action is missing the opt-in Snyk installer"
 grep -q 'SNYK_VERSION=' .github/actions/setup/action.yml || err "Snyk CLI must be pinned and Renovate-manageable"
+if [ -f prettier.config.cjs ] || [ -f pyproject.toml ]; then
+    grep -q '^  install-deps:' .github/actions/setup/action.yml ||
+        err "dependency-bearing profiles must expose the install-deps input"
+else
+    ! grep -q '^  install-deps:' .github/actions/setup/action.yml ||
+        err "dependency-free profiles must not expose an unused install-deps input"
+fi
+if [ -f pyproject.toml ]; then
+    grep -q 'if \[ -f uv.lock \]; then' .github/actions/setup/action.yml ||
+        err "Python setup must detect a committed uv.lock"
+    grep -q 'uv sync --locked' .github/actions/setup/action.yml ||
+        err "Python setup must enforce the committed uv.lock"
+fi
 grep -q 'task security:sast' .github/workflows/build.yml || err "build workflow is missing the Semgrep SAST route"
 jq -e '.vulnerabilityAlerts.enabled == true' renovate.json >/dev/null ||
     err "Renovate vulnerability-alert remediation must be enabled"

--- a/template/.github/actions/setup/action.yml.jinja
+++ b/template/.github/actions/setup/action.yml.jinja
@@ -1,15 +1,17 @@
 name: Setup toolchain
 description: >-
-  Install the shared toolchain (Node[% if use_node %]/pnpm[% endif %], Python/uv[% if include_terraform %], Terraform[% endif %], Task), project
-  dependencies, and — behind inputs — the lint + security CLIs. Single source of
+  Install the shared toolchain (Node[% if use_node %]/pnpm[% endif %], Python/uv[% if include_terraform %], Terraform[% endif %], Task)[% if use_node or use_python %], project
+  dependencies,[% endif %] and — behind inputs — the lint + security CLIs. Single source of
   truth for the CI jobs and the Claude automation workflows so local, CI, and
   agent runs all execute the same Taskfile targets. Callers must run
   actions/checkout first.
 
 inputs:
+[% if use_node or use_python %]
   install-deps:
     description: Install project dependencies ([% if use_node %]pnpm install[% if use_python %], [% endif %][% endif %][% if use_python %]uv sync[% endif %]) when present.
     default: "true"
+[% endif %]
   lint-tools:
     description: >-
       Install shellcheck, shfmt, actionlint, yamllint[% if use_skills_sync %], yq[% endif %] — required by
@@ -122,7 +124,12 @@ runs:
     - name: Install Python dependencies
       if: inputs.install-deps == 'true'
       shell: bash
-      run: uv sync
+      run: |
+        if [ -f uv.lock ]; then
+          uv sync --locked
+        else
+          uv sync
+        fi
 [% endif %]
 [% if use_node %]
     - name: Install dependencies

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -49,9 +49,14 @@ tasks:
   ci:
     # Full local mirror of the CI pipeline — run before (or instead of) opening
     # a PR to catch everything CI would, on demand, without waiting on a PR run.
-    # Builds on `verify` and adds the heavier / environment-dependent checks
-    # (the devcontainer permission assert needs a Docker daemon, like CI has).
-    desc: Full CI mirror (verify → [test:devcontainer:permissions →] security)
+[% if devcontainer %]
+    # Builds on `verify` and adds the devcontainer permission assertion plus the
+    # heavier security checks.
+    desc: Full CI mirror (verify → test:devcontainer:permissions → security)
+[% else %]
+    # Builds on `verify` and adds the heavier security checks.
+    desc: Full CI mirror (verify → security)
+[% endif %]
     cmds:
       - task: verify
 [% if devcontainer %]
@@ -63,8 +68,7 @@ tasks:
     # The definition-of-done gate — everything that must pass before a change
     # is done. Foreman v2 calls this the "check + build + test" tier; the desc
     # below lists this repo's exact steps. For the fast inner loop use `check`;
-    # heavier environment-dependent checks (security, the devcontainer
-    # permission assert) stay in `ci`.
+    # heavier security checks[% if devcontainer %] and the devcontainer permission assertion[% endif %] stay in `ci`.
     desc: Definition-of-done gate (check[% if use_node %] → build[% endif %] → validate → guards → test)
     cmds:
       - task: check

--- a/template/scripts/run-semgrep.sh
+++ b/template/scripts/run-semgrep.sh
@@ -7,11 +7,12 @@ set -euo pipefail
 # renovate: datasource=pypi depName=semgrep
 SEMGREP_VERSION=1.170.0
 
+# Semgrep defaults to the current directory when no target is provided. Do not
+# append one here: callers can scope local scans with `task security:sast -- <path>`.
 exec uvx --from "semgrep==${SEMGREP_VERSION}" semgrep scan \
     --config p/default \
     --metrics=off \
     --error \
     --severity ERROR \
     --exclude=.worktrees \
-    "$@" \
-    .
+    "$@"

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -18,6 +18,9 @@ fail() {
     exit 1
 }
 
+test_tmp="$(mktemp -d)"
+trap 'rm -rf "$test_tmp"' EXIT
+
 echo "==> Taskfile compiles (every task parses)"
 if ! task --list-all >/dev/null 2>&1; then
     fail "task --list-all failed — the Taskfile does not compile"
@@ -30,6 +33,23 @@ if command -v brew >/dev/null 2>&1; then
     fi
 else
     echo "    (skipped: brew not on PATH)"
+fi
+
+echo "==> Semgrep wrapper preserves explicit scan targets"
+semgrep_bin="${test_tmp}/semgrep-bin"
+semgrep_args="${test_tmp}/semgrep-args"
+mkdir -p "$semgrep_bin"
+cat >"${semgrep_bin}/uvx" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"${SEMGREP_ARGS:?}"
+EOF
+chmod +x "${semgrep_bin}/uvx"
+PATH="${semgrep_bin}:${PATH}" SEMGREP_ARGS="$semgrep_args" \
+    ./scripts/run-semgrep.sh scripts
+[ "$(tail -n 1 "$semgrep_args")" = "scripts" ] ||
+    fail "Semgrep wrapper did not preserve the explicit target"
+if grep -Fxq . "$semgrep_args"; then
+    fail "Semgrep wrapper appended a repository-wide target"
 fi
 
 echo "==> secret helper tasks reject missing destination metadata"


### PR DESCRIPTION
## Description

Fix the shared setup and Semgrep behavior surfaced while applying harmon-init 4.0 across the platform repos:

- use `uv sync --locked` when a committed Python lockfile is present
- omit the dependency-install input and description for dependency-free profiles
- preserve caller-supplied Semgrep targets instead of always appending a repository-wide target
- cover the generated action and Semgrep wrapper behavior with regression assertions

The dogfood root and template copies are updated together.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Task / chore (maintenance, tooling, no product change)

## How Has This Been Tested?

- [x] `task verify`
- [x] pre-commit and commit-msg hooks
- [x] pre-push skills drift, secret scan, and minimal template checks

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes