### PR TITLE
fix(devcontainer): probe tailscale through a shell in container asserts

### DIFF
--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -174,10 +174,16 @@ assert_container() {
         *) fail "bot git name '${git_name}' does not end with '-bot'" ;;
         esac
 
-        if docker exec -u vscode "$container_id" command -v tailscale >/dev/null 2>&1; then
+        # `command` is a shell BUILTIN, so it must run inside a shell: bare
+        # `docker exec <id> command -v x` execs a binary that does not exist
+        # and always fails, which silently made this check vacuous.
+        if docker exec -u vscode "$container_id" sh -c 'command -v tailscale' >/dev/null 2>&1; then
             fail "tailscale CLI is present in the bot container"
         fi
 
+        # Captured, never echoed: the failure message reports only that a key
+        # is set, never its value. Do NOT run this script under `set -x` — the
+        # trace would expand the real key into stderr and CI logs.
         local ts_authkey
         ts_authkey="$(docker exec -u vscode "$container_id" printenv TS_AUTHKEY 2>/dev/null || true)"
         [ -z "$ts_authkey" ] || fail "TS_AUTHKEY is set in the bot container"
@@ -189,7 +195,9 @@ assert_container() {
         *-bot) fail "dev git name '${git_name}' unexpectedly ends with '-bot'" ;;
         esac
 
-        if ! docker exec -u vscode "$container_id" command -v tailscale >/dev/null 2>&1; then
+        # Same builtin caveat as the bot branch above — without `sh -c` this
+        # never passes, regardless of whether tailscale is installed.
+        if ! docker exec -u vscode "$container_id" sh -c 'command -v tailscale' >/dev/null 2>&1; then
             fail "tailscale CLI is missing from the dev container"
         fi
     fi

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -174,10 +174,16 @@ assert_container() {
         *) fail "bot git name '${git_name}' does not end with '-bot'" ;;
         esac
 
-        if docker exec -u vscode "$container_id" command -v tailscale >/dev/null 2>&1; then
+        # `command` is a shell BUILTIN, so it must run inside a shell: bare
+        # `docker exec <id> command -v x` execs a binary that does not exist
+        # and always fails, which silently made this check vacuous.
+        if docker exec -u vscode "$container_id" sh -c 'command -v tailscale' >/dev/null 2>&1; then
             fail "tailscale CLI is present in the bot container"
         fi
 
+        # Captured, never echoed: the failure message reports only that a key
+        # is set, never its value. Do NOT run this script under `set -x` — the
+        # trace would expand the real key into stderr and CI logs.
         local ts_authkey
         ts_authkey="$(docker exec -u vscode "$container_id" printenv TS_AUTHKEY 2>/dev/null || true)"
         [ -z "$ts_authkey" ] || fail "TS_AUTHKEY is set in the bot container"
@@ -189,7 +195,9 @@ assert_container() {
         *-bot) fail "dev git name '${git_name}' unexpectedly ends with '-bot'" ;;
         esac
 
-        if ! docker exec -u vscode "$container_id" command -v tailscale >/dev/null 2>&1; then
+        # Same builtin caveat as the bot branch above — without `sh -c` this
+        # never passes, regardless of whether tailscale is installed.
+        if ! docker exec -u vscode "$container_id" sh -c 'command -v tailscale' >/dev/null 2>&1; then
             fail "tailscale CLI is missing from the dev container"
         fi
     fi


### PR DESCRIPTION
## The bug

`scripts/devcontainer-assert.sh` probes for the Tailscale CLI with:

```sh
docker exec -u vscode "$container_id" command -v tailscale
```

`command` is a **shell builtin**, but `docker exec` execs the binary directly — no shell. That binary doesn't exist, so the probe **always fails**, whether or not tailscale is installed.

One broken construct, opposite symptoms per profile:

| Line | Profile | Intent | Actual |
| --- | --- | --- | --- |
| 177 | bot | fail if tailscale is **present** | never fires — silently vacuous |
| 192 | dev | fail if tailscale is **missing** | always fires — `task test:devcontainer:dev` can never pass |

## Isolation is not affected

Worth stating plainly, since the bot check looks security-relevant: **the bot container's Tailscale isolation is still genuinely verified.** `assert_config_invariants` asserts it statically from `devcontainer.json` (`has_ts_feature = 0`, plus the 1Password feature, `/dev/net/tun`, and `TS_AUTHKEY` in `initializeCommand`), and that assertion works. What was lost is the runtime confirmation of a property the static check already covers.

The neighbouring `printenv TS_AUTHKEY` check also works fine — `printenv` is a real binary, which is exactly why it worked while its neighbour couldn't.

## Verified against a live container

```
container WITHOUT tailscale -> not detected   (want: not detected)
container WITH tailscale    -> detected       (want: detected)
--- old broken form, same container WITH tailscale installed ---
not detected  <-- false negative, the bug
```

## Changes

- `sh -c 'command -v tailscale'` in both probes, with a comment explaining why a builtin needs a shell.
- Applied to **both** copies, which are kept byte-identical: the dogfooded `scripts/devcontainer-assert.sh` and the Copier source `template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]`.
- Documents that this script must never run under `set -x` — the trace would expand the captured `TS_AUTHKEY` into stderr and CI logs. The value is otherwise only tested for emptiness and never echoed.

## Why it went unnoticed

No workflow runs `test:devcontainer:dev` — it's a local-only gate, so CI stayed green while `task verify` was unpassable in generated repos. Found while running `verify` in harmon-infra, where it fails as `ASSERT FAIL: tailscale CLI is missing from the dev container`.

Worth considering separately: whether the dev-profile container assertion should run in CI, or whether the vacuous-check class deserves a lint guard. Both felt out of scope for a one-line correctness fix.

## Verification

`task verify` passes (exit 0), including `test:template`, which renders the whole template and so exercises the template copy.

Downstream repos need the same fix applied directly or via a template update — harmon-infra's copy has drifted ahead of the template (it carries a `devcontainer_cli()` helper and a `--docker-path` fix that were never upstreamed), so a plain `copier update` there is not a safe no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
