### PR TITLE
fix(template): correct verified defects in generated repo tooling and defaults

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -30,6 +30,9 @@ brew "yq"
 
 # Python tooling (uv; foreman lint runs pinned ruff/black via uvx)
 brew "uv"
+# foreman runs as bare `python3 -m foreman` and needs >= 3.11 (tomllib);
+# stock macOS ships 3.9, so the interpreter itself is a dependency.
+brew "python"
 
 # Runtime for npx-based tools (commitlint, markdownlint-cli2)
 brew "node"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,6 +59,7 @@ tasks:
       - task: check
       - task: test:tasks
       - task: test:ci-results
+      - task: test:renovate-pins
       - task: test:release-title
       - task: foreman:test
       - task: test:hooks
@@ -76,6 +77,7 @@ tasks:
       - task: check
       - task: test:tasks
       - task: test:ci-results
+      - task: test:renovate-pins
       - task: test:release-title
       - task: test:dogfood-parity
       - task: foreman:test
@@ -301,6 +303,11 @@ tasks:
     desc: Unit-test the fail-closed CI aggregate result helper
     cmds:
       - ./scripts/test-ci-results.sh
+
+  test:renovate-pins:
+    desc: Check every annotated shell version pin is extractable by Renovate
+    cmds:
+      - ./scripts/test-renovate-pins.sh
 
   test:release-title:
     desc: Unit-test the release-content title guard (require-release-title.sh)

--- a/copier.yml
+++ b/copier.yml
@@ -64,7 +64,11 @@ github_org:
 code_owner:
   type: str
   help: "CODE OWNER: GitHub user/team for CODEOWNERS (org repos may use org/team)"
-  default: "[[ github_org ]]"
+  # Defaults to the human author, NOT github_org: GitHub rejects a bare org as a
+  # CODEOWNERS principal ("Unknown owner"), which silently makes
+  # require-code-owner-review match nobody. An org/team (`@org/team`) is a valid
+  # answer, but must be chosen deliberately.
+  default: "[[ author_git_provider_username ]]"
 
 claude_authorized_members:
   type: str

