### PR TITLE
docs: inventory harmon-init-managed repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ This repo is part of **harmon-platform** — my custom development platform with
 | [harmon-ops](https://github.com/evanharmon1/harmon-ops) | Personal machine bootstrapping, package management & dev-environment setup across macOS/Windows/Linux. |
 | [harmon-infra](https://github.com/harmonops/harmon-infra) | Homelab infrastructure as code — Terraform, Ansible, and Docker Compose services. |
 
+The production repositories intentionally kept current with this template are
+listed in [`managed-repositories.yml`](./managed-repositories.yml). The inventory
+tracks fleet membership only; each repository records its own template version.
+
 ## Usage
 
 ### New project

--- a/managed-repositories.yml
+++ b/managed-repositories.yml
@@ -7,6 +7,11 @@ repositories:
   - evanharmon1/harmon-dotfiles
   - evanharmon1/harmon-ops
   - harmonops/harmon-infra
+  - ponderousdev/foreman
+  - ponderousdev/lawnomator-site
+  - ponderousdev/omator
+  - ponderousdev/ponderous-infra
+  - ponderousdev/ponderous-site
   - sommerlawn/sommerlawn-infra
   - sommerlawn/sommerlawn-site
   - sommerlawn/sommerlawn-zoho

--- a/managed-repositories.yml
+++ b/managed-repositories.yml
@@ -1,0 +1,12 @@
+# Production repositories intentionally kept current with harmon-init.
+# Keep this as a simple fleet inventory; version state belongs in each repo's
+# .copier-answers.yml and exceptions are handled in the update PR.
+repositories:
+  - evanharmon1/evanharmon-site
+  - evanharmon1/harmon-devkit
+  - evanharmon1/harmon-dotfiles
+  - evanharmon1/harmon-ops
+  - harmonops/harmon-infra
+  - sommerlawn/sommerlawn-infra
+  - sommerlawn/sommerlawn-site
+  - sommerlawn/sommerlawn-zoho


### PR DESCRIPTION
## Summary

- add a machine-readable inventory of production repositories intentionally kept current with harmon-init
- link the inventory from the README
- keep version state decentralized in each repository's `.copier-answers.yml`

The initial list was confirmed from repositories carrying harmon-init lineage. Ephemeral `test-project` and `test-wind` repositories are intentionally excluded.

## Verification

- `task check`
- pre-push minimal template render and gitleaks scan
