### PR TITLE
fix(template): tell generated repos to index their runbooks

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -6,6 +6,22 @@ Named-incident, step-by-step procedures read *under pressure* when prod breaks
 A runbook is one specific operational procedure — e.g. "rotate the API key",
 "restore from backup", "roll back a bad deploy" — written so someone can follow
 it mid-incident without thinking. **Add one when** a real production procedure
-exists; this folder stays a stub until there's something in prod to operate.
+exists.
 
-TODO: add a runbook per recurring operational / incident procedure.
+## Index
+
+Add a row here whenever you add a runbook. An index is consulted at exactly the
+moment there is no time to go looking, and a runbook nobody can find is a
+runbook nobody reads.
+
+| Runbook | Use it when |
+| --- | --- |
+| *(none yet)* | |
+
+Two rules for the "use it when" column:
+
+- **Say what the runbook does *not* cover** when a neighbouring procedure could
+  be confused with it. Scoping is often the half someone needs while scanning.
+- **Never advertise coverage you have not verified.** A wrong pointer is worse
+  than a missing one — it costs time under pressure and can walk someone
+  through a procedure that leaves the system half-changed.

--- a/template/docs/runbooks/README.md
+++ b/template/docs/runbooks/README.md
@@ -6,6 +6,22 @@ Named-incident, step-by-step procedures read *under pressure* when prod breaks
 A runbook is one specific operational procedure — e.g. "rotate the API key",
 "restore from backup", "roll back a bad deploy" — written so someone can follow
 it mid-incident without thinking. **Add one when** a real production procedure
-exists; this folder stays a stub until there's something in prod to operate.
+exists.
 
-TODO: add a runbook per recurring operational / incident procedure.
+## Index
+
+Add a row here whenever you add a runbook. An index is consulted at exactly the
+moment there is no time to go looking, and a runbook nobody can find is a
+runbook nobody reads.
+
+| Runbook | Use it when |
+| --- | --- |
+| *(none yet)* | |
+
+Two rules for the "use it when" column:
+
+- **Say what the runbook does *not* cover** when a neighbouring procedure could
+  be confused with it. Scoping is often the half someone needs while scanning.
+- **Never advertise coverage you have not verified.** A wrong pointer is worse
+  than a missing one — it costs time under pressure and can walk someone
+  through a procedure that leaves the system half-changed.


### PR DESCRIPTION
## The gap

The template's `docs/runbooks/README.md` says the folder *"stays a stub until there's something in prod to operate"*, with a `TODO: add a runbook per recurring operational / incident procedure`.

For a freshly generated repo that's **accurate** — the folder really is empty. The defect is that it never says to *record* runbooks anywhere. So every generated repo drifts the same way: runbooks accumulate, none get indexed, and the README ends up asserting the folder is empty while sitting on top of several.

## This is observed, not theoretical

harmon-infra reached **four** production runbooks — Authelia secret rotation, CI Ansible deploy, Terraform remote state, Windows host bootstrap — with none listed and the stub text still claiming there was nothing there. The most recent one was reachable only by knowing its filename.

A README that says a directory is empty actively trains people not to look in it. That's worse than merely stale.

## What changes

Replaces the `TODO` with an index table and the instruction to add a row when adding a runbook, plus two rules for the "use it when" column:

- **Say what a runbook does *not* cover** when a neighbouring procedure could be confused with it.
- **Never advertise coverage you have not verified.**

Both come from a live mistake made while fixing the downstream instance. The harmon-infra index initially advertised its Authelia rotation runbook as covering *OIDC client secrets*. That runbook covers three secrets — storage encryption key, session secret, password-reset JWT — and never mentions OIDC. Rotating an OIDC client secret is a different **two-host** procedure: Authelia reads a per-client secrets file on the proxy, while Coder consumes `CODER_OIDC_CLIENT_SECRET` from `.env` on another machine. Following that pointer would have left Coder unable to authenticate.

An index is read under pressure. A wrong entry costs more than a missing one, which is why "state what it doesn't cover" earns a line in the guidance rather than being left to taste.

## Parity

Root and `template/` copies kept byte-identical, same convention as the devcontainer scripts in #330 / #333.

## Verification

`task verify` passes (exit 0), including `test:template`.

One note: the first attempt failed `lint:markdown` on MD049 (`_(none yet)_` — underscore emphasis where this repo requires asterisks). Fixed and re-verified; worth knowing the template repo's markdown rules are stricter than harmon-infra's on emphasis style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
