### PR TITLE
feat: add Codex second-model review (challenge/review tasks, stop-gate toggle)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,15 @@
 {
+  "extraKnownMarketplaces": {
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "codex@openai-codex": true
+  },
   "permissions": {
     "additionalDirectories": [
       "../harmon-devkit",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,12 @@
       "Bash(git log:*)"
     ],
     "ask": [
+      "Bash(task codex:gate:enable)",
+      "Bash(task codex:gate:enable:*)",
+      "Bash(task codex:gate:disable)",
+      "Bash(task codex:gate:disable:*)",
+      "Bash(./scripts/codex-gate.sh:*)",
+      "Bash(scripts/codex-gate.sh:*)",
       "Bash(gh pr merge)",
       "Bash(gh pr merge:*)",
       "Bash(git merge)",

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,8 @@
+# Project-level Codex CLI config (see docs/guides/codex-review.md).
+# Loaded only once the repo is trusted by Codex (`codex` prompts on first run,
+# or set [projects."<path>"] trust_level = "trusted" in ~/.codex/config.toml).
+#
+# Reviews (task review / task challenge) benefit from deeper reasoning than a
+# fast interactive default. The model is deliberately left unpinned so reviews
+# track the Codex CLI's current default instead of an aging snapshot.
+model_reasoning_effort = "high"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Lint
         run: task check
       - run: task test:tasks
+      - run: task test:codex-review
       - run: task test:ci-results
       - run: task test:release-title
       - run: task foreman:test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,10 +139,13 @@ something to ask permission for.
 - **`task verify`** — when the change feels done, loop edit → verify until
   green; verify is the definition-of-done gate (includes the render matrix).
 - **`task challenge`** — adversarial second-model review. Adjudicate per
-  "Second-Model Review" below, fix confirmed findings, re-run `task verify`.
-  Max **3** challenge → fix → re-challenge rounds.
-- **`task review`** — verification-checkpoint review; same adjudication, its
-  own max **3** rounds.
+  "Second-Model Review" below, fix confirmed findings, re-run `task verify`,
+  then **re-run `task challenge`**. The stage passes only when a re-run comes
+  back with **no material findings** — fixing the findings is not the exit
+  condition, a clean pass is. Max **3** challenge → fix → re-challenge
+  rounds; if findings persist, stop and escalate to Evan.
+- **`task review`** — verification-checkpoint review; same adjudication and
+  same clean-pass exit condition, with its own max **3** rounds.
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
   a clear what/why/verification summary (mind the `template/` → `fix:`/`feat:`
@@ -242,9 +245,11 @@ the cloud run failed.
 6. Finish with a concise adjudication table: finding → classification →
    evidence → action taken.
 
-**Loop cap:** at most **3** iterations per loop (challenge → fix →
-re-challenge, and likewise for review). If material disagreement persists
-after 3, stop and surface it to Evan instead of iterating further.
+**Loop cap and exit:** a stage exits only on a **clean re-run** (no material
+findings) — never on "findings fixed" alone — with at most **3** iterations
+per loop (challenge → fix → re-challenge, and likewise for review). If
+material disagreement persists after 3, stop and surface it to Evan instead
+of iterating further.
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,11 @@ task test:template
 # Free security baseline (Semgrep CE + gitleaks + dependency audit)
 task security
 
+# Optional Codex second-model review — advisory, never part of verify/ci
+task challenge       # adversarial review (task challenge:codex under the hood)
+task review          # verification checkpoint (task review:codex)
+task codex:gate:enable   # auto Claude → Codex stop-gate (also :disable / :status)
+
 # Foreman: dispatch ready issues to headless agents, shepherd their PRs
 task foreman:plan -- --milestone <n|title>   # dry-run the graph/waves
 task foreman:dispatch -- --issue <n>         # worktree → agent → verify → PR
@@ -166,6 +171,45 @@ and ADR 0002. It ships to generated repos, so its files are two-layer twins.
   changes (docs, this repo's own tooling) keep their normal type. Pre-flight it
   locally before opening the PR with your intended title:
   `PR_TITLE="<title>" BASE_SHA=main task guard:release-title`.
+
+## Second-Model Review (Codex)
+
+A second AI model (the OpenAI Codex CLI) reviews changes on demand — opt-in
+for generated repos via the `use_codex_review` answer; this repo dogfoods it.
+Local and advisory only: nothing runs in CI, and no `verify`/`ci` step depends
+on Codex. Setup and mechanics: `docs/guides/codex-review.md`.
+
+- `task challenge` (→ `challenge:codex`) — adversarial review: challenges the
+  architecture and approach; hunts authorization bypasses, data-loss paths,
+  unsafe rollback, races, hidden coupling, operational failure modes, and
+  needless complexity. Steer it with e.g.
+  `task challenge -- --base main focus on the update/migration path`.
+- `task review` (→ `review:codex`) — verification checkpoint: double-checks
+  the implementation, consistency, and test coverage before `task ci`.
+- `task codex:gate:enable` / `:disable` / `:status` — the automatic
+  Claude Code → Codex stop-gate (the codex plugin's Stop hook reviews each
+  editing turn and blocks completion on material findings). Per-repo,
+  per-machine state; defaults off. Inside Claude Code the equivalents are
+  `/codex:review`, `/codex:adversarial-review`, and `/codex:setup`.
+
+The intended flow once a change feels done:
+`task check` → `task verify` → `task challenge` → `task review` → `task ci` → PR.
+
+**Treat Codex findings as hypotheses, not authority.** For every finding:
+
+1. Verify it against the actual implementation, surrounding code,
+   requirements, and tests.
+2. Classify it: confirmed, plausible but unproven, or false positive.
+3. Fix only confirmed findings; add or improve regression tests where
+   appropriate.
+4. Explain why any rejected finding is incorrect or irrelevant.
+5. Re-run `task verify` (and the other relevant gates) after fixes.
+6. Finish with a concise adjudication table: finding → classification →
+   evidence → action taken.
+
+**Loop cap:** at most **3** iterations per loop (challenge → fix →
+re-challenge, and likewise for review). If material disagreement persists
+after 3, stop and surface it to Evan instead of iterating further.
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,15 +142,15 @@ something to ask permission for.
   "Second-Model Review" below, fix confirmed findings, re-run `task verify`,
   then **re-run `task challenge`**. The stage passes only when a re-run comes
   back with **no material findings** — fixing the findings is not the exit
-  condition, a clean pass is. Max **3** challenge → fix → re-challenge
+  condition, a clean pass is. Max **5** challenge → fix → re-challenge
   rounds; if findings persist, stop and escalate to Evan.
 - **`task review`** — verification-checkpoint review; same adjudication and
-  same clean-pass exit condition, with its own max **3** rounds.
+  same clean-pass exit condition, with its own max **4** rounds.
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
   a clear what/why/verification summary (mind the `template/` → `fix:`/`feat:`
   title rule below).
-- **Shepherd the PR (max 3 rounds).** Opening the PR is not the end. Watch CI
+- **Shepherd the PR (max 4 rounds).** Opening the PR is not the end. Watch CI
   (`gh pr checks <n> --watch`) and incoming bot/human reviews. When a check
   fails or a review lands findings, treat the findings as hypotheses: verify
   them against the code, fix only what's confirmed, explain rejections in a
@@ -158,7 +158,7 @@ something to ask permission for.
   must pass `task verify` before each push; the local challenge/review loops
   are not re-entered — the post-push cloud/bot review is the second-model
   check at this stage. This cap is independent of the other loop caps. If
-  checks still fail or material findings remain after 3 rounds, stop and
+  checks still fail or material findings remain after 4 rounds, stop and
   summarize what's unresolved on the PR for Evan.
 - **Stop at green.** Report that checks pass, then stop — merging is always a
   human decision.
@@ -252,9 +252,10 @@ the cloud run failed.
    evidence → action taken.
 
 **Loop cap and exit:** a stage exits only on a **clean re-run** (no material
-findings) — never on "findings fixed" alone — with at most **3** iterations
-per loop (challenge → fix → re-challenge, and likewise for review). If
-material disagreement persists after 3, stop and surface it to Evan instead
+findings) — never on "findings fixed" alone — with at most **5** challenge
+iterations and **4** review iterations (challenge → fix → re-challenge, and
+likewise for review). If material disagreement persists at the cap, stop and
+surface it to Evan instead
 of iterating further.
 
 ## Code Style

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,38 @@ supervisor for milestone-driven agent dispatch: explicit arming via
 write contract, and **never a merge** — see `docs/architecture/foreman.md`
 and ADR 0002. It ships to generated repos, so its files are two-layer twins.
 
+## Dev Loop
+
+Bias toward shipping: drive every change to an open PR instead of stopping at
+a green local diff. Work in small, PR-sized units, and move to the next stage
+on your own — an open PR with green checks is the default deliverable, not
+something to ask permission for.
+
+- **Branch** — feature branch off `main`; never commit directly to `main`.
+- **Edit + `task check`** — the fast inner loop; run it constantly and fix
+  lint immediately. (Remember dogfood parity: template twins in the same
+  change.)
+- **`task verify`** — when the change feels done, loop edit → verify until
+  green; verify is the definition-of-done gate (includes the render matrix).
+- **`task challenge`** — adversarial second-model review. Adjudicate per
+  "Second-Model Review" below, fix confirmed findings, re-run `task verify`.
+  Max **3** challenge → fix → re-challenge rounds.
+- **`task review`** — verification-checkpoint review; same adjudication, its
+  own max **3** rounds.
+- **`task ci`** — the full CI mirror; fix anything it catches.
+- **Open the PR** — conventional commit, push the branch, `gh pr create` with
+  a clear what/why/verification summary (mind the `template/` → `fix:`/`feat:`
+  title rule below).
+- **Shepherd the PR (max 3 rounds).** Opening the PR is not the end. Watch CI
+  (`gh pr checks <n> --watch`) and incoming bot/human reviews. When a check
+  fails or a review lands findings, treat the findings as hypotheses: verify
+  them against the code, fix only what's confirmed, explain rejections in a
+  PR comment, push the fix commit, and watch again. This cap is independent
+  of the other loop caps. If checks still fail or material findings remain
+  after 3 rounds, stop and summarize what's unresolved on the PR for Evan.
+- **Stop at green.** Report that checks pass, then stop — merging is always a
+  human decision.
+
 ## Critical Copier Gotchas
 
 - **`--vcs-ref=HEAD` is load-bearing.** Without it, `copier copy` from a local path
@@ -192,8 +224,11 @@ on Codex. Setup and mechanics: `docs/guides/codex-review.md`.
   per-machine state; defaults off. Inside Claude Code the equivalents are
   `/codex:review`, `/codex:adversarial-review`, and `/codex:setup`.
 
-The intended flow once a change feels done:
-`task check` → `task verify` → `task challenge` → `task review` → `task ci` → PR.
+These tasks slot into the **Dev Loop** above: after `task verify` goes green,
+before `task ci`. Codex cloud review is also connected to this repo's PRs —
+it posts inline comments only for high-priority findings; a bare 👍 reaction
+from the Codex bot is its clean pass, and a lone 👀 that never resolves means
+the cloud run failed.
 
 **Treat Codex findings as hypotheses, not authority.** For every finding:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,7 +228,10 @@ on Codex. Setup and mechanics: `docs/guides/codex-review.md`.
   Claude Code → Codex stop-gate (the codex plugin's Stop hook reviews each
   editing turn and blocks completion on material findings). Per-repo,
   per-machine state; defaults off. Inside Claude Code the equivalents are
-  `/codex:review`, `/codex:adversarial-review`, and `/codex:setup`.
+  `/codex:review`, `/codex:adversarial-review`, and `/codex:setup`. The
+  toggles are approval-gated (`permissions.ask`), and agents must **never
+  disable the gate to get past a BLOCK** — adjudicate the finding or
+  escalate to Evan instead.
 
 These tasks slot into the **Dev Loop** above: after `task verify` goes green,
 before `task ci`. Codex cloud review is also connected to this repo's PRs —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,9 +154,12 @@ something to ask permission for.
   (`gh pr checks <n> --watch`) and incoming bot/human reviews. When a check
   fails or a review lands findings, treat the findings as hypotheses: verify
   them against the code, fix only what's confirmed, explain rejections in a
-  PR comment, push the fix commit, and watch again. This cap is independent
-  of the other loop caps. If checks still fail or material findings remain
-  after 3 rounds, stop and summarize what's unresolved on the PR for Evan.
+  PR comment, push the fix commit, and watch again. Shepherd-round fixes
+  must pass `task verify` before each push; the local challenge/review loops
+  are not re-entered — the post-push cloud/bot review is the second-model
+  check at this stage. This cap is independent of the other loop caps. If
+  checks still fail or material findings remain after 3 rounds, stop and
+  summarize what's unresolved on the PR for Evan.
 - **Stop at green.** Report that checks pass, then stop — merging is always a
   human decision.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,9 +229,9 @@ on Codex. Setup and mechanics: `docs/guides/codex-review.md`.
   editing turn and blocks completion on material findings). Per-repo,
   per-machine state; defaults off. Inside Claude Code the equivalents are
   `/codex:review`, `/codex:adversarial-review`, and `/codex:setup`. The
-  toggles are approval-gated (`permissions.ask`), and agents must **never
-  disable the gate to get past a BLOCK** — adjudicate the finding or
-  escalate to Evan instead.
+  toggles are approval-gated (`permissions.ask`), `disable` refuses
+  non-interactive shells, and agents must **never disable the gate to get
+  past a BLOCK** — adjudicate the finding or escalate to Evan instead.
 
 These tasks slot into the **Dev Loop** above: after `task verify` goes green,
 before `task ci`. Codex cloud review is also connected to this repo's PRs —

--- a/Brewfile
+++ b/Brewfile
@@ -55,3 +55,6 @@ brew "act"
 # macOS apps
 cask "visual-studio-code"
 cask "bunch"
+# Second-model review (task challenge / task review drive the Codex CLI).
+# Cask = macOS; on Linux/devcontainers install with `npm install -g @openai/codex`.
+cask "codex"

--- a/Brewfile
+++ b/Brewfile
@@ -56,5 +56,7 @@ brew "act"
 cask "visual-studio-code"
 cask "bunch"
 # Second-model review (task challenge / task review drive the Codex CLI).
-# Cask = macOS; on Linux/devcontainers install with `npm install -g @openai/codex`.
-cask "codex"
+# Cask = macOS only; on Linux/devcontainers install with
+# `npm install -g @openai/codex` (a bare cask line would abort `brew bundle`
+# on Linux before any of the remaining deps install).
+cask "codex" if OS.mac?

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ and canonical AGENTS.md. Projects generated from v2 should be re-templated
 | `task security` | Free local baseline: Semgrep CE + gitleaks + dependency audit |
 | `task security:sast` / `security:sca` | Semgrep CE / package-manager dependency audit |
 | `task security:sast:snyk` / `security:sca:snyk` | Optional Snyk second-opinion scans (manual or explicitly scheduled) |
+| `task challenge` / `task review` | Optional Codex second-model reviews: adversarial / verification checkpoint (advisory, local-only) |
+| `task codex:gate:enable` | Automatic Claude → Codex stop-gate for this repo + machine (also `:disable` / `:status`) |
 | `task install` | Brewfile deps + lefthook hooks |
 | `task release:patch` | Tag + GitHub release (also `:minor`/`:major`) |
 | `task status` | Project dashboard (also `status:git`/`:gh`/`:code`/`:env`) |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,6 +63,7 @@ tasks:
       - task: test:release-title
       - task: foreman:test
       - task: test:hooks
+      - task: test:codex-review
       - task: test:devcontainer:permissions
       - task: test
       - task: security
@@ -82,6 +83,7 @@ tasks:
       - task: test:dogfood-parity
       - task: foreman:test
       - task: test:hooks
+      - task: test:codex-review
       - task: test:template
 
   # ── Quality Checks ────────────────────────────────────────────
@@ -311,6 +313,11 @@ tasks:
     cmds:
       - ./scripts/test-dogfood-parity.sh
 
+  test:codex-review:
+    desc: Unit-test codex-review.sh target selection (offline, stubbed codex)
+    cmds:
+      - ./scripts/test-codex-review.sh
+
   # ── Skills sync ────────────────────────────────────────────────
   # Vendor shared agent skills from harmon-devkit, pinned in .skills-sync.yaml.
   # The verify:skills* drift checks skip cleanly until the first `task sync:skills`,
@@ -329,6 +336,48 @@ tasks:
     desc: "Fast offline check that the vendored ref matches the manifest (no network)"
     cmds:
       - ./scripts/sync-skills.sh verify-offline
+
+  # ── Second-model review (Codex) ───────────────────────────────
+  # Optional second AI model (the OpenAI Codex CLI) reviewing the current
+  # change — local and advisory only, never part of verify/ci. Findings are
+  # hypotheses for the primary agent to adjudicate (AGENTS.md "Second-Model
+  # Review"). The codex:gate:* tasks toggle the Claude Code codex plugin's
+  # automatic stop-time review for this repo + machine. See
+  # docs/guides/codex-review.md for setup, mechanics, and the loop caps.
+  review:
+    desc: Second-model verification review of the current change (Codex)
+    cmds:
+      - task: review:codex
+
+  challenge:
+    desc: Second-model adversarial review of the current change (Codex)
+    cmds:
+      - task: challenge:codex
+
+  review:codex:
+    desc: "Codex verification review (usage: task review:codex -- [--base <ref>|--uncommitted] [focus text])"
+    cmds:
+      - ./scripts/codex-review.sh review {{.CLI_ARGS}}
+
+  challenge:codex:
+    desc: "Codex adversarial review (usage: task challenge:codex -- [--base <ref>|--uncommitted] [focus text])"
+    cmds:
+      - ./scripts/codex-review.sh challenge {{.CLI_ARGS}}
+
+  codex:gate:enable:
+    desc: Enable the automatic Claude → Codex stop-gate review (this repo, this machine)
+    cmds:
+      - ./scripts/codex-gate.sh enable
+
+  codex:gate:disable:
+    desc: Disable the automatic Claude → Codex stop-gate review
+    cmds:
+      - ./scripts/codex-gate.sh disable
+
+  codex:gate:status:
+    desc: Show whether the Claude → Codex stop-gate review is enabled
+    cmds:
+      - ./scripts/codex-gate.sh status
 
   # ── Security ──────────────────────────────────────────────────
   security:

--- a/copier.yml
+++ b/copier.yml
@@ -194,6 +194,19 @@ codeql_languages:
     or use_foreman) else [])) if use_codeql else [] ]]
   validator: "[% if use_codeql and not codeql_languages %]Select at least one first-party CodeQL language.[% endif %]"
 
+use_codex_review:
+  type: bool
+  help: >-
+    CODEX REVIEW: Add second-model review tasks (task review / task challenge →
+    OpenAI Codex CLI) plus a toggle for the automatic Claude Code → Codex
+    stop-gate review? Requires each developer to install and authenticate the
+    Codex CLI themselves (ChatGPT account — free tier has tight usage limits —
+    or a billed OpenAI API key); the Claude Code codex plugin (for the gate) is
+    offered automatically on folder trust via .claude/settings.json. Local and
+    advisory only: nothing runs in CI, no PR check depends on it, and the gate
+    defaults off.
+  default: no
+
 devcontainer:
   type: bool
   help: "DEVCONTAINER: Add dual-profile .devcontainer (AI bot + human dev)?"

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -21,5 +21,8 @@ Calm, repeatable how-tos read *in advance* (the crisis counterpart is
 - [devcontainer-incidents.md](devcontainer-incidents.md) — worked diagnoses of
   real devcontainer failures (lifecycle chain aborts, Claude auth lost on
   rebuild, stale Coder volumes) and where the shipped fix for each lives.
+- [codex-review.md](codex-review.md) — second-model review via the OpenAI
+  Codex CLI: `task challenge` / `task review`, the automatic Claude → Codex
+  stop-gate toggle, and where the finding-adjudication protocol lives.
 
 TODO: add more guides, e.g. "local development setup", "add a feature", "how X works".

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -70,9 +70,14 @@ protocol) before it can finish. Non-editing turns are allowed through.
 The tasks flip the same per-workspace `stopReviewGate` flag as
 `/codex:setup --enable-review-gate` (plugin data dir keyed by workspace path
 — note a git worktree is a different workspace with its own flag; the state
-is per-user and per-machine, never committed). If Codex itself is missing or
-unauthenticated the gate fails **open**: the hook logs guidance and lets
-Claude stop.
+is per-user and per-machine, never committed). Fail-open is **narrower than
+it looks**: only a missing codex binary makes the hook log guidance and let
+Claude stop. An installed-but-unauthenticated codex makes the review task
+fail, which the hook converts into a **block on every turn** — so
+`task codex:gate:enable` refuses to arm the gate unless `codex login status`
+succeeds, and if auth expires while the gate is on, recover with
+`codex login` or `task codex:gate:disable` (disable/status never require
+auth).
 
 Loop safety: Claude Code caps consecutive stop-hook continuations, and repo
 policy caps adversarial/review loops at 3 iterations each (AGENTS.md). The

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -88,8 +88,15 @@ task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate findings, ≤3 loops
 task review     # verification checkpoint — adjudicate findings, ≤3 loops
 task ci         # full CI mirror
-# → open the PR (merging stays a human decision)
+# → open the PR, then shepherd it: watch CI + reviews, adjudicate → fix →
+#   push, ≤3 rounds (independent of the loops above)
+# → merging stays a human decision
 ```
+
+The full staged loop — including the PR-shepherding rounds — is defined in
+AGENTS.md ("Dev Loop"). If Codex cloud review is connected to the repo, PRs
+get a cloud pass too: inline comments only for high-priority findings, a
+bare 👍 reaction as the clean pass.
 
 ## Troubleshooting
 

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -85,8 +85,9 @@ release plumbing), disable it for routine development.
 ```text
 task check      # fast inner loop while editing
 task verify     # definition-of-done gate
