### PR TITLE
fix: update harmon-devkit skills to v0.7.2

### DIFF
--- a/.claude/skills/.SKILLS_PROVENANCE
+++ b/.claude/skills/.SKILLS_PROVENANCE
@@ -1,6 +1,6 @@
 # VENDORED from harmon-devkit — DO NOT EDIT the managed skills here.
 # source: https://github.com/evanharmon1/harmon-devkit.git
-# ref: v0.7.1 (e4ed36b44bb593511ca1374a79c17caf6a41d7c3)
+# ref: v0.7.2 (29f815debc79e2126d7a6268f9c5ae16923c10f2)
 # path: ai/skills
 # categories: repo
 # managed: standardize-repo

--- a/.claude/skills/standardize-repo/SKILL.md
+++ b/.claude/skills/standardize-repo/SKILL.md
@@ -53,16 +53,18 @@ differently.
 
 These are load-bearing. Full rationale and edge cases in `references/copier-gotchas.md`.
 
-- **When *rendering* from a local path (`copier copy`), always pass `--vcs-ref=HEAD`.**
-  Without it, copier renders the **latest git tag** of harmon-init and silently
-  ignores all uncommitted *and* committed-but-untagged work. With it, copier
-  auto-includes dirty/untracked changes via a throwaway commit in a temp clone
-  (`DirtyLocalWarning`) — the working tree is never touched. This rule is about
-  *which ref* to render, not *where* the template lives — and it applies to
-  `copier copy`, **not** `copier update`. An update reuses the recorded `_src_path`
-  and tracks released **tags**: a generated repo's committed `_src_path` should be
-  the GitHub URL (not a machine-local path), and a normal `copier update` takes
-  **no** `--vcs-ref`. See `copier-gotchas.md` gotchas 1 (render ref) & 8 (`_src_path`).
+- **Production scaffolds use the canonical GitHub URL at a released ref.** Run
+  `copier copy --trust --vcs-ref=v3.26.1
+  https://github.com/evanharmon1/harmon-init.git <dest> ...` (substitute the
+  reviewed current release). This records durable lineage that another machine
+  can resolve. A local-path `--vcs-ref=HEAD` render is only for a disposable
+  preview/test of unreleased template work. Copier may represent dirty local work
+  with a throwaway commit that does not exist on GitHub; never promote that render
+  by rewriting only `_src_path`. The recorded `_src_path` and `_commit` are one
+  lineage tuple: before changing a local path to the canonical URL, prove the
+  recorded commit is reachable from that remote, or re-render/re-adopt from a
+  released remote ref. A normal `copier update` reuses that tuple and takes no
+  `--vcs-ref`. See `copier-gotchas.md` gotchas 1 and 8.
 - **Side-effectful answers default to `no`** in `copier.yml` (`github_remote_create`,
   `github_release_init`, `bunch_add`, `obsidian_project_add`, `run_task_install`).
   Leave them off unless the user explicitly asks; only flip them on with confirmation.
@@ -71,8 +73,8 @@ These are load-bearing. Full rationale and edge cases in `references/copier-gotc
   (the template has `_tasks`). Example shape:
 
   ```bash
-  copier copy ~/git/harmon-init ./new-project \
-    --vcs-ref=HEAD --trust \
+  copier copy https://github.com/evanharmon1/harmon-init.git ./new-project \
+    --vcs-ref=v3.26.1 --trust \
     --data project_name="My Project" --data project_type=general --defaults
   ```
 
@@ -103,7 +105,7 @@ assets/verify-applied.sh <target-repo-dir>
 ```
 
 It confirms the expected files/tooling landed and then runs the repo's own gate
-(`task verify` = lint + template/output checks; `task check` for lint only;
+(`task verify` = the repo's fast check/build/validate/guard set; `task check` for lint only;
 `task install:hooks` to wire lefthook). Report what passed and surface any gaps
 against `references/standards-catalog.md`. Never bypass hooks (`--no-verify` is
 prohibited); commit on a feature branch and open a PR — no direct commits to `main`.

--- a/.claude/skills/standardize-repo/assets/diff-template.sh
+++ b/.claude/skills/standardize-repo/assets/diff-template.sh
@@ -9,12 +9,18 @@
 #               legitimately customized it (terraform tasks, a custom status
 #               section) OR because it's missing template improvements (the
 #               recurring status.sh / lint-hygiene / bootstrap class).
+#   • MODE    — executable-bit differences in that same curated set. Copier can
+#               preserve content while a manual copy silently drops `+x`, leaving
+#               a generated script present but unusable.
 #   • MISSING — template files the repo lacks ENTIRELY. This scan is
 #               manifest-INDEPENDENT (it walks the whole render), because the
 #               manifest is hand-maintained and lags the template — a file added
 #               after the last manifest edit, or dropped by a hand-reconciled
 #               `copier update`, would otherwise slip through silently. (.gitkeep
 #               dir-stubs are listed as benign ABSENT, not flagged as drift.)
+#               A tracked file deleted only from the working tree is compared
+#               from the index, so an unstaged/transient delete is not reported
+#               as drift; once the deletion is staged it is real MISSING.
 # This is a REVIEW AID for apply/update/audit, not a pass/fail gate. For each
 # DRIFT/MISSING, inspect and reconcile — pull template improvements in via
 # `copier update`, keep legit local customizations.
@@ -77,6 +83,7 @@ answers="$target/.copier-answers.yml"
 workdir="$(mktemp -d -t harmon-init-render-XXXXXX)"
 trap 'rm -rf "$workdir"' EXIT
 render="$workdir/render"
+index_root="$workdir/index-snapshot"
 
 # Reconstruct the recorded answers as a --data-file (skip copier's _ keys and
 # nulls). A YAML data file — not per-key `--data k=v` strings — is required to
@@ -111,20 +118,48 @@ copier copy "$template" "$render" --vcs-ref="$src_ref" --trust --defaults \
     exit 2
 }
 
-# Resolve a repo file path, honoring .yml<->.yaml (each tool's own convention).
-repo_variant() {
+# Materialize an index copy when a tracked file is absent only from the working
+# tree. This makes audit output stable while an editor/tool has a transient
+# unstaged deletion. A staged deletion has no index entry and remains MISSING.
+index_variant() {
+    p="$1"
+    git -C "$target" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+    git -C "$target" cat-file -e ":$p" 2>/dev/null || return 1
+    out="$index_root/$p"
+    mkdir -p "$(dirname "$out")"
+    git -C "$target" show ":$p" >"$out" 2>/dev/null || return 1
+    mode="$(git -C "$target" ls-files -s -- "$p" | awk 'NR == 1 { print $1 }')"
+    [ "$mode" != "100755" ] || chmod +x "$out"
+    echo "$out"
+}
+
+resolve_variant() {
     p="$1"
     if [ -f "$target/$p" ]; then
         echo "$target/$p"
+        return 0
+    fi
+    if iv="$(index_variant "$p")"; then
+        echo "$iv"
+        return 0
+    fi
+    return 1
+}
+
+# Resolve a repo file path, honoring .yml<->.yaml (each tool's own convention).
+repo_variant() {
+    p="$1"
+    if rv="$(resolve_variant "$p")"; then
+        echo "$rv"
         return
     fi
     case "$p" in
-    *.yml) [ -f "$target/${p%.yml}.yaml" ] && {
-        echo "$target/${p%.yml}.yaml"
+    *.yml) rv="$(resolve_variant "${p%.yml}.yaml")" && {
+        echo "$rv"
         return
     } ;;
-    *.yaml) [ -f "$target/${p%.yaml}.yml" ] && {
-        echo "$target/${p%.yaml}.yml"
+    *.yaml) rv="$(resolve_variant "${p%.yaml}.yml")" && {
+        echo "$rv"
         return
     } ;;
     esac
@@ -134,6 +169,7 @@ repo_variant() {
 drift=0
 checked=0
 drift_count=0
+mode_count=0
 missing_count=0
 while IFS= read -r f; do
     case "$f" in '' | \#*) continue ;; esac
@@ -146,8 +182,26 @@ while IFS= read -r f; do
         missing_count=$((missing_count + 1))
         continue
     fi
+    rv_display="${rv#"$target"/}"
+    if [ "$rv_display" = "$rv" ]; then
+        rv_display="${rv#"$index_root"/}"
+    fi
+    render_exec=0
+    repo_exec=0
+    [ -x "$render/$f" ] && render_exec=1
+    [ -x "$rv" ] && repo_exec=1
+    if [ "$render_exec" -ne "$repo_exec" ]; then
+        if [ "$render_exec" -eq 1 ]; then
+            mode_note="template is executable; repo is not"
+        else
+            mode_note="repo is executable; template is not"
+        fi
+        echo "MODE     $rv_display  ($mode_note)"
+        drift=1
+        mode_count=$((mode_count + 1))
+    fi
     if ! diff -q "$render/$f" "$rv" >/dev/null 2>&1; then
-        echo "DRIFT    ${rv#"$target"/}"
+        echo "DRIFT    $rv_display"
         drift=1
         drift_count=$((drift_count + 1))
         if [ "$show" -eq 1 ]; then
@@ -164,8 +218,51 @@ done <"$manifest"
 # loop above only catches CONTENT drift in curated files; a file the repo is
 # missing outright — added after the last manifest edit, or dropped by a
 # hand-reconciled `copier update` — needs this manifest-free scan or it slips
-# through silently. .gitkeep dir-stubs are benign (a populated dir legitimately
-# omits them), so they're shown as ABSENT but not counted as drift.
+# through silently. A mature repo can intentionally replace two seed shapes:
+# flat Terraform starter files with nested/split Terraform roots, and the seed
+# ADR with a renumbered equivalent or an already-active ADR log. Report those as
+# benign EQUIV instead of false MISSING. .gitkeep dir-stubs are likewise benign.
+equivalent_note=""
+has_repo_equivalent() {
+    g="$1"
+    equivalent_note=""
+    case "$g" in
+    terraform/main.tf | terraform/variables.tf | terraform/outputs.tf | terraform/tfvars.env.example)
+        if [ -d "$target/terraform" ] &&
+            find "$target/terraform" -type f -name '*.tf' 2>/dev/null |
+            awk -v root="$target/terraform/" '
+                    index($0, root) == 1 {
+                        rel = substr($0, length(root) + 1)
+                        if (rel ~ /\//) found = 1
+                    }
+                    END { exit(found ? 0 : 1) }
+                '; then
+            equivalent_note="repo uses nested/split Terraform roots"
+            return 0
+        fi
+        ;;
+    docs/decisions/0001-record-architecture-decisions.md)
+        for adr in "$target"/docs/decisions/[0-9]*.md; do
+            [ -f "$adr" ] || continue
+            case "${adr##*/}" in
+            *-record-architecture-decisions.md)
+                equivalent_note="repo carries a renumbered equivalent ADR"
+                return 0
+                ;;
+            esac
+        done
+        if [ -f "$target/docs/decisions/README.md" ]; then
+            for adr in "$target"/docs/decisions/[0-9]*.md; do
+                [ -f "$adr" ] || continue
+                equivalent_note="repo already has an active ADR log; the seed ADR is redundant"
+                return 0
+            done
+        fi
+        ;;
+    esac
+    return 1
+}
+
 while IFS= read -r abs; do
     g="${abs#"$render"/}"
     case "$g" in
@@ -173,6 +270,10 @@ while IFS= read -r abs; do
     esac
     grep -qxF "$g" "$manifest" 2>/dev/null && continue # manifest loop owns it
     [ -n "$(repo_variant "$g")" ] && continue          # repo has it (or .yml/.yaml twin)
+    if has_repo_equivalent "$g"; then
+        echo "EQUIV    $g  ($equivalent_note)"
+        continue
+    fi
     case "$g" in
     *.gitkeep) echo "ABSENT   $g  (template dir-stub — benign if the dir has real content)" ;;
     *)
@@ -187,7 +288,7 @@ echo ""
 if [ "$drift" -ne 0 ]; then
     # The counts make truncated output self-evident: if you can't see
     # $drift_count DRIFT + $missing_count MISSING lines above, you cut them off.
-    echo "diff-template: ${drift_count} DRIFT + ${missing_count} MISSING across $checked curated files"
+    echo "diff-template: ${drift_count} DRIFT + ${mode_count} MODE + ${missing_count} MISSING across $checked curated files"
     echo "  checked and a whole-render missing-file scan. Findings above. For each,"
     echo "  review the diff (\`diff-template.sh --show\`): pull missed template"
     echo "  improvements in with \`copier update\`, keep legit local customizations."

--- a/.claude/skills/standardize-repo/assets/template-owned-files.txt
+++ b/.claude/skills/standardize-repo/assets/template-owned-files.txt
@@ -8,21 +8,40 @@
 #
 # Lines starting with # and blank lines are ignored. Paths use the template's
 # default extension; diff-template.sh maps .yml<->.yaml to whatever the repo uses.
-# Entries not present in a given render (e.g. codeql.yml for a non-node/python
-# repo) are skipped automatically.
+# Entries not present in a given render (e.g. codeql.yml when `use_codeql=false`
+# or the stack has no supported Node/Python language) are skipped automatically.
 
 # ── Task runner + git hooks ──────────────────────────────────────────────────
 Taskfile.yml
 lefthook.yml
+Brewfile
+.claude/settings.json
+.skills-sync.yaml
 
 # ── Shared scripts ───────────────────────────────────────────────────────────
 scripts/status.sh
 scripts/lint-hygiene.sh
+scripts/shell-quality.sh
+scripts/markdownlint.sh
+scripts/secret-set-1p.sh
+scripts/secret-set-gh.sh
+scripts/python-audit.sh
+scripts/terraform-provider-locks.sh
+scripts/terraform-changed.sh
+scripts/terraform-ci.sh
+scripts/test-codeql-result.sh
+scripts/test-required-results.sh
+scripts/test-terraform-provider-locks.sh
+scripts/test-terraform-ci.sh
+scripts/verify-codeql-result.sh
+scripts/verify-required-results.sh
+scripts/sync-skills.sh
 scripts/summarize-gitleaks.mjs
 scripts/run-semgrep.sh
 scripts/test-tasks.sh
 scripts/test-hooks.sh
 scripts/devcontainer-assert.sh
+scripts/devcontainer-smoke.sh
 
 # ── Lint / format / security config ──────────────────────────────────────────
 .editorconfig
@@ -43,8 +62,45 @@ commitlint.config.mjs
 .github/workflows/codeql.yml
 .github/workflows/snyk-scheduled.yml
 .github/workflows/release.yml
+.github/workflows/close-milestone-on-release.yml
 .github/workflows/devcontainer-build.yml
+.github/workflows/deploy-preview.yml
 .github/workflows/project-automation.yml
+.github/workflows/terraform.yml
+
+# ── Foreman (conditional on use_foreman) ─────────────────────────────────────
+.foreman.toml
+taskfiles/foreman.yml
+docs/architecture/foreman.md
+.claude/agents/foreman-implementer.md
+.claude/agents/foreman-preflight.md
+.claude/agents/foreman-shepherd.md
+scripts/foreman/__init__.py
+scripts/foreman/__main__.py
+scripts/foreman/backend.py
+scripts/foreman/backends/claude.sh
+scripts/foreman/backends/mock.sh
+scripts/foreman/cli.py
+scripts/foreman/config.py
+scripts/foreman/dispatch.py
+scripts/foreman/github.py
+scripts/foreman/graph.py
+scripts/foreman/inputs.py
+scripts/foreman/pr.py
+scripts/foreman/prompts/implementer-preamble.md
+scripts/foreman/prompts/preflight.md
+scripts/foreman/prompts/shepherd-adjudicate.md
+scripts/foreman/prompts/shepherd-ci-fix.md
+scripts/foreman/prompts/shepherd-rebase.md
+scripts/foreman/report.py
+scripts/foreman/shepherd.py
+scripts/foreman/signatures.py
+scripts/foreman/signatures.toml
+scripts/foreman/spec.py
+scripts/foreman/util.py
+scripts/foreman/verify.py
+scripts/foreman/watch.py
+scripts/foreman/worktree.py
 .github/actions/setup/action.yml
 
 # ── Devcontainer (template-owned lifecycle + tooling) ─────────────────────────

--- a/.claude/skills/standardize-repo/assets/verify-applied.sh
+++ b/.claude/skills/standardize-repo/assets/verify-applied.sh
@@ -3,7 +3,9 @@
 # verify-applied.sh — validate a repo AFTER harmon-init conventions were applied.
 #
 # Usage:
-#   verify-applied.sh [TARGET_DIR]   # TARGET_DIR defaults to "."
+#   verify-applied.sh [--ack-codeowner-change @old=@new]... [TARGET_DIR]
+#   TARGET_DIR defaults to ".". Each acknowledgement must name one owner that
+#   was actually dropped from main and one replacement present in the new file.
 #
 # Mirrors the validation philosophy of harmon-init's scripts/test-template.sh,
 # but runs against an ALREADY-RENDERED, real repo (the result of `copier copy`
@@ -21,7 +23,65 @@
 
 set -euo pipefail
 
