### PR TITLE
fix(template): document the devcontainer's known failure modes

### DIFF
--- a/.devcontainer/dev/devcontainer.json
+++ b/.devcontainer/dev/devcontainer.json
@@ -40,12 +40,12 @@
     "ghcr.io/itsmechlark/features/1password:1.5.0": {}
   },
   "mounts": [
-    "source=claude-code-config-${devcontainerId},target=/home/vscode/.claude,type=volume",
-    "source=codex-config-${devcontainerId},target=/home/vscode/.codex,type=volume",
-    "source=gemini-config-${devcontainerId},target=/home/vscode/.gemini,type=volume",
-    "source=agent-deck-config-${devcontainerId},target=/home/vscode/.agent-deck,type=volume",
-    "source=shell-history-${devcontainerId},target=/home/vscode/.shell-history,type=volume",
-    "source=zoxide-data-${devcontainerId},target=/home/vscode/.local/share/zoxide,type=volume"
+    "source=claude-code-config-${localWorkspaceFolderBasename},target=/home/vscode/.claude,type=volume",
+    "source=codex-config-${localWorkspaceFolderBasename},target=/home/vscode/.codex,type=volume",
+    "source=gemini-config-${localWorkspaceFolderBasename},target=/home/vscode/.gemini,type=volume",
+    "source=agent-deck-config-${localWorkspaceFolderBasename},target=/home/vscode/.agent-deck,type=volume",
+    "source=shell-history-${localWorkspaceFolderBasename},target=/home/vscode/.shell-history,type=volume",
+    "source=zoxide-data-${localWorkspaceFolderBasename},target=/home/vscode/.local/share/zoxide,type=volume"
   ],
   // CLAUDE_CODE_EFFORT_LEVEL: default Claude Code thinking effort. Set here
   // (not in settings.json) because Claude Code's settings schema only accepts

--- a/.devcontainer/dev/devcontainer.json
+++ b/.devcontainer/dev/devcontainer.json
@@ -40,12 +40,12 @@
     "ghcr.io/itsmechlark/features/1password:1.5.0": {}
   },
   "mounts": [
-    "source=claude-code-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.claude,type=volume",
-    "source=codex-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.codex,type=volume",
-    "source=gemini-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.gemini,type=volume",
-    "source=agent-deck-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.agent-deck,type=volume",
-    "source=shell-history-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.shell-history,type=volume",
-    "source=zoxide-data-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.local/share/zoxide,type=volume"
+    "source=claude-code-config-evanharmon1-harmon-init-dev,target=/home/vscode/.claude,type=volume",
+    "source=codex-config-evanharmon1-harmon-init-dev,target=/home/vscode/.codex,type=volume",
+    "source=gemini-config-evanharmon1-harmon-init-dev,target=/home/vscode/.gemini,type=volume",
+    "source=agent-deck-config-evanharmon1-harmon-init-dev,target=/home/vscode/.agent-deck,type=volume",
+    "source=shell-history-evanharmon1-harmon-init-dev,target=/home/vscode/.shell-history,type=volume",
+    "source=zoxide-data-evanharmon1-harmon-init-dev,target=/home/vscode/.local/share/zoxide,type=volume"
   ],
   // CLAUDE_CODE_EFFORT_LEVEL: default Claude Code thinking effort. Set here
   // (not in settings.json) because Claude Code's settings schema only accepts