-task challenge  # adversarial second model — adjudicate findings, ≤3 loops
-task review     # verification checkpoint — adjudicate findings, ≤3 loops
+task challenge  # adversarial second model — adjudicate, fix, re-challenge
+                # until a CLEAN pass (no material findings), ≤3 rounds
+task review     # verification checkpoint — same clean-pass exit, ≤3 rounds
 task ci         # full CI mirror
 # → open the PR, then shepherd it: watch CI + reviews, adjudicate → fix →
 #   push, ≤3 rounds (independent of the loops above)

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -60,6 +60,13 @@ task codex:gate:disable   # turn off
 task codex:gate:status    # inspect
 ```
 
+The toggles sit in `permissions.ask` in `.claude/settings.json`, so an agent
+cannot flip the gate without a human approving the command — in particular, a
+gated agent must never disable the gate to get past a BLOCK. `enable` also
+refuses when the plugin is explicitly disabled in Claude Code settings
+(`enabledPlugins`): an installed-but-disabled plugin registers no Stop hook,
+so the armed flag would report protection that does not exist.
+
 Mechanics: the codex plugin registers a Claude Code **Stop hook**. While the
 gate is enabled for a workspace, every time Claude finishes a turn the hook
 runs a fresh, read-only Codex task over the repo and Claude's last message;

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -5,7 +5,7 @@ A second AI model — the [OpenAI Codex CLI](https://developers.openai.com/codex
 automatic Claude Code → Codex stop-gate. Everything is local and advisory:
 nothing runs in CI, no PR check depends on Codex, and `verify`/`ci` never
 invoke it. Findings are hypotheses for the primary agent to adjudicate — the
-protocol and the 3-iteration loop cap live in AGENTS.md ("Second-Model
+protocol and the loop caps live in AGENTS.md ("Second-Model
 Review").
 
 ## Setup
@@ -93,7 +93,7 @@ succeeds, and if auth expires while the gate is on, recover with
 auth; disable does require an interactive terminal).
 
 Loop safety: Claude Code caps consecutive stop-hook continuations, and repo
-policy caps adversarial/review loops at 3 iterations each (AGENTS.md). The
+policy caps the adversarial/review loops (AGENTS.md "Dev Loop"). The
 gate reviews after **every** turn while enabled and each run costs Codex
 usage — enable it for high-consequence work (migrations, auth, concurrency,
 release plumbing), disable it for routine development.
@@ -104,11 +104,11 @@ release plumbing), disable it for routine development.
 task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
-                # until a CLEAN pass (no material findings), ≤3 rounds
-task review     # verification checkpoint — same clean-pass exit, ≤3 rounds
+                # until a CLEAN pass (no material findings), ≤5 rounds
+task review     # verification checkpoint — same clean-pass exit, ≤4 rounds
 task ci         # full CI mirror
 # → open the PR, then shepherd it: watch CI + reviews, adjudicate → fix →
-#   push, ≤3 rounds (independent of the loops above)
+#   push, ≤4 rounds (independent of the loops above)
 # → merging stays a human decision
 ```
 

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -1,0 +1,111 @@
+# Codex second-model review
+
+A second AI model — the [OpenAI Codex CLI](https://developers.openai.com/codex/cli)
+— reviews changes in this repo: manual review/challenge tasks, plus an optional
+automatic Claude Code → Codex stop-gate. Everything is local and advisory:
+nothing runs in CI, no PR check depends on Codex, and `verify`/`ci` never
+invoke it. Findings are hypotheses for the primary agent to adjudicate — the
+protocol and the 3-iteration loop cap live in AGENTS.md ("Second-Model
+Review").
+
+## Setup
+
+1. **Install the Codex CLI**: `brew install --cask codex` (macOS) or
+   `npm install -g @openai/codex` (anywhere Node ≥ 18 runs).
+2. **Authenticate**: `codex login` (browser OAuth against a ChatGPT account —
+   the free tier has tight usage limits) or
+   `printenv OPENAI_API_KEY | codex login --with-api-key` (billed API usage).
+   Confirm with `codex login status`.
+3. **Trust the repo in Codex** when prompted on first run. The committed
+   `.codex/config.toml` (review-grade `model_reasoning_effort = "high"`; model
+   deliberately unpinned) only loads for trusted projects.
+4. **For the automatic stop-gate only — the Claude Code codex plugin.** This
+   repo's `.claude/settings.json` declares the `openai-codex` marketplace and
+   enables `codex@openai-codex`, so Claude Code installs/offers the plugin
+   when you trust the folder. Manual install, inside Claude Code:
+
+   ```text
+   /plugin marketplace add openai/codex-plugin-cc
+   /plugin install codex@openai-codex
+   /codex:setup
+   ```
+
+## Manual reviews
+
+| Command | What it does |
+|---|---|
+| `task challenge` (= `challenge:codex`) | Adversarial review — tries to break the change: architecture, authz bypasses, data-loss paths, unsafe rollback, races, hidden coupling, operational failure modes, needless complexity |
+| `task review` (= `review:codex`) | Verification checkpoint — double-checks implementation, consistency with repo conventions, error handling, and test coverage |
+
+Both accept an explicit target and free-text focus after `--`:
+
+```bash
+task challenge                                     # auto: dirty tree → uncommitted; clean → --base main
+task challenge -- --base main                      # branch vs main explicitly
+task review -- --uncommitted                       # staged + unstaged + untracked only
+task challenge -- --base main focus on the update/migration path
+```
+
+Inside Claude Code the plugin's slash commands are the interactive
+equivalents: `/codex:review` and
+`/codex:adversarial-review --base main --background` (with extra focus text
+allowed after the flags), plus `/codex:status` / `/codex:result` for
+background runs.
+
+## The automatic stop-gate
+
+```bash
+task codex:gate:enable    # turn on for this repo on this machine
+task codex:gate:disable   # turn off
+task codex:gate:status    # inspect
+```
+
+Mechanics: the codex plugin registers a Claude Code **Stop hook**. While the
+gate is enabled for a workspace, every time Claude finishes a turn the hook
+runs a fresh, read-only Codex task over the repo and Claude's last message;
+Codex answers `ALLOW:` or `BLOCK: <reason>`. A block feeds the reason back
+into Claude, which must address it (or refute it — see the adjudication
+protocol) before it can finish. Non-editing turns are allowed through.
+
+The tasks flip the same per-workspace `stopReviewGate` flag as
+`/codex:setup --enable-review-gate` (plugin data dir keyed by workspace path
+— note a git worktree is a different workspace with its own flag; the state
+is per-user and per-machine, never committed). If Codex itself is missing or
+unauthenticated the gate fails **open**: the hook logs guidance and lets
+Claude stop.
+
+Loop safety: Claude Code caps consecutive stop-hook continuations, and repo
+policy caps adversarial/review loops at 3 iterations each (AGENTS.md). The
+gate reviews after **every** turn while enabled and each run costs Codex
+usage — enable it for high-consequence work (migrations, auth, concurrency,
+release plumbing), disable it for routine development.
+
+## Intended workflow
+
+```text
+task check      # fast inner loop while editing
+task verify     # definition-of-done gate
+task challenge  # adversarial second model — adjudicate findings, ≤3 loops
+task review     # verification checkpoint — adjudicate findings, ≤3 loops
+task ci         # full CI mirror
+# → open the PR (merging stays a human decision)
+```
+
+## Troubleshooting
+
+- **`codex` not found** — install per Setup; on Linux/devcontainers use the
+  npm install (the Homebrew `codex` cask is macOS-only).
+- **Auth expired** — `codex login status`, then `codex login` (or
+  `codex login --device-auth` without a browser).
+- **`/codex:*` commands missing in Claude Code** — trust the folder so the
+  repo-declared plugin installs, or install manually (Setup step 4), then
+  restart Claude Code.
+- **Gate toggle "plugin not installed"** — the `codex:gate:*` tasks drive the
+  plugin's own runtime under `~/.claude/plugins`; install the plugin first
+  (Setup step 4).
+- **Gate enabled but nothing happens** — `task codex:gate:status`; remember
+  the flag is per workspace path (worktrees toggle separately) and fails open
+  when Codex is unavailable.
+- **Nothing to review** — a clean tree with no commits beyond the base exits
+  early; pass `--base <ref>`, `--uncommitted`, or `--commit <sha>` to pick
+  the target explicitly.

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -60,12 +60,18 @@ task codex:gate:disable   # turn off
 task codex:gate:status    # inspect
 ```
 
-The toggles sit in `permissions.ask` in `.claude/settings.json`, so an agent
-cannot flip the gate without a human approving the command — in particular, a
-gated agent must never disable the gate to get past a BLOCK. `enable` also
-refuses when the plugin is explicitly disabled in Claude Code settings
-(`enabledPlugins`): an installed-but-disabled plugin registers no Stop hook,
-so the armed flag would report protection that does not exist.
+Disarming the gate is a human-only action, enforced in layers: the toggles
+sit in `permissions.ask` in `.claude/settings.json`, and `disable`
+additionally refuses to run without an interactive terminal — permission
+prefix rules alone can be sidestepped with flag placement (e.g.
+`task --silent codex:gate:disable`), but agent shells never have a TTY. A
+gated agent must never disable the gate to get past a BLOCK — adjudicate or
+escalate instead. (This is friction against silent disarmament, not an
+absolute boundary: the plugin's own `/codex:setup --disable-review-gate` is
+outside this repo's control, which is why the AGENTS.md prohibition exists.)
+`enable` also refuses when the plugin is explicitly disabled in Claude Code
+settings (`enabledPlugins`): an installed-but-disabled plugin registers no
+Stop hook, so the armed flag would report protection that does not exist.
 
 Mechanics: the codex plugin registers a Claude Code **Stop hook**. While the
 gate is enabled for a workspace, every time Claude finishes a turn the hook
@@ -84,7 +90,7 @@ fail, which the hook converts into a **block on every turn** — so
 `task codex:gate:enable` refuses to arm the gate unless `codex login status`
 succeeds, and if auth expires while the gate is on, recover with
 `codex login` or `task codex:gate:disable` (disable/status never require
-auth).
+auth; disable does require an interactive terminal).
 
 Loop safety: Claude Code caps consecutive stop-hook continuations, and repo
 policy caps adversarial/review loops at 3 iterations each (AGENTS.md). The

--- a/scripts/codex-gate.sh
+++ b/scripts/codex-gate.sh
@@ -106,11 +106,12 @@ export CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:-${claude_dir}/plugins/data/code
 # `setup --json` can exit 0 with ready:false (e.g. the app-server cannot
 # initialize its state runtime), and an armed gate would then BLOCK every
 # turn while `codex login status` still passes.
-if [ "$ACTION" = "enable" ]; then
+if [ "$ACTION" = "enable" ] || [ "$ACTION" = "status" ]; then
     # Best-effort effective-enablement check (settings.local.json > project
     # settings.json > user settings.json; managed/enterprise layers are not
     # consulted). An installed-but-disabled plugin registers NO Stop hook, so
-    # arming the flag would report protection that does not exist.
+    # an armed flag would report protection that does not exist — refuse to
+    # arm, and mark status output as inert.
     enabled="$(node -e '
 const fs = require("fs");
 const read = (p) => { try { return JSON.parse(fs.readFileSync(p, "utf8")); } catch { return null; } };
@@ -121,13 +122,24 @@ for (const p of process.argv.slice(1)) {
 }
 process.stdout.write("unknown");
 ' "$(pwd)/.claude/settings.local.json" "$(pwd)/.claude/settings.json" "${claude_dir}/settings.json" 2>/dev/null || echo unknown)"
-    if [ "$enabled" = "false" ]; then
+    if [ "$enabled" = "false" ] && [ "$ACTION" = "enable" ]; then
         echo "Refusing to enable the stop gate: the codex plugin is explicitly disabled in" >&2
         echo "your Claude Code settings (enabledPlugins), so its Stop hook is not active —" >&2
         echo "the armed flag would report protection that does not exist. Re-enable the" >&2
         echo "plugin first (/plugin, or enabledPlugins in .claude/settings*.json)." >&2
         exit 1
     fi
+    if [ "$enabled" = "false" ] && [ "$ACTION" = "status" ]; then
+        echo "WARNING: the codex plugin is explicitly disabled in Claude Code settings" >&2
+        echo "(enabledPlugins) — no Stop hook is active, so any enabled gate flag" >&2
+        echo "reported below is INERT until the plugin is re-enabled." >&2
+    fi
+fi
+
+# Auth + companion-readiness preflights gate ONLY `enable` — status and
+# disable must stay usable as the inspection/escape hatch when auth or the
+# runtime has gone bad after arming.
+if [ "$ACTION" = "enable" ]; then
     if ! command -v codex >/dev/null 2>&1 || ! codex login status >/dev/null 2>&1; then
         echo "Refusing to enable the stop gate: codex is missing or not authenticated." >&2
         echo "The plugin fails open only when the codex BINARY is missing; an installed" >&2

--- a/scripts/codex-gate.sh
+++ b/scripts/codex-gate.sh
@@ -17,8 +17,12 @@
 # Notes:
 #   - The flag is per-user, per-machine, per-workspace path — never committed.
 #     A git worktree is a different workspace path with its own flag.
-#   - Upstream is fail-open by design: with the gate on but Codex missing or
-#     unauthenticated, the hook logs guidance and lets Claude stop.
+#   - Upstream fails open ONLY when the codex binary/runtime is missing: the
+#     hook then logs guidance and lets Claude stop. An installed-but-
+#     unauthenticated codex instead makes the spawned review task fail, which
+#     the hook converts into a BLOCK on every turn — so `enable` refuses to
+#     arm the gate unless `codex login status` succeeds (disable/status stay
+#     unguarded as the escape hatch if auth expires later).
 #   - Claude Code caps consecutive stop-hook continuations, so an enabled gate
 #     cannot loop forever; the AGENTS.md 3-iteration policy still applies.
 set -euo pipefail
@@ -41,14 +45,21 @@ fi
 claude_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 manifest="${claude_dir}/plugins/installed_plugins.json"
 
+# Only accept an install that is actually active for THIS workspace: a
+# user-scoped entry, or a project-scoped entry whose projectPath is this
+# repo — entries[0] blindly could be another repo's project-scoped install
+# (wrong version, and its Stop hook is not even active here).
 plugin_root=""
 if [ -f "$manifest" ]; then
     plugin_root="$(node -e '
 const fs = require("fs");
 const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
 const entries = (manifest.plugins || {})["codex@openai-codex"] || [];
-if (entries.length > 0 && entries[0].installPath) process.stdout.write(entries[0].installPath);
-' "$manifest" 2>/dev/null || true)"
+const root = process.argv[2];
+const pick = entries.find((e) => e.scope === "project" && e.projectPath === root)
+  || entries.find((e) => e.scope === "user");
+if (pick && pick.installPath) process.stdout.write(pick.installPath);
+' "$manifest" "$(pwd)" 2>/dev/null || true)"
 fi
 if [ -z "$plugin_root" ] || [ ! -f "${plugin_root}/scripts/codex-companion.mjs" ]; then
     # Fallback: newest cached copy (lexical sort — fine for a fallback).
@@ -68,6 +79,18 @@ Install it inside Claude Code:
 trust the folder in Claude Code.) See docs/guides/codex-review.md.
 EOF
     exit 1
+fi
+
+# Arming the gate while codex cannot actually review would trap Claude in
+# stop-blocks (see header) — refuse unless codex is present AND authenticated.
+if [ "$ACTION" = "enable" ]; then
+    if ! command -v codex >/dev/null 2>&1 || ! codex login status >/dev/null 2>&1; then
+        echo "Refusing to enable the stop gate: codex is missing or not authenticated." >&2
+        echo "The plugin fails open only when the codex BINARY is missing; an installed" >&2
+        echo "but unauthenticated codex makes the Stop hook BLOCK every Claude turn." >&2
+        echo "Run 'codex login' first. (codex-gate.sh disable/status work without auth.)" >&2
+        exit 1
+    fi
 fi
 
 # Write the SAME per-workspace state the Claude Code hook reads: outside

--- a/scripts/codex-gate.sh
+++ b/scripts/codex-gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# codex-gate.sh — enable/disable/inspect the automatic Claude → Codex
+# "stop-gate" review for THIS repo on THIS machine.
+#
+# The gate ships with the `codex@openai-codex` Claude Code plugin: a Stop hook
+# that, when a Claude turn finishes, has Codex review the turn (read-only) and
+# blocks Claude from stopping (BLOCK: <reason>) until material issues are
+# addressed. The hook is always registered while the plugin is installed;
+# whether it acts is a per-workspace `stopReviewGate` flag in the plugin's
+# data dir. This script flips that same flag through the plugin's own
+# companion runtime — identical state to running
+# `/codex:setup --enable-review-gate` inside Claude Code — so the toggle is
+# scriptable (task codex:gate:enable / codex:gate:disable / codex:gate:status).
+#
+# Usage: codex-gate.sh <enable|disable|status>
+#
+# Notes:
+#   - The flag is per-user, per-machine, per-workspace path — never committed.
+#     A git worktree is a different workspace path with its own flag.
+#   - Upstream is fail-open by design: with the gate on but Codex missing or
+#     unauthenticated, the hook logs guidance and lets Claude stop.
+#   - Claude Code caps consecutive stop-hook continuations, so an enabled gate
+#     cannot loop forever; the AGENTS.md 3-iteration policy still applies.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ACTION="${1:-}"
+case "$ACTION" in
+enable | disable | status) ;;
+*)
+    echo "usage: $0 <enable|disable|status>" >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v node >/dev/null 2>&1; then
+    echo "node is required (the gate toggle drives the Claude Code codex plugin's Node runtime)." >&2
+    exit 1
+fi
+
+claude_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+manifest="${claude_dir}/plugins/installed_plugins.json"
+
+plugin_root=""
+if [ -f "$manifest" ]; then
+    plugin_root="$(node -e '
+const fs = require("fs");
+const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+const entries = (manifest.plugins || {})["codex@openai-codex"] || [];
+if (entries.length > 0 && entries[0].installPath) process.stdout.write(entries[0].installPath);
+' "$manifest" 2>/dev/null || true)"
+fi
+if [ -z "$plugin_root" ] || [ ! -f "${plugin_root}/scripts/codex-companion.mjs" ]; then
+    # Fallback: newest cached copy (lexical sort — fine for a fallback).
+    for d in "${claude_dir}"/plugins/cache/openai-codex/codex/*/; do
+        if [ -f "${d}scripts/codex-companion.mjs" ]; then
+            plugin_root="${d%/}"
+        fi
+    done
+fi
+if [ -z "$plugin_root" ] || [ ! -f "${plugin_root}/scripts/codex-companion.mjs" ]; then
+    cat >&2 <<'EOF'
+The codex Claude Code plugin is not installed for this user.
+Install it inside Claude Code:
+  /plugin marketplace add openai/codex-plugin-cc
+  /plugin install codex@openai-codex
+(This repo's .claude/settings.json also offers it automatically when you
+trust the folder in Claude Code.) See docs/guides/codex-review.md.
+EOF
+    exit 1
+fi
+
+# Write the SAME per-workspace state the Claude Code hook reads: outside
+# Claude Code the companion falls back to a temp dir, so pin CLAUDE_PLUGIN_DATA
+# to the plugin's real data dir (~/.claude/plugins/data/<plugin>-<marketplace>).
+export CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:-${claude_dir}/plugins/data/codex-openai-codex}"
+
+case "$ACTION" in
+enable) exec node "${plugin_root}/scripts/codex-companion.mjs" setup --enable-review-gate ;;
+disable) exec node "${plugin_root}/scripts/codex-companion.mjs" setup --disable-review-gate ;;
+status) exec node "${plugin_root}/scripts/codex-companion.mjs" setup ;;
+esac

--- a/scripts/codex-gate.sh
+++ b/scripts/codex-gate.sh
@@ -76,8 +76,17 @@ EOF
     exit 1
 fi
 
+# Write the SAME per-workspace state the Claude Code hook reads: outside
+# Claude Code the companion falls back to a temp dir, so pin CLAUDE_PLUGIN_DATA
+# to the plugin's real data dir (~/.claude/plugins/data/<plugin>-<marketplace>).
+export CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:-${claude_dir}/plugins/data/codex-openai-codex}"
+
 # Arming the gate while codex cannot actually review would trap Claude in
-# stop-blocks (see header) — refuse unless codex is present AND authenticated.
+# stop-blocks (see header) — refuse unless codex is present, authenticated,
+# AND the plugin's own companion reports ready. Auth alone is not enough:
+# `setup --json` can exit 0 with ready:false (e.g. the app-server cannot
+# initialize its state runtime), and an armed gate would then BLOCK every
+# turn while `codex login status` still passes.
 if [ "$ACTION" = "enable" ]; then
     if ! command -v codex >/dev/null 2>&1 || ! codex login status >/dev/null 2>&1; then
         echo "Refusing to enable the stop gate: codex is missing or not authenticated." >&2
@@ -86,12 +95,15 @@ if [ "$ACTION" = "enable" ]; then
         echo "Run 'codex login' first. (codex-gate.sh disable/status work without auth.)" >&2
         exit 1
     fi
+    ready="$(node "${plugin_root}/scripts/codex-companion.mjs" setup --json 2>/dev/null |
+        node -e 'let s="";process.stdin.on("data",(d)=>{s+=d;}).on("end",()=>{let r=false;try{r=JSON.parse(s).ready===true;}catch{}process.stdout.write(r?"true":"false");});' || echo false)"
+    if [ "$ready" != "true" ]; then
+        echo "Refusing to enable the stop gate: the codex plugin companion reports it is" >&2
+        echo "not ready (run 'task codex:gate:status' for details). An armed gate with an" >&2
+        echo "unusable runtime would BLOCK every Claude turn instead of reviewing." >&2
+        exit 1
+    fi
 fi
-
-# Write the SAME per-workspace state the Claude Code hook reads: outside
-# Claude Code the companion falls back to a temp dir, so pin CLAUDE_PLUGIN_DATA
-# to the plugin's real data dir (~/.claude/plugins/data/<plugin>-<marketplace>).
-export CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:-${claude_dir}/plugins/data/codex-openai-codex}"
 
 case "$ACTION" in
 enable) exec node "${plugin_root}/scripts/codex-companion.mjs" setup --enable-review-gate ;;

--- a/scripts/codex-gate.sh
+++ b/scripts/codex-gate.sh
@@ -88,6 +88,27 @@ export CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:-${claude_dir}/plugins/data/code
 # initialize its state runtime), and an armed gate would then BLOCK every
 # turn while `codex login status` still passes.
 if [ "$ACTION" = "enable" ]; then
+    # Best-effort effective-enablement check (settings.local.json > project
+    # settings.json > user settings.json; managed/enterprise layers are not
+    # consulted). An installed-but-disabled plugin registers NO Stop hook, so
+    # arming the flag would report protection that does not exist.
+    enabled="$(node -e '
+const fs = require("fs");
+const read = (p) => { try { return JSON.parse(fs.readFileSync(p, "utf8")); } catch { return null; } };
+for (const p of process.argv.slice(1)) {
+  const v = read(p)?.enabledPlugins?.["codex@openai-codex"];
+  if (v === true) { process.stdout.write("true"); process.exit(0); }
+  if (v === false) { process.stdout.write("false"); process.exit(0); }
+}
+process.stdout.write("unknown");
+' "$(pwd)/.claude/settings.local.json" "$(pwd)/.claude/settings.json" "${claude_dir}/settings.json" 2>/dev/null || echo unknown)"
+    if [ "$enabled" = "false" ]; then
+        echo "Refusing to enable the stop gate: the codex plugin is explicitly disabled in" >&2
+        echo "your Claude Code settings (enabledPlugins), so its Stop hook is not active —" >&2
+        echo "the armed flag would report protection that does not exist. Re-enable the" >&2
+        echo "plugin first (/plugin, or enabledPlugins in .claude/settings*.json)." >&2
+        exit 1
+    fi
     if ! command -v codex >/dev/null 2>&1 || ! codex login status >/dev/null 2>&1; then
         echo "Refusing to enable the stop gate: codex is missing or not authenticated." >&2
         echo "The plugin fails open only when the codex BINARY is missing; an installed" >&2

--- a/scripts/codex-gate.sh
+++ b/scripts/codex-gate.sh
@@ -61,18 +61,13 @@ const pick = entries.find((e) => e.scope === "project" && e.projectPath === root
 if (pick && pick.installPath) process.stdout.write(pick.installPath);
 ' "$manifest" "$(pwd)" 2>/dev/null || true)"
 fi
-if [ -z "$plugin_root" ] || [ ! -f "${plugin_root}/scripts/codex-companion.mjs" ]; then
-    # Fallback: newest cached copy (lexical sort — fine for a fallback).
-    for d in "${claude_dir}"/plugins/cache/openai-codex/codex/*/; do
-        if [ -f "${d}scripts/codex-companion.mjs" ]; then
-            plugin_root="${d%/}"
-        fi
-    done
-fi
+# No cache-directory fallback on purpose: a cached runtime is NOT an active
+# plugin — flipping state through another repo's project-scoped install would
+# report the gate "enabled" while no Stop hook runs in this workspace.
 if [ -z "$plugin_root" ] || [ ! -f "${plugin_root}/scripts/codex-companion.mjs" ]; then
     cat >&2 <<'EOF'
-The codex Claude Code plugin is not installed for this user.
-Install it inside Claude Code:
+The codex Claude Code plugin is not installed for this user (or not active
+for this workspace). Install it inside Claude Code:
   /plugin marketplace add openai/codex-plugin-cc
   /plugin install codex@openai-codex
 (This repo's .claude/settings.json also offers it automatically when you

--- a/scripts/codex-gate.sh
+++ b/scripts/codex-gate.sh
@@ -24,7 +24,7 @@
 #     arm the gate unless `codex login status` succeeds (disable/status stay
 #     unguarded as the escape hatch if auth expires later).
 #   - Claude Code caps consecutive stop-hook continuations, so an enabled gate
-#     cannot loop forever; the AGENTS.md 3-iteration policy still applies.
+#     cannot loop forever; the AGENTS.md loop-cap policy still applies.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -42,20 +42,22 @@ if ! command -v node >/dev/null 2>&1; then
     exit 1
 fi
 
-# Disarming the gate is a human-only action. Permission prefix rules cannot
-# hold this line — `task --silent codex:gate:disable` slips past exact-prefix
-# ask rules while matching the broad Bash(task:*) allow — so enforce it here:
-# agent/CI shells have no TTY on stdin, an interactive human terminal does.
-# (The permissions.ask entries remain as a second layer. This is friction
-# against silent disarmament, not a cryptographic boundary: a policy-violating
-# agent with file-write access could still edit scripts or state — which is
-# why AGENTS.md forbids it and adjudication is the sanctioned way past a
-# BLOCK.)
-if [ "$ACTION" = "disable" ] && [ ! -t 0 ]; then
-    echo "Refusing to disable the stop gate from a non-interactive shell: disarming the" >&2
+# Toggling the gate is a human-only action in BOTH directions: disable lets a
+# blocked agent disarm its reviewer; enable silently commits the human to
+# billed every-turn reviews. Permission prefix rules cannot hold this line —
+# `task --silent codex:gate:<action>` slips past exact-prefix ask rules while
+# matching the broad Bash(task:*) allow — so enforce it here: agent/CI shells
+# have no TTY on stdin, an interactive human terminal does. (The
+# permissions.ask entries remain as a second layer. This is friction against
+# silent toggling, not a cryptographic boundary: a policy-violating agent
+# with file-write access could still edit scripts or state — which is why
+# AGENTS.md forbids it and adjudication is the sanctioned way past a BLOCK.)
+if [ "$ACTION" != "status" ] && [ ! -t 0 ]; then
+    echo "Refusing to ${ACTION} the stop gate from a non-interactive shell: toggling the" >&2
     echo "gate is a human decision (agents must adjudicate or escalate a BLOCK, never" >&2
-    echo "disarm). Run 'task codex:gate:disable' yourself in a terminal, or use" >&2
-    echo "/codex:setup --disable-review-gate inside Claude Code." >&2
+    echo "disarm — and arming commits the human to per-turn review costs). Run" >&2
+    echo "'task codex:gate:${ACTION}' yourself in a terminal, or use /codex:setup inside" >&2
+    echo "Claude Code." >&2
     exit 1
 fi
 

--- a/scripts/codex-gate.sh
+++ b/scripts/codex-gate.sh
@@ -42,6 +42,23 @@ if ! command -v node >/dev/null 2>&1; then
     exit 1
 fi
 
+# Disarming the gate is a human-only action. Permission prefix rules cannot
+# hold this line — `task --silent codex:gate:disable` slips past exact-prefix
+# ask rules while matching the broad Bash(task:*) allow — so enforce it here:
+# agent/CI shells have no TTY on stdin, an interactive human terminal does.
+# (The permissions.ask entries remain as a second layer. This is friction
+# against silent disarmament, not a cryptographic boundary: a policy-violating
+# agent with file-write access could still edit scripts or state — which is
+# why AGENTS.md forbids it and adjudication is the sanctioned way past a
+# BLOCK.)
+if [ "$ACTION" = "disable" ] && [ ! -t 0 ]; then
+    echo "Refusing to disable the stop gate from a non-interactive shell: disarming the" >&2
+    echo "gate is a human decision (agents must adjudicate or escalate a BLOCK, never" >&2
+    echo "disarm). Run 'task codex:gate:disable' yourself in a terminal, or use" >&2
+    echo "/codex:setup --disable-review-gate inside Claude Code." >&2
+    exit 1
+fi
+
 claude_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 manifest="${claude_dir}/plugins/installed_plugins.json"
 

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -139,10 +139,9 @@ behavior; race conditions, ordering and idempotency gaps; hidden coupling and
 assumptions that stop holding under stress; operational failure modes (empty
 state, timeouts, retries, partial failure, degraded dependencies); and
 unnecessarily complex design choices where a simpler alternative would do.
-Report only material, defensible findings tied to concrete files and lines —
-no style nits, no speculation you cannot support from the code. Prefer one
-strong finding over several weak ones; if the change looks safe, say so
-directly."
+Report EVERY materially defensible finding tied to concrete files and lines —
+do not stop at the first strong one. No style nits, no speculation you cannot
+support from the code. If the change looks safe, say so directly."
 else
     instructions="${scope}
 

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -53,6 +53,12 @@ cap_manifest() {
 scope=""
 manifest=""
 focus=""
+require_single_target() {
+    if [ -n "$scope" ]; then
+        echo "conflicting target flags: --base, --uncommitted, and --commit are mutually exclusive." >&2
+        exit 2
+    fi
+}
 while [ $# -gt 0 ]; do
     case "$1" in
     --base)
@@ -60,6 +66,7 @@ while [ $# -gt 0 ]; do
             echo "$1 requires a value" >&2
             exit 2
         fi
+        require_single_target
         # Fail fast on a typo/stale/unfetched ref: without this, an expensive
         # Codex run would launch with a nonsense scope and no manifest.
         if ! git rev-parse --verify --quiet "$2^{commit}" >/dev/null; then
@@ -75,6 +82,7 @@ while [ $# -gt 0 ]; do
             echo "$1 requires a value" >&2
             exit 2
         fi
+        require_single_target
         if ! git rev-parse --verify --quiet "$2^{commit}" >/dev/null; then
             echo "--commit '$2' does not resolve to a commit." >&2
             exit 2
@@ -84,6 +92,7 @@ while [ $# -gt 0 ]; do
         shift 2
         ;;
     --uncommitted)
+        require_single_target
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
         manifest="$(git status --porcelain | cap_manifest || true)"
         shift

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -43,6 +43,7 @@ if ! command -v codex >/dev/null 2>&1; then
 fi
 
 scope=""
+manifest=""
 focus=""
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -52,6 +53,7 @@ while [ $# -gt 0 ]; do
             exit 2
         fi
         scope="Review the changes on the current branch relative to base branch '$2' (the merge-base diff $2...HEAD)."
+        manifest="$(git diff --name-status "$2...HEAD" 2>/dev/null | head -200 || true)"
         shift 2
         ;;
     --commit)
@@ -60,10 +62,12 @@ while [ $# -gt 0 ]; do
             exit 2
         fi
         scope="Review the changes introduced by commit $2."
+        manifest="$(git diff-tree --no-commit-id --name-status -r "$2" 2>/dev/null | head -200 || true)"
         shift 2
         ;;
     --uncommitted)
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
+        manifest="$(git status --porcelain | head -200)"
         shift
         ;;
     *)
@@ -76,6 +80,7 @@ done
 if [ -z "$scope" ]; then
     if [ -n "$(git status --porcelain)" ]; then
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
+        manifest="$(git status --porcelain | head -200)"
         echo "==> Reviewing uncommitted work (dirty tree; pass --base <ref> to review the branch instead)"
     else
         base=""
@@ -100,6 +105,7 @@ if [ -z "$scope" ]; then
             exit 0
         fi
         scope="Review the changes on the current branch relative to base branch '${base}' (the merge-base diff ${base}...HEAD)."
+        manifest="$(git diff --name-status "${base}...HEAD" | head -200)"
         echo "==> Reviewing branch changes against ${base}"
     fi
 fi
@@ -135,6 +141,20 @@ if [ -n "$focus" ]; then
     instructions="${instructions}
 
 Additional focus from the invoker (weight it heavily): ${focus}"
+fi
+
+# Custom review instructions bypass the CLI's native diff-target modes (the
+# two are mutually exclusive), leaving diff collection to the model. Anchor it
+# with an authoritative, git-generated file manifest so nothing in scope —
+# untracked files included — can be silently skipped.
+if [ -n "$manifest" ]; then
+    instructions="${instructions}
+
+Authoritative changed-file manifest from git for this scope (status + path;
+cover EVERY entry, including untracked files, collecting the diffs yourself
+with git):
+
+${manifest}"
 fi
 
 exec codex exec review "$instructions"

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -60,6 +60,12 @@ while [ $# -gt 0 ]; do
             echo "$1 requires a value" >&2
             exit 2
         fi
+        # Fail fast on a typo/stale/unfetched ref: without this, an expensive
+        # Codex run would launch with a nonsense scope and no manifest.
+        if ! git rev-parse --verify --quiet "$2^{commit}" >/dev/null; then
+            echo "--base '$2' does not resolve to a commit (typo, or fetch the ref first)." >&2
+            exit 2
+        fi
         scope="Review the changes on the current branch relative to base branch '$2' (the merge-base diff $2...HEAD)."
         manifest="$(git diff --name-status "$2...HEAD" 2>/dev/null | cap_manifest || true)"
         shift 2
@@ -67,6 +73,10 @@ while [ $# -gt 0 ]; do
     --commit)
         if [ $# -lt 2 ]; then
             echo "$1 requires a value" >&2
+            exit 2
+        fi
+        if ! git rev-parse --verify --quiet "$2^{commit}" >/dev/null; then
+            echo "--commit '$2' does not resolve to a commit." >&2
             exit 2
         fi
         scope="Review the changes introduced by commit $2."

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -42,6 +42,14 @@ if ! command -v codex >/dev/null 2>&1; then
     exit 1
 fi
 
+# Cap the manifest at 200 entries WITHOUT `head`: head exits early, the git
+# producer takes SIGPIPE, and under `set -o pipefail` a >200-entry tree would
+# abort the review before Codex ever runs. awk reads to EOF (no SIGPIPE) and
+# marks the truncation so the reviewer knows to re-enumerate with git.
+cap_manifest() {
+    awk 'NR <= 200 { print } NR == 201 { print "... (manifest truncated at 200 entries; re-enumerate with git for the full set)" }'
+}
+
 scope=""
 manifest=""
 focus=""
@@ -53,7 +61,7 @@ while [ $# -gt 0 ]; do
             exit 2
         fi
         scope="Review the changes on the current branch relative to base branch '$2' (the merge-base diff $2...HEAD)."
-        manifest="$(git diff --name-status "$2...HEAD" 2>/dev/null | head -200 || true)"
+        manifest="$(git diff --name-status "$2...HEAD" 2>/dev/null | cap_manifest || true)"
         shift 2
         ;;
     --commit)
@@ -62,12 +70,12 @@ while [ $# -gt 0 ]; do
             exit 2
         fi
         scope="Review the changes introduced by commit $2."
-        manifest="$(git diff-tree --no-commit-id --name-status -r "$2" 2>/dev/null | head -200 || true)"
+        manifest="$(git diff-tree --no-commit-id --name-status -r "$2" 2>/dev/null | cap_manifest || true)"
         shift 2
         ;;
     --uncommitted)
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
-        manifest="$(git status --porcelain | head -200)"
+        manifest="$(git status --porcelain | cap_manifest || true)"
         shift
         ;;
     *)
@@ -80,7 +88,7 @@ done
 if [ -z "$scope" ]; then
     if [ -n "$(git status --porcelain)" ]; then
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
-        manifest="$(git status --porcelain | head -200)"
+        manifest="$(git status --porcelain | cap_manifest || true)"
         echo "==> Reviewing uncommitted work (dirty tree; pass --base <ref> to review the branch instead)"
     else
         base=""
@@ -105,7 +113,7 @@ if [ -z "$scope" ]; then
             exit 0
         fi
         scope="Review the changes on the current branch relative to base branch '${base}' (the merge-base diff ${base}...HEAD)."
-        manifest="$(git diff --name-status "${base}...HEAD" | head -200)"
+        manifest="$(git diff --name-status "${base}...HEAD" | cap_manifest || true)"
         echo "==> Reviewing branch changes against ${base}"
     fi
 fi

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -199,4 +199,7 @@ with git):
 ${manifest}"
 fi
 
-exec codex exec review "$instructions"
+# Feed the prompt through stdin (`review -`): a single argv element is
+# capped (~128 KiB per arg on Linux), and cap_manifest bounds entry count,
+# not bytes — 200 deep paths plus instructions can exceed the argv limit.
+printf '%s\n' "$instructions" | codex exec review -

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -92,7 +92,14 @@ while [ $# -gt 0 ]; do
             exit 2
         fi
         scope="Review the changes introduced by commit $2."
-        manifest="$(git diff-tree --no-commit-id --name-status -r --root -m "$2" 2>/dev/null | cap_manifest || true)"
+        # First-parent diff for commits with a parent: diff-tree -m would also
+        # emit each merge parent's diff, pulling pre-merge mainline files into
+        # the "authoritative" manifest. --root covers parentless root commits.
+        if git rev-parse --verify --quiet "$2^" >/dev/null; then
+            manifest="$(git diff --name-status "$2^" "$2" 2>/dev/null | cap_manifest || true)"
+        else
+            manifest="$(git diff-tree --no-commit-id --name-status -r --root "$2" 2>/dev/null | cap_manifest || true)"
+        fi
         shift 2
         ;;
     --uncommitted)

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -92,13 +92,13 @@ while [ $# -gt 0 ]; do
             exit 2
         fi
         scope="Review the changes introduced by commit $2."
-        manifest="$(git diff-tree --no-commit-id --name-status -r "$2" 2>/dev/null | cap_manifest || true)"
+        manifest="$(git diff-tree --no-commit-id --name-status -r --root -m "$2" 2>/dev/null | cap_manifest || true)"
         shift 2
         ;;
     --uncommitted)
         require_single_target
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
-        manifest="$(git status --porcelain | cap_manifest || true)"
+        manifest="$(git status --porcelain --untracked-files=all | cap_manifest || true)"
         shift
         ;;
     *)
@@ -111,7 +111,7 @@ done
 if [ -z "$scope" ]; then
     if [ -n "$(git status --porcelain)" ]; then
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
-        manifest="$(git status --porcelain | cap_manifest || true)"
+        manifest="$(git status --porcelain --untracked-files=all | cap_manifest || true)"
         echo "==> Reviewing uncommitted work (dirty tree; pass --base <ref> to review the branch instead)"
     else
         # origin/HEAD (the remote's actual default branch) outranks local

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# codex-review.sh — second-model review of the current change via the OpenAI
+# Codex CLI (`codex exec review`). Two modes:
+#
+#   review    — verification checkpoint: double-check the implementation,
+#               consistency with repo conventions, and test coverage.
+#   challenge — adversarial review: actively try to break the change
+#               (architecture, authz, data loss, rollback, races, hidden
+#               coupling, operational failure modes, overdesign).
+#
+# Usage: codex-review.sh <review|challenge> [--base <ref>|--uncommitted|--commit <sha>] [focus text ...]
+#
+# Target selection when no explicit flag is given (mirrors the Codex Claude
+# Code plugin's auto scope): a dirty working tree reviews staged + unstaged +
+# untracked work; a clean tree reviews the branch against the default base.
+# The CLI's --base/--uncommitted/--commit flags are mutually exclusive with
+# custom instructions ("custom review instructions" is its own review mode),
+# so the resolved scope is written INTO the instructions instead.
+# Codex reviews read-only; findings are advisory hypotheses for the primary
+# agent/human to adjudicate (AGENTS.md "Second-Model Review") — this is never
+# part of `verify`/`ci`. Requires an authenticated Codex CLI (`codex login`);
+# see docs/guides/codex-review.md.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+usage() {
+    echo "usage: $0 <review|challenge> [--base <ref>|--uncommitted|--commit <sha>] [focus text ...]" >&2
+}
+
+MODE="${1:-}"
+case "$MODE" in
+review | challenge) shift ;;
+*)
+    usage
+    exit 2
+    ;;
+esac
+
+if ! command -v codex >/dev/null 2>&1; then
+    echo "codex CLI not found. Install it (brew install --cask codex, or npm install -g @openai/codex)," >&2
+    echo "authenticate with 'codex login', then re-run. See docs/guides/codex-review.md." >&2
+    exit 1
+fi
+
+scope=""
+focus=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --base)
+        if [ $# -lt 2 ]; then
+            echo "$1 requires a value" >&2
+            exit 2
+        fi
+        scope="Review the changes on the current branch relative to base branch '$2' (the merge-base diff $2...HEAD)."
+        shift 2
+        ;;
+    --commit)
+        if [ $# -lt 2 ]; then
+            echo "$1 requires a value" >&2
+            exit 2
+        fi
+        scope="Review the changes introduced by commit $2."
+        shift 2
+        ;;
+    --uncommitted)
+        scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
+        shift
+        ;;
+    *)
+        focus="${focus:+${focus} }$1"
+        shift
+        ;;
+    esac
+done
+
+if [ -z "$scope" ]; then
+    if [ -n "$(git status --porcelain)" ]; then
+        scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
+        echo "==> Reviewing uncommitted work (dirty tree; pass --base <ref> to review the branch instead)"
+    else
+        base=""
+        for candidate in main master; do
+            if git rev-parse --verify --quiet "$candidate" >/dev/null; then
+                base="$candidate"
+                break
+            fi
+        done
+        if [ -z "$base" ]; then
+            # Keep the remote-qualified ref (origin/<branch>): stripping it
+            # would name a local branch that may not exist, and the rev-list
+            # fallback below would then silently report nothing to review.
+            base="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+        fi
+        if [ -z "$base" ] || ! git rev-parse --verify --quiet "$base" >/dev/null; then
+            echo "Could not detect a base branch; pass --base <ref> or --uncommitted." >&2
+            exit 2
+        fi
+        if [ "$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)" -eq 0 ]; then
+            echo "Nothing to review: the working tree is clean and HEAD has no commits beyond ${base}."
+            exit 0
+        fi
+        scope="Review the changes on the current branch relative to base branch '${base}' (the merge-base diff ${base}...HEAD)."
+        echo "==> Reviewing branch changes against ${base}"
+    fi
+fi
+
+if [ "$MODE" = "challenge" ]; then
+    instructions="${scope}
+
+Run an ADVERSARIAL review: your job is to break confidence in this change,
+not to validate it. Challenge the architecture and the chosen approach, not
+just the diff hunks. Actively hunt for: authorization bypasses and trust
+boundary gaps; data-loss or corruption paths; unsafe rollback and migration
+behavior; race conditions, ordering and idempotency gaps; hidden coupling and
+assumptions that stop holding under stress; operational failure modes (empty
+state, timeouts, retries, partial failure, degraded dependencies); and
+unnecessarily complex design choices where a simpler alternative would do.
+Report only material, defensible findings tied to concrete files and lines —
+no style nits, no speculation you cannot support from the code. Prefer one
+strong finding over several weak ones; if the change looks safe, say so
+directly."
+else
+    instructions="${scope}
+
+Run a VERIFICATION-CHECKPOINT review of this change: double-check that the
+implementation actually does what it claims, is internally consistent and
+consistent with this repository's existing conventions and docs, handles
+errors and edge cases, and has adequate test coverage (including regression
+tests for anything it fixes). Flag docs the change should have updated.
+Report only material, defensible findings tied to concrete files and lines —
+no style nits. If the change holds up, say so directly."
+fi
+
+if [ -n "$focus" ]; then
+    instructions="${instructions}
+
+Additional focus from the invoker (weight it heavily): ${focus}"
+fi
+
+exec codex exec review "$instructions"

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -73,6 +73,10 @@ while [ $# -gt 0 ]; do
             echo "--base '$2' does not resolve to a commit (typo, or fetch the ref first)." >&2
             exit 2
         fi
+        if ! git merge-base "$2" HEAD >/dev/null 2>&1; then
+            echo "--base '$2' shares no merge base with HEAD (unrelated history) — the diff would be meaningless." >&2
+            exit 2
+        fi
         scope="Review the changes on the current branch relative to base branch '$2' (the merge-base diff $2...HEAD)."
         manifest="$(git diff --name-status "$2...HEAD" 2>/dev/null | cap_manifest || true)"
         shift 2
@@ -110,21 +114,26 @@ if [ -z "$scope" ]; then
         manifest="$(git status --porcelain | cap_manifest || true)"
         echo "==> Reviewing uncommitted work (dirty tree; pass --base <ref> to review the branch instead)"
     else
-        base=""
-        for candidate in main master; do
-            if git rev-parse --verify --quiet "$candidate" >/dev/null; then
-                base="$candidate"
-                break
-            fi
-        done
+        # origin/HEAD (the remote's actual default branch) outranks local
+        # branch-name guesses: a stray local `main` in a develop-default repo
+        # must not silently become the comparison base. The remote-qualified
+        # ref is kept as-is — stripping origin/ could name a branch that does
+        # not exist locally. Name guesses only apply to remoteless repos.
+        base="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"
         if [ -z "$base" ]; then
-            # Keep the remote-qualified ref (origin/<branch>): stripping it
-            # would name a local branch that may not exist, and the rev-list
-            # fallback below would then silently report nothing to review.
-            base="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+            for candidate in main master; do
+                if git rev-parse --verify --quiet "$candidate" >/dev/null; then
+                    base="$candidate"
+                    break
+                fi
+            done
         fi
         if [ -z "$base" ] || ! git rev-parse --verify --quiet "$base" >/dev/null; then
             echo "Could not detect a base branch; pass --base <ref> or --uncommitted." >&2
+            exit 2
+        fi
+        if ! git merge-base "$base" HEAD >/dev/null 2>&1; then
+            echo "Auto-detected base '${base}' shares no merge base with HEAD; pass --base <ref> or --uncommitted." >&2
             exit 2
         fi
         if [ "$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)" -eq 0 ]; then

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -58,6 +58,20 @@ echo "$out" | grep -q "base branch 'origin/develop'" || fail "remote-qualified f
 echo "$out" | grep -q "ADVERSARIAL" || fail "challenge mode instructions missing: $out"
 echo "$out" | grep -q "feature.txt" || fail "changed-file manifest missing from branch-scope prompt: $out"
 
+echo "==> origin/HEAD outranks a stray local main"
+git branch -q main "$(git rev-list --max-parents=0 HEAD)"
+out="$(run challenge)" || fail "challenge with stray local main exited non-zero: $out"
+echo "$out" | grep -q "base branch 'origin/develop'" || fail "stray local main hijacked base detection: $out"
+git branch -q -D main
+
+echo "==> --base with no merge base fails fast"
+unrelated="$(git commit-tree "$(git mktree </dev/null)" -m orphan)"
+if out="$(run review --base "$unrelated" 2>&1)"; then
+    fail "--base with unrelated history accepted: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite no merge base: $out"
+echo "$out" | grep -q "no merge base" || fail "missing no-merge-base message: $out"
+
 echo "==> explicit --base and focus text reach the prompt"
 out="$(run review --base origin/develop watch the hooks)" || fail "review --base exited non-zero: $out"
 echo "$out" | grep -q "base branch 'origin/develop'" || fail "--base not honored: $out"
@@ -113,4 +127,27 @@ fi
 echo "$out" | grep -q "mutually exclusive" || fail "missing conflicting-flags message: $out"
 echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite conflicting flags: $out"
 
-echo "codex-review target selection OK (8 cases)"
+echo "==> gate: another repo's project-scoped plugin install is not accepted"
+fake_claude="${test_tmp}/claude-config"
+mkdir -p "${fake_claude}/plugins"
+cat >"${fake_claude}/plugins/installed_plugins.json" <<'JSON'
+{
+  "version": 2,
+  "plugins": {
+    "codex@openai-codex": [
+      {
+        "scope": "project",
+        "projectPath": "/some/other/repo",
+        "installPath": "/nonexistent/plugin/root",
+        "version": "1.0.6"
+      }
+    ]
+  }
+}
+JSON
+if out="$(CLAUDE_CONFIG_DIR="$fake_claude" "${repo}/scripts/codex-gate.sh" enable 2>&1)"; then
+    fail "gate enable accepted an install scoped to another repo: $out"
+fi
+echo "$out" | grep -q "not installed" || fail "missing not-installed message for foreign-scoped install: $out"
+
+echo "codex-review + codex-gate guards OK (11 cases)"

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -42,7 +42,9 @@ git init -q -b develop "${test_tmp}/upstream"
 git clone -q "${test_tmp}/upstream" "${test_tmp}/clone"
 cd "${test_tmp}/clone"
 git checkout -q -b feature
-git_t commit -q --allow-empty -m work
+echo change >feature.txt
+git add feature.txt
+git_t commit -q -m work
 git branch -q -D develop
 
 run() {
@@ -54,6 +56,7 @@ out="$(run challenge)" || fail "challenge exited non-zero: $out"
 echo "$out" | grep -q "STUB-ARGS:exec review" || fail "codex exec review not invoked: $out"
 echo "$out" | grep -q "base branch 'origin/develop'" || fail "remote-qualified fallback base missing: $out"
 echo "$out" | grep -q "ADVERSARIAL" || fail "challenge mode instructions missing: $out"
+echo "$out" | grep -q "feature.txt" || fail "changed-file manifest missing from branch-scope prompt: $out"
 
 echo "==> explicit --base and focus text reach the prompt"
 out="$(run review --base origin/develop watch the hooks)" || fail "review --base exited non-zero: $out"
@@ -65,6 +68,7 @@ echo "==> dirty tree auto-selects uncommitted scope"
 echo x >dirty.txt
 out="$(run review)" || fail "dirty-tree review exited non-zero: $out"
 echo "$out" | grep -q "uncommitted work" || fail "dirty tree did not select uncommitted scope: $out"
+echo "$out" | grep -q "dirty.txt" || fail "untracked file missing from uncommitted manifest: $out"
 rm -f dirty.txt
 
 echo "==> clean tree at the base tip reports nothing to review"

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -106,4 +106,11 @@ if out="$(run challenge --commit 0000000000000000000000000000000000000000 2>&1)"
 fi
 echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite bad --commit sha: $out"
 
-echo "codex-review target selection OK (7 cases)"
+echo "==> conflicting target flags are rejected"
+if out="$(run review --base origin/develop --uncommitted 2>&1)"; then
+    fail "conflicting target flags accepted (last-wins regression): $out"
+fi
+echo "$out" | grep -q "mutually exclusive" || fail "missing conflicting-flags message: $out"
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite conflicting flags: $out"
+
+echo "codex-review target selection OK (8 cases)"

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -144,7 +144,8 @@ git checkout -q mergetest
 git_t merge -q --no-ff -m merge sidebr >/dev/null 2>&1 || fail "fixture merge failed"
 merge_sha="$(git rev-parse HEAD)"
 out="$(run review --commit "$merge_sha")" || fail "merge-commit review exited non-zero: $out"
-echo "$out" | grep -q "side.txt" || fail "merge commit manifest empty (missing -m): $out"
+echo "$out" | grep -q "side.txt" || fail "merge commit manifest missing first-parent change: $out"
+echo "$out" | grep -q "feature.txt" && fail "merge manifest includes pre-merge mainline files (diff-tree -m regression): $out"
 
 echo "==> gate: another repo's project-scoped plugin install is not accepted"
 fake_claude="${test_tmp}/claude-config"
@@ -210,4 +211,10 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "explicitly disabled" || fail "missing disabled-plugin refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (15 cases)"
+echo "==> gate: disable refuses in a non-interactive shell"
+if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" "${repo}/scripts/codex-gate.sh" disable </dev/null 2>&1)"; then
+    fail "non-interactive disable was accepted (agent could disarm its own gate): $out"
+fi
+echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
+
+echo "codex-review + codex-gate guards OK (16 cases)"

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -20,7 +20,7 @@ trap 'rm -rf "$test_tmp"' EXIT
 
 # Stub codex: print the invocation so assertions can grep it.
 mkdir -p "${test_tmp}/bin"
-printf '%s\n' '#!/usr/bin/env bash' 'printf "STUB-ARGS:%s %s\n" "$1" "$2"' 'printf "STUB-PROMPT:%s\n" "$3"' >"${test_tmp}/bin/codex"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "STUB-ARGS:%s %s %s\n" "$1" "$2" "${3:-}"' 'if [ "${3:-}" = "-" ]; then printf "STUB-PROMPT:%s\n" "$(cat)"; fi' >"${test_tmp}/bin/codex"
 chmod +x "${test_tmp}/bin/codex"
 PATH="${test_tmp}/bin:${PATH}"
 export PATH
@@ -36,7 +36,9 @@ run_tty() {
     if [ "$(uname)" = "Darwin" ]; then
         script -q /dev/null "$@" </dev/null
     else
-        script -qec "$*" /dev/null </dev/null
+        # printf %q keeps argv intact through script -c's shell reparse
+        # (paths with spaces/metacharacters would split under a bare $*).
+        script -qec "$(printf '%q ' "$@")" /dev/null </dev/null
     fi
 }
 
@@ -234,6 +236,15 @@ if out="$( (
 fi
 echo "$out" | grep -q "explicitly disabled" || fail "missing disabled-plugin refusal message: $out"
 
+echo "==> gate: status warns that an armed flag is inert when the plugin is disabled"
+out="$(
+    (
+        export CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data"
+        "${ws}/scripts/codex-gate.sh" status
+    ) 2>&1
+)" || fail "status exited non-zero in disabled-plugin workspace: $out"
+echo "$out" | grep -q "INERT" || fail "status did not flag the inert gate flag: $out"
+
 echo "==> gate: enable refuses in a non-interactive shell"
 if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true "${repo}/scripts/codex-gate.sh" enable </dev/null 2>&1)"; then
     fail "non-interactive enable was accepted (silent arming bypass): $out"
@@ -246,4 +257,4 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (17 cases)"
+echo "codex-review + codex-gate guards OK (18 cases)"

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# test-codex-review.sh — offline unit tests for scripts/codex-review.sh's
+# target selection and prompt assembly. A stub `codex` on PATH records its
+# arguments, so no network, auth, or real review is involved. Guards the
+# regression a real adversarial review caught: with no local main/master and
+# origin/HEAD pointing at another default branch, the base fallback used to
+# strip `origin/` into a nonexistent local ref and silently report nothing
+# to review. Run via `task test:codex-review`.
+set -euo pipefail
+
+repo="$(git rev-parse --show-toplevel)"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+test_tmp="$(mktemp -d)"
+trap 'rm -rf "$test_tmp"' EXIT
+
+# Stub codex: print the invocation so assertions can grep it.
+mkdir -p "${test_tmp}/bin"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "STUB-ARGS:%s %s\n" "$1" "$2"' 'printf "STUB-PROMPT:%s\n" "$3"' >"${test_tmp}/bin/codex"
+chmod +x "${test_tmp}/bin/codex"
+PATH="${test_tmp}/bin:${PATH}"
+export PATH
+
+git_t() {
+    git -c user.email=test@test -c user.name=test "$@"
+}
+
+# Fixture: an upstream whose default branch is `develop` (not main/master),
+# and a clone with only origin/develop plus a feature branch.
+git init -q -b develop "${test_tmp}/upstream"
+(
+    cd "${test_tmp}/upstream"
+    mkdir scripts
+    cp "${repo}/scripts/codex-review.sh" scripts/
+    git add -A
+    git_t commit -q -m base
+)
+git clone -q "${test_tmp}/upstream" "${test_tmp}/clone"
+cd "${test_tmp}/clone"
+git checkout -q -b feature
+git_t commit -q --allow-empty -m work
+git branch -q -D develop
+
+run() {
+    ./scripts/codex-review.sh "$@" 2>&1
+}
+
+echo "==> clean tree, no local main/master: falls back to origin/HEAD's branch"
+out="$(run challenge)" || fail "challenge exited non-zero: $out"
+echo "$out" | grep -q "STUB-ARGS:exec review" || fail "codex exec review not invoked: $out"
+echo "$out" | grep -q "base branch 'origin/develop'" || fail "remote-qualified fallback base missing: $out"
+echo "$out" | grep -q "ADVERSARIAL" || fail "challenge mode instructions missing: $out"
+
+echo "==> explicit --base and focus text reach the prompt"
+out="$(run review --base origin/develop watch the hooks)" || fail "review --base exited non-zero: $out"
+echo "$out" | grep -q "base branch 'origin/develop'" || fail "--base not honored: $out"
+echo "$out" | grep -q "VERIFICATION-CHECKPOINT" || fail "review mode instructions missing: $out"
+echo "$out" | grep -q "watch the hooks" || fail "focus text missing from prompt: $out"
+
+echo "==> dirty tree auto-selects uncommitted scope"
+echo x >dirty.txt
+out="$(run review)" || fail "dirty-tree review exited non-zero: $out"
+echo "$out" | grep -q "uncommitted work" || fail "dirty tree did not select uncommitted scope: $out"
+rm -f dirty.txt
+
+echo "==> clean tree at the base tip reports nothing to review"
+git checkout -q -b tipcheck origin/develop
+out="$(run review)" || fail "nothing-to-review case exited non-zero: $out"
+echo "$out" | grep -q "Nothing to review" || fail "expected nothing-to-review message: $out"
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite nothing to review: $out"
+
+echo "==> bad mode is rejected"
+if out="$(run bogus 2>&1)"; then
+    fail "bogus mode accepted: $out"
+fi
+
+echo "codex-review target selection OK (5 cases)"

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -29,6 +29,17 @@ git_t() {
     git -c user.email=test@test -c user.name=test "$@"
 }
 
+run_tty() {
+    # Gate toggles demand a TTY on stdin; allocate a pty so fixtures can get
+    # past the interactivity guard and exercise the logic behind it (macOS
+    # and util-linux `script` have incompatible CLIs).
+    if [ "$(uname)" = "Darwin" ]; then
+        script -q /dev/null "$@" </dev/null
+    else
+        script -qec "$*" /dev/null </dev/null
+    fi
+}
+
 # Fixture: an upstream whose default branch is `develop` (not main/master),
 # and a clone with only origin/develop plus a feature branch.
 git init -q -b develop "${test_tmp}/upstream"
@@ -65,7 +76,7 @@ echo "$out" | grep -q "base branch 'origin/develop'" || fail "stray local main h
 git branch -q -D main
 
 echo "==> --base with no merge base fails fast"
-unrelated="$(git commit-tree "$(git mktree </dev/null)" -m orphan)"
+unrelated="$(git_t commit-tree "$(git mktree </dev/null)" -m orphan)"
 if out="$(run review --base "$unrelated" 2>&1)"; then
     fail "--base with unrelated history accepted: $out"
 fi
@@ -165,7 +176,10 @@ cat >"${fake_claude}/plugins/installed_plugins.json" <<'JSON'
   }
 }
 JSON
-if out="$(CLAUDE_CONFIG_DIR="$fake_claude" "${repo}/scripts/codex-gate.sh" enable 2>&1)"; then
+if out="$( (
+    export CLAUDE_CONFIG_DIR="$fake_claude"
+    run_tty "${repo}/scripts/codex-gate.sh" enable
+) 2>&1)"; then
     fail "gate enable accepted an install scoped to another repo: $out"
 fi
 echo "$out" | grep -q "not installed" || fail "missing not-installed message for foreign-scoped install: $out"
@@ -191,13 +205,19 @@ cat >"${fake_claude}2/plugins/installed_plugins.json" <<JSON
   }
 }
 JSON
-if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=false "${repo}/scripts/codex-gate.sh" enable 2>&1)"; then
+if out="$( (
+    export CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=false
+    run_tty "${repo}/scripts/codex-gate.sh" enable
+) 2>&1)"; then
     fail "gate armed despite companion ready:false: $out"
 fi
 echo "$out" | grep -q "not ready" || fail "missing not-ready refusal message: $out"
 
 echo "==> gate: arms when the companion reports ready"
-out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true "${repo}/scripts/codex-gate.sh" enable 2>&1)" ||
+out="$( (
+    export CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true
+    run_tty "${repo}/scripts/codex-gate.sh" enable
+) 2>&1)" ||
     fail "gate enable failed with companion ready:true: $out"
 echo "$out" | grep -q "companion invoked: setup --enable-review-gate" || fail "companion toggle not invoked after readiness pass: $out"
 
@@ -206,10 +226,19 @@ ws="${test_tmp}/ws"
 mkdir -p "${ws}/scripts" "${ws}/.claude"
 cp "${repo}/scripts/codex-gate.sh" "${ws}/scripts/"
 printf '%s\n' '{ "enabledPlugins": { "codex@openai-codex": false } }' >"${ws}/.claude/settings.local.json"
-if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true "${ws}/scripts/codex-gate.sh" enable 2>&1)"; then
+if out="$( (
+    export CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true
+    run_tty "${ws}/scripts/codex-gate.sh" enable
+) 2>&1)"; then
     fail "gate armed despite plugin disabled in settings: $out"
 fi
 echo "$out" | grep -q "explicitly disabled" || fail "missing disabled-plugin refusal message: $out"
+
+echo "==> gate: enable refuses in a non-interactive shell"
+if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true "${repo}/scripts/codex-gate.sh" enable </dev/null 2>&1)"; then
+    fail "non-interactive enable was accepted (silent arming bypass): $out"
+fi
+echo "$out" | grep -q "non-interactive" || fail "missing non-interactive enable refusal message: $out"
 
 echo "==> gate: disable refuses in a non-interactive shell"
 if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" "${repo}/scripts/codex-gate.sh" disable </dev/null 2>&1)"; then
@@ -217,4 +246,4 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (16 cases)"
+echo "codex-review + codex-gate guards OK (17 cases)"

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -71,6 +71,19 @@ echo "$out" | grep -q "uncommitted work" || fail "dirty tree did not select unco
 echo "$out" | grep -q "dirty.txt" || fail "untracked file missing from uncommitted manifest: $out"
 rm -f dirty.txt
 
+echo "==> a >200-entry dirty tree still reviews (no SIGPIPE abort) and marks truncation"
+# Top-level files: git status collapses an untracked directory into a single
+# "?? dir/" entry, which would defeat the >200-entry premise.
+i=1
+while [ "$i" -le 250 ]; do
+    : >"bulk_f${i}.txt"
+    i=$((i + 1))
+done
+out="$(run review)" || fail "large dirty tree aborted the review (pipefail/SIGPIPE regression): $out"
+echo "$out" | grep -q "STUB-ARGS:exec review" || fail "codex not invoked on large dirty tree: $out"
+echo "$out" | grep -q "manifest truncated at 200 entries" || fail "truncation marker missing on >200-entry manifest: $out"
+rm -f bulk_f*.txt
+
 echo "==> clean tree at the base tip reports nothing to review"
 git checkout -q -b tipcheck origin/develop
 out="$(run review)" || fail "nothing-to-review case exited non-zero: $out"
@@ -82,4 +95,4 @@ if out="$(run bogus 2>&1)"; then
     fail "bogus mode accepted: $out"
 fi
 
-echo "codex-review target selection OK (5 cases)"
+echo "codex-review target selection OK (6 cases)"

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -95,4 +95,15 @@ if out="$(run bogus 2>&1)"; then
     fail "bogus mode accepted: $out"
 fi
 
-echo "codex-review target selection OK (6 cases)"
+echo "==> invalid explicit targets fail fast without invoking codex"
+if out="$(run review --base no-such-ref 2>&1)"; then
+    fail "--base with an unresolvable ref was accepted: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite bad --base ref: $out"
+echo "$out" | grep -q "does not resolve" || fail "missing fail-fast message for bad --base: $out"
+if out="$(run challenge --commit 0000000000000000000000000000000000000000 2>&1)"; then
+    fail "--commit with an unresolvable sha was accepted: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite bad --commit sha: $out"
+
+echo "codex-review target selection OK (7 cases)"

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -78,12 +78,15 @@ echo "$out" | grep -q "base branch 'origin/develop'" || fail "--base not honored
 echo "$out" | grep -q "VERIFICATION-CHECKPOINT" || fail "review mode instructions missing: $out"
 echo "$out" | grep -q "watch the hooks" || fail "focus text missing from prompt: $out"
 
-echo "==> dirty tree auto-selects uncommitted scope"
+echo "==> dirty tree auto-selects uncommitted scope and enumerates untracked dirs"
 echo x >dirty.txt
+mkdir newdir
+echo y >newdir/inner.txt
 out="$(run review)" || fail "dirty-tree review exited non-zero: $out"
 echo "$out" | grep -q "uncommitted work" || fail "dirty tree did not select uncommitted scope: $out"
 echo "$out" | grep -q "dirty.txt" || fail "untracked file missing from uncommitted manifest: $out"
-rm -f dirty.txt
+echo "$out" | grep -q "newdir/inner.txt" || fail "file inside untracked dir missing from manifest (collapsed to dir entry): $out"
+rm -rf dirty.txt newdir
 
 echo "==> a >200-entry dirty tree still reviews (no SIGPIPE abort) and marks truncation"
 # Top-level files: git status collapses an untracked directory into a single
@@ -127,6 +130,22 @@ fi
 echo "$out" | grep -q "mutually exclusive" || fail "missing conflicting-flags message: $out"
 echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite conflicting flags: $out"
 
+echo "==> --commit manifests cover root and merge commits"
+root_sha="$(git rev-list --max-parents=0 HEAD | tail -1)"
+out="$(run review --commit "$root_sha")" || fail "root-commit review exited non-zero: $out"
+echo "$out" | grep -q "codex-review.sh" || fail "root commit manifest empty (missing --root): $out"
+git checkout -q -b mergetest feature
+git branch -q sidebr "$root_sha"
+git checkout -q sidebr
+echo s >side.txt
+git add side.txt
+git_t commit -q -m side
+git checkout -q mergetest
+git_t merge -q --no-ff -m merge sidebr >/dev/null 2>&1 || fail "fixture merge failed"
+merge_sha="$(git rev-parse HEAD)"
+out="$(run review --commit "$merge_sha")" || fail "merge-commit review exited non-zero: $out"
+echo "$out" | grep -q "side.txt" || fail "merge commit manifest empty (missing -m): $out"
+
 echo "==> gate: another repo's project-scoped plugin install is not accepted"
 fake_claude="${test_tmp}/claude-config"
 mkdir -p "${fake_claude}/plugins"
@@ -150,4 +169,35 @@ if out="$(CLAUDE_CONFIG_DIR="$fake_claude" "${repo}/scripts/codex-gate.sh" enabl
 fi
 echo "$out" | grep -q "not installed" || fail "missing not-installed message for foreign-scoped install: $out"
 
-echo "codex-review + codex-gate guards OK (11 cases)"
+echo "==> gate: refuses to arm when the companion reports not ready"
+fake_plugin="${test_tmp}/fake-plugin"
+mkdir -p "${fake_plugin}/scripts" "${fake_claude}2/plugins"
+cat >"${fake_plugin}/scripts/codex-companion.mjs" <<'MJS'
+const args = process.argv.slice(2);
+if (args.includes("--json")) {
+  console.log(JSON.stringify({ ready: process.env.FAKE_READY === "true" }));
+} else {
+  console.log(`companion invoked: ${args.join(" ")}`);
+}
+MJS
+cat >"${fake_claude}2/plugins/installed_plugins.json" <<JSON
+{
+  "version": 2,
+  "plugins": {
+    "codex@openai-codex": [
+      { "scope": "user", "installPath": "${fake_plugin}", "version": "1.0.6" }
+    ]
+  }
+}
+JSON
+if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=false "${repo}/scripts/codex-gate.sh" enable 2>&1)"; then
+    fail "gate armed despite companion ready:false: $out"
+fi
+echo "$out" | grep -q "not ready" || fail "missing not-ready refusal message: $out"
+
+echo "==> gate: arms when the companion reports ready"
+out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true "${repo}/scripts/codex-gate.sh" enable 2>&1)" ||
+    fail "gate enable failed with companion ready:true: $out"
+echo "$out" | grep -q "companion invoked: setup --enable-review-gate" || fail "companion toggle not invoked after readiness pass: $out"
+
+echo "codex-review + codex-gate guards OK (14 cases)"

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -200,4 +200,14 @@ out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugi
     fail "gate enable failed with companion ready:true: $out"
 echo "$out" | grep -q "companion invoked: setup --enable-review-gate" || fail "companion toggle not invoked after readiness pass: $out"
 
-echo "codex-review + codex-gate guards OK (14 cases)"
+echo "==> gate: refuses when the plugin is explicitly disabled in settings"
+ws="${test_tmp}/ws"
+mkdir -p "${ws}/scripts" "${ws}/.claude"
+cp "${repo}/scripts/codex-gate.sh" "${ws}/scripts/"
+printf '%s\n' '{ "enabledPlugins": { "codex@openai-codex": false } }' >"${ws}/.claude/settings.local.json"
+if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true "${ws}/scripts/codex-gate.sh" enable 2>&1)"; then
+    fail "gate armed despite plugin disabled in settings: $out"
+fi
+echo "$out" | grep -q "explicitly disabled" || fail "missing disabled-plugin refusal message: $out"
+
+echo "codex-review + codex-gate guards OK (15 cases)"

--- a/scripts/test-dogfood-parity.sh
+++ b/scripts/test-dogfood-parity.sh
@@ -14,10 +14,11 @@ cd "$(dirname "$0")/.."
 # Intentional root-only divergences (the template copy is what consumers get):
 #   .yamllint — root adds the template/ exclusion (jinja YAML is not valid YAML
 #               until rendered) and trims artifact dirs harmon-init never makes.
-#   .devcontainer/related-repos.txt and .claude/settings.json — harmon-init's
-#               curated sibling-repo list and Claude read permissions; generated
-#               repositories begin with an empty, consumer-owned list instead.
-ALLOW_DIVERGE=".yamllint .devcontainer/related-repos.txt .claude/settings.json"
+#   .devcontainer/related-repos.txt — harmon-init's curated sibling-repo list;
+#               generated repositories begin with an empty, consumer-owned list.
+#   (.claude/settings.json is a jinja twin now — root additionally grants the
+#   sibling-repo read permissions/sandbox dirs, reconciled by hand.)
+ALLOW_DIVERGE=".yamllint .devcontainer/related-repos.txt"
 
 fail=0
 checked=0

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -105,6 +105,7 @@ full)
         --data project_management=github
         --data snyk_scan_schedule=weekly
         --data release_content_paths="src docs"
+        --data use_codex_review=true
     )
     ;;
 meta)
@@ -707,6 +708,31 @@ else
     [ -f .claude/agents/foreman-implementer.md ] || err "foreman agent definitions missing"
     grep -q 'foreman: taskfiles/foreman.yml' Taskfile.yml || err "foreman Taskfile include missing"
     grep -q 'expected_login' .foreman.toml || err ".foreman.toml missing expected_login"
+fi
+
+# ── 9d3. codex review renders per use_codex_review (default off) ────
+# Only `full` opts in; every other profile uses the default (off). The
+# tasks, helper scripts, project Codex config, Claude plugin enablement,
+# and guide are all conditional — assert they appear/disappear together so
+# a broken gate can't ship dead weight into opted-out repos or drop the
+# wiring from opted-in ones.
+if [ "$profile" = "full" ]; then
+    [ -x scripts/codex-review.sh ] || err "scripts/codex-review.sh missing or not executable (use_codex_review=true)"
+    [ -x scripts/codex-gate.sh ] || err "scripts/codex-gate.sh missing or not executable (use_codex_review=true)"
+    [ -x scripts/test-codex-review.sh ] || err "scripts/test-codex-review.sh missing or not executable (use_codex_review=true)"
+    grep -q 'test:codex-review:' Taskfile.yml || err "test:codex-review task missing (use_codex_review=true)"
+    [ -f .codex/config.toml ] || err ".codex/config.toml missing (use_codex_review=true)"
+    [ -f docs/guides/codex-review.md ] || err "docs/guides/codex-review.md missing (use_codex_review=true)"
+    grep -q 'challenge:codex:' Taskfile.yml || err "challenge:codex task missing (use_codex_review=true)"
+    grep -q 'codex:gate:enable:' Taskfile.yml || err "codex:gate:enable task missing (use_codex_review=true)"
+    grep -q '"codex@openai-codex": true' .claude/settings.json || err ".claude/settings.json missing codex plugin enablement (use_codex_review=true)"
+else
+    [ ! -f scripts/codex-review.sh ] || err "scripts/codex-review.sh rendered but use_codex_review is off"
+    [ ! -f scripts/codex-gate.sh ] || err "scripts/codex-gate.sh rendered but use_codex_review is off"
+    [ ! -d .codex ] || err ".codex/ rendered but use_codex_review is off"
+    [ ! -f docs/guides/codex-review.md ] || err "docs/guides/codex-review.md rendered but use_codex_review is off"
+    ! grep -q 'challenge:codex' Taskfile.yml || err "challenge:codex task rendered but use_codex_review is off"
+    ! grep -q 'codex@openai-codex' .claude/settings.json || err "codex plugin enablement rendered but use_codex_review is off"
 fi
 
 # ── 9e. devcontainer machinery renders per the devcontainer answer ──

--- a/template/.claude/settings.json.jinja
+++ b/template/.claude/settings.json.jinja
@@ -1,4 +1,17 @@
 {
+[% if use_codex_review %]
+  "extraKnownMarketplaces": {
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "codex@openai-codex": true
+  },
+[% endif %]
   "permissions": {
     "allow": [
       "Bash(task:*)",

--- a/template/.claude/settings.json.jinja
+++ b/template/.claude/settings.json.jinja
@@ -20,6 +20,14 @@
       "Bash(git log:*)"
     ],
     "ask": [
+[% if use_codex_review %]
+      "Bash(task codex:gate:enable)",
+      "Bash(task codex:gate:enable:*)",
+      "Bash(task codex:gate:disable)",
+      "Bash(task codex:gate:disable:*)",
+      "Bash(./scripts/codex-gate.sh:*)",
+      "Bash(scripts/codex-gate.sh:*)",
+[% endif %]
       "Bash(gh pr merge)",
       "Bash(gh pr merge:*)",
       "Bash(git merge)",

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -41,6 +41,9 @@ jobs:
       - name: Lint[% if use_node %] + typecheck[% endif +%]
         run: task check
       - run: task test:tasks
+[% if use_codex_review %]
+      - run: task test:codex-review
+[% endif %]
 [% if use_release_please %]
       - run: task test:release-title
 [% endif %]

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -151,9 +151,9 @@ Setup and mechanics: [docs/guides/codex-review.md](docs/guides/codex-review.md).
   editing turn and blocks completion on material findings). Per-repo,
   per-machine state; defaults off. Inside Claude Code the equivalents are
   `/codex:review`, `/codex:adversarial-review`, and `/codex:setup`. The
-  toggles are approval-gated (`permissions.ask`), and agents must **never
-  disable the gate to get past a BLOCK** — adjudicate the finding or
-  escalate to the maintainer instead.
+  toggles are approval-gated (`permissions.ask`), `disable` refuses
+  non-interactive shells, and agents must **never disable the gate to get
+  past a BLOCK** — adjudicate the finding or escalate to the maintainer instead.
 
 These tasks slot into the **Dev Loop** above: after `task verify` goes green,
 before `task ci`. If Codex cloud review is also connected to the repo, it

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -41,6 +41,10 @@ task ci          # FULL CI mirror — run before/instead of opening a PR
 task fix         # auto-format then lint
 task test        # tests
 task security    # Semgrep CE + gitleaks + dependency audit
+[% if use_codex_review %]
+task challenge   # adversarial Codex second-model review — advisory, not in verify/ci
+task review      # Codex verification checkpoint before task ci
+[% endif %]
 [% if use_foreman %]
 task foreman:plan -- --milestone <n>  # foreman: dry-run the dispatch graph
 [% endif %]
@@ -90,6 +94,46 @@ run locally on demand instead of waiting on a PR.
   `PR_TITLE="<title>" BASE_SHA=main task guard:release-title`.
 [% endif %]
 
+[% if use_codex_review %]
+## Second-Model Review (Codex)
+
+A second AI model (the OpenAI Codex CLI) reviews changes on demand. Local and
+advisory only: nothing runs in CI, and no `verify`/`ci` step depends on Codex.
+Setup and mechanics: [docs/guides/codex-review.md](docs/guides/codex-review.md).
+
+- `task challenge` (→ `challenge:codex`) — adversarial review: challenges the
+  architecture and approach; hunts authorization bypasses, data-loss paths,
+  unsafe rollback, races, hidden coupling, operational failure modes, and
+  needless complexity. Steer it with e.g.
+  `task challenge -- --base main focus on the migration path`.
+- `task review` (→ `review:codex`) — verification checkpoint: double-checks
+  the implementation, consistency, and test coverage before `task ci`.
+- `task codex:gate:enable` / `:disable` / `:status` — the automatic
+  Claude Code → Codex stop-gate (the codex plugin's Stop hook reviews each
+  editing turn and blocks completion on material findings). Per-repo,
+  per-machine state; defaults off. Inside Claude Code the equivalents are
+  `/codex:review`, `/codex:adversarial-review`, and `/codex:setup`.
+
+The intended flow once a change feels done:
+`task check` → `task verify` → `task challenge` → `task review` → `task ci` → PR.
+
+**Treat Codex findings as hypotheses, not authority.** For every finding:
+
+1. Verify it against the actual implementation, surrounding code,
+   requirements, and tests.
+2. Classify it: confirmed, plausible but unproven, or false positive.
+3. Fix only confirmed findings; add or improve regression tests where
+   appropriate.
+4. Explain why any rejected finding is incorrect or irrelevant.
+5. Re-run `task verify` (and the other relevant gates) after fixes.
+6. Finish with a concise adjudication table: finding → classification →
+   evidence → action taken.
+
+**Loop cap:** at most **3** iterations per loop (challenge → fix →
+re-challenge, and likewise for review). If material disagreement persists
+after 3, stop and surface it to the maintainer instead of iterating further.
+
+[% endif %]
 ## Conventions
 
 Full reference: [docs/conventions.md](docs/conventions.md). Highlights:

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -82,15 +82,15 @@ something to ask permission for.
   "Second-Model Review" below, fix confirmed findings, re-run `task verify`,
   then **re-run `task challenge`**. The stage passes only when a re-run comes
   back with **no material findings** — fixing the findings is not the exit
-  condition, a clean pass is. Max **3** challenge → fix → re-challenge
+  condition, a clean pass is. Max **5** challenge → fix → re-challenge
   rounds; if findings persist, stop and escalate to the maintainer.
 - **`task review`** — verification-checkpoint review; same adjudication and
-  same clean-pass exit condition, with its own max **3** rounds.
+  same clean-pass exit condition, with its own max **4** rounds.
 [% endif %]
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
   a clear what/why/verification summary.
-- **Shepherd the PR (max 3 rounds).** Opening the PR is not the end. Watch CI
+- **Shepherd the PR (max 4 rounds).** Opening the PR is not the end. Watch CI
   (`gh pr checks <n> --watch`) and incoming bot/human reviews. When a check
   fails or a review lands findings, treat the findings as hypotheses: verify
   them against the code, fix only what's confirmed, explain rejections in a
@@ -98,7 +98,7 @@ something to ask permission for.
   must pass `task verify` before each push; the local challenge/review loops
   are not re-entered — the post-push cloud/bot review is the second-model
   check at this stage. This cap is independent of the other loop caps. If
-  checks still fail or material findings remain after 3 rounds, stop and
+  checks still fail or material findings remain after 4 rounds, stop and
   summarize what's unresolved on the PR for the maintainer.
 - **Stop at green.** Report that checks pass, then stop — merging is always a
   human decision.
@@ -174,9 +174,10 @@ never resolves means the cloud run failed.
    evidence → action taken.
 
 **Loop cap and exit:** a stage exits only on a **clean re-run** (no material
-findings) — never on "findings fixed" alone — with at most **3** iterations
-per loop (challenge → fix → re-challenge, and likewise for review). If
-material disagreement persists after 3, stop and surface it to the
+findings) — never on "findings fixed" alone — with at most **5** challenge
+iterations and **4** review iterations (challenge → fix → re-challenge, and
+likewise for review). If material disagreement persists at the cap, stop and
+surface it to the
 maintainer instead of iterating further.
 
 [% endif %]

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -79,10 +79,13 @@ something to ask permission for.
   green; verify is the definition-of-done gate.
 [% if use_codex_review %]
 - **`task challenge`** — adversarial second-model review. Adjudicate per
-  "Second-Model Review" below, fix confirmed findings, re-run `task verify`.
-  Max **3** challenge → fix → re-challenge rounds.
-- **`task review`** — verification-checkpoint review; same adjudication, its
-  own max **3** rounds.
+  "Second-Model Review" below, fix confirmed findings, re-run `task verify`,
+  then **re-run `task challenge`**. The stage passes only when a re-run comes
+  back with **no material findings** — fixing the findings is not the exit
+  condition, a clean pass is. Max **3** challenge → fix → re-challenge
+  rounds; if findings persist, stop and escalate to the maintainer.
+- **`task review`** — verification-checkpoint review; same adjudication and
+  same clean-pass exit condition, with its own max **3** rounds.
 [% endif %]
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
@@ -165,9 +168,11 @@ never resolves means the cloud run failed.
 6. Finish with a concise adjudication table: finding → classification →
    evidence → action taken.
 
-**Loop cap:** at most **3** iterations per loop (challenge → fix →
-re-challenge, and likewise for review). If material disagreement persists
-after 3, stop and surface it to the maintainer instead of iterating further.
+**Loop cap and exit:** a stage exits only on a **clean re-run** (no material
+findings) — never on "findings fixed" alone — with at most **3** iterations
+per loop (challenge → fix → re-challenge, and likewise for review). If
+material disagreement persists after 3, stop and surface it to the
+maintainer instead of iterating further.
 
 [% endif %]
 ## Conventions

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -65,6 +65,39 @@ test). `ci` is the full pipeline — everything CI runs (`verify` +
 `security`[% if devcontainer %] + the devcontainer permission assert[% endif %]) — so you can reproduce a CI
 run locally on demand instead of waiting on a PR.
 
+## Dev Loop
+
+Bias toward shipping: drive every change to an open PR instead of stopping at
+a green local diff. Work in small, PR-sized units, and move to the next stage
+on your own — an open PR with green checks is the default deliverable, not
+something to ask permission for.
+
+- **Branch** — feature branch off `main`; never commit directly to `main`.
+- **Edit + `task check`** — the fast inner loop; run it constantly and fix
+  lint immediately.
+- **`task verify`** — when the change feels done, loop edit → verify until
+  green; verify is the definition-of-done gate.
+[% if use_codex_review %]
+- **`task challenge`** — adversarial second-model review. Adjudicate per
+  "Second-Model Review" below, fix confirmed findings, re-run `task verify`.
+  Max **3** challenge → fix → re-challenge rounds.
+- **`task review`** — verification-checkpoint review; same adjudication, its
+  own max **3** rounds.
+[% endif %]
+- **`task ci`** — the full CI mirror; fix anything it catches.
+- **Open the PR** — conventional commit, push the branch, `gh pr create` with
+  a clear what/why/verification summary.
+- **Shepherd the PR (max 3 rounds).** Opening the PR is not the end. Watch CI
+  (`gh pr checks <n> --watch`) and incoming bot/human reviews. When a check
+  fails or a review lands findings, treat the findings as hypotheses: verify
+  them against the code, fix only what's confirmed, explain rejections in a
+  PR comment, push the fix commit, and watch again. This cap is independent
+  of the other loop caps. If checks still fail or material findings remain
+  after 3 rounds, stop and summarize what's unresolved on the PR for the
+  maintainer.
+- **Stop at green.** Report that checks pass, then stop — merging is always a
+  human decision.
+
 ## Definition of Done
 
 - `task verify` passes.
@@ -114,8 +147,11 @@ Setup and mechanics: [docs/guides/codex-review.md](docs/guides/codex-review.md).
   per-machine state; defaults off. Inside Claude Code the equivalents are
   `/codex:review`, `/codex:adversarial-review`, and `/codex:setup`.
 
-The intended flow once a change feels done:
-`task check` → `task verify` → `task challenge` → `task review` → `task ci` → PR.
+These tasks slot into the **Dev Loop** above: after `task verify` goes green,
+before `task ci`. If Codex cloud review is also connected to the repo, it
+reviews PRs too — it posts inline comments only for high-priority findings;
+a bare 👍 reaction from the Codex bot is its clean pass, and a lone 👀 that
+never resolves means the cloud run failed.
 
 **Treat Codex findings as hypotheses, not authority.** For every finding:
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -94,10 +94,12 @@ something to ask permission for.
   (`gh pr checks <n> --watch`) and incoming bot/human reviews. When a check
   fails or a review lands findings, treat the findings as hypotheses: verify
   them against the code, fix only what's confirmed, explain rejections in a
-  PR comment, push the fix commit, and watch again. This cap is independent
-  of the other loop caps. If checks still fail or material findings remain
-  after 3 rounds, stop and summarize what's unresolved on the PR for the
-  maintainer.
+  PR comment, push the fix commit, and watch again. Shepherd-round fixes
+  must pass `task verify` before each push; the local challenge/review loops
+  are not re-entered — the post-push cloud/bot review is the second-model
+  check at this stage. This cap is independent of the other loop caps. If
+  checks still fail or material findings remain after 3 rounds, stop and
+  summarize what's unresolved on the PR for the maintainer.
 - **Stop at green.** Report that checks pass, then stop — merging is always a
   human decision.
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -150,7 +150,10 @@ Setup and mechanics: [docs/guides/codex-review.md](docs/guides/codex-review.md).
   Claude Code → Codex stop-gate (the codex plugin's Stop hook reviews each
   editing turn and blocks completion on material findings). Per-repo,
   per-machine state; defaults off. Inside Claude Code the equivalents are
-  `/codex:review`, `/codex:adversarial-review`, and `/codex:setup`.
+  `/codex:review`, `/codex:adversarial-review`, and `/codex:setup`. The
+  toggles are approval-gated (`permissions.ask`), and agents must **never
+  disable the gate to get past a BLOCK** — adjudicate the finding or
+  escalate to the maintainer instead.
 
 These tasks slot into the **Dev Loop** above: after `task verify` goes green,
 before `task ci`. If Codex cloud review is also connected to the repo, it

--- a/template/Brewfile.jinja
+++ b/template/Brewfile.jinja
@@ -64,8 +64,10 @@ brew "television"   # interactive task menu (`task` / task menu-tv → tv)
 [% if use_codex_review %]
 
 # Second-model review (task challenge / task review drive the Codex CLI).
-# Cask = macOS; on Linux/devcontainers install with `npm install -g @openai/codex`.
-cask "codex"
+# Cask = macOS only; on Linux/devcontainers install with
+# `npm install -g @openai/codex` (a bare cask line would abort `brew bundle`
+# on Linux before any of the remaining deps install).
+cask "codex" if OS.mac?
 [% endif %]
 [% if bunch_add %]
 

--- a/template/Brewfile.jinja
+++ b/template/Brewfile.jinja
@@ -61,6 +61,12 @@ brew "bat"
 brew "tokei"
 brew "gum"          # status dashboard rendering (scripts/status.sh)
 brew "television"   # interactive task menu (`task` / task menu-tv → tv)
+[% if use_codex_review %]
+
+# Second-model review (task challenge / task review drive the Codex CLI).
+# Cask = macOS; on Linux/devcontainers install with `npm install -g @openai/codex`.
+cask "codex"
+[% endif %]
 [% if bunch_add %]
 
 # macOS apps

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -118,6 +118,10 @@ See [DESIGN.md](DESIGN.md) for visual/UX direction.
 | `task security` | Free local baseline: Semgrep CE + gitleaks + dependency audit |
 | `task security:sast` / `security:sca` | Semgrep CE / package-manager dependency audit |
 | `task security:sast:snyk` / `security:sca:snyk` | Optional Snyk second-opinion scans (manual or explicitly scheduled) |
+[% if use_codex_review %]
+| `task challenge` / `task review` | Codex second-model reviews: adversarial / verification checkpoint (advisory, local-only) |
+| `task codex:gate:enable` | Automatic Claude → Codex stop-gate for this repo + machine (also `:disable` / `:status`) |
+[% endif %]
 | `task release:patch` | Tag + GitHub release (also `:minor` / `:major`) |
 | `task status` | Project status dashboard (also `status:git`/`:gh`/`:code`/`:env`) |
 | `task status:setup` | Setup audit: GitHub config, toolchain, devcontainer, dev env |

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -77,6 +77,9 @@ tasks:
 [% endif %]
       - task: validate
       - task: test:tasks
+[% if use_codex_review %]
+      - task: test:codex-review
+[% endif %]
 [% if use_release_please %]
       - task: test:release-title
 [% endif %]
@@ -472,6 +475,13 @@ tasks:
     desc: Guard the Taskfile itself (compiles; setup tasks are safe no-ops)
     cmds:
       - ./scripts/test-tasks.sh
+[% if use_codex_review %]
+
+  test:codex-review:
+    desc: Unit-test codex-review.sh target selection (offline, stubbed codex)
+    cmds:
+      - ./scripts/test-codex-review.sh
+[% endif %]
 [% if use_release_please %]
 
   test:release-title:
@@ -546,6 +556,50 @@ tasks:
 [% endif %]
 [% endif %]
 
+[% if use_codex_review %]
+  # ── Second-model review (Codex) ───────────────────────────────
+  # Optional second AI model (the OpenAI Codex CLI) reviewing the current
+  # change — local and advisory only, never part of verify/ci. Findings are
+  # hypotheses for the primary agent to adjudicate (AGENTS.md "Second-Model
+  # Review"). The codex:gate:* tasks toggle the Claude Code codex plugin's
+  # automatic stop-time review for this repo + machine. See
+  # docs/guides/codex-review.md for setup, mechanics, and the loop caps.
+  review:
+    desc: Second-model verification review of the current change (Codex)
+    cmds:
+      - task: review:codex
+
+  challenge:
+    desc: Second-model adversarial review of the current change (Codex)
+    cmds:
+      - task: challenge:codex
+
+  review:codex:
+    desc: "Codex verification review (usage: task review:codex -- [--base <ref>|--uncommitted] [focus text])"
+    cmds:
+      - ./scripts/codex-review.sh review {{.CLI_ARGS}}
+
+  challenge:codex:
+    desc: "Codex adversarial review (usage: task challenge:codex -- [--base <ref>|--uncommitted] [focus text])"
+    cmds:
+      - ./scripts/codex-review.sh challenge {{.CLI_ARGS}}
+
+  codex:gate:enable:
+    desc: Enable the automatic Claude → Codex stop-gate review (this repo, this machine)
+    cmds:
+      - ./scripts/codex-gate.sh enable
+
+  codex:gate:disable:
+    desc: Disable the automatic Claude → Codex stop-gate review
+    cmds:
+      - ./scripts/codex-gate.sh disable
+
+  codex:gate:status:
+    desc: Show whether the Claude → Codex stop-gate review is enabled
+    cmds:
+      - ./scripts/codex-gate.sh status
+
+[% endif %]
   # ── Security ───────────────────────────────────────────────────
   security:
     desc: Run all free local security checks (Semgrep CE + gitleaks + dependency audit)

--- a/template/[% if use_codex_review %].codex[% endif %]/config.toml
+++ b/template/[% if use_codex_review %].codex[% endif %]/config.toml
@@ -1,0 +1,8 @@
+# Project-level Codex CLI config (see docs/guides/codex-review.md).
+# Loaded only once the repo is trusted by Codex (`codex` prompts on first run,
+# or set [projects."<path>"] trust_level = "trusted" in ~/.codex/config.toml).
+#
+# Reviews (task review / task challenge) benefit from deeper reasoning than a
+# fast interactive default. The model is deliberately left unpinned so reviews
+# track the Codex CLI's current default instead of an aging snapshot.
+model_reasoning_effort = "high"

--- a/template/docs/guides/README.md.jinja
+++ b/template/docs/guides/README.md.jinja
@@ -30,5 +30,10 @@ Calm, repeatable how-tos read *in advance* (the crisis counterpart is
   real devcontainer failures (lifecycle chain aborts, Claude auth lost on
   rebuild, stale Coder volumes) and where the shipped fix for each lives.
 [% endif %]
+[% if use_codex_review %]
+- [codex-review.md](codex-review.md) — second-model review via the OpenAI
+  Codex CLI: `task challenge` / `task review`, the automatic Claude → Codex
+  stop-gate toggle, and where the finding-adjudication protocol lives.
+[% endif %]
 
 TODO: add more guides, e.g. "local development setup", "add a feature", "how X works".

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -70,9 +70,14 @@ protocol) before it can finish. Non-editing turns are allowed through.
 The tasks flip the same per-workspace `stopReviewGate` flag as
 `/codex:setup --enable-review-gate` (plugin data dir keyed by workspace path
 — note a git worktree is a different workspace with its own flag; the state
-is per-user and per-machine, never committed). If Codex itself is missing or
-unauthenticated the gate fails **open**: the hook logs guidance and lets
-Claude stop.
+is per-user and per-machine, never committed). Fail-open is **narrower than
+it looks**: only a missing codex binary makes the hook log guidance and let
+Claude stop. An installed-but-unauthenticated codex makes the review task
+fail, which the hook converts into a **block on every turn** — so
+`task codex:gate:enable` refuses to arm the gate unless `codex login status`
+succeeds, and if auth expires while the gate is on, recover with
+`codex login` or `task codex:gate:disable` (disable/status never require
+auth).
 
 Loop safety: Claude Code caps consecutive stop-hook continuations, and repo
 policy caps adversarial/review loops at 3 iterations each (AGENTS.md). The

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -88,8 +88,15 @@ task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate findings, ≤3 loops
 task review     # verification checkpoint — adjudicate findings, ≤3 loops
 task ci         # full CI mirror
-# → open the PR (merging stays a human decision)
+# → open the PR, then shepherd it: watch CI + reviews, adjudicate → fix →
+#   push, ≤3 rounds (independent of the loops above)
+# → merging stays a human decision
 ```
+
+The full staged loop — including the PR-shepherding rounds — is defined in
+AGENTS.md ("Dev Loop"). If Codex cloud review is connected to the repo, PRs
+get a cloud pass too: inline comments only for high-priority findings, a
+bare 👍 reaction as the clean pass.
 
 ## Troubleshooting
 

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -85,8 +85,9 @@ release plumbing), disable it for routine development.
 ```text
 task check      # fast inner loop while editing
 task verify     # definition-of-done gate
-task challenge  # adversarial second model — adjudicate findings, ≤3 loops
-task review     # verification checkpoint — adjudicate findings, ≤3 loops
+task challenge  # adversarial second model — adjudicate, fix, re-challenge
+                # until a CLEAN pass (no material findings), ≤3 rounds
+task review     # verification checkpoint — same clean-pass exit, ≤3 rounds
 task ci         # full CI mirror
 # → open the PR, then shepherd it: watch CI + reviews, adjudicate → fix →
 #   push, ≤3 rounds (independent of the loops above)

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -60,6 +60,13 @@ task codex:gate:disable   # turn off
 task codex:gate:status    # inspect
 ```
 
+The toggles sit in `permissions.ask` in `.claude/settings.json`, so an agent
+cannot flip the gate without a human approving the command — in particular, a
+gated agent must never disable the gate to get past a BLOCK. `enable` also
+refuses when the plugin is explicitly disabled in Claude Code settings
+(`enabledPlugins`): an installed-but-disabled plugin registers no Stop hook,
+so the armed flag would report protection that does not exist.
+
 Mechanics: the codex plugin registers a Claude Code **Stop hook**. While the
 gate is enabled for a workspace, every time Claude finishes a turn the hook
 runs a fresh, read-only Codex task over the repo and Claude's last message;

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -5,7 +5,7 @@ A second AI model — the [OpenAI Codex CLI](https://developers.openai.com/codex
 automatic Claude Code → Codex stop-gate. Everything is local and advisory:
 nothing runs in CI, no PR check depends on Codex, and `verify`/`ci` never
 invoke it. Findings are hypotheses for the primary agent to adjudicate — the
-protocol and the 3-iteration loop cap live in AGENTS.md ("Second-Model
+protocol and the loop caps live in AGENTS.md ("Second-Model
 Review").
 
 ## Setup
@@ -93,7 +93,7 @@ succeeds, and if auth expires while the gate is on, recover with
 auth; disable does require an interactive terminal).
 
 Loop safety: Claude Code caps consecutive stop-hook continuations, and repo
-policy caps adversarial/review loops at 3 iterations each (AGENTS.md). The
+policy caps the adversarial/review loops (AGENTS.md "Dev Loop"). The
 gate reviews after **every** turn while enabled and each run costs Codex
 usage — enable it for high-consequence work (migrations, auth, concurrency,
 release plumbing), disable it for routine development.
@@ -104,11 +104,11 @@ release plumbing), disable it for routine development.
 task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
-                # until a CLEAN pass (no material findings), ≤3 rounds
-task review     # verification checkpoint — same clean-pass exit, ≤3 rounds
+                # until a CLEAN pass (no material findings), ≤5 rounds
+task review     # verification checkpoint — same clean-pass exit, ≤4 rounds
 task ci         # full CI mirror
 # → open the PR, then shepherd it: watch CI + reviews, adjudicate → fix →
-#   push, ≤3 rounds (independent of the loops above)
+#   push, ≤4 rounds (independent of the loops above)
 # → merging stays a human decision
 ```
 

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -1,0 +1,111 @@
+# Codex second-model review
+
+A second AI model — the [OpenAI Codex CLI](https://developers.openai.com/codex/cli)
+— reviews changes in this repo: manual review/challenge tasks, plus an optional
+automatic Claude Code → Codex stop-gate. Everything is local and advisory:
+nothing runs in CI, no PR check depends on Codex, and `verify`/`ci` never
+invoke it. Findings are hypotheses for the primary agent to adjudicate — the
+protocol and the 3-iteration loop cap live in AGENTS.md ("Second-Model
+Review").
+
+## Setup
+
+1. **Install the Codex CLI**: `brew install --cask codex` (macOS) or
+   `npm install -g @openai/codex` (anywhere Node ≥ 18 runs).
+2. **Authenticate**: `codex login` (browser OAuth against a ChatGPT account —
+   the free tier has tight usage limits) or
+   `printenv OPENAI_API_KEY | codex login --with-api-key` (billed API usage).
+   Confirm with `codex login status`.
+3. **Trust the repo in Codex** when prompted on first run. The committed
+   `.codex/config.toml` (review-grade `model_reasoning_effort = "high"`; model
+   deliberately unpinned) only loads for trusted projects.
+4. **For the automatic stop-gate only — the Claude Code codex plugin.** This
+   repo's `.claude/settings.json` declares the `openai-codex` marketplace and
+   enables `codex@openai-codex`, so Claude Code installs/offers the plugin
+   when you trust the folder. Manual install, inside Claude Code:
+
+   ```text
+   /plugin marketplace add openai/codex-plugin-cc
+   /plugin install codex@openai-codex
+   /codex:setup
+   ```
+
+## Manual reviews
+
+| Command | What it does |
+|---|---|
+| `task challenge` (= `challenge:codex`) | Adversarial review — tries to break the change: architecture, authz bypasses, data-loss paths, unsafe rollback, races, hidden coupling, operational failure modes, needless complexity |
+| `task review` (= `review:codex`) | Verification checkpoint — double-checks implementation, consistency with repo conventions, error handling, and test coverage |
+
+Both accept an explicit target and free-text focus after `--`:
+
+```bash
+task challenge                                     # auto: dirty tree → uncommitted; clean → --base main
+task challenge -- --base main                      # branch vs main explicitly
+task review -- --uncommitted                       # staged + unstaged + untracked only
+task challenge -- --base main focus on the update/migration path
+```
+
+Inside Claude Code the plugin's slash commands are the interactive
+equivalents: `/codex:review` and
+`/codex:adversarial-review --base main --background` (with extra focus text
+allowed after the flags), plus `/codex:status` / `/codex:result` for
+background runs.
+
+## The automatic stop-gate
+
+```bash
+task codex:gate:enable    # turn on for this repo on this machine
+task codex:gate:disable   # turn off
+task codex:gate:status    # inspect
+```
+
+Mechanics: the codex plugin registers a Claude Code **Stop hook**. While the
+gate is enabled for a workspace, every time Claude finishes a turn the hook
+runs a fresh, read-only Codex task over the repo and Claude's last message;
+Codex answers `ALLOW:` or `BLOCK: <reason>`. A block feeds the reason back
+into Claude, which must address it (or refute it — see the adjudication
+protocol) before it can finish. Non-editing turns are allowed through.
+
+The tasks flip the same per-workspace `stopReviewGate` flag as
+`/codex:setup --enable-review-gate` (plugin data dir keyed by workspace path
+— note a git worktree is a different workspace with its own flag; the state
+is per-user and per-machine, never committed). If Codex itself is missing or
+unauthenticated the gate fails **open**: the hook logs guidance and lets
+Claude stop.
+
+Loop safety: Claude Code caps consecutive stop-hook continuations, and repo
+policy caps adversarial/review loops at 3 iterations each (AGENTS.md). The
+gate reviews after **every** turn while enabled and each run costs Codex
+usage — enable it for high-consequence work (migrations, auth, concurrency,
+release plumbing), disable it for routine development.
+
+## Intended workflow
+
+```text
+task check      # fast inner loop while editing
+task verify     # definition-of-done gate
+task challenge  # adversarial second model — adjudicate findings, ≤3 loops
+task review     # verification checkpoint — adjudicate findings, ≤3 loops
+task ci         # full CI mirror
+# → open the PR (merging stays a human decision)
+```
+
+## Troubleshooting
+
+- **`codex` not found** — install per Setup; on Linux/devcontainers use the
+  npm install (the Homebrew `codex` cask is macOS-only).
+- **Auth expired** — `codex login status`, then `codex login` (or
+  `codex login --device-auth` without a browser).
+- **`/codex:*` commands missing in Claude Code** — trust the folder so the
+  repo-declared plugin installs, or install manually (Setup step 4), then
+  restart Claude Code.
+- **Gate toggle "plugin not installed"** — the `codex:gate:*` tasks drive the
+  plugin's own runtime under `~/.claude/plugins`; install the plugin first
+  (Setup step 4).
+- **Gate enabled but nothing happens** — `task codex:gate:status`; remember
+  the flag is per workspace path (worktrees toggle separately) and fails open
+  when Codex is unavailable.
+- **Nothing to review** — a clean tree with no commits beyond the base exits
+  early; pass `--base <ref>`, `--uncommitted`, or `--commit <sha>` to pick
+  the target explicitly.

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -60,12 +60,18 @@ task codex:gate:disable   # turn off
 task codex:gate:status    # inspect
 ```
 
-The toggles sit in `permissions.ask` in `.claude/settings.json`, so an agent
-cannot flip the gate without a human approving the command — in particular, a
-gated agent must never disable the gate to get past a BLOCK. `enable` also
-refuses when the plugin is explicitly disabled in Claude Code settings
-(`enabledPlugins`): an installed-but-disabled plugin registers no Stop hook,
-so the armed flag would report protection that does not exist.
+Disarming the gate is a human-only action, enforced in layers: the toggles
+sit in `permissions.ask` in `.claude/settings.json`, and `disable`
+additionally refuses to run without an interactive terminal — permission
+prefix rules alone can be sidestepped with flag placement (e.g.
+`task --silent codex:gate:disable`), but agent shells never have a TTY. A
+gated agent must never disable the gate to get past a BLOCK — adjudicate or
+escalate instead. (This is friction against silent disarmament, not an
+absolute boundary: the plugin's own `/codex:setup --disable-review-gate` is
+outside this repo's control, which is why the AGENTS.md prohibition exists.)
+`enable` also refuses when the plugin is explicitly disabled in Claude Code
+settings (`enabledPlugins`): an installed-but-disabled plugin registers no
+Stop hook, so the armed flag would report protection that does not exist.
 
 Mechanics: the codex plugin registers a Claude Code **Stop hook**. While the
 gate is enabled for a workspace, every time Claude finishes a turn the hook
@@ -84,7 +90,7 @@ fail, which the hook converts into a **block on every turn** — so
 `task codex:gate:enable` refuses to arm the gate unless `codex login status`
 succeeds, and if auth expires while the gate is on, recover with
 `codex login` or `task codex:gate:disable` (disable/status never require
-auth).
+auth; disable does require an interactive terminal).
 
 Loop safety: Claude Code caps consecutive stop-hook continuations, and repo
 policy caps adversarial/review loops at 3 iterations each (AGENTS.md). The

--- a/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
@@ -106,11 +106,12 @@ export CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:-${claude_dir}/plugins/data/code
 # `setup --json` can exit 0 with ready:false (e.g. the app-server cannot
 # initialize its state runtime), and an armed gate would then BLOCK every
 # turn while `codex login status` still passes.
-if [ "$ACTION" = "enable" ]; then
+if [ "$ACTION" = "enable" ] || [ "$ACTION" = "status" ]; then
     # Best-effort effective-enablement check (settings.local.json > project
     # settings.json > user settings.json; managed/enterprise layers are not
     # consulted). An installed-but-disabled plugin registers NO Stop hook, so
-    # arming the flag would report protection that does not exist.
+    # an armed flag would report protection that does not exist — refuse to
+    # arm, and mark status output as inert.
     enabled="$(node -e '
 const fs = require("fs");
 const read = (p) => { try { return JSON.parse(fs.readFileSync(p, "utf8")); } catch { return null; } };
@@ -121,13 +122,24 @@ for (const p of process.argv.slice(1)) {
 }
 process.stdout.write("unknown");
 ' "$(pwd)/.claude/settings.local.json" "$(pwd)/.claude/settings.json" "${claude_dir}/settings.json" 2>/dev/null || echo unknown)"
-    if [ "$enabled" = "false" ]; then
+    if [ "$enabled" = "false" ] && [ "$ACTION" = "enable" ]; then
         echo "Refusing to enable the stop gate: the codex plugin is explicitly disabled in" >&2
         echo "your Claude Code settings (enabledPlugins), so its Stop hook is not active —" >&2
         echo "the armed flag would report protection that does not exist. Re-enable the" >&2
         echo "plugin first (/plugin, or enabledPlugins in .claude/settings*.json)." >&2
         exit 1
     fi
+    if [ "$enabled" = "false" ] && [ "$ACTION" = "status" ]; then
+        echo "WARNING: the codex plugin is explicitly disabled in Claude Code settings" >&2
+        echo "(enabledPlugins) — no Stop hook is active, so any enabled gate flag" >&2
+        echo "reported below is INERT until the plugin is re-enabled." >&2
+    fi
+fi
+
+# Auth + companion-readiness preflights gate ONLY `enable` — status and
+# disable must stay usable as the inspection/escape hatch when auth or the
+# runtime has gone bad after arming.
+if [ "$ACTION" = "enable" ]; then
     if ! command -v codex >/dev/null 2>&1 || ! codex login status >/dev/null 2>&1; then
         echo "Refusing to enable the stop gate: codex is missing or not authenticated." >&2
         echo "The plugin fails open only when the codex BINARY is missing; an installed" >&2

--- a/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
@@ -17,8 +17,12 @@
 # Notes:
 #   - The flag is per-user, per-machine, per-workspace path — never committed.
 #     A git worktree is a different workspace path with its own flag.
-#   - Upstream is fail-open by design: with the gate on but Codex missing or
-#     unauthenticated, the hook logs guidance and lets Claude stop.
+#   - Upstream fails open ONLY when the codex binary/runtime is missing: the
+#     hook then logs guidance and lets Claude stop. An installed-but-
+#     unauthenticated codex instead makes the spawned review task fail, which
+#     the hook converts into a BLOCK on every turn — so `enable` refuses to
+#     arm the gate unless `codex login status` succeeds (disable/status stay
+#     unguarded as the escape hatch if auth expires later).
 #   - Claude Code caps consecutive stop-hook continuations, so an enabled gate
 #     cannot loop forever; the AGENTS.md 3-iteration policy still applies.
 set -euo pipefail
@@ -41,14 +45,21 @@ fi
 claude_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 manifest="${claude_dir}/plugins/installed_plugins.json"
 
+# Only accept an install that is actually active for THIS workspace: a
+# user-scoped entry, or a project-scoped entry whose projectPath is this
+# repo — entries[0] blindly could be another repo's project-scoped install
+# (wrong version, and its Stop hook is not even active here).
 plugin_root=""
 if [ -f "$manifest" ]; then
     plugin_root="$(node -e '
 const fs = require("fs");
 const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
 const entries = (manifest.plugins || {})["codex@openai-codex"] || [];
-if (entries.length > 0 && entries[0].installPath) process.stdout.write(entries[0].installPath);
-' "$manifest" 2>/dev/null || true)"
+const root = process.argv[2];
+const pick = entries.find((e) => e.scope === "project" && e.projectPath === root)
+  || entries.find((e) => e.scope === "user");
+if (pick && pick.installPath) process.stdout.write(pick.installPath);
+' "$manifest" "$(pwd)" 2>/dev/null || true)"
 fi
 if [ -z "$plugin_root" ] || [ ! -f "${plugin_root}/scripts/codex-companion.mjs" ]; then
     # Fallback: newest cached copy (lexical sort — fine for a fallback).
@@ -68,6 +79,18 @@ Install it inside Claude Code:
 trust the folder in Claude Code.) See docs/guides/codex-review.md.
 EOF
     exit 1
+fi
+
+# Arming the gate while codex cannot actually review would trap Claude in
+# stop-blocks (see header) — refuse unless codex is present AND authenticated.
+if [ "$ACTION" = "enable" ]; then
+    if ! command -v codex >/dev/null 2>&1 || ! codex login status >/dev/null 2>&1; then
+        echo "Refusing to enable the stop gate: codex is missing or not authenticated." >&2
+        echo "The plugin fails open only when the codex BINARY is missing; an installed" >&2
+        echo "but unauthenticated codex makes the Stop hook BLOCK every Claude turn." >&2
+        echo "Run 'codex login' first. (codex-gate.sh disable/status work without auth.)" >&2
+        exit 1
+    fi
 fi
 
 # Write the SAME per-workspace state the Claude Code hook reads: outside

--- a/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# codex-gate.sh — enable/disable/inspect the automatic Claude → Codex
+# "stop-gate" review for THIS repo on THIS machine.
+#
+# The gate ships with the `codex@openai-codex` Claude Code plugin: a Stop hook
+# that, when a Claude turn finishes, has Codex review the turn (read-only) and
+# blocks Claude from stopping (BLOCK: <reason>) until material issues are
+# addressed. The hook is always registered while the plugin is installed;
+# whether it acts is a per-workspace `stopReviewGate` flag in the plugin's
+# data dir. This script flips that same flag through the plugin's own
+# companion runtime — identical state to running
+# `/codex:setup --enable-review-gate` inside Claude Code — so the toggle is
+# scriptable (task codex:gate:enable / codex:gate:disable / codex:gate:status).
+#
+# Usage: codex-gate.sh <enable|disable|status>
+#
+# Notes:
+#   - The flag is per-user, per-machine, per-workspace path — never committed.
+#     A git worktree is a different workspace path with its own flag.
+#   - Upstream is fail-open by design: with the gate on but Codex missing or
+#     unauthenticated, the hook logs guidance and lets Claude stop.
+#   - Claude Code caps consecutive stop-hook continuations, so an enabled gate
+#     cannot loop forever; the AGENTS.md 3-iteration policy still applies.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ACTION="${1:-}"
+case "$ACTION" in
+enable | disable | status) ;;
+*)
+    echo "usage: $0 <enable|disable|status>" >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v node >/dev/null 2>&1; then
+    echo "node is required (the gate toggle drives the Claude Code codex plugin's Node runtime)." >&2
+    exit 1
+fi
+
+claude_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+manifest="${claude_dir}/plugins/installed_plugins.json"
+
+plugin_root=""
+if [ -f "$manifest" ]; then
+    plugin_root="$(node -e '
+const fs = require("fs");
+const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+const entries = (manifest.plugins || {})["codex@openai-codex"] || [];
+if (entries.length > 0 && entries[0].installPath) process.stdout.write(entries[0].installPath);
+' "$manifest" 2>/dev/null || true)"
+fi
+if [ -z "$plugin_root" ] || [ ! -f "${plugin_root}/scripts/codex-companion.mjs" ]; then
+    # Fallback: newest cached copy (lexical sort — fine for a fallback).
+    for d in "${claude_dir}"/plugins/cache/openai-codex/codex/*/; do
+        if [ -f "${d}scripts/codex-companion.mjs" ]; then
+            plugin_root="${d%/}"
+        fi
+    done
+fi
+if [ -z "$plugin_root" ] || [ ! -f "${plugin_root}/scripts/codex-companion.mjs" ]; then
+    cat >&2 <<'EOF'
+The codex Claude Code plugin is not installed for this user.
+Install it inside Claude Code:
+  /plugin marketplace add openai/codex-plugin-cc
+  /plugin install codex@openai-codex
+(This repo's .claude/settings.json also offers it automatically when you
+trust the folder in Claude Code.) See docs/guides/codex-review.md.
+EOF
+    exit 1
+fi
+
+# Write the SAME per-workspace state the Claude Code hook reads: outside
+# Claude Code the companion falls back to a temp dir, so pin CLAUDE_PLUGIN_DATA
+# to the plugin's real data dir (~/.claude/plugins/data/<plugin>-<marketplace>).
+export CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:-${claude_dir}/plugins/data/codex-openai-codex}"
+
+case "$ACTION" in
+enable) exec node "${plugin_root}/scripts/codex-companion.mjs" setup --enable-review-gate ;;
+disable) exec node "${plugin_root}/scripts/codex-companion.mjs" setup --disable-review-gate ;;
+status) exec node "${plugin_root}/scripts/codex-companion.mjs" setup ;;
+esac

--- a/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
@@ -76,8 +76,17 @@ EOF
     exit 1
 fi
 
+# Write the SAME per-workspace state the Claude Code hook reads: outside
+# Claude Code the companion falls back to a temp dir, so pin CLAUDE_PLUGIN_DATA
+# to the plugin's real data dir (~/.claude/plugins/data/<plugin>-<marketplace>).
+export CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:-${claude_dir}/plugins/data/codex-openai-codex}"
+
 # Arming the gate while codex cannot actually review would trap Claude in
-# stop-blocks (see header) — refuse unless codex is present AND authenticated.
+# stop-blocks (see header) — refuse unless codex is present, authenticated,
+# AND the plugin's own companion reports ready. Auth alone is not enough:
+# `setup --json` can exit 0 with ready:false (e.g. the app-server cannot
+# initialize its state runtime), and an armed gate would then BLOCK every
+# turn while `codex login status` still passes.
 if [ "$ACTION" = "enable" ]; then
     if ! command -v codex >/dev/null 2>&1 || ! codex login status >/dev/null 2>&1; then
         echo "Refusing to enable the stop gate: codex is missing or not authenticated." >&2
@@ -86,12 +95,15 @@ if [ "$ACTION" = "enable" ]; then
         echo "Run 'codex login' first. (codex-gate.sh disable/status work without auth.)" >&2
         exit 1
     fi
+    ready="$(node "${plugin_root}/scripts/codex-companion.mjs" setup --json 2>/dev/null |
+        node -e 'let s="";process.stdin.on("data",(d)=>{s+=d;}).on("end",()=>{let r=false;try{r=JSON.parse(s).ready===true;}catch{}process.stdout.write(r?"true":"false");});' || echo false)"
+    if [ "$ready" != "true" ]; then
+        echo "Refusing to enable the stop gate: the codex plugin companion reports it is" >&2
+        echo "not ready (run 'task codex:gate:status' for details). An armed gate with an" >&2
+        echo "unusable runtime would BLOCK every Claude turn instead of reviewing." >&2
+        exit 1
+    fi
 fi
-
-# Write the SAME per-workspace state the Claude Code hook reads: outside
-# Claude Code the companion falls back to a temp dir, so pin CLAUDE_PLUGIN_DATA
-# to the plugin's real data dir (~/.claude/plugins/data/<plugin>-<marketplace>).
-export CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:-${claude_dir}/plugins/data/codex-openai-codex}"
 
 case "$ACTION" in
 enable) exec node "${plugin_root}/scripts/codex-companion.mjs" setup --enable-review-gate ;;

--- a/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
@@ -88,6 +88,27 @@ export CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:-${claude_dir}/plugins/data/code
 # initialize its state runtime), and an armed gate would then BLOCK every
 # turn while `codex login status` still passes.
 if [ "$ACTION" = "enable" ]; then
+    # Best-effort effective-enablement check (settings.local.json > project
+    # settings.json > user settings.json; managed/enterprise layers are not
+    # consulted). An installed-but-disabled plugin registers NO Stop hook, so
+    # arming the flag would report protection that does not exist.
+    enabled="$(node -e '
+const fs = require("fs");
+const read = (p) => { try { return JSON.parse(fs.readFileSync(p, "utf8")); } catch { return null; } };
+for (const p of process.argv.slice(1)) {
+  const v = read(p)?.enabledPlugins?.["codex@openai-codex"];
+  if (v === true) { process.stdout.write("true"); process.exit(0); }
+  if (v === false) { process.stdout.write("false"); process.exit(0); }
+}
+process.stdout.write("unknown");
+' "$(pwd)/.claude/settings.local.json" "$(pwd)/.claude/settings.json" "${claude_dir}/settings.json" 2>/dev/null || echo unknown)"
+    if [ "$enabled" = "false" ]; then
+        echo "Refusing to enable the stop gate: the codex plugin is explicitly disabled in" >&2
+        echo "your Claude Code settings (enabledPlugins), so its Stop hook is not active —" >&2
+        echo "the armed flag would report protection that does not exist. Re-enable the" >&2
+        echo "plugin first (/plugin, or enabledPlugins in .claude/settings*.json)." >&2
+        exit 1
+    fi
     if ! command -v codex >/dev/null 2>&1 || ! codex login status >/dev/null 2>&1; then
         echo "Refusing to enable the stop gate: codex is missing or not authenticated." >&2
         echo "The plugin fails open only when the codex BINARY is missing; an installed" >&2

--- a/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
@@ -61,18 +61,13 @@ const pick = entries.find((e) => e.scope === "project" && e.projectPath === root
 if (pick && pick.installPath) process.stdout.write(pick.installPath);
 ' "$manifest" "$(pwd)" 2>/dev/null || true)"
 fi
-if [ -z "$plugin_root" ] || [ ! -f "${plugin_root}/scripts/codex-companion.mjs" ]; then
-    # Fallback: newest cached copy (lexical sort — fine for a fallback).
-    for d in "${claude_dir}"/plugins/cache/openai-codex/codex/*/; do
-        if [ -f "${d}scripts/codex-companion.mjs" ]; then
-            plugin_root="${d%/}"
-        fi
-    done
-fi
+# No cache-directory fallback on purpose: a cached runtime is NOT an active
+# plugin — flipping state through another repo's project-scoped install would
+# report the gate "enabled" while no Stop hook runs in this workspace.
 if [ -z "$plugin_root" ] || [ ! -f "${plugin_root}/scripts/codex-companion.mjs" ]; then
     cat >&2 <<'EOF'
