### PR TITLE
fix: require per-thread replies to PR review comments in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,14 @@ something to ask permission for.
   the ruleset would allow it. Open the PR, report that checks pass, then stop;
   merging is always a human decision. (`.claude/settings.json` backstops this
   with `permissions.ask` rules on merge commands.)
+- **Reply to every inline PR review comment in its own thread** — bot
+  reviewers (Codex, CodeRabbit, …) and humans alike. Treat findings as
+  hypotheses: verify each against the code, fix what's confirmed, and post the
+  rejection reasoning with evidence otherwise. Post replies with
+  `gh api repos/{owner}/{repo}/pulls/<n>/comments/<comment-id>/replies -f body=…`
+  (comment IDs from `gh api …/pulls/<n>/comments`). A rollup summary comment
+  on the PR is optional in addition, never a substitute for per-thread
+  replies.
 - Git hooks are managed by **lefthook** (`task install:hooks`); every hook delegates
   to a Taskfile target so local hooks, CI, and manual runs execute identical
   commands. Never bypass hooks with `--no-verify`.

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -114,6 +114,14 @@ something to ask permission for.
   `main` without the maintainer's explicit, per-merge approval, even when CI is
   green and the ruleset would allow it. Open the PR, report that checks pass,
   then stop; merging is always a human decision.
+- **Reply to every inline PR review comment in its own thread** — bot
+  reviewers (Codex, CodeRabbit, …) and humans alike. Treat findings as
+  hypotheses: verify each against the code, fix what's confirmed, and post the
+  rejection reasoning with evidence otherwise. Post replies with
+  `gh api repos/{owner}/{repo}/pulls/<n>/comments/<comment-id>/replies -f body=…`
+  (comment IDs from `gh api …/pulls/<n>/comments`). A rollup summary comment
+  on the PR is optional in addition, never a substitute for per-thread
+  replies.
 [% if use_release_please %]
 - Releases are intentional: release-please keeps a rolling release PR from
   conventional commits; merging it cuts the tag/release. Nothing bumps on a


### PR DESCRIPTION
## What

Adds an explicit rule to the template's `AGENTS.md.jinja` Definition of Done (so every scaffolded repo inherits it on the next `copier update`) and to this repo's own `AGENTS.md` Development Workflow: **every inline PR review comment** from bot reviewers (Codex, CodeRabbit, …) or humans gets a reply in its own thread — the fix applied, or the rejection reasoning with evidence — with the `gh api …/replies` commands inline. A rollup summary comment is optional in addition, never a substitute.

## Why

Maintainer feedback on harmonops/harmon-infra#412: a single rollup adjudication table left the reviewer's four inline threads unanswered. The matching harmon-infra-side change is harmonops/harmon-infra#413; this PR propagates the rule to the template so future scaffolds get it by default.

`fix:` title on purpose — the `template/` change must cut a release for consumers to receive it via `copier update` (pre-flighted with `task guard:release-title`).

## Verification

`task verify` green (lint + template generation tests + gitleaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)