--- a/.devcontainer/dev/devcontainer.json
+++ b/.devcontainer/dev/devcontainer.json
@@ -40,12 +40,12 @@
     "ghcr.io/itsmechlark/features/1password:1.5.0": {}
   },
   "mounts": [
-    "source=claude-code-config-${localWorkspaceFolderBasename},target=/home/vscode/.claude,type=volume",
-    "source=codex-config-${localWorkspaceFolderBasename},target=/home/vscode/.codex,type=volume",
-    "source=gemini-config-${localWorkspaceFolderBasename},target=/home/vscode/.gemini,type=volume",
-    "source=agent-deck-config-${localWorkspaceFolderBasename},target=/home/vscode/.agent-deck,type=volume",
-    "source=shell-history-${localWorkspaceFolderBasename},target=/home/vscode/.shell-history,type=volume",
-    "source=zoxide-data-${localWorkspaceFolderBasename},target=/home/vscode/.local/share/zoxide,type=volume"
+    "source=claude-code-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.claude,type=volume",
+    "source=codex-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.codex,type=volume",
+    "source=gemini-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.gemini,type=volume",
+    "source=agent-deck-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.agent-deck,type=volume",
+    "source=shell-history-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.shell-history,type=volume",
+    "source=zoxide-data-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.local/share/zoxide,type=volume"
   ],
   // CLAUDE_CODE_EFFORT_LEVEL: default Claude Code thinking effort. Set here
   // (not in settings.json) because Claude Code's settings schema only accepts

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,12 +41,12 @@
     "ghcr.io/devcontainers-extra/features/go-task:1": {}
   },
   "mounts": [
-    "source=claude-code-config-${localWorkspaceFolderBasename},target=/home/vscode/.claude,type=volume",
-    "source=codex-config-${localWorkspaceFolderBasename},target=/home/vscode/.codex,type=volume",
-    "source=gemini-config-${localWorkspaceFolderBasename},target=/home/vscode/.gemini,type=volume",
-    "source=agent-deck-config-${localWorkspaceFolderBasename},target=/home/vscode/.agent-deck,type=volume",
-    "source=shell-history-${localWorkspaceFolderBasename},target=/home/vscode/.shell-history,type=volume",
-    "source=zoxide-data-${localWorkspaceFolderBasename},target=/home/vscode/.local/share/zoxide,type=volume"
+    "source=claude-code-config-evanharmon1-harmon-init,target=/home/vscode/.claude,type=volume",
+    "source=codex-config-evanharmon1-harmon-init,target=/home/vscode/.codex,type=volume",
+    "source=gemini-config-evanharmon1-harmon-init,target=/home/vscode/.gemini,type=volume",
+    "source=agent-deck-config-evanharmon1-harmon-init,target=/home/vscode/.agent-deck,type=volume",
+    "source=shell-history-evanharmon1-harmon-init,target=/home/vscode/.shell-history,type=volume",
+    "source=zoxide-data-evanharmon1-harmon-init,target=/home/vscode/.local/share/zoxide,type=volume"
   ],
   // Secrets (GH_TOKEN) are populated into the --env-file by init-env.sh
   // (from 1Password locally, or from host env on Coder/Codespaces).

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -18,5 +18,8 @@ Calm, repeatable how-tos read *in advance* (the crisis counterpart is
   **Coder** setup.
 - [devcontainer-performance.md](devcontainer-performance.md) — tuning CPU/RAM
   for the devcontainer; the real levers live in Coder and WSL2, not this repo.
+- [devcontainer-incidents.md](devcontainer-incidents.md) — worked diagnoses of
+  real devcontainer failures (lifecycle chain aborts, Claude auth lost on
+  rebuild, stale Coder volumes) and where the shipped fix for each lives.
 
 TODO: add more guides, e.g. "local development setup", "add a feature", "how X works".

--- a/docs/guides/devcontainer-incidents.md
+++ b/docs/guides/devcontainer-incidents.md
@@ -1,0 +1,141 @@
+# Devcontainer incidents
+
+Worked diagnoses of real failures in this devcontainer, and where the shipped
+fix for each lives. Every one is already handled by the scripts in
+`.devcontainer/` — this exists so that when something *looks* like one of these,
+you can tell quickly whether the guard failed or you have found something new.
+
+For everyday problems see [troubleshooting.md](troubleshooting.md); this file is
+the deep end.
+
+## The conductor and Telegram bridge do not start
+
+**Symptom.** After launching the container, the agent-deck conductor reports
+"stopped", and Telegram messages to the bot get no reply or return errors.
+
+This was one visible symptom with five independent causes, all of which had to
+be fixed before it worked reliably on Coder. That matters diagnostically: fixing
+one and still seeing "stopped" does not mean the fix was wrong.
+
+### 1. A missing `pnpm` kills every later lifecycle command
+
+Node is installed from NodeSource, but without `corepack enable pnpm` the
+`postCreateCommand` fails at `pnpm install` with exit 127 — and
+`@devcontainers/cli` then **skips all remaining lifecycle commands**, including
+`postStartCommand`. The conductor never starts, and the error you see is about
+pnpm, not about the conductor.
+
+Shipped fix: `corepack enable pnpm` in the Dockerfile's Node layer.
+
+**Generalize this one.** Any non-zero exit in `postCreateCommand` silently
+cancels `postStartCommand`. If a start-time service is mysteriously absent,
+read the *create* log before investigating the service.
+
+### 2. A status grep matched the wrong process
+
+The conductor start was guarded by `! grep -qi "running"` over
+`conductor status`, which also matched the *bridge's* "RUNNING" line — so the
+conductor block was skipped whenever the bridge was up.
+
+Shipped fix: grep for `"stopped"` specifically, and start the conductor before
+the bridge.
+
+Case-insensitive greps over multi-service status output are a recurring trap;
+match the service you mean, not a word that appears somewhere in the output.
+
+### 3. A stale token survived a rebuild
+
+`init-env.sh` skipped secrets already present in `.devcontainer/devcontainer.env`.
+On Coder that file lives on the home volume and persists across rebuilds, so a
+token rotated in the workspace parameters was ignored in favour of the old value.
+
+Shipped fix: delete-then-append, so host environment always wins; plus token
+re-injection in `postStartCommand` so a change takes effect without a rebuild.
+
+### 4. `ModuleNotFoundError: No module named 'toml'`
+
+The Dockerfile installs `toml` and `aiogram` for the **system** Python, but the
+devcontainer Python feature installs its own and takes over `python3` on PATH.
+The bridge therefore starts once on the Dockerfile's Python and crashes on
+restart under the feature's.
+
+Shipped fix: `pip install --quiet toml aiogram` in `post-create-common.sh`,
+which runs *after* features are installed.
+
+**Generalize this one too.** Anything the Dockerfile installs into a runtime a
+devcontainer feature later replaces must be reinstalled post-create.
+
+### 5. Coder rebuilds reused a stale checkout
+
+Coder's git-clone module clones only at workspace creation. Rebuilding the
+container reuses the old checkout, so merged fixes to the Dockerfile or
+lifecycle scripts are not applied — and you debug code that is not running.
+
+Shipped fix: a fast-forward pull of `origin/main` in `initializeCommand`, guarded
+to run only on a clean main branch.
+
+## Claude Code demands a fresh login after every rebuild
+
+**Symptom.** `claude auth status` reports logged in and `claude -p "hi"` works,
+but launching `claude` interactively forces a full OAuth flow again.
+
+The split between working headless and broken interactive is the clue: the
+credentials are fine, the *session state* is missing.
+
+### 1. Volume names that change with the image
+
+Mounts keyed on `${devcontainerId}` hash the container image, so **every
+Dockerfile edit mints new empty volumes** — losing Claude auth, shell history,
+and agent-deck config together.
+
+Shipped fix: key the volumes on `${localWorkspaceFolderBasename}`, which is
+stable across rebuilds (see `.devcontainer/devcontainer.json`). Each Coder
+workspace has its own Docker-in-Docker, so name collisions are not a concern.
+
+If several kinds of persisted state vanish at once, suspect the volume identity,
+not the individual tools.
+
+### 2. `~/.claude.json` sits outside the persistent volume
+
+Interactive session state lives in `~/.claude.json` — the home directory, *not*
+the `~/.claude/` volume. Credentials in `~/.claude/.credentials.json` survive, so
+headless keeps working while the TUI re-prompts.
+
+Shipped fix: `post-start-common.sh` symlinks `~/.claude.json` into the persistent
+`~/.claude/` volume, and `post-create-common.sh` seeds it with
+`hasCompletedOnboarding` on an empty volume. Expect one more login the first
+time this applies; rebuilds after that keep state.
+
+## A recreated Coder workspace reuses stale volumes
+
+**Symptom.** Deleting a Coder workspace and recreating it with the same name
+yields an old git branch and outdated config.
+
+**Cause.** `lifecycle { prevent_destroy = true }` on the persist volume makes
+`terraform destroy` fail, orphaning every Docker volume for that workspace —
+home, docker, persist, and the devcontainer named volumes.
+
+This one is **infrastructure, not this repo**: the fix is removing
+`prevent_destroy` from the volume resource in the Coder devcontainer template.
+
+## Diagnostics
+
+```bash
+# conductor, bridge, notifier
+agent-deck conductor status harmon-init
+
+# devcontainer start log — read this FIRST for anything start-related
+cat /tmp/devcontainer-post-start.log
+
+# Telegram bridge
+tail -30 ~/.agent-deck/conductor/bridge.log
+
+# Claude credentials (headless path)
+claude auth status
+
+# prove the persistent volume is actually mounted
+cat /proc/self/mountinfo | grep claude
+
+# attach to the conductor session to watch prompts (Ctrl+B d detaches)
+agent-deck session attach conductor-harmon-init
+```

--- a/docs/guides/devcontainer-incidents.md
+++ b/docs/guides/devcontainer-incidents.md
@@ -89,8 +89,14 @@ Dockerfile edit mints new empty volumes** — losing Claude auth, shell history,
 and agent-deck config together.
 
 Shipped fix: key the volumes on `${localWorkspaceFolderBasename}`, which is
-stable across rebuilds (see `.devcontainer/devcontainer.json`). Each Coder
-workspace has its own Docker-in-Docker, so name collisions are not a concern.
+stable across rebuilds — in **both** the bot and dev profiles. Each Coder
+workspace has its own Docker-in-Docker, so name collisions are not a concern
+there; locally, two clones of the same repo name in different parent
+directories would share volumes, which is the accepted trade for not losing
+state on every image change.
+
+Switching a profile to this scheme costs one final state loss, because the new
+volume names start empty. After that, rebuilds preserve state.
 
 If several kinds of persisted state vanish at once, suspect the volume identity,
 not the individual tools.

--- a/docs/guides/devcontainer-incidents.md
+++ b/docs/guides/devcontainer-incidents.md
@@ -127,8 +127,13 @@ This one is **infrastructure, not this repo**: the fix is removing
 ## Diagnostics
 
 ```bash
+# The lifecycle scripts name the conductor after the CHECKOUT DIRECTORY
+# (post-start-common.sh: REPO_NAME="$(basename "$PWD")"), which is not
+# necessarily the project slug — derive it the same way rather than guessing.
+REPO_NAME="$(basename "$PWD")"
+
 # conductor, bridge, notifier
-agent-deck conductor status harmon-init
+agent-deck conductor status "$REPO_NAME"
 
 # devcontainer start log — read this FIRST for anything start-related
 cat /tmp/devcontainer-post-start.log
@@ -143,5 +148,5 @@ claude auth status
 cat /proc/self/mountinfo | grep claude
 
 # attach to the conductor session to watch prompts (Ctrl+B d detaches)
-agent-deck session attach conductor-harmon-init
+agent-deck session attach "conductor-$REPO_NAME"
 ```

--- a/docs/guides/devcontainer-incidents.md
+++ b/docs/guides/devcontainer-incidents.md
@@ -88,15 +88,28 @@ Mounts keyed on `${devcontainerId}` hash the container image, so **every
 Dockerfile edit mints new empty volumes** — losing Claude auth, shell history,
 and agent-deck config together.
 
-Shipped fix: key the volumes on `${localWorkspaceFolderBasename}`, which is
-stable across rebuilds — in **both** the bot and dev profiles. Each Coder
-workspace has its own Docker-in-Docker, so name collisions are not a concern
-there; locally, two clones of the same repo name in different parent
-directories would share volumes, which is the accepted trade for not losing
-state on every image change.
+Shipped fix: key the volumes on the rendered `<github_org>-<project_slug>`,
+plus a `-dev` suffix on the human profile. That name has to satisfy three
+constraints at once, and missing any one of them has bitten this repo:
 
-Switching a profile to this scheme costs one final state loss, because the new
-volume names start empty. After that, rebuilds preserve state.
+- **Stable across image changes**, or every Dockerfile edit discards state —
+  the failure above.
+- **Distinct per profile.** The bot profile deliberately omits `TS_AUTHKEY` and
+  has no 1Password feature; if both profiles shared `.claude`, a bot container
+  could read credentials a human authenticated in the dev profile.
+- **Distinct per repository.** Local Docker volumes are global to the daemon,
+  not scoped to a checkout. Keying on the directory basename alone means two
+  clones sharing a name — `~/git/harmon-init` and
+  `~/git/orgs/other-org/harmon-init`, say — share credential volumes. That is
+  not hypothetical; it is the normal shape of an org-scoped checkout layout.
+
+`${devcontainerId}` satisfies the last two but fails the first. The basename
+satisfies the first but fails the last. `<github_org>-<project_slug>` plus a
+profile suffix satisfies all three, and Coder's per-workspace
+Docker-in-Docker makes it a non-issue there regardless.
+
+Changing the scheme costs one final state loss, since the new volume names
+start empty. After that, rebuilds preserve state.
 
 If several kinds of persisted state vanish at once, suspect the volume identity,
 not the individual tools.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -17,4 +17,12 @@ Common issues in Harmon Init and how to fix them.
 - **Required check missing on a PR** — ensure Build & Validate and CodeQL ran;
   required checks are `verify`, `security`, and `codeql-verify`.
 
+## Deeper devcontainer failures
+
+The above are the everyday cases. For failures already hit and diagnosed in
+this devcontainer — a `postCreateCommand` abort silently cancelling every
+later lifecycle command, Claude Code re-prompting for login after each
+rebuild, a recreated Coder workspace reusing stale volumes — see
+[devcontainer-incidents.md](devcontainer-incidents.md).
+
 TODO: add project-specific issues as they come up.

--- a/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
@@ -46,12 +46,12 @@
     "ghcr.io/itsmechlark/features/1password:1.5.0": {}
   },
   "mounts": [
-    "source=claude-code-config-${localWorkspaceFolderBasename},target=/home/vscode/.claude,type=volume",
-    "source=codex-config-${localWorkspaceFolderBasename},target=/home/vscode/.codex,type=volume",
-    "source=gemini-config-${localWorkspaceFolderBasename},target=/home/vscode/.gemini,type=volume",
-    "source=agent-deck-config-${localWorkspaceFolderBasename},target=/home/vscode/.agent-deck,type=volume",
-    "source=shell-history-${localWorkspaceFolderBasename},target=/home/vscode/.shell-history,type=volume",
-    "source=zoxide-data-${localWorkspaceFolderBasename},target=/home/vscode/.local/share/zoxide,type=volume"
+    "source=claude-code-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.claude,type=volume",
+    "source=codex-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.codex,type=volume",
+    "source=gemini-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.gemini,type=volume",
+    "source=agent-deck-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.agent-deck,type=volume",
+    "source=shell-history-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.shell-history,type=volume",
+    "source=zoxide-data-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.local/share/zoxide,type=volume"
   ],
   // CLAUDE_CODE_EFFORT_LEVEL: default Claude Code thinking effort. Set here
   // (not in settings.json) because Claude Code's settings schema only accepts