-The codex Claude Code plugin is not installed for this user.
-Install it inside Claude Code:
+The codex Claude Code plugin is not installed for this user (or not active
+for this workspace). Install it inside Claude Code:
   /plugin marketplace add openai/codex-plugin-cc
   /plugin install codex@openai-codex
 (This repo's .claude/settings.json also offers it automatically when you

--- a/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
@@ -24,7 +24,7 @@
 #     arm the gate unless `codex login status` succeeds (disable/status stay
 #     unguarded as the escape hatch if auth expires later).
 #   - Claude Code caps consecutive stop-hook continuations, so an enabled gate
-#     cannot loop forever; the AGENTS.md 3-iteration policy still applies.
+#     cannot loop forever; the AGENTS.md loop-cap policy still applies.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -42,20 +42,22 @@ if ! command -v node >/dev/null 2>&1; then
     exit 1
 fi
 
-# Disarming the gate is a human-only action. Permission prefix rules cannot
-# hold this line — `task --silent codex:gate:disable` slips past exact-prefix
-# ask rules while matching the broad Bash(task:*) allow — so enforce it here:
-# agent/CI shells have no TTY on stdin, an interactive human terminal does.
-# (The permissions.ask entries remain as a second layer. This is friction
-# against silent disarmament, not a cryptographic boundary: a policy-violating
-# agent with file-write access could still edit scripts or state — which is
-# why AGENTS.md forbids it and adjudication is the sanctioned way past a
-# BLOCK.)
-if [ "$ACTION" = "disable" ] && [ ! -t 0 ]; then
-    echo "Refusing to disable the stop gate from a non-interactive shell: disarming the" >&2
+# Toggling the gate is a human-only action in BOTH directions: disable lets a
+# blocked agent disarm its reviewer; enable silently commits the human to
+# billed every-turn reviews. Permission prefix rules cannot hold this line —
+# `task --silent codex:gate:<action>` slips past exact-prefix ask rules while
+# matching the broad Bash(task:*) allow — so enforce it here: agent/CI shells
+# have no TTY on stdin, an interactive human terminal does. (The
+# permissions.ask entries remain as a second layer. This is friction against
+# silent toggling, not a cryptographic boundary: a policy-violating agent
+# with file-write access could still edit scripts or state — which is why
+# AGENTS.md forbids it and adjudication is the sanctioned way past a BLOCK.)
+if [ "$ACTION" != "status" ] && [ ! -t 0 ]; then
+    echo "Refusing to ${ACTION} the stop gate from a non-interactive shell: toggling the" >&2
     echo "gate is a human decision (agents must adjudicate or escalate a BLOCK, never" >&2
-    echo "disarm). Run 'task codex:gate:disable' yourself in a terminal, or use" >&2
-    echo "/codex:setup --disable-review-gate inside Claude Code." >&2
+    echo "disarm — and arming commits the human to per-turn review costs). Run" >&2
+    echo "'task codex:gate:${ACTION}' yourself in a terminal, or use /codex:setup inside" >&2
+    echo "Claude Code." >&2
     exit 1
 fi
 

--- a/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-gate.sh[% endif %]
@@ -42,6 +42,23 @@ if ! command -v node >/dev/null 2>&1; then
     exit 1
 fi
 
+# Disarming the gate is a human-only action. Permission prefix rules cannot
+# hold this line — `task --silent codex:gate:disable` slips past exact-prefix
+# ask rules while matching the broad Bash(task:*) allow — so enforce it here:
+# agent/CI shells have no TTY on stdin, an interactive human terminal does.
+# (The permissions.ask entries remain as a second layer. This is friction
+# against silent disarmament, not a cryptographic boundary: a policy-violating
+# agent with file-write access could still edit scripts or state — which is
+# why AGENTS.md forbids it and adjudication is the sanctioned way past a
+# BLOCK.)
+if [ "$ACTION" = "disable" ] && [ ! -t 0 ]; then
+    echo "Refusing to disable the stop gate from a non-interactive shell: disarming the" >&2
+    echo "gate is a human decision (agents must adjudicate or escalate a BLOCK, never" >&2
+    echo "disarm). Run 'task codex:gate:disable' yourself in a terminal, or use" >&2
+    echo "/codex:setup --disable-review-gate inside Claude Code." >&2
+    exit 1
+fi
+
 claude_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 manifest="${claude_dir}/plugins/installed_plugins.json"
 

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -139,10 +139,9 @@ behavior; race conditions, ordering and idempotency gaps; hidden coupling and
 assumptions that stop holding under stress; operational failure modes (empty
 state, timeouts, retries, partial failure, degraded dependencies); and
 unnecessarily complex design choices where a simpler alternative would do.
-Report only material, defensible findings tied to concrete files and lines —
-no style nits, no speculation you cannot support from the code. Prefer one
-strong finding over several weak ones; if the change looks safe, say so
-directly."
+Report EVERY materially defensible finding tied to concrete files and lines —
+do not stop at the first strong one. No style nits, no speculation you cannot
+support from the code. If the change looks safe, say so directly."
 else
     instructions="${scope}
 

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -53,6 +53,12 @@ cap_manifest() {
 scope=""
 manifest=""
 focus=""
+require_single_target() {
+    if [ -n "$scope" ]; then
+        echo "conflicting target flags: --base, --uncommitted, and --commit are mutually exclusive." >&2
+        exit 2
+    fi
+}
 while [ $# -gt 0 ]; do
     case "$1" in
     --base)
@@ -60,6 +66,7 @@ while [ $# -gt 0 ]; do
             echo "$1 requires a value" >&2
             exit 2
         fi
+        require_single_target
         # Fail fast on a typo/stale/unfetched ref: without this, an expensive
         # Codex run would launch with a nonsense scope and no manifest.
         if ! git rev-parse --verify --quiet "$2^{commit}" >/dev/null; then
@@ -75,6 +82,7 @@ while [ $# -gt 0 ]; do
             echo "$1 requires a value" >&2
             exit 2
         fi
+        require_single_target
         if ! git rev-parse --verify --quiet "$2^{commit}" >/dev/null; then
             echo "--commit '$2' does not resolve to a commit." >&2
             exit 2
@@ -84,6 +92,7 @@ while [ $# -gt 0 ]; do
         shift 2
         ;;
     --uncommitted)
+        require_single_target
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
         manifest="$(git status --porcelain | cap_manifest || true)"
         shift

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -43,6 +43,7 @@ if ! command -v codex >/dev/null 2>&1; then
 fi
 
 scope=""
+manifest=""
 focus=""
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -52,6 +53,7 @@ while [ $# -gt 0 ]; do
             exit 2
         fi
         scope="Review the changes on the current branch relative to base branch '$2' (the merge-base diff $2...HEAD)."
+        manifest="$(git diff --name-status "$2...HEAD" 2>/dev/null | head -200 || true)"
         shift 2
         ;;
     --commit)
@@ -60,10 +62,12 @@ while [ $# -gt 0 ]; do
             exit 2
         fi
         scope="Review the changes introduced by commit $2."
+        manifest="$(git diff-tree --no-commit-id --name-status -r "$2" 2>/dev/null | head -200 || true)"
         shift 2
         ;;
     --uncommitted)
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
+        manifest="$(git status --porcelain | head -200)"
         shift
         ;;
     *)
@@ -76,6 +80,7 @@ done
 if [ -z "$scope" ]; then
     if [ -n "$(git status --porcelain)" ]; then
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
+        manifest="$(git status --porcelain | head -200)"
         echo "==> Reviewing uncommitted work (dirty tree; pass --base <ref> to review the branch instead)"
     else
         base=""
@@ -100,6 +105,7 @@ if [ -z "$scope" ]; then
             exit 0
         fi
         scope="Review the changes on the current branch relative to base branch '${base}' (the merge-base diff ${base}...HEAD)."
+        manifest="$(git diff --name-status "${base}...HEAD" | head -200)"
         echo "==> Reviewing branch changes against ${base}"
     fi
 fi
@@ -135,6 +141,20 @@ if [ -n "$focus" ]; then
     instructions="${instructions}
 
 Additional focus from the invoker (weight it heavily): ${focus}"
+fi
+
+# Custom review instructions bypass the CLI's native diff-target modes (the
+# two are mutually exclusive), leaving diff collection to the model. Anchor it
+# with an authoritative, git-generated file manifest so nothing in scope —
+# untracked files included — can be silently skipped.
+if [ -n "$manifest" ]; then
+    instructions="${instructions}
+
+Authoritative changed-file manifest from git for this scope (status + path;
+cover EVERY entry, including untracked files, collecting the diffs yourself
+with git):
+
+${manifest}"
 fi
 
 exec codex exec review "$instructions"

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -60,6 +60,12 @@ while [ $# -gt 0 ]; do
             echo "$1 requires a value" >&2
             exit 2
         fi
+        # Fail fast on a typo/stale/unfetched ref: without this, an expensive
+        # Codex run would launch with a nonsense scope and no manifest.
+        if ! git rev-parse --verify --quiet "$2^{commit}" >/dev/null; then
+            echo "--base '$2' does not resolve to a commit (typo, or fetch the ref first)." >&2
+            exit 2
+        fi
         scope="Review the changes on the current branch relative to base branch '$2' (the merge-base diff $2...HEAD)."
         manifest="$(git diff --name-status "$2...HEAD" 2>/dev/null | cap_manifest || true)"
         shift 2
@@ -67,6 +73,10 @@ while [ $# -gt 0 ]; do
     --commit)
         if [ $# -lt 2 ]; then
             echo "$1 requires a value" >&2
+            exit 2
+        fi
+        if ! git rev-parse --verify --quiet "$2^{commit}" >/dev/null; then
+            echo "--commit '$2' does not resolve to a commit." >&2
             exit 2
         fi
         scope="Review the changes introduced by commit $2."

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -42,6 +42,14 @@ if ! command -v codex >/dev/null 2>&1; then
     exit 1
 fi
 
+# Cap the manifest at 200 entries WITHOUT `head`: head exits early, the git
+# producer takes SIGPIPE, and under `set -o pipefail` a >200-entry tree would
+# abort the review before Codex ever runs. awk reads to EOF (no SIGPIPE) and
+# marks the truncation so the reviewer knows to re-enumerate with git.
+cap_manifest() {
+    awk 'NR <= 200 { print } NR == 201 { print "... (manifest truncated at 200 entries; re-enumerate with git for the full set)" }'
+}
+
 scope=""
 manifest=""
 focus=""
@@ -53,7 +61,7 @@ while [ $# -gt 0 ]; do
             exit 2
         fi
         scope="Review the changes on the current branch relative to base branch '$2' (the merge-base diff $2...HEAD)."
-        manifest="$(git diff --name-status "$2...HEAD" 2>/dev/null | head -200 || true)"
+        manifest="$(git diff --name-status "$2...HEAD" 2>/dev/null | cap_manifest || true)"
         shift 2
         ;;
     --commit)
@@ -62,12 +70,12 @@ while [ $# -gt 0 ]; do
             exit 2
         fi
         scope="Review the changes introduced by commit $2."
-        manifest="$(git diff-tree --no-commit-id --name-status -r "$2" 2>/dev/null | head -200 || true)"
+        manifest="$(git diff-tree --no-commit-id --name-status -r "$2" 2>/dev/null | cap_manifest || true)"
         shift 2
         ;;
     --uncommitted)
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
-        manifest="$(git status --porcelain | head -200)"
+        manifest="$(git status --porcelain | cap_manifest || true)"
         shift
         ;;
     *)
@@ -80,7 +88,7 @@ done
 if [ -z "$scope" ]; then
     if [ -n "$(git status --porcelain)" ]; then
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
-        manifest="$(git status --porcelain | head -200)"
+        manifest="$(git status --porcelain | cap_manifest || true)"
         echo "==> Reviewing uncommitted work (dirty tree; pass --base <ref> to review the branch instead)"
     else
         base=""
@@ -105,7 +113,7 @@ if [ -z "$scope" ]; then
             exit 0
         fi
         scope="Review the changes on the current branch relative to base branch '${base}' (the merge-base diff ${base}...HEAD)."
-        manifest="$(git diff --name-status "${base}...HEAD" | head -200)"
+        manifest="$(git diff --name-status "${base}...HEAD" | cap_manifest || true)"
         echo "==> Reviewing branch changes against ${base}"
     fi
 fi

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -199,4 +199,7 @@ with git):
 ${manifest}"
 fi
 
-exec codex exec review "$instructions"
+# Feed the prompt through stdin (`review -`): a single argv element is
+# capped (~128 KiB per arg on Linux), and cap_manifest bounds entry count,
+# not bytes — 200 deep paths plus instructions can exceed the argv limit.
+printf '%s\n' "$instructions" | codex exec review -

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -92,7 +92,14 @@ while [ $# -gt 0 ]; do
             exit 2
         fi
         scope="Review the changes introduced by commit $2."
-        manifest="$(git diff-tree --no-commit-id --name-status -r --root -m "$2" 2>/dev/null | cap_manifest || true)"
+        # First-parent diff for commits with a parent: diff-tree -m would also
+        # emit each merge parent's diff, pulling pre-merge mainline files into
+        # the "authoritative" manifest. --root covers parentless root commits.
+        if git rev-parse --verify --quiet "$2^" >/dev/null; then
+            manifest="$(git diff --name-status "$2^" "$2" 2>/dev/null | cap_manifest || true)"
+        else
+            manifest="$(git diff-tree --no-commit-id --name-status -r --root "$2" 2>/dev/null | cap_manifest || true)"
+        fi
         shift 2
         ;;
     --uncommitted)

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -92,13 +92,13 @@ while [ $# -gt 0 ]; do
             exit 2
         fi
         scope="Review the changes introduced by commit $2."
-        manifest="$(git diff-tree --no-commit-id --name-status -r "$2" 2>/dev/null | cap_manifest || true)"
+        manifest="$(git diff-tree --no-commit-id --name-status -r --root -m "$2" 2>/dev/null | cap_manifest || true)"
         shift 2
         ;;
     --uncommitted)
         require_single_target
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
-        manifest="$(git status --porcelain | cap_manifest || true)"
+        manifest="$(git status --porcelain --untracked-files=all | cap_manifest || true)"
         shift
         ;;
     *)
@@ -111,7 +111,7 @@ done
 if [ -z "$scope" ]; then
     if [ -n "$(git status --porcelain)" ]; then
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
-        manifest="$(git status --porcelain | cap_manifest || true)"
+        manifest="$(git status --porcelain --untracked-files=all | cap_manifest || true)"
         echo "==> Reviewing uncommitted work (dirty tree; pass --base <ref> to review the branch instead)"
     else
         # origin/HEAD (the remote's actual default branch) outranks local

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# codex-review.sh — second-model review of the current change via the OpenAI
+# Codex CLI (`codex exec review`). Two modes:
+#
+#   review    — verification checkpoint: double-check the implementation,
+#               consistency with repo conventions, and test coverage.
+#   challenge — adversarial review: actively try to break the change
+#               (architecture, authz, data loss, rollback, races, hidden
+#               coupling, operational failure modes, overdesign).
+#
+# Usage: codex-review.sh <review|challenge> [--base <ref>|--uncommitted|--commit <sha>] [focus text ...]
+#
+# Target selection when no explicit flag is given (mirrors the Codex Claude
+# Code plugin's auto scope): a dirty working tree reviews staged + unstaged +
+# untracked work; a clean tree reviews the branch against the default base.
+# The CLI's --base/--uncommitted/--commit flags are mutually exclusive with
+# custom instructions ("custom review instructions" is its own review mode),
+# so the resolved scope is written INTO the instructions instead.
+# Codex reviews read-only; findings are advisory hypotheses for the primary
+# agent/human to adjudicate (AGENTS.md "Second-Model Review") — this is never
+# part of `verify`/`ci`. Requires an authenticated Codex CLI (`codex login`);
+# see docs/guides/codex-review.md.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+usage() {
+    echo "usage: $0 <review|challenge> [--base <ref>|--uncommitted|--commit <sha>] [focus text ...]" >&2
+}
+
+MODE="${1:-}"
+case "$MODE" in
+review | challenge) shift ;;
+*)
+    usage
+    exit 2
+    ;;
+esac
+
+if ! command -v codex >/dev/null 2>&1; then
+    echo "codex CLI not found. Install it (brew install --cask codex, or npm install -g @openai/codex)," >&2
+    echo "authenticate with 'codex login', then re-run. See docs/guides/codex-review.md." >&2
+    exit 1
+fi
+
+scope=""
+focus=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --base)
+        if [ $# -lt 2 ]; then
+            echo "$1 requires a value" >&2
+            exit 2
+        fi
+        scope="Review the changes on the current branch relative to base branch '$2' (the merge-base diff $2...HEAD)."
+        shift 2
+        ;;
+    --commit)
+        if [ $# -lt 2 ]; then
+            echo "$1 requires a value" >&2
+            exit 2
+        fi
+        scope="Review the changes introduced by commit $2."
+        shift 2
+        ;;
+    --uncommitted)
+        scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
+        shift
+        ;;
+    *)
+        focus="${focus:+${focus} }$1"
+        shift
+        ;;
+    esac
+done
+
+if [ -z "$scope" ]; then
+    if [ -n "$(git status --porcelain)" ]; then
+        scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
+        echo "==> Reviewing uncommitted work (dirty tree; pass --base <ref> to review the branch instead)"
+    else
+        base=""
+        for candidate in main master; do
+            if git rev-parse --verify --quiet "$candidate" >/dev/null; then
+                base="$candidate"
+                break
+            fi
+        done
+        if [ -z "$base" ]; then
+            # Keep the remote-qualified ref (origin/<branch>): stripping it
+            # would name a local branch that may not exist, and the rev-list
+            # fallback below would then silently report nothing to review.
+            base="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+        fi
+        if [ -z "$base" ] || ! git rev-parse --verify --quiet "$base" >/dev/null; then
+            echo "Could not detect a base branch; pass --base <ref> or --uncommitted." >&2
+            exit 2
+        fi
+        if [ "$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)" -eq 0 ]; then
+            echo "Nothing to review: the working tree is clean and HEAD has no commits beyond ${base}."
+            exit 0
+        fi
+        scope="Review the changes on the current branch relative to base branch '${base}' (the merge-base diff ${base}...HEAD)."
+        echo "==> Reviewing branch changes against ${base}"
+    fi
+fi
+
+if [ "$MODE" = "challenge" ]; then
+    instructions="${scope}
+
+Run an ADVERSARIAL review: your job is to break confidence in this change,
+not to validate it. Challenge the architecture and the chosen approach, not
+just the diff hunks. Actively hunt for: authorization bypasses and trust
+boundary gaps; data-loss or corruption paths; unsafe rollback and migration
+behavior; race conditions, ordering and idempotency gaps; hidden coupling and
+assumptions that stop holding under stress; operational failure modes (empty
+state, timeouts, retries, partial failure, degraded dependencies); and
+unnecessarily complex design choices where a simpler alternative would do.
+Report only material, defensible findings tied to concrete files and lines —
+no style nits, no speculation you cannot support from the code. Prefer one
+strong finding over several weak ones; if the change looks safe, say so
+directly."
+else
+    instructions="${scope}
+
+Run a VERIFICATION-CHECKPOINT review of this change: double-check that the
+implementation actually does what it claims, is internally consistent and
+consistent with this repository's existing conventions and docs, handles
+errors and edge cases, and has adequate test coverage (including regression
+tests for anything it fixes). Flag docs the change should have updated.
+Report only material, defensible findings tied to concrete files and lines —
+no style nits. If the change holds up, say so directly."
+fi
+
+if [ -n "$focus" ]; then
+    instructions="${instructions}
+
+Additional focus from the invoker (weight it heavily): ${focus}"
+fi
+
+exec codex exec review "$instructions"

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -73,6 +73,10 @@ while [ $# -gt 0 ]; do
             echo "--base '$2' does not resolve to a commit (typo, or fetch the ref first)." >&2
             exit 2
         fi
+        if ! git merge-base "$2" HEAD >/dev/null 2>&1; then
+            echo "--base '$2' shares no merge base with HEAD (unrelated history) — the diff would be meaningless." >&2
+            exit 2
+        fi
         scope="Review the changes on the current branch relative to base branch '$2' (the merge-base diff $2...HEAD)."
         manifest="$(git diff --name-status "$2...HEAD" 2>/dev/null | cap_manifest || true)"
         shift 2
@@ -110,21 +114,26 @@ if [ -z "$scope" ]; then
         manifest="$(git status --porcelain | cap_manifest || true)"
         echo "==> Reviewing uncommitted work (dirty tree; pass --base <ref> to review the branch instead)"
     else
-        base=""
-        for candidate in main master; do
-            if git rev-parse --verify --quiet "$candidate" >/dev/null; then
-                base="$candidate"
-                break
-            fi
-        done
+        # origin/HEAD (the remote's actual default branch) outranks local
+        # branch-name guesses: a stray local `main` in a develop-default repo
+        # must not silently become the comparison base. The remote-qualified
+        # ref is kept as-is — stripping origin/ could name a branch that does
+        # not exist locally. Name guesses only apply to remoteless repos.
+        base="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"
         if [ -z "$base" ]; then
-            # Keep the remote-qualified ref (origin/<branch>): stripping it
-            # would name a local branch that may not exist, and the rev-list
-            # fallback below would then silently report nothing to review.
-            base="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+            for candidate in main master; do
+                if git rev-parse --verify --quiet "$candidate" >/dev/null; then
+                    base="$candidate"
+                    break
+                fi
+            done
         fi
         if [ -z "$base" ] || ! git rev-parse --verify --quiet "$base" >/dev/null; then
             echo "Could not detect a base branch; pass --base <ref> or --uncommitted." >&2
+            exit 2
+        fi
+        if ! git merge-base "$base" HEAD >/dev/null 2>&1; then
+            echo "Auto-detected base '${base}' shares no merge base with HEAD; pass --base <ref> or --uncommitted." >&2
             exit 2
         fi
         if [ "$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)" -eq 0 ]; then

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -58,6 +58,20 @@ echo "$out" | grep -q "base branch 'origin/develop'" || fail "remote-qualified f
 echo "$out" | grep -q "ADVERSARIAL" || fail "challenge mode instructions missing: $out"
 echo "$out" | grep -q "feature.txt" || fail "changed-file manifest missing from branch-scope prompt: $out"
 
+echo "==> origin/HEAD outranks a stray local main"
+git branch -q main "$(git rev-list --max-parents=0 HEAD)"
+out="$(run challenge)" || fail "challenge with stray local main exited non-zero: $out"
+echo "$out" | grep -q "base branch 'origin/develop'" || fail "stray local main hijacked base detection: $out"
+git branch -q -D main
+
+echo "==> --base with no merge base fails fast"
+unrelated="$(git commit-tree "$(git mktree </dev/null)" -m orphan)"
+if out="$(run review --base "$unrelated" 2>&1)"; then
+    fail "--base with unrelated history accepted: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite no merge base: $out"
+echo "$out" | grep -q "no merge base" || fail "missing no-merge-base message: $out"
+
 echo "==> explicit --base and focus text reach the prompt"
 out="$(run review --base origin/develop watch the hooks)" || fail "review --base exited non-zero: $out"
 echo "$out" | grep -q "base branch 'origin/develop'" || fail "--base not honored: $out"
@@ -113,4 +127,27 @@ fi
 echo "$out" | grep -q "mutually exclusive" || fail "missing conflicting-flags message: $out"
 echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite conflicting flags: $out"
 
-echo "codex-review target selection OK (8 cases)"
+echo "==> gate: another repo's project-scoped plugin install is not accepted"
+fake_claude="${test_tmp}/claude-config"
+mkdir -p "${fake_claude}/plugins"
+cat >"${fake_claude}/plugins/installed_plugins.json" <<'JSON'
+{
+  "version": 2,
+  "plugins": {
+    "codex@openai-codex": [
+      {
+        "scope": "project",
+        "projectPath": "/some/other/repo",
+        "installPath": "/nonexistent/plugin/root",
+        "version": "1.0.6"
+      }
+    ]
+  }
+}
+JSON
+if out="$(CLAUDE_CONFIG_DIR="$fake_claude" "${repo}/scripts/codex-gate.sh" enable 2>&1)"; then
+    fail "gate enable accepted an install scoped to another repo: $out"
+fi
+echo "$out" | grep -q "not installed" || fail "missing not-installed message for foreign-scoped install: $out"
+
+echo "codex-review + codex-gate guards OK (11 cases)"

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -42,7 +42,9 @@ git init -q -b develop "${test_tmp}/upstream"
 git clone -q "${test_tmp}/upstream" "${test_tmp}/clone"
 cd "${test_tmp}/clone"
 git checkout -q -b feature
-git_t commit -q --allow-empty -m work
+echo change >feature.txt
+git add feature.txt
+git_t commit -q -m work
 git branch -q -D develop
 
 run() {
@@ -54,6 +56,7 @@ out="$(run challenge)" || fail "challenge exited non-zero: $out"
 echo "$out" | grep -q "STUB-ARGS:exec review" || fail "codex exec review not invoked: $out"
 echo "$out" | grep -q "base branch 'origin/develop'" || fail "remote-qualified fallback base missing: $out"
 echo "$out" | grep -q "ADVERSARIAL" || fail "challenge mode instructions missing: $out"
+echo "$out" | grep -q "feature.txt" || fail "changed-file manifest missing from branch-scope prompt: $out"
 
 echo "==> explicit --base and focus text reach the prompt"
 out="$(run review --base origin/develop watch the hooks)" || fail "review --base exited non-zero: $out"
@@ -65,6 +68,7 @@ echo "==> dirty tree auto-selects uncommitted scope"
 echo x >dirty.txt
 out="$(run review)" || fail "dirty-tree review exited non-zero: $out"
 echo "$out" | grep -q "uncommitted work" || fail "dirty tree did not select uncommitted scope: $out"
+echo "$out" | grep -q "dirty.txt" || fail "untracked file missing from uncommitted manifest: $out"
 rm -f dirty.txt
 
 echo "==> clean tree at the base tip reports nothing to review"

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -106,4 +106,11 @@ if out="$(run challenge --commit 0000000000000000000000000000000000000000 2>&1)"
 fi
 echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite bad --commit sha: $out"
 
-echo "codex-review target selection OK (7 cases)"
+echo "==> conflicting target flags are rejected"
+if out="$(run review --base origin/develop --uncommitted 2>&1)"; then
+    fail "conflicting target flags accepted (last-wins regression): $out"
+fi
+echo "$out" | grep -q "mutually exclusive" || fail "missing conflicting-flags message: $out"
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite conflicting flags: $out"
+
+echo "codex-review target selection OK (8 cases)"

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -144,7 +144,8 @@ git checkout -q mergetest
 git_t merge -q --no-ff -m merge sidebr >/dev/null 2>&1 || fail "fixture merge failed"
 merge_sha="$(git rev-parse HEAD)"
 out="$(run review --commit "$merge_sha")" || fail "merge-commit review exited non-zero: $out"
-echo "$out" | grep -q "side.txt" || fail "merge commit manifest empty (missing -m): $out"
+echo "$out" | grep -q "side.txt" || fail "merge commit manifest missing first-parent change: $out"
+echo "$out" | grep -q "feature.txt" && fail "merge manifest includes pre-merge mainline files (diff-tree -m regression): $out"
 
 echo "==> gate: another repo's project-scoped plugin install is not accepted"
 fake_claude="${test_tmp}/claude-config"
@@ -210,4 +211,10 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "explicitly disabled" || fail "missing disabled-plugin refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (15 cases)"
+echo "==> gate: disable refuses in a non-interactive shell"
+if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" "${repo}/scripts/codex-gate.sh" disable </dev/null 2>&1)"; then
+    fail "non-interactive disable was accepted (agent could disarm its own gate): $out"
+fi
+echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
+
+echo "codex-review + codex-gate guards OK (16 cases)"

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -20,7 +20,7 @@ trap 'rm -rf "$test_tmp"' EXIT
 
 # Stub codex: print the invocation so assertions can grep it.
 mkdir -p "${test_tmp}/bin"
-printf '%s\n' '#!/usr/bin/env bash' 'printf "STUB-ARGS:%s %s\n" "$1" "$2"' 'printf "STUB-PROMPT:%s\n" "$3"' >"${test_tmp}/bin/codex"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "STUB-ARGS:%s %s %s\n" "$1" "$2" "${3:-}"' 'if [ "${3:-}" = "-" ]; then printf "STUB-PROMPT:%s\n" "$(cat)"; fi' >"${test_tmp}/bin/codex"
 chmod +x "${test_tmp}/bin/codex"
 PATH="${test_tmp}/bin:${PATH}"
 export PATH
@@ -36,7 +36,9 @@ run_tty() {
     if [ "$(uname)" = "Darwin" ]; then
         script -q /dev/null "$@" </dev/null
     else
-        script -qec "$*" /dev/null </dev/null
+        # printf %q keeps argv intact through script -c's shell reparse
+        # (paths with spaces/metacharacters would split under a bare $*).
+        script -qec "$(printf '%q ' "$@")" /dev/null </dev/null
     fi
 }
 
@@ -234,6 +236,15 @@ if out="$( (
 fi
 echo "$out" | grep -q "explicitly disabled" || fail "missing disabled-plugin refusal message: $out"
 
+echo "==> gate: status warns that an armed flag is inert when the plugin is disabled"
+out="$(
+    (
+        export CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data"
+        "${ws}/scripts/codex-gate.sh" status
+    ) 2>&1
+)" || fail "status exited non-zero in disabled-plugin workspace: $out"
+echo "$out" | grep -q "INERT" || fail "status did not flag the inert gate flag: $out"
+
 echo "==> gate: enable refuses in a non-interactive shell"
 if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true "${repo}/scripts/codex-gate.sh" enable </dev/null 2>&1)"; then
     fail "non-interactive enable was accepted (silent arming bypass): $out"