--- a/renovate.json
+++ b/renovate.json
@@ -36,8 +36,8 @@
     },
     {
       "customType": "regex",
-      "description": "Workflow/composite-action and script tool pins, `FOO_VERSION=x.y.z` shell-variable style",
-      "managerFilePatterns": ["/(\\.github/(actions|workflows)/.*\\.ya?ml(\\.jinja)?|scripts/.*\\.sh)$/"],
+      "description": "Workflow/composite-action and script tool pins, `FOO_VERSION=x.y.z` shell-variable style. Template scripts carry jinja in the FILENAME (`…foo.sh[% endif %]`), so the .sh alternative tolerates that suffix — without it every pin under template/scripts/ is invisible here.",
+      "managerFilePatterns": ["/(\\.github/(actions|workflows)/.*\\.ya?ml(\\.jinja)?|scripts/.*\\.sh(\\[% endif %\\])?)$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+[A-Z_]+_VERSION=(?<currentValue>\\S+)"
       ]

--- a/scripts/lint-hygiene.sh
+++ b/scripts/lint-hygiene.sh
@@ -125,7 +125,10 @@ for f in "${files[@]}"; do
         devcontainer.json | */devcontainer.json | .devcontainer.json | */.devcontainer.json | \
             tsconfig*.json | */tsconfig*.json | template/*) ;;
         *)
-            if ! python3 -c "import json; json.load(open('$f'))" 2>/dev/null; then
+            # Pass the path as argv, never interpolated into the Python source:
+            # an apostrophe in a filename would otherwise be a SyntaxError
+            # reported as invalid JSON, and a crafted name would execute.
+            if ! python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$f" 2>/dev/null; then
                 warn "$f: invalid JSON"
             fi
             ;;
@@ -137,7 +140,7 @@ for f in "${files[@]}"; do
     case "$f" in
     template/*.toml) ;;
     *.toml)
-        if ! python3 -c "import tomllib; tomllib.load(open('$f','rb'))" 2>/dev/null; then
+        if ! python3 -c 'import tomllib,sys; tomllib.load(open(sys.argv[1],"rb"))' "$f" 2>/dev/null; then
             warn "$f: invalid TOML"
         fi
         ;;

--- a/scripts/test-renovate-pins.sh
+++ b/scripts/test-renovate-pins.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# test-renovate-pins.sh — every `# renovate:`-annotated shell pin must actually
+# be extractable by the manager that is supposed to manage it.
+#
+# Three ways a pin silently stops updating, all of which look fine in review and
+# produce NO error from Renovate — it just skips the dependency:
+#   1. quoted value      FOO_VERSION="1.2.3"  -> currentValue is `"1.2.3"`,
+#                        which pep440/semver reject
+#   2. non-adjacent      a comment between `# renovate:` and the assignment
+#                        breaks the `\s+` join
+#   3. unmatched path    the file is not covered by any managerFilePatterns
+#                        (template scripts carry jinja in the FILENAME)
+#
+# Rather than re-describe the rules, this runs the regexes the repo actually
+# ships, so the test cannot drift from the config.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+python3 - <<'PY'
+import json, re, sys, pathlib
+
+def load_shell_manager(path):
+    raw = pathlib.Path(path).read_text()
+    # The template config is jinja-templated, so it is not always valid JSON;
+    # pull the manager out textually and fall back to a JSON parse when clean.
+    try:
+        cfg = json.loads(raw)
+        mgrs = cfg.get("customManagers", [])
+    except json.JSONDecodeError:
+        mgrs = []
+        for m in re.finditer(r'\{[^{}]*"matchStrings"\s*:\s*\[[^\]]*\][^{}]*\}', raw, re.S):
+            try:
+                mgrs.append(json.loads(m.group(0)))
+            except json.JSONDecodeError:
+                pass
+    for m in mgrs:
+        if any("_VERSION=" in s for s in m.get("matchStrings", [])):
+            return m
+    return None
+
+def js_to_py(rx):
+    return rx.replace("(?<", "(?P<")
+
+errors = []
+
+root_mgr = load_shell_manager("renovate.json")
+tmpl_mgr = load_shell_manager("template/renovate.json.jinja")
+if not root_mgr:
+    errors.append("renovate.json: no shell-variable custom manager found")
+if not tmpl_mgr:
+    errors.append("template/renovate.json.jinja: no shell-variable custom manager found")
+
+ANNOT = re.compile(r"^\s*#\s*renovate:\s*datasource=", re.M)
+
+def rendered(path):
+    """Path as it appears in a GENERATED repo: no `template/` prefix, no jinja
+    in the filename. The template config's patterns are anchored at the
+    generated repo root, so they must be tested against this form."""
+    return re.sub(r"\[%.*?%\]", "", path).removeprefix("template/")
+
+for p in sorted(pathlib.Path(".").glob("scripts/*.sh")) + sorted(
+    pathlib.Path("template/scripts").iterdir() if pathlib.Path("template/scripts").is_dir() else []
+):
+    if not p.is_file():
+        continue
+    text = p.read_text(errors="replace")
+    if not ANNOT.search(text):
+        continue
+
+    is_template = str(p).startswith("template/")
+    mgr = tmpl_mgr if is_template else root_mgr
+    # The root config must ALSO see template sources — that is how harmon-init
+    # gets bump PRs for the pins it ships downstream.
+    configs = [("template/renovate.json.jinja", mgr, rendered(str(p)))] if is_template else []
+    configs.append(("renovate.json", root_mgr, str(p)))
+
+    n_annot = len(ANNOT.findall(text))
+    for cfg_name, m, path_for_match in configs:
+        if not m:
+            continue
+        matched = len(re.findall(js_to_py(m["matchStrings"][0]), text))
+        if matched < n_annot:
+            errors.append(
+                f"{p}: {n_annot} '# renovate:' annotation(s) but {matched} extractable by "
+                f"{cfg_name} — check adjacency (no comment between annotation and "
+                f"assignment) and that the value is unquoted"
+            )
+        for mo in re.finditer(js_to_py(m["matchStrings"][0]), text):
+            val = mo.group("currentValue")
+            if val.startswith('"') or val.startswith("'"):
+                errors.append(f"{p}: pin value {val} is quoted; quotes end up inside currentValue")
+
+        pats = [re.compile(x.strip("/")) for x in m.get("managerFilePatterns", [])]
+        if pats and not any(rx.search(path_for_match) for rx in pats):
+            errors.append(
+                f"{p}: not matched by any managerFilePatterns in {cfg_name} "
+                f"(tested as {path_for_match!r}) — the pin is invisible to Renovate"
+            )
+
+if errors:
+    for e in errors:
+        print(f"FAIL: {e}", file=sys.stderr)
+    print(f"test-renovate-pins: {len(errors)} issue(s) found", file=sys.stderr)
+    sys.exit(1)
+print("renovate pins: every annotated shell pin is extractable and in scope")
+PY

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -2,7 +2,7 @@
 # test-template.sh — render the Copier template into a temp dir and validate it.
 #
 # Usage: ./scripts/test-template.sh <profile>
-# Profiles: minimal | web | iac | full | meta
+# Profiles: minimal | web | webapp | iac | full | meta
 #
 # IMPORTANT: files with CONDITIONAL NAMES are never even compiled by jinja
 # unless some profile makes the condition true (copier skips files whose
@@ -282,6 +282,50 @@ if [ -f .github/workflows/snyk-scheduled.yml ]; then
     grep -q 'SNYK_TOKEN' .github/workflows/snyk-scheduled.yml || err "scheduled Snyk workflow is missing token wiring"
     grep -q 'remote-repo-url' .github/workflows/snyk-scheduled.yml || err "scheduled Snyk workflow must identify public repository context"
     grep -q 'matrix.scan' .github/workflows/snyk-scheduled.yml || err "scheduled Snyk workflow must run SAST and SCA"
+fi
+
+# ── 1c. CODEOWNERS names a principal GitHub will actually accept ────
+# `code_owner` defaults to the human author, NOT github_org: GitHub rejects a
+# bare org ("Unknown owner"), which silently makes require-code-owner-review
+# match nobody. The `full` profile renders with github_org=test-org, so this
+# also proves the default does not follow the org.
+if [ -f .github/CODEOWNERS ]; then
+    grep -Fxq '* @evanharmon1' .github/CODEOWNERS ||
+        err "CODEOWNERS does not name the author as owner: $(cat .github/CODEOWNERS)"
+fi
+
+# ── 1d. Python audit is fail-closed and audits the locked graph ─────
+# The previous form piped `uv pip compile` through process substitution, so a
+# failed resolve produced an empty requirements file and a green audit.
+# Keyed on pyproject.toml, NOT a use_python answer: `when: false` questions are
+# computed, and copier does not persist them to .copier-answers.yml.
+if [ -f pyproject.toml ]; then
+    [ -x scripts/python-audit.sh ] || err "python-audit.sh missing or not executable"
+    grep -q './scripts/python-audit.sh' Taskfile.yml ||
+        err "security:audit does not call the fail-closed python audit helper"
+    ! grep -q 'pip-audit .*--requirement <(' Taskfile.yml ||
+        err "security:audit still resolves requirements through process substitution"
+    grep -q 'uv export' scripts/python-audit.sh ||
+        err "python-audit.sh must audit the locked graph, not a fresh resolve"
+    grep -q -- '--all-groups\|--group dev' scripts/python-audit.sh ||
+        err "python-audit.sh must include development dependencies"
+    grep -q 'pip-audit==' scripts/python-audit.sh ||
+        err "python-audit.sh must pin pip-audit"
+fi
+
+# ── 1e. Renovate can see the pins the template actually ships ───────
+# foreman's taskfiles/foreman.yml carries `# renovate:`-annotated ruff/black
+# pins in `FOO_VERSION: x.y.z` form; without a Taskfile manager they rot
+# invisibly in every generated repo.
+if grep -q '^use_foreman:[[:space:]]*\(true\|yes\)$' .copier-answers.yml; then
+    # Anchor on the managerFilePatterns entry, not on "Taskfile" or the
+    # `FOO_VERSION: ` matchString: both also appear in this manager's own
+    # description (and "Taskfile" in other managers' patterns), so grepping for
+    # those silently passes even when the manager is gutted.
+    grep -q 'taskfiles\\\\/' renovate.json ||
+        err "renovate.json has no Taskfile manager for the shipped FOO_VERSION pins"
+    grep -q 'brew "python"' Brewfile ||
+        err "Brewfile lacks python; foreman needs >= 3.11 and macOS ships 3.9"
 fi
 
 # ── 2. No unrendered Copier variables leaked into output ────────────

--- a/template/Brewfile.jinja
+++ b/template/Brewfile.jinja
@@ -27,6 +27,11 @@ brew "lychee"
 [% endif %]
 # Python tool runner (Semgrep CE[% if use_python %] + project dependencies[% endif %][% if use_foreman %] + foreman lint[% endif %] use uv/uvx)
 brew "uv"
+[% if use_foreman or use_python %]
+# [% if use_foreman %]foreman runs as bare `python3 -m foreman` and needs >= 3.11 (tomllib)[% else %]this project targets Python >= 3.11[% endif %];
+# stock macOS ships 3.9, so the interpreter itself is a dependency.
+brew "python"
+[% endif %]
 [% if include_terraform %]
 
 # Terraform

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -583,7 +583,7 @@ tasks:
       - pnpm audit --audit-level=high
 [% endif %]
 [% if use_python %]
-      - uvx pip-audit --desc --requirement <(uv pip compile pyproject.toml 2>/dev/null)
+      - ./scripts/python-audit.sh
 [% endif %]
 [% if not use_node and not use_python %]
       - echo "No package manifests to audit yet."

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -46,6 +46,17 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+[A-Z_]+_VERSION=(?<currentValue>\\S+)"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Taskfile tool pins (root Taskfile + included taskfiles/), `FOO_VERSION: x.y.z` var style",
+      "managerFilePatterns": [
+        "/(^|\\/)Taskfile\\.ya?ml$/",
+        "/taskfiles\\/[^/]+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+[A-Z_]+_VERSION: \"?(?<currentValue>[^\"\\s]+)\"?"
+      ]
     }[% if include_ansible %],
     {
       "customType": "regex",

--- a/template/scripts/[% if use_python %]python-audit.sh[% endif %]
+++ b/template/scripts/[% if use_python %]python-audit.sh[% endif %]
@@ -33,9 +33,11 @@ else
         --output-file "$requirements"
 fi
 
+# The `# renovate:` line must sit IMMEDIATELY above the assignment (the manager
+# joins them with \s+, so any comment between breaks the match), and the value
+# must be unquoted (currentValue is captured with \S+, so quotes land inside it
+# and pep440 rejects them). scripts/test-renovate-pins.sh enforces both.
 # renovate: datasource=pypi depName=pip-audit
-# Unquoted on purpose: the shell-variable manager captures currentValue with
-# \S+, so quotes end up inside it and pep440 rejects the version.
 PIP_AUDIT_VERSION=2.10.1
 uvx --from "pip-audit==${PIP_AUDIT_VERSION}" pip-audit \
     --desc \

--- a/template/scripts/[% if use_python %]python-audit.sh[% endif %]
+++ b/template/scripts/[% if use_python %]python-audit.sh[% endif %]
@@ -34,7 +34,9 @@ else
 fi
 
 # renovate: datasource=pypi depName=pip-audit
-PIP_AUDIT_VERSION="2.10.1"
+# Unquoted on purpose: the shell-variable manager captures currentValue with
+# \S+, so quotes end up inside it and pep440 rejects the version.
+PIP_AUDIT_VERSION=2.10.1
 uvx --from "pip-audit==${PIP_AUDIT_VERSION}" pip-audit \
     --desc \
     --requirement "$requirements"

--- a/template/scripts/[% if use_python %]python-audit.sh[% endif %]
+++ b/template/scripts/[% if use_python %]python-audit.sh[% endif %]
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Audit the exact locked Python dependency graph, including development tools.
+#
+# Replaces `uvx pip-audit --requirement <(uv pip compile pyproject.toml)`, which
+# was fail-open in three ways: process substitution discards the compile step's
+# exit status, so a failed resolve produced an EMPTY requirements file that
+# pip-audit happily reported as "no known vulnerabilities" with exit 0; it
+# re-resolved instead of auditing the committed lock; and it never included the
+# dev group, which is where this project's real dependencies live.
+set -euo pipefail
+
+requirements="$(mktemp)"
+trap 'rm -f "$requirements"' EXIT
+
+if [ -f uv.lock ]; then
+    # --locked fails rather than silently rewriting a stale lock in CI, so the
+    # audit always describes the dependency graph that was actually reviewed.
+    uv export \
+        --locked \
+        --all-extras \
+        --all-groups \
+        --no-emit-project \
+        --no-hashes \
+        --quiet \
+        --output-file "$requirements"
+else
+    # Fresh scaffolds have no uv.lock yet; resolve to a temp file without
+    # mutating the repository.
+    uv pip compile pyproject.toml \
+        --all-extras \
+        --group dev \
+        --quiet \
+        --output-file "$requirements"
+fi
+
+# renovate: datasource=pypi depName=pip-audit
+PIP_AUDIT_VERSION="2.10.1"
+uvx --from "pip-audit==${PIP_AUDIT_VERSION}" pip-audit \
+    --desc \
+    --requirement "$requirements"

--- a/template/scripts/lint-hygiene.sh
+++ b/template/scripts/lint-hygiene.sh
@@ -125,7 +125,10 @@ for f in "${files[@]}"; do
         devcontainer.json | */devcontainer.json | .devcontainer.json | */.devcontainer.json | \
             tsconfig*.json | */tsconfig*.json | template/*) ;;
         *)
-            if ! python3 -c "import json; json.load(open('$f'))" 2>/dev/null; then
+            # Pass the path as argv, never interpolated into the Python source:
+            # an apostrophe in a filename would otherwise be a SyntaxError
+            # reported as invalid JSON, and a crafted name would execute.
+            if ! python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$f" 2>/dev/null; then
                 warn "$f: invalid JSON"
             fi
             ;;
@@ -137,7 +140,7 @@ for f in "${files[@]}"; do
     case "$f" in
     template/*.toml) ;;
     *.toml)
-        if ! python3 -c "import tomllib; tomllib.load(open('$f','rb'))" 2>/dev/null; then
+        if ! python3 -c 'import tomllib,sys; tomllib.load(open(sys.argv[1],"rb"))' "$f" 2>/dev/null; then
             warn "$f: invalid TOML"
         fi
         ;;


### PR DESCRIPTION
Salvage from #289, which is superseded and being closed. These are the items later PRs never covered. Each was verified against `main` before being written, and each is independent — see #328 for the full triage.

Deliberately **excludes** the `devcontainer-assert.sh --docker-path` item from #328, because #330 is currently editing the same byte-equality twins. That one should ride along with #330.

## 1. `lint-hygiene.sh` executed filenames as Python source

```sh
python3 -c "import json; json.load(open('$f'))"
```

An apostrophe in a path closes the string literal, so Python raises `SyntaxError` and a perfectly valid file is reported as **invalid JSON**. A crafted filename executes arbitrary Python.

`lint:hygiene` runs on every pre-commit and in CI, and enumerates `git ls-files --cached --others` — so **untracked** files in the working tree count too. Ships to every generated repo.

Verified against the previous version:

```
OLD: FAIL: fixture's data.json: invalid JSON     (exit 1)   ← valid JSON
NEW: (no output)                                 (exit 0)
```

Genuinely malformed JSON still fails. Both layers moved together (verbatim twin).

## 2. The Python dependency audit was fail-open

```yaml
uvx pip-audit --desc --requirement <(uv pip compile pyproject.toml 2>/dev/null)
```

Process substitution discards the compile's exit status and `2>/dev/null` hides the error, so **a failed resolve produces an empty requirements file and a green "no known vulnerabilities" with exit 0**. It also re-resolved instead of auditing the committed lock, and never included the dev group — which for the ansible/iac profiles is the entire real dependency set.

Replaced with `scripts/python-audit.sh`: `uv export --locked` when `uv.lock` exists, temp-file compile for fresh scaffolds, extras + dev group in both paths, pip-audit pinned with a `# renovate:` annotation the existing `scripts/*.sh` manager already tracks. Template-only — harmon-init's own answers set `use_python=false`.

## 3. CODEOWNERS defaulted to an invalid principal

`code_owner` defaulted to `[[ github_org ]]`, rendering `* @<org>` for every org repo. GitHub rejects a bare org, so require-code-owner-review matched **nobody**. Confirmed live on `ponderousdev/omator`:

```
$ gh api repos/ponderousdev/omator/codeowners/errors
Unknown owner on line 1: make sure @ponderousdev exists and has write access
```

Seven other org repos carry a hand-corrected answer — the default was overridden nearly every time it mattered. Now defaults to the author, valid for personal and org repos alike; `@org/team` stays a deliberate opt-in. Not breaking: the answer is recorded and `.github/CODEOWNERS` is in `_skip_if_exists`, so only fresh scaffolds change.

## 4. Renovate could not see the pins the template ships

The root `renovate.json` has had a Taskfile `FOO_VERSION: x.y.z` manager for a long time, and `taskfiles/foreman.yml` carries annotated ruff/black pins — but `template/renovate.json.jinja` had no such manager. Every generated repo with `use_foreman` (the default) had two silently rotting pins.

## 5. Foreman could not run on a clean Mac

It executes as bare `python3 -m foreman` and refuses below 3.11 (`tomllib`), but neither Brewfile installed Python. Stock macOS ships 3.9.6.

## Verification

`task verify` exits 0; all seven render profiles pass (`minimal`, `web`, `webapp`, `iac`, `full`, `meta`, `update`).

Every new `test-template.sh` assertion was **negative-tested** — the defect reintroduced, the suite confirmed to fail:

| Assertion | Reintroduced defect → result |
|---|---|
| CODEOWNERS principal | `* @test-org` → `test-template (full): FAILED` |
| pip-audit fail-open | process substitution restored → `test-template (iac): FAILED` |
| Renovate Taskfile manager | managerFilePatterns gutted → `test-template (iac): FAILED` |
| `brew "python"` | entry removed → `test-template (iac): FAILED` |

Worth flagging: **two of the four assertions were no-ops on the first attempt** and only the negative test caught it. The python one keyed on a `use_python` answer that copier never persists (`when: false` questions are computed, not recorded), and the renovate one grepped a string that also appears in its own `description`. Both were rewritten to anchor on something real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)