### PR TITLE
fix(template): sync harmon-devkit skills to v0.8.2

### DIFF
--- a/.claude/skills/.SKILLS_PROVENANCE
+++ b/.claude/skills/.SKILLS_PROVENANCE
@@ -1,6 +1,6 @@
 # VENDORED from harmon-devkit — DO NOT EDIT the managed skills here.
 # source: https://github.com/evanharmon1/harmon-devkit.git
-# ref: v0.8.1 (f068fdfe8b888bde5f7465fcbfbeb6e63e33dd40)
+# ref: v0.8.2 (9056b68bb993414da151da19d534e015a18b94b7)
 # path: ai/skills
 # categories: repo
 # managed: standardize-repo

--- a/.claude/skills/standardize-repo/SKILL.md
+++ b/.claude/skills/standardize-repo/SKILL.md
@@ -23,6 +23,13 @@ ones. harmon-init is NOT an application — it is used via
 [Copier](https://copier.readthedocs.io/en/stable/), so the heavy lifting is
 `copier copy` / `copier update`, not hand-copying files.
 
+## Credential boundary
+
+Keep secret and credential-store writes human-only. Use read-only checks to confirm
+that a credential is configured without revealing its value. If CI is blocked by a
+missing credential, report the exact maintainer action; never create, rotate, delete,
+or widen access to credentials, or weaken a workflow merely to make CI green.
+
 ## Preconditions
 
 Verify these before doing anything; stop and tell the user if one is unmet.
@@ -80,12 +87,18 @@ These are load-bearing. Full rationale and edge cases in `references/copier-gotc
 
 - **Validate after every apply.** Re-running `copier` or changing answers can churn
   files — confirm the result with the verification step below before committing.
+- **Optimize for regular rolling updates, not every historical migration path.**
+  harmon-init-managed repositories are expected to stay near the current release.
+  Review new answers against the target repository and pass the decisions
+  explicitly. Do not add or expect permanent version-pair migrations for unusual
+  gaps or customizations; reconcile those case by case in the downstream PR.
 
 The asked questions live in `~/git/harmon-init/copier.yml` (e.g. `project_name`,
 `project_slug`, `project_description`, `github_org`, `project_type`
 [general / web-astro / web-app / iac / docs], `snyk_scan_schedule`
 [off / weekly / daily], `include_terraform`, `include_ansible`, `ci_runner`,
-`license`, `use_release_please`, `devcontainer`, `git_init`). Read that file to
+`license`, `use_codeql`, `codeql_languages`, `use_release_please`, `devcontainer`,
+`git_init`). Read that file to
 confirm names/choices/defaults before scaffolding — do not invent answers.
 
 ## Standards catalog
@@ -98,6 +111,15 @@ catalog) as the source of truth, not memory.
 
 ## Verification
 
+After a template apply or update, if `.skills-sync.yaml` exists, refresh and verify
+the managed skills before running the repository gate:
+
+```bash
+task sync:skills
+task verify:skills
+task verify:skills:offline
+```
+
 After applying any mode, run the bundled check:
 
 ```bash
@@ -109,3 +131,7 @@ It confirms the expected files/tooling landed and then runs the repo's own gate
 `task install:hooks` to wire lefthook). Report what passed and surface any gaps
 against `references/standards-catalog.md`. Never bypass hooks (`--no-verify` is
 prohibited); commit on a feature branch and open a PR — no direct commits to `main`.
+When the work includes a PR, watch every required check to a terminal green result
+and inspect every review thread after each push. Apply feedback you agree with and
+reply with a concrete repository-specific rationale when you disagree. Never merge;
+report the reviewed, green PR for human handoff.

--- a/.claude/skills/standardize-repo/assets/template-owned-files.txt
+++ b/.claude/skills/standardize-repo/assets/template-owned-files.txt
@@ -9,7 +9,7 @@
 # Lines starting with # and blank lines are ignored. Paths use the template's
 # default extension; diff-template.sh maps .yml<->.yaml to whatever the repo uses.
 # Entries not present in a given render (e.g. codeql.yml when `use_codeql=false`
-# or the stack has no supported Node/Python language) are skipped automatically.
+# or use_codeql=false) are skipped automatically.
 
 # ── Task runner + git hooks ──────────────────────────────────────────────────
 Taskfile.yml
@@ -29,12 +29,9 @@ scripts/python-audit.sh
 scripts/terraform-provider-locks.sh
 scripts/terraform-changed.sh
 scripts/terraform-ci.sh
-scripts/test-codeql-result.sh
-scripts/test-required-results.sh
 scripts/test-terraform-provider-locks.sh
 scripts/test-terraform-ci.sh
