### PR TITLE
fix: keep shipped scripts clear of literal copier markers (standardize-repo scan)

### DIFF
--- a/scripts/format-shell.sh
+++ b/scripts/format-shell.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Format every tracked shell file without splitting paths on whitespace.
 #
-# `git ls-files -z` and a NUL-delimited read keep Copier/Jinja paths such as
-# `template/[% if ... %]/...` intact. `set -o pipefail` ensures a shfmt failure
+# `git ls-files -z` and a NUL-delimited read keep Copier/Jinja paths (a
+# "[%"-delimited conditional dir name) intact. `set -o pipefail` ensures a shfmt failure
 # reaches `task format` instead of being mistaken for an empty file list.
 set -euo pipefail
 

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -81,7 +81,14 @@ fi
 
 echo "==> shell formatter preserves tracked paths and failures"
 format_repo="${test_tmp}/format-repo"
-format_path="${format_repo}/template/[% if sample %]/script with spaces.sh"
+# Assemble the jinja-style segment so this file never contains a literal
+# copier marker: the standardize-repo skill's unrendered-marker scan
+# (verify-applied.sh) would otherwise flag scripts/test-tasks.sh in every
+# generated repo. The RUNTIME path still opens a real block marker ("[%"
+# followed by " if ... %]") plus whitespace — the case format-shell.sh
+# must survive.
+jinja_open='[%'
+format_path="${format_repo}/template/${jinja_open} if sample %]/script with spaces.sh"
 mkdir -p "$(dirname "$format_path")"
 git -C "$format_repo" init -q
 printf '%s\n' '#!/usr/bin/env bash' 'if true;then' 'echo ok' 'fi' >"$format_path"

--- a/template/scripts/format-shell.sh
+++ b/template/scripts/format-shell.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Format every tracked shell file without splitting paths on whitespace.
 #
-# `git ls-files -z` and a NUL-delimited read keep Copier/Jinja paths such as
-# `template/[% if ... %]/...` intact. `set -o pipefail` ensures a shfmt failure
+# `git ls-files -z` and a NUL-delimited read keep Copier/Jinja paths (a
+# "[%"-delimited conditional dir name) intact. `set -o pipefail` ensures a shfmt failure
 # reaches `task format` instead of being mistaken for an empty file list.
 set -euo pipefail
 

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -81,7 +81,14 @@ fi
 
 echo "==> shell formatter preserves tracked paths and failures"
 format_repo="${test_tmp}/format-repo"
-format_path="${format_repo}/template/[% if sample %]/script with spaces.sh"
+# Assemble the jinja-style segment so this file never contains a literal
+# copier marker: the standardize-repo skill's unrendered-marker scan
+# (verify-applied.sh) would otherwise flag scripts/test-tasks.sh in every
+# generated repo. The RUNTIME path still opens a real block marker ("[%"
+# followed by " if ... %]") plus whitespace — the case format-shell.sh
+# must survive.
+jinja_open='[%'
+format_path="${format_repo}/template/${jinja_open} if sample %]/script with spaces.sh"
 mkdir -p "$(dirname "$format_path")"
 git -C "$format_repo" init -q
 printf '%s\n' '#!/usr/bin/env bash' 'if true;then' 'echo ok' 'fi' >"$format_path"


### PR DESCRIPTION
## What / Why

Fixes #348. harmon-init v4.3.0 ships two verbatim (non-jinja) files whose *contents* contain a literal `[%`-style block marker, so the standardize-repo skill's `verify-applied.sh` unrendered-marker scan hard-fails **every** repo updated to v4.3.0 (first hit: evanharmon1/harmon-devkit#116, worked around locally there):

- `scripts/test-tasks.sh` — the whitespace-safety fixture path embedded the marker literally. Now the jinja-style segment is assembled at runtime (`jinja_open='[%'` + concatenation): the **runtime path is byte-identical** to before, so the test still proves `format-shell.sh` survives a real marker-named directory with spaces; only the static source stops matching the scan.
- `scripts/format-shell.sh` — the header comment spelled the delimiter sequence; reworded.

Both changes applied to the root + `template/` twins (byte-equal; `test:dogfood-parity` enforces it).

Deliberately **not** touched: `scripts/test-template.sh` and `scripts/test-dogfood-parity.sh` also match the scan pattern, but they are root-only template-dev tooling that never ships to generated repos, and their marker literals are functional grep patterns for the leak checks they implement.

Chose the template-side fix over the skill-side alternative (excluding `test-tasks.sh` from the scan in harmon-devkit) so the whole fleet is fixed by the next release with no skill change or `.skills-sync.yaml` pin churn.

## Verification

- Swept every verbatim-shipped template file against the skill's exact `marker_re` — only these two matched; both now clean
- `task verify` ✅ · `task ci` ✅
- `task challenge` round 1 found a real P1 (the `format-shell.sh` comment — fixed); round 2 clean pass ✅
- `task review` clean pass ✅ (rendered a generated project and ran the marker scan against it)
- Root/template twins byte-equal; runtime fixture path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)