@@ -246,4 +257,4 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (17 cases)"
+echo "codex-review + codex-gate guards OK (18 cases)"

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# test-codex-review.sh — offline unit tests for scripts/codex-review.sh's
+# target selection and prompt assembly. A stub `codex` on PATH records its
+# arguments, so no network, auth, or real review is involved. Guards the
+# regression a real adversarial review caught: with no local main/master and
+# origin/HEAD pointing at another default branch, the base fallback used to
+# strip `origin/` into a nonexistent local ref and silently report nothing
+# to review. Run via `task test:codex-review`.
+set -euo pipefail
+
+repo="$(git rev-parse --show-toplevel)"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+test_tmp="$(mktemp -d)"
+trap 'rm -rf "$test_tmp"' EXIT
+
+# Stub codex: print the invocation so assertions can grep it.
+mkdir -p "${test_tmp}/bin"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "STUB-ARGS:%s %s\n" "$1" "$2"' 'printf "STUB-PROMPT:%s\n" "$3"' >"${test_tmp}/bin/codex"
+chmod +x "${test_tmp}/bin/codex"
+PATH="${test_tmp}/bin:${PATH}"
+export PATH
+
+git_t() {
+    git -c user.email=test@test -c user.name=test "$@"
+}
+
+# Fixture: an upstream whose default branch is `develop` (not main/master),
+# and a clone with only origin/develop plus a feature branch.
+git init -q -b develop "${test_tmp}/upstream"
+(
+    cd "${test_tmp}/upstream"
+    mkdir scripts
+    cp "${repo}/scripts/codex-review.sh" scripts/
+    git add -A
+    git_t commit -q -m base
+)
+git clone -q "${test_tmp}/upstream" "${test_tmp}/clone"
+cd "${test_tmp}/clone"
+git checkout -q -b feature
+git_t commit -q --allow-empty -m work
+git branch -q -D develop
+
+run() {
+    ./scripts/codex-review.sh "$@" 2>&1
+}
+
+echo "==> clean tree, no local main/master: falls back to origin/HEAD's branch"
+out="$(run challenge)" || fail "challenge exited non-zero: $out"
+echo "$out" | grep -q "STUB-ARGS:exec review" || fail "codex exec review not invoked: $out"
+echo "$out" | grep -q "base branch 'origin/develop'" || fail "remote-qualified fallback base missing: $out"
+echo "$out" | grep -q "ADVERSARIAL" || fail "challenge mode instructions missing: $out"
+
+echo "==> explicit --base and focus text reach the prompt"
+out="$(run review --base origin/develop watch the hooks)" || fail "review --base exited non-zero: $out"
+echo "$out" | grep -q "base branch 'origin/develop'" || fail "--base not honored: $out"
+echo "$out" | grep -q "VERIFICATION-CHECKPOINT" || fail "review mode instructions missing: $out"
+echo "$out" | grep -q "watch the hooks" || fail "focus text missing from prompt: $out"
+
+echo "==> dirty tree auto-selects uncommitted scope"
+echo x >dirty.txt
+out="$(run review)" || fail "dirty-tree review exited non-zero: $out"
+echo "$out" | grep -q "uncommitted work" || fail "dirty tree did not select uncommitted scope: $out"
+rm -f dirty.txt
+
+echo "==> clean tree at the base tip reports nothing to review"
+git checkout -q -b tipcheck origin/develop
+out="$(run review)" || fail "nothing-to-review case exited non-zero: $out"
+echo "$out" | grep -q "Nothing to review" || fail "expected nothing-to-review message: $out"
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite nothing to review: $out"
+
+echo "==> bad mode is rejected"
+if out="$(run bogus 2>&1)"; then
+    fail "bogus mode accepted: $out"
+fi
+
+echo "codex-review target selection OK (5 cases)"

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -29,6 +29,17 @@ git_t() {
     git -c user.email=test@test -c user.name=test "$@"
 }
 
