### PR TITLE
fix: correct generated template rendering

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -115,9 +115,12 @@ jobs:
           # shell can compose, so this is defense-in-depth, not a hard sandbox —
           # the real boundaries are the narrow token, branch protection, and the
           # ephemeral runner. Widen if a real run stalls on a denied command.
+          # The single allowedTools token cannot be wrapped without changing it.
+          # yamllint disable rule:line-length
           claude_args: >-
             --model opus --effort high --max-budget-usd 25 --max-turns 200
             --allowedTools "Edit,MultiEdit,Write,Read,NotebookEdit,Glob,Grep,LS,TodoWrite,Bash(task *),Bash(pnpm *),Bash(npx *),Bash(node *),Bash(git *),Bash(gh *),Bash(cd *),Bash(ls *),Bash(cat *),Bash(head *),Bash(tail *),Bash(grep *),Bash(rg *),Bash(find *),Bash(sed *),Bash(awk *),Bash(jq *),Bash(wc *),Bash(sort *),Bash(diff *),Bash(echo *),Bash(mkdir *),Bash(cp *),Bash(mv *),Bash(which *),Bash(pwd)"
+          # yamllint enable rule:line-length
           prompt: |
             Implement the change requested in this issue or comment.
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,7 +22,10 @@ jobs:
        github.event_name == 'pull_request_review_comment' ||
        github.event_name == 'pull_request_review' ||
        github.event_name == 'pull_request') &&
-      (github.event.sender.login == 'evanharmon1' || github.event.sender.login == 'renovate[bot]' || github.event.sender.login == 'coderabbitai[bot]' || github.event.sender.login == 'dependabot[bot]') &&
+      (github.event.sender.login == 'evanharmon1' ||
+       github.event.sender.login == 'renovate[bot]' ||
+       github.event.sender.login == 'coderabbitai[bot]' ||
+       github.event.sender.login == 'dependabot[bot]') &&
       (contains(github.event.comment.body, '@claude review') ||
        contains(github.event.review.body, '@claude review') ||
        (github.event.action == 'labeled' &&

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -474,7 +474,8 @@ if [[ "${SECTION}" == "setup" ]]; then
         has_codeql_wf=0
         find .github/workflows -maxdepth 1 \( -name 'codeql.yml' -o -name 'codeql.yaml' \) 2>/dev/null | grep -q . && has_codeql_wf=1
         has_semgrep_ci=0
-        grep -rq 'task security:sast' .github/workflows >/dev/null 2>&1 && has_semgrep_ci=1
+        grep -rEq 'task[[:space:]]+security:sast([[:space:]]|$)' .github/workflows \
+            >/dev/null 2>&1 && has_semgrep_ci=1
         uses_full_scan=0
         grep -rq 'FULL_SECURITY_SCAN' .github/workflows >/dev/null 2>&1 && uses_full_scan=1
 

--- a/scripts/test-release-title.sh
+++ b/scripts/test-release-title.sh
@@ -18,13 +18,19 @@ run() {
     _c="$2"
     shift 2
     _rc=0
-    PR_TITLE="$_t" CHANGED_FILES="$_c" "$guard" "$@" >/dev/null 2>&1 || _rc=$?
+    PR_TITLE="$_t" PR_BODY="" CHANGED_FILES="$_c" "$guard" "$@" >/dev/null 2>&1 || _rc=$?
     echo "$_rc"
 }
 
 echo "==> content change under a chore title fails"
 [ "$(run 'chore: update to harmon-init v4.0.0' "$(printf 'ai/skills/repo/x.md\nREADME.md')" ai/skills templates scripts)" = 1 ] ||
     fail "chore + skill change should fail"
+
+echo "==> ambient PR_BODY cannot make an unrelated case pass"
+PR_BODY='BREAKING CHANGE: inherited from the caller'
+[ "$(run 'chore: update to harmon-init v4.0.0' 'ai/skills/repo/x.md' ai/skills)" = 1 ] ||
+    fail "run helper leaked the caller's PR_BODY into an isolated test case"
+unset PR_BODY
 
 echo "==> the same content change under a fix title passes"
 [ "$(run 'fix(standardize-repo): publish skill updates' 'ai/skills/repo/x.md' ai/skills templates scripts)" = 0 ] ||

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -101,6 +101,7 @@ full)
         --data devcontainer=true
         --data ci_runner=self-hosted
         --data github_org=test-org
+        --data claude_authorized_members="evanharmon1,reviewer-a,reviewer-b"
         --data project_management=github
         --data snyk_scan_schedule=weekly
         --data release_content_paths="src docs"
@@ -464,7 +465,50 @@ meta) # project_management=linear
     ;;
 esac
 