-target="${1:-.}"
+usage() {
+    cat >&2 <<'USAGE'
+Usage:
+  verify-applied.sh [--ack-codeowner-change @old=@new]... [TARGET_DIR]
+
+The CODEOWNERS acknowledgement is intentionally exact: repeat it for each
+intentional owner migration. The verifier rejects stale, extra, malformed, or
+non-materialized mappings; there is no blanket access-control bypass.
+USAGE
+}
+
+target=""
+codeowner_ack_count=0
+codeowner_acks=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --ack-codeowner-change)
+        [ $# -ge 2 ] || {
+            usage
+            echo "FAIL: --ack-codeowner-change requires @old=@new" >&2
+            exit 2
+        }
+        ack="$2"
+        if ! printf '%s\n' "$ack" | grep -qE '^@[A-Za-z0-9_/-]+=@[A-Za-z0-9_/-]+$'; then
+            usage
+            echo "FAIL: malformed CODEOWNERS acknowledgement: $ack" >&2
+            exit 2
+        fi
+        old="${ack%%=*}"
+        new="${ack#*=}"
+        if [ "$old" = "$new" ]; then
+            echo "FAIL: CODEOWNERS acknowledgement must name a real migration: $ack" >&2
+            exit 2
+        fi
+        codeowner_acks+=("$ack")
+        codeowner_ack_count=$((codeowner_ack_count + 1))
+        shift 2
+        ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    -*)
+        usage
+        echo "FAIL: unknown argument: $1" >&2
+        exit 2
+        ;;
+    *)
+        if [ -n "$target" ]; then
+            usage
+            echo "FAIL: more than one target directory given" >&2
+            exit 2
+        fi
+        target="$1"
+        shift
+        ;;
+    esac
+done
+[ -n "$target" ] || target="."
 
 if [ ! -d "$target" ]; then
     echo "FAIL: target directory not found: $target" >&2
@@ -93,7 +153,7 @@ fi
 # `task verify` above would catch this too, but a broken Taskfile makes that
 # step error out ambiguously; this gives a precise message.
 if { [ -f Taskfile.yml ] || [ -f Taskfile.yaml ]; } && have task; then
-    if ! task --list-all >/dev/null 2>&1; then
+    if ! task --color=false --list-all >/dev/null 2>&1; then
         err "Taskfile does not parse ('task --list-all' failed)"
     fi
 fi
@@ -104,7 +164,7 @@ fi
 # recurring example is status:setup (the setup-completeness audit), which older
 # forks of scripts/status.sh + Taskfile never had.
 if { [ -f Taskfile.yml ] || [ -f Taskfile.yaml ]; } && have task; then
-    tasklist="$(task --list-all 2>/dev/null || true)"
+    tasklist="$(task --color=false --list-all 2>/dev/null || true)"
     for t in verify check security status:setup install:hooks; do
         if ! printf '%s\n' "$tasklist" | grep -qE "^[* ]*${t}:([[:space:]]|\$)"; then
             err "Taskfile missing required target: ${t}"
@@ -125,15 +185,974 @@ fi
 # `&& task <t>` — so prose ("the specific task described"), renovate comments
 # (`go-task/task extractVersion`), and `setup-task@<sha>` never match.
 if [ -d .github/workflows ] && { [ -f Taskfile.yml ] || [ -f Taskfile.yaml ]; } && have task; then
-    tasklist="$(task --list-all 2>/dev/null || true)"
-    called="$(grep -rhoE '(run:[[:space:]]*|^[[:space:]]*|&&[[:space:]]*)task +[a-z][a-z0-9:_-]*' .github/workflows/ 2>/dev/null |
-        sed -E 's/.*task +//' | sort -u)"
+    tasklist="$(task --color=false --list-all 2>/dev/null || true)"
+    called="$(
+        grep -rhoE '(run:[[:space:]]*|^[[:space:]]*|&&[[:space:]]*)task +[a-z][a-z0-9:_-]*' .github/workflows/ 2>/dev/null |
+            sed -E 's/.*task +//' | sort -u || true
+    )"
     for t in $called; do
         if ! printf '%s\n' "$tasklist" | grep -qE "^[* ]*${t}:([[:space:]]|\$)"; then
             err "workflow calls 'task ${t}' but the Taskfile has no such target"
         fi
     done
 fi
