### PR TITLE
fix(foreman): harden review and execution boundaries

### DIFF
--- a/.claude/skills/.SKILLS_PROVENANCE
+++ b/.claude/skills/.SKILLS_PROVENANCE
@@ -1,6 +1,6 @@
 # VENDORED from harmon-devkit — DO NOT EDIT the managed skills here.
 # source: https://github.com/evanharmon1/harmon-devkit.git
-# ref: v0.7.0 (64b6dc3cf6c8297e06f76737ccacc0ebd179a56c)
+# ref: v0.7.1 (e4ed36b44bb593511ca1374a79c17caf6a41d7c3)
 # path: ai/skills
 # categories: repo
 # managed: standardize-repo

--- a/.foreman.toml
+++ b/.foreman.toml
@@ -13,6 +13,10 @@ max_parallel = 3
 branch_prefix = "foreman"
 expected_login = "evanharmon1-bot"
 
+# Only these GitHub logins, trusted author associations, and Foreman's own
+# account may contribute unresolved review-thread content to agent prompts.
+review_sender_trust = ["coderabbitai", "Copilot"]
+
 # subscription (default): adapters inherit CLAUDE_CODE_OAUTH_TOKEN; USD
 # budgets are inert (guardrails bind on timeout/turns). api: adapters export
 # FOREMAN_ANTHROPIC_API_KEY process-locally; USD budgets bind.

--- a/.skills-sync.yaml
+++ b/.skills-sync.yaml
@@ -8,7 +8,7 @@
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
   # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
-  ref: v0.7.0 # pinned tag — bump deliberately to a released harmon-devkit tag
+  ref: v0.7.1 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
   - repo
 dest: .claude/skills

--- a/docs/architecture/foreman.md
+++ b/docs/architecture/foreman.md
@@ -15,8 +15,8 @@ progression. Zero tokens are spent on coordination.
 
 - **No AI ever merges to main. Ever.** No auto-merge, no enabling flag. The
   human merge is the only mechanism that advances the dependency graph;
-  foreman's job ends at "this PR is verified, adjudicated, and mergeable —
-  here is the suggested merge order." Server-side enforcement (branch
+  foreman's job ends at "this PR is verified, adjudicated, and has GitHub
+  `mergeStateStatus=CLEAN` — here is the suggested merge order." Server-side enforcement (branch
   ruleset, code-owner review, bot token without bypass) is the boundary;
   prompts are only a mitigation.
 - **Stateless in the repo.** Human inputs are stored (issue bodies, labels /
@@ -150,9 +150,9 @@ Deterministic triggers → bounded agent actions on open foreman PRs:
   (commit + reply + resolve) or decline with technical reasoning (bots are
   sometimes wrong; deterministic facts beat speculation). Blanket-accepting
   is prohibited. Foreman re-checks disposition completeness afterwards.
-- **Green + adjudicated + mergeable** → `ready-to-merge` label plus a
-  dependency-aware suggested merge order. Foreman performs no merge action
-  of any kind.
+- **Green + adjudicated + `mergeStateStatus=CLEAN`** → `ready-to-merge` label
+  plus a dependency-aware suggested merge order. Foreman performs no merge
+  action of any kind.
 
 ## Watch mode and unattended runs
 

--- a/docs/architecture/foreman.md
+++ b/docs/architecture/foreman.md
@@ -194,8 +194,10 @@ USD budgets bind. Switching is a config flip plus one secret.
   or reopen issues, edit issue bodies/titles, touch human comments, or write
   fields/types/dependency edges — those operations do not exist in the
   module, and the test suite greps to keep them absent.
-- **Prompt-injection surface**: only trusted-association comments enter
-  prompts; review-bot findings and CI logs are framed as claims to
+- **Prompt-injection surface**: only trusted-association issue comments and
+  review threads whose authors match a trusted association, Foreman's account,
+  or `review_sender_trust` enter prompts. Other unresolved review threads go to
+  the human queue. Trusted review-bot findings and CI logs are framed as claims to
   adjudicate, not instructions; agents run with conservative permission
   modes outside the sandboxed bot devcontainer (`FOREMAN_SANDBOXED=1`
   relaxes inside it).
@@ -212,6 +214,7 @@ branch_prefix = "foreman"
 expected_login = "your-bot"   # identity assertion; "" skips
 billing = "subscription"      # subscription | api
 sandboxed = false             # FOREMAN_SANDBOXED=1 env inside the bot container
+review_sender_trust = ["coderabbitai", "Copilot"]
 
 [budgets]
 dispatch_usd = 20.0           # binds in api billing mode

--- a/docs/architecture/foreman.md
+++ b/docs/architecture/foreman.md
@@ -201,6 +201,12 @@ USD budgets bind. Switching is a config flip plus one secret.
   adjudicate, not instructions; agents run with conservative permission
   modes outside the sandboxed bot devcontainer (`FOREMAN_SANDBOXED=1`
   relaxes inside it).
+- **Backend environment**: agent subprocesses receive an explicit runtime and
+  authentication allowlist, not the complete parent environment. Dispatch,
+  CI-repair, rebase, and preflight agents do not receive `GH_TOKEN`; only the
+  adjudication agent receives the intentionally scoped bot token needed for its
+  reply-and-resolve contract. Cloud, 1Password, SSH-agent, and unrelated host
+  credentials never cross the adapter boundary.
 
 ## Configuration (.foreman.toml)
 

--- a/scripts/foreman/backend.py
+++ b/scripts/foreman/backend.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import signal
 import subprocess
 import time
@@ -30,6 +31,48 @@ from foreman.config import Config
 from foreman.util import ForemanError, run, tail, utc_now_iso, write_text
 
 BACKENDS_DIR = Path(__file__).resolve().parent / "backends"
+BACKEND_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+# Process/runtime settings required by the adapter and Claude CLI. Secrets are
+# added conditionally below; arbitrary parent credentials never cross the
+# backend boundary.
+BACKEND_ENV_ALLOWLIST = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "LANG",
+        "TERM",
+        "COLORTERM",
+        "NO_COLOR",
+        "FORCE_COLOR",
+        "TZ",
+        "XDG_CONFIG_HOME",
+        "XDG_CACHE_HOME",
+        "XDG_DATA_HOME",
+        "XDG_STATE_HOME",
+        "CLAUDE_CONFIG_DIR",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "NODE_EXTRA_CA_CERTS",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "no_proxy",
+        "FOREMAN_READONLY",
+        "FOREMAN_MOCK_STATUS",
+        "FOREMAN_MOCK_FILE",
+    }
+)
 
 RESULT_STATUSES = ("completed", "blocked")
 
@@ -48,13 +91,43 @@ class BackendResult:
 
 
 def adapter_path(name: str) -> Path:
-    path = BACKENDS_DIR / f"{name}.sh"
-    if not path.exists():
+    backends_dir = BACKENDS_DIR.resolve()
+    path = (backends_dir / f"{name}.sh").resolve()
+    if (
+        BACKEND_NAME_RE.fullmatch(name) is None
+        or path.parent != backends_dir
+        or not path.is_file()
+    ):
         available = sorted(p.stem for p in BACKENDS_DIR.glob("*.sh"))
         raise ForemanError(
             f"unknown backend '{name}' (available: {', '.join(available)})"
         )
     return path