+run_tty() {
+    # Gate toggles demand a TTY on stdin; allocate a pty so fixtures can get
+    # past the interactivity guard and exercise the logic behind it (macOS
+    # and util-linux `script` have incompatible CLIs).
+    if [ "$(uname)" = "Darwin" ]; then
+        script -q /dev/null "$@" </dev/null
+    else
+        script -qec "$*" /dev/null </dev/null
+    fi
+}
+
 # Fixture: an upstream whose default branch is `develop` (not main/master),
 # and a clone with only origin/develop plus a feature branch.
 git init -q -b develop "${test_tmp}/upstream"
@@ -65,7 +76,7 @@ echo "$out" | grep -q "base branch 'origin/develop'" || fail "stray local main h
 git branch -q -D main
 
 echo "==> --base with no merge base fails fast"
-unrelated="$(git commit-tree "$(git mktree </dev/null)" -m orphan)"
+unrelated="$(git_t commit-tree "$(git mktree </dev/null)" -m orphan)"
 if out="$(run review --base "$unrelated" 2>&1)"; then
     fail "--base with unrelated history accepted: $out"
 fi
@@ -165,7 +176,10 @@ cat >"${fake_claude}/plugins/installed_plugins.json" <<'JSON'
   }
 }
 JSON
-if out="$(CLAUDE_CONFIG_DIR="$fake_claude" "${repo}/scripts/codex-gate.sh" enable 2>&1)"; then
+if out="$( (
+    export CLAUDE_CONFIG_DIR="$fake_claude"
+    run_tty "${repo}/scripts/codex-gate.sh" enable
+) 2>&1)"; then
     fail "gate enable accepted an install scoped to another repo: $out"
 fi
 echo "$out" | grep -q "not installed" || fail "missing not-installed message for foreign-scoped install: $out"