+
+# ── 3d. Terraform lint + provider-lock contract ──────────────────────
+# Terraform coverage is capability-gated, not universal. When a repo selected
+# include_terraform OR contains first-party .tf files, `task check` must actually
+# reach fmt, TFLint, Checkov, and the cross-platform provider-lock check. Merely
+# naming those tools in docs (or committing one host's lock file) is not proof.
+include_terraform_answer=""
+if [ -f .copier-answers.yml ]; then
+    include_terraform_answer="$(
+        sed -n -E 's/^[[:space:]]*include_terraform:[[:space:]]*([^#[:space:]]+).*$/\1/p' .copier-answers.yml |
+            tail -n 1 | tr '[:upper:]' '[:lower:]' | tr -d "\"'"
+    )"
+fi
+
+repo_files=""
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    repo_files="$(git ls-files --cached --others --exclude-standard 2>/dev/null || true)"
+else
+    repo_files="$(find . -type f 2>/dev/null | sed 's#^\./##' || true)"
+fi
+terraform_sources="$(
+    printf '%s\n' "$repo_files" |
+        grep -E '\.tf$' |
+        grep -vE '(^|/)(\.terraform|node_modules|vendor|dist|build)/' || true
+)"
+
+provider_lock_init_modes_are_safe() {
+    local helper="$1"
+    local probe fake_terraform check_root update_root result
+
+    probe="$(mktemp -d "${TMPDIR:-/tmp}/verify-provider-lock-init.XXXXXX")" || return 1
+    fake_terraform="$probe/terraform"
+    check_root="$probe/check"
+    update_root="$probe/update"
+    result=0
+
+    cat >"$fake_terraform" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+-chdir=*) ;;
+*) exit 2 ;;
+esac
+shift
+
+case "${1:-}" in
+init)
+    shift
+    upgrade=false
+    for arg in "$@"; do
+        if [ "$arg" = -upgrade ]; then
+            upgrade=true
+        fi
+    done
+    case "${EXPECT_INIT_UPGRADE:-}:$upgrade" in
+    false:false | true:true) ;;
+    *) exit 90 ;;
+    esac
+    ;;
+providers)
+    shift
+    [ "${1:-}" = lock ] || exit 2
+    ;;
+*) exit 2 ;;
+esac
+EOF
+    chmod +x "$fake_terraform"
+    mkdir "$check_root" "$update_root"
+    printf '%s\n' 'terraform {}' >"$check_root/main.tf"
+    printf '%s\n' 'terraform {}' >"$update_root/main.tf"
+
+    if ! EXPECT_INIT_UPGRADE=false TERRAFORM_BIN="$fake_terraform" \
+        "$helper" check "$check_root" >/dev/null 2>&1; then
+        result=1
+    fi
+    if ! EXPECT_INIT_UPGRADE=true TERRAFORM_BIN="$fake_terraform" \
+        "$helper" update "$update_root" >/dev/null 2>&1; then
+        result=1
+    fi
+
+    rm -rf "$probe"
+    [ "$result" -eq 0 ]
+}
+
+has_terraform=false
+case "$include_terraform_answer" in
+true | yes)
+    has_terraform=true
+    ;;
+false | no | "") ;;
+*)
+    err "invalid include_terraform value in .copier-answers.yml: $include_terraform_answer"
+    ;;
+esac
+if [ -n "$terraform_sources" ]; then
+    has_terraform=true
+fi
+
+if [ "$has_terraform" = true ]; then
+    provider_lock_helper="scripts/terraform-provider-locks.sh"
+    if [ ! -f "$provider_lock_helper" ]; then
+        err "Terraform is present but $provider_lock_helper is missing"
+    else
+        if [ ! -x "$provider_lock_helper" ]; then
+            err "$provider_lock_helper must be executable"
+        fi
+        provider_lock_program="$(sed -E 's/[[:space:]]*#.*$//' "$provider_lock_helper")"
+        for lock_contract in \
+            'providers lock' \
+            '-platform=darwin_arm64' \
+            '-platform=linux_amd64'; do
+            if ! grep -qF -- "$lock_contract" <<<"$provider_lock_program"; then
+                err "$provider_lock_helper does not establish '$lock_contract'"
+            fi
+        done
+        if [ -x "$provider_lock_helper" ] &&
+            ! provider_lock_init_modes_are_safe "$provider_lock_helper"; then
+            err "$provider_lock_helper must pass -upgrade to init only in update mode"
+        fi
+    fi
+
+    provider_lock_regression="scripts/test-terraform-provider-locks.sh"
+    if [ ! -f "$provider_lock_regression" ]; then
+        err "Terraform is present but $provider_lock_regression is missing"
+    elif [ ! -x "$provider_lock_regression" ]; then
+        err "$provider_lock_regression must be executable"
+    elif ! "$provider_lock_regression" >/dev/null 2>&1; then
+        err "$provider_lock_regression failed its hermetic lock-process checks"
+    fi
+
+    if have task && { [ -f Taskfile.yml ] || [ -f Taskfile.yaml ]; }; then
+        terraform_tasklist="$(task --color=false --list-all 2>/dev/null || true)"
+        for terraform_task in lint:terraform terraform:providers:lock; do
+            if ! grep -qE "^[* ]*${terraform_task}:([[:space:]]|\$)" \
+                <<<"$terraform_tasklist"; then
+                err "Terraform Taskfile contract is missing target: $terraform_task"
+            fi
+        done
+
+        terraform_lint_dry="$(task --color=false --dry lint:terraform 2>&1 || true)"
+        terraform_check_dry="$(task --color=false --dry check 2>&1 || true)"
+        terraform_lock_dry="$(task --color=false --dry terraform:providers:lock 2>&1 || true)"
+
+        for dry_contract in \
+            'terraform fmt -check' \
+            'tflint --recursive' \
+            'checkov==' \
+            'checkov -d'; do
+            if ! grep -qF -- "$dry_contract" <<<"$terraform_lint_dry"; then
+                err "task lint:terraform does not reach '$dry_contract'"
+            fi
+            if ! grep -qF -- "$dry_contract" <<<"$terraform_check_dry"; then
+                err "task check does not reach Terraform contract '$dry_contract'"
+            fi
+        done
+        if ! grep -qE 'terraform-provider-locks\.sh[[:space:]]+check[[:space:]]+[^[:space:]]' \
+            <<<"$terraform_lint_dry"; then
+            err "task lint:terraform does not reach the provider-lock check helper"
+        fi
+        if ! grep -qE 'terraform-provider-locks\.sh[[:space:]]+check[[:space:]]+[^[:space:]]' \
+            <<<"$terraform_check_dry"; then
+            err "task check does not reach the Terraform provider-lock check helper"
+        fi
+        if ! grep -qE 'uvx .*--from .*checkov==' <<<"$terraform_lint_dry"; then
+            err "task lint:terraform must run pinned Checkov through uvx --from"
+        fi
+        if ! grep -qE 'terraform-provider-locks\.sh[[:space:]]+update[[:space:]]+[^[:space:]]' \
+            <<<"$terraform_lock_dry"; then
+            err "task terraform:providers:lock does not reach the explicit lock update helper"
+        fi
+    else
+        echo "WARN: task is unavailable; Terraform lint/lock task reachability needs manual audit." >&2
+    fi
+
+    if [ ! -f Brewfile ]; then
+        err "Terraform is present but Brewfile is missing its local tool contract"
+    else
+        for formula in terraform tflint uv; do
+            if ! grep -qE "^[[:space:]]*brew[[:space:]]+['\"]${formula}['\"]" Brewfile; then
+                err "Terraform local lint contract is missing brew formula: $formula"
+            fi
+        done
+    fi
+
+    build_workflow=""
+    for candidate in .github/workflows/build.yml .github/workflows/build.yaml; do
+        if [ -f "$candidate" ]; then
+            build_workflow="$candidate"
+            break
+        fi
+    done
+    if [ -z "$build_workflow" ]; then
+        err "Terraform is present but no build workflow provisions its lint tools"
+    else
+        for setup_action in \
+            'hashicorp/setup-terraform@' \
+            'terraform-linters/setup-tflint@' \
+            'astral-sh/setup-uv@'; do
+            if ! grep -qE "^[[:space:]]*-[[:space:]]+uses:[[:space:]]+${setup_action}" \
+                "$build_workflow"; then
+                err "$build_workflow does not provision Terraform lint dependency: $setup_action"
+            fi
+        done
+    fi
+fi
+
+# ── 3e. Build/devcontainer aggregate result contracts ──────────────
+# A generic "success or skipped" aggregate is not fail-closed: on a trusted
+# event it can disguise a job that never ran, and on a fork it can disguise a
+# repository-controlled job that unexpectedly ran. The standard has two exact
+# branches. Fork PRs validate every suppressed leaf as `skipped` in workflow-
+# inline shell without checkout/repo code; trusted events check out only after
+# the fork branch and require every leaf to be `success` through the tested
+# helper.
+aggregate_job_contract_is_safe() {
+    local workflow="$1"
+    local aggregate_job="$2"
+
+    awk -v target="$aggregate_job" '
+        function clear_step_refs(key) {
+            for (key in step_refs) {
+                delete step_refs[key]
+            }
+        }
+        function reset_step() {
+            clear_step_refs()
+            in_step = 0
+            is_boundary = 0
+            fork_condition = 0
+            trusted_condition = 0
+            is_checkout = 0
+            is_helper = 0
+            has_run = 0
+            checks_skipped = 0
+            boundary_message = 0
+            expected_success = 0
+            uses_any = 0
+            repo_code = 0
+        }
+        function finish_step(key) {
+            if (!in_step) {
+                return
+            }
+            if (is_boundary) {
+                if (fork_condition && has_run && checks_skipped &&
+                    boundary_message && !uses_any && !repo_code) {
+                    safe_boundary = 1
+                }
+                for (key in step_refs) {
+                    fork_refs[key] = 1
+                }
+            }
+            if (is_checkout) {
+                if (trusted_condition) {
+                    safe_checkout = 1
+                } else {
+                    unsafe_checkout = 1
+                }
+            }
+            if (is_helper) {
+                if (trusted_condition && expected_success) {
+                    safe_helper = 1
+                } else {
+                    unsafe_helper = 1
+                }
+                for (key in step_refs) {
+                    trusted_refs[key] = 1
+                }
+            }
+            reset_step()
+        }
+        function collect_refs(value, token) {
+            value = $0
+            while (match(value, /needs\.[A-Za-z0-9_-]+\.result/)) {
+                token = substr(value, RSTART, RLENGTH)
+                step_refs[token] = 1
+                value = substr(value, RSTART + RLENGTH)
+            }
+        }
+        BEGIN {
+            in_job = 0
+            found_job = 0
+            always_job = 0
+            fork_expression = 0
+            safe_boundary = 0
+            safe_checkout = 0
+            safe_helper = 0
+            unsafe_checkout = 0
+            unsafe_helper = 0
+            generic_allowlist = 0
+            reset_step()
+        }
+        {
+            line = $0
+            if (!in_job) {
+                if (line ~ ("^  " target ":[ ]*(#.*)?$")) {
+                    in_job = 1
+                    found_job = 1
+                }
+                next
+            }
+            if (line ~ /^  [A-Za-z0-9_-]+:[ ]*(#.*)?$/) {
+                finish_step()
+                in_job = 0
+                next
+            }
+            if (line ~ /^[[:space:]]*if:[[:space:]]*always\(\)/) {
+                always_job = 1
+            }
+            if (index(line, "IS_FORK:") &&
+                index(line, "github.event_name ==") && index(line, "pull_request") &&
+                index(line, "head.repo.full_name != github.repository")) {
+                fork_expression = 1
+            }
+            if (index(line, "success") && index(line, "skipped") &&
+                index(line, "||")) {
+                generic_allowlist = 1
+            }
+            if (line ~ /^      - /) {
+                finish_step()
+                in_step = 1
+            }
+            if (!in_step || line ~ /^[[:space:]]*#/) {
+                next
+            }
+            if (index(line, "name:") && index(line, "untrusted-fork boundary")) {
+                is_boundary = 1
+            }
+            if (index(line, "if:") && index(line, "env.IS_FORK ==") &&
+                index(line, "true")) {
+                fork_condition = 1
+            }
+            if (index(line, "if:") && index(line, "env.IS_FORK !=") &&
+                index(line, "true")) {
+                trusted_condition = 1
+            }
+            if (line ~ /uses:[ ]*actions\/checkout@/) {
+                is_checkout = 1
+            }
+            if (line ~ /run:[ ]*\.\/scripts\/verify-required-results\.sh/) {
+                is_helper = 1
+            }
+            if (line ~ /^[[:space:]]*run:/) {
+                has_run = 1
+            }
+            if (index(line, "EXPECTED_RESULT:") && index(line, "success")) {
+                expected_success = 1
+            }
+            if (index(line, "!=") && index(line, "skipped")) {
+                checks_skipped = 1
+            }
+            if (index(line, "Untrusted fork trust boundary enforced:")) {
+                boundary_message = 1
+            }
+            if (line ~ /uses:/) {
+                uses_any = 1
+            }
+            if (is_boundary &&
+                (line ~ /scripts\// || line ~ /run:[ ]*(\.\/|bash |sh )/)) {
+                repo_code = 1
+            }
+            collect_refs()
+        }
+        END {
+            finish_step()
+            ref_count = 0
+            refs_match = 1
+            for (key in fork_refs) {
+                ref_count++
+                if (!(key in trusted_refs)) {
+                    refs_match = 0
+                }
+            }
+            for (key in trusted_refs) {
+                if (!(key in fork_refs)) {
+                    refs_match = 0
+                }
+            }
+            exit(found_job && always_job && fork_expression && safe_boundary &&
+                 safe_checkout && safe_helper && !unsafe_checkout &&
+                 !unsafe_helper && !generic_allowlist && ref_count > 0 &&
+                 refs_match ? 0 : 1)
+        }
+    ' "$workflow"
+}
+
+workflow_job_has_fork_guard() {
+    local workflow="$1"
+    local leaf_job="$2"
+
+    awk -v target="$leaf_job" '
+        BEGIN { in_job = 0; found = 0; event_guard = 0; repo_guard = 0 }
+        {
+            line = $0
+            if (!in_job) {
+                if (line ~ ("^  " target ":[ ]*(#.*)?$")) {
+                    in_job = 1
+                    found = 1
+                }
+                next
+            }
+            if (line ~ /^  [A-Za-z0-9_-]+:[ ]*(#.*)?$/) {
+                in_job = 0
+                next
+            }
+            if (index(line, "github.event_name !=") && index(line, "pull_request")) {
+                event_guard = 1
+            }
+            if (index(line, "head.repo.full_name == github.repository")) {
+                repo_guard = 1
+            }
+        }
+        END { exit(found && event_guard && repo_guard ? 0 : 1) }
+    ' "$workflow"
+}
+
+required_results_helper="scripts/verify-required-results.sh"
+aggregate_workflows=""
+for aggregate_spec in \
+    '.github/workflows/build.yml:verify' \
+    '.github/workflows/build.yaml:verify' \
+    '.github/workflows/devcontainer-build.yml:devcontainer-verify' \
+    '.github/workflows/devcontainer-build.yaml:devcontainer-verify'; do
+    aggregate_workflow="${aggregate_spec%:*}"
+    aggregate_job="${aggregate_spec##*:}"
+    [ -f "$aggregate_workflow" ] || continue
+    aggregate_workflows="${aggregate_workflows}${aggregate_workflow}:${aggregate_job}
+"
+done
+
+if [ -n "$aggregate_workflows" ]; then
+    if [ ! -f "$required_results_helper" ]; then
+        err "aggregate workflows exist but $required_results_helper is missing"
+    elif [ ! -x "$required_results_helper" ]; then
+        err "$required_results_helper must be executable because trusted aggregates run it directly"
+    else
+        required_results_contract_ok=true
+        if ! EXPECTED_RESULT=success "$required_results_helper" \
+            lint=success security=success >/dev/null 2>&1; then
+            required_results_contract_ok=false
+        fi
+        if ! EXPECTED_RESULT=skipped "$required_results_helper" \
+            lint=skipped security=skipped >/dev/null 2>&1; then
+            required_results_contract_ok=false
+        fi
+        for rejected_contract in \
+            'success lint=success security=skipped' \
+            'skipped lint=skipped security=success' \
+            'success lint=success security=failure' \
+            'success lint=success security=cancelled' \
+            'success lint=success security=unknown'; do
+            rejected_expected="${rejected_contract%% *}"
+            rejected_pairs="${rejected_contract#* }"
+            # Intentional word splitting: each fixture token is one name=result pair.
+            # shellcheck disable=SC2086
+            if EXPECTED_RESULT="$rejected_expected" "$required_results_helper" \
+                $rejected_pairs >/dev/null 2>&1; then
+                required_results_contract_ok=false
+            fi
+        done
+        if [ "$required_results_contract_ok" != true ]; then
+            err "$required_results_helper does not enforce one exact expected result for every leaf"
+        fi
+    fi
+
+    while IFS=: read -r aggregate_workflow aggregate_job; do
+        [ -n "$aggregate_workflow" ] || continue
+        if ! aggregate_job_contract_is_safe "$aggregate_workflow" "$aggregate_job"; then
+            err "$aggregate_workflow job '$aggregate_job' must enforce exact fork-skipped/trusted-success results without fork checkout or repository code"
+            continue
+        fi
+        aggregate_leaves="$(
+            awk -v target="$aggregate_job" '
+                BEGIN { in_job = 0 }
+                {
+                    if (!in_job) {
+                        if ($0 ~ ("^  " target ":[ ]*(#.*)?$")) in_job = 1
+                        next
+                    }
+                    if ($0 ~ /^  [A-Za-z0-9_-]+:[ ]*(#.*)?$/) exit
+                    print
+                }
+            ' "$aggregate_workflow" |
+                grep -oE 'needs\.[A-Za-z0-9_-]+\.result' |
+                sed -E 's/^needs\.//; s/\.result$//' | sort -u || true
+        )"
+        for aggregate_leaf in $aggregate_leaves; do
+            if ! workflow_job_has_fork_guard "$aggregate_workflow" "$aggregate_leaf"; then
+                err "$aggregate_workflow leaf '$aggregate_leaf' is aggregated as fork-skipped but lacks the same-repository PR guard"
+            fi
+        done
+    done <<<"$aggregate_workflows"
+fi
+
+# The shipped ruleset has an exact profile-derived required-check set. CodeQL is
+# fail-closed inside its workflow today, but is not merge-gating until its
+# workflow also supports merge_group and the ruleset requires codeql-verify.
+ruleset_file=".github/Branch Protection Ruleset - Protect Main.json"
+if [ -f "$ruleset_file" ]; then
+    ruleset_contexts="$(
+        sed -n -E 's/.*"context"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' \
+            "$ruleset_file" | sort -u
+    )"
+    expected_contexts="security
+verify"
+    if [ "$has_terraform" = true ]; then
+        expected_contexts="security
+terraform-verify
+verify"
+    fi
+    if [ "$ruleset_contexts" != "$expected_contexts" ]; then
+        err "$ruleset_file required checks must be verify + security$(
+            if [ "$has_terraform" = true ]; then printf '%s' ' + terraform-verify'; fi
+        ); found: $(printf '%s' "$ruleset_contexts" | tr '\n' ' ')"
+    fi
+fi
+
+# ── 3f. CodeQL selection, result truth table, and live capability ──
+# CodeQL is not universal merely because a repo contains Node/Python. The Copier
+# answer selects it, FULL_SECURITY_SCAN starts it, and GitHub must accept SARIF.
+# Public repositories have Code Security by default; private/internal repos need
+# the live feature enabled. The API check below is GET-only. Missing permissions
+# produce a manual-audit warning, never a guessed claim of coverage.
+codeql_workflow=""
+for candidate in .github/workflows/codeql.yml .github/workflows/codeql.yaml; do
+    if [ -f "$candidate" ]; then
+        codeql_workflow="$candidate"
+        break
+    fi
+done
+
+if [ -n "$codeql_workflow" ] && awk '
+    function indentation(value) {
+        match(value, /^[ ]*/)
+        return RLENGTH
+    }
+    function finish_step() {
+        if (step_is_analyze && step_continues) {
+            fail_open = 1
+        }
+        step_is_analyze = 0
+        step_continues = 0
+    }
+    BEGIN {
+        in_analyze_job = 0
+        job_indent = -1
+        steps_indent = -1
+        step_indent = -1
+        fail_open = 0
+    }
+    {
+        line = $0
+        normalized = tolower(line)
+        if (line ~ /^[[:space:]]*(#|$)/) {
+            next
+        }
+        indent = indentation(line)
+        if (!in_analyze_job) {
+            if (line ~ /^[ ]*analyze:[ ]*(#.*)?$/) {
+                in_analyze_job = 1
+                job_indent = indent
+            }
+            next
+        }
+        if (indent <= job_indent) {
+            finish_step()
+            in_analyze_job = 0
+            next
+        }
+        if (indent == job_indent + 2 &&
+            normalized ~ /^[ ]*continue-on-error:[ ]*true([ ]|$)/) {
+            fail_open = 1
+        }
+        if (indent == job_indent + 2 && line ~ /^[ ]*steps:[ ]*$/) {
+            steps_indent = indent
+            next
+        }
+        if (steps_indent >= 0) {
+            if (indent == steps_indent + 2 && line ~ /^[ ]*-[ ]/) {
+                finish_step()
+                step_indent = indent
+            }
+            if (step_indent >= 0) {
+                if (normalized ~ /uses:[ ]*github\/codeql-action\/analyze@/) {
+                    step_is_analyze = 1
+                }
+                if (normalized ~ /^[ ]*continue-on-error:[ ]*true([ ]|$)/) {
+                    step_continues = 1
+                }
+            }
+        }
+    }
+    END {
+        finish_step()
+        exit(fail_open ? 0 : 1)
+    }
+' "$codeql_workflow"; then
+    err "$codeql_workflow lets the CodeQL analyze job/action fail via 'continue-on-error: true'"
+fi
+
+if [ -n "$codeql_workflow" ] && ! awk '
+    BEGIN {
+        in_analyze = 0
+        scan_gate = 0
+        trusted_event = 0
+        trusted_repo = 0
+    }
+    {
+        line = $0
+        if (!in_analyze) {
+            if (line ~ /^  analyze:[ ]*(#.*)?$/) {
+                in_analyze = 1
+            }
+            next
+        }
+        if (line ~ /^  [A-Za-z0-9_-]+:[ ]*(#.*)?$/) {
+            in_analyze = 0
+            next
+        }
+        if (index(line, "vars.FULL_SECURITY_SCAN ==") && index(line, "true")) {
+            scan_gate = 1
+        }
+        if (index(line, "github.event_name !=") && index(line, "pull_request")) {
+            trusted_event = 1
+        }
+        if (index(line, "head.repo.full_name == github.repository")) {
+            trusted_repo = 1
+        }
+    }
+    END {
+        exit(scan_gate && trusted_event && trusted_repo ? 0 : 1)
+    }
+' "$codeql_workflow"; then
+    err "$codeql_workflow analyze job must require FULL_SECURITY_SCAN=true and a trusted same-repository event"
+fi
+
+if [ -n "$codeql_workflow" ]; then
+    codeql_result_helper="scripts/verify-codeql-result.sh"
+    if [ ! -f "$codeql_result_helper" ]; then
+        err "$codeql_workflow has no $codeql_result_helper fail-closed aggregate helper"
+    else
+        if [ ! -x "$codeql_result_helper" ]; then
+            err "$codeql_result_helper must be executable because the workflow runs it directly"
+        fi
+
+        codeql_result_contract_ok=true
+        if ! env -u FULL_SECURITY_SCAN IS_FORK=false ANALYZE_RESULT=skipped \
+            "$codeql_result_helper" >/dev/null 2>&1; then
+            codeql_result_contract_ok=false
+        fi
+        if ! env FULL_SECURITY_SCAN= IS_FORK=false ANALYZE_RESULT=skipped \
+            "$codeql_result_helper" >/dev/null 2>&1; then
+            codeql_result_contract_ok=false
+        fi
+        if ! env FULL_SECURITY_SCAN=false IS_FORK=false ANALYZE_RESULT=skipped \
+            "$codeql_result_helper" >/dev/null 2>&1; then
+            codeql_result_contract_ok=false
+        fi
+        if ! env FULL_SECURITY_SCAN=true IS_FORK=true ANALYZE_RESULT=skipped \
+            "$codeql_result_helper" >/dev/null 2>&1; then
+            codeql_result_contract_ok=false
+        fi
+        if ! env FULL_SECURITY_SCAN=true IS_FORK=false ANALYZE_RESULT=success \
+            "$codeql_result_helper" >/dev/null 2>&1; then
+            codeql_result_contract_ok=false
+        fi
+        for rejected_contract in \
+            'true false skipped' \
+            'true false failure' \
+            'true false cancelled' \
+            'false false success' \
+            'yes false skipped' \
+            'TRUE false skipped' \
+            'true false unknown'; do
+            rejected_scan="${rejected_contract%% *}"
+            rejected_rest="${rejected_contract#* }"
+            rejected_fork="${rejected_rest%% *}"
+            rejected_result="${rejected_rest#* }"
+            if env FULL_SECURITY_SCAN="$rejected_scan" IS_FORK="$rejected_fork" \
+                ANALYZE_RESULT="$rejected_result" \
+                "$codeql_result_helper" >/dev/null 2>&1; then
+                codeql_result_contract_ok=false
+            fi
+        done
+        if [ "$codeql_result_contract_ok" != true ]; then
+            err "$codeql_result_helper does not enforce the disabled/fork/enabled CodeQL result truth table"
+        fi
+    fi
+
+    for workflow_contract in \
+        'FULL_SECURITY_SCAN:' \
+        'vars.FULL_SECURITY_SCAN' \
+        'IS_FORK:' \
+        'github.event.pull_request.head.repo.full_name != github.repository' \
+        'ANALYZE_RESULT:' \
+        'needs.analyze.result' \
+        'run: ./scripts/verify-codeql-result.sh'; do
+        if ! grep -qF "$workflow_contract" "$codeql_workflow"; then
+            err "$codeql_workflow does not wire the aggregate result contract: $workflow_contract"
+        fi
+    done
+
+    # A fork PR must not make a potentially self-hosted aggregate runner check
+    # out and execute fork-controlled repository code. Trusted events may run the
+    # tested helper; forks use a tiny workflow-defined diagnostic instead.
+    if ! awk '
+        function reset_step() {
+            is_checkout = 0
+            is_helper = 0
+            is_fork_check = 0
+            trusted_event = 0
+            trusted_repo = 0
+            fork_event = 0
+            fork_repo = 0
+            defaults_scan = 0
+            validates_scan = 0
+            validates_skip = 0
+            executes_repo_code = 0
+        }
+        function finish_step() {
+            if (is_checkout && trusted_event && trusted_repo) {
+                safe_checkout = 1
+            }
+            if (is_helper && trusted_event && trusted_repo) {
+                safe_helper = 1
+            }
+            if (is_fork_check && fork_event && fork_repo && defaults_scan &&
+                validates_scan && validates_skip && !executes_repo_code) {
+                safe_fork_check = 1
+            }
+            reset_step()
+        }
+        BEGIN {
+            in_verify = 0
+            in_step = 0
+            safe_checkout = 0
+            safe_helper = 0
+            safe_fork_check = 0
+            reset_step()
+        }
+        {
+            line = $0
+            if (!in_verify) {
+                if (line ~ /^  codeql-verify:[ ]*(#.*)?$/) {
+                    in_verify = 1
+                }
+                next
+            }
+            if (line ~ /^  [A-Za-z0-9_-]+:[ ]*(#.*)?$/) {
+                finish_step()
+                in_verify = 0
+                next
+            }
+            if (line ~ /^      - /) {
+                if (in_step) {
+                    finish_step()
+                }
+                in_step = 1
+            }
+            if (!in_step || line ~ /^[[:space:]]*#/) {
+                next
+            }
+            if (line ~ /uses:[ ]*actions\/checkout@/) {
+                is_checkout = 1
+            }
+            if (line ~ /run:[ ]*\.\/scripts\/verify-codeql-result\.sh/) {
+                is_helper = 1
+            }
+            if (line ~ /name:[ ]*Check deliberate fork skip/) {
+                is_fork_check = 1
+            }
+            if (index(line, "github.event_name !=") && index(line, "pull_request")) {
+                trusted_event = 1
+            }
+            if (index(line, "head.repo.full_name == github.repository")) {
+                trusted_repo = 1
+            }
+            if (index(line, "github.event_name ==") && index(line, "pull_request")) {
+                fork_event = 1
+            }
+            if (index(line, "head.repo.full_name != github.repository")) {
+                fork_repo = 1
+            }
+            if (index(line, "scan=\"${FULL_SECURITY_SCAN:-false}\"")) {
+                defaults_scan = 1
+            }
+            if (index(line, "case \"$scan\" in")) {
+                validates_scan = 1
+            }
+            if (index(line, "ANALYZE_RESULT") && index(line, "!=") &&
+                index(line, "skipped")) {
+                validates_skip = 1
+            }
+            if (is_fork_check &&
+                (line ~ /uses:/ || line ~ /run:[ ]*(\.\/|bash |sh ).*scripts\// ||
+                 line ~ /(^|[ ])\.\/scripts\//)) {
+                executes_repo_code = 1
+            }
+        }
+        END {
+            if (in_step) {
+                finish_step()
+            }
+            exit(safe_checkout && safe_helper && safe_fork_check ? 0 : 1)
+        }
+    ' "$codeql_workflow"; then
+        err "$codeql_workflow must guard aggregate checkout/helper execution to trusted events and validate fork skips without repository code"
+    fi
+
+    # The Copier stack flags decide which languages can be rendered, but they do
+    # not prove that a repository actually contains that first-party language.
+    # Warn on source/matrix drift so an audit can choose the explicit language
+    # set rather than silently scanning only tooling or missing real code.
+    first_party_source_files="$(
+        printf '%s\n' "$repo_files" |
+            grep -vE '(^|/)(\.git|\.github|\.claude|\.codex|\.agents|node_modules|\.venv|\.terraform|vendor|dist|build|coverage|generated|_generated)/' |
+            grep -vE '(^|/)(astro|commitlint|eslint|knip|playwright|postcss|prettier|tailwind|vite|vitest|webpack)\.config\.(cjs|mjs|js|jsx|ts|tsx)$' |
+            grep -vE '(^|/)scripts/summarize-gitleaks\.mjs$' || true
+    )"
+    has_javascript_source=false
+    has_python_source=false
+    if printf '%s\n' "$first_party_source_files" |
+        grep -qE '\.(cjs|mjs|js|jsx|cts|mts|ts|tsx)$'; then
+        has_javascript_source=true
+    fi
+    if printf '%s\n' "$first_party_source_files" | grep -qE '\.py$'; then
+        has_python_source=true
+    fi
+
+    matrix_has_javascript=false
+    matrix_has_python=false
+    if grep -qF 'javascript-typescript' "$codeql_workflow"; then
+        matrix_has_javascript=true
+    fi
+    if grep -qE '(^|[^[:alnum:]_-])python([^[:alnum:]_-]|$)' "$codeql_workflow"; then
+        matrix_has_python=true
+    fi
+
+    if [ "$matrix_has_javascript" = true ] && [ "$has_javascript_source" = false ]; then
+        echo "WARN: CodeQL matrix includes javascript-typescript but no first-party JS/TS source was found." >&2
+    elif [ "$matrix_has_javascript" = false ] && [ "$has_javascript_source" = true ]; then
+        echo "WARN: first-party JS/TS source exists but CodeQL omits javascript-typescript." >&2
+    fi
+    if [ "$matrix_has_python" = true ] && [ "$has_python_source" = false ]; then
+        echo "WARN: CodeQL matrix includes python but no first-party Python source was found." >&2
+    elif [ "$matrix_has_python" = false ] && [ "$has_python_source" = true ]; then
+        echo "WARN: first-party Python source exists but CodeQL omits python." >&2
+    fi
+fi
+
+use_codeql_answer=""
+if [ -f .copier-answers.yml ]; then
+    use_codeql_answer="$(
+        sed -n -E 's/^[[:space:]]*use_codeql:[[:space:]]*([^#[:space:]]+).*$/\1/p' .copier-answers.yml |
+            tail -n 1 | tr '[:upper:]' '[:lower:]' | tr -d "\"'"
+    )"
+fi
+
+if [ -n "$codeql_workflow" ]; then
+    echo "INFO: CodeQL workflow presence and FULL_SECURITY_SCAN are configuration only;" >&2
+    echo "      verify a successful analysis/SARIF upload before claiming coverage." >&2
+
+    codeql_nwo=""
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        remote_url="$(git remote get-url origin 2>/dev/null || true)"
+        case "$remote_url" in
+        https://github.com/*)
+            codeql_nwo="${remote_url#https://github.com/}"
+            ;;
+        git@github.com:*)
+            codeql_nwo="${remote_url#git@github.com:}"
+            ;;
+        ssh://git@github.com/*)
+            codeql_nwo="${remote_url#ssh://git@github.com/}"
+            ;;
+        esac
+        codeql_nwo="${codeql_nwo%.git}"
+        codeql_nwo="${codeql_nwo%/}"
+    fi
+
+    if [ -n "$codeql_nwo" ] && have gh; then
+        if repo_security="$(gh api "repos/$codeql_nwo" \
+            --jq '[.visibility, (.security_and_analysis.code_security.status // "unknown")] | @tsv' \
+            2>/dev/null)"; then
+            IFS=$'\t' read -r visibility code_security <<<"$repo_security"
+            [ -n "$code_security" ] || code_security="unknown"
+            case "$visibility" in
+            public)
+                echo "INFO: $codeql_nwo is public; GitHub Code Security is available by default." >&2
+                ;;
+            private | internal)
+                case "$code_security" in
+                enabled)
+                    echo "INFO: $codeql_nwo reports GitHub Code Security enabled." >&2
+                    ;;
+                disabled)
+                    err "CodeQL workflow exists but $codeql_nwo is $visibility with GitHub Code Security disabled; enable it first or select use_codeql=false and remove the workflow/coverage claims"
+                    ;;
+                *)
+                    echo "WARN: $codeql_nwo is $visibility but Code Security capability is '$code_security' —" >&2
+                    echo "      verify Settings > Code security manually; do not infer CodeQL coverage." >&2
+                    ;;
+                esac
+                ;;
+            *)
+                echo "WARN: could not classify repository visibility for $codeql_nwo —" >&2
+                echo "      verify Code Security capability manually; do not infer coverage." >&2
+                ;;
+            esac
+        else
+            echo "WARN: read-only Code Security API audit failed for $codeql_nwo —" >&2
+            echo "      verify Settings > Code security manually; do not infer CodeQL coverage." >&2
+        fi
+    else
+        echo "WARN: no queryable GitHub origin/gh CLI for the CodeQL capability audit —" >&2
+        echo "      verify Code Security manually; do not infer coverage from workflow files." >&2
+    fi
+fi
+
+case "$use_codeql_answer" in
+true | yes)
+    if [ -z "$codeql_workflow" ]; then
+        err "use_codeql=true but no .github/workflows/codeql.yml or codeql.yaml exists"
+    fi
+    if [ -f docs/architecture/security.md ] &&
+        grep -qF 'CodeQL is deliberately omitted' docs/architecture/security.md; then
+        err "use_codeql=true but security docs still say CodeQL is deliberately omitted"
+    fi
+    ;;
+false | no)
+    if [ -n "$codeql_workflow" ]; then
+        err "use_codeql=false but $codeql_workflow still exists"
+    fi
+    for taskfile in Taskfile.yml Taskfile.yaml; do
+        if [ -f "$taskfile" ] && grep -qF 'FULL_SECURITY_SCAN' "$taskfile"; then
+            err "use_codeql=false but $taskfile still configures FULL_SECURITY_SCAN"
+        fi
+    done
+    if [ -f README.md ] && grep -qE 'actions/workflows/codeql\.ya?ml' README.md; then
+        err "use_codeql=false but README.md still advertises the CodeQL workflow"
+    fi
+    if [ -f docs/architecture/security.md ] &&
+        ! grep -qF 'CodeQL is deliberately omitted' docs/architecture/security.md; then
+        err "use_codeql=false but security docs do not explicitly document the SAST gap"
+    fi
+    ;;
+"")
+    if [ -n "$codeql_workflow" ]; then
+        echo "WARN: CodeQL workflow exists but .copier-answers.yml has no explicit use_codeql answer —" >&2
+        echo "      review stack + live capability on the next template update." >&2
+    fi
+    ;;
+*)
+    err "invalid use_codeql value in .copier-answers.yml: $use_codeql_answer"
+    ;;
+esac
 
 # ── 4. No unrendered template markers leaked into the repo ──────────
 # harmon-init uses CUSTOM jinja delimiters ([[ var ]], [% block %]). Legitimate