--- a/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
@@ -46,12 +46,12 @@
     "ghcr.io/itsmechlark/features/1password:1.5.0": {}
   },
   "mounts": [
-    "source=claude-code-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.claude,type=volume",
-    "source=codex-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.codex,type=volume",
-    "source=gemini-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.gemini,type=volume",
-    "source=agent-deck-config-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.agent-deck,type=volume",
-    "source=shell-history-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.shell-history,type=volume",
-    "source=zoxide-data-${localWorkspaceFolderBasename}-dev,target=/home/vscode/.local/share/zoxide,type=volume"
+    "source=claude-code-config-[[ github_org ]]-[[ project_slug ]]-dev,target=/home/vscode/.claude,type=volume",
+    "source=codex-config-[[ github_org ]]-[[ project_slug ]]-dev,target=/home/vscode/.codex,type=volume",
+    "source=gemini-config-[[ github_org ]]-[[ project_slug ]]-dev,target=/home/vscode/.gemini,type=volume",
+    "source=agent-deck-config-[[ github_org ]]-[[ project_slug ]]-dev,target=/home/vscode/.agent-deck,type=volume",
+    "source=shell-history-[[ github_org ]]-[[ project_slug ]]-dev,target=/home/vscode/.shell-history,type=volume",
+    "source=zoxide-data-[[ github_org ]]-[[ project_slug ]]-dev,target=/home/vscode/.local/share/zoxide,type=volume"
   ],
   // CLAUDE_CODE_EFFORT_LEVEL: default Claude Code thinking effort. Set here
   // (not in settings.json) because Claude Code's settings schema only accepts

