### PR TITLE
feat(ci): guard release-worthy content against non-releasing PR titles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Lint
         run: task check
       - run: task test:tasks
+      - run: task test:release-title
       - run: task foreman:test
       - name: Skills drift check (vendored skills vs pinned harmon-devkit ref)
         run: task verify:skills

--- a/.github/workflows/release-content-guard.yml
+++ b/.github/workflows/release-content-guard.yml
@@ -50,4 +50,4 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: task release:guard-title
+        run: task guard:release-title

--- a/.github/workflows/release-content-guard.yml
+++ b/.github/workflows/release-content-guard.yml
@@ -1,0 +1,53 @@
+name: Release Content Guard
+run-name: release-content-guard checking the PR title
+
+# Squash-merge uses the PR title as the commit subject, and release-please only
+# tags feat/fix/breaking — so a chore/docs title on a change to release-worthy
+# content (this repo: the template/ consumers get via `copier update`) would
+# merge WITHOUT cutting a release, and tag-pinned consumers would never receive
+# it. This guard fails such a PR at review time. `edited` re-runs it when the
+# title changes, so retitling clears the check. See docs/conventions.md.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+concurrency:
+  group: release-content-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    # Skip forks (same gate as build.yml) and automated dependency PRs, whose
+    # titles follow their own tool's convention (retitle by hand if a dep bump
+    # to guarded content must ship in a release).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'renovate[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Full history so the guard can diff the PR's merge base against HEAD.
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
+          version: 3.51.1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Require a releasing title for release-worthy content changes
+        # PR title/body are untrusted input — pass them through the environment
+        # (never interpolate into the run script) and only string-match on them.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: task release:guard-title

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,9 @@ and ADR 0002. It ships to generated repos, so its files are two-layer twins.
   without cutting a release and downstream repos would never pick the change up.
   The `release-content-guard.yml` check enforces this; **retitle rather than
   bypass** (e.g. `fix: update to harmon-init …`, not `chore:`). Non-`template/`