@@ -214,17 +1233,63 @@ fi
 # access-control change that must be surfaced and confirmed, never auto-applied.
 # harmon-init also freezes CODEOWNERS via _skip_if_exists; this is the belt to
 # that suspenders (and catches a hand-overwritten CODEOWNERS too). Compare the
-# @owners in the pre-adopt CODEOWNERS (on `main`) against the current one; skip
-# cleanly when there is no main, no CODEOWNERS, or not a git tree.
+# @owners in the pre-adopt CODEOWNERS (on `main`) against the current one. An
+# intentional migration is acknowledged only with an exact
+# `--ack-codeowner-change @old=@new` mapping: @old must truly be dropped and
+# @new must be present now. Extra/stale mappings fail, so this cannot become a
+# blanket bypass. Skip cleanly only when there is no main or not a git tree.
 co=".github/CODEOWNERS"
-if [ -f "$co" ] && git rev-parse --is-inside-work-tree >/dev/null 2>&1 &&
+codeowners_compared=0
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1 &&
     git cat-file -e "main:$co" 2>/dev/null; then
+    codeowners_compared=1
     before="$(git show "main:$co" 2>/dev/null | grep -oE '@[A-Za-z0-9_/-]+' | sort -u)"
-    after="$(grep -oE '@[A-Za-z0-9_/-]+' "$co" 2>/dev/null | sort -u)"
-    dropped="$(comm -23 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep -v '^$' || true)"
-    if [ -n "$dropped" ]; then
-        err "CODEOWNERS dropped owner(s) present on main: $(printf '%s ' $dropped)— adopting must NOT silently reduce access. The template's single code_owner answer can't hold multiple owners/teams; restore the dropped owner(s) and confirm the change with the user."
+    if [ -f "$co" ]; then
+        after="$(grep -oE '@[A-Za-z0-9_/-]+' "$co" 2>/dev/null | sort -u)"
+    else
+        after=""
     fi
+    dropped="$(comm -23 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep -v '^$' || true)"
+    acknowledged_old=""
+    if [ "$codeowner_ack_count" -gt 0 ]; then
+        for ack in "${codeowner_acks[@]}"; do
+            old="${ack%%=*}"
+            new="${ack#*=}"
+            if ! printf '%s\n' "$before" | grep -qxF "$old"; then
+                err "CODEOWNERS acknowledgement is stale: $old was not present on main"
+                continue
+            fi
+            if ! printf '%s\n' "$dropped" | grep -qxF "$old"; then
+                err "CODEOWNERS acknowledgement is extra: $old was not actually dropped"
+                continue
+            fi
+            if ! printf '%s\n' "$after" | grep -qxF "$new"; then
+                err "CODEOWNERS acknowledgement is not materialized: replacement $new is absent"
+                continue
+            fi
+            if printf '%s' "$acknowledged_old" | grep -qxF "$old"; then
+                err "CODEOWNERS owner acknowledged more than once: $old"
+                continue
+            fi
+            acknowledged_old="${acknowledged_old}${old}
+"
+            echo "ACK: intentional CODEOWNERS migration $old -> $new"
+        done
+    fi
+
+    unacknowledged=""
+    for owner in $dropped; do
+        if ! printf '%s' "$acknowledged_old" | grep -qxF "$owner"; then
+            unacknowledged="${unacknowledged}${owner}
+"
+        fi
+    done
+    if [ -n "$unacknowledged" ]; then
+        err "CODEOWNERS dropped owner(s) present on main without an exact migration acknowledgement: $(printf '%s ' $unacknowledged)— restore them, or repeat --ack-codeowner-change @old=@new for each intentional migration after confirming it with the user."
+    fi
+fi
+if [ "$codeowner_ack_count" -gt 0 ] && [ "$codeowners_compared" -eq 0 ]; then
+    err "CODEOWNERS acknowledgement supplied, but main has no comparable .github/CODEOWNERS"
 fi
 
 # ── Result ──────────────────────────────────────────────────────────

--- a/.claude/skills/standardize-repo/references/copier-gotchas.md
+++ b/.claude/skills/standardize-repo/references/copier-gotchas.md
@@ -22,8 +22,11 @@ state with zero warning.
 the **latest git tag**, not your working tree. All uncommitted AND committed-but-
 untagged work is silently ignored.
 
-**Rule:** Always pass `--vcs-ref=HEAD` when rendering from a local checkout for
-testing. With it, copier auto-includes dirty **and** untracked changes via a
+**Rule:** Production scaffolds use the canonical URL and a released ref, for
+example `copier copy --trust --vcs-ref=v3.26.1
+https://github.com/evanharmon1/harmon-init.git <dest>`. Pass `--vcs-ref=HEAD`
+only when rendering from a local checkout into a disposable preview/test. With
+it, copier auto-includes dirty **and** untracked changes via a
 throwaway `wip` commit in a temporary clone (you'll see a `DirtyLocalWarning`). Your
 real working tree is never touched. `scripts/test-template.sh` always passes
 `--vcs-ref=HEAD` — mirror that for any manual render of work-in-progress.
@@ -189,15 +192,15 @@ copy`. If the repo was scaffolded with a **relative or machine-local path** (e.g
 harmon-init`), that string doesn't resolve to a git repo from the target's directory
 later, so copier can't find a git-tracked template to diff against.
 
-**Rule:** Record a **globally resolvable** `_src_path` — the GitHub URL
-`https://github.com/evanharmon1/harmon-init` (works on any machine and in CI). When
-adopting/auditing an existing repo whose `_src_path` is relative or local-absolute,
-normalize it **before** running `copier update`:
-
-```bash
-# one-time fix, committed; copier overwrites _src_path on its next run anyway
-yq -i '._src_path = "https://github.com/evanharmon1/harmon-init"' .copier-answers.yml
-```
+**Rule:** Record a durable lineage tuple: a globally resolvable `_src_path`
+(`https://github.com/evanharmon1/harmon-init.git`) **and** an `_commit` reachable
+from that source. Never normalize only `_src_path` without first proving the
+recorded commit exists on the canonical remote. A dirty local `--vcs-ref=HEAD`
+render may record a Copier-created throwaway commit that no remote clone can
+resolve; changing the path disguises rather than repairs that broken base. Use the
+local render only as a preview, then re-render/re-adopt from the canonical URL at
+a released ref. If a deliberately pushed pre-release commit is used, verify its
+remote reachability and commit both lineage fields together.
 
 This is independent of `--vcs-ref` (gotcha 1): `--vcs-ref` picks *which ref* of the
 source to render; `_src_path` is *where the source is*. A local checkout is fine for
@@ -209,8 +212,8 @@ updatable everywhere.
 ## Quick checklist when touching the template
 
 - Rendering local WIP to test? → `--vcs-ref=HEAD`.
-- Generated repo must stay updatable? → committed `_src_path` is the GitHub URL, not
-  a relative/local path (gotcha 8).
+- Generated repo must stay updatable? → `_src_path` is canonical **and** `_commit`
+  is reachable from it; never rewrite the path alone (gotcha 8).
 - New templating? → `[[ ]]` / `[% %]` / `[# #]`; POSIX `[ ]` in shell; `[% endif +%]`
   inline.
 - New side-effect question? → default `no`.

--- a/.claude/skills/standardize-repo/references/mode-adopt-existing.md
+++ b/.claude/skills/standardize-repo/references/mode-adopt-existing.md
@@ -6,8 +6,8 @@ Copier template to a repo that **already has app code**. The hard rule: this is 
 **never blind-clobber existing app code.** Read each conflict, prefer merging, and
 work on a feature branch the whole time.
 
-For Copier mechanics (custom `[[ ]]`/`[% %]` jinja delimiters, the load-bearing
-`--vcs-ref=HEAD`, `--trust`, side-effect answers) see
+For Copier mechanics (custom `[[ ]]`/`[% %]` jinja delimiters, released production
+refs versus local-preview `--vcs-ref=HEAD`, `--trust`, side-effect answers) see
 [`copier-gotchas.md`](./copier-gotchas.md). For the GitHub-side wiring after the
 files land (branch ruleset import, Renovate/CodeRabbit apps, Actions secrets, etc.)
 see [`post-generation-checklist.md`](./post-generation-checklist.md).
@@ -109,9 +109,10 @@ copier update --trust --defaults
 to prompt (`OSError: [Errno 22]`). See [`mode-update.md`](./mode-update.md) §2.
 
 `copier update` takes no source argument — it reuses the `_src_path` recorded in
-`.copier-answers.yml`, which must be a **resolvable git URL** (see
-[copier-gotchas.md](./copier-gotchas.md) gotcha 8; normalize it first if it's a
-relative/local path). **Always do a full update to the latest released version** —
+`.copier-answers.yml`, whose `_src_path` and `_commit` must form a resolvable
+lineage tuple (see [copier-gotchas.md](./copier-gotchas.md) gotcha 8; never
+normalize only a local path unless the recorded commit is reachable from the
+canonical remote). **Always do a full update to the latest released version** —
 plain `copier update` goes to harmon-init's newest tag and three-way-merges the whole
 delta into your files; don't scope it to a specific intermediate version. Override
 stale answers with `--data key=value` as needed (e.g. a changed `github_org`).
@@ -130,11 +131,14 @@ write `.copier-answers.yml` so future runs can use `copier update`:
 
 ```bash
 ls .copier-answers.yml          # absent → adopt fresh
-copier copy --trust ~/git/harmon-init . --vcs-ref=HEAD --defaults --overwrite \
+: "${USE_CODEQL:?set USE_CODEQL=true or false after the capability review}"
+copier copy --trust https://github.com/evanharmon1/harmon-init.git . \
+  --vcs-ref=v3.26.1 --defaults --overwrite \
   --data project_type="$PROJECT_TYPE" \
   --data project_name="<Formal Project Name>" \
   --data project_slug="$(basename "$(pwd)")" \
   --data github_org="<org-or-user>" \
+  --data use_codeql="$USE_CODEQL" \
   --data git_init=false \
   --data github_remote_create=false --data github_release_init=false \
   --data bunch_add=false --data obsidian_project_add=false --data run_task_install=false
@@ -142,9 +146,16 @@ copier copy --trust ~/git/harmon-init . --vcs-ref=HEAD --defaults --overwrite \
   #   defaults from the stale .copier-answers.yml, so they do NOT "default to no".
 ```
 