--- a/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
@@ -46,12 +46,12 @@
     "ghcr.io/itsmechlark/features/1password:1.5.0": {}
   },
   "mounts": [
-    "source=claude-code-config-${devcontainerId},target=/home/vscode/.claude,type=volume",
-    "source=codex-config-${devcontainerId},target=/home/vscode/.codex,type=volume",
-    "source=gemini-config-${devcontainerId},target=/home/vscode/.gemini,type=volume",
-    "source=agent-deck-config-${devcontainerId},target=/home/vscode/.agent-deck,type=volume",
-    "source=shell-history-${devcontainerId},target=/home/vscode/.shell-history,type=volume",
-    "source=zoxide-data-${devcontainerId},target=/home/vscode/.local/share/zoxide,type=volume"
+    "source=claude-code-config-${localWorkspaceFolderBasename},target=/home/vscode/.claude,type=volume",
+    "source=codex-config-${localWorkspaceFolderBasename},target=/home/vscode/.codex,type=volume",
+    "source=gemini-config-${localWorkspaceFolderBasename},target=/home/vscode/.gemini,type=volume",
+    "source=agent-deck-config-${localWorkspaceFolderBasename},target=/home/vscode/.agent-deck,type=volume",
+    "source=shell-history-${localWorkspaceFolderBasename},target=/home/vscode/.shell-history,type=volume",
+    "source=zoxide-data-${localWorkspaceFolderBasename},target=/home/vscode/.local/share/zoxide,type=volume"
   ],
   // CLAUDE_CODE_EFFORT_LEVEL: default Claude Code thinking effort. Set here
   // (not in settings.json) because Claude Code's settings schema only accepts

