### PR TITLE
test: surface copier's output when the update test fails

### DIFF
--- a/scripts/test-template-update.sh
+++ b/scripts/test-template-update.sh
@@ -61,7 +61,12 @@ copier copy "$tmpl" "$gen" --vcs-ref=v0.0.1 --trust --defaults \
     --data github_org="someorg" --data project_type="iac" \
     --data git_init=false --data github_remote_create=false \
     --data github_release_init=false --data run_task_install=false \
-    --data bunch_add=false --data obsidian_project_add=false >/dev/null 2>&1
+    --data bunch_add=false --data obsidian_project_add=false >"$work/copy.log" 2>&1 ||
+    {
+        echo "FAIL: copier copy failed — output follows" >&2
+        cat "$work/copy.log" >&2
+        exit 1
+    }
 git -C "$gen" init -q
 gitq "$gen" add -A
 gitq "$gen" commit -qm "initial scaffold"
@@ -91,7 +96,13 @@ gitq "$tmpl" commit -qm v0.0.2
 git -C "$tmpl" tag v0.0.2
 
 # 5. Update the generated repo.
-(cd "$gen" && copier update --trust --defaults) >/dev/null 2>&1 || err "copier update failed"
+# Keep copier's own output: when this fails in CI, "copier update failed" alone
+# is not enough to diagnose it, and the failure is not always reproducible
+# locally (copier version, git config, and checkout differences all matter).
+if ! (cd "$gen" && copier update --trust --defaults) >"$work/update.log" 2>&1; then
+    err "copier update failed — output follows"
+    sed 's/^/    /' "$work/update.log" >&2
+fi
 
 # 6. Assertions.
 after="$(git -C "$gen" rev-list --count HEAD)"


### PR DESCRIPTION
`template-test (update)` failed on the 4.2.4 release PR (#338). The **entire** CI output was:

```
FAIL: copier update failed
```

Both copier invocations redirected to `/dev/null 2>&1`, so nothing about the actual failure survived.

## What it cost to learn nothing

Establishing that it was a flake required ruling out, one at a time:

- **the release PR's content** — ran the test in a worktree off that exact ref: passes
- **the copier version** — CI installs 9.17.0, local had 9.16.0; shimmed 9.17.0 in and re-ran: passes
- **anything deterministic in the tree** — `main` ran the same job successfully minutes earlier

A re-run then passed with no code change. So: flake, cause unknown.

That is a lot of elimination to arrive at "try again" — and had it been a real defect, the log would have been exactly as useless. The job is flaky, so there **will** be a next occurrence; this makes that one produce evidence instead of another round of guessing.

## Change

Both `copier copy` and `copier update` now write to a log and print it, indented, on failure.

`copier copy` additionally **exits** rather than continuing. Previously a failed generate fell through into the assertions, which would report whatever confusing thing they hit first rather than the generate failure that caused it.

## Verification

Pointed the update at a nonexistent tag to force a genuine failure:

```
FAIL: copier update failed — output follows
    Traceback (most recent call last):
      File "/opt/homebrew/bin/copier", line 6, in <module>
        sys.exit(CopierApp.run())
      ...
```

Previously that produced the bare `FAIL:` line and nothing else. Test still passes normally; shellcheck and shfmt clean.

## What this does not do

**It does not fix the flake, and does not claim to.** Content, copier version, and anything deterministic are ruled out, which leaves something environmental — most plausibly a transient in copier's git operations against the throwaway tagged template. That's a hypothesis, not a finding. This is the instrumentation needed to turn the next occurrence into a diagnosis.

Note the release-content guard correctly reads this as non-releasing (`no release-worthy paths changed`), so a `test:` title is right here — nothing under `template/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)