-`--vcs-ref=HEAD` is **mandatory** here when `~/git/harmon-init` is a local path:
-without it copier silently renders the latest git tag and ignores
-committed-but-untagged + uncommitted template work.
+`v3.26.1` is the current reviewed release example; deliberately select a newer
+released ref when appropriate. Local `--vcs-ref=HEAD` adoption is for a disposable
+preview only, never the production apply: dirty local renders can record a
+throwaway `_commit` that no later remote update can resolve.
+
+Set `USE_CODEQL` deliberately before rendering. Use `true` only for a supported
+Node/Python stack when Code Security is available (public repositories have it by
+default; inspect private/internal repositories with the read-only check in
+[`mode-audit.md`](./mode-audit.md), drift class G). Otherwise use `false`; do not
+render a workflow whose SARIF upload cannot succeed.
 
 `--defaults` is **required non-interactively** (no TTY → `OSError: [Errno 22]`), and
 because copier can't prompt per-file, `--overwrite` makes the run deterministic
@@ -177,6 +188,12 @@ from git rather than hand-merging conflict markers:
      security regression, not a tooling sync. (harmon-init ≥ the CODEOWNERS-freeze
      change keeps it via `_skip_if_exists`, and `verify-applied.sh` FAILS if an
      owner present on `main` is missing post-adopt — but check it by hand too.)