-  changes (docs, this repo's own tooling) keep their normal type.
+  changes (docs, this repo's own tooling) keep their normal type. Pre-flight it
+  locally before opening the PR with your intended title:
+  `PR_TITLE="<title>" BASE_SHA=main task guard:release-title`.
 
 ## Code Style
 
@@ -199,6 +201,6 @@ and ADR 0002. It ships to generated repos, so its files are two-layer twins.
 - `release-content-guard.yml` fails a PR that changes `template/` under a
   non-releasing title (see Development Workflow) — the guard logic is
   `scripts/require-release-title.sh` (unit-tested by `task test:release-title`),
-  driven by the `RELEASE_CONTENT_PATHS` var on the `release:guard-title` task.
+  driven by the `RELEASE_CONTENT_PATHS` var on the `guard:release-title` task.
   Generated repos render the same guard from the `release_content_paths` copier
   answer (empty = no guard).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,14 @@ and ADR 0002. It ships to generated repos, so its files are two-layer twins.
 - Commit messages follow **Conventional Commits** (enforced by commitlint):
   types `build, chore, ci, docs, feat, fix, perf, refactor, revert, style,
   test`.
+- **A PR that changes `template/` must use a `fix:`/`feat:` (or breaking) PR
+  title.** Consumers receive harmon-init only via `copier update` to a released
+  tag, and squash-merge feeds the PR title to release-please, which tags only
+  feat/fix/breaking — so a `chore:`/`docs:` title over `template/` would merge
+  without cutting a release and downstream repos would never pick the change up.
+  The `release-content-guard.yml` check enforces this; **retitle rather than
+  bypass** (e.g. `fix: update to harmon-init …`, not `chore:`). Non-`template/`
+  changes (docs, this repo's own tooling) keep their normal type.
 
 ## Code Style
 
@@ -188,3 +196,9 @@ and ADR 0002. It ships to generated repos, so its files are two-layer twins.
   (`.coderabbit.yaml`).
 - `release.yml` runs release-please: releases stay intentional (merge the rolling
   release PR to cut a tag); `task release:*` remains a manual override.
+- `release-content-guard.yml` fails a PR that changes `template/` under a
+  non-releasing title (see Development Workflow) — the guard logic is
+  `scripts/require-release-title.sh` (unit-tested by `task test:release-title`),
+  driven by the `RELEASE_CONTENT_PATHS` var on the `release:guard-title` task.
+  Generated repos render the same guard from the `release_content_paths` copier
+  answer (empty = no guard).

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,6 +58,7 @@ tasks:
     cmds:
       - task: check
       - task: test:tasks
+      - task: test:release-title
       - task: foreman:test
       - task: test:hooks
       - task: test:devcontainer:permissions
@@ -73,6 +74,7 @@ tasks:
     cmds:
       - task: check
       - task: test:tasks
+      - task: test:release-title
       - task: test:dogfood-parity
       - task: foreman:test
       - task: test:hooks
@@ -280,6 +282,11 @@ tasks:
     cmds:
       - ./scripts/test-tasks.sh
 
+  test:release-title:
+    desc: Unit-test the release-content title guard (require-release-title.sh)
+    cmds:
+      - ./scripts/test-release-title.sh
+
   test:dogfood-parity:
     desc: Verbatim (non-jinja) template files must byte-match their root twins
     cmds:
@@ -423,6 +430,18 @@ tasks:
 
   # ── Release ───────────────────────────────────────────────────
   # Releases are intentional — never automated on merge to main.
+  release:guard-title:
+    # CI-only (release-content-guard.yml): fail a PR that changes release-worthy
+    # content under a non-releasing title, which squash-merge + release-please
+    # would otherwise merge without cutting a tag. RELEASE_CONTENT_PATHS is this
+    # repo's guarded prefixes; generated repos render it from release_content_paths.
+    # Needs PR_TITLE (+ PR_BODY) and CHANGED_FILES or BASE_SHA/HEAD_SHA in the env.
+    desc: "Guard: a PR touching release-worthy paths needs a fix:/feat: title"
+    vars:
+      RELEASE_CONTENT_PATHS: template
+    cmds:
+      - ./scripts/require-release-title.sh {{.RELEASE_CONTENT_PATHS}}
+
   release:init:
     desc: Create initial v0.1.0 tag
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -158,6 +158,21 @@ tasks:
           exit 1
         fi
 
+  guard:release-title:
+    # The CI counterpart of a pre-commit hook — enforced by release-content-guard.yml
+    # at PR time because the thing it checks (the PR title, which squash-merge feeds
+    # to release-please) does not exist locally. A non-releasing title over
+    # release-worthy content would merge without cutting a tag. RELEASE_CONTENT_PATHS
+    # is this repo's guarded prefixes; generated repos render it from
+    # release_content_paths. Pre-flight before opening a PR with an intended title:
+    #   PR_TITLE="<title>" BASE_SHA=main task guard:release-title
+    # (CI passes PR_TITLE/PR_BODY + BASE_SHA/HEAD_SHA; CHANGED_FILES overrides the diff.)
+    desc: "Guard: a PR touching release-worthy paths needs a fix:/feat: title"
+    vars:
+      RELEASE_CONTENT_PATHS: template
+    cmds:
+      - ./scripts/require-release-title.sh {{.RELEASE_CONTENT_PATHS}}
+
   format:
     desc: Auto-format code
     cmds:
@@ -430,18 +445,6 @@ tasks:
 
   # ── Release ───────────────────────────────────────────────────
   # Releases are intentional — never automated on merge to main.
-  release:guard-title:
-    # CI-only (release-content-guard.yml): fail a PR that changes release-worthy
-    # content under a non-releasing title, which squash-merge + release-please
-    # would otherwise merge without cutting a tag. RELEASE_CONTENT_PATHS is this
-    # repo's guarded prefixes; generated repos render it from release_content_paths.
-    # Needs PR_TITLE (+ PR_BODY) and CHANGED_FILES or BASE_SHA/HEAD_SHA in the env.
-    desc: "Guard: a PR touching release-worthy paths needs a fix:/feat: title"
-    vars:
-      RELEASE_CONTENT_PATHS: template
-    cmds:
-      - ./scripts/require-release-title.sh {{.RELEASE_CONTENT_PATHS}}
-
   release:init:
     desc: Create initial v0.1.0 tag
     cmds:

--- a/copier.yml
+++ b/copier.yml
@@ -131,6 +131,12 @@ use_release_please:
   help: "RELEASE-PLEASE: Manage releases with release-please? (opens a rolling release PR you merge intentionally; CHANGELOG auto-generated from conventional commits)"
   default: yes
 
+release_content_paths:
+  type: str
+  help: "RELEASE GUARD: Space-separated folders whose changes MUST ship in a release, e.g. 'src' or 'ai/skills templates' (a folder matches everything beneath it). Because squash-merge uses the PR title and release-please only tags feat/fix, a PR touching these must use a fix:/feat: title — a CI check (release-content-guard.yml) enforces it so tag-pinned consumers actually receive the change. Empty = no guard."
+  default: ""
+  when: "[[ use_release_please ]]"
+
 use_skills_sync:
   type: bool
   help: "SKILLS SYNC: Vendor shared agent skills from harmon-devkit (pinned, drift-checked)?"

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -114,6 +114,18 @@ it points here.
   Fixes** (patch), `feat!` / `BREAKING CHANGE:` → major. The rest (`build`,
   `chore`, `ci`, `docs`, `perf`, `refactor`, `revert`, `style`, `test`) don't cut
   a release on their own — they ride along in the next one.
+- **On a squash-merge repo the PR title _is_ the release type.** GitHub sets the
+  squash commit subject from the PR title for a multi-commit PR, and release-please
+  reads only that subject — the individual `fix:`/`feat:` commits inside the PR are
+  invisible in the squashed body. So a PR whose title is `chore:`/`docs:` merges
+  with **no release**, even when it carries releasable content. The
+  **release-content guard** (`release-content-guard.yml` →
+  `scripts/require-release-title.sh`, unit-tested by `task test:release-title`)
+  fails a PR that changes release-worthy paths under a non-releasing title. For
+  harmon-init that path is `template/` (all consumers get it via `copier update`
+  to a tag); generated repos configure their own via the `release_content_paths`
+  copier answer (empty = no guard). Automated dependency PRs (Renovate/Dependabot)
+  are skipped — retitle by hand if a dep bump to guarded content must ship.
 - Issue types map many-to-one onto these commit types — see
   [project-management.md](project-management.md).
 - **Milestones are named after release versions** (`v1.1.0` = the git tag): the

--- a/scripts/require-release-title.sh
+++ b/scripts/require-release-title.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# require-release-title.sh — fail a PR whose squash-merge title would silently
+# skip a release even though the PR changes release-worthy content.
+#
+# Why: PRs are squash-merged and release-please reads ONLY the squash commit
+# subject — which GitHub sets from the PR title for a multi-commit PR. A
+# non-releasing title (chore/docs/ci/…) on a content change therefore merges
+# with NO tag cut, so downstream consumers pinning a released tag never receive
+# the change. This guard makes that loud at PR time instead of silent at merge
+# time. See docs/conventions.md ("Releases").
+#
+# Usage:
+#   PR_TITLE="<title>" [PR_BODY="…"] \
+#   [CHANGED_FILES=$'a\nb'  |  BASE_SHA=<sha> [HEAD_SHA=<sha>]] \
+#     require-release-title.sh PREFIX [PREFIX …]
+#
+# PREFIXes are release-worthy path prefixes: a literal directory that matches
+# itself and everything beneath it (so `ai/skills` matches `ai/skills/x`, but
+# NOT the sibling `ai/skills-extra`). Changed files come from $CHANGED_FILES
+# (newline-separated) when set, else from `git diff --name-only BASE...HEAD`.
+# A title is "releasing" iff its type is feat/fix, or it marks a breaking
+# change (`!` before the colon, or a BREAKING CHANGE note in the body).
+#
+# Exit: 0 = ok (releasing title, or no release-worthy path touched, or no
+#       prefixes configured), 1 = violation, 2 = usage error.
+set -euo pipefail
+
+# No prefixes configured -> the guard is inert (a repo that has not opted in).
+if [ "$#" -eq 0 ]; then
+    echo "require-release-title: no release-worthy path prefixes configured — nothing to guard"
+    exit 0
+fi
+
+title="${PR_TITLE:-}"
+[ -n "$title" ] || {
+    echo "require-release-title: PR_TITLE is empty (set it to the PR title)" >&2
+    exit 2
+}
+
+# is_releasing_title TITLE BODY — 0 when the title would cut a release.
+is_releasing_title() {
+    _rt_title="$1"
+    _rt_body="${2:-}"
+    # Breaking change flagged with `!` before the colon: feat!:, fix(api)!:.
+    case "$_rt_title" in
+    *"!:"*) return 0 ;;
+    esac
+    # Breaking change footer in the body.
+    case "$_rt_body" in
+    *"BREAKING CHANGE"* | *"BREAKING-CHANGE"*) return 0 ;;
+    esac
+    # Leading conventional type, before an optional (scope) and the colon.
+    _rt_type="${_rt_title%%:*}" # everything up to the first ':'
+    _rt_type="${_rt_type%%(*}"  # drop an optional '(scope)'
+    _rt_type="${_rt_type%%\!*}" # drop a trailing '!' (defensive)
+    case "$_rt_type" in
+    feat | fix) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+if is_releasing_title "$title" "${PR_BODY:-}"; then
+    echo "require-release-title: title is a releasing type — ok: ${title}"
+    exit 0
+fi
+
+# Non-releasing title: only a problem if the PR touches release-worthy content.
+if [ -n "${CHANGED_FILES+x}" ]; then
+    files="$CHANGED_FILES"
+else
+    [ -n "${BASE_SHA:-}" ] || {
+        echo "require-release-title: set CHANGED_FILES, or BASE_SHA for a git diff" >&2
+        exit 2
+    }
+    files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA:-HEAD}")"
+fi
+
+matched=""
+while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    for prefix in "$@"; do
+        case "$f" in
+        "$prefix" | "$prefix"/*)
+            matched="${matched}  - ${f}"$'\n'
+            break
+            ;;
+        esac
+    done
+done <<EOF
+${files}
+EOF
+
+if [ -z "$matched" ]; then
+    echo "require-release-title: no release-worthy paths changed — ok: ${title}"
+    exit 0
+fi
+
+paths_joined="$*"
+cat >&2 <<EOF
+require-release-title: this PR changes release-worthy content, but its title
+
+    ${title}
+
+is not a releasing type. Squash-merge uses the PR title as the commit subject,
+and release-please only cuts a release for feat / fix / breaking changes — so as
+titled, this would merge WITHOUT a release and downstream consumers pinning a
+released tag would never receive it.
+
+Release-worthy paths changed:
+${matched}
+Fix: retitle the PR with a releasing type —
+    fix: …    (patch)      feat: …    (minor)      feat!: …    (major, breaking)
+or, if this genuinely should not release, keep the change out of these prefixes:
+    ${paths_joined}
+EOF
+exit 1

--- a/scripts/require-release-title.sh
+++ b/scripts/require-release-title.sh
@@ -41,18 +41,23 @@ title="${PR_TITLE:-}"
 is_releasing_title() {
     _rt_title="$1"
     _rt_body="${2:-}"
-    # Breaking change flagged with `!` before the colon: feat!:, fix(api)!:.
+    # The conventional "type(scope)!" prefix is everything before the FIRST colon;
+    # a title with no colon has no type line (only the body can declare breaking).
     case "$_rt_title" in
-    *"!:"*) return 0 ;;
+    *:*) _rt_head="${_rt_title%%:*}" ;;
+    *) _rt_head="" ;;
+    esac
+    # Breaking change: a `!` immediately before that first colon (feat!:, fix(api)!:).
+    # Matching a bare "!:" anywhere would let `chore: … !: …` bypass the guard.
+    case "$_rt_head" in
+    *"!") return 0 ;;
     esac
     # Breaking change footer in the body.
     case "$_rt_body" in
     *"BREAKING CHANGE"* | *"BREAKING-CHANGE"*) return 0 ;;
     esac
-    # Leading conventional type, before an optional (scope) and the colon.
-    _rt_type="${_rt_title%%:*}" # everything up to the first ':'
-    _rt_type="${_rt_type%%(*}"  # drop an optional '(scope)'
-    _rt_type="${_rt_type%%\!*}" # drop a trailing '!' (defensive)
+    # Leading conventional type (feat/fix), before an optional (scope).
+    _rt_type="${_rt_head%%(*}"
     case "$_rt_type" in
     feat | fix) return 0 ;;
     *) return 1 ;;
@@ -79,6 +84,7 @@ matched=""
 while IFS= read -r f; do
     [ -n "$f" ] || continue
     for prefix in "$@"; do
+        prefix="${prefix%/}" # tolerate a configured prefix written as "dir/"
         case "$f" in
         "$prefix" | "$prefix"/*)
             matched="${matched}  - ${f}"$'\n'

--- a/scripts/test-release-title.sh
+++ b/scripts/test-release-title.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# test-release-title.sh — unit-test require-release-title.sh: a content change
+# under a non-releasing title fails; releasing titles and non-content chores
+# pass; path-prefix matching respects the `/` boundary. Run via
+# `task test:release-title`.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+guard="./scripts/require-release-title.sh"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+# run TITLE CHANGED_FILES PREFIX... -> echoes the guard's exit code.
+run() {
+    _t="$1"
+    _c="$2"
+    shift 2
+    _rc=0
+    PR_TITLE="$_t" CHANGED_FILES="$_c" "$guard" "$@" >/dev/null 2>&1 || _rc=$?
+    echo "$_rc"
+}
+
+echo "==> content change under a chore title fails"
+[ "$(run 'chore: update to harmon-init v4.0.0' "$(printf 'ai/skills/repo/x.md\nREADME.md')" ai/skills templates scripts)" = 1 ] ||
+    fail "chore + skill change should fail"
+
+echo "==> the same content change under a fix title passes"
+[ "$(run 'fix(standardize-repo): publish skill updates' 'ai/skills/repo/x.md' ai/skills templates scripts)" = 0 ] ||
+    fail "fix + skill change should pass"
+
+echo "==> a feat title passes"
+[ "$(run 'feat: add a skill' 'ai/skills/new.md' ai/skills)" = 0 ] || fail "feat should pass"
+
+echo "==> a breaking-change (!) chore-shaped title passes"
+[ "$(run 'refactor!: drop a skill' 'ai/skills/old.md' ai/skills)" = 0 ] || fail "! breaking should pass"
+
+echo "==> BREAKING CHANGE in the body passes even with a chore title"
+_rc=0
+PR_TITLE='chore: x' PR_BODY='BREAKING CHANGE: removed foo' CHANGED_FILES='ai/skills/x.md' \
+    "$guard" ai/skills >/dev/null 2>&1 || _rc=$?
+[ "$_rc" = 0 ] || fail "BREAKING CHANGE body should pass"
+
+echo "==> a chore touching only non-content paths passes"
+[ "$(run 'chore: tidy docs' "$(printf 'docs/x.md\nREADME.md')" ai/skills templates scripts)" = 0 ] ||
+    fail "chore without content change should pass"
+
+echo "==> docs is non-releasing: docs title touching a guarded path fails"
+[ "$(run 'docs(standardize-repo): tweak' 'ai/skills/repo/x.md' ai/skills)" = 1 ] ||
+    fail "docs + guarded content should fail"
+
+echo "==> a nested file under a prefix matches"
+[ "$(run 'chore: x' 'templates/scriptTemplates/shellScriptTemplate.sh' templates)" = 1 ] ||
+    fail "nested file under templates should match"
+
+echo "==> prefix boundary: a sibling dir sharing a name prefix does NOT match"
+[ "$(run 'chore: x' 'ai/skills-extra/x.md' ai/skills)" = 0 ] ||
+    fail "ai/skills-extra must not match the ai/skills prefix"
+
+echo "==> an unconventional title with a content change fails"
+[ "$(run 'update the skills' 'ai/skills/x.md' ai/skills)" = 1 ] ||
+    fail "unconventional title + content change should fail"
+
+echo "==> no prefixes configured is inert (exit 0)"
+[ "$(run 'chore: x' 'ai/skills/x.md')" = 0 ] || fail "no prefixes should be inert"
+
+echo "==> an empty title is a usage error (exit 2)"
+_rc=0
+PR_TITLE='' CHANGED_FILES='ai/skills/x.md' "$guard" ai/skills >/dev/null 2>&1 || _rc=$?
+[ "$_rc" = 2 ] || fail "empty title should be a usage error"
+
+echo "release-title guard: all cases passed"

--- a/scripts/test-release-title.sh
+++ b/scripts/test-release-title.sh
@@ -36,6 +36,10 @@ echo "==> a feat title passes"
 echo "==> a breaking-change (!) chore-shaped title passes"
 [ "$(run 'refactor!: drop a skill' 'ai/skills/old.md' ai/skills)" = 0 ] || fail "! breaking should pass"
 
+echo "==> a stray '!:' later in a chore title does NOT bypass the guard"
+[ "$(run 'chore: update docs !: not breaking' 'ai/skills/x.md' ai/skills)" = 1 ] ||
+    fail "a bare !: elsewhere in the title must not count as breaking"
+
 echo "==> BREAKING CHANGE in the body passes even with a chore title"
 _rc=0
 PR_TITLE='chore: x' PR_BODY='BREAKING CHANGE: removed foo' CHANGED_FILES='ai/skills/x.md' \
@@ -57,6 +61,10 @@ echo "==> a nested file under a prefix matches"
 echo "==> prefix boundary: a sibling dir sharing a name prefix does NOT match"
 [ "$(run 'chore: x' 'ai/skills-extra/x.md' ai/skills)" = 0 ] ||
     fail "ai/skills-extra must not match the ai/skills prefix"
+
+echo "==> a configured prefix written with a trailing slash still matches"
+[ "$(run 'chore: x' 'templates/x.sh' templates/)" = 1 ] ||
+    fail "a trailing-slash prefix (templates/) must still match templates/x.sh"
 
 echo "==> an unconventional title with a content change fails"
 [ "$(run 'update the skills' 'ai/skills/x.md' ai/skills)" = 1 ] ||

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -510,7 +510,7 @@ fi
 
 # ── 9g. release-content guard renders per use_release_please + paths ──
 # The guard SCRIPT + unit test are gated on use_release_please; the WORKFLOW and
-# the release:guard-title task additionally need a non-empty release_content_paths.
+# the guard:release-title task additionally need a non-empty release_content_paths.
 # 'minimal' has use_release_please=false (nothing renders); 'full' sets
 # release_content_paths (everything renders); the rest default to "" (script +
 # unit test present, but no workflow wired). Assert they move together so a broken
@@ -524,13 +524,13 @@ elif [ "$profile" = "full" ]; then # use_release_please on + release_content_pat
     [ -x scripts/require-release-title.sh ] || err "require-release-title.sh missing or not executable (use_release_please on)"
     grep -q 'test:release-title' Taskfile.yml || err "test:release-title task missing (use_release_please on)"
     [ -f .github/workflows/release-content-guard.yml ] || err "release-content-guard.yml missing (release_content_paths set)"
-    grep -q '^  release:guard-title:' Taskfile.yml || err "release:guard-title task missing (release_content_paths set)"
-    grep -q 'RELEASE_CONTENT_PATHS: "src docs"' Taskfile.yml || err "release:guard-title missing the configured RELEASE_CONTENT_PATHS"
+    grep -q '^  guard:release-title:' Taskfile.yml || err "guard:release-title task missing (release_content_paths set)"
+    grep -q 'RELEASE_CONTENT_PATHS: "src docs"' Taskfile.yml || err "guard:release-title missing the configured RELEASE_CONTENT_PATHS"
 else # use_release_please default on, release_content_paths="" (guard present, unwired)
     [ -x scripts/require-release-title.sh ] || err "require-release-title.sh missing (use_release_please on)"
     grep -q 'test:release-title' Taskfile.yml || err "test:release-title task missing (use_release_please on)"
     [ ! -f .github/workflows/release-content-guard.yml ] || err "release-content-guard.yml rendered but release_content_paths empty"
-    ! grep -q 'release:guard-title' Taskfile.yml || err "release:guard-title task rendered but release_content_paths empty"
+    ! grep -q 'guard:release-title' Taskfile.yml || err "guard:release-title task rendered but release_content_paths empty"
 fi
 
 # ── 10. No secrets in the rendered tree (gitleaks) ──────────────────

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -103,6 +103,7 @@ full)
         --data github_org=test-org
         --data project_management=github
         --data snyk_scan_schedule=weekly
+        --data release_content_paths="src docs"
     )
     ;;
 meta)
@@ -505,6 +506,31 @@ if [ -f .prettierignore ]; then
     else
         ! grep -q 'convex\|routeTree' .prettierignore || err ".prettierignore leaks web-app-only entries into profile '$profile'"
     fi
+fi
+
+# ── 9g. release-content guard renders per use_release_please + paths ──
+# The guard SCRIPT + unit test are gated on use_release_please; the WORKFLOW and
+# the release:guard-title task additionally need a non-empty release_content_paths.
+# 'minimal' has use_release_please=false (nothing renders); 'full' sets
+# release_content_paths (everything renders); the rest default to "" (script +
+# unit test present, but no workflow wired). Assert they move together so a broken
+# gate can't ship silently.
+if [ "$profile" = "minimal" ]; then # use_release_please=false
+    [ ! -f scripts/require-release-title.sh ] || err "require-release-title.sh rendered but use_release_please=false"
+    [ ! -f scripts/test-release-title.sh ] || err "test-release-title.sh rendered but use_release_please=false"
+    ! grep -q 'test:release-title' Taskfile.yml || err "test:release-title task rendered but use_release_please=false"
+    [ ! -f .github/workflows/release-content-guard.yml ] || err "release-content-guard.yml rendered but use_release_please=false"
+elif [ "$profile" = "full" ]; then # use_release_please on + release_content_paths set
+    [ -x scripts/require-release-title.sh ] || err "require-release-title.sh missing or not executable (use_release_please on)"
+    grep -q 'test:release-title' Taskfile.yml || err "test:release-title task missing (use_release_please on)"
+    [ -f .github/workflows/release-content-guard.yml ] || err "release-content-guard.yml missing (release_content_paths set)"
+    grep -q '^  release:guard-title:' Taskfile.yml || err "release:guard-title task missing (release_content_paths set)"
+    grep -q 'RELEASE_CONTENT_PATHS: "src docs"' Taskfile.yml || err "release:guard-title missing the configured RELEASE_CONTENT_PATHS"
+else # use_release_please default on, release_content_paths="" (guard present, unwired)
+    [ -x scripts/require-release-title.sh ] || err "require-release-title.sh missing (use_release_please on)"
+    grep -q 'test:release-title' Taskfile.yml || err "test:release-title task missing (use_release_please on)"
+    [ ! -f .github/workflows/release-content-guard.yml ] || err "release-content-guard.yml rendered but release_content_paths empty"
+    ! grep -q 'release:guard-title' Taskfile.yml || err "release:guard-title task rendered but release_content_paths empty"
 fi
 
 # ── 10. No secrets in the rendered tree (gitleaks) ──────────────────

--- a/template/.github/workflows/[% if use_release_please and release_content_paths %]release-content-guard.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_release_please and release_content_paths %]release-content-guard.yml[% endif %].jinja
@@ -1,0 +1,55 @@
+name: Release Content Guard
+run-name: release-content-guard checking the PR title
+
+# Squash-merge uses the PR title as the commit subject, and release-please only
+# tags feat/fix/breaking — so a chore/docs title on a change to release-worthy
+# content ([[ release_content_paths ]]) would merge WITHOUT cutting a release,
+# and tag-pinned consumers would never receive it. This guard fails such a PR at
+# review time. `edited` re-runs it when the title changes, so retitling clears
+# the check. See docs/conventions.md.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+concurrency:
+  group: release-content-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    # Skip forks (same gate as build.yml) and automated dependency PRs, whose
+    # titles follow their own tool's convention (retitle by hand if a dep bump
+    # to guarded content must ship in a release).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'renovate[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Full history so the guard can diff the PR's merge base against HEAD.
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
+          version: 3.51.1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Require a releasing title for release-worthy content changes
+        # PR title/body are untrusted input — pass them through the environment
+        # (never interpolate into the run script) and only string-match on them.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: task release:guard-title

--- a/template/.github/workflows/[% if use_release_please and release_content_paths %]release-content-guard.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_release_please and release_content_paths %]release-content-guard.yml[% endif %].jinja
@@ -52,4 +52,4 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: task release:guard-title
+        run: task guard:release-title

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -41,6 +41,9 @@ jobs:
       - name: Lint[% if use_node %] + typecheck[% endif +%]
         run: task check
       - run: task test:tasks
+[% if use_release_please %]
+      - run: task test:release-title
+[% endif %]
 [% if use_foreman %]
       - run: task foreman:test
 [% endif %]

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -79,6 +79,14 @@ run locally on demand instead of waiting on a PR.
 [% else %]
 - Releases are manual (`task release:*`) — never trigger one automatically.
 [% endif %]
+[% if use_release_please and release_content_paths %]
+- **A PR that changes `[[ release_content_paths ]]` must use a `fix:`/`feat:`
+  (or breaking) PR title.** Squash-merge feeds the PR title to release-please,
+  which tags only feat/fix/breaking — so a `chore:`/`docs:` title over these
+  paths would merge without cutting a release, and consumers pinning a released
+  tag would never receive the change. The `release-content-guard.yml` check
+  enforces this; retitle rather than bypass. Other changes keep their normal type.
+[% endif %]
 
 ## Conventions
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -86,6 +86,8 @@ run locally on demand instead of waiting on a PR.
   paths would merge without cutting a release, and consumers pinning a released
   tag would never receive the change. The `release-content-guard.yml` check
   enforces this; retitle rather than bypass. Other changes keep their normal type.
+  Pre-flight it locally with your intended title:
+  `PR_TITLE="<title>" BASE_SHA=main task guard:release-title`.
 [% endif %]
 
 ## Conventions

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -77,6 +77,9 @@ tasks:
 [% endif %]
       - task: validate
       - task: test:tasks
+[% if use_release_please %]
+      - task: test:release-title
+[% endif %]
 [% if use_foreman %]
       - task: foreman:test
 [% endif %]
@@ -462,6 +465,13 @@ tasks:
     desc: Guard the Taskfile itself (compiles; setup tasks are safe no-ops)
     cmds:
       - ./scripts/test-tasks.sh
+[% if use_release_please %]
+
+  test:release-title:
+    desc: Unit-test the release-content title guard (require-release-title.sh)
+    cmds:
+      - ./scripts/test-release-title.sh
+[% endif %]
 [% if devcontainer %]
 
   test:devcontainer:root:
@@ -706,6 +716,20 @@ tasks:
   # v0.1.0 tag; the release:patch/minor/major tasks remain as a manual override.
 [% else %]
   # Releases are intentional — never automated on merge to main.
+[% endif %]
+[% if use_release_please and release_content_paths %]
+  release:guard-title:
+    # CI-only (release-content-guard.yml): fail a PR that changes release-worthy
+    # content under a non-releasing title, which squash-merge + release-please
+    # would otherwise merge without cutting a tag. RELEASE_CONTENT_PATHS comes
+    # from the release_content_paths copier answer. Needs PR_TITLE (+ PR_BODY)
+    # and CHANGED_FILES or BASE_SHA/HEAD_SHA in the env.
+    desc: "Guard: a PR touching release-worthy paths needs a fix:/feat: title"
+    vars:
+      RELEASE_CONTENT_PATHS: "[[ release_content_paths ]]"
+    cmds:
+      - ./scripts/require-release-title.sh {{.RELEASE_CONTENT_PATHS}}
+
 [% endif %]
   release:init:
     desc: Create initial v0.1.0 tag

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -334,6 +334,23 @@ tasks:
           echo "Direct commits to main are blocked. Use a feature branch."
           exit 1
         fi
+[% if use_release_please and release_content_paths %]
+
+  guard:release-title:
+    # The CI counterpart of a pre-commit hook — enforced by release-content-guard.yml
+    # at PR time because the thing it checks (the PR title, which squash-merge feeds
+    # to release-please) does not exist locally. A non-releasing title over
+    # release-worthy content would merge without cutting a tag. RELEASE_CONTENT_PATHS
+    # comes from the release_content_paths copier answer. Pre-flight before opening a
+    # PR with an intended title:
+    #   PR_TITLE="<title>" BASE_SHA=main task guard:release-title
+    # (CI passes PR_TITLE/PR_BODY + BASE_SHA/HEAD_SHA; CHANGED_FILES overrides the diff.)
+    desc: "Guard: a PR touching release-worthy paths needs a fix:/feat: title"
+    vars:
+      RELEASE_CONTENT_PATHS: "[[ release_content_paths ]]"
+    cmds:
+      - ./scripts/require-release-title.sh {{.RELEASE_CONTENT_PATHS}}
+[% endif %]
 [% if use_skills_sync %]
 
   # ── Skills sync ────────────────────────────────────────────────
@@ -716,20 +733,6 @@ tasks:
   # v0.1.0 tag; the release:patch/minor/major tasks remain as a manual override.
 [% else %]
   # Releases are intentional — never automated on merge to main.
-[% endif %]
-[% if use_release_please and release_content_paths %]
-  release:guard-title:
-    # CI-only (release-content-guard.yml): fail a PR that changes release-worthy
-    # content under a non-releasing title, which squash-merge + release-please
-    # would otherwise merge without cutting a tag. RELEASE_CONTENT_PATHS comes
-    # from the release_content_paths copier answer. Needs PR_TITLE (+ PR_BODY)
-    # and CHANGED_FILES or BASE_SHA/HEAD_SHA in the env.
-    desc: "Guard: a PR touching release-worthy paths needs a fix:/feat: title"
-    vars:
-      RELEASE_CONTENT_PATHS: "[[ release_content_paths ]]"
-    cmds:
-      - ./scripts/require-release-title.sh {{.RELEASE_CONTENT_PATHS}}
-
 [% endif %]
   release:init:
     desc: Create initial v0.1.0 tag

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -148,6 +148,17 @@ it points here.
   Fixes** (patch), `feat!` / `BREAKING CHANGE:` → major. The rest (`build`,
   `chore`, `ci`, `docs`, `perf`, `refactor`, `revert`, `style`, `test`) don't cut
   a release on their own — they ride along in the next one.
+[% if release_content_paths %]
+- **On a squash-merge repo the PR title _is_ the release type.** GitHub sets the
+  squash commit subject from the PR title, and release-please reads only that
+  subject — so a `chore:`/`docs:`-titled PR merges with **no release** even when it
+  carries releasable content. The **release-content guard**
+  (`release-content-guard.yml` → `scripts/require-release-title.sh`, unit-tested by
+  `task test:release-title`) fails a PR that changes `[[ release_content_paths ]]`
+  under a non-releasing title, so consumers pinning a released tag actually receive
+  the change. Retitle with `fix:`/`feat:` rather than bypass. Automated dependency
+  PRs (Renovate/Dependabot) are skipped.
+[% endif %]
 [% if project_management == 'github' %]
 - Issue types map many-to-one onto these commit types — see
   [project-management.md](project-management.md).

--- a/template/scripts/[% if use_release_please %]require-release-title.sh[% endif %]
+++ b/template/scripts/[% if use_release_please %]require-release-title.sh[% endif %]
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# require-release-title.sh — fail a PR whose squash-merge title would silently
+# skip a release even though the PR changes release-worthy content.
+#
+# Why: PRs are squash-merged and release-please reads ONLY the squash commit
+# subject — which GitHub sets from the PR title for a multi-commit PR. A
+# non-releasing title (chore/docs/ci/…) on a content change therefore merges
+# with NO tag cut, so downstream consumers pinning a released tag never receive
+# the change. This guard makes that loud at PR time instead of silent at merge
+# time. See docs/conventions.md ("Releases").
+#
+# Usage:
+#   PR_TITLE="<title>" [PR_BODY="…"] \
+#   [CHANGED_FILES=$'a\nb'  |  BASE_SHA=<sha> [HEAD_SHA=<sha>]] \
+#     require-release-title.sh PREFIX [PREFIX …]
+#
+# PREFIXes are release-worthy path prefixes: a literal directory that matches
+# itself and everything beneath it (so `ai/skills` matches `ai/skills/x`, but
+# NOT the sibling `ai/skills-extra`). Changed files come from $CHANGED_FILES
+# (newline-separated) when set, else from `git diff --name-only BASE...HEAD`.
+# A title is "releasing" iff its type is feat/fix, or it marks a breaking
+# change (`!` before the colon, or a BREAKING CHANGE note in the body).
+#
+# Exit: 0 = ok (releasing title, or no release-worthy path touched, or no
+#       prefixes configured), 1 = violation, 2 = usage error.
+set -euo pipefail
+
+# No prefixes configured -> the guard is inert (a repo that has not opted in).
+if [ "$#" -eq 0 ]; then
+    echo "require-release-title: no release-worthy path prefixes configured — nothing to guard"
+    exit 0
+fi
+
+title="${PR_TITLE:-}"
+[ -n "$title" ] || {
+    echo "require-release-title: PR_TITLE is empty (set it to the PR title)" >&2
+    exit 2
+}
+
+# is_releasing_title TITLE BODY — 0 when the title would cut a release.
+is_releasing_title() {
+    _rt_title="$1"
+    _rt_body="${2:-}"
+    # Breaking change flagged with `!` before the colon: feat!:, fix(api)!:.
+    case "$_rt_title" in
+    *"!:"*) return 0 ;;
+    esac
+    # Breaking change footer in the body.
+    case "$_rt_body" in
+    *"BREAKING CHANGE"* | *"BREAKING-CHANGE"*) return 0 ;;
+    esac
+    # Leading conventional type, before an optional (scope) and the colon.
+    _rt_type="${_rt_title%%:*}" # everything up to the first ':'
+    _rt_type="${_rt_type%%(*}"  # drop an optional '(scope)'
+    _rt_type="${_rt_type%%\!*}" # drop a trailing '!' (defensive)
+    case "$_rt_type" in
+    feat | fix) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+if is_releasing_title "$title" "${PR_BODY:-}"; then
+    echo "require-release-title: title is a releasing type — ok: ${title}"
+    exit 0
+fi
+
+# Non-releasing title: only a problem if the PR touches release-worthy content.
+if [ -n "${CHANGED_FILES+x}" ]; then
+    files="$CHANGED_FILES"
+else
+    [ -n "${BASE_SHA:-}" ] || {
+        echo "require-release-title: set CHANGED_FILES, or BASE_SHA for a git diff" >&2
+        exit 2
+    }
+    files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA:-HEAD}")"
+fi
+
+matched=""
+while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    for prefix in "$@"; do
+        case "$f" in
+        "$prefix" | "$prefix"/*)
+            matched="${matched}  - ${f}"$'\n'
+            break
+            ;;
+        esac
+    done
+done <<EOF
+${files}
+EOF
+
+if [ -z "$matched" ]; then
+    echo "require-release-title: no release-worthy paths changed — ok: ${title}"
+    exit 0
+fi
+
+paths_joined="$*"
+cat >&2 <<EOF
+require-release-title: this PR changes release-worthy content, but its title
+
+    ${title}
+
+is not a releasing type. Squash-merge uses the PR title as the commit subject,
+and release-please only cuts a release for feat / fix / breaking changes — so as
+titled, this would merge WITHOUT a release and downstream consumers pinning a
+released tag would never receive it.
+
+Release-worthy paths changed:
+${matched}
+Fix: retitle the PR with a releasing type —
+    fix: …    (patch)      feat: …    (minor)      feat!: …    (major, breaking)
+or, if this genuinely should not release, keep the change out of these prefixes:
+    ${paths_joined}
+EOF
+exit 1

--- a/template/scripts/[% if use_release_please %]require-release-title.sh[% endif %]
+++ b/template/scripts/[% if use_release_please %]require-release-title.sh[% endif %]
@@ -41,18 +41,23 @@ title="${PR_TITLE:-}"
 is_releasing_title() {
     _rt_title="$1"
     _rt_body="${2:-}"
-    # Breaking change flagged with `!` before the colon: feat!:, fix(api)!:.
+    # The conventional "type(scope)!" prefix is everything before the FIRST colon;
+    # a title with no colon has no type line (only the body can declare breaking).
     case "$_rt_title" in
-    *"!:"*) return 0 ;;
+    *:*) _rt_head="${_rt_title%%:*}" ;;
+    *) _rt_head="" ;;
+    esac
+    # Breaking change: a `!` immediately before that first colon (feat!:, fix(api)!:).
+    # Matching a bare "!:" anywhere would let `chore: … !: …` bypass the guard.
+    case "$_rt_head" in
+    *"!") return 0 ;;
     esac
     # Breaking change footer in the body.
     case "$_rt_body" in
     *"BREAKING CHANGE"* | *"BREAKING-CHANGE"*) return 0 ;;
     esac
-    # Leading conventional type, before an optional (scope) and the colon.
-    _rt_type="${_rt_title%%:*}" # everything up to the first ':'
-    _rt_type="${_rt_type%%(*}"  # drop an optional '(scope)'
-    _rt_type="${_rt_type%%\!*}" # drop a trailing '!' (defensive)
+    # Leading conventional type (feat/fix), before an optional (scope).
+    _rt_type="${_rt_head%%(*}"
     case "$_rt_type" in
     feat | fix) return 0 ;;
     *) return 1 ;;
@@ -79,6 +84,7 @@ matched=""
 while IFS= read -r f; do
     [ -n "$f" ] || continue
     for prefix in "$@"; do
+        prefix="${prefix%/}" # tolerate a configured prefix written as "dir/"
         case "$f" in
         "$prefix" | "$prefix"/*)
             matched="${matched}  - ${f}"$'\n'

--- a/template/scripts/[% if use_release_please %]test-release-title.sh[% endif %]
+++ b/template/scripts/[% if use_release_please %]test-release-title.sh[% endif %]
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# test-release-title.sh — unit-test require-release-title.sh: a content change
+# under a non-releasing title fails; releasing titles and non-content chores
+# pass; path-prefix matching respects the `/` boundary. Run via
+# `task test:release-title`.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+guard="./scripts/require-release-title.sh"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+# run TITLE CHANGED_FILES PREFIX... -> echoes the guard's exit code.
+run() {
+    _t="$1"
+    _c="$2"
+    shift 2
+    _rc=0
+    PR_TITLE="$_t" CHANGED_FILES="$_c" "$guard" "$@" >/dev/null 2>&1 || _rc=$?
+    echo "$_rc"
+}
+
+echo "==> content change under a chore title fails"
+[ "$(run 'chore: update to harmon-init v4.0.0' "$(printf 'ai/skills/repo/x.md\nREADME.md')" ai/skills templates scripts)" = 1 ] ||
+    fail "chore + skill change should fail"
+
+echo "==> the same content change under a fix title passes"
+[ "$(run 'fix(standardize-repo): publish skill updates' 'ai/skills/repo/x.md' ai/skills templates scripts)" = 0 ] ||
+    fail "fix + skill change should pass"
+
+echo "==> a feat title passes"
+[ "$(run 'feat: add a skill' 'ai/skills/new.md' ai/skills)" = 0 ] || fail "feat should pass"
+
+echo "==> a breaking-change (!) chore-shaped title passes"
+[ "$(run 'refactor!: drop a skill' 'ai/skills/old.md' ai/skills)" = 0 ] || fail "! breaking should pass"
+
+echo "==> BREAKING CHANGE in the body passes even with a chore title"
+_rc=0
+PR_TITLE='chore: x' PR_BODY='BREAKING CHANGE: removed foo' CHANGED_FILES='ai/skills/x.md' \
+    "$guard" ai/skills >/dev/null 2>&1 || _rc=$?
+[ "$_rc" = 0 ] || fail "BREAKING CHANGE body should pass"
+
+echo "==> a chore touching only non-content paths passes"
+[ "$(run 'chore: tidy docs' "$(printf 'docs/x.md\nREADME.md')" ai/skills templates scripts)" = 0 ] ||
+    fail "chore without content change should pass"
+
+echo "==> docs is non-releasing: docs title touching a guarded path fails"
+[ "$(run 'docs(standardize-repo): tweak' 'ai/skills/repo/x.md' ai/skills)" = 1 ] ||
+    fail "docs + guarded content should fail"
+
+echo "==> a nested file under a prefix matches"
+[ "$(run 'chore: x' 'templates/scriptTemplates/shellScriptTemplate.sh' templates)" = 1 ] ||
+    fail "nested file under templates should match"
+
+echo "==> prefix boundary: a sibling dir sharing a name prefix does NOT match"
+[ "$(run 'chore: x' 'ai/skills-extra/x.md' ai/skills)" = 0 ] ||
+    fail "ai/skills-extra must not match the ai/skills prefix"
+
+echo "==> an unconventional title with a content change fails"
+[ "$(run 'update the skills' 'ai/skills/x.md' ai/skills)" = 1 ] ||
+    fail "unconventional title + content change should fail"
+
+echo "==> no prefixes configured is inert (exit 0)"
+[ "$(run 'chore: x' 'ai/skills/x.md')" = 0 ] || fail "no prefixes should be inert"
+
+echo "==> an empty title is a usage error (exit 2)"
+_rc=0
+PR_TITLE='' CHANGED_FILES='ai/skills/x.md' "$guard" ai/skills >/dev/null 2>&1 || _rc=$?
+[ "$_rc" = 2 ] || fail "empty title should be a usage error"
+
+echo "release-title guard: all cases passed"

--- a/template/scripts/[% if use_release_please %]test-release-title.sh[% endif %]
+++ b/template/scripts/[% if use_release_please %]test-release-title.sh[% endif %]
@@ -36,6 +36,10 @@ echo "==> a feat title passes"
 echo "==> a breaking-change (!) chore-shaped title passes"
 [ "$(run 'refactor!: drop a skill' 'ai/skills/old.md' ai/skills)" = 0 ] || fail "! breaking should pass"
 
+echo "==> a stray '!:' later in a chore title does NOT bypass the guard"
+[ "$(run 'chore: update docs !: not breaking' 'ai/skills/x.md' ai/skills)" = 1 ] ||
+    fail "a bare !: elsewhere in the title must not count as breaking"
+
 echo "==> BREAKING CHANGE in the body passes even with a chore title"
 _rc=0
 PR_TITLE='chore: x' PR_BODY='BREAKING CHANGE: removed foo' CHANGED_FILES='ai/skills/x.md' \
@@ -57,6 +61,10 @@ echo "==> a nested file under a prefix matches"
 echo "==> prefix boundary: a sibling dir sharing a name prefix does NOT match"
 [ "$(run 'chore: x' 'ai/skills-extra/x.md' ai/skills)" = 0 ] ||
     fail "ai/skills-extra must not match the ai/skills prefix"
+
+echo "==> a configured prefix written with a trailing slash still matches"
+[ "$(run 'chore: x' 'templates/x.sh' templates/)" = 1 ] ||
+    fail "a trailing-slash prefix (templates/) must still match templates/x.sh"
 
 echo "==> an unconventional title with a content change fails"
 [ "$(run 'update the skills' 'ai/skills/x.md' ai/skills)" = 1 ] ||


### PR DESCRIPTION
## Problem

On a squash-merge repo, GitHub sets the squash commit subject from the **PR title**, and release-please reads only that subject — the individual `fix:`/`feat:` commits inside a squashed PR are invisible. So a PR titled `chore:`/`docs:` that changes published content **merges with no release**, and downstream repos pinning a released tag never receive it.

This is the harmon-devkit **#91** symptom: a `chore: update harmon-init to v4.0.0` PR carried skill/template changes but cut no release, so `v0.7.2` never happened and consumers couldn't sync the skill updates.

harmon-init self-releases too and is consumed via `copier update` to a tag, so it has the identical latent bug for `template/` changes.

## Fix — an opt-in, per-repo release-content guard

- **`scripts/require-release-title.sh`** — pure-shell, portable (bash 3.2). Fails a PR whose title is a non-releasing type when any changed file falls under a configured release-worthy path prefix. Releasing = `feat`/`fix`/breaking (`!` or `BREAKING CHANGE`). Prefix match respects the `/` boundary (`ai/skills` ≠ `ai/skills-extra`). Untrusted PR title/body flow through the env and are only string-matched (no injection).
- **`release-content-guard.yml`** — runs on `pull_request` incl. `edited` (retitling clears the check); fork-gated, minimal `contents: read`, skips Renovate/Dependabot.
- **`release:guard-title`** task drives it from `RELEASE_CONTENT_PATHS`; **`test:release-title`** unit-tests the logic (wired into `verify`/`ci`/build).
- **`release_content_paths`** copier answer (default empty = no guard) makes it per-repo: `src`, `ai/skills templates`, whatever fits. harmon-init itself guards `template/`.
- **AGENTS.md + docs/conventions.md** (own + template) name the guarded folders so agents pick the right commit type up front instead of tripping the check.

## Validation

- `task check`, `task test:release-title`, `task test:tasks`, `task test:dogfood-parity` green.
- `task test:template` profiles **minimal** (release-please off → nothing renders), **web** (on, paths empty → script+test present, workflow unwired), **full** (paths set → full guard renders, actionlint-clean) all PASS. New 9g assertions cover appear/disappear.

## Follow-ups (not in this PR)

- **Branch protection**: to *block* merges, `release-content-guard` must be added as a required status check — a security-relevant settings change for @evanharmon1 to approve, not done here.
- **harmon-devkit**: adopt via `copier update` (a `fix:`/`feat:`-titled PR) — which also unsticks #91 into `v0.7.2` — then bump the `.skills-sync.yaml` devkit ref to `v0.7.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)