@@ -191,13 +205,19 @@ cat >"${fake_claude}2/plugins/installed_plugins.json" <<JSON
   }
 }
 JSON
-if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=false "${repo}/scripts/codex-gate.sh" enable 2>&1)"; then
+if out="$( (
+    export CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=false
+    run_tty "${repo}/scripts/codex-gate.sh" enable
+) 2>&1)"; then
     fail "gate armed despite companion ready:false: $out"
 fi
 echo "$out" | grep -q "not ready" || fail "missing not-ready refusal message: $out"
 
 echo "==> gate: arms when the companion reports ready"
-out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true "${repo}/scripts/codex-gate.sh" enable 2>&1)" ||
+out="$( (
+    export CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true
+    run_tty "${repo}/scripts/codex-gate.sh" enable
+) 2>&1)" ||
     fail "gate enable failed with companion ready:true: $out"
 echo "$out" | grep -q "companion invoked: setup --enable-review-gate" || fail "companion toggle not invoked after readiness pass: $out"
 
@@ -206,10 +226,19 @@ ws="${test_tmp}/ws"
 mkdir -p "${ws}/scripts" "${ws}/.claude"
 cp "${repo}/scripts/codex-gate.sh" "${ws}/scripts/"
 printf '%s\n' '{ "enabledPlugins": { "codex@openai-codex": false } }' >"${ws}/.claude/settings.local.json"