--- a/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
@@ -47,12 +47,12 @@
     "ghcr.io/devcontainers-extra/features/go-task:1": {}
   },
   "mounts": [
-    "source=claude-code-config-${localWorkspaceFolderBasename},target=/home/vscode/.claude,type=volume",
-    "source=codex-config-${localWorkspaceFolderBasename},target=/home/vscode/.codex,type=volume",
-    "source=gemini-config-${localWorkspaceFolderBasename},target=/home/vscode/.gemini,type=volume",
-    "source=agent-deck-config-${localWorkspaceFolderBasename},target=/home/vscode/.agent-deck,type=volume",
-    "source=shell-history-${localWorkspaceFolderBasename},target=/home/vscode/.shell-history,type=volume",
-    "source=zoxide-data-${localWorkspaceFolderBasename},target=/home/vscode/.local/share/zoxide,type=volume"
+    "source=claude-code-config-[[ github_org ]]-[[ project_slug ]],target=/home/vscode/.claude,type=volume",
+    "source=codex-config-[[ github_org ]]-[[ project_slug ]],target=/home/vscode/.codex,type=volume",
+    "source=gemini-config-[[ github_org ]]-[[ project_slug ]],target=/home/vscode/.gemini,type=volume",
+    "source=agent-deck-config-[[ github_org ]]-[[ project_slug ]],target=/home/vscode/.agent-deck,type=volume",
+    "source=shell-history-[[ github_org ]]-[[ project_slug ]],target=/home/vscode/.shell-history,type=volume",
+    "source=zoxide-data-[[ github_org ]]-[[ project_slug ]],target=/home/vscode/.local/share/zoxide,type=volume"
   ],
   // Secrets (GH_TOKEN) are populated into the --env-file by init-env.sh
   // (from 1Password locally, or from host env on Coder/Codespaces).