-# ── 9c. Issue forms: default assignee always renders; the org issue `type:` key
+# ── 9c. Conditional prose and generated workflow layout ────────────
+# Inline block tags at the end of Markdown lines can consume the following
+# newline. Keep conditional checklist items structurally separate when the
+# feature is disabled.
+if grep -Fq 'alerts.- [ ]' docs/CHECKLIST.md; then
+    err "docs/CHECKLIST.md joined adjacent checklist items"
+fi
+case "$profile" in
+minimal)
+    ! grep -q '\*\*Bot PAT\*\*' docs/CHECKLIST.md || err "Bot PAT checklist item rendered with devcontainer=false"
+    ;;
+*)
+    grep -q '\*\*Bot PAT\*\*' docs/CHECKLIST.md || err "Bot PAT checklist item missing with devcontainer=true"
+    ;;
+esac
+
+# The dependency-audit parenthetical should name only tools that exist for the
+# rendered stack. The full profile deliberately enables both ecosystems.
+sca_row="$(grep '^| \*\*SCA\*\*' docs/architecture/security.md || true)"
+case "$profile" in
+iac)
+    printf '%s\n' "$sca_row" | grep -q 'pip-audit' || err "Python SCA row is missing pip-audit"
+    ! printf '%s\n' "$sca_row" | grep -q 'pnpm audit' || err "Python-only SCA row mentions pnpm audit"
+    ;;
+web | webapp | meta)
+    printf '%s\n' "$sca_row" | grep -q 'pnpm audit' || err "Node SCA row is missing pnpm audit"
+    ! printf '%s\n' "$sca_row" | grep -q 'pip-audit' || err "Node-only SCA row mentions pip-audit"
+    ;;
+full)
+    printf '%s\n' "$sca_row" | grep -q 'pnpm audit' || err "combined SCA row is missing pnpm audit"
+    printf '%s\n' "$sca_row" | grep -q 'pip-audit' || err "combined SCA row is missing pip-audit"
+    ;;
+minimal)
+    ! printf '%s\n' "$sca_row" | grep -Eq 'pnpm audit|pip-audit' || err "tool-free SCA row names an ecosystem audit"
+    ;;
+esac
+
+# Each authorized sender gets its own continuation line; otherwise a larger
+# allowlist silently creates an overlong generated YAML expression.
+if grep -Eq 'sender\.login.*sender\.login' .github/workflows/claude-review.yml; then
+    err "claude-review sender expression contains multiple senders on one line"
+fi
+
+# ── 9d. Issue forms: default assignee always renders; the org issue `type:` key
 #       is present only on org repos (issue types are org-level) ──
 if [ -f .github/ISSUE_TEMPLATE/bug.yml ]; then
     grep -q '^assignees:' .github/ISSUE_TEMPLATE/bug.yml || err "bug.yml is missing the default assignee"
@@ -478,7 +522,7 @@ if [ -f .github/ISSUE_TEMPLATE/bug.yml ]; then
     esac
 fi
 
-# ── 9d. skills-sync renders per use_skills_sync (default on) ────────
+# ── 9e. skills-sync renders per use_skills_sync (default on) ────────
 # minimal renders with use_skills_sync=false (OFF branch); every other profile
 # uses the default (on). Assert the conditionally-named files + gated tasks
 # appear/disappear together so a broken gate can't ship silently.

--- a/template/.github/workflows/claude-implement.yml.jinja
+++ b/template/.github/workflows/claude-implement.yml.jinja
@@ -196,9 +196,12 @@ jobs:
           # shell can compose, so this is defense-in-depth, not a hard sandbox —
           # the real boundaries are the narrow token, branch protection, and the
           # ephemeral runner. Widen if a real run stalls on a denied command.