+
+
+def backend_environment(cfg: Config, *, allow_github: bool = False) -> dict[str, str]:
+    """Least-privilege environment for a backend subprocess."""
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key in BACKEND_ENV_ALLOWLIST or key.startswith("LC_")
+    }
+    if cfg.billing == "api":
+        api_key = os.environ.get("FOREMAN_ANTHROPIC_API_KEY", "")
+        if not api_key:
+            raise ForemanError("billing=api but FOREMAN_ANTHROPIC_API_KEY is not set")
+        env["FOREMAN_ANTHROPIC_API_KEY"] = api_key
+    else:
+        oauth_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")
+        if oauth_token:
+            env["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
+    # Adjudication alone needs the scoped bot credential to reply and resolve.
+    # Dispatch, CI repair, rebase, and preflight agents never receive it.
+    if allow_github:
+        gh_token = os.environ.get("GH_TOKEN", "")
+        if gh_token:
+            env["GH_TOKEN"] = gh_token
+    return env
 
 
 def capabilities(adapter: Path) -> set[str]:
@@ -92,6 +165,7 @@ def run_backend(
     prompt_file: Path,
     timeout_min: int,
     resume_ref: str | None = None,
+    allow_github: bool = False,
 ) -> BackendResult:
     session_file = unit_run_dir / "session"
     log_file = unit_run_dir / "agent.log"
@@ -100,7 +174,7 @@ def run_backend(
     if result_file.exists():
         result_file.unlink()
 
-    env = os.environ.copy()
+    env = backend_environment(cfg, allow_github=allow_github)
     env.update(
         {
             "FOREMAN_PROMPT_FILE": str(prompt_file),
@@ -113,9 +187,6 @@ def run_backend(
             "FOREMAN_MAX_TURNS": str(cfg.max_turns),
         }
     )
-    if cfg.billing == "api" and not env.get("FOREMAN_ANTHROPIC_API_KEY"):
-        raise ForemanError("billing=api but FOREMAN_ANTHROPIC_API_KEY is not set")
-
     argv = [str(adapter), "resume", resume_ref] if resume_ref else [str(adapter), "run"]
     timed_out = False
     with stdout_file.open("a", encoding="utf-8") as out_fh:

--- a/scripts/foreman/config.py
+++ b/scripts/foreman/config.py
@@ -32,6 +32,9 @@ class Config:
     comment_trust: list[str] = field(
         default_factory=lambda: ["OWNER", "MEMBER", "COLLABORATOR"]
     )
+    review_sender_trust: list[str] = field(
+        default_factory=lambda: ["coderabbitai", "Copilot"]
+    )
     branch_prefix: str = "foreman"
     worktrees_dir: str = ".worktrees/foreman"
     runtime_dir: str = ".foreman"

--- a/scripts/foreman/github.py
+++ b/scripts/foreman/github.py
@@ -71,7 +71,7 @@ query($owner: String!, $name: String!, $number: Int!) {
           isOutdated
           path
           comments(first: 50) {
-            nodes { author { login } body url }
+            nodes { author { login } authorAssociation body url }
           }
         }
       }

--- a/scripts/foreman/github.py
+++ b/scripts/foreman/github.py
@@ -23,7 +23,7 @@ import json
 from typing import Any, Callable
 
 from foreman.config import Config
-from foreman.util import ForemanError, run, warn
+from foreman.util import ForemanError, run
 
 Runner = Callable[[list[str], str | None], tuple[int, str, str]]
 
@@ -271,11 +271,21 @@ class GitHub:
                 f"number={number}",
             ]
         )
+        if not isinstance(out, dict) or out.get("errors"):
+            raise ForemanError(
+                f"review threads: indeterminate GraphQL response for PR #{number}"
+            )
         try:
-            return out["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
-        except (KeyError, TypeError):
-            warn(f"review threads: unexpected GraphQL shape for PR #{number}")
-            return []
+            nodes = out["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+        except (KeyError, TypeError) as exc:
+            raise ForemanError(
+                f"review threads: unexpected GraphQL shape for PR #{number}"
+            ) from exc
+        if not isinstance(nodes, list) or not all(
+            isinstance(thread, dict) for thread in nodes
+        ):
+            raise ForemanError(f"review threads: invalid thread list for PR #{number}")
+        return nodes
 
     def branch_exists_remote(self, branch: str) -> bool:
         return self.gh.ok(["api", f"repos/{self.repo_slug()}/branches/{branch}"])

--- a/scripts/foreman/graph.py
+++ b/scripts/foreman/graph.py
@@ -218,7 +218,17 @@ def dependency_satisfied(
         return Doneness(False, "open")
 
     marked_prs = foreman_prs_for_issue(gh, cfg, number)
-    if marked_prs and not (inputs is not None and inputs.external):
+    external = inputs is not None and inputs.external
+    if not external:
+        if not marked_prs:
+            return Doneness(
+                False,
+                "closed, but no foreman PR satisfies the merge chain",
+                warnings=[
+                    f"#{number}: closed managed issue has no foreman-marked PR — "
+                    "resolve manually, mark foreman:satisfied, or mark foreman:external"
+                ],
+            )
         expected_author = cfg.expected_login or gh.viewer()
         default_branch = gh.default_branch()
         for pr in marked_prs:

--- a/scripts/foreman/shepherd.py
+++ b/scripts/foreman/shepherd.py
@@ -92,6 +92,35 @@ def classify_checks(rollup: list[dict] | None) -> tuple[str, list[dict]]:
     return "green", []
 
 
+def trusted_review_threads(
+    gh: GitHub, cfg: Config, threads: list[dict]
+) -> tuple[list[dict], int]:
+    """Threads safe to embed in prompts + count requiring human handling."""
+    kept: list[dict] = []
+    excluded = 0
+    viewer = gh.viewer().casefold()
+    trusted_senders = {login.casefold() for login in cfg.review_sender_trust}
+    trusted_associations = set(cfg.comment_trust)
+    for thread in threads:
+        comments = (thread.get("comments") or {}).get("nodes") or []
+        safe = bool(comments)
+        for comment in comments:
+            author = (comment.get("author") or {}).get("login", "")
+            association = comment.get("authorAssociation", "")
+            if (
+                association not in trusted_associations
+                and author.casefold() != viewer
+                and author.casefold() not in trusted_senders
+            ):
+                safe = False
+                break
+        if safe:
+            kept.append(thread)
+        else:
+            excluded += 1
+    return kept, excluded
+
+
 def _failure_text(gh: GitHub, failed: list[dict]) -> str:
     parts = []
     for ctx in failed[:5]:
@@ -287,7 +316,8 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
             work.state, work.detail = "escalated", "agent could not resolve the rebase"
         return work
 
-    threads = [t for t in gh.review_threads(work.number) if not t.get("isResolved")]
+    unresolved = [t for t in gh.review_threads(work.number) if not t.get("isResolved")]
+    threads, excluded_threads = trusted_review_threads(gh, cfg, unresolved)
     if threads:
         work.actions += 1
         rendered = []
@@ -319,7 +349,15 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
             ]
             if remaining:
                 work.state = "escalated"
-                work.detail = f"{len(remaining)} review thread(s) still undispositioned"
+                if excluded_threads:
+                    work.detail = (
+                        f"{excluded_threads} review thread(s) from untrusted authors "
+                        f"require human handling; {len(remaining)} total still undispositioned"
+                    )
+                else:
+                    work.detail = (
+                        f"{len(remaining)} review thread(s) still undispositioned"
+                    )
             else:
                 work.state, work.detail = (
                     "adjudicated",
@@ -327,6 +365,14 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
                 )
         else:
             work.state, work.detail = "escalated", "adjudication agent failed"
+        return work
+
+    if excluded_threads:
+        work.state = "escalated"
+        work.detail = (
+            f"{excluded_threads} unresolved review thread(s) from untrusted authors "
+            "require human handling"
+        )
         return work
 
     mergeable = (status.get("mergeable") or "").upper()

--- a/scripts/foreman/shepherd.py
+++ b/scripts/foreman/shepherd.py
@@ -160,6 +160,8 @@ def _resume_agent(
     work: PrWork,
     prompt_name: str,
     tokens: dict[str, str],
+    *,
+    allow_github: bool = False,
 ) -> backend_mod.BackendResult:
     run_dir = backend_mod.unit_dir(cfg, root, work.unit_number)
     prompt = spec.load_prompt(prompt_name, tokens)
@@ -192,6 +194,7 @@ def _resume_agent(
         prompt_file=prompt_file,
         timeout_min=cfg.shepherd_timeout_min,
         resume_ref=resume_ref,
+        allow_github=allow_github,
     )
 
 
@@ -331,7 +334,15 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
             )
         tokens = _common_tokens(gh, cfg, work)
         tokens["THREADS"] = "\n".join(rendered)
-        result = _resume_agent(gh, cfg, root, work, "shepherd-adjudicate", tokens)
+        result = _resume_agent(
+            gh,
+            cfg,
+            root,
+            work,
+            "shepherd-adjudicate",
+            tokens,
+            allow_github=True,
+        )
         wt_path = _ensure_worktree(
             cfg, root, work.unit_number, work.branch, remote_name
         )

--- a/scripts/foreman/shepherd.py
+++ b/scripts/foreman/shepherd.py
@@ -8,7 +8,7 @@ Deterministic triggers → bounded agent actions:
                 ones go to the agent (rebase additively, re-verify, push)
   unresolved review-bot threads → resume the agent to adjudicate each finding
                 (apply or decline-with-reasoning; blanket-accepting prohibited)
-  green ∧ adjudicated ∧ mergeable ∧ not behind → label ready-to-merge and
+  green ∧ adjudicated ∧ mergeStateStatus=CLEAN → label ready-to-merge and
                 report a dependency-aware suggested merge order.
 
 Foreman never merges. `gh run rerun` is assumed unavailable to the bot token;
@@ -386,12 +386,11 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
         )
         return work
 