-scripts/verify-codeql-result.sh
-scripts/verify-required-results.sh
+scripts/verify-ci-results.sh
 scripts/sync-skills.sh
 scripts/summarize-gitleaks.mjs
 scripts/run-semgrep.sh

--- a/.claude/skills/standardize-repo/assets/verify-applied.sh
+++ b/.claude/skills/standardize-repo/assets/verify-applied.sh
@@ -536,7 +536,7 @@ aggregate_job_contract_is_safe() {
             if (line ~ /uses:[ ]*actions\/checkout@/) {
                 is_checkout = 1
             }
-            if (line ~ /run:[ ]*\.\/scripts\/verify-required-results\.sh/) {
+            if (line ~ /run:[ ]*\.\/scripts\/verify-ci-results\.sh/) {
                 is_helper = 1
             }
             if (line ~ /^[[:space:]]*run:/) {
@@ -613,7 +613,7 @@ workflow_job_has_fork_guard() {
     ' "$workflow"
 }
 
-required_results_helper="scripts/verify-required-results.sh"
+required_results_helper="scripts/verify-ci-results.sh"
 aggregate_workflows=""
 for aggregate_spec in \
     '.github/workflows/build.yml:verify' \
@@ -691,9 +691,22 @@ if [ -n "$aggregate_workflows" ]; then
     done <<<"$aggregate_workflows"
 fi
 
-# The shipped ruleset has an exact profile-derived required-check set. CodeQL is
-# fail-closed inside its workflow today, but is not merge-gating until its
-# workflow also supports merge_group and the ruleset requires codeql-verify.
+# The shipped ruleset has an exact answer-derived required-check set.
+use_codeql_answer=""
+if [ -f .copier-answers.yml ]; then
+    use_codeql_answer="$(
+        sed -n -E 's/^[[:space:]]*use_codeql:[[:space:]]*([^#[:space:]]+).*$/\1/p' .copier-answers.yml |
+            tail -n 1 | tr '[:upper:]' '[:lower:]' | tr -d "\"'"
+    )"
+fi
+
+codeql_required=false
+case "$use_codeql_answer" in
+true | yes)
+    codeql_required=true
+    ;;
+esac
+
 ruleset_file=".github/Branch Protection Ruleset - Protect Main.json"
 if [ -f "$ruleset_file" ]; then
     ruleset_contexts="$(
@@ -702,15 +715,20 @@ if [ -f "$ruleset_file" ]; then
     )"
     expected_contexts="security
 verify"
+    expected_contexts_label="verify + security"
     if [ "$has_terraform" = true ]; then
-        expected_contexts="security
-terraform-verify
-verify"
+        expected_contexts="$expected_contexts
+terraform-verify"
+        expected_contexts_label="$expected_contexts_label + terraform-verify"
     fi
+    if [ "$codeql_required" = true ]; then
+        expected_contexts="$expected_contexts
+codeql-verify"
+        expected_contexts_label="$expected_contexts_label + codeql-verify"
+    fi
+    expected_contexts="$(printf '%s\n' "$expected_contexts" | sort -u)"
     if [ "$ruleset_contexts" != "$expected_contexts" ]; then
-        err "$ruleset_file required checks must be verify + security$(
-            if [ "$has_terraform" = true ]; then printf '%s' ' + terraform-verify'; fi
-        ); found: $(printf '%s' "$ruleset_contexts" | tr '\n' ' ')"
+        err "$ruleset_file required checks must be $expected_contexts_label; found: $(printf '%s' "$ruleset_contexts" | tr '\n' ' ')"
     fi
 fi
 
@@ -727,6 +745,60 @@ for candidate in .github/workflows/codeql.yml .github/workflows/codeql.yaml; do
         break
     fi
 done