+          # The single allowedTools token cannot be wrapped without changing it.
+          # yamllint disable rule:line-length
           claude_args: >-
             --model opus --effort high --max-budget-usd 25 --max-turns 200
             --allowedTools "Edit,MultiEdit,Write,Read,NotebookEdit,Glob,Grep,LS,TodoWrite,Bash(task *),Bash(pnpm *),Bash(npx *),Bash(node *),Bash(git *),Bash(gh *),Bash(cd *),Bash(ls *),Bash(cat *),Bash(head *),Bash(tail *),Bash(grep *),Bash(rg *),Bash(find *),Bash(sed *),Bash(awk *),Bash(jq *),Bash(wc *),Bash(sort *),Bash(diff *),Bash(echo *),Bash(mkdir *),Bash(cp *),Bash(mv *),Bash(which *),Bash(pwd)"
+          # yamllint enable rule:line-length
           prompt: |
             Implement the change requested in this issue or comment.
 

--- a/template/.github/workflows/claude-review.yml.jinja
+++ b/template/.github/workflows/claude-review.yml.jinja
@@ -23,7 +23,9 @@ jobs:
        github.event_name == 'pull_request_review_comment' ||
        github.event_name == 'pull_request_review' ||
        github.event_name == 'pull_request') &&
-      ([% for s in _review_senders %]github.event.sender.login == '[[ s ]]'[% if not loop.last %] || [% endif %][% endfor %]) &&
+[% for s in _review_senders %]
+      [[ '(' if loop.first else ' ' ]]github.event.sender.login == '[[ s ]]'[[ ' ||' if not loop.last else ') &&' ]]
+[% endfor %]
       (contains(github.event.comment.body, '@claude review') ||
        contains(github.event.review.body, '@claude review') ||
        (github.event.action == 'labeled' &&

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -38,13 +38,15 @@ config, toolchain, devcontainer, and dev environment — against the items below
       reporting** when public[% if github_org != author_git_provider_username %], and adds
       the `[[ author_git_provider_username ]]-bot` machine account as a Write
       collaborator[% endif %]. Do not add `dependabot.yml`: Renovate owns routine
-      and vulnerability-remediation PRs; Dependabot owns advisory alerts.[% if devcontainer %]
+      and vulnerability-remediation PRs; Dependabot owns advisory alerts.
+[% if devcontainer %]
 - [ ] **Bot PAT** — the agent's `GH_TOKEN`. If a fine-grained PAT already covers
       [% if github_org != author_git_provider_username %]`[[ github_org ]]`[% else %]`[[ author_git_provider_username ]]`[% endif %],
       just add this repo to its **selected repositories**; a token is scoped to one
       resource owner, so a **new owner needs a new PAT**. Both layers are required —
       the collaborator grant above sets the ceiling, the PAT's repo list reaches it.
-      Procedure: [guides/bot-account.md](guides/bot-account.md).[% endif %]
+      Procedure: [guides/bot-account.md](guides/bot-account.md).
+[% endif %]
 - [ ] Import the branch ruleset (see [architecture/branch-protection.md](architecture/branch-protection.md)) — do this once `build.yml`[% if use_codeql %] and `codeql.yml`[% endif %] are on `main` so the required `verify`/`security`[% if use_codeql %]/`codeql-verify`[% endif %] checks resolve. **Use the UI import:** Settings → Rules → Rulesets → **New ruleset ▸ Import a ruleset** → select `.github/Branch Protection Ruleset - Protect Main.json`. (Prefer the UI over `gh api … rulesets`: the API `POST` is not idempotent — re-running creates a duplicate ruleset — and currently rejects the `merge_queue` rule. To later change the ruleset, edit the existing one in the UI rather than re-importing.)
 
 - [ ] Install the [Renovate app](https://github.com/apps/renovate) on the repo

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -35,7 +35,7 @@ repositories and for profiles without a CodeQL workflow.
 [% else %]
 | **SAST** — flaws in *your own code* | injection, XSS, SSRF, path traversal, crypto/auth misuse | **Semgrep CE** | CI and `task security:sast`; this profile has no generated CodeQL workflow |
 [% endif %]
-| **SCA** — CVEs in *dependencies* | vulnerable third-party packages | **Dependabot alerts** + **`task security:audit`** (`pnpm audit` / `pip-audit`) | Dependabot continuous; audit in the CI `security` job + `task security` locally |
+| **SCA** — CVEs in *dependencies* | vulnerable third-party packages | **Dependabot alerts** + **`task security:audit`**[% if use_node or use_python %] ([% if use_node %]`pnpm audit`[% endif %][% if use_node and use_python %] / [% endif %][% if use_python %]`pip-audit`[% endif %])[% endif %] | Dependabot continuous; audit in the CI `security` job + `task security` locally |
 | **Secrets** — committed credentials | keys, tokens, certs, `.env` | **gitleaks** (`task security:secrets`) | pre-push git hook + CI `security` job |
 | **IaC** — insecure infrastructure | open security groups, public buckets, … | **checkov** (`task lint:terraform:security`) | CI `lint` job + `task check` locally (Terraform repos) |
 | **Freshness/remediation** — stale or vulnerable dependencies | a widening exposure window | **Renovate** (`minimumReleaseAge: 3 days`, Dependabot-alert remediation enabled) | continuous update and vulnerability-fix PRs |

--- a/template/scripts/[% if use_release_please %]test-release-title.sh[% endif %]
+++ b/template/scripts/[% if use_release_please %]test-release-title.sh[% endif %]
@@ -18,13 +18,19 @@ run() {
     _c="$2"
     shift 2
     _rc=0
-    PR_TITLE="$_t" CHANGED_FILES="$_c" "$guard" "$@" >/dev/null 2>&1 || _rc=$?
+    PR_TITLE="$_t" PR_BODY="" CHANGED_FILES="$_c" "$guard" "$@" >/dev/null 2>&1 || _rc=$?
     echo "$_rc"
 }
 
 echo "==> content change under a chore title fails"
 [ "$(run 'chore: update to harmon-init v4.0.0' "$(printf 'ai/skills/repo/x.md\nREADME.md')" ai/skills templates scripts)" = 1 ] ||
     fail "chore + skill change should fail"
+
+echo "==> ambient PR_BODY cannot make an unrelated case pass"
+PR_BODY='BREAKING CHANGE: inherited from the caller'
+[ "$(run 'chore: update to harmon-init v4.0.0' 'ai/skills/repo/x.md' ai/skills)" = 1 ] ||
+    fail "run helper leaked the caller's PR_BODY into an isolated test case"
+unset PR_BODY
 
 echo "==> the same content change under a fix title passes"
 [ "$(run 'fix(standardize-repo): publish skill updates' 'ai/skills/repo/x.md' ai/skills templates scripts)" = 0 ] ||

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -474,7 +474,8 @@ if [[ "${SECTION}" == "setup" ]]; then
         has_codeql_wf=0
         find .github/workflows -maxdepth 1 \( -name 'codeql.yml' -o -name 'codeql.yaml' \) 2>/dev/null | grep -q . && has_codeql_wf=1
         has_semgrep_ci=0
-        grep -rq 'task security:sast' .github/workflows >/dev/null 2>&1 && has_semgrep_ci=1
+        grep -rEq 'task[[:space:]]+security:sast([[:space:]]|$)' .github/workflows \
+            >/dev/null 2>&1 && has_semgrep_ci=1
         uses_full_scan=0
         grep -rq 'FULL_SECURITY_SCAN' .github/workflows >/dev/null 2>&1 && uses_full_scan=1
 


### PR DESCRIPTION
## Summary

- preserve Markdown checklist boundaries when devcontainer content is disabled
- render only stack-applicable dependency audit tools
- tighten Semgrep task detection and isolate release-title test state
- keep generated Claude workflow expressions within lint constraints
- add regression coverage across the template profile matrix

## Verification

- task verify
- pre-push skills drift, gitleaks, and minimal template render