+     For a user-confirmed replacement, pass
+     `--ack-codeowner-change @old=@new` to `verify-applied.sh`, repeating the
+     exact mapping for each dropped owner. The verifier checks that `@old`
+     existed on `main` and is now absent, that `@new` is present now, and
+     rejects stale, extra, malformed, or non-materialized mappings. There is no
+     blanket access-control bypass.
    - **If you restore a customized `Taskfile.yml` but keep the template's
      workflows, reconcile the contract.** The template's `.github/workflows/*`
      delegate to `task` targets (e.g. `test:tasks`, `test:hooks`,
@@ -187,8 +204,10 @@ from git rather than hand-merging conflict markers:
      `grep -rhoE '(run:[[:space:]]*|^[[:space:]]*|&&[[:space:]]*)task +[a-z][a-z0-9:_-]*' .github/workflows/ | sed -E 's/.*task +//' | sort -u`.
      `verify-applied.sh` §3c enforces this (see [mode-audit.md](./mode-audit.md)
      drift class L).
-3. **Keep** the template version for uncustomized tooling **and all additive new
-   files** (docs scaffold, codeql/release-please, helper scripts, `.copier-answers.yml`).
+3. **Keep** the template version for uncustomized tooling **and all applicable
+   additive new files** (docs scaffold, release-please, helper scripts,
+   `.copier-answers.yml`; CodeQL only when `use_codeql=true` and the live
+   capability supports it).
 4. **Canonicalize AGENTS.md** — fold the old real guidance (often the pre-existing
    real `CLAUDE.md`) into `AGENTS.md`; leave `CLAUDE.md`/`GEMINI.md`/
    `.github/copilot-instructions.md` as the symlinks copier wrote (§4.1).
@@ -233,8 +252,8 @@ When in genuine doubt about a specific file, keep the existing version and leave
 
 ## 4. Reconciliation steps specific to existing repos
 
-These are the recurring drifts harmon-init exists to fix (source:
-`harmon-init/docs/sourceRepoFollowUps.md`). Walk each one after the copier run:
+These are the recurring drifts observed across existing repos. Walk each one
+after the copier run:
 
 1. **AGENTS.md is canonical; everything else symlinks to it.** The template ships
    `AGENTS.md` as the real file with `CLAUDE.md`, `GEMINI.md`, and
@@ -332,14 +351,14 @@ These are the recurring drifts harmon-init exists to fix (source:
    `diff-template.sh` to report those files as DRIFT + `prettier.config.cjs`
    as MISSING — both intentional.
 
-   **Normalize `.copier-answers.yml` after a local-path render.** Rendering
-   with `--vcs-ref=HEAD` from a *dirty* local template checkout records a
-   throwaway `_commit` describe-string (e.g. `v3.16.0-3-g<sha>` — a commit
-   that exists in no clone), which breaks the next `copier update` (the
-   three-way-merge base ref is unresolvable). Post-adopt, reset both keys:
-   `_commit` → the real released tag the render corresponds to (e.g.
-   `v3.16.0`), `_src_path` → the GitHub URL (gotcha 8). If the render
-   included commits past that tag, the next update harmlessly re-offers them.
+   **Preserve a truthful `.copier-answers.yml` lineage tuple.** A dirty local
+   `--vcs-ref=HEAD` preview can record a throwaway `_commit` that exists in no
+   clone. Do not relabel that output by changing `_src_path` or substituting a
+   nearby release tag: either action makes the recorded base differ from what
+   was rendered. Re-run the production adoption from the canonical URL at the
+   reviewed release. Only a deliberately pushed pre-release commit is eligible
+   for promotion, after proving `_commit` is reachable from the canonical remote
+   and verifying both lineage fields together.
 
    **Four traps that block the first commit/push after a v2→v3 render:**
    (a) **Stale pre-commit.com hook** — deleting `.pre-commit-config.yaml` leaves the

--- a/.claude/skills/standardize-repo/references/mode-audit.md
+++ b/.claude/skills/standardize-repo/references/mode-audit.md
@@ -31,14 +31,17 @@ TEMPLATE=~/git/harmon-init           # source of truth
    template: look for `.copier-answers.yml` at the target root.
    - Present → it can be reconciled with `copier update --trust` (it records
      `_commit` / `_src_path`). Note the recorded commit; drift is "template moved
-     ahead since then." **Also check `_src_path` is a resolvable git URL** — if it's
-     a relative/machine-local path (e.g. `harmon-init`), `copier update` aborts with
-     `Updating is only supported in git-tracked templates`; normalize it to
-     `https://github.com/evanharmon1/harmon-init` first (a real finding — see
+     ahead since then." **Also check `_src_path` and `_commit` form a resolvable
+     lineage tuple.** A relative/machine-local path can make `copier update` abort
+     with `Updating is only supported in git-tracked templates`, but do not
+     rewrite the path alone unless the recorded commit is reachable from the
+     canonical remote (a real finding — see
      [copier-gotchas.md](./copier-gotchas.md) gotcha 8 / [mode-update.md](./mode-update.md) §2).
    - Absent → it was never templated (or was adopted by a raw `copier copy`).
      Reconciling the templated bits means a fresh adopt:
-     `copier copy --trust ~/git/harmon-init . --vcs-ref=HEAD` (see §4). Treat
+     `copier copy --trust --vcs-ref=v3.26.1
+     https://github.com/evanharmon1/harmon-init.git .` (substitute the reviewed
+     current release; see §4). Treat
      every catalog area as hand-verifiable rather than diff-against-answers.
 
 2. **Walk each catalog area against the target.** For every area in
@@ -67,7 +70,7 @@ TEMPLATE=~/git/harmon-init           # source of truth
    # Renovate/version-pin annotations (drift class C)
    grep -rnE 'GITLEAKS_VERSION|setup-task|# renovate:' "$TARGET/.github/workflows/" 2>/dev/null
 
-   # Required status checks / merge_queue in the ruleset (drift class D)
+   # Required checks and account-appropriate merge_queue policy (drift class D)
    find "$TARGET/.github" -iname '*ruleset*'
    ```
 
@@ -75,7 +78,7 @@ TEMPLATE=~/git/harmon-init           # source of truth
    signal of conformance (they are themselves part of the standard):
 
    ```bash
-   ( cd "$TARGET" && task verify )    # check (lint) -> test:template
+   ( cd "$TARGET" && task verify )    # repo's fast check/build/validate/guard gate
    ( cd "$TARGET" && task security )  # secrets (gitleaks) + audit
    ```
 
@@ -127,9 +130,8 @@ hand-edit, and the verification command set from §4.
 ## 3. Common drift classes to check
 
 These are the recurring divergences observed when porting real repos onto the
-template (seeded from `~/git/harmon-init/docs/sourceRepoFollowUps.md`). Treat the
-list as a checklist of likely findings — confirm each against the target before
-reporting, and map each to its catalog area.
+template. Treat the list as a checklist of likely findings — confirm each
+against the target before reporting, and map each to its catalog area.
 
 **A. AGENTS.md symlink direction.** Canonical layout: `AGENTS.md` is the real
 file; `CLAUDE.md`, `GEMINI.md`, **and `.github/copilot-instructions.md`** are
@@ -169,21 +171,29 @@ template `build.yml`; do **not** hardcode a version from this doc — read the l
 value from `$TEMPLATE/.github/workflows/build.yml`. Severity: **should** (blocker
 if an unpinned/missing tool breaks the `security` job).
 
-**D. Stale branch ruleset / old job names / missing `merge_queue`.** Canonical
+**D. Stale branch ruleset / old job names / wrong `merge_queue` policy.** Canonical
 ruleset (`template/.github/Branch Protection Ruleset - Protect Main.json`) requires
-exactly two status-check contexts — **`verify`** and **`security`** — plus a
-**`merge_queue`** rule. Old repos reference retired job names (`secrets`,
-`validate`, `build-homepage`) and lack the merge-queue rule. Note this drift can
+the baseline contexts **`verify`** and **`security`**, plus
+**`terraform-verify`** exactly when `include_terraform=true`, and
+**`codeql-verify`** when `use_node or use_python` generates CodeQL. The
+**`merge_queue`** rule is conditional: org repos
+(`github_org != author_git_provider_username`) get it; personal-account repos do
+not. Missing it is drift only for an org repo, while adding it to a personal repo
+is itself drift. Old repos may reference retired job names (`secrets`, `validate`,
+`build-homepage`) or carry the wrong account-type variant. Note this drift can
 also live in *prose*: even the harmon-init root `docs/architecture/branch-protection.md`
 still narrates the old `secrets`/`validate`/`build-homepage` contexts while the
-shipped ruleset JSON is already `verify`+`security` — so check the JSON, not just
-the doc. Relatedly, ambiguous `verify` contexts: if both `build.yml` and the
+shipped non-Terraform ruleset JSON is already `verify`+`security` — so check the
+rendered JSON, not just the doc. Relatedly, ambiguous `verify` contexts: if both
+`build.yml` and the
 devcontainer workflow define a job literally named `verify`, either can satisfy
 the required check — the template renames the devcontainer job to
 **`devcontainer-verify`**. Fix: re-import the ruleset via the GitHub UI
-(Settings → Rules → Rulesets → **Import a ruleset**; avoid `gh api … rulesets`,
-which is non-idempotent and rejects the `merge_queue` rule), rename the
-devcontainer job, and align CI job names to `verify` + `security`.
+(Settings → Rules → Rulesets → **Import a ruleset**) and choose the rendered
+ruleset for the repo's account type. REST supports `merge_queue`, but a blind
+`POST` is non-idempotent and can create duplicate rulesets; automation must
+discover exactly one matching live ruleset and `PUT` that ruleset's id. Rename
+the devcontainer job and align CI job names to the rendered required-check set.
 Severity: **blocker** (wrong contexts mean the gate is unenforced or unsatisfiable).
 
 **E. YAML file extensions — NOT drift; do not flag.** `.yml` vs `.yaml` is left
@@ -206,6 +216,17 @@ GitHub Code Security is an explicit `FULL_SECURITY_SCAN=true` opt-in. Fix: add
 `codeql.yml`, `scripts/run-semgrep.sh`, and the visibility-aware `build.yml` /
 Taskfile targets from the template (a re-template with the right answers includes
 them). Severity: **should**.
+
+Presence of the workflow alone is not coverage. The analyze job/action must not use
+`continue-on-error`; public and paid-private analyses must succeed, while the
+stable `codeql-verify` aggregate may accept `skipped` only for a free-private
+route or an untrusted fork. That fork aggregate must not check out or execute
+fork-controlled repository code on the aggregate runner. Treat unset/empty
+`FULL_SECURITY_SCAN` as the free-private opt-out, and verify the language matrix
+against real first-party source rather than tooling flags. When a legacy
+`.copier-answers.yml` has no `use_codeql` field, infer the intended route from
+the workflow, repository visibility, live Code Security capability, and actual
+source before changing it.
 
 **G2. Snyk policy drift.** Snyk is not required PR CI. The default Copier answer
 is `snyk_scan_schedule=off`, with manual/local second-opinion targets named
@@ -258,7 +279,7 @@ devcontainer `Dockerfile` if one exists. Severity: **blocker** if the missing
 tool makes a routine `task` target fail on a host (e.g. bare `task` → `tv`);
 **should** if the task degrades gracefully (e.g. `status` without `gum`).
 
-**Also seeded from sourceRepoFollowUps (verify per repo):** legacy-bloated
+**Additional recurring findings (verify per repo):** legacy-bloated
 `Brewfile` (deprecated formulae, missing gitleaks/yamllint/actionlint); CI that
 reinstalls lint tools inline every run instead of using the prebuilt devcontainer
 image / a composite action; auto-release-on-merge `release.yml` (standard is
@@ -300,6 +321,11 @@ It renders harmon-init **at the repo's own `_commit`** (from its
 `MISSING` scan walks the whole render and is **manifest-independent**, so a file the
 template added after the curated list was last edited — or one a hand-reconciled
 update dropped — is still caught (`.gitkeep` dir-stubs show as benign `ABSENT`).
+An absent tracked path that still exists in the index is compared from an index
+snapshot, so a transient, unstaged working-tree deletion does not create false
+drift; once the deletion is staged it is real `MISSING`. Mature nested Terraform
+roots and an established or renumbered ADR log are reported as benign `EQUIV`
+instead of false `MISSING` and do not affect the exit status.
 Because the render is at `_commit`, each **`DRIFT`** is the repo's **local
 customization** relative to its own baseline — or a **regression** where a past
 hand-reconcile dropped a same-baseline improvement (the status.sh / lint-hygiene /
@@ -310,20 +336,21 @@ reconciling **in place** (keep it in its normal file — do not extract it elsew
 required gate, e.g. a non-portable `lint-hygiene.sh`). Run this as a standard step of
 every audit.
 
-**Known false-`MISSING` categories — verify before "fixing".** Some `MISSING`
-findings are legitimate divergences, not gaps; re-adding the template's version is
-wrong. The recurring ones (nearly every iac/dotfiles repo hit ≥1):
+**Recognized equivalents and remaining false-`MISSING` categories — verify
+before "fixing".** Some apparent gaps are legitimate divergences, not missing
+standards; re-adding the template's seed is wrong. The recurring ones:
 
 - **chezmoi `private_`/`dot_` prefix** — a dotfiles repo names the template's root
   `Brewfile` `private_Brewfile` (→ `~/Brewfile`), so `Brewfile` reads `MISSING`. Add
   a root `Brewfile` per [mode-adopt-existing.md](./mode-adopt-existing.md) §4.7, not
   a "restored" copy.
 - **ADR renumbering** — the seed `docs/decisions/0001-record-architecture-decisions.md`
-  shows `MISSING` when the repo renumbered it (its `0001`/`0002` are real decisions).
-  Don't re-add — it would duplicate.
+  is `EQUIV` when the repo carries a renumbered record-decisions ADR or already
+  has a README-backed numbered ADR log. Don't re-add — it would duplicate.
 - **Replaced terraform skeleton** — an iac repo with real infra (e.g.
   `terraform/environments/…`) deleted the template's flat
-  `terraform/{main,variables,outputs}.tf` skeleton. `MISSING`, but correct — leave it.
+  `terraform/{main,variables,outputs}.tf` skeleton. Nested `*.tf` roots make
+  these seed paths `EQUIV`; leave the real layout in place.
 - **Gitignored `.envrc`** — a repo that resolves `.envrc`/`.envrc.local` from an
   `.envrc.tpl` via `op inject` gitignores the resolved file, so it reads `MISSING`.
   Leave it (it's the secure pattern the template now ships).
@@ -335,7 +362,7 @@ wrong. The recurring ones (nearly every iac/dotfiles repo hit ≥1):
   versions, so nothing is added and no dead second config results. Confirm the repo
   actually has a `.prettierrc*`/`prettier` package.json key, then leave it.
 
-**L. Workflow ↔ Taskfile contract.** Every `task <target>` referenced in
+**L. Workflow ↔ Taskfile/runtime contract.** Every `task <target>` referenced in
 `.github/workflows/*.yml` must exist in `Taskfile.yml`. CI's `lint`/`build` jobs
 call targets `task verify` never runs (e.g. `test:tasks`, `test:hooks`,
 `test:devcontainer:permissions`), so a Taskfile that drifted from the template —
@@ -355,6 +382,82 @@ grep -rhoE '(run:[[:space:]]*|^[[:space:]]*|&&[[:space:]]*)task +[a-z][a-z0-9:_-
 their `scripts/*.sh` helpers from the template (or reconcile the preserved Taskfile
 against the adopted workflows). Severity: **blocker** (the gate is unenforced and CI
 is unsatisfiable until the targets exist).
+
+A repo-specific test is a gate only when all three links exist: the root
+`Brewfile`/`task install` provides its runtime locally, the workflow provisions
+that runtime in CI, and the workflow invokes `task test` (or the specific target)
+rather than a narrower `test:tasks`. Check this manually for every added test;
+this audit found both Copier-backed skill tests and a chezmoi render test that
+passed locally but were initially unreachable or unprovisioned in CI.
+
+Target names are also insufficient to prove workflow semantics. Compare the
+`on` events/inputs and each job's `if`, `needs`, permissions, and side effects
+against the pre-update workflow. In particular, preserve intentional
+`workflow_dispatch` deploy/apply paths and their guards; YAML/actionlint can be
+green while a Terraform apply path has silently disappeared.
+
+For every aggregate job under `if: always()`, inspect its result reduction.
+Generic `success || skipped` acceptance is fail-open. A fork PR must require every
+fork-suppressed leaf to be exactly `skipped` in a workflow-inline diagnostic that
+does not check out or execute repository-controlled code. Same-repository and
+non-PR events must require every required leaf to be exactly `success`.
+Conditionally disabled leaves may skip only when the aggregate derives that exact
+expectation from the same explicit change/enabled predicates. Apply this contract
+to both build `verify` and `devcontainer-verify`; reject cancellation, timeout,
+unexpected skip/success, and unknown states.
+
+For Python CI that consumes an existing `uv.lock`, distinguish validation from
+mutation. Exports must use `uv export --locked`; syncs must use
+`uv sync --locked` (or first run `uv lock --check`). `--frozen` skips the
+freshness check. Treat a stale lock or a tracked lock rewrite as a blocker; keep
+lock creation and updates in explicit local/update workflows.
+
+When `runs-on` is variable-controlled (for example, `CI_RUNS_ON`), audit both
+repository visibility and event trust. Every public `pull_request` job must
+resolve to a GitHub-hosted runner. A same-repository job guard is defense in
+depth, not a complete trust boundary. Self-hosted use in private/trusted repos or
+on trusted push/dispatch events also needs server-side repository-scoped runner
+groups and clean ephemeral/JIT isolation; otherwise treat it as a blocker. This
+is currently a manual residual: do not assume the template's configurable
+`runs-on` expression mechanically enforces the hosted-only public-PR policy.
+
+For a Terraform-capable repo (`include_terraform=true` or real first-party `.tf`
+files), prove the local/CI lint chain before reviewing mutation. Both
+`task --dry check` and `task --dry lint:terraform` must reach format check,
+TFLint, Renovate-pinned Checkov through `uvx --from`, and the provider-lock check. The
+root `Brewfile` must provision Terraform/TFLint/uv locally, and the build workflow
+must provision the same capabilities before the shared task runs. Task names or
+documentation without command/tool reachability are not coverage.
+
+Then trace the Terraform workflow chain: change detection → validation → saved
+plan → exact-plan apply → aggregate. A tracked `.terraform.lock.hcl` makes CI init
+use `-lockfile=readonly`, but file presence alone says nothing about platform
+checksums. Require `scripts/terraform-provider-locks.sh`: lint calls `check`, the
+explicit `terraform:providers:lock` mutation task calls `update`, and the helper
+targets exactly `darwin_arm64` + `linux_amd64` in a scratch copy. Run its hermetic
+regression and prove update initialization receives `-upgrade` while check
+initialization does not; otherwise a constraint bump beyond the committed lock
+fails before `providers lock`, or check mode compares against upgraded selections
+instead of the committed-lock semantics. A fresh no-provider scaffold may skip
+cleanly. Only explicit fresh scaffolding may create the first lock, while an
+intentional local provider update may refresh it.
+Plan/apply must be downstream of validation, guarded/namespaced to the trusted
+run, and apply must refuse to re-plan if the private run-scoped saved plan is
+absent. Confirm the summary displays that same plan, state-lock waits are bounded
+(never `-lock=false`), and cleanup runs under `if: always()`.
+
+A required `terraform-verify` must always emit on `push`, `pull_request`,
+`merge_group`, and `workflow_dispatch`, including unrelated-path no-ops; use an
+internal change detector, not workflow-level path filters. Derive every accepted
+`skipped` result from explicit fork/change/enabled predicates and reject all
+other states. Agents must also retain the exact-operation approval rule for
+Terraform mutation; only the reviewed trusted-main exact-plan CI path is exempt.
+
+On workflows that may use self-hosted runners, reject shared fixed `/tmp`
+filenames for sensitive or cross-step artifacts (especially saved Terraform
+plans). Use a private per-repo/run directory beneath `${{ runner.temp }}`,
+propagate the exact path, and clean it up so concurrent or later jobs cannot
+read, replace, or collide with it.
 
 ---
 
@@ -384,14 +487,15 @@ Apply fixes on a branch, prefer re-templating for files copier owns, then verify
      - Never templated / adopting fresh:
 
        ```bash
-       ( cd "$TARGET" && copier copy --trust ~/git/harmon-init . --vcs-ref=HEAD )
+       ( cd "$TARGET" && copier copy --trust --vcs-ref=v3.26.1 \
+           https://github.com/evanharmon1/harmon-init.git . )
        ```
 
-     `--vcs-ref=HEAD` is **load-bearing**: from a local path copier otherwise
-     renders the latest git tag and silently ignores committed-but-untagged work;
-     with it, copier includes dirty/untracked template changes via a throwaway
-     commit in a temp clone (your template working tree is untouched). Answer the
-     questions to match the repo, and keep all side-effectful answers
+     Replace `v3.26.1` only with a deliberately selected newer release. A local
+     `--vcs-ref=HEAD` render is appropriate for a disposable pre-release preview,
+     not the production adoption, because dirty work can record an unreachable
+     throwaway commit. Answer the questions to match the repo, and keep all
+     side-effectful answers
      (`github_remote_create`, `github_release_init`, `bunch_add`,
      `obsidian_project_add`, `run_task_install`) at their **no** defaults so the
      adopt has no side effects. Review the resulting diff carefully and discard
@@ -407,12 +511,13 @@ Apply fixes on a branch, prefer re-templating for files copier owns, then verify
 3. **Verify locally.** Run the same gates the standard requires, from the target:
 
    ```bash
-   ( cd "$TARGET" && task verify )    # check (lint) -> test:template
+   ( cd "$TARGET" && task verify )    # repo's fast check/build/validate/guard gate
    ( cd "$TARGET" && task security )  # gitleaks + dependency audit
    ```
 
-   Fix anything red and re-run until clean. (`task verify` ≙ `task check` +
-   `task test:template`; `task ci` additionally chains `test` and `security`.)
+   Fix anything red and re-run until clean. The exact fast targets are
+   profile/repo-specific; `task ci` additionally chains the heavier `test` and
+   `security` aggregates.
 
 4. **Run the applied-state verifier.** Confirm the audited drift classes are
    actually resolved by running the skill's checker:

--- a/.claude/skills/standardize-repo/references/mode-new-repo.md
+++ b/.claude/skills/standardize-repo/references/mode-new-repo.md
@@ -15,8 +15,9 @@ Verify before running anything:
 - [ ] **Tools installed:** `copier` (>= 9.4.0, per `_min_copier_version`),
       `git`, and — if you will create the remote or release — `gh` (GitHub CLI,
       authenticated: `gh auth status`).
-- [ ] **Template available locally.** Default location is `~/git/harmon-init`.
-      If absent, clone it: `git clone https://github.com/evanharmon1/harmon-init ~/git/harmon-init`.
+- [ ] **Released template ref chosen.** Production scaffolds use the canonical
+      GitHub source and a reviewed release such as `v3.26.1`. A local checkout is
+      needed only to inspect source or preview unreleased work.
 - [ ] **Destination does not already exist / is empty.** Copier writes into
       `<dest>`; pick a path that is free.
 - [ ] **Hidden author/org defaults are correct for you.** Identity, org info,
@@ -33,15 +34,15 @@ The `--trust` flag is required: it allows copier to run the `_tasks` (git init,
 commit, etc.) defined in `copier.yml`.
 
 ```bash
-copier copy ~/git/harmon-init <dest> --trust --vcs-ref=HEAD
+copier copy https://github.com/evanharmon1/harmon-init.git <dest> \
+  --trust --vcs-ref=v3.26.1
 ```
 
-(`harmon-init` here is the template source — usually a local checkout like
-`~/git/harmon-init`. **From a local path, always pass `--vcs-ref=HEAD`** — without
-it copier renders the **latest git tag** and silently ignores any
-committed-but-untagged *and* uncommitted template work, the trap detailed in
-`copier-gotchas.md`. Omit `--vcs-ref=HEAD` only when you deliberately want the last
-tagged release, or when sourcing the template by its GitHub URL/a pinned tag.)
+`v3.26.1` is the current reviewed example; replace it when a newer release has
+been deliberately selected. Do not use a moving branch for production lineage.
+For an unreleased template preview only, a developer may render a local checkout
+with `--vcs-ref=HEAD` into a disposable destination. That preview can contain a
+Copier-created throwaway commit and must not be promoted as a production scaffold.
 
 Copier prompts for each asked question. Answer them; everything else falls back
 to the hidden defaults.
@@ -53,7 +54,8 @@ questions all default to `no`, so omitting them is safe in CI. Add `--defaults`
 to accept the default for any key you do not pass.
 
 ```bash
-copier copy harmon-init <dest> --trust --defaults \
+copier copy https://github.com/evanharmon1/harmon-init.git <dest> \
+  --trust --vcs-ref=v3.26.1 --defaults \
   --data project_name="My Project" \
   --data project_slug="my-project" \
   --data project_description="One-line description of the project" \
@@ -61,6 +63,7 @@ copier copy harmon-init <dest> --trust --defaults \
   --data project_type="general" \
   --data include_terraform=false \
   --data include_ansible=false \
+  --data use_codeql=false \
   --data ci_runner="ubuntu-latest" \
   --data license="mit" \
   --data use_release_please=true \
@@ -84,6 +87,7 @@ copier copy harmon-init <dest> --trust --defaults \
 | `project_type` | str | `general` | `general` \| `web-astro` \| `web-app` \| `iac` \| `docs`. Drives Taskfile, CI jobs, devcontainer tooling. |
 | `include_terraform` | bool | `true` iff `project_type == 'iac'` | Adds `terraform/` skeleton + terraform linting. |
 | `include_ansible` | bool | `true` iff `project_type == 'iac'` | Adds `ansible/` skeleton + ansible linting. |
+| `use_codeql` | bool | `true` iff derived `use_node` or `use_python` | Includes CodeQL SAST; explicitly override the tooling-derived default when planned source or capability does not support it. Public repositories have Code Security by default; for a private/internal repo, enable GitHub Code Security first or answer `false`. |
 | `ci_runner` | str | `ubuntu-latest` | `ubuntu-latest` \| `self-hosted`. |
 | `license` | str | `mit` | `mit` \| `private`. |
 | `use_release_please` | bool | `true` | release-please rolling release PR + auto CHANGELOG. |
@@ -98,6 +102,13 @@ copier copy harmon-init <dest> --trust --defaults \
 Notes:
 - Several defaults are *computed* from earlier answers. Setting `project_type=iac`
   flips `include_terraform`/`include_ansible` to `true` unless you override them.
+- Decide `use_codeql` explicitly whenever first-party JS/TS/Python is planned. A
+  generated workflow and `FULL_SECURITY_SCAN=true` configure CodeQL but do not
+  prove that SARIF was accepted; private/internal repos also require the live Code
+  Security capability. The current template derives the matrix from `use_node` /
+  `use_python`, which are tooling flags rather than source evidence, so reconcile
+  the rendered languages with the real source until harmon-init exposes an
+  explicit `codeql_languages` multiselect/override.
 - Hidden, derived flags you do **not** answer but that follow from your choices:
   `use_node` (true for `web-astro`/`web-app`), `use_python` (true for `iac` or
   `include_ansible`), `repo_url`, `devcontainer_image`, `ci_runner_labels`.
@@ -128,27 +139,23 @@ If you left the side-effectful answers at their `no` defaults (the CI-safe,
 recommended path for unattended generation), only steps 1–2 run and you finish
 setup manually in the next section.
 
-## 4a. Normalize `_src_path` (local-path renders) — REQUIRED for updatability
+## 4a. Verify durable Copier lineage
 
-When you rendered from a **local checkout** (`copier copy ~/git/harmon-init …`),
-copier records that machine-local path as `_src_path` in the generated
-`.copier-answers.yml`, and the auto-run genesis commit (§4, task 2) captures it.
-A relative/local `_src_path` makes a later `copier update` abort with *"Updating
-is only supported in git-tracked templates"* (`copier-gotchas.md` §8) — the repo
-can pass every gate yet never accept a template update. Rewrite it to the
-canonical GitHub URL and fold the fix into the genesis commit **before the first
-push**:
+The production command above records both the canonical `_src_path` and the
+released `_commit` in `.copier-answers.yml`. Treat those fields as one lineage
+tuple and verify both before the first push:
 
 ```bash
-cd <dest>
-yq -i '._src_path = "https://github.com/evanharmon1/harmon-init"' .copier-answers.yml
-git add .copier-answers.yml && git commit --amend --no-edit   # fold into the genesis scaffold commit
+grep -E '^(_src_path|_commit):' .copier-answers.yml
 ```
 
-Skip this only if you rendered from the GitHub URL directly (then `_src_path` is
-already the URL). If the remote was **already** created/pushed (you set
-`github_remote_create=true`), don't amend — make it a normal follow-up commit
-instead. Always verify: `grep _src_path .copier-answers.yml` should show the URL.
+If a repo was rendered from a local checkout, **do not rewrite only `_src_path`**.
+A dirty `--vcs-ref=HEAD` render may record a temporary commit that is not reachable
+from the canonical remote, leaving the next `copier update` unable to reconstruct
+its base. Use that render only as a preview, then re-render/re-adopt production
+from the canonical URL and a released ref. The narrow exception is a deliberately
+pushed pre-release commit: first prove the recorded `_commit` is reachable from
+the canonical remote, then verify and commit both lineage fields together.
 
 ## 5. After generation — local setup & self-check
 

--- a/.claude/skills/standardize-repo/references/mode-update.md
+++ b/.claude/skills/standardize-repo/references/mode-update.md
@@ -47,8 +47,8 @@ assets/diff-template.sh .
 # add --show to print the full per-file diff
 ```
 
-This renders harmon-init from the repo's own `.copier-answers.yml` and runs two
-checks (mapping `.yml`↔`.yaml`):
+This renders harmon-init from the repo's own `.copier-answers.yml` and reports
+the following result classes (mapping `.yml`↔`.yaml`):
 
 - **`DRIFT`** — a curated file differs from a render at the repo's **own recorded
   `_commit`** (diff-template.sh renders at `_commit`, not the template's HEAD). So
@@ -62,38 +62,122 @@ checks (mapping `.yml`↔`.yaml`):
 - **`MISSING`** — a template file the repo lacks entirely. This scan walks the
   whole render (it does **not** depend on the curated list), so a file the
   template added later, or one a previous hand-reconciled update dropped, can't
-  slip through silently. (`.gitkeep` dir-stubs show as benign `ABSENT`.) Some
+  slip through silently. A tracked path deleted only from the working tree is
+  compared from the index; staging that deletion makes it real `MISSING`.
+  (`.gitkeep` dir-stubs show as benign `ABSENT`.) Some
   `MISSING` findings are **intentional divergences, not gaps** — see the
   known-false-`MISSING` list in [`mode-audit.md`](./mode-audit.md) §3 (drift
   class K) before "restoring" any of them (e.g. a repo using `.prettierrc.cjs`
-  instead of the template's `prettier.config.cjs`, a replaced terraform
-  skeleton, or a renumbered seed ADR).
+  instead of the template's `prettier.config.cjs`).
+- **`EQUIV`** — a mature nested Terraform layout or established/renumbered ADR
+  log intentionally replaces a generated seed path. This is informational and
+  does not fail the comparison.
 
 Together these are your reconciliation worklist for §3.
 
+### Preview the release and review new answers
+
+Before accepting `--defaults`, identify both the target release and any Copier
+questions added since the repo's recorded `_commit`:
+
+```bash
+copier check-update --output-format json .
+git -C ~/git/harmon-init diff "$(yq -r '._commit' .copier-answers.yml)"..v<TARGET> -- copier.yml
+```
+
+Every newly introduced question needs an explicit decision. This is especially
+important for a feature with a material footprint or an external capability:
+
+- `use_foreman` adds its supervisor, agents, taskfile, configuration,
+  documentation, and tests. It was default-on when introduced in v3.26.1;
+  current template source defaults it off. Update mode must still decide whether
+  the target should opt in.
+- `use_codeql` includes CodeQL only when the matrix corresponds to planned/actual
+  first-party JS/TS/Python source. `use_node` / `use_python` are tooling flags,
+  not source evidence; reconcile the rendered matrix and record an explicit
+  `codeql_languages` multiselect/override as a harmon-init source follow-up.
+  Public repositories have GitHub Code Security by default. For a
+  private/internal repo, perform a read-only capability check before selecting it
+  — and perform the same check whenever a legacy workflow exists without a
+  `use_codeql` answer:
+
+  ```bash
+  gh api "repos/<owner>/<repo>" \
+    --jq '{visibility, code_security: (.security_and_analysis.code_security.status // "unknown")}'
+  ```
+
+  If Code Security is disabled and will not be enabled, pass
+  `--data use_codeql=false`; the update must remove the workflow, badge,
+  `FULL_SECURITY_SCAN` setup, and CodeQL coverage claims. If the API field is
+  unavailable because the caller lacks permission, verify the capability in
+  **Settings → Code security** rather than inferring it. A workflow file or
+  `FULL_SECURITY_SCAN=true` proves configuration, not successful SARIF coverage.
+  Require the fail-closed result contract: the helper's hermetic truth table
+  normalizes unset/empty `FULL_SECURITY_SCAN` to disabled, accepts disabled/fork
+  runs only as `skipped`, and accepts enabled non-forks only as `success`. At
+  runtime, trusted events conditionally check out and execute that helper; fork
+  aggregates must not execute repository code and use the workflow-inline
+  deliberate-skip diagnostic. Nonempty malformed/unexpected results fail.
+
+- `include_terraform=true` now carries a reachable four-part lint contract:
+  format, TFLint, pinned Checkov, and a provider-lock check. Reconcile customized
+  Taskfiles by proving both `task --dry lint:terraform` and `task --dry check`
+  reach all four commands, and keep Terraform/TFLint/uv reachable locally and in
+  CI. Adopt `scripts/terraform-provider-locks.sh` plus its hermetic regression;
+  the check/update task paths generate exactly `darwin_arm64` and `linux_amd64`
+  checksums. Update-mode scratch initialization must pass `-upgrade`, while
+  check-mode initialization must omit it. Do not accept a pre-existing
+  `.terraform.lock.hcl` as proof of that process.
+
+Pass each reviewed answer with `--data`, even when the decision happens to match
+the current default.
+
+Preview the exact answer set before the real update:
+
+```bash
+: "${USE_CODEQL:?set USE_CODEQL=true or false after the capability review}"
+copier update --trust --defaults --pretend \
+  --data use_foreman=false \
+  --data use_codeql="$USE_CODEQL"
+```
+
+`--pretend` confirms rendering succeeds but its output can be terse. For a heavily
+customized or high-impact repo, make a disposable clone under a temporary directory,
+run the same update there without `--pretend`, and inspect its full `git diff` before
+touching the working branch. A preview complements the pinned-baseline drift report;
+neither replaces the post-update reconciliation in §3.
+
 ## 2. Run the update
 
-**Preflight — ensure `_src_path` is a resolvable git source.** `copier update`
-reuses the `_src_path` recorded in `.copier-answers.yml`; if it's a relative or
-machine-local path (e.g. `harmon-init`), the update aborts with `Updating is only
-supported in git-tracked templates` (see [copier-gotchas.md](./copier-gotchas.md)
-gotcha 8). Normalize it to the GitHub URL first — once, committed:
+**Preflight — ensure the recorded lineage tuple is resolvable.** `copier update`
+reuses both `_src_path` and `_commit` from `.copier-answers.yml`. A relative or
+machine-local path may abort with `Updating is only supported in git-tracked
+templates`; changing that path alone is safe only when the recorded commit is
+reachable from the canonical remote (see [copier-gotchas.md](./copier-gotchas.md)
+gotcha 8). Inspect both fields:
 
 ```bash
-grep '^_src_path:' .copier-answers.yml   # is it a URL? if relative/local, fix it:
-yq -i '._src_path = "https://github.com/evanharmon1/harmon-init"' .copier-answers.yml
-git commit -am "chore: point copier _src_path at the harmon-init GitHub URL"
+grep -E '^(_src_path|_commit):' .copier-answers.yml
 ```
+
+If `_src_path` is local, first prove `_commit` exists on the canonical remote.
+Then update and commit the tuple together. If it is a dirty-render throwaway or
+otherwise unreachable, do not fabricate lineage by swapping only the path or
+commit; re-adopt from the canonical GitHub URL at a reviewed released ref.
 
 ```bash
-copier update --trust --defaults
+copier update --trust --defaults \
+  --data <new-question>=<reviewed-answer>
 ```
 
-**`--defaults` is mandatory when running non-interactively (agents have no TTY).**
-Without it copier tries to prompt for answers and crashes with
+**`--defaults` is mandatory when running non-interactively (agents have no TTY),
+but it is not permission to accept newly introduced behavior.** Review and pass
+new answers explicitly as described above. Without `--defaults`, Copier tries to
+prompt for answers and crashes with
 `OSError: [Errno 22] Invalid argument` (prompt_toolkit can't attach to a missing
 terminal). It reuses the stored answers and accepts defaults for any new questions
-the template added since `_commit`.
+the template added since `_commit`; explicit `--data` values override those
+defaults and are recorded in `.copier-answers.yml`.
 
 **Always do a full update to the latest released version.** Plain `copier update`
 goes to harmon-init's newest **tag** and three-way-merges the *entire* delta from the
@@ -355,6 +439,19 @@ assets/diff-template.sh .   # should now show only legit customizations
 task verify
 assets/verify-applied.sh .
 ```
+
+Current harmon-init renders a hermetic `test:tasks`: fake `brew`, `npm`, and
+`curl` commands exercise bootstrap without installing or updating shared
+machine tooling. If a target still carries the older live-tool version, port the
+current test before parallel fleet verification; until then, run those repo gates
+serially so concurrent audits cannot contend on or mutate shared package-manager
+state.
+
+Review reconciled workflows semantically, not only syntactically: compare
+`push`/`pull_request`/`merge_group`/`workflow_dispatch` events and inputs,
+then each deploy/apply job's `if`, `needs`, permissions, and side effects.
+Preserve deliberate manual Terraform apply or deploy paths. A green actionlint
+run proves syntax, not trigger semantics.
 
 **A green `task verify` does NOT cover the Lighthouse gates on web repos.** For
 web-astro repos the a11y/perf/SEO assertions (`lighthouserc.json`) run in the

--- a/.claude/skills/standardize-repo/references/post-generation-checklist.md
+++ b/.claude/skills/standardize-repo/references/post-generation-checklist.md
@@ -52,9 +52,10 @@ push so the remote exists.
       `.github/Branch Protection Ruleset - Protect Main.json`. To change an
       existing ruleset, edit it in the UI — don't re-import.
 
-  > Avoid `gh api … rulesets`: `POST` is **not idempotent** (re-running creates a
-  > duplicate ruleset) and both `POST`/`PUT` currently reject the `merge_queue`
-  > rule (`422 Invalid rule 'merge_queue'`). The UI import handles every rule type.
+  > REST supports `merge_queue`, but a blind `POST` is **not idempotent**
+  > (re-running can create a duplicate ruleset). Safe automation must first
+  > discover exactly one matching live ruleset and then `PUT` that ruleset's id.
+  > Keep the initial import explicit in the UI.
 
 - [ ] **[scriptable via gh]** Enable **Dependabot alerts**. Do NOT add a
       `dependabot.yml` — Renovate owns version updates; Dependabot is alerts-only.
@@ -196,7 +197,21 @@ push so the remote exists.
   ```
 
   The variable is a run switch, not an entitlement, and cannot disable public
-  CodeQL.
+  CodeQL. A generated workflow or a true variable by itself does not establish
+  coverage; require a successful analysis/upload on every route where CodeQL is
+  required.
+
+- [ ] **[scriptable]** (Terraform repos) Prove the advertised lint and provider
+      lock contract rather than relying on docs or a pre-existing lock file.
+      `task --dry lint:terraform` and `task --dry check` must both reach fmt,
+      TFLint, pinned Checkov, and `terraform-provider-locks.sh check`; the root
+      Brewfile and build workflow must provision Terraform/TFLint/uv. Run the
+      hermetic provider-lock regression, then use the explicit
+      `task terraform:providers:lock` mutation task when provider requirements
+      exist. Its helper targets both `darwin_arm64` and `linux_amd64`, passes
+      `-upgrade` to scratch init only in update mode, and leaves it off in check
+      mode; a fresh provider-free scaffold may skip without creating
+      `.terraform.lock.hcl`.
 
 - [ ] **[human-only]** (devcontainer projects) Ensure the org/user **allows
       GHCR package publishing** so the first `devcontainer-build.yml` prebuild on

--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -8,10 +8,11 @@ should this repo have, and where does it come from?"**
 Ground-truth sources (read these, don't trust memory): `harmon-init/copier.yml`,
 `harmon-init/AGENTS.md`, the `harmon-init/template/` tree. Live reference repos
 that have been generated from the template: `harmonops/harmon-infra` (an `iac`
-project) and `sommerlawn/sommerlawn-site` (a `web-astro` project). The platform
-and client repos are kept current via mode-update passes (all six were at
-v3.15.2 as of 2026-07-03), so their remaining divergences are **deliberate
-customizations** (Part 3.2), not lag — but they can drift between passes, so
+project) and `sommerlawn/sommerlawn-site` (a `web-astro` project). This catalog
+was refreshed against harmon-init v3.26.1 and harmon-devkit v0.6.2 on 2026-07-13.
+The platform and client repos are kept current via mode-update passes, so their
+remaining divergences are often **deliberate customizations** (Part 3.2), not lag
+— but they can drift between passes, so
 read the repo's actual `_commit` in `.copier-answers.yml` rather than assuming
 either way. Treat the **template** as canonical; treat divergences in a live
 repo as legit project-type/stack specifics (Part 3), deliberate customizations,
@@ -85,9 +86,11 @@ refreshed by `copier update`'s three-way merge, which preserves a repo's own edi
 Customize them **normally, in place** — there is no extension-file convention a
 repo's developers need to learn. `assets/diff-template.sh` reports both content
 `DRIFT` in the curated set and `MISSING` template files the repo lacks entirely
-(a whole-render, manifest-independent scan), so an audit/update pulls in missed
-improvements (the recurring status.sh / lint-hygiene / bootstrap class) and missed
-whole files without losing local customizations — see mode-audit drift class **K**.
+(a whole-render, manifest-independent scan). It compares an unstaged tracked
+deletion from the index and reports mature nested Terraform/ADR replacements as
+benign `EQUIV`, so an audit/update pulls in missed improvements (the recurring
+status.sh / lint-hygiene / bootstrap class) and missed whole files without losing
+local customizations — see mode-audit drift class **K**.
 
 Naming & structure conventions:
 
@@ -98,14 +101,25 @@ Naming & structure conventions:
 - **Pipeline order:** `check → build → validate → test → security`, with
   `verify` (fast local gate) and `ci` (full CI mirror) as aggregates.
   **`verify`** is tuned to stay well under a minute so editors, git hooks, and AI
-  agents can run it on every change: `check [→ build] → validate → test:tasks
-  [→ test:hooks]`. **`ci`** reproduces the whole CI pipeline on demand (run it
-  locally instead of opening a PR): `verify [→ test:devcontainer:permissions] →
-  test → security`. The rule: a check only belongs in `verify` if it stays fast;
-  heavy or Docker-dependent checks (`test`, `security`, `test:devcontainer:permissions`)
-  live in `ci`. Every `task` target a workflow invokes must still exist (drift
+  agents can run it on every change: `check [→ build] → validate
+  [→ test:devcontainer:permissions] → test:tasks [→ test:hooks]`. The devcontainer
+  permission assertion is a static, daemon-free configuration check. **`ci`**
+  reproduces the whole CI pipeline on demand (run it locally instead of opening a
+  PR): `verify → test → security`. The rule: a check only belongs in `verify` if
+  it stays fast; genuinely heavy or environment-dependent checks (`test`,
+  `security`, container smoke/build tests) live in `ci`. Every `task` target a
+  workflow invokes must still exist (drift
   class L) — but `verify` is intentionally a *subset* of what CI runs, so "`verify`
   is green" is not "CI is green"; use `ci` for that.
+- **Repo-specific test reachability:** a test is a real local/CI gate only when
+  `task install` (the root `Brewfile`) supplies its local runtime, CI
+  provisions the same runtime, and the workflow invokes `task test` or that
+  specific target. Merely adding it beneath the Taskfile's `test` aggregate is
+  not enough when the workflow still calls only `test:tasks`.
+- **Hermetic task regression tests:** current `test:tasks` uses temporary fake
+  `brew`, `npm`, and `curl` commands; it must not install or update shared
+  machine tools. When auditing multiple repos, run older live-tool variants
+  serially until the current hermetic script is ported.
 - **Parallel deps:** umbrella tasks fan out via `deps:` (which run in parallel),
   e.g. `lint` deps on `lint:yaml`, `lint:shell`, `lint:markdown`,
   `lint:actions`, `lint:hygiene`; `security` deps on `security:sast` +
@@ -156,14 +170,27 @@ repo.
 
 Notable command bodies (for an auditor checking they match):
 
-- `lint:shell` → `shellcheck --severity=error` + `shfmt -d`
+- `lint:shell` → `scripts/shell-quality.sh check`, which passes NUL-delimited
+  tracked `*.sh`/`*.bash` paths (or explicit argv paths) intact to
+  `shellcheck --severity=error` + `shfmt -d`; `format` calls the same helper
+  in write mode
 - `lint:markdown` → markdownlint-cli2 `'**/*.md' '#.claude/**' …` — prefers the
-  repo-pinned `node_modules/.bin` copy via `pnpm exec` when installed, falls
-  back to `npx --yes` (non-node repos, fresh scaffolds); same pattern in
+  repo-pinned `node_modules/.bin` copy when installed, then a global
+  `markdownlint-cli2` from the Brewfile, then a version-pinned npx fallback;
+  same pattern in
   `format`/`format:file` for prettier + markdownlint (check-only here; **no
   `--fix`** — auto-fix lives in `format`)
 - `lint:hygiene` → `./scripts/lint-hygiene.sh`
 - `security:secrets` → `gitleaks detect --no-banner --redact --source .`
+- Python `security:audit` → fail-closed `scripts/python-audit.sh`: with a
+  `uv.lock`, require it to match `pyproject.toml` while exporting the exact graph
+  with `uv export --locked --all-extras --all-groups`; before the first lock,
+  compile the project plus `dev` group to a temporary requirements file. Audit
+  it with pinned `pip-audit==2.10.1`; no `|| true` or ignored exit status. Any
+  CI-only command that consumes an existing lock must use `--locked` (for
+  example, `uv sync --locked`) or first run `uv lock --check`; CI must fail on
+  staleness and never silently rewrite the lock. Local install/update workflows
+  may intentionally create or refresh it.
 - `security:sast` → `./scripts/run-semgrep.sh` (Semgrep CE; no account/token)
 - `security:sca` → the same free package-manager audit as `security:audit`
 - `security:sast:snyk` / `security:sca:snyk` → explicit optional Snyk Code /
@@ -323,7 +350,14 @@ Shared structure:
   generated repo's `docs/guides/devcontainers.md` has the full walkthrough.
 - **`devcontainer.env`** is gitignored; only `devcontainer.env.example` is
   committed. **[manual]** to populate real secrets.
-- Smoke tests: `task test:devcontainer:root` / `test:devcontainer:dev`.
+- **Static permission test:** `test:devcontainer:permissions` calls
+  `read-configuration` with `--docker-path /usr/bin/true`, so the fast
+  configuration/permission assertion remains Docker-daemon-independent.
+- **Smoke tests:** `task test:devcontainer:root` /
+  `test:devcontainer:dev` require Docker and GNU `timeout`. They hard-bound
+  daemon preflight and cleanup at `-k 5 20`, and the full `devcontainer up`
+  lifecycle at `-k 30 1800`, so a wedged daemon or build cannot hang fleet
+  verification indefinitely.
 
 ### 1.7 CI/CD (GitHub Actions)
 
@@ -336,11 +370,39 @@ Shared structure:
 - **Least-privilege `permissions:`** per job (top-level `contents: read`).
 - **`merge_group`** trigger on `build.yml` (merge-queue support).
 - **Aggregate gate:** a final `verify` job (`if: always()`, `needs: [lint,
-  security, …]`) reports one rollup status. Branch protection requires the
-  **`verify`** and **`security`** checks, plus **`codeql-verify`** when a
-  Node/Python profile generates CodeQL.
+  security, …]`) reports one rollup status. Branch protection requires
+  **`verify`** and **`security`**, plus **`codeql-verify`** when a Node/Python
+  profile generates CodeQL and **`terraform-verify`** for a Terraform-capable
+  repo (when `include_terraform=true`, the Terraform aggregate is required).
+  Result acceptance is predicate-exact, never a generic
+  `success || skipped` allowlist. On a fork PR, every fork-suppressed leaf must be
+  exactly `skipped`; the diagnostic is workflow-inline, states the untrusted-fork
+  boundary explicitly, and neither checks out nor executes repository-controlled
+  code. On a same-repository PR or non-PR event, every required leaf must be
+  exactly `success`; a conditionally disabled leaf may be `skipped` only when its
+  explicit change/enabled predicate proves that exact result. Reject `failure`,
+  `cancelled`, `timed_out`, unexpected `skipped`, unexpected `success`, and every
+  unknown state. A check that rejects only `failure` is fail-open. The
+  `devcontainer-verify` aggregate follows the identical fork-skipped/trusted-
+  success contract for its build leaf.
 - Fork-PR guard: jobs gate on
   `github.event.pull_request.head.repo.full_name == github.repository`.
+- **Runner trust boundary [manual residual / audit requirement]:** public
+  `pull_request` jobs must stay GitHub-hosted; never let `CI_RUNS_ON` redirect
+  them to persistent self-hosted runners.
+  Self-hosted execution is limited to private/trusted repositories or trusted
+  `push`/`workflow_dispatch` events, with server-side repository-scoped runner
+  groups **and** clean ephemeral/JIT isolation. Keep same-repository guards on
+  configurable-runner jobs as defense in depth, but a job guard alone is not a
+  complete trust boundary. The current template's configurable-runner pattern
+  does not mechanically enforce hosted-only public PRs: audit repository
+  visibility, events, and `CI_RUNS_ON`, then specialize `runs-on` where needed.
+  See [GitHub's self-hosted runner hardening
+  guidance](https://docs.github.com/en/actions/reference/security/secure-use#hardening-for-self-hosted-runners).
+- **Self-hosted-safe temporary artifacts:** never use a shared fixed `/tmp`
+  path for sensitive or cross-step state such as a saved Terraform plan. Create
+  a private per-repo/run path beneath `${{ runner.temp }}` (include run
+  id/attempt), pass that exact path between steps, and clean it up.
 
 Workflow inventory:
 
@@ -403,7 +465,15 @@ The repository-class policy is:
 - **CodeQL** — `codeql.yml` is generated for Node/Python. It runs automatically
   on public repositories; private/internal repositories run it only with paid
   GitHub Code Security + `FULL_SECURITY_SCAN=true`, otherwise `build.yml` uses
-  Semgrep CE. **[copier]**; **[manual]** only for the paid private opt-in.
+  Semgrep CE. An unset/empty `FULL_SECURITY_SCAN` normalizes to the free-private
+  route. The analyze job/action never uses `continue-on-error`; its stable
+  aggregate requires success for public/paid-private analysis and reports a
+  successful not-applicable result only for free-private or untrusted-fork
+  routes. The fork path does not check out or execute fork-controlled repository
+  code on the aggregate runner. `use_node` and `use_python` describe tooling;
+  neither proves that its corresponding source language exists, so reconcile the
+  generated matrix with real first-party source. **[copier]**; **[manual]** only
+  for the paid private opt-in.
 - **Snyk** — optional `security:sast:snyk` (`snyk code test`) +
   `security:sca:snyk` (`snyk test --all-projects`) second opinions. The default
   `snyk_scan_schedule=off` keeps `SNYK_TOKEN` local and Snyk outside required PR
@@ -422,15 +492,22 @@ The repository-class policy is:
   squash/rebase; org repos add a `merge_queue` rule. Scheduled Snyk and Snyk App
   checks are never required by default. **[copier]** ships the file; **[manual]**
   import via the GitHub UI (Settings → Rules → Rulesets → **Import a ruleset**) — not
-  `gh api … rulesets`, whose `POST` is non-idempotent (duplicates the ruleset)
-  and rejects the `merge_queue` rule (422); edit the existing ruleset in the UI
-  to change it later.
+  a blind `gh api … rulesets` `POST`, which is non-idempotent and can duplicate
+  the ruleset. REST supports `merge_queue`; safe automation must discover
+  exactly one matching ruleset and `PUT` its id. Edit the existing ruleset in
+  the UI to change it later.
 - **`SECURITY.md`** lives in **`.github/`** (Private Vulnerability Reporting).
   **[copier]**
 - **Renovate, NOT Dependabot** for version updates. CHECKLIST explicitly says
   enable Dependabot *alerts* + Private vulnerability reporting but **do NOT add
   `dependabot.yml`** — Renovate owns updates. **[manual]** repo settings.
-- **`CODEOWNERS`** = `* @<code_owner>` — an asked question that defaults to `github_org`. **[copier]**
+- **`CODEOWNERS`** = `* @<code_owner>` — an asked question that defaults to
+  `author_git_provider_username` (a bare organization is not a valid CODEOWNERS
+  principal; org repos can deliberately choose `org/team`). **[copier]**
+  Existing owners are access control: an intentional replacement must be
+  user-confirmed and acknowledged to `verify-applied.sh` as the exact
+  `--ack-codeowner-change @old=@new` mapping. Old must exist on `main` and be
+  dropped, new must be present, and extra/stale mappings fail.
 - **Secrets via 1Password** locally (`op run`/`op inject`); CI reads Actions
   secrets. **`.env` is fully gitignored** (`.env`, `**/.env`, `.env.*`) with a
   single committed exception, `!/.env.example` (names/placeholders only; node
@@ -440,9 +517,18 @@ The repository-class policy is:
   NAME=… REPO=owner/repo` (GitHub repo secrets), backed by
   `scripts/secret-set-{1p,gh}.sh`: the value is read from **stdin only** — never
   argv, `--body`, exported env vars, or Taskfile vars (history/process-listing
-  hygiene). Both fail without destination metadata (`test-tasks.sh` asserts it),
-  and agents still must not write to a password manager without explicit
-  per-write confirmation. **[copier]**
+  hygiene). The 1Password helper fully materializes and validates the item JSON
+  before `op item edit` can start; it requires one matching `CONCEALED` field
+  and rejects `SSH_KEY`/`PASSKEY` categories, `SSHKEY` fields, and structured
+  values because a full-item edit can clobber those credentials. Both helpers
+  fail without destination metadata (`test-tasks.sh` asserts it), and agents
+  still must not write to a password manager without explicit per-write
+  confirmation. **[copier]**
+- **`op` is a deliberate human-only toolchain exception.** Root `Brewfile` /
+  `task install` does not provision 1Password CLI: install and authenticate it
+  explicitly on a human host, or use the human DEV devcontainer profile that
+  supplies the feature. The BOT profile must continue to omit every credential-
+  store path; never satisfy parity by adding `op` there.
 - **1Password credential naming (source of truth).** Authoritative convention is
   in the generated repo's `docs/architecture/security.md` ("1Password
   conventions"); when creating a repo's credentials, follow it verbatim:
@@ -503,12 +589,15 @@ install the Renovate GitHub App on the repo. Conventions:
   `bypassPermissions`, e.g. the devcontainer bot profile — the AGENTS.md rule
   is the binding convention there). **[copier]**
 - **`.claude/skills/`** — vendored shared agent skills from harmon-devkit via
