### PR TITLE
feat: ship the CI result helper regression (test:ci-results) to generated repos

### DIFF
--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -214,8 +214,10 @@ jq -e '.vulnerabilityAlerts.enabled == true' renovate.json >/dev/null ||
     err "Renovate vulnerability-alert remediation must be enabled"
 grep -q '^use_codeql:' .copier-answers.yml || err "answers file does not persist explicit use_codeql intent"
 grep -q '^codeql_languages:' .copier-answers.yml || err "answers file does not persist explicit codeql_languages"
-! grep -q 'task test:ci-results' .github/workflows/build.yml ||
-    err "rendered build workflow references the root-only CI result tests"
+grep -q 'task test:ci-results' .github/workflows/build.yml ||
+    err "rendered build workflow does not run the CI result helper regression (test:ci-results)"
+[ -x scripts/test-ci-results.sh ] || err "CI result helper regression missing or not executable"
+./scripts/test-ci-results.sh >/dev/null || err "rendered CI result helper regression failed"
 [ -x scripts/verify-ci-results.sh ] || err "fail-closed CI result helper missing or not executable"
 EXPECTED_RESULT=success ./scripts/verify-ci-results.sh lint=success security=success >/dev/null ||
     err "rendered CI result helper rejected successful trusted jobs"

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -44,6 +44,7 @@ jobs:
 [% if use_codex_review %]
       - run: task test:codex-review
 [% endif %]
+      - run: task test:ci-results
 [% if use_release_please %]
       - run: task test:release-title
 [% endif %]

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -77,6 +77,7 @@ tasks:
 [% endif %]
       - task: validate
       - task: test:tasks
+      - task: test:ci-results
 [% if use_codex_review %]
       - task: test:codex-review
 [% endif %]
@@ -475,6 +476,11 @@ tasks:
     desc: Guard the Taskfile itself (compiles; setup tasks are safe no-ops)
     cmds:
       - ./scripts/test-tasks.sh
+
+  test:ci-results:
+    desc: Unit-test the fail-closed CI aggregate result helper
+    cmds:
+      - ./scripts/test-ci-results.sh
 [% if use_codex_review %]
 
   test:codex-review:

--- a/template/scripts/test-ci-results.sh
+++ b/template/scripts/test-ci-results.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Hermetic truth-table regressions for the fail-closed CI result helper.
+set -euo pipefail
+
+repo="$(git rev-parse --show-toplevel)"
+verifier="${repo}/scripts/verify-ci-results.sh"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+accept_required() {
+    label="$1"
+    expected="$2"
+    shift 2
+    if ! EXPECTED_RESULT="$expected" "$verifier" "$@" >/dev/null 2>&1; then
+        fail "CI result helper rejected ${label}"
+    fi
+}
+
+reject_required() {
+    label="$1"
+    expected="$2"
+    shift 2
+    if EXPECTED_RESULT="$expected" "$verifier" "$@" >/dev/null 2>&1; then
+        fail "CI result helper accepted ${label}"
+    fi
+}
+
+accept_required "trusted jobs succeeding" success lint=success security=success
+accept_required "fork-suppressed jobs skipping" skipped lint=skipped security=skipped
+reject_required "a skipped trusted job" success lint=success security=skipped
+reject_required "a successful fork-suppressed job" skipped lint=skipped security=success
+reject_required "a failed job" success lint=success security=failure
+reject_required "a cancelled job" success lint=success security=cancelled
+reject_required "an unknown job result" success lint=success security=unknown
+reject_required "an empty result" success lint=success security=
+reject_required "an empty job name" success =success
+reject_required "a malformed pair" success lint
+reject_required "an unsupported expectation" neutral lint=neutral
+reject_required "an empty result set" success
+
+echo "CI result helper truth tables: PASS"


### PR DESCRIPTION
## What

Closes #353 — dogfood-parity gap found during the harmon-infra v4.3.1 update (harmonops/harmon-infra#411): the template ships the fail-closed CI aggregate helper (`verify-ci-results.sh`) that branch-protection aggregates depend on, but not its truth-table regression. Root has `scripts/test-ci-results.sh`; generated repos only had coverage if an update PR hand-copied it.

## Changes

- **`template/scripts/test-ci-results.sh`** — new **verbatim twin** of the root copy (repo-agnostic fixture pairs). `task test:dogfood-parity` now enforces byte-equality going forward.
- **Template Taskfile** — `test:ci-results` task, wired into the generated `verify` right after `test:tasks` (mirrors root's layout).
- **Template `build.yml`** — `task test:ci-results` step in the lint job at root's position (after the codex conditional, before release-title).
- **`scripts/test-template.sh`** — the previous guard asserted rendered repos do **not** reference `test:ci-results` (it was root-only by design); inverted: rendered repos must ship it, have it executable, and it must pass in the render.

## Verification

- `task verify` green (includes dogfood parity + full render checks); `task ci` green.
- `task test:template:all` — all 7 profiles PASS (minimal, update, iac, meta, full, webapp, web) with the new assertions active.
- `task challenge` (Codex adversarial) — clean first pass: "no materially defensible regression was found."
- `task review` (Codex checkpoint) — clean first pass: "no material implementation, coverage, or documentation gaps." (Its one FAIL artifact was its own sandbox lacking npm network access, confirmed by re-running the matrix locally: all PASS.)
- `PR_TITLE=… task guard:release-title` — releasing type confirmed (`template/` change ⇒ `feat:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)