### PR TITLE
fix: install pnpm with Homebrew in generated repos

### DIFF
--- a/scripts/bootstrap-pnpm.sh
+++ b/scripts/bootstrap-pnpm.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Ensure Homebrew owns the active pnpm links, including after legacy bootstraps.
+set -euo pipefail
+
+export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+
+brew install node
+
+# A legacy npm-global link can make `brew install` fail after staging the keg.
+# Continue only when Homebrew confirms the formula is installed; a real install
+# failure with no available keg remains fatal.
+if ! brew install pnpm; then
+    if ! brew list --formula pnpm >/dev/null 2>&1; then
+        echo "bootstrap: Homebrew could not install pnpm" >&2
+        exit 1
+    fi
+fi
+
+brew_prefix=$(brew --prefix)
+legacy_pnpm="${brew_prefix}/lib/node_modules/pnpm"
+
+# Retire only the npm-global package installed into Homebrew's own prefix by
+# older bootstrap versions. An explicit prefix prevents whichever npm happens
+# to be first on PATH from touching nvm, Volta, or another managed toolchain.
+if [ -d "$legacy_pnpm" ]; then
+    npm uninstall --global --prefix "$brew_prefix" pnpm
+fi
+
+# Recreate the links instead of trusting stale linked-keg metadata. Overwriting
+# only Homebrew-prefix links avoids deleting packages managed by npm, nvm, Volta,
+# or another toolchain and leaves Homebrew as the active owner in its prefix.
+brew unlink pnpm >/dev/null 2>&1 || true
+brew link --overwrite pnpm
+
+pnpm_prefix=$(realpath "$(brew --prefix pnpm)")
+pnpm_executable=$(realpath "${brew_prefix}/bin/pnpm")
+case "$pnpm_executable" in
+"${pnpm_prefix}"/*) ;;
+*)
+    echo "bootstrap: pnpm does not resolve to Homebrew's pnpm keg" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/bootstrap-pnpm.sh
+++ b/scripts/bootstrap-pnpm.sh
@@ -32,8 +32,21 @@ fi
 brew unlink pnpm >/dev/null 2>&1 || true
 brew link --overwrite pnpm
 
-pnpm_prefix=$(realpath "$(brew --prefix pnpm)")
-pnpm_executable=$(realpath "${brew_prefix}/bin/pnpm")
+resolve_path() {
+    path=$1
+    while [ -L "$path" ]; do
+        target=$(readlink "$path")
+        case "$target" in
+        /*) path=$target ;;
+        *) path="$(dirname "$path")/$target" ;;
+        esac
+    done
+    directory=$(cd -P "$(dirname "$path")" && pwd)
+    printf '%s/%s\n' "$directory" "$(basename "$path")"
+}
+
+pnpm_prefix=$(resolve_path "$(brew --prefix pnpm)")
+pnpm_executable=$(resolve_path "${brew_prefix}/bin/pnpm")
 case "$pnpm_executable" in
 "${pnpm_prefix}"/*) ;;
 *)

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -29,7 +29,7 @@ fi
 echo "==> bootstrap is a no-op when Homebrew is already installed"
 # Run against STUBS, never the real toolchain. `test:tasks` is part of `verify`,
 # and in a generated use_node repo `bootstrap` runs `brew install node` plus
-# `npm install -g pnpm` — so invoking it for real made running the tests mutate
+# the pnpm bootstrap helper — so invoking it for real made running the tests mutate
 # the developer's machine, and CI too (GitHub's ubuntu images carry linuxbrew on
 # PATH). A test must not install a global toolchain as a side effect.
 #
@@ -37,11 +37,26 @@ echo "==> bootstrap is a no-op when Homebrew is already installed"
 # runs everywhere instead of silently doing nothing on most CI runners.
 bootstrap_bin="${test_tmp}/bootstrap-bin"
 installer_marker="${test_tmp}/homebrew-installer-fetched"
+brew_prefix="${test_tmp}/homebrew"
+pnpm_prefix="${brew_prefix}/opt/pnpm"
 mkdir -p "$bootstrap_bin"
-for stub in brew npm node pnpm; do
+for stub in npm node pnpm; do
     printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"${bootstrap_bin}/${stub}"
     chmod +x "${bootstrap_bin}/${stub}"
 done
+mkdir -p "${brew_prefix}/bin" "${pnpm_prefix}/bin"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"${pnpm_prefix}/bin/pnpm"
+chmod +x "${pnpm_prefix}/bin/pnpm"
+ln -s "${pnpm_prefix}/bin/pnpm" "${brew_prefix}/bin/pnpm"
+cat >"${bootstrap_bin}/brew" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+--prefix) printf '%s\\n' "${brew_prefix}" ;;
+"--prefix pnpm") printf '%s\\n' "${pnpm_prefix}" ;;
+esac
+exit 0
+EOF
+chmod +x "${bootstrap_bin}/brew"
 # Fake curl records any attempt to fetch the Homebrew installer, so we can prove
 # the `command -v brew` guard short-circuited instead of re-running setup.
 cat >"${bootstrap_bin}/curl" <<EOF
@@ -60,6 +75,70 @@ if ! PATH="${bootstrap_bin}:${PATH}" task bootstrap >/dev/null 2>&1; then
 fi
 if [ -f "$installer_marker" ]; then
     fail "task bootstrap fetched the Homebrew installer despite brew being on PATH"
+fi
+
+if [ -x scripts/bootstrap-pnpm.sh ]; then
+    echo "==> pnpm bootstrap migrates legacy npm-global ownership to Homebrew"
+    pnpm_test_bin="${test_tmp}/pnpm-test-bin"
+    pnpm_brew_prefix="${test_tmp}/pnpm-homebrew"
+    pnpm_cellar="${pnpm_brew_prefix}/Cellar/pnpm/11.0.0"
+    pnpm_opt="${pnpm_brew_prefix}/opt/pnpm"
+    pnpm_legacy="${pnpm_brew_prefix}/lib/node_modules/pnpm"
+    pnpm_uninstall_marker="${test_tmp}/pnpm-uninstalled"
+    pnpm_install_entry_marker="${test_tmp}/pnpm-install-entry"
+    mkdir -p "$pnpm_test_bin" "${pnpm_brew_prefix}/bin" "${pnpm_brew_prefix}/opt" "${pnpm_cellar}/bin" "$pnpm_legacy"
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"${pnpm_cellar}/bin/pnpm"
+    chmod +x "${pnpm_cellar}/bin/pnpm"
+    ln -s "$pnpm_cellar" "$pnpm_opt"
+    ln -s "${pnpm_legacy}/bin/pnpm.cjs" "${pnpm_brew_prefix}/bin/pnpm"
+    cat >"${pnpm_test_bin}/brew" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+"install node") : >"${pnpm_install_entry_marker}" ;;
+"install pnpm") exit 1 ;;
+"list --formula pnpm") exit 0 ;;
+bundle\ --file=*)
+    case "\$(readlink "${pnpm_brew_prefix}/bin/pnpm")" in
+    "${pnpm_legacy}"/*) exit 1 ;;
+    esac
+    ;;
+--prefix) printf '%s\\n' "${pnpm_brew_prefix}" ;;
+"--prefix pnpm") printf '%s\\n' "${pnpm_opt}" ;;
+"unlink pnpm")
+    [ ! -L "${pnpm_brew_prefix}/bin/pnpm" ] || unlink "${pnpm_brew_prefix}/bin/pnpm"
+    ;;
+"link --overwrite pnpm")
+    ln -s "${pnpm_cellar}/bin/pnpm" "${pnpm_brew_prefix}/bin/pnpm"
+    ;;
+*) exit 1 ;;
+esac
+EOF
+    chmod +x "${pnpm_test_bin}/brew"
+    cat >"${pnpm_test_bin}/npm" <<EOF
+#!/usr/bin/env bash
+[ "\$*" = "uninstall --global --prefix ${pnpm_brew_prefix} pnpm" ] || exit 1
+rmdir "${pnpm_legacy}"
+: >"${pnpm_uninstall_marker}"
+EOF
+    chmod +x "${pnpm_test_bin}/npm"
+    for stub in pnpm lefthook uv; do
+        printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"${pnpm_test_bin}/${stub}"
+        chmod +x "${pnpm_test_bin}/${stub}"
+    done
+    PATH="${pnpm_test_bin}:${PATH}" ./scripts/bootstrap-pnpm.sh >/dev/null
+    [ -f "$pnpm_uninstall_marker" ] ||
+        fail "pnpm bootstrap did not retire the Homebrew-prefix npm package"
+    [ "$(realpath "${pnpm_brew_prefix}/bin/pnpm")" = "$(realpath "${pnpm_cellar}/bin/pnpm")" ] ||
+        fail "pnpm bootstrap did not transfer executable ownership to Homebrew"
+    if [ "$(grep -c -- './scripts/bootstrap-pnpm.sh' Taskfile.yml)" -ge 2 ]; then
+        unlink "$pnpm_install_entry_marker"
+        unlink "${pnpm_brew_prefix}/bin/pnpm"
+        mkdir -p "$pnpm_legacy"
+        ln -s "${pnpm_legacy}/bin/pnpm.cjs" "${pnpm_brew_prefix}/bin/pnpm"
+        PATH="${pnpm_test_bin}:${PATH}" task install >/dev/null
+        [ -f "$pnpm_install_entry_marker" ] ||
+            fail "task install did not invoke the pnpm ownership migration"
+    fi
 fi
 
 echo "==> Semgrep wrapper preserves explicit scan targets"

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -141,6 +141,10 @@ EOF
     fi
 fi
 
+if [ -n "${HARMON_TEST_PNPM_BOOTSTRAP_ONLY:-}" ]; then
+    exit 0
+fi
+
 echo "==> Semgrep wrapper preserves explicit scan targets"
 semgrep_bin="${test_tmp}/semgrep-bin"
 semgrep_args="${test_tmp}/semgrep-args"

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -125,10 +125,12 @@ EOF
         printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"${pnpm_test_bin}/${stub}"
         chmod +x "${pnpm_test_bin}/${stub}"
     done
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 127' >"${pnpm_test_bin}/realpath"
+    chmod +x "${pnpm_test_bin}/realpath"
     PATH="${pnpm_test_bin}:${PATH}" ./scripts/bootstrap-pnpm.sh >/dev/null
     [ -f "$pnpm_uninstall_marker" ] ||
         fail "pnpm bootstrap did not retire the Homebrew-prefix npm package"
-    [ "$(realpath "${pnpm_brew_prefix}/bin/pnpm")" = "$(realpath "${pnpm_cellar}/bin/pnpm")" ] ||
+    [ "$(readlink "${pnpm_brew_prefix}/bin/pnpm")" = "${pnpm_cellar}/bin/pnpm" ] ||
         fail "pnpm bootstrap did not transfer executable ownership to Homebrew"
     if [ "$(grep -c -- './scripts/bootstrap-pnpm.sh' Taskfile.yml)" -ge 2 ]; then
         unlink "$pnpm_install_entry_marker"

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -212,7 +212,8 @@ if grep -q 'brew "pnpm"' Brewfile; then
     ! grep -q -- '- npm install -g pnpm' Taskfile.yml ||
         err "Node bootstrap must not install pnpm globally with npm"
     if have task; then
-        task test:tasks || err "rendered Node task tests failed"
+        HARMON_TEST_PNPM_BOOTSTRAP_ONLY=1 task test:tasks ||
+            err "rendered Node pnpm bootstrap tests failed"
     else
         required task "rendered Node task tests" || fail=1
     fi

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -191,6 +191,32 @@ fi
 [ -x scripts/run-semgrep.sh ] || err "pinned Semgrep CE runner missing or not executable"
 grep -q 'brew "uv"' Brewfile || err "Brewfile must install uv for the Semgrep runner"
 ! grep -qi 'snyk' Brewfile || err "Brewfile must not install optional Snyk"
+if grep -q 'brew "pnpm"' Brewfile; then
+    sed -n '/^  install:/,/^  install:hooks:/p' Taskfile.yml |
+        grep -q -- '- ./scripts/bootstrap-pnpm.sh' ||
+        err "Node install must invoke pnpm ownership migration"
+    [ -x scripts/bootstrap-pnpm.sh ] ||
+        err "Node bootstrap pnpm migration helper is missing or not executable"
+    grep -q 'brew install node' scripts/bootstrap-pnpm.sh ||
+        err "Node bootstrap must install npm before migrating pnpm ownership"
+    grep -q 'HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1' scripts/bootstrap-pnpm.sh ||
+        err "Node bootstrap must suppress cascading dependent upgrades"
+    grep -q 'brew install pnpm' scripts/bootstrap-pnpm.sh ||
+        err "Node bootstrap must install pnpm with Homebrew"
+    grep -q 'npm uninstall --global --prefix "$brew_prefix" pnpm' scripts/bootstrap-pnpm.sh ||
+        err "Node bootstrap must retire only Homebrew-prefix npm ownership"
+    grep -q 'brew unlink pnpm' scripts/bootstrap-pnpm.sh ||
+        err "Node bootstrap must clear stale Homebrew link metadata"
+    grep -q 'brew link --overwrite pnpm' scripts/bootstrap-pnpm.sh ||
+        err "Node bootstrap must link the pnpm formula"
+    ! grep -q -- '- npm install -g pnpm' Taskfile.yml ||
+        err "Node bootstrap must not install pnpm globally with npm"
+    if have task; then
+        task test:tasks || err "rendered Node task tests failed"
+    else
+        required task "rendered Node task tests" || fail=1
+    fi
+fi
 grep -q '^  security:sast:snyk:' Taskfile.yml || err "explicit optional Snyk SAST target missing"
 grep -q '^  security:sca:snyk:' Taskfile.yml || err "explicit optional Snyk SCA target missing"
 grep -q 'snyk test --all-projects' Taskfile.yml || err "Snyk SCA must scan every detected manifest"

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -685,13 +685,15 @@ tasks:
       # even when there is nothing to install, so guard on `brew` existing.
       - command -v brew >/dev/null 2>&1 || NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 [% if use_node %]
-      - brew install node
-      - npm install -g pnpm
+      - ./scripts/bootstrap-pnpm.sh
 [% endif %]
 
   install:
     desc: Install all project dependencies and tools
     cmds:
+[% if use_node %]
+      - ./scripts/bootstrap-pnpm.sh
+[% endif %]
       # Use THIS repo's Brewfile by absolute path (never a user/global one), and
       # don't cascade-upgrade unrelated already-installed brew dependents.
       - HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew bundle --file={{.ROOT_DIR}}/Brewfile

--- a/template/scripts/[% if use_node %]bootstrap-pnpm.sh[% endif %]
+++ b/template/scripts/[% if use_node %]bootstrap-pnpm.sh[% endif %]
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Ensure Homebrew owns the active pnpm links, including after legacy bootstraps.
+set -euo pipefail
+
+export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+
+brew install node
+
+# A legacy npm-global link can make `brew install` fail after staging the keg.
+# Continue only when Homebrew confirms the formula is installed; a real install
+# failure with no available keg remains fatal.
+if ! brew install pnpm; then
+    if ! brew list --formula pnpm >/dev/null 2>&1; then
+        echo "bootstrap: Homebrew could not install pnpm" >&2
+        exit 1
+    fi
+fi
+
+brew_prefix=$(brew --prefix)
+legacy_pnpm="${brew_prefix}/lib/node_modules/pnpm"
+
+# Retire only the npm-global package installed into Homebrew's own prefix by
+# older bootstrap versions. An explicit prefix prevents whichever npm happens
+# to be first on PATH from touching nvm, Volta, or another managed toolchain.
+if [ -d "$legacy_pnpm" ]; then
+    npm uninstall --global --prefix "$brew_prefix" pnpm
+fi
+
+# Recreate the links instead of trusting stale linked-keg metadata. Overwriting
+# only Homebrew-prefix links avoids deleting packages managed by npm, nvm, Volta,
+# or another toolchain and leaves Homebrew as the active owner in its prefix.
+brew unlink pnpm >/dev/null 2>&1 || true
+brew link --overwrite pnpm
+
+pnpm_prefix=$(realpath "$(brew --prefix pnpm)")
+pnpm_executable=$(realpath "${brew_prefix}/bin/pnpm")
+case "$pnpm_executable" in
+"${pnpm_prefix}"/*) ;;
+*)
+    echo "bootstrap: pnpm does not resolve to Homebrew's pnpm keg" >&2
+    exit 1
+    ;;
+esac

--- a/template/scripts/[% if use_node %]bootstrap-pnpm.sh[% endif %]
+++ b/template/scripts/[% if use_node %]bootstrap-pnpm.sh[% endif %]
@@ -32,8 +32,21 @@ fi
 brew unlink pnpm >/dev/null 2>&1 || true
 brew link --overwrite pnpm
 
-pnpm_prefix=$(realpath "$(brew --prefix pnpm)")
-pnpm_executable=$(realpath "${brew_prefix}/bin/pnpm")
+resolve_path() {
+    path=$1
+    while [ -L "$path" ]; do
+        target=$(readlink "$path")
+        case "$target" in
+        /*) path=$target ;;
+        *) path="$(dirname "$path")/$target" ;;
+        esac
+    done
+    directory=$(cd -P "$(dirname "$path")" && pwd)
+    printf '%s/%s\n' "$directory" "$(basename "$path")"
+}
+
+pnpm_prefix=$(resolve_path "$(brew --prefix pnpm)")
+pnpm_executable=$(resolve_path "${brew_prefix}/bin/pnpm")
 case "$pnpm_executable" in
 "${pnpm_prefix}"/*) ;;
 *)

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -29,7 +29,7 @@ fi
 echo "==> bootstrap is a no-op when Homebrew is already installed"
 # Run against STUBS, never the real toolchain. `test:tasks` is part of `verify`,
 # and in a generated use_node repo `bootstrap` runs `brew install node` plus
-# `npm install -g pnpm` — so invoking it for real made running the tests mutate
+# the pnpm bootstrap helper — so invoking it for real made running the tests mutate
 # the developer's machine, and CI too (GitHub's ubuntu images carry linuxbrew on
 # PATH). A test must not install a global toolchain as a side effect.
 #
@@ -37,11 +37,26 @@ echo "==> bootstrap is a no-op when Homebrew is already installed"
 # runs everywhere instead of silently doing nothing on most CI runners.
 bootstrap_bin="${test_tmp}/bootstrap-bin"
 installer_marker="${test_tmp}/homebrew-installer-fetched"
+brew_prefix="${test_tmp}/homebrew"
+pnpm_prefix="${brew_prefix}/opt/pnpm"
 mkdir -p "$bootstrap_bin"
-for stub in brew npm node pnpm; do
+for stub in npm node pnpm; do
     printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"${bootstrap_bin}/${stub}"
     chmod +x "${bootstrap_bin}/${stub}"
 done
+mkdir -p "${brew_prefix}/bin" "${pnpm_prefix}/bin"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"${pnpm_prefix}/bin/pnpm"
+chmod +x "${pnpm_prefix}/bin/pnpm"
+ln -s "${pnpm_prefix}/bin/pnpm" "${brew_prefix}/bin/pnpm"
+cat >"${bootstrap_bin}/brew" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+--prefix) printf '%s\\n' "${brew_prefix}" ;;
+"--prefix pnpm") printf '%s\\n' "${pnpm_prefix}" ;;
+esac
+exit 0
+EOF
+chmod +x "${bootstrap_bin}/brew"
 # Fake curl records any attempt to fetch the Homebrew installer, so we can prove
 # the `command -v brew` guard short-circuited instead of re-running setup.
 cat >"${bootstrap_bin}/curl" <<EOF
@@ -60,6 +75,70 @@ if ! PATH="${bootstrap_bin}:${PATH}" task bootstrap >/dev/null 2>&1; then
 fi
 if [ -f "$installer_marker" ]; then
     fail "task bootstrap fetched the Homebrew installer despite brew being on PATH"
+fi
+
+if [ -x scripts/bootstrap-pnpm.sh ]; then
+    echo "==> pnpm bootstrap migrates legacy npm-global ownership to Homebrew"
+    pnpm_test_bin="${test_tmp}/pnpm-test-bin"
+    pnpm_brew_prefix="${test_tmp}/pnpm-homebrew"
+    pnpm_cellar="${pnpm_brew_prefix}/Cellar/pnpm/11.0.0"
+    pnpm_opt="${pnpm_brew_prefix}/opt/pnpm"
+    pnpm_legacy="${pnpm_brew_prefix}/lib/node_modules/pnpm"
+    pnpm_uninstall_marker="${test_tmp}/pnpm-uninstalled"
+    pnpm_install_entry_marker="${test_tmp}/pnpm-install-entry"
+    mkdir -p "$pnpm_test_bin" "${pnpm_brew_prefix}/bin" "${pnpm_brew_prefix}/opt" "${pnpm_cellar}/bin" "$pnpm_legacy"
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"${pnpm_cellar}/bin/pnpm"
+    chmod +x "${pnpm_cellar}/bin/pnpm"
+    ln -s "$pnpm_cellar" "$pnpm_opt"
+    ln -s "${pnpm_legacy}/bin/pnpm.cjs" "${pnpm_brew_prefix}/bin/pnpm"
+    cat >"${pnpm_test_bin}/brew" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+"install node") : >"${pnpm_install_entry_marker}" ;;
+"install pnpm") exit 1 ;;
+"list --formula pnpm") exit 0 ;;
+bundle\ --file=*)
+    case "\$(readlink "${pnpm_brew_prefix}/bin/pnpm")" in
+    "${pnpm_legacy}"/*) exit 1 ;;
+    esac
+    ;;
+--prefix) printf '%s\\n' "${pnpm_brew_prefix}" ;;
+"--prefix pnpm") printf '%s\\n' "${pnpm_opt}" ;;
+"unlink pnpm")
+    [ ! -L "${pnpm_brew_prefix}/bin/pnpm" ] || unlink "${pnpm_brew_prefix}/bin/pnpm"
+    ;;
+"link --overwrite pnpm")
+    ln -s "${pnpm_cellar}/bin/pnpm" "${pnpm_brew_prefix}/bin/pnpm"
+    ;;
+*) exit 1 ;;
+esac
+EOF
+    chmod +x "${pnpm_test_bin}/brew"
+    cat >"${pnpm_test_bin}/npm" <<EOF
+#!/usr/bin/env bash
+[ "\$*" = "uninstall --global --prefix ${pnpm_brew_prefix} pnpm" ] || exit 1
+rmdir "${pnpm_legacy}"
+: >"${pnpm_uninstall_marker}"
+EOF
+    chmod +x "${pnpm_test_bin}/npm"
+    for stub in pnpm lefthook uv; do
+        printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"${pnpm_test_bin}/${stub}"
+        chmod +x "${pnpm_test_bin}/${stub}"
+    done
+    PATH="${pnpm_test_bin}:${PATH}" ./scripts/bootstrap-pnpm.sh >/dev/null
+    [ -f "$pnpm_uninstall_marker" ] ||
+        fail "pnpm bootstrap did not retire the Homebrew-prefix npm package"
+    [ "$(realpath "${pnpm_brew_prefix}/bin/pnpm")" = "$(realpath "${pnpm_cellar}/bin/pnpm")" ] ||
+        fail "pnpm bootstrap did not transfer executable ownership to Homebrew"
+    if [ "$(grep -c -- './scripts/bootstrap-pnpm.sh' Taskfile.yml)" -ge 2 ]; then
+        unlink "$pnpm_install_entry_marker"
+        unlink "${pnpm_brew_prefix}/bin/pnpm"
+        mkdir -p "$pnpm_legacy"
+        ln -s "${pnpm_legacy}/bin/pnpm.cjs" "${pnpm_brew_prefix}/bin/pnpm"
+        PATH="${pnpm_test_bin}:${PATH}" task install >/dev/null
+        [ -f "$pnpm_install_entry_marker" ] ||
+            fail "task install did not invoke the pnpm ownership migration"
+    fi
 fi
 
 echo "==> Semgrep wrapper preserves explicit scan targets"

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -141,6 +141,10 @@ EOF
     fi
 fi
 
+if [ -n "${HARMON_TEST_PNPM_BOOTSTRAP_ONLY:-}" ]; then
+    exit 0
+fi
+
 echo "==> Semgrep wrapper preserves explicit scan targets"
 semgrep_bin="${test_tmp}/semgrep-bin"
 semgrep_args="${test_tmp}/semgrep-args"

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -125,10 +125,12 @@ EOF
         printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"${pnpm_test_bin}/${stub}"
         chmod +x "${pnpm_test_bin}/${stub}"
     done
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 127' >"${pnpm_test_bin}/realpath"
+    chmod +x "${pnpm_test_bin}/realpath"
     PATH="${pnpm_test_bin}:${PATH}" ./scripts/bootstrap-pnpm.sh >/dev/null
     [ -f "$pnpm_uninstall_marker" ] ||
         fail "pnpm bootstrap did not retire the Homebrew-prefix npm package"
-    [ "$(realpath "${pnpm_brew_prefix}/bin/pnpm")" = "$(realpath "${pnpm_cellar}/bin/pnpm")" ] ||
+    [ "$(readlink "${pnpm_brew_prefix}/bin/pnpm")" = "${pnpm_cellar}/bin/pnpm" ] ||
         fail "pnpm bootstrap did not transfer executable ownership to Homebrew"
     if [ "$(grep -c -- './scripts/bootstrap-pnpm.sh' Taskfile.yml)" -ge 2 ]; then
         unlink "$pnpm_install_entry_marker"


### PR DESCRIPTION
## What changed

- install Node and pnpm through Homebrew during generated-repo bootstrap
- migrate legacy npm-global pnpm ownership within the Homebrew prefix
- run the migration before `brew bundle` during `task install`
- add behavioral coverage for fresh bootstrap, legacy-link migration, Node/non-Node renders, and the rendered install entry point

## Why

Older generated repositories installed pnpm globally with npm while their Brewfile also declared the Homebrew pnpm formula. That left Homebrew unable to link its formula, causing `task install` to fail repeatedly.

The migration scopes cleanup to Homebrew's own npm prefix, preserves the dependent-upgrade guard, relinks pnpm through Homebrew, and verifies the executable resolves into the Homebrew keg.

## Validation

- `task verify`
- `task ci`
- release-title guard for `fix: install pnpm with Homebrew in generated repos`