-if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true "${ws}/scripts/codex-gate.sh" enable 2>&1)"; then
+if out="$( (
+    export CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true
+    run_tty "${ws}/scripts/codex-gate.sh" enable
+) 2>&1)"; then
     fail "gate armed despite plugin disabled in settings: $out"
 fi
 echo "$out" | grep -q "explicitly disabled" || fail "missing disabled-plugin refusal message: $out"
+
+echo "==> gate: enable refuses in a non-interactive shell"
+if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true "${repo}/scripts/codex-gate.sh" enable </dev/null 2>&1)"; then
+    fail "non-interactive enable was accepted (silent arming bypass): $out"
+fi
+echo "$out" | grep -q "non-interactive" || fail "missing non-interactive enable refusal message: $out"
 
 echo "==> gate: disable refuses in a non-interactive shell"
 if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" "${repo}/scripts/codex-gate.sh" disable </dev/null 2>&1)"; then
@@ -217,4 +246,4 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (16 cases)"
+echo "codex-review + codex-gate guards OK (17 cases)"

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -71,6 +71,19 @@ echo "$out" | grep -q "uncommitted work" || fail "dirty tree did not select unco
 echo "$out" | grep -q "dirty.txt" || fail "untracked file missing from uncommitted manifest: $out"
 rm -f dirty.txt
 
