### PR TITLE
fix(template): align design handoff bundle wording with the renamed skill

### DIFF
--- a/.claude/skills/.SKILLS_PROVENANCE
+++ b/.claude/skills/.SKILLS_PROVENANCE
@@ -1,6 +1,6 @@
 # VENDORED from harmon-devkit — DO NOT EDIT the managed skills here.
 # source: https://github.com/evanharmon1/harmon-devkit.git
-# ref: v0.7.2 (29f815debc79e2126d7a6268f9c5ae16923c10f2)
+# ref: v0.8.1 (f068fdfe8b888bde5f7465fcbfbeb6e63e33dd40)
 # path: ai/skills
 # categories: repo
 # managed: standardize-repo

--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -260,7 +260,7 @@ Conditional formatters/linters (see Part 2 for which project types):
 - **ansible-lint** — `.ansible-lint` (ansible only).
 
 **Design-bundle shield (`specs/*/`)** — spec *subdirectories* hold vendored
-design-handoff bundles (Claude Design exports; deleted at sign-off, never
+design handoff bundles (Claude Design exports; deleted at sign-off, never
 committed) and are excluded from git and every linter, while top-level
 `specs/*.md` stay tracked and linted. Audit that all surfaces agree:
 `.gitignore` + `.prettierignore` (`specs/*/`), `.yamllint` ignores

--- a/.skills-sync.yaml
+++ b/.skills-sync.yaml
@@ -8,7 +8,7 @@
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
   # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
-  ref: v0.7.2 # pinned tag — bump deliberately to a released harmon-devkit tag
+  ref: v0.8.1 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
   - repo
 dest: .claude/skills

--- a/specs/README.md
+++ b/specs/README.md
@@ -15,9 +15,9 @@ against. (Specs cover *what* and *why*; `docs/architecture/` covers *how*, and
 3. Keep one spec per feature/change; link it from the implementing PR, and
    update or supersede it as the work evolves.
 
-## Design-handoff bundles
+## Design handoff bundles
 
-Claude Design exports (the `design-handoff` skill's input) are unpacked into
+Claude Design exports (the `implement-design` skill's input) are unpacked into
 **subdirectories** here — `specs/handoff-<feature>/`. They are vendored,
 temporary reference material: ignored by git and every linter (`specs/*/` in
 the ignore configs) and **deleted at sign-off**, never committed. Top-level

--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -40,7 +40,7 @@ node_modules/
 # Git worktrees
 .worktrees/
 
-# Design-handoff bundles (Claude Design exports) live as specs/ subdirectories
+# Design handoff bundles (Claude Design exports) live as specs/ subdirectories
 # while being implemented and are deleted at sign-off — never committed.
 # Top-level specs/*.md (README, _template, feature specs) stay tracked.
 specs/*/

--- a/template/[% if project_type == 'web-app' %]eslint.config.js[% endif %]
+++ b/template/[% if project_type == 'web-app' %]eslint.config.js[% endif %]
@@ -13,7 +13,7 @@ import prettier from 'eslint-config-prettier'
 // so formatting rules never fight Prettier.
 export default tseslint.config(
   {
-    // specs/*/ holds vendored design-handoff bundles (deleted at sign-off);
+    // specs/*/ holds vendored design handoff bundles (deleted at sign-off);
     // routeTree.gen.ts + convex/_generated/ are generated (committed but not linted);
     // .claude/ holds vendored agent skills whose .ts/.mjs assets must never hit type-aware lint.
     ignores: [

--- a/template/[% if project_type == 'web-astro' %]eslint.config.js[% endif %]
+++ b/template/[% if project_type == 'web-astro' %]eslint.config.js[% endif %]
@@ -4,7 +4,7 @@ import tseslint from 'typescript-eslint'
 import astro from 'eslint-plugin-astro'
 
 export default [
-  // specs/*/ holds vendored design-handoff bundles (deleted at sign-off);
+  // specs/*/ holds vendored design handoff bundles (deleted at sign-off);
   // .claude/ holds vendored agent skills whose .ts/.mjs assets must never be linted.
   { ignores: ['**/dist/', '**/.astro/', 'specs/', '.claude/'] },
   js.configs.recommended,

--- a/template/[% if use_node %].prettierignore[% endif %].jinja
+++ b/template/[% if use_node %].prettierignore[% endif %].jinja
@@ -37,7 +37,7 @@ pnpm-lock.yaml
 _tmp_*
 *.tmp
 *~
-# Design-handoff bundles under specs/ (vendored Claude Design exports).
+# Design handoff bundles under specs/ (vendored Claude Design exports).
 specs/*/
 
 # release-please owns CHANGELOG.md (writes double blanks Prettier would strip).

--- a/template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja
+++ b/template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja
@@ -9,7 +9,7 @@
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
   # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
-  ref: v0.7.2 # pinned tag — bump deliberately to a released harmon-devkit tag
+  ref: v0.8.1 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
 [% for cat in skill_categories %]
   - [[ cat ]]

--- a/template/specs/README.md
+++ b/template/specs/README.md
@@ -15,9 +15,9 @@ against. (Specs cover *what* and *why*; `docs/architecture/` covers *how*, and
 3. Keep one spec per feature/change; link it from the implementing PR, and
    update or supersede it as the work evolves.
 
-## Design-handoff bundles
+## Design handoff bundles
 
-Claude Design exports (the `design-handoff` skill's input) are unpacked into
+Claude Design exports (the `implement-design` skill's input) are unpacked into
 **subdirectories** here — `specs/handoff-<feature>/`. They are vendored,
 temporary reference material: ignored by git and every linter (`specs/*/` in
 the ignore configs) and **deleted at sign-off**, never committed. Top-level


### PR DESCRIPTION
## Why

harmon-devkit renamed its `design-handoff` skill to `implement-design` ([harmon-devkit#108](https://github.com/evanharmon1/harmon-devkit/pull/108)), leaving this repo's template references stale — and they propagate into every generated repo.

## Two fixes, deliberately worded differently

The stale references split into two kinds, and collapsing them would repeat the original mistake:

1. **Naming the skill** — `specs/README.md`'s "the `design-handoff` skill's input" → `implement-design`. This one *should* name the skill.
2. **Naming the artifact** — the "Design-handoff bundles" headings and ignore-file comments now read "design handoff bundles", dropping the skill name entirely. The bundle is **Claude Design's handoff export**; it was never the skill. Tying the artifact's name to the skill is precisely what made these go stale, so the fix is to stop doing that, not to substitute the new name.

## Files

- `template/specs/README.md` + `specs/README.md` (this repo's own copy — same file, kept in lockstep)
- `template/.gitignore.jinja`
- `template/[% if use_node %].prettierignore[% endif %].jinja`
- `template/…web-app eslint.config.js` and `…web-astro eslint.config.js`

## Verification

- `task verify` green, including `test-template (web): PASS` (web-astro shipped toolchain clean on a real generated app).
- `grep -rIni "design.handoff"` — every remaining hit is the intentional concept phrasing.

## Follow-up in this PR

`.claude/skills/standardize-repo` is vendored from harmon-devkit and carries the same stale wording. The pin bump is **not** in this PR yet: syncing at devkit `v0.8.0` would vendor a bad phrase — the rename's blanket replacement produced "vendored implement-design bundles" there, fixed by [harmon-devkit#109](https://github.com/evanharmon1/harmon-devkit/pull/109) (green, awaiting merge). Once that releases, I'll push the `.skills-sync.yaml` bump + re-sync as a second commit here rather than opening a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)