-  **skills-sync**, gated on the **`use_skills_sync`** copier answer (default yes;
-  a repo may opt out — its ABSENCE of vendoring is then deliberate, not drift).
-  When on: `.skills-sync.yaml` (categories from the **`skill_categories`**
-  multiselect, seeded from `project_type` — `general`→`universal`,
-  `web-astro`→`+frontend`, `web-app`→`+frontend,backend`, `iac`→`+infra`),
-  `scripts/sync-skills.sh`, the
+  **skills-sync**, gated on the **`use_skills_sync`** copier answer. v3.26.1
+  defaulted it on universally; current template source defaults it on only for
+  `web-astro` and `web-app`. The profile-seeded `universal` and `infra`
+  categories are currently empty, so new general/iac repos default off instead
+  of managing an empty set; repos updated through v3.26.1 may already record
+  `true` and need an explicit review. When enabled, `skill_categories` starts with
+  `universal`, adds `frontend` for both web types, `backend` for `web-app`,
+  and `infra` when Terraform/Ansible or the iac type applies. The generated
+  machinery is `.skills-sync.yaml`, `scripts/sync-skills.sh`, the
   `sync:skills`/`verify:skills`/`verify:skills:offline` tasks, a CI drift check
   (in the `lint` job) and a pre-push offline check. The drift checks skip cleanly
   until the first `task sync:skills`, so a fresh scaffold stays green. **[copier]**