+echo "==> a >200-entry dirty tree still reviews (no SIGPIPE abort) and marks truncation"
+# Top-level files: git status collapses an untracked directory into a single
+# "?? dir/" entry, which would defeat the >200-entry premise.
+i=1
+while [ "$i" -le 250 ]; do
+    : >"bulk_f${i}.txt"
+    i=$((i + 1))
+done
+out="$(run review)" || fail "large dirty tree aborted the review (pipefail/SIGPIPE regression): $out"
+echo "$out" | grep -q "STUB-ARGS:exec review" || fail "codex not invoked on large dirty tree: $out"
+echo "$out" | grep -q "manifest truncated at 200 entries" || fail "truncation marker missing on >200-entry manifest: $out"
+rm -f bulk_f*.txt
+
 echo "==> clean tree at the base tip reports nothing to review"
 git checkout -q -b tipcheck origin/develop
 out="$(run review)" || fail "nothing-to-review case exited non-zero: $out"
@@ -82,4 +95,4 @@ if out="$(run bogus 2>&1)"; then
     fail "bogus mode accepted: $out"
 fi
 
-echo "codex-review target selection OK (5 cases)"
+echo "codex-review target selection OK (6 cases)"

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -95,4 +95,15 @@ if out="$(run bogus 2>&1)"; then
     fail "bogus mode accepted: $out"
 fi
 
-echo "codex-review target selection OK (6 cases)"
+echo "==> invalid explicit targets fail fast without invoking codex"
+if out="$(run review --base no-such-ref 2>&1)"; then
+    fail "--base with an unresolvable ref was accepted: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite bad --base ref: $out"
+echo "$out" | grep -q "does not resolve" || fail "missing fail-fast message for bad --base: $out"
+if out="$(run challenge --commit 0000000000000000000000000000000000000000 2>&1)"; then
+    fail "--commit with an unresolvable sha was accepted: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite bad --commit sha: $out"
+
+echo "codex-review target selection OK (7 cases)"

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -78,12 +78,15 @@ echo "$out" | grep -q "base branch 'origin/develop'" || fail "--base not honored
 echo "$out" | grep -q "VERIFICATION-CHECKPOINT" || fail "review mode instructions missing: $out"
 echo "$out" | grep -q "watch the hooks" || fail "focus text missing from prompt: $out"
 
-echo "==> dirty tree auto-selects uncommitted scope"
+echo "==> dirty tree auto-selects uncommitted scope and enumerates untracked dirs"
 echo x >dirty.txt
+mkdir newdir
+echo y >newdir/inner.txt
 out="$(run review)" || fail "dirty-tree review exited non-zero: $out"
 echo "$out" | grep -q "uncommitted work" || fail "dirty tree did not select uncommitted scope: $out"
 echo "$out" | grep -q "dirty.txt" || fail "untracked file missing from uncommitted manifest: $out"
-rm -f dirty.txt
+echo "$out" | grep -q "newdir/inner.txt" || fail "file inside untracked dir missing from manifest (collapsed to dir entry): $out"
+rm -rf dirty.txt newdir
 
 echo "==> a >200-entry dirty tree still reviews (no SIGPIPE abort) and marks truncation"
 # Top-level files: git status collapses an untracked directory into a single
@@ -127,6 +130,22 @@ fi
 echo "$out" | grep -q "mutually exclusive" || fail "missing conflicting-flags message: $out"
 echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite conflicting flags: $out"
 
+echo "==> --commit manifests cover root and merge commits"
+root_sha="$(git rev-list --max-parents=0 HEAD | tail -1)"
+out="$(run review --commit "$root_sha")" || fail "root-commit review exited non-zero: $out"
+echo "$out" | grep -q "codex-review.sh" || fail "root commit manifest empty (missing --root): $out"
+git checkout -q -b mergetest feature
+git branch -q sidebr "$root_sha"
+git checkout -q sidebr
+echo s >side.txt
+git add side.txt
+git_t commit -q -m side
+git checkout -q mergetest
+git_t merge -q --no-ff -m merge sidebr >/dev/null 2>&1 || fail "fixture merge failed"
+merge_sha="$(git rev-parse HEAD)"
+out="$(run review --commit "$merge_sha")" || fail "merge-commit review exited non-zero: $out"
+echo "$out" | grep -q "side.txt" || fail "merge commit manifest empty (missing -m): $out"
+
 echo "==> gate: another repo's project-scoped plugin install is not accepted"
 fake_claude="${test_tmp}/claude-config"
 mkdir -p "${fake_claude}/plugins"
@@ -150,4 +169,35 @@ if out="$(CLAUDE_CONFIG_DIR="$fake_claude" "${repo}/scripts/codex-gate.sh" enabl
 fi
 echo "$out" | grep -q "not installed" || fail "missing not-installed message for foreign-scoped install: $out"
 
-echo "codex-review + codex-gate guards OK (11 cases)"
+echo "==> gate: refuses to arm when the companion reports not ready"
+fake_plugin="${test_tmp}/fake-plugin"
+mkdir -p "${fake_plugin}/scripts" "${fake_claude}2/plugins"
+cat >"${fake_plugin}/scripts/codex-companion.mjs" <<'MJS'
+const args = process.argv.slice(2);
+if (args.includes("--json")) {
+  console.log(JSON.stringify({ ready: process.env.FAKE_READY === "true" }));
+} else {
+  console.log(`companion invoked: ${args.join(" ")}`);
+}
+MJS
+cat >"${fake_claude}2/plugins/installed_plugins.json" <<JSON
+{
+  "version": 2,
+  "plugins": {
+    "codex@openai-codex": [
+      { "scope": "user", "installPath": "${fake_plugin}", "version": "1.0.6" }
+    ]
+  }
+}
+JSON
+if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=false "${repo}/scripts/codex-gate.sh" enable 2>&1)"; then
+    fail "gate armed despite companion ready:false: $out"
+fi
+echo "$out" | grep -q "not ready" || fail "missing not-ready refusal message: $out"
+
+echo "==> gate: arms when the companion reports ready"
+out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true "${repo}/scripts/codex-gate.sh" enable 2>&1)" ||
+    fail "gate enable failed with companion ready:true: $out"
+echo "$out" | grep -q "companion invoked: setup --enable-review-gate" || fail "companion toggle not invoked after readiness pass: $out"
+
+echo "codex-review + codex-gate guards OK (14 cases)"

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -200,4 +200,14 @@ out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugi
     fail "gate enable failed with companion ready:true: $out"
 echo "$out" | grep -q "companion invoked: setup --enable-review-gate" || fail "companion toggle not invoked after readiness pass: $out"
 
-echo "codex-review + codex-gate guards OK (14 cases)"
+echo "==> gate: refuses when the plugin is explicitly disabled in settings"
+ws="${test_tmp}/ws"
+mkdir -p "${ws}/scripts" "${ws}/.claude"
+cp "${repo}/scripts/codex-gate.sh" "${ws}/scripts/"
+printf '%s\n' '{ "enabledPlugins": { "codex@openai-codex": false } }' >"${ws}/.claude/settings.local.json"
+if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/plugin-data" FAKE_READY=true "${ws}/scripts/codex-gate.sh" enable 2>&1)"; then
+    fail "gate armed despite plugin disabled in settings: $out"
+fi
+echo "$out" | grep -q "explicitly disabled" || fail "missing disabled-plugin refusal message: $out"
+
+echo "codex-review + codex-gate guards OK (15 cases)"


### PR DESCRIPTION
## What

Wires the OpenAI Codex CLI in as an optional **second-model reviewer**, in both layers (root dogfoods it; generated repos opt in via the new `use_codex_review` copier answer, **default off** per the no-SaaS-by-default hard rule). Local and advisory only: nothing runs in CI, no PR check depends on Codex, and `verify`/`ci` never invoke it.

- `task challenge` (→ `challenge:codex`) — adversarial review via `codex exec review`: challenges architecture/approach; hunts authz bypasses, data-loss paths, unsafe rollback, races, hidden coupling, operational failure modes, needless complexity. Supports `-- --base <ref> | --uncommitted | --commit <sha>` plus free-text focus.
- `task review` (→ `review:codex`) — verification-checkpoint review (implementation, consistency, tests) before `task ci`.
- `task codex:gate:enable|disable|status` — toggles the Claude Code codex plugin's automatic stop-gate (Stop hook: Codex reviews each editing turn, `ALLOW:`/`BLOCK:`). The script drives the plugin's own companion runtime with `CLAUDE_PLUGIN_DATA` pinned to its real data dir, so it flips the **same per-workspace flag** as `/codex:setup --enable-review-gate` (verified live: enable → state file `stopReviewGate: true` → disable).
- `.codex/config.toml` — project-level Codex config (review-grade `model_reasoning_effort = "high"`, model unpinned); loads for trusted checkouts.
- AGENTS.md — findings-are-hypotheses adjudication protocol (verify → classify → fix only confirmed → regression-test → explain rejections → adjudication table) with a **3-iteration loop cap** per challenge/review loop; intended flow `check → verify → challenge → review → ci → PR`.
- `docs/guides/codex-review.md` — install/auth, plugin setup, gate mechanics (incl. fail-open when Codex is absent and per-worktree state), troubleshooting.
- `scripts/test-codex-review.sh` (`task test:codex-review`, wired into `verify`/`ci`) — offline stubbed-codex regression tests for target selection.

## ⚠️ Security-relevant settings change (called out per repo policy)

`.claude/settings.json` now declares the `openai-codex` marketplace (`openai/codex-plugin-cc`) and enables `codex@openai-codex`, so **Claude Code auto-offers/installs this third-party plugin for anyone who trusts this folder**. The template ships the same block only when `use_codex_review=true` (the template settings file became `.jinja`; it was already an allowed parity divergence and root-vs-template reconciliation stays manual).

## Dogfood: the adversarial review reviewed itself

`task challenge -- focus on the new codex wiring` ran against this change before commit. Adjudication:

| Finding | Classification | Evidence | Action |
|---|---|---|---|
| [P2] Base fallback strips `origin/` from `origin/HEAD`, producing a possibly nonexistent local ref; `rev-list ... \|\| echo 0` then silently reports "Nothing to review" | **Confirmed** | Reproduced in a fixture repo (default branch `develop`, no local main/master): review was silently skipped | Fixed (keep remote-qualified ref + verify it exists, fail loudly otherwise); regression covered by `scripts/test-codex-review.sh` |

One CLI quirk was also found and fixed during smoke testing: `codex exec review` treats custom instructions as their own review mode (mutually exclusive with `--base`/`--uncommitted`/`--commit`), so the script writes the resolved scope into the instructions.

## Verification

- `task verify` — green (lint, guards, dogfood parity, new unit test, full 7-profile render matrix incl. `full` with `use_codex_review=true` and default-off assertions everywhere else)
- `task security` — green (Semgrep CE, gitleaks, audit)
- `PR_TITLE=... task guard:release-title` — releasing title confirmed (`template/` changed)
- Live smoke: real `codex exec review` adversarial run + gate enable/disable round-trip against the actual plugin state file

🤖 Generated with [Claude Code](https://claude.com/claude-code)