--- a/template/docs/guides/README.md.jinja
+++ b/template/docs/guides/README.md.jinja
@@ -26,6 +26,9 @@ Calm, repeatable how-tos read *in advance* (the crisis counterpart is
   **Coder** setup.
 - [devcontainer-performance.md](devcontainer-performance.md) — tuning CPU/RAM
   for the devcontainer; the real levers live in Coder and WSL2, not this repo.
+- [devcontainer-incidents.md](devcontainer-incidents.md) — worked diagnoses of
+  real devcontainer failures (lifecycle chain aborts, Claude auth lost on
+  rebuild, stale Coder volumes) and where the shipped fix for each lives.
 [% endif %]
 
 TODO: add more guides, e.g. "local development setup", "add a feature", "how X works".

--- a/template/docs/guides/[% if devcontainer %]devcontainer-incidents.md[% endif %]
+++ b/template/docs/guides/[% if devcontainer %]devcontainer-incidents.md[% endif %]
@@ -127,8 +127,13 @@ This one is **infrastructure, not this repo**: the fix is removing
 ## Diagnostics
 
 ```bash
+# The lifecycle scripts name the conductor after the CHECKOUT DIRECTORY
+# (post-start-common.sh: REPO_NAME="$(basename "$PWD")"), which is not
+# necessarily the project slug — derive it the same way rather than guessing.
+REPO_NAME="$(basename "$PWD")"
+
 # conductor, bridge, notifier
-agent-deck conductor status [[ project_slug ]]
+agent-deck conductor status "$REPO_NAME"
 
 # devcontainer start log — read this FIRST for anything start-related
 cat /tmp/devcontainer-post-start.log
@@ -143,5 +148,5 @@ claude auth status
 cat /proc/self/mountinfo | grep claude
 
 # attach to the conductor session to watch prompts (Ctrl+B d detaches)
-agent-deck session attach conductor-[[ project_slug ]]
+agent-deck session attach "conductor-$REPO_NAME"
 ```

--- a/template/docs/guides/[% if devcontainer %]devcontainer-incidents.md[% endif %]
+++ b/template/docs/guides/[% if devcontainer %]devcontainer-incidents.md[% endif %]
@@ -88,15 +88,28 @@ Mounts keyed on `${devcontainerId}` hash the container image, so **every
 Dockerfile edit mints new empty volumes** — losing Claude auth, shell history,
 and agent-deck config together.
 
-Shipped fix: key the volumes on `${localWorkspaceFolderBasename}`, which is
-stable across rebuilds — in **both** the bot and dev profiles. Each Coder
-workspace has its own Docker-in-Docker, so name collisions are not a concern
-there; locally, two clones of the same repo name in different parent
-directories would share volumes, which is the accepted trade for not losing
-state on every image change.
+Shipped fix: key the volumes on the rendered `<github_org>-<project_slug>`,
+plus a `-dev` suffix on the human profile. That name has to satisfy three
+constraints at once, and missing any one of them has bitten this repo:
 
-Switching a profile to this scheme costs one final state loss, because the new
-volume names start empty. After that, rebuilds preserve state.
+- **Stable across image changes**, or every Dockerfile edit discards state —
+  the failure above.
+- **Distinct per profile.** The bot profile deliberately omits `TS_AUTHKEY` and
+  has no 1Password feature; if both profiles shared `.claude`, a bot container
+  could read credentials a human authenticated in the dev profile.
+- **Distinct per repository.** Local Docker volumes are global to the daemon,
+  not scoped to a checkout. Keying on the directory basename alone means two
+  clones sharing a name — `~/git/harmon-init` and
+  `~/git/orgs/other-org/harmon-init`, say — share credential volumes. That is
+  not hypothetical; it is the normal shape of an org-scoped checkout layout.
+
+`${devcontainerId}` satisfies the last two but fails the first. The basename
+satisfies the first but fails the last. `<github_org>-<project_slug>` plus a
+profile suffix satisfies all three, and Coder's per-workspace
+Docker-in-Docker makes it a non-issue there regardless.
+
+Changing the scheme costs one final state loss, since the new volume names
+start empty. After that, rebuilds preserve state.
 
 If several kinds of persisted state vanish at once, suspect the volume identity,
 not the individual tools.

--- a/template/docs/guides/[% if devcontainer %]devcontainer-incidents.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainer-incidents.md[% endif %].jinja
@@ -1,0 +1,141 @@
+# Devcontainer incidents
+
+Worked diagnoses of real failures in this devcontainer, and where the shipped
+fix for each lives. Every one is already handled by the scripts in
+`.devcontainer/` — this exists so that when something *looks* like one of these,
+you can tell quickly whether the guard failed or you have found something new.
+
+For everyday problems see [troubleshooting.md](troubleshooting.md); this file is
+the deep end.
+
+## The conductor and Telegram bridge do not start
+
+**Symptom.** After launching the container, the agent-deck conductor reports
+"stopped", and Telegram messages to the bot get no reply or return errors.
+
+This was one visible symptom with five independent causes, all of which had to
+be fixed before it worked reliably on Coder. That matters diagnostically: fixing
+one and still seeing "stopped" does not mean the fix was wrong.
+
+### 1. A missing `pnpm` kills every later lifecycle command
+
+Node is installed from NodeSource, but without `corepack enable pnpm` the
+`postCreateCommand` fails at `pnpm install` with exit 127 — and
+`@devcontainers/cli` then **skips all remaining lifecycle commands**, including
+`postStartCommand`. The conductor never starts, and the error you see is about
+pnpm, not about the conductor.
+
+Shipped fix: `corepack enable pnpm` in the Dockerfile's Node layer.
+
+**Generalize this one.** Any non-zero exit in `postCreateCommand` silently
+cancels `postStartCommand`. If a start-time service is mysteriously absent,
+read the *create* log before investigating the service.
+
+### 2. A status grep matched the wrong process
+
+The conductor start was guarded by `! grep -qi "running"` over
+`conductor status`, which also matched the *bridge's* "RUNNING" line — so the
+conductor block was skipped whenever the bridge was up.
+
+Shipped fix: grep for `"stopped"` specifically, and start the conductor before
+the bridge.
+
+Case-insensitive greps over multi-service status output are a recurring trap;
+match the service you mean, not a word that appears somewhere in the output.
+
+### 3. A stale token survived a rebuild
+
+`init-env.sh` skipped secrets already present in `.devcontainer/devcontainer.env`.
+On Coder that file lives on the home volume and persists across rebuilds, so a
+token rotated in the workspace parameters was ignored in favour of the old value.
+
+Shipped fix: delete-then-append, so host environment always wins; plus token
+re-injection in `postStartCommand` so a change takes effect without a rebuild.
+
+### 4. `ModuleNotFoundError: No module named 'toml'`
+
+The Dockerfile installs `toml` and `aiogram` for the **system** Python, but the
+devcontainer Python feature installs its own and takes over `python3` on PATH.
+The bridge therefore starts once on the Dockerfile's Python and crashes on
+restart under the feature's.
+
+Shipped fix: `pip install --quiet toml aiogram` in `post-create-common.sh`,
+which runs *after* features are installed.
+
+**Generalize this one too.** Anything the Dockerfile installs into a runtime a
+devcontainer feature later replaces must be reinstalled post-create.
+
+### 5. Coder rebuilds reused a stale checkout
+
+Coder's git-clone module clones only at workspace creation. Rebuilding the
+container reuses the old checkout, so merged fixes to the Dockerfile or
+lifecycle scripts are not applied — and you debug code that is not running.
+
+Shipped fix: a fast-forward pull of `origin/main` in `initializeCommand`, guarded
+to run only on a clean main branch.
+
+## Claude Code demands a fresh login after every rebuild
+
+**Symptom.** `claude auth status` reports logged in and `claude -p "hi"` works,
+but launching `claude` interactively forces a full OAuth flow again.
+
+The split between working headless and broken interactive is the clue: the
+credentials are fine, the *session state* is missing.
+
+### 1. Volume names that change with the image
+
+Mounts keyed on `${devcontainerId}` hash the container image, so **every
+Dockerfile edit mints new empty volumes** — losing Claude auth, shell history,
+and agent-deck config together.
+
+Shipped fix: key the volumes on `${localWorkspaceFolderBasename}`, which is
+stable across rebuilds (see `.devcontainer/devcontainer.json`). Each Coder
+workspace has its own Docker-in-Docker, so name collisions are not a concern.
+
+If several kinds of persisted state vanish at once, suspect the volume identity,
+not the individual tools.
+
+### 2. `~/.claude.json` sits outside the persistent volume
+
+Interactive session state lives in `~/.claude.json` — the home directory, *not*
+the `~/.claude/` volume. Credentials in `~/.claude/.credentials.json` survive, so
+headless keeps working while the TUI re-prompts.
+
+Shipped fix: `post-start-common.sh` symlinks `~/.claude.json` into the persistent
+`~/.claude/` volume, and `post-create-common.sh` seeds it with
+`hasCompletedOnboarding` on an empty volume. Expect one more login the first
+time this applies; rebuilds after that keep state.
+
+## A recreated Coder workspace reuses stale volumes
+
+**Symptom.** Deleting a Coder workspace and recreating it with the same name
+yields an old git branch and outdated config.
+
+**Cause.** `lifecycle { prevent_destroy = true }` on the persist volume makes
+`terraform destroy` fail, orphaning every Docker volume for that workspace —
+home, docker, persist, and the devcontainer named volumes.
+
+This one is **infrastructure, not this repo**: the fix is removing
+`prevent_destroy` from the volume resource in the Coder devcontainer template.
+
+## Diagnostics
+
+```bash
+# conductor, bridge, notifier
+agent-deck conductor status [[ project_slug ]]
+
+# devcontainer start log — read this FIRST for anything start-related
+cat /tmp/devcontainer-post-start.log
+
+# Telegram bridge
+tail -30 ~/.agent-deck/conductor/bridge.log
+
+# Claude credentials (headless path)
+claude auth status
+
+# prove the persistent volume is actually mounted
+cat /proc/self/mountinfo | grep claude
+
+# attach to the conductor session to watch prompts (Ctrl+B d detaches)
+agent-deck session attach conductor-[[ project_slug ]]
+```

--- a/template/docs/guides/[% if devcontainer %]devcontainer-incidents.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainer-incidents.md[% endif %].jinja
@@ -89,8 +89,14 @@ Dockerfile edit mints new empty volumes** — losing Claude auth, shell history,
 and agent-deck config together.
 
 Shipped fix: key the volumes on `${localWorkspaceFolderBasename}`, which is
-stable across rebuilds (see `.devcontainer/devcontainer.json`). Each Coder
-workspace has its own Docker-in-Docker, so name collisions are not a concern.
+stable across rebuilds — in **both** the bot and dev profiles. Each Coder
+workspace has its own Docker-in-Docker, so name collisions are not a concern
+there; locally, two clones of the same repo name in different parent
+directories would share volumes, which is the accepted trade for not losing
+state on every image change.
+
+Switching a profile to this scheme costs one final state loss, because the new
+volume names start empty. After that, rebuilds preserve state.
 
 If several kinds of persisted state vanish at once, suspect the volume identity,
 not the individual tools.

--- a/template/docs/guides/troubleshooting.md.jinja
+++ b/template/docs/guides/troubleshooting.md.jinja
@@ -17,4 +17,12 @@ Common issues in [[ project_name ]] and how to fix them.
 - **Required check missing on a PR** — ensure Build & Validate[% if use_codeql %] and CodeQL[% endif %] ran;
   required checks are `verify`, `security`[% if use_codeql %], and `codeql-verify`[% endif %].
 
-TODO: add project-specific issues as they come up.
+[% if devcontainer %]## Deeper devcontainer failures
+
+The above are the everyday cases. For failures already hit and diagnosed in
+this devcontainer — a `postCreateCommand` abort silently cancelling every
+later lifecycle command, Claude Code re-prompting for login after each
+rebuild, a recreated Coder workspace reusing stale volumes — see
+[devcontainer-incidents.md](devcontainer-incidents.md).
+
+[% endif %]TODO: add project-specific issues as they come up.


### PR DESCRIPTION
harmon-init ships an agent-deck conductor, a Telegram bridge, persistent Coder volumes, and Claude Code session state — and documented **none** of the ways they fail. `guides/troubleshooting.md` had three generic bullets and a `TODO`.

That knowledge existed. It was just in the wrong repo.

## Where it was

A 104-line writeup sat in **sommerlawn-site**, referenced by nothing, describing failures in the devcontainer *this* repo ships. Two things make it clearly universal rather than repo-specific:

1. The only repo-specific text was a conductor session name.
2. **Every fix it describes already lives in `.devcontainer/`** — the `toml`/`aiogram` reinstall in `post-create-common.sh`, the `AGENT_DECK_TELEGRAM_KEY` injection, the `CLAUDE_SESSION_FILE` seeding, and the `${localWorkspaceFolderBasename}` volume keys in `devcontainer.json`.

So it isn't a consumer's notes — it's harmon-init's own incident history, and it explains why several lines of the shipped scripts exist. It has been invisible to every other generated repo the whole time.

## What this adds

`guides/devcontainer-incidents.md` in **both layers**, gated on `devcontainer`, session name templated from `project_slug`. Linked from the guides index and from `troubleshooting.md`, both gated so a non-devcontainer repo gets no dangling reference.

**Rewritten, not copied.** The original read as a changelog of one repo's PRs (`Fix: … (PR #145)`), which is meaningless in a generated repo. This version states the failure, then names where the shipped guard lives — so a reader can tell whether the guard failed or they've found something new.

Two causes generalize well past their incident, and are flagged as such:

- **A non-zero `postCreateCommand` exit silently cancels every later lifecycle command.** The original symptom was "the conductor never starts"; the actual error was `pnpm: command not found` during *create*. If a start-time service is mysteriously absent, read the create log first.
- **Anything the Dockerfile installs into a runtime a devcontainer feature later replaces must be reinstalled post-create.** The Python feature takes over `python3`, stranding Dockerfile-installed modules — which is why `post-create-common.sh` reinstalls them.

There's also a nice diagnostic tell preserved in the Claude auth section: headless working while the interactive TUI re-prompts means the *credentials* are fine and the *session state* is missing — which points straight at `~/.claude.json` living outside the persistent volume.

## Verification

A conditionally-named file that never renders fails **silently**, so I rendered both branches rather than trusting the suite:

```
devcontainer=true  → file present, project_slug rendered ("gate-test"), troubleshooting links it
devcontainer=false → file absent, and no link left behind
```

`task verify` passes (all seven profiles); markdownlint clean across 47 files.

## Follow-up

sommerlawn-site#431 currently moves that file *within* that repo. It should be reduced to deleting the orphan once this lands, so `copier update` delivers the canonical copy instead of leaving a divergent local one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)