+
+if [ -n "$codeql_workflow" ] && ! awk '
+    function record_event(value) {
+        gsub(/^[[:space:]]+/, "", value)
+        gsub(/[[:space:]]+$/, "", value)
+        if (value == "pull_request") {
+            has_pull_request = 1
+        } else if (value == "merge_group") {
+            has_merge_group = 1
+        }
+    }
+    function record_inline_events(value, count, events, i) {
+        sub(/^on:[ ]*\[/, "", value)
+        sub(/\].*$/, "", value)
+        count = split(value, events, /[ ]*,[ ]*/)
+        for (i = 1; i <= count; i++) {
+            record_event(events[i])
+        }
+    }
+    BEGIN {
+        in_events = 0
+        has_pull_request = 0
+        has_merge_group = 0
+    }
+    /^on:[ ]*\[/ {
+        record_inline_events($0)
+        in_events = 0
+        next
+    }
+    /^on:[ ]*(#.*)?$/ {
+        in_events = 1
+        next
+    }
+    in_events && /^[^[:space:]#]/ {
+        in_events = 0
+    }
+    in_events && /^  pull_request:/ {
+        has_pull_request = 1
+    }
+    in_events && /^  merge_group:/ {
+        has_merge_group = 1
+    }
+    in_events && /^  -[ ]*(pull_request|merge_group)([ ]*(#.*)?)?$/ {
+        event = $0
+        sub(/^  -[ ]*/, "", event)
+        sub(/[ ]*#.*/, "", event)
+        record_event(event)
+    }
+    END {
+        exit(has_pull_request && has_merge_group ? 0 : 1)
+    }
+' "$codeql_workflow"; then
+    err "$codeql_workflow must trigger on pull_request and merge_group so required codeql-verify checks are reported"
+fi
 
 if [ -n "$codeql_workflow" ] && awk '
     function indentation(value) {
@@ -834,66 +906,13 @@ if [ -n "$codeql_workflow" ] && ! awk '
 fi
 
 if [ -n "$codeql_workflow" ]; then
-    codeql_result_helper="scripts/verify-codeql-result.sh"
-    if [ ! -f "$codeql_result_helper" ]; then
-        err "$codeql_workflow has no $codeql_result_helper fail-closed aggregate helper"
-    else
-        if [ ! -x "$codeql_result_helper" ]; then
-            err "$codeql_result_helper must be executable because the workflow runs it directly"
-        fi
-
-        codeql_result_contract_ok=true
-        if ! env -u FULL_SECURITY_SCAN IS_FORK=false ANALYZE_RESULT=skipped \
-            "$codeql_result_helper" >/dev/null 2>&1; then
-            codeql_result_contract_ok=false
-        fi
-        if ! env FULL_SECURITY_SCAN= IS_FORK=false ANALYZE_RESULT=skipped \
-            "$codeql_result_helper" >/dev/null 2>&1; then
-            codeql_result_contract_ok=false
-        fi
-        if ! env FULL_SECURITY_SCAN=false IS_FORK=false ANALYZE_RESULT=skipped \
-            "$codeql_result_helper" >/dev/null 2>&1; then
-            codeql_result_contract_ok=false
-        fi
-        if ! env FULL_SECURITY_SCAN=true IS_FORK=true ANALYZE_RESULT=skipped \
-            "$codeql_result_helper" >/dev/null 2>&1; then
-            codeql_result_contract_ok=false
-        fi
-        if ! env FULL_SECURITY_SCAN=true IS_FORK=false ANALYZE_RESULT=success \
-            "$codeql_result_helper" >/dev/null 2>&1; then
-            codeql_result_contract_ok=false
-        fi
-        for rejected_contract in \
-            'true false skipped' \
-            'true false failure' \
-            'true false cancelled' \
-            'false false success' \
-            'yes false skipped' \
-            'TRUE false skipped' \
-            'true false unknown'; do
-            rejected_scan="${rejected_contract%% *}"
-            rejected_rest="${rejected_contract#* }"
-            rejected_fork="${rejected_rest%% *}"
-            rejected_result="${rejected_rest#* }"
-            if env FULL_SECURITY_SCAN="$rejected_scan" IS_FORK="$rejected_fork" \
-                ANALYZE_RESULT="$rejected_result" \
-                "$codeql_result_helper" >/dev/null 2>&1; then
-                codeql_result_contract_ok=false
-            fi
-        done
-        if [ "$codeql_result_contract_ok" != true ]; then
-            err "$codeql_result_helper does not enforce the disabled/fork/enabled CodeQL result truth table"
-        fi
-    fi
-
     for workflow_contract in \
-        'FULL_SECURITY_SCAN:' \
+        'EXPECTED_RESULT:' \
         'vars.FULL_SECURITY_SCAN' \
-        'IS_FORK:' \
         'github.event.pull_request.head.repo.full_name != github.repository' \
         'ANALYZE_RESULT:' \
         'needs.analyze.result' \
-        'run: ./scripts/verify-codeql-result.sh'; do
+        'run: ./scripts/verify-ci-results.sh'; do
         if ! grep -qF "$workflow_contract" "$codeql_workflow"; then
             err "$codeql_workflow does not wire the aggregate result contract: $workflow_contract"
         fi
@@ -911,8 +930,6 @@ if [ -n "$codeql_workflow" ]; then
             trusted_repo = 0
             fork_event = 0
             fork_repo = 0
-            defaults_scan = 0
-            validates_scan = 0
             validates_skip = 0
             executes_repo_code = 0
         }
@@ -923,8 +940,8 @@ if [ -n "$codeql_workflow" ]; then
             if (is_helper && trusted_event && trusted_repo) {
                 safe_helper = 1
             }
-            if (is_fork_check && fork_event && fork_repo && defaults_scan &&
-                validates_scan && validates_skip && !executes_repo_code) {
+            if (is_fork_check && fork_event && fork_repo && validates_skip &&
+                !executes_repo_code) {
                 safe_fork_check = 1
             }
             reset_step()
@@ -962,7 +979,7 @@ if [ -n "$codeql_workflow" ]; then
             if (line ~ /uses:[ ]*actions\/checkout@/) {
                 is_checkout = 1
             }
-            if (line ~ /run:[ ]*\.\/scripts\/verify-codeql-result\.sh/) {
+            if (line ~ /run:[ ]*\.\/scripts\/verify-ci-results\.sh/) {
                 is_helper = 1
             }
             if (line ~ /name:[ ]*Check deliberate fork skip/) {
@@ -979,12 +996,6 @@ if [ -n "$codeql_workflow" ]; then
             }
             if (index(line, "head.repo.full_name != github.repository")) {
                 fork_repo = 1
-            }
-            if (index(line, "scan=\"${FULL_SECURITY_SCAN:-false}\"")) {
-                defaults_scan = 1
-            }
-            if (index(line, "case \"$scan\" in")) {
-                validates_scan = 1
             }
             if (index(line, "ANALYZE_RESULT") && index(line, "!=") &&
                 index(line, "skipped")) {
@@ -1045,14 +1056,6 @@ if [ -n "$codeql_workflow" ]; then
     elif [ "$matrix_has_python" = false ] && [ "$has_python_source" = true ]; then
         echo "WARN: first-party Python source exists but CodeQL omits python." >&2
     fi
-fi
-
-use_codeql_answer=""
-if [ -f .copier-answers.yml ]; then
-    use_codeql_answer="$(
-        sed -n -E 's/^[[:space:]]*use_codeql:[[:space:]]*([^#[:space:]]+).*$/\1/p' .copier-answers.yml |
-            tail -n 1 | tr '[:upper:]' '[:lower:]' | tr -d "\"'"
-    )"
 fi
 
 if [ -n "$codeql_workflow" ]; then

--- a/.claude/skills/standardize-repo/references/mode-adopt-existing.md
+++ b/.claude/skills/standardize-repo/references/mode-adopt-existing.md
@@ -139,6 +139,7 @@ copier copy --trust https://github.com/evanharmon1/harmon-init.git . \
   --data project_slug="$(basename "$(pwd)")" \
   --data github_org="<org-or-user>" \
   --data use_codeql="$USE_CODEQL" \
+  --data codeql_languages="$CODEQL_LANGUAGES" \
   --data git_init=false \
   --data github_remote_create=false --data github_release_init=false \
   --data bunch_add=false --data obsidian_project_add=false --data run_task_install=false
@@ -151,11 +152,13 @@ released ref when appropriate. Local `--vcs-ref=HEAD` adoption is for a disposab
 preview only, never the production apply: dirty local renders can record a
 throwaway `_commit` that no later remote update can resolve.
 
-Set `USE_CODEQL` deliberately before rendering. Use `true` only for a supported
-Node/Python stack when Code Security is available (public repositories have it by
-default; inspect private/internal repositories with the read-only check in
+Set `USE_CODEQL` and `CODEQL_LANGUAGES` deliberately before rendering. Use
+`true` only when supported first-party JS/TS or Python source is present and Code
+Security is available (public repositories have it by default; inspect
+private/internal repositories with the read-only check in
 [`mode-audit.md`](./mode-audit.md), drift class G). Otherwise use `false`; do not
-render a workflow whose SARIF upload cannot succeed.
+render a workflow whose SARIF upload cannot succeed. The language selection must
+be nonempty when enabled and match the real source.
 
 `--defaults` is **required non-interactively** (no TTY → `OSError: [Errno 22]`), and
 because copier can't prompt per-file, `--overwrite` makes the run deterministic
@@ -315,8 +318,8 @@ after the copier run:
 
 5. **Other recurring fixes** (apply if present): consolidate duplicate Claude
    workflows (`claude-*-max.yml` → the base `claude-plan/implement/review.yml`);
-   add the CodeQL + Semgrep visibility route if the repo uses Node/Python (or
-   Semgrep CE alone for other profiles); replace legacy Snyk PR CI with the
+   align the explicit CodeQL selection/languages with real supported source and
+   live capability (or use Semgrep CE alone); replace legacy Snyk PR CI with the
    manual/local default or the explicit weekly/daily advisory schedule; drop any
    bump-on-merge `release.yml` in favor of release-please; de-bloat a legacy
    `Brewfile`; make scripts portable to macOS bash 3.2 (no `mapfile`, no

--- a/.claude/skills/standardize-repo/references/mode-audit.md
+++ b/.claude/skills/standardize-repo/references/mode-audit.md
@@ -175,7 +175,7 @@ if an unpinned/missing tool breaks the `security` job).
 ruleset (`template/.github/Branch Protection Ruleset - Protect Main.json`) requires
 the baseline contexts **`verify`** and **`security`**, plus
 **`terraform-verify`** exactly when `include_terraform=true`, and
-**`codeql-verify`** when `use_node or use_python` generates CodeQL. The
+**`codeql-verify`** exactly when `use_codeql=true`. The
 **`merge_queue`** rule is conditional: org repos
 (`github_org != author_git_provider_username`) get it; personal-account repos do
 not. Missing it is drift only for an org repo, while adding it to a personal repo
@@ -207,15 +207,15 @@ carry duplicates like `claude-review-max.yml` / `claude-implement-max.yml`. Fix:
 delete the `-max` duplicates, keep the three canonical workflows. Severity:
 **should** (blocker if a duplicate fires redundant/conflicting automation).
 
-**G. Missing `codeql.yml`.** The template ships a CodeQL workflow gated on
-`use_node or use_python` (`template/.github/workflows/[% if use_node or use_python %]codeql.yml[% endif %].jinja`).
-Repos with Node/Python code but no `codeql.yml` are missing the standard SAST
-route. Public repositories run it automatically and for free; free private
-repositories skip CodeQL and run Semgrep CE from `build.yml`; paid private
-GitHub Code Security is an explicit `FULL_SECURITY_SCAN=true` opt-in. Fix: add
-`codeql.yml`, `scripts/run-semgrep.sh`, and the visibility-aware `build.yml` /
-Taskfile targets from the template (a re-template with the right answers includes
-them). Severity: **should**.
+**G. CodeQL selection drift.** The template ships a CodeQL workflow only when
+`use_codeql=true`, using exactly the persisted `codeql_languages` matrix.
+Repositories with supported first-party source and live Code Security capability
+should make that intent explicit; tooling flags alone are not evidence. Public
+repositories run it automatically and for free; private/internal repositories
+require GitHub Code Security plus the explicit `FULL_SECURITY_SCAN=true` opt-in.
+When `use_codeql=false`, CodeQL artifacts and claims must be absent and Semgrep CE
+provides the baseline SAST route. Fix by re-templating with reviewed answers.
+Severity: **should**.
 
 Presence of the workflow alone is not coverage. The analyze job/action must not use
 `continue-on-error`; public and paid-private analyses must succeed, while the

--- a/.claude/skills/standardize-repo/references/mode-new-repo.md
+++ b/.claude/skills/standardize-repo/references/mode-new-repo.md
@@ -87,7 +87,8 @@ copier copy https://github.com/evanharmon1/harmon-init.git <dest> \
 | `project_type` | str | `general` | `general` \| `web-astro` \| `web-app` \| `iac` \| `docs`. Drives Taskfile, CI jobs, devcontainer tooling. |
 | `include_terraform` | bool | `true` iff `project_type == 'iac'` | Adds `terraform/` skeleton + terraform linting. |
 | `include_ansible` | bool | `true` iff `project_type == 'iac'` | Adds `ansible/` skeleton + ansible linting. |
-| `use_codeql` | bool | `true` iff derived `use_node` or `use_python` | Includes CodeQL SAST; explicitly override the tooling-derived default when planned source or capability does not support it. Public repositories have Code Security by default; for a private/internal repo, enable GitHub Code Security first or answer `false`. |
+| `use_codeql` | bool | `true` for `web-astro` / `web-app`; otherwise `false` | Includes CodeQL SAST. Public repositories have Code Security by default; for a private/internal repo, enable GitHub Code Security first or answer `false`. |
+| `codeql_languages` | multiselect | JS/TS for web; Python for supported Python/IaC selections when CodeQL is enabled | Exact CodeQL matrix; must be nonempty when `use_codeql=true` and should match real first-party source. |
 | `ci_runner` | str | `ubuntu-latest` | `ubuntu-latest` \| `self-hosted`. |
 | `license` | str | `mit` | `mit` \| `private`. |
 | `use_release_please` | bool | `true` | release-please rolling release PR + auto CHANGELOG. |
@@ -105,10 +106,8 @@ Notes:
 - Decide `use_codeql` explicitly whenever first-party JS/TS/Python is planned. A
   generated workflow and `FULL_SECURITY_SCAN=true` configure CodeQL but do not
   prove that SARIF was accepted; private/internal repos also require the live Code
-  Security capability. The current template derives the matrix from `use_node` /
-  `use_python`, which are tooling flags rather than source evidence, so reconcile
-  the rendered languages with the real source until harmon-init exposes an
-  explicit `codeql_languages` multiselect/override.
+  Security capability. Review `codeql_languages` against real first-party source;
+  `use_node` / `use_python` remain tooling flags rather than source evidence.
 - Hidden, derived flags you do **not** answer but that follow from your choices:
   `use_node` (true for `web-astro`/`web-app`), `use_python` (true for `iac` or
   `include_ansible`), `repo_url`, `devcontainer_image`, `ci_runner_labels`.

--- a/.claude/skills/standardize-repo/references/mode-update.md
+++ b/.claude/skills/standardize-repo/references/mode-update.md
@@ -94,12 +94,13 @@ important for a feature with a material footprint or an external capability:
   the target should opt in.
 - `use_codeql` includes CodeQL only when the matrix corresponds to planned/actual
   first-party JS/TS/Python source. `use_node` / `use_python` are tooling flags,
-  not source evidence; reconcile the rendered matrix and record an explicit
-  `codeql_languages` multiselect/override as a harmon-init source follow-up.
+  not source evidence; review and persist the explicit `codeql_languages`
+  multiselect alongside the selection. When these answers are new to the target,
+  make that repository-aware decision in this PR instead of assuming an existing
+  workflow must be preserved forever.
   Public repositories have GitHub Code Security by default. For a
   private/internal repo, perform a read-only capability check before selecting it
-  — and perform the same check whenever a legacy workflow exists without a
-  `use_codeql` answer:
+  — including when an older answer file has no `use_codeql` field:
 
   ```bash
   gh api "repos/<owner>/<repo>" \
@@ -112,12 +113,11 @@ important for a feature with a material footprint or an external capability:
   unavailable because the caller lacks permission, verify the capability in
   **Settings → Code security** rather than inferring it. A workflow file or
   `FULL_SECURITY_SCAN=true` proves configuration, not successful SARIF coverage.
-  Require the fail-closed result contract: the helper's hermetic truth table
-  normalizes unset/empty `FULL_SECURITY_SCAN` to disabled, accepts disabled/fork
-  runs only as `skipped`, and accepts enabled non-forks only as `success`. At
-  runtime, trusted events conditionally check out and execute that helper; fork
-  aggregates must not execute repository code and use the workflow-inline
-  deliberate-skip diagnostic. Nonempty malformed/unexpected results fail.
+  Require the fail-closed result contract: the workflow maps the scan decision
+  to one expected result, and the shared helper accepts only that exact result.
+  Trusted events conditionally check out and execute the helper; fork aggregates
+  must not execute repository code and use the workflow-inline deliberate-skip
+  diagnostic.
 
 - `include_terraform=true` now carries a reachable four-part lint contract:
   format, TFLint, pinned Checkov, and a provider-lock check. Reconcile customized
@@ -244,6 +244,19 @@ app content was clobbered and no copier marker leaked (`[[`, `[%`,
 resolves some conflicts with a delete-then-add, which a bare `git diff` renders as a
 misleading whole-file rewrite (`DA` in `git status`, every line shown as removed +
 re-added); staging first and diffing against `HEAD` shows the true, small delta.
+
+**Deletion audit — justify every removed pre-existing path.** Inspect staged
+deletions before proceeding:
+
+```bash
+git diff --name-status --diff-filter=D HEAD
+```
+
+For each path, compare the pre-update file, the recorded Copier answers, and the
+template condition that controls it. A condition becoming false is evidence to
+review, not permission to discard repo-owned behavior. Restore and ask when the
+deletion is uncertain. Never delete or weaken a workflow to clear a credential or
+external-capability failure; report the human-only blocker instead.
 
 **Silent reverts have NO conflict marker.** copier only emits markers / `.rej`
 where edits *overlap*. A file the repo customized **outside copier's tracked

--- a/.claude/skills/standardize-repo/references/post-generation-checklist.md
+++ b/.claude/skills/standardize-repo/references/post-generation-checklist.md
@@ -46,7 +46,7 @@ push so the remote exists.
 
 - [ ] **[manual — GitHub UI]** Import the branch ruleset that protects `main`
       (required reviews + the `verify`/`security` status checks, plus
-      `codeql-verify` for Node/Python profiles). The JSON is generated into the
+      `codeql-verify` when `use_codeql=true`). The JSON is generated into the
       repo's `.github/`. Import it via the UI:
       **Settings → Rules → Rulesets → New ruleset ▸ Import a ruleset** → select
       `.github/Branch Protection Ruleset - Protect Main.json`. To change an
@@ -184,13 +184,13 @@ push so the remote exists.
   See `docs/architecture/security.md` for blast-radius and rotation notes.
 
 - [ ] **[human-only entitlement decision; scriptable via gh]** Confirm the
-      visibility-appropriate SAST route. Node/Python **public** repositories run
-      the generated CodeQL workflow automatically and for free—confirm a
-      successful Security-tab upload; do not set a variable. Free **private**
-      repositories use Semgrep CE in `build.yml`. Profiles without a generated
-      CodeQL workflow use Semgrep CE at either visibility. Only after enabling
-      paid GitHub Code Security for a private/internal repository, opt it into
-      private CodeQL and confirm the upload:
+      visibility-appropriate SAST route. Repositories with `use_codeql=true`
+      analyze exactly `codeql_languages`; public repositories run that workflow
+      automatically and for free—confirm a successful Security-tab upload; do
+      not set a variable. Private repositories with CodeQL disabled use Semgrep
+      CE in `build.yml`, as do all repositories with `use_codeql=false`. Only
+      after enabling GitHub Code Security for a private/internal repository, opt
+      it into private CodeQL and confirm the upload:
 
   ```bash
   gh variable set FULL_SECURITY_SCAN --repo "<org>/<repo>" --body "true"

--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -371,8 +371,8 @@ Shared structure:
 - **`merge_group`** trigger on `build.yml` (merge-queue support).
 - **Aggregate gate:** a final `verify` job (`if: always()`, `needs: [lint,
   security, …]`) reports one rollup status. Branch protection requires
-  **`verify`** and **`security`**, plus **`codeql-verify`** when a Node/Python
-  profile generates CodeQL and **`terraform-verify`** for a Terraform-capable
+  **`verify`** and **`security`**, plus **`codeql-verify`** exactly when
+  `use_codeql=true` and **`terraform-verify`** for a Terraform-capable
   repo (when `include_terraform=true`, the Terraform aggregate is required).
   Result acceptance is predicate-exact, never a generic
   `success || skipped` allowlist. On a fork PR, every fork-suppressed leaf must be
@@ -413,7 +413,7 @@ Workflow inventory:
 | `claude-implement.yml` | `@claude implement` / label → opens a PR on a `claude/` branch (`--model sonnet`) | [copier] |
 | `claude-review.yml` | `@claude review` / label → review comment, no writes (sticky comment) | [copier] |
 | `release.yml` | release-please; only when `use_release_please` | [copier] |
-| `codeql.yml` | only when `use_node or use_python`; automatic/free for public repos; private/internal requires paid GitHub Code Security + `FULL_SECURITY_SCAN=true`; aggregate `codeql-verify` always reports | [copier] |
+| `codeql.yml` | only when `use_codeql=true`; triggers on PR and `merge_group` so required `codeql-verify` reports; matrix is exactly `codeql_languages`; automatic/free for public repos; private/internal requires GitHub Code Security + `FULL_SECURITY_SCAN=true` | [copier] |
 | `snyk-scheduled.yml` | only when `snyk_scan_schedule` is `weekly` or `daily`; schedule/manual advisory SAST + SCA, no PR/push trigger or required check | [copier] |
 | `devcontainer-build.yml` | only when `devcontainer`; builds bot+dev images, pushes GHCR caches on merge to main | [copier] |
 | `project-automation.yml` | only when `github_org != author_git_provider_username` (org repos); syncs org Project V2 Status field | [copier] |
@@ -462,8 +462,9 @@ The repository-class policy is:
   monitoring for public and private repositories; `task security:audit` /
   `security:sca` runs the package-manager audit. **[manual]** to enable alerts;
   **[copier]** for tasks.
-- **CodeQL** — `codeql.yml` is generated for Node/Python. It runs automatically
-  on public repositories; private/internal repositories run it only with paid
+- **CodeQL** — `codeql.yml` is generated only when `use_codeql=true`, with the
+  exact persisted `codeql_languages` matrix. It runs automatically on public
+  repositories; private/internal repositories run it only with
   GitHub Code Security + `FULL_SECURITY_SCAN=true`, otherwise `build.yml` uses
   Semgrep CE. An unset/empty `FULL_SECURITY_SCAN` normalizes to the free-private
   route. The analyze job/action never uses `continue-on-error`; its stable
@@ -472,7 +473,7 @@ The repository-class policy is:
   routes. The fork path does not check out or execute fork-controlled repository
   code on the aggregate runner. `use_node` and `use_python` describe tooling;
   neither proves that its corresponding source language exists, so reconcile the
-  generated matrix with real first-party source. **[copier]**; **[manual]** only
+  persisted matrix with real first-party source. **[copier]**; **[manual]** only
   for the paid private opt-in.
 - **Snyk** — optional `security:sast:snyk` (`snyk code test`) +
   `security:sca:snyk` (`snyk test --all-projects`) second opinions. The default
@@ -488,7 +489,8 @@ The repository-class policy is:
 - **Branch protection ruleset** — `.github/Branch Protection Ruleset - Protect
   Main.json`: blocks deletion/non-ff/creation, requires linear history, PR with 1
   code-owner approval + thread resolution + last-push approval, required status
-  checks `verify` + `security` (+ `codeql-verify` for Node/Python), merge methods
+  checks `verify` + `security` (+ `codeql-verify` exactly when
+  `use_codeql=true`), merge methods
   squash/rebase; org repos add a `merge_queue` rule. Scheduled Snyk and Snyk App
   checks are never required by default. **[copier]** ships the file; **[manual]**
   import via the GitHub UI (Settings → Rules → Rulesets → **Import a ruleset**) — not
@@ -917,11 +919,11 @@ Adds (all [copier]):
   existing); lefthook ansible-syntax (pre-push); `ANSIBLE_CONFIG` remoteEnv;
   Renovate ansible regex managers; redhat.ansible extension.
 - **Python toolchain** active (uv, black, `.python-version`, pyproject).
-- Do not infer Python CodeQL coverage from the iac type. The current renderer adds
-  `python` when `use_codeql=true` because iac enables the Python tooling flag, but
-  an infrastructure repo may have no first-party `.py` files. Reconcile the
-  matrix with actual source (and include another real language such as
-  `javascript-typescript` when present) plus live Code Security capability.
+- Do not infer Python CodeQL coverage from the iac type. An infrastructure repo
+  may have no first-party `.py` files. Select `use_codeql` deliberately and
+  reconcile `codeql_languages` with actual source (including another supported
+  language such as `javascript-typescript` when present) plus live Code Security
+  capability.
 - **[manual] CHECKLIST:** lay out `terraform/` and/or `ansible/site.yml` — lint
   tasks activate automatically once `ansible/site.yml` exists.
 - The live `harmon-infra` shows how deep the namespacing legitimately goes:
@@ -958,11 +960,11 @@ Legitimately repo- or type-specific differences. An auditor should treat these a
   later added its own `.devcontainer/`).
 - **No `release.yml` / release-please manifest** when `use_release_please: no`
   (then releases are purely `task release:*`).
-- **No `codeql.yml`** when there is no Node/Python tooling profile. A
-  private/internal repo without paid GitHub Code Security still keeps the
-  generated workflow's stable not-applicable aggregate and uses Semgrep CE.
-  Current rendering is gated by `use_node`/`use_python`, so audit the matrix
-  against real source rather than treating those tooling flags as coverage.
+- **No `codeql.yml`** when `use_codeql=false`. When enabled, the workflow matrix
+  is exactly the persisted `codeql_languages`; audit that selection against real
+  first-party source rather than treating tooling flags as coverage. A
+  private/internal repository should select CodeQL only when GitHub Code Security
+  is enabled; otherwise it uses Semgrep CE and documents the deliberate omission.
 - **No `project-automation.yml`, no org `merge_queue` rule, no
   `permission-organization-projects`/`permission-members`** for personal-account
   repos (`github_org == author_git_provider_username`). Org repos get all three.

--- a/.skills-sync.yaml
+++ b/.skills-sync.yaml
@@ -8,7 +8,7 @@
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
   # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
-  ref: v0.8.1 # pinned tag — bump deliberately to a released harmon-devkit tag
+  ref: v0.8.2 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
   - repo
 dest: .claude/skills

--- a/template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja
+++ b/template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja
@@ -9,7 +9,7 @@
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
   # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
-  ref: v0.8.1 # pinned tag — bump deliberately to a released harmon-devkit tag
+  ref: v0.8.2 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
 [% for cat in skill_categories %]
   - [[ cat ]]


### PR DESCRIPTION
## Summary

- bump the root and generated `.skills-sync.yaml` pins from harmon-devkit v0.8.1 to v0.8.2
- refresh the vendored `standardize-repo` skill and provenance via `task sync:skills`
- preserve the two-layer template/dogfood contract with no file deletions

## Verification

- `task sync:skills`
- `task verify:skills`
- `task verify:skills:offline`
- `task test:dogfood-parity` (94 twins)
- `task test:template:all`
- `task verify`
- pre-commit and pre-push hooks