-    mergeable = (status.get("mergeable") or "").upper()
-    if merge_state == "CLEAN" or mergeable == "MERGEABLE":
+    if merge_state == "CLEAN":
         gh.label_own_pr(work.number, add=["ready-to-merge"])
         work.state, work.detail = (
             "ready",
-            "green, adjudicated, mergeable — awaiting human merge",
+            "green, adjudicated, mergeState=CLEAN — awaiting human merge",
         )
     else:
         work.state, work.detail = "healthy", f"mergeState={merge_state or 'UNKNOWN'}"

--- a/scripts/foreman/tests/test_backend.py
+++ b/scripts/foreman/tests/test_backend.py
@@ -1,0 +1,86 @@
+"""Backend path containment and least-privilege subprocess environment."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from foreman import backend
+from foreman.config import Config
+from foreman.util import ForemanError
+
+
+class AdapterPathContainment(unittest.TestCase):
+    def test_only_direct_backend_files_are_allowed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "backends"
+            root.mkdir()
+            direct = root / "mock.sh"
+            direct.write_text("#!/bin/sh\n", encoding="utf-8")
+            outside = Path(tmp) / "outside.sh"
+            outside.write_text("#!/bin/sh\n", encoding="utf-8")
+            (root / "linked.sh").symlink_to(outside)
+            with patch.object(backend, "BACKENDS_DIR", root):
+                self.assertEqual(backend.adapter_path("mock"), direct.resolve())
+                for name in ("../outside", "linked", "/tmp/evil", "bad/name", ""):
+                    with self.subTest(name=name), self.assertRaises(ForemanError):
+                        backend.adapter_path(name)
+
+
+class BackendEnvironment(unittest.TestCase):
+    def test_subscription_environment_excludes_unrelated_credentials(self):
+        parent = {
+            "PATH": "/bin",
+            "HOME": "/tmp/home",
+            "LC_ALL": "C",
+            "CLAUDE_CODE_OAUTH_TOKEN": "oauth",
+            "GH_TOKEN": "scoped-github-token",
+            "OP_SESSION_personal": "one-password",
+            "AWS_SECRET_ACCESS_KEY": "cloud-secret",
+            "CLOUDFLARE_API_TOKEN": "cloudflare-secret",
+            "SSH_AUTH_SOCK": "/tmp/agent.sock",
+            "ANTHROPIC_API_KEY": "forbidden-override",
+            "FOREMAN_READONLY": "1",
+        }
+        with patch.dict(os.environ, parent, clear=True):
+            env = backend.backend_environment(Config(billing="subscription"))
+            privileged = backend.backend_environment(
+                Config(billing="subscription"), allow_github=True
+            )
+        self.assertEqual(env["CLAUDE_CODE_OAUTH_TOKEN"], "oauth")
+        self.assertEqual(env["LC_ALL"], "C")
+        self.assertEqual(env["FOREMAN_READONLY"], "1")
+        self.assertNotIn("GH_TOKEN", env)
+        self.assertEqual(privileged["GH_TOKEN"], "scoped-github-token")
+        for key in (
+            "OP_SESSION_personal",
+            "AWS_SECRET_ACCESS_KEY",
+            "CLOUDFLARE_API_TOKEN",
+            "SSH_AUTH_SOCK",
+            "ANTHROPIC_API_KEY",
+        ):
+            self.assertNotIn(key, env)
+            self.assertNotIn(key, privileged)
+
+    def test_api_billing_passes_only_the_foreman_api_key(self):
+        parent = {
+            "PATH": "/bin",
+            "CLAUDE_CODE_OAUTH_TOKEN": "oauth",
+            "FOREMAN_ANTHROPIC_API_KEY": "api-key",
+        }
+        with patch.dict(os.environ, parent, clear=True):
+            env = backend.backend_environment(Config(billing="api"))
+        self.assertEqual(env["FOREMAN_ANTHROPIC_API_KEY"], "api-key")
+        self.assertNotIn("CLAUDE_CODE_OAUTH_TOKEN", env)
+
+    def test_api_billing_requires_the_foreman_api_key(self):
+        with patch.dict(os.environ, {"PATH": "/bin"}, clear=True):
+            with self.assertRaises(ForemanError):
+                backend.backend_environment(Config(billing="api"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/foreman/tests/test_doneness.py
+++ b/scripts/foreman/tests/test_doneness.py
@@ -18,7 +18,9 @@ class ExternalDependencies(unittest.TestCase):
     def test_open_issue_is_unsatisfied(self):
         gh, runner = make_github(cfg_with_bot())
         runner.when(["issue", "view", "5"], issue_json(5, state="OPEN"))
-        done = dependency_satisfied(gh, cfg_with_bot(), 5)
+        done = dependency_satisfied(
+            gh, cfg_with_bot(), 5, inputs=UnitInputs(external=True)
+        )
         self.assertFalse(done.satisfied)
         self.assertEqual(done.how, "open")
 
@@ -28,7 +30,9 @@ class ExternalDependencies(unittest.TestCase):
             ["issue", "view", "5"],
             issue_json(5, state="CLOSED", state_reason="completed"),
         )
-        done = dependency_satisfied(gh, cfg_with_bot(), 5)
+        done = dependency_satisfied(
+            gh, cfg_with_bot(), 5, inputs=UnitInputs(external=True)
+        )
         self.assertTrue(done.satisfied)
         self.assertIn("external", done.how)
 
@@ -38,7 +42,9 @@ class ExternalDependencies(unittest.TestCase):
             ["issue", "view", "5"],
             issue_json(5, state="CLOSED", state_reason="not_planned"),
         )
-        done = dependency_satisfied(gh, cfg_with_bot(), 5)
+        done = dependency_satisfied(
+            gh, cfg_with_bot(), 5, inputs=UnitInputs(external=True)
+        )
         self.assertFalse(done.satisfied)
         self.assertTrue(done.warnings)
 
@@ -49,7 +55,9 @@ class ExternalDependencies(unittest.TestCase):
             ["issue", "view", "5"],
             issue_json(5, state="CLOSED", state_reason="not_planned"),
         )
-        self.assertTrue(dependency_satisfied(gh, cfg, 5).satisfied)
+        self.assertTrue(
+            dependency_satisfied(gh, cfg, 5, inputs=UnitInputs(external=True)).satisfied
+        )
 
     def test_human_override_wins_even_when_open(self):
         gh, runner = make_github(cfg_with_bot())
@@ -76,6 +84,17 @@ class ForemanManagedDependencies(unittest.TestCase):
         done = dependency_satisfied(gh, cfg, 7)
         self.assertTrue(done.satisfied)
         self.assertIn("PR #90 merged into main", done.how)
+
+    def test_closed_issue_without_marked_pr_fails_loud(self):
+        cfg = cfg_with_bot()
+        gh, runner = make_github(cfg)
+        runner.when(
+            ["issue", "view", "7"],
+            issue_json(7, state="CLOSED", state_reason="completed"),
+        )
+        done = dependency_satisfied(gh, cfg, 7, inputs=UnitInputs())
+        self.assertFalse(done.satisfied)
+        self.assertTrue(done.warnings)
 
     def test_unmerged_marker_pr_fails_loud(self):
         gh, cfg = self._gh(pr_kwargs={"merged": False})

--- a/scripts/foreman/tests/test_shepherd.py
+++ b/scripts/foreman/tests/test_shepherd.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from foreman import signatures as signatures_mod
 from foreman.config import Config
-from foreman.shepherd import classify_checks, trusted_review_threads
+from foreman.github import GitHub
+from foreman.shepherd import classify_checks, shepherd_pr, trusted_review_threads
 from foreman.tests.fakes import make_github
+from foreman.util import ForemanError
 
 
 class ClassifyChecks(unittest.TestCase):
@@ -97,6 +101,65 @@ class TrustedReviewThreads(unittest.TestCase):
         kept, excluded = trusted_review_threads(gh, cfg, [thread])
         self.assertEqual(kept, [])
         self.assertEqual(excluded, 1)
+
+
+class ReviewThreadRetrieval(unittest.TestCase):
+    @staticmethod
+    def response(nodes: object) -> dict:
+        return {
+            "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}
+        }
+
+    def test_valid_empty_thread_list_is_distinct_from_failure(self):
+        gh, runner = make_github()
+        runner.when(["api", "graphql"], self.response([]))
+        self.assertEqual(gh.review_threads(17), [])
+
+    def test_graphql_errors_fail_closed(self):
+        gh, runner = make_github()
+        response = self.response([])
+        response["errors"] = [{"message": "partial response"}]
+        runner.when(["api", "graphql"], response)
+        with self.assertRaisesRegex(ForemanError, "indeterminate GraphQL response"):
+            gh.review_threads(17)
+
+    def test_malformed_thread_list_fails_closed(self):
+        gh, runner = make_github()
+        runner.when(["api", "graphql"], self.response(None))
+        with self.assertRaisesRegex(ForemanError, "invalid thread list"):
+            gh.review_threads(17)
+
+
+class MergeReadiness(unittest.TestCase):
+    @staticmethod
+    def github(merge_state: str, mergeable: str) -> MagicMock:
+        gh = MagicMock(spec=GitHub)
+        gh.pr_status.return_value = {
+            "number": 23,
+            "title": "Example",
+            "url": "https://github.com/owner/repo/pull/23",
+            "headRefName": "foreman/feat/17-example",
+            "mergeStateStatus": merge_state,
+            "mergeable": mergeable,
+            "statusCheckRollup": [],
+        }
+        gh.review_threads.return_value = []
+        gh.viewer.return_value = "bot"
+        return gh
+
+    @patch("foreman.shepherd.worktree.remote", return_value="origin")
+    def test_mergeable_but_blocked_pr_is_not_ready(self, _remote):
+        gh = self.github("BLOCKED", "MERGEABLE")
+        work = shepherd_pr(gh, Config(), Path("."), {"number": 23, "_unit": 17}, [])
+        self.assertEqual(work.state, "healthy")
+        gh.label_own_pr.assert_not_called()
+
+    @patch("foreman.shepherd.worktree.remote", return_value="origin")
+    def test_clean_pr_is_ready(self, _remote):
+        gh = self.github("CLEAN", "MERGEABLE")
+        work = shepherd_pr(gh, Config(), Path("."), {"number": 23, "_unit": 17}, [])
+        self.assertEqual(work.state, "ready")
+        gh.label_own_pr.assert_called_once_with(23, add=["ready-to-merge"])
 
 
 class SignatureCatalog(unittest.TestCase):

--- a/scripts/foreman/tests/test_shepherd.py
+++ b/scripts/foreman/tests/test_shepherd.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import unittest
 
 from foreman import signatures as signatures_mod
-from foreman.shepherd import classify_checks
+from foreman.config import Config
+from foreman.shepherd import classify_checks, trusted_review_threads
+from foreman.tests.fakes import make_github
 
 
 class ClassifyChecks(unittest.TestCase):
@@ -40,6 +42,61 @@ class ClassifyChecks(unittest.TestCase):
         state, failed = classify_checks([{"state": "FAILURE", "context": "ci/legacy"}])
         self.assertEqual(state, "red")
         self.assertEqual(failed[0]["context"], "ci/legacy")
+
+
+class TrustedReviewThreads(unittest.TestCase):
+    def test_untrusted_authors_are_excluded(self):
+        cfg = Config()
+        gh, _runner = make_github(cfg)
+
+        def thread(author: str, association: str) -> dict:
+            return {
+                "id": author,
+                "comments": {
+                    "nodes": [
+                        {
+                            "author": {"login": author},
+                            "authorAssociation": association,
+                            "body": f"finding from {author}",
+                        }
+                    ]
+                },
+            }
+
+        threads = [
+            thread("owner", "OWNER"),
+            thread("CodeRabbitAI", "NONE"),
+            thread("bot", "NONE"),
+            thread("rando", "NONE"),
+            {"id": "empty", "comments": {"nodes": []}},
+        ]
+        kept, excluded = trusted_review_threads(gh, cfg, threads)
+        self.assertEqual(
+            [item["id"] for item in kept], ["owner", "CodeRabbitAI", "bot"]
+        )
+        self.assertEqual(excluded, 2)
+
+    def test_any_untrusted_reply_excludes_the_thread(self):
+        cfg = Config()
+        gh, _runner = make_github(cfg)
+        thread = {
+            "id": "mixed",
+            "comments": {
+                "nodes": [
+                    {
+                        "author": {"login": "coderabbitai"},
+                        "authorAssociation": "NONE",
+                    },
+                    {
+                        "author": {"login": "rando"},
+                        "authorAssociation": "NONE",
+                    },
+                ]
+            },
+        }
+        kept, excluded = trusted_review_threads(gh, cfg, [thread])
+        self.assertEqual(kept, [])
+        self.assertEqual(excluded, 1)
 
 
 class SignatureCatalog(unittest.TestCase):

--- a/scripts/secret-set-1p.sh
+++ b/scripts/secret-set-1p.sh
@@ -71,7 +71,7 @@ op item get "$item" --vault "$vault" --format json --reveal |
         # field carrying a structured (object) value — plain STRING/CONCEALED
         # fields are scalars, so an object value marks a passkey/SSH-key/document
         # credential we must not touch.
-        | if (.category == "SSHKEY" or .category == "PASSKEY")
+        | if (.category == "SSH_KEY" or .category == "PASSKEY")
              or (([.fields[] | select((.value | type) == "object")] | length) > 0) then
             error("item holds a passkey or SSH key; refusing full-item edit (op would clobber it)")
           else

--- a/scripts/secret-set-1p.sh
+++ b/scripts/secret-set-1p.sh
@@ -42,12 +42,13 @@ command -v jq >/dev/null 2>&1 || fail "jq is required"
 # 1Password item JSON from the pipeline.
 exec 3<&0
 
-op item get "$item" --vault "$vault" --format json --reveal |
-    jq \
-        --arg field "$field" \
-        --arg section "$section" \
-        --rawfile secret /dev/fd/3 \
-        '
+updated_item="$(
+    op item get "$item" --vault "$vault" --format json --reveal |
+        jq \
+            --arg field "$field" \
+            --arg section "$section" \
+            --rawfile secret /dev/fd/3 \
+            '
         def secret_value:
           $secret | sub("\r?\n$"; "");
 
@@ -71,7 +72,7 @@ op item get "$item" --vault "$vault" --format json --reveal |
         # field carrying a structured (object) value — plain STRING/CONCEALED
         # fields are scalars, so an object value marks a passkey/SSH-key/document
         # credential we must not touch.
-        | if (.category == "SSH_KEY" or .category == "PASSKEY")
+        | if (.category == "SSH_KEY" or .category == "SSHKEY" or .category == "PASSKEY")
              or (([.fields[] | select((.value | type) == "object")] | length) > 0) then
             error("item holds a passkey or SSH key; refusing full-item edit (op would clobber it)")
           else
@@ -90,7 +91,10 @@ op item get "$item" --vault "$vault" --format json --reveal |
           else
             (.fields[] |= if field_matches then .value = $value else . end)
           end
-        ' |
+        '
+)"
+printf '%s\n' "$updated_item" |
     op item edit "$item" --vault "$vault" >/dev/null
+unset updated_item
 
 echo "Updated 1Password item '$item' field '$field'."

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -76,11 +76,44 @@ case "$out" in
 *) fail "task secret:set:gh failed for the wrong reason: $out" ;;
 esac
 
-echo "==> 1Password helper recognizes the SSH Key category"
-grep -Fq '.category == "SSH_KEY"' scripts/secret-set-1p.sh ||
-    fail "secret:set:1p does not fail closed for SSH_KEY items"
-if grep -Fq '.category == "SSHKEY"' scripts/secret-set-1p.sh; then
-    fail "secret:set:1p uses the invalid SSHKEY category spelling"
-fi
+echo "==> 1Password helper rejects SSH Key categories at runtime"
+op_bin="${test_tmp}/op-bin"
+op_edit_called="${test_tmp}/op-edit-called"
+mkdir -p "$op_bin"
+cat >"${op_bin}/op" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-} ${2:-}" in
+"item get")
+    printf '{"category":"%s","fields":[{"label":"password","type":"CONCEALED","value":"old"}]}\n' \
+        "${OP_FIXTURE_CATEGORY:?}"
+    ;;
+"item edit")
+    : >"${OP_EDIT_CALLED:?}"
+    cat >/dev/null
+    ;;
+*)
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${op_bin}/op"
+for category in SSH_KEY SSHKEY; do
+    rm -f "$op_edit_called"
+    out=$(printf '%s' 'dummy-secret' |
+        PATH="${op_bin}:${PATH}" OP_FIXTURE_CATEGORY="$category" \
+            OP_EDIT_CALLED="$op_edit_called" VAULT=test ITEM=test FIELD=password \
+            ./scripts/secret-set-1p.sh 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        fail "secret:set:1p accepted unsupported category $category"
+    fi
+    case "$out" in
+    *"item holds a passkey or SSH key"*) ;;
+    *) fail "secret:set:1p rejected $category for the wrong reason: $out" ;;
+    esac
+    if [ -e "$op_edit_called" ]; then
+        fail "secret:set:1p attempted an item edit for $category"
+    fi
+done
 
 echo "==> task targets OK (compile + bootstrap idempotency)"

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -76,4 +76,11 @@ case "$out" in
 *) fail "task secret:set:gh failed for the wrong reason: $out" ;;
 esac
 
+echo "==> 1Password helper recognizes the SSH Key category"
+grep -Fq '.category == "SSH_KEY"' scripts/secret-set-1p.sh ||
+    fail "secret:set:1p does not fail closed for SSH_KEY items"
+if grep -Fq '.category == "SSHKEY"' scripts/secret-set-1p.sh; then
+    fail "secret:set:1p uses the invalid SSHKEY category spelling"
+fi
+
 echo "==> task targets OK (compile + bootstrap idempotency)"

--- a/template/[% if use_foreman %].foreman.toml[% endif %].jinja
+++ b/template/[% if use_foreman %].foreman.toml[% endif %].jinja
@@ -14,6 +14,10 @@ max_parallel = 3
 branch_prefix = "foreman"
 expected_login = "[[ author_git_provider_username ]]-bot"
 
+# Only these GitHub logins, trusted author associations, and Foreman's own
+# account may contribute unresolved review-thread content to agent prompts.
+review_sender_trust = ["coderabbitai", "Copilot"]
+
 # subscription (default): adapters inherit CLAUDE_CODE_OAUTH_TOKEN; USD
 # budgets are inert (guardrails bind on timeout/turns). api: adapters export
 # FOREMAN_ANTHROPIC_API_KEY process-locally; USD budgets bind.

--- a/template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja
+++ b/template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja
@@ -9,7 +9,7 @@
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
   # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
-  ref: v0.7.0 # pinned tag — bump deliberately to a released harmon-devkit tag
+  ref: v0.7.1 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
 [% for cat in skill_categories %]
   - [[ cat ]]

--- a/template/docs/architecture/[% if use_foreman %]foreman.md[% endif %]
+++ b/template/docs/architecture/[% if use_foreman %]foreman.md[% endif %]
@@ -15,8 +15,8 @@ progression. Zero tokens are spent on coordination.
 
 - **No AI ever merges to main. Ever.** No auto-merge, no enabling flag. The
   human merge is the only mechanism that advances the dependency graph;
-  foreman's job ends at "this PR is verified, adjudicated, and mergeable —
-  here is the suggested merge order." Server-side enforcement (branch
+  foreman's job ends at "this PR is verified, adjudicated, and has GitHub
+  `mergeStateStatus=CLEAN` — here is the suggested merge order." Server-side enforcement (branch
   ruleset, code-owner review, bot token without bypass) is the boundary;
   prompts are only a mitigation.
 - **Stateless in the repo.** Human inputs are stored (issue bodies, labels /
@@ -150,9 +150,9 @@ Deterministic triggers → bounded agent actions on open foreman PRs:
   (commit + reply + resolve) or decline with technical reasoning (bots are
   sometimes wrong; deterministic facts beat speculation). Blanket-accepting
   is prohibited. Foreman re-checks disposition completeness afterwards.
-- **Green + adjudicated + mergeable** → `ready-to-merge` label plus a
-  dependency-aware suggested merge order. Foreman performs no merge action
-  of any kind.
+- **Green + adjudicated + `mergeStateStatus=CLEAN`** → `ready-to-merge` label
+  plus a dependency-aware suggested merge order. Foreman performs no merge
+  action of any kind.
 
 ## Watch mode and unattended runs
 

--- a/template/docs/architecture/[% if use_foreman %]foreman.md[% endif %]
+++ b/template/docs/architecture/[% if use_foreman %]foreman.md[% endif %]
@@ -194,8 +194,10 @@ USD budgets bind. Switching is a config flip plus one secret.
   or reopen issues, edit issue bodies/titles, touch human comments, or write
   fields/types/dependency edges — those operations do not exist in the
   module, and the test suite greps to keep them absent.
-- **Prompt-injection surface**: only trusted-association comments enter
-  prompts; review-bot findings and CI logs are framed as claims to
+- **Prompt-injection surface**: only trusted-association issue comments and
+  review threads whose authors match a trusted association, Foreman's account,
+  or `review_sender_trust` enter prompts. Other unresolved review threads go to
+  the human queue. Trusted review-bot findings and CI logs are framed as claims to
   adjudicate, not instructions; agents run with conservative permission
   modes outside the sandboxed bot devcontainer (`FOREMAN_SANDBOXED=1`
   relaxes inside it).
@@ -212,6 +214,7 @@ branch_prefix = "foreman"
 expected_login = "your-bot"   # identity assertion; "" skips
 billing = "subscription"      # subscription | api
 sandboxed = false             # FOREMAN_SANDBOXED=1 env inside the bot container
+review_sender_trust = ["coderabbitai", "Copilot"]
 
 [budgets]
 dispatch_usd = 20.0           # binds in api billing mode

--- a/template/docs/architecture/[% if use_foreman %]foreman.md[% endif %]
+++ b/template/docs/architecture/[% if use_foreman %]foreman.md[% endif %]
@@ -201,6 +201,12 @@ USD budgets bind. Switching is a config flip plus one secret.
   adjudicate, not instructions; agents run with conservative permission
   modes outside the sandboxed bot devcontainer (`FOREMAN_SANDBOXED=1`
   relaxes inside it).
+- **Backend environment**: agent subprocesses receive an explicit runtime and
+  authentication allowlist, not the complete parent environment. Dispatch,
+  CI-repair, rebase, and preflight agents do not receive `GH_TOKEN`; only the
+  adjudication agent receives the intentionally scoped bot token needed for its
+  reply-and-resolve contract. Cloud, 1Password, SSH-agent, and unrelated host
+  credentials never cross the adapter boundary.
 
 ## Configuration (.foreman.toml)
 

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/backend.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/backend.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import signal
 import subprocess
 import time
@@ -30,6 +31,48 @@ from foreman.config import Config
 from foreman.util import ForemanError, run, tail, utc_now_iso, write_text
 
 BACKENDS_DIR = Path(__file__).resolve().parent / "backends"
+BACKEND_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+# Process/runtime settings required by the adapter and Claude CLI. Secrets are
+# added conditionally below; arbitrary parent credentials never cross the
+# backend boundary.
+BACKEND_ENV_ALLOWLIST = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "LANG",
+        "TERM",
+        "COLORTERM",
+        "NO_COLOR",
+        "FORCE_COLOR",
+        "TZ",
+        "XDG_CONFIG_HOME",
+        "XDG_CACHE_HOME",
+        "XDG_DATA_HOME",
+        "XDG_STATE_HOME",
+        "CLAUDE_CONFIG_DIR",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "NODE_EXTRA_CA_CERTS",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "no_proxy",
+        "FOREMAN_READONLY",
+        "FOREMAN_MOCK_STATUS",
+        "FOREMAN_MOCK_FILE",
+    }
+)
 
 RESULT_STATUSES = ("completed", "blocked")
 
@@ -48,13 +91,43 @@ class BackendResult:
 
 
 def adapter_path(name: str) -> Path:
-    path = BACKENDS_DIR / f"{name}.sh"
-    if not path.exists():
+    backends_dir = BACKENDS_DIR.resolve()
+    path = (backends_dir / f"{name}.sh").resolve()
+    if (
+        BACKEND_NAME_RE.fullmatch(name) is None
+        or path.parent != backends_dir
+        or not path.is_file()
+    ):
         available = sorted(p.stem for p in BACKENDS_DIR.glob("*.sh"))
         raise ForemanError(
             f"unknown backend '{name}' (available: {', '.join(available)})"
         )
     return path
+
+
+def backend_environment(cfg: Config, *, allow_github: bool = False) -> dict[str, str]:
+    """Least-privilege environment for a backend subprocess."""
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key in BACKEND_ENV_ALLOWLIST or key.startswith("LC_")
+    }
+    if cfg.billing == "api":
+        api_key = os.environ.get("FOREMAN_ANTHROPIC_API_KEY", "")
+        if not api_key:
+            raise ForemanError("billing=api but FOREMAN_ANTHROPIC_API_KEY is not set")
+        env["FOREMAN_ANTHROPIC_API_KEY"] = api_key
+    else:
+        oauth_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")
+        if oauth_token:
+            env["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
+    # Adjudication alone needs the scoped bot credential to reply and resolve.
+    # Dispatch, CI repair, rebase, and preflight agents never receive it.
+    if allow_github:
+        gh_token = os.environ.get("GH_TOKEN", "")
+        if gh_token:
+            env["GH_TOKEN"] = gh_token
+    return env
 
 
 def capabilities(adapter: Path) -> set[str]:
@@ -92,6 +165,7 @@ def run_backend(
     prompt_file: Path,
     timeout_min: int,
     resume_ref: str | None = None,
+    allow_github: bool = False,
 ) -> BackendResult:
     session_file = unit_run_dir / "session"
     log_file = unit_run_dir / "agent.log"
@@ -100,7 +174,7 @@ def run_backend(
     if result_file.exists():
         result_file.unlink()
 
-    env = os.environ.copy()
+    env = backend_environment(cfg, allow_github=allow_github)
     env.update(
         {
             "FOREMAN_PROMPT_FILE": str(prompt_file),
@@ -113,9 +187,6 @@ def run_backend(
             "FOREMAN_MAX_TURNS": str(cfg.max_turns),
         }
     )
-    if cfg.billing == "api" and not env.get("FOREMAN_ANTHROPIC_API_KEY"):
-        raise ForemanError("billing=api but FOREMAN_ANTHROPIC_API_KEY is not set")
-
     argv = [str(adapter), "resume", resume_ref] if resume_ref else [str(adapter), "run"]
     timed_out = False
     with stdout_file.open("a", encoding="utf-8") as out_fh:

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/config.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/config.py
@@ -32,6 +32,9 @@ class Config:
     comment_trust: list[str] = field(
         default_factory=lambda: ["OWNER", "MEMBER", "COLLABORATOR"]
     )
+    review_sender_trust: list[str] = field(
+        default_factory=lambda: ["coderabbitai", "Copilot"]
+    )
     branch_prefix: str = "foreman"
     worktrees_dir: str = ".worktrees/foreman"
     runtime_dir: str = ".foreman"

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/github.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/github.py
@@ -71,7 +71,7 @@ query($owner: String!, $name: String!, $number: Int!) {
           isOutdated
           path
           comments(first: 50) {
-            nodes { author { login } body url }
+            nodes { author { login } authorAssociation body url }
           }
         }
       }

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/github.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/github.py
@@ -23,7 +23,7 @@ import json
 from typing import Any, Callable
 
 from foreman.config import Config
-from foreman.util import ForemanError, run, warn
+from foreman.util import ForemanError, run
 
 Runner = Callable[[list[str], str | None], tuple[int, str, str]]
 
@@ -271,11 +271,21 @@ class GitHub:
                 f"number={number}",
             ]
         )
+        if not isinstance(out, dict) or out.get("errors"):
+            raise ForemanError(
+                f"review threads: indeterminate GraphQL response for PR #{number}"
+            )
         try:
-            return out["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
-        except (KeyError, TypeError):
-            warn(f"review threads: unexpected GraphQL shape for PR #{number}")
-            return []
+            nodes = out["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+        except (KeyError, TypeError) as exc:
+            raise ForemanError(
+                f"review threads: unexpected GraphQL shape for PR #{number}"
+            ) from exc
+        if not isinstance(nodes, list) or not all(
+            isinstance(thread, dict) for thread in nodes
+        ):
+            raise ForemanError(f"review threads: invalid thread list for PR #{number}")
+        return nodes
 
     def branch_exists_remote(self, branch: str) -> bool:
         return self.gh.ok(["api", f"repos/{self.repo_slug()}/branches/{branch}"])

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/graph.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/graph.py
@@ -218,7 +218,17 @@ def dependency_satisfied(
         return Doneness(False, "open")
 
     marked_prs = foreman_prs_for_issue(gh, cfg, number)
-    if marked_prs and not (inputs is not None and inputs.external):
+    external = inputs is not None and inputs.external
+    if not external:
+        if not marked_prs:
+            return Doneness(
+                False,
+                "closed, but no foreman PR satisfies the merge chain",
+                warnings=[
+                    f"#{number}: closed managed issue has no foreman-marked PR — "
+                    "resolve manually, mark foreman:satisfied, or mark foreman:external"
+                ],
+            )
         expected_author = cfg.expected_login or gh.viewer()
         default_branch = gh.default_branch()
         for pr in marked_prs:

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/shepherd.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/shepherd.py
@@ -92,6 +92,35 @@ def classify_checks(rollup: list[dict] | None) -> tuple[str, list[dict]]:
     return "green", []
 
 
+def trusted_review_threads(
+    gh: GitHub, cfg: Config, threads: list[dict]
+) -> tuple[list[dict], int]:
+    """Threads safe to embed in prompts + count requiring human handling."""
+    kept: list[dict] = []
+    excluded = 0
+    viewer = gh.viewer().casefold()
+    trusted_senders = {login.casefold() for login in cfg.review_sender_trust}
+    trusted_associations = set(cfg.comment_trust)
+    for thread in threads:
+        comments = (thread.get("comments") or {}).get("nodes") or []
+        safe = bool(comments)
+        for comment in comments:
+            author = (comment.get("author") or {}).get("login", "")
+            association = comment.get("authorAssociation", "")
+            if (
+                association not in trusted_associations
+                and author.casefold() != viewer
+                and author.casefold() not in trusted_senders
+            ):
+                safe = False
+                break
+        if safe:
+            kept.append(thread)
+        else:
+            excluded += 1
+    return kept, excluded
+
+
 def _failure_text(gh: GitHub, failed: list[dict]) -> str:
     parts = []
     for ctx in failed[:5]:
@@ -287,7 +316,8 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
             work.state, work.detail = "escalated", "agent could not resolve the rebase"
         return work
 
-    threads = [t for t in gh.review_threads(work.number) if not t.get("isResolved")]
+    unresolved = [t for t in gh.review_threads(work.number) if not t.get("isResolved")]
+    threads, excluded_threads = trusted_review_threads(gh, cfg, unresolved)
     if threads:
         work.actions += 1
         rendered = []
@@ -319,7 +349,15 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
             ]
             if remaining:
                 work.state = "escalated"
-                work.detail = f"{len(remaining)} review thread(s) still undispositioned"
+                if excluded_threads:
+                    work.detail = (
+                        f"{excluded_threads} review thread(s) from untrusted authors "
+                        f"require human handling; {len(remaining)} total still undispositioned"
+                    )
+                else:
+                    work.detail = (
+                        f"{len(remaining)} review thread(s) still undispositioned"
+                    )
             else:
                 work.state, work.detail = (
                     "adjudicated",
@@ -327,6 +365,14 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
                 )
         else:
             work.state, work.detail = "escalated", "adjudication agent failed"
+        return work
+
+    if excluded_threads:
+        work.state = "escalated"
+        work.detail = (
+            f"{excluded_threads} unresolved review thread(s) from untrusted authors "
+            "require human handling"
+        )
         return work
 
     mergeable = (status.get("mergeable") or "").upper()

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/shepherd.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/shepherd.py
@@ -160,6 +160,8 @@ def _resume_agent(
     work: PrWork,
     prompt_name: str,
     tokens: dict[str, str],
+    *,
+    allow_github: bool = False,
 ) -> backend_mod.BackendResult:
     run_dir = backend_mod.unit_dir(cfg, root, work.unit_number)
     prompt = spec.load_prompt(prompt_name, tokens)
@@ -192,6 +194,7 @@ def _resume_agent(
         prompt_file=prompt_file,
         timeout_min=cfg.shepherd_timeout_min,
         resume_ref=resume_ref,
+        allow_github=allow_github,
     )
 
 
@@ -331,7 +334,15 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
             )
         tokens = _common_tokens(gh, cfg, work)
         tokens["THREADS"] = "\n".join(rendered)
-        result = _resume_agent(gh, cfg, root, work, "shepherd-adjudicate", tokens)
+        result = _resume_agent(
+            gh,
+            cfg,
+            root,
+            work,
+            "shepherd-adjudicate",
+            tokens,
+            allow_github=True,
+        )
         wt_path = _ensure_worktree(
             cfg, root, work.unit_number, work.branch, remote_name
         )

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/shepherd.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/shepherd.py
@@ -8,7 +8,7 @@ Deterministic triggers → bounded agent actions:
                 ones go to the agent (rebase additively, re-verify, push)
   unresolved review-bot threads → resume the agent to adjudicate each finding
                 (apply or decline-with-reasoning; blanket-accepting prohibited)
-  green ∧ adjudicated ∧ mergeable ∧ not behind → label ready-to-merge and
+  green ∧ adjudicated ∧ mergeStateStatus=CLEAN → label ready-to-merge and
                 report a dependency-aware suggested merge order.
 
 Foreman never merges. `gh run rerun` is assumed unavailable to the bot token;
@@ -386,12 +386,11 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
         )
         return work
 
-    mergeable = (status.get("mergeable") or "").upper()
-    if merge_state == "CLEAN" or mergeable == "MERGEABLE":
+    if merge_state == "CLEAN":
         gh.label_own_pr(work.number, add=["ready-to-merge"])
         work.state, work.detail = (
             "ready",
-            "green, adjudicated, mergeable — awaiting human merge",
+            "green, adjudicated, mergeState=CLEAN — awaiting human merge",
         )
     else:
         work.state, work.detail = "healthy", f"mergeState={merge_state or 'UNKNOWN'}"

--- a/template/scripts/secret-set-1p.sh
+++ b/template/scripts/secret-set-1p.sh
@@ -71,7 +71,7 @@ op item get "$item" --vault "$vault" --format json --reveal |
         # field carrying a structured (object) value — plain STRING/CONCEALED
         # fields are scalars, so an object value marks a passkey/SSH-key/document
         # credential we must not touch.
-        | if (.category == "SSHKEY" or .category == "PASSKEY")
+        | if (.category == "SSH_KEY" or .category == "PASSKEY")
              or (([.fields[] | select((.value | type) == "object")] | length) > 0) then
             error("item holds a passkey or SSH key; refusing full-item edit (op would clobber it)")
           else

--- a/template/scripts/secret-set-1p.sh
+++ b/template/scripts/secret-set-1p.sh
@@ -42,12 +42,13 @@ command -v jq >/dev/null 2>&1 || fail "jq is required"
 # 1Password item JSON from the pipeline.
 exec 3<&0
 
-op item get "$item" --vault "$vault" --format json --reveal |
-    jq \
-        --arg field "$field" \
-        --arg section "$section" \
-        --rawfile secret /dev/fd/3 \
-        '
+updated_item="$(
+    op item get "$item" --vault "$vault" --format json --reveal |
+        jq \
+            --arg field "$field" \
+            --arg section "$section" \
+            --rawfile secret /dev/fd/3 \
+            '
         def secret_value:
           $secret | sub("\r?\n$"; "");
 
@@ -71,7 +72,7 @@ op item get "$item" --vault "$vault" --format json --reveal |
         # field carrying a structured (object) value — plain STRING/CONCEALED
         # fields are scalars, so an object value marks a passkey/SSH-key/document
         # credential we must not touch.
-        | if (.category == "SSH_KEY" or .category == "PASSKEY")
+        | if (.category == "SSH_KEY" or .category == "SSHKEY" or .category == "PASSKEY")
              or (([.fields[] | select((.value | type) == "object")] | length) > 0) then
             error("item holds a passkey or SSH key; refusing full-item edit (op would clobber it)")
           else
@@ -90,7 +91,10 @@ op item get "$item" --vault "$vault" --format json --reveal |
           else
             (.fields[] |= if field_matches then .value = $value else . end)
           end
-        ' |
+        '
+)"
+printf '%s\n' "$updated_item" |
     op item edit "$item" --vault "$vault" >/dev/null
+unset updated_item
 
 echo "Updated 1Password item '$item' field '$field'."

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -76,11 +76,44 @@ case "$out" in
 *) fail "task secret:set:gh failed for the wrong reason: $out" ;;
 esac
 
-echo "==> 1Password helper recognizes the SSH Key category"
-grep -Fq '.category == "SSH_KEY"' scripts/secret-set-1p.sh ||
-    fail "secret:set:1p does not fail closed for SSH_KEY items"
-if grep -Fq '.category == "SSHKEY"' scripts/secret-set-1p.sh; then
-    fail "secret:set:1p uses the invalid SSHKEY category spelling"
-fi
+echo "==> 1Password helper rejects SSH Key categories at runtime"
+op_bin="${test_tmp}/op-bin"
+op_edit_called="${test_tmp}/op-edit-called"
+mkdir -p "$op_bin"
+cat >"${op_bin}/op" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-} ${2:-}" in
+"item get")
+    printf '{"category":"%s","fields":[{"label":"password","type":"CONCEALED","value":"old"}]}\n' \
+        "${OP_FIXTURE_CATEGORY:?}"
+    ;;
+"item edit")
+    : >"${OP_EDIT_CALLED:?}"
+    cat >/dev/null
+    ;;
+*)
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${op_bin}/op"
+for category in SSH_KEY SSHKEY; do
+    rm -f "$op_edit_called"
+    out=$(printf '%s' 'dummy-secret' |
+        PATH="${op_bin}:${PATH}" OP_FIXTURE_CATEGORY="$category" \
+            OP_EDIT_CALLED="$op_edit_called" VAULT=test ITEM=test FIELD=password \
+            ./scripts/secret-set-1p.sh 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        fail "secret:set:1p accepted unsupported category $category"
+    fi
+    case "$out" in
+    *"item holds a passkey or SSH key"*) ;;
+    *) fail "secret:set:1p rejected $category for the wrong reason: $out" ;;
+    esac
+    if [ -e "$op_edit_called" ]; then
+        fail "secret:set:1p attempted an item edit for $category"
+    fi
+done
 
 echo "==> task targets OK (compile + bootstrap idempotency)"

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -76,4 +76,11 @@ case "$out" in
 *) fail "task secret:set:gh failed for the wrong reason: $out" ;;
 esac
 
+echo "==> 1Password helper recognizes the SSH Key category"
+grep -Fq '.category == "SSH_KEY"' scripts/secret-set-1p.sh ||
+    fail "secret:set:1p does not fail closed for SSH_KEY items"
+if grep -Fq '.category == "SSHKEY"' scripts/secret-set-1p.sh; then
+    fail "secret:set:1p uses the invalid SSHKEY category spelling"
+fi
+
 echo "==> task targets OK (compile + bootstrap idempotency)"


### PR DESCRIPTION
## Summary

- trust review threads only when every comment comes from an allowed association, sender, or the authenticated viewer
- fail closed when review-thread GraphQL data is partial or malformed, and require `mergeStateStatus=CLEAN` before labeling a PR ready
- constrain Foreman adapter paths and replace inherited process environments with an explicit credential allowlist
- require a valid marked PR for closed managed dependencies instead of silently treating them as external completion
- recognize 1Password's actual `SSH_KEY` category and cover the guard with a task regression assertion
- keep root/template code and Foreman architecture documentation in lockstep

## Verification

- `task verify`
- 100 Foreman unit tests
- all Copier answer-profile renders and the template-update scenario
- dogfood parity, lint, security, and pre-push gates

## Context

These are generally applicable fixes discovered while applying harmon-init 4.0.1 and adjudicating CodeRabbit review findings in the consumer repositories.
