### PR TITLE
fix(devcontainer): harden the devcontainer scripts against wedged Docker and unpinned CLI

### DIFF
--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -20,6 +20,17 @@ fail() {
     exit 1
 }
 
+# renovate: datasource=npm depName=@devcontainers/cli
+DEVCONTAINER_CLI_VERSION="0.87.0"
+
+devcontainer_cli() {
+    if command -v devcontainer >/dev/null 2>&1; then
+        devcontainer "$@"
+    else
+        npx --yes "@devcontainers/cli@${DEVCONTAINER_CLI_VERSION}" "$@"
+    fi
+}
+
 # ── unit mode ─────────────────────────────────────────────────────────
 assert_unit() {
     # Resolve the repo root from the script's own location BEFORE we cd away,
@@ -123,7 +134,11 @@ assert_config_invariants() {
     local repo_root="$1" config="$2" profile="$3"
     local cfg has_ts_feature has_op_feature has_tun has_ts_init
 
-    cfg="$(npx -y @devcontainers/cli read-configuration \
+    # read-configuration 0.87+ probes Docker for an existing container even
+    # though this assertion only needs the static JSONC. A no-op docker path
+    # keeps this unit check daemon-independent as documented.
+    cfg="$(devcontainer_cli read-configuration \
+        --docker-path /usr/bin/true \
         --workspace-folder "$repo_root" \
         --config "$config")" ||
         fail "read-configuration failed for ${config}"

--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -21,7 +21,7 @@ fail() {
 }
 
 # renovate: datasource=npm depName=@devcontainers/cli
-DEVCONTAINER_CLI_VERSION="0.87.0"
+DEVCONTAINER_CLI_VERSION=0.87.0
 
 devcontainer_cli() {
     if command -v devcontainer >/dev/null 2>&1; then

--- a/scripts/devcontainer-smoke.sh
+++ b/scripts/devcontainer-smoke.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # renovate: datasource=npm depName=@devcontainers/cli
-DEVCONTAINER_CLI_VERSION="0.87.0"
+DEVCONTAINER_CLI_VERSION=0.87.0
 
 if [ "$#" -ne 1 ]; then
     echo "Usage: $0 <devcontainer-config-path>" >&2

--- a/scripts/devcontainer-smoke.sh
+++ b/scripts/devcontainer-smoke.sh
@@ -1,13 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=npm depName=@devcontainers/cli
+DEVCONTAINER_CLI_VERSION="0.87.0"
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <devcontainer-config-path>" >&2
+    exit 1
+fi
+
+if command -v devcontainer >/dev/null 2>&1; then
+    DEVCONTAINER_CMD=(devcontainer)
+else
+    DEVCONTAINER_CMD=(npx --yes "@devcontainers/cli@${DEVCONTAINER_CLI_VERSION}")
+fi
+
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout"
+else
+    echo "GNU timeout is required (install coreutils on macOS)." >&2
+    exit 1
+fi
+
 if ! command -v jq >/dev/null 2>&1; then
     echo "jq is required for devcontainer smoke tests." >&2
     exit 1
 fi
 
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 <devcontainer-config-path>" >&2
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required for devcontainer smoke tests." >&2
+    exit 1
+fi
+
+# Fail before the devcontainer CLI when the daemon is absent or wedged. The
+# CLI can otherwise block indefinitely while probing Docker, which makes a
+# fleet verification hang rather than produce an actionable failure.
+if ! "$TIMEOUT_BIN" -k 5 20 docker info >/dev/null 2>&1; then
+    echo "Docker daemon is unavailable or did not answer within 20 seconds." >&2
     exit 1
 fi
 
@@ -20,14 +51,14 @@ CONTAINER_ID=""
 
 cleanup() {
     if [ -n "${CONTAINER_ID}" ]; then
-        docker rm -f "${CONTAINER_ID}" >/dev/null 2>&1 || true
+        "$TIMEOUT_BIN" -k 5 20 docker rm -f "${CONTAINER_ID}" >/dev/null 2>&1 || true
     fi
     rm -rf "${USER_DATA_DIR}" "${SESSION_DATA_DIR}" "${LOG_FILE}"
 }
 trap cleanup EXIT
 
 echo "==> Running devcontainer smoke test for ${CONFIG_PATH}..."
-npx -y @devcontainers/cli up \
+"$TIMEOUT_BIN" -k 30 1800 "${DEVCONTAINER_CMD[@]}" up \
     --workspace-folder "${WORKSPACE_ROOT}" \
     --config "${CONFIG_PATH}" \
     --remove-existing-container \

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -20,6 +20,17 @@ fail() {
     exit 1
 }
 
+# renovate: datasource=npm depName=@devcontainers/cli
+DEVCONTAINER_CLI_VERSION="0.87.0"
+
+devcontainer_cli() {
+    if command -v devcontainer >/dev/null 2>&1; then
+        devcontainer "$@"
+    else
+        npx --yes "@devcontainers/cli@${DEVCONTAINER_CLI_VERSION}" "$@"
+    fi
+}
+
 # ── unit mode ─────────────────────────────────────────────────────────
 assert_unit() {
     # Resolve the repo root from the script's own location BEFORE we cd away,
@@ -123,7 +134,11 @@ assert_config_invariants() {
     local repo_root="$1" config="$2" profile="$3"
     local cfg has_ts_feature has_op_feature has_tun has_ts_init
 
-    cfg="$(npx -y @devcontainers/cli read-configuration \
+    # read-configuration 0.87+ probes Docker for an existing container even
+    # though this assertion only needs the static JSONC. A no-op docker path
+    # keeps this unit check daemon-independent as documented.
+    cfg="$(devcontainer_cli read-configuration \
+        --docker-path /usr/bin/true \
         --workspace-folder "$repo_root" \
         --config "$config")" ||
         fail "read-configuration failed for ${config}"

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -21,7 +21,7 @@ fail() {
 }
 
 # renovate: datasource=npm depName=@devcontainers/cli
-DEVCONTAINER_CLI_VERSION="0.87.0"
+DEVCONTAINER_CLI_VERSION=0.87.0
 
 devcontainer_cli() {
     if command -v devcontainer >/dev/null 2>&1; then

--- a/template/scripts/[% if devcontainer %]devcontainer-smoke.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-smoke.sh[% endif %]
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # renovate: datasource=npm depName=@devcontainers/cli
-DEVCONTAINER_CLI_VERSION="0.87.0"
+DEVCONTAINER_CLI_VERSION=0.87.0
 
 if [ "$#" -ne 1 ]; then
     echo "Usage: $0 <devcontainer-config-path>" >&2

--- a/template/scripts/[% if devcontainer %]devcontainer-smoke.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-smoke.sh[% endif %]
@@ -1,13 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# renovate: datasource=npm depName=@devcontainers/cli
+DEVCONTAINER_CLI_VERSION="0.87.0"
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <devcontainer-config-path>" >&2
+    exit 1
+fi
+
+if command -v devcontainer >/dev/null 2>&1; then
+    DEVCONTAINER_CMD=(devcontainer)
+else
+    DEVCONTAINER_CMD=(npx --yes "@devcontainers/cli@${DEVCONTAINER_CLI_VERSION}")
+fi
+
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout"
+else
+    echo "GNU timeout is required (install coreutils on macOS)." >&2
+    exit 1
+fi
+
 if ! command -v jq >/dev/null 2>&1; then
     echo "jq is required for devcontainer smoke tests." >&2
     exit 1
 fi
 
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 <devcontainer-config-path>" >&2
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required for devcontainer smoke tests." >&2
+    exit 1
+fi
+
+# Fail before the devcontainer CLI when the daemon is absent or wedged. The
+# CLI can otherwise block indefinitely while probing Docker, which makes a
+# fleet verification hang rather than produce an actionable failure.
+if ! "$TIMEOUT_BIN" -k 5 20 docker info >/dev/null 2>&1; then
+    echo "Docker daemon is unavailable or did not answer within 20 seconds." >&2
     exit 1
 fi
 
@@ -20,14 +51,14 @@ CONTAINER_ID=""
 
 cleanup() {
     if [ -n "${CONTAINER_ID}" ]; then
-        docker rm -f "${CONTAINER_ID}" >/dev/null 2>&1 || true
+        "$TIMEOUT_BIN" -k 5 20 docker rm -f "${CONTAINER_ID}" >/dev/null 2>&1 || true
     fi
     rm -rf "${USER_DATA_DIR}" "${SESSION_DATA_DIR}" "${LOG_FILE}"
 }
 trap cleanup EXIT
 
 echo "==> Running devcontainer smoke test for ${CONFIG_PATH}..."
-npx -y @devcontainers/cli up \
+"$TIMEOUT_BIN" -k 30 1800 "${DEVCONTAINER_CMD[@]}" up \
     --workspace-folder "${WORKSPACE_ROOT}" \
     --config "${CONFIG_PATH}" \
     --remove-existing-container \


### PR DESCRIPTION
> **Stacked on #330.** That PR fixes the shell-builtin probe in the same two files; this one carries only the drift. Merge #330 first and this reduces to a clean diff.

## Why

harmon-infra's copies of `devcontainer-assert.sh` and `devcontainer-smoke.sh` had **drifted ahead of the template** with fixes that were never upstreamed. Two consequences:

- every repo generated from harmon-init shipped the weaker versions
- a `copier update` in harmon-infra would have **reverted** the improvements

Adopted wholesale — the downstream copies are strict supersets, and I checked they contain nothing repo-specific (no references to harmon-infra, terraform, ansible, or its services).

## What came upstream

- **Pin `@devcontainers/cli`** (renovate-annotated) and prefer a locally installed `devcontainer` binary over `npx`.
- **`--docker-path /usr/bin/true`** on `read-configuration`. CLI 0.87+ probes Docker even though the unit assertions only need the static JSONC; this keeps that check daemon-independent, as its own docs claim.
- **Require GNU `timeout`** (`timeout`/`gtimeout`, with a clear message to install coreutils on macOS), check `docker` is present, and **fail fast when the daemon is missing or wedged** instead of letting the CLI block indefinitely. `devcontainer up` and `docker rm -f` are bounded too.

That last guard is not hypothetical — a stalled OrbStack socket is what surfaced this whole thread. Without it, `task verify` hangs rather than failing usefully; with it you get `Docker daemon is unavailable or did not answer within 20 seconds.`

## Parity

Both copies stay byte-identical — the dogfooded `scripts/` pair and the Copier source under `template/scripts/` — and both now match harmon-infra exactly, so the next `copier update` there is a genuine no-op. Verified:

```
devcontainer-assert.sh: template == dogfooded, == harmon-infra
devcontainer-smoke.sh:  template == dogfooded, == harmon-infra
```

## Verification

`task verify` passes (exit 0), including `test:template`, which renders the whole template and exercises the template copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