@@ -523,7 +612,19 @@ install the Renovate GitHub App on the repo. Conventions:
   (Renovate can't do the re-sync half). Source-repo exception: **harmon-devkit
   itself sets `use_skills_sync: false`** — it IS the source of the skills;
   self-vendoring a pinned copy of its own `ai/skills/` would be circular.
+  The harmon-devkit **v0.6 series** introduced this managed-set behavior and
+  upgrades a legacy provenance stamp on the first sync; v0.6.2 also rejects an
+  absolute or `..`-traversing destination before deletion. Repos on older pins
+  need an engine update plus one deliberate re-sync, not merely a ref edit.
   **[copier]**
+- **Foreman** — milestone/issue-driven agent dispatch, gated on the
+  **`use_foreman`** Copier answer. When enabled it adds `.foreman.toml`,
+  `taskfiles/foreman.yml`, `scripts/foreman/`, three `.claude/agents/`, the
+  architecture doc, Taskfile targets, hooks, and Python tooling. The v3.26
+  release introduced it default-on; current template source now deliberately
+  defaults to `no`. Always pass an explicit per-repo answer on update because
+  this is a substantial operational subsystem, not a passive lint config.
+  Absence is deliberate when `use_foreman: false`. **[copier]**
 - Devcontainer ships richer `config/claude-settings.json` as managed settings (see
   1.6). **[copier]**
 - **`DESIGN.md`** — AI-facing statement of design intent (the *why*/prose rules);
@@ -554,6 +655,10 @@ install the Renovate GitHub App on the repo. Conventions:
   `tv` binary) power the universal
   `status`/`status:*` dashboard and the interactive `task` menu (`menu-tv`), so
   they are required for the dashboard and the bare-`task` menu to work on a host.
+  `scripts/status.sh` resolves GNU `timeout` on Linux or Homebrew `gtimeout` on
+  macOS, falling back to an unbounded command before dependencies are installed.
+  Python is universal because hygiene parses TOML and the secret helpers use
+  `python3`; it is not limited to projects that opt into the Python stack.
   Installed via `task install`. `Brewfile.lock.json` is gitignored. **[copier]**
 - **Python** (when `use_python`): `pyproject.toml` (`requires-python >=3.14`,
   dev group with `black`; ansible adds `ansible-lint`/`ansible-core`),
@@ -704,7 +809,10 @@ Adds (all [copier] unless noted):
   ≥0.9.
 - **`docs/architecture/design-language.md`** + DESIGN.md "Visual & UX direction".
 - Devcontainer forwards port **4321** (Astro dev server); `astro-build.astro-vscode` extension.
-- `codeql.yml` analyzes `javascript-typescript`.
+- With first-party JS/TS source, `use_codeql=true`, and live Code Security
+  capability, `codeql.yml` analyzes `javascript-typescript`; otherwise the
+  workflow is intentionally absent and the SAST gap is documented. Do not count
+  an ESLint/Prettier/Astro config file by itself as application source.
 - **[manual] CHECKLIST:** `pnpm create astro@latest .`; add **Tailwind v4**
   (`@tailwindcss/vite`), **zod**, **vitest**, **lucide**; move lint tooling into
   `devDependencies` (the Taskfile auto-prefers repo-pinned `node_modules` bins
@@ -758,17 +866,62 @@ Same node tooling as web-astro **except**:
 Adds (all [copier]):
 
 - **`include_terraform`** → `terraform/` skeleton (`main.tf`, `variables.tf`,
-  `outputs.tf`, `tfvars.env.example`); tasks `lint:terraform` (`fmt -check`),
-  `lint:terraform:validate`, `validate`→validate; lefthook terraform (pre-commit)
-  - terraform-validate (pre-push); terraform devcontainer feature; Renovate
-  Terraform-providers group; hashicorp/terraform extension.
+  `outputs.tf`, `tfvars.env.example`). `lint:terraform`, reached transitively by
+  `check`, aggregates `lint:terraform:fmt` (`terraform fmt -check -recursive`),
+  `lint:terraform:tflint`, `lint:terraform:security` (Renovate-pinned Checkov via
+  `uvx --from "checkov==…"`), and `lint:terraform:locks`.
+  `lint:terraform:validate` remains the separate validation path. The root
+  `Brewfile` supplies Terraform, TFLint, and uv locally; the build workflow
+  provisions Terraform, pinned TFLint, and uv before invoking the shared task
+  gate. A docs claim or a defined-but-unreachable leaf task is not lint coverage.
+  Lefthook runs the lint aggregate pre-commit and validate pre-push; the
+  devcontainer includes Terraform; Renovate groups Terraform providers; VS Code
+  includes hashicorp/terraform.
+- **Terraform CI invariants:** commit `.terraform.lock.hcl` after the explicit
+  first provider-bearing initialization. `task terraform:providers:lock` calls
+  `scripts/terraform-provider-locks.sh update terraform`; the lint aggregate calls
+  the same helper in `check` mode. The helper generates and compares checksums for
+  exactly `darwin_arm64` (developer) and `linux_amd64` (GitHub CI) in a scratch
+  copy, leaving the checkout untouched in check mode. Scratch initialization
+  passes `-upgrade` only in update mode, so an intentional provider constraint
+  bump can move beyond the selection in the committed lock; check mode must omit
+  `-upgrade`. A fresh scaffold with no provider requirements cleanly skips lock
+  creation. The hermetic
+  `scripts/test-terraform-provider-locks.sh` regression must remain reachable
+  through the task tests. A lock file's mere presence does **not** prove platform
+  coverage; require this authoritative update/check process.
+
+  Once a lock is tracked, CI uses
+  `terraform init -lockfile=readonly`; only an explicit fresh-scaffold/local
+  initialization may create the initial lock, and an intentional local provider
+  update may refresh it; ordinary CI must not. The workflow listens to `push`,
+  `pull_request`, `merge_group`, and `workflow_dispatch` with no top-level
+  `paths` filter. Its internal change detector makes unrelated paths a no-op,
+  while the required GitHub-hosted `terraform-verify` aggregate runs under
+  `if: always()` and accepts `skipped` only when the explicit fork/change/enabled
+  predicates prove that result deliberate.
+
+  Credentialed plan/apply is downstream of successful validation and guarded by
+  the change result, an explicit enable flag, same-repository trust, and a
+  trusted-main push/dispatch apply condition. Repository/ref concurrency plus a
+  repository/run/attempt artifact key namespaces each run. Save the binary plan
+  under a private run-scoped directory, display that exact artifact, and apply
+  it without re-planning; use bounded state-lock waits (`-lock-timeout`), never
+  `-lock=false`, and clean up under `if: always()`. Agents never run
+  `terraform apply`, `destroy`, `import`, or state-mutating commands without
+  explicit approval for that exact operation. The reviewed trusted-main CI apply
+  of its own saved plan is the defined automation exception.
 - **`include_ansible`** → `ansible/` skeleton (`ansible.cfg`, `requirements.yaml`,
   `inventory/ playbooks/ roles/` each `.gitkeep`); **`.ansible-lint`**; tasks
   `lint:ansible`, `validate:ansible:syntax` (both guard on `ansible/site.yml`
   existing); lefthook ansible-syntax (pre-push); `ANSIBLE_CONFIG` remoteEnv;
   Renovate ansible regex managers; redhat.ansible extension.
 - **Python toolchain** active (uv, black, `.python-version`, pyproject).
-- `codeql.yml` analyzes `python` (if use_python).
+- Do not infer Python CodeQL coverage from the iac type. The current renderer adds
+  `python` when `use_codeql=true` because iac enables the Python tooling flag, but
+  an infrastructure repo may have no first-party `.py` files. Reconcile the
+  matrix with actual source (and include another real language such as
+  `javascript-typescript` when present) plus live Code Security capability.
 - **[manual] CHECKLIST:** lay out `terraform/` and/or `ansible/site.yml` — lint
   tasks activate automatically once `ansible/site.yml` exists.
 - The live `harmon-infra` shows how deep the namespacing legitimately goes:
@@ -805,7 +958,11 @@ Legitimately repo- or type-specific differences. An auditor should treat these a
   later added its own `.devcontainer/`).
 - **No `release.yml` / release-please manifest** when `use_release_please: no`
   (then releases are purely `task release:*`).
-- **No `codeql.yml`** when neither node nor python.
+- **No `codeql.yml`** when there is no Node/Python tooling profile. A
+  private/internal repo without paid GitHub Code Security still keeps the
+  generated workflow's stable not-applicable aggregate and uses Semgrep CE.
+  Current rendering is gated by `use_node`/`use_python`, so audit the matrix
+  against real source rather than treating those tooling flags as coverage.
 - **No `project-automation.yml`, no org `merge_queue` rule, no
   `permission-organization-projects`/`permission-members`** for personal-account
   repos (`github_org == author_git_provider_username`). Org repos get all three.

--- a/.skills-sync.yaml
+++ b/.skills-sync.yaml
@@ -8,7 +8,7 @@
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
   # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
-  ref: v0.7.1 # pinned tag — bump deliberately to a released harmon-devkit tag
+  ref: v0.7.2 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
   - repo
 dest: .claude/skills

--- a/template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja
+++ b/template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja
@@ -9,7 +9,7 @@
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
   # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
-  ref: v0.7.1 # pinned tag — bump deliberately to a released harmon-devkit tag
+  ref: v0.7.2 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
 [% for cat in skill_categories %]
   - [[ cat ]]


### PR DESCRIPTION
## Summary

- bump the root and generated skills-sync pins to harmon-devkit v0.7.2
- refresh the vendored standardize-repo skill and provenance from the released tag

## Verification

- task verify
- task test:template:all
- task verify:skills
- task verify:skills:offline
- release-title guard with this fix title