### PR TITLE
fix: bump harmon-devkit skills pin to v0.8.4

### DIFF
--- a/.claude/skills/.SKILLS_PROVENANCE
+++ b/.claude/skills/.SKILLS_PROVENANCE
@@ -1,6 +1,6 @@
 # VENDORED from harmon-devkit — DO NOT EDIT the managed skills here.
 # source: https://github.com/evanharmon1/harmon-devkit.git
-# ref: v0.8.2 (9056b68bb993414da151da19d534e015a18b94b7)
+# ref: v0.8.4 (71b445276696d3070da33ca3a2735aedb9a4c658)
 # path: ai/skills
 # categories: repo
 # managed: standardize-repo

--- a/.claude/skills/standardize-repo/assets/verify-applied.sh
+++ b/.claude/skills/standardize-repo/assets/verify-applied.sh
@@ -381,23 +381,45 @@ if [ "$has_terraform" = true ]; then
         done
     fi
 
-    build_workflow=""
-    for candidate in .github/workflows/build.yml .github/workflows/build.yaml; do
-        if [ -f "$candidate" ]; then
-            build_workflow="$candidate"
-            break
-        fi
+    # The toolchain must be reachable from the workflow that actually runs the
+    # shared gate (`task check`) — split repos provision it there directly
+    # (harmon-infra's validate.yml), while freshly rendered repos provision it
+    # through a local composite action the gate workflow invokes
+    # (.github/actions/setup). Scan the gate workflows plus the composite
+    # actions they reference, so a dead workflow carrying the setup actions
+    # cannot satisfy the contract.
+    gate_provision_files=""
+    for workflow_file in .github/workflows/*.y*ml; do
+        [ -f "$workflow_file" ] || continue
+        grep -q 'task check' "$workflow_file" || continue
+        gate_provision_files="$gate_provision_files$workflow_file
+"
+        while IFS= read -r composite_ref; do
+            [ -n "$composite_ref" ] || continue
+            for composite_file in "$composite_ref"/action.yml "$composite_ref"/action.yaml; do
+                [ -f "$composite_file" ] || continue
+                gate_provision_files="$gate_provision_files$composite_file
+"
+            done
+        done <<<"$(sed -n -E 's|^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*(\./\.github/actions/[A-Za-z0-9_./-]+).*|\1|p' "$workflow_file")"
     done
-    if [ -z "$build_workflow" ]; then
-        err "Terraform is present but no build workflow provisions its lint tools"
+    if [ -z "$gate_provision_files" ]; then
+        err "Terraform is present but no CI workflow runs 'task check' to reach its lint contract"
     else
         for setup_action in \
             'hashicorp/setup-terraform@' \
             'terraform-linters/setup-tflint@' \
             'astral-sh/setup-uv@'; do
-            if ! grep -qE "^[[:space:]]*-[[:space:]]+uses:[[:space:]]+${setup_action}" \
-                "$build_workflow"; then
-                err "$build_workflow does not provision Terraform lint dependency: $setup_action"
+            found_setup=false
+            while IFS= read -r provision_file; do
+                [ -n "$provision_file" ] || continue
+                if grep -qE "^[[:space:]]*-?[[:space:]]*uses:[[:space:]]+${setup_action}" "$provision_file"; then
+                    found_setup=true
+                    break
+                fi
+            done <<<"$gate_provision_files"
+            if [ "$found_setup" = false ]; then
+                err "no 'task check' workflow (or composite action it invokes) provisions Terraform lint dependency: $setup_action"
             fi
         done
     fi
@@ -614,15 +636,42 @@ workflow_job_has_fork_guard() {
 }
 
 required_results_helper="scripts/verify-ci-results.sh"
+# The aggregate job is discovered, not hardcoded: split-workflow repos name
+# their rollups per workflow (`build-verify`, `validate-verify`, …) instead of
+# the template's `verify`. The job that runs the trusted-results helper IS the
+# trusted aggregate for that workflow.
+find_aggregate_job() {
+    # Only 2-space keys inside the jobs: block are job headers — the same
+    # indent appears under on:/permissions:, and a paths: trigger can name
+    # verify-ci-results.sh without being an aggregate job.
+    awk '
+        /^jobs:[ ]*(#.*)?$/ {
+            in_jobs = 1
+            next
+        }
+        in_jobs && /^[A-Za-z0-9_-]+:/ {
+            in_jobs = 0
+        }
+        in_jobs && /^  [A-Za-z0-9_-]+:[ ]*(#.*)?$/ {
+            job = $1
+            sub(/:$/, "", job)
+        }
+        in_jobs && /verify-ci-results\.sh/ && job != "" {
+            print job
+            exit
+        }
+    ' "$1"
+}
 aggregate_workflows=""
-for aggregate_spec in \
-    '.github/workflows/build.yml:verify' \
-    '.github/workflows/build.yaml:verify' \
-    '.github/workflows/devcontainer-build.yml:devcontainer-verify' \
-    '.github/workflows/devcontainer-build.yaml:devcontainer-verify'; do
-    aggregate_workflow="${aggregate_spec%:*}"
-    aggregate_job="${aggregate_spec##*:}"
+for aggregate_workflow in \
+    .github/workflows/build.yml .github/workflows/build.yaml \
+    .github/workflows/devcontainer-build.yml .github/workflows/devcontainer-build.yaml; do
     [ -f "$aggregate_workflow" ] || continue
+    aggregate_job="$(find_aggregate_job "$aggregate_workflow")"
+    if [ -z "$aggregate_job" ]; then
+        err "$aggregate_workflow has no job running $required_results_helper — the trusted aggregate is missing"
+        continue
+    fi
     aggregate_workflows="${aggregate_workflows}${aggregate_workflow}:${aggregate_job}
 "
 done
@@ -713,23 +762,194 @@ if [ -f "$ruleset_file" ]; then
         sed -n -E 's/.*"context"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' \
             "$ruleset_file" | sort -u
     )"
-    expected_contexts="security
-verify"
-    expected_contexts_label="verify + security"
-    if [ "$has_terraform" = true ]; then
-        expected_contexts="$expected_contexts
-terraform-verify"
-        expected_contexts_label="$expected_contexts_label + terraform-verify"
+    has_ruleset_context() {
+        printf '%s\n' "$ruleset_contexts" | grep -qxF "$1"
+    }
+    # A split rollup standing in for the template's verify/security must be
+    # result-gated — it needs `needs:` and must inspect `needs.<leaf>.result`
+    # (or run the trusted-results helper). A job that exists but just echoes
+    # success would launder a failing leaf into a green required check.
+    # DELIBERATE BOUNDARY: this is a drift auditor, not a proof system — it
+    # rejects the launderable shapes (no needs:, or no result inspection at
+    # all) but does not statically prove the shell enforces exact outcomes;
+    # without `if: always()` branch protection is already fail-closed (a
+    # failing leaf skips the rollup and blocks the merge), and exact-contract
+    # verification belongs to the repo's own regression (e.g. harmon-infra's
+    # test-tasks.sh aggregate assertions).
+    # The shipped ruleset stacks a merge_queue rule on the required checks, so
+    # a required context must report on BOTH pull_request and merge_group — a
+    # PR-only workflow wedges the merge queue exactly like a dispatch-only one.
+    workflow_reports_on_protected_events() {
+        awk '
+            BEGIN { in_on = 0; pr = 0; mg = 0 }
+            {
+                line = $0
+                sub(/#.*$/, "", line)
+            }
+            line ~ /^on:/ {
+                in_on = 1
+                if (line ~ /pull_request([^_a-z]|$)/) pr = 1
+                if (line ~ /merge_group([^_a-z]|$)/) mg = 1
+                next
+            }
+            in_on && line ~ /^[A-Za-z_-]+:/ { in_on = 0 }
+            in_on {
+                if (line ~ /pull_request([^_a-z]|$)/) pr = 1
+                if (line ~ /merge_group([^_a-z]|$)/) mg = 1
+            }
+            END { exit(pr && mg ? 0 : 1) }
+        ' "$1"
+    }
+    ruleset_job_is_result_gated() {
+        local context="$1" workflow_file
+        for workflow_file in .github/workflows/*.y*ml; do
+            [ -f "$workflow_file" ] || continue
+            # Bind gating to a workflow that actually reports on protected
+            # events — a stale dispatch-only file containing a gated job must
+            # not vouch for an echo-only job in the reporting workflow.
+            workflow_reports_on_protected_events "$workflow_file" || continue
+            if awk -v target="$context" '
+                function finalize() {
+                    if ((key_match || name_match) && has_needs && gated && always) ok = 1
+                }
+                BEGIN { in_jobs = 0; ok = 0 }
+                {
+                    line = $0
+                    sub(/#.*$/, "", line)
+                }
+                line ~ /^jobs:[ ]*$/ { in_jobs = 1; next }
+                in_jobs && line ~ /^[A-Za-z_-]+:/ { finalize(); in_jobs = 0 }
+                in_jobs && line ~ /^  [A-Za-z0-9_-]+:[ ]*$/ {
+                    finalize()
+                    key_match = (line ~ ("^  " target ":[ ]*$"))
+                    name_match = 0
+                    has_needs = 0
+                    gated = 0
+                    always = 0
+                    next
+                }
+                in_jobs && line ~ ("^    name:[ ]*[\"\047]?" target "[\"\047]?[ ]*$") { name_match = 1 }
+                in_jobs && line ~ /^    needs:/ { has_needs = 1 }
+                in_jobs && line ~ /always\(\)/ { always = 1 }
+                in_jobs && (line ~ /needs\.[A-Za-z0-9_-]+\.result/ || line ~ /verify-ci-results\.sh/) { gated = 1 }
+                END {
+                    finalize()
+                    exit(ok ? 0 : 1)
+                }
+            ' "$workflow_file"; then
+                return 0
+            fi
+        done
+        return 1
+    }
+    require_result_gated_substitute() {
+        local context="$1"
+        if ! ruleset_job_is_result_gated "$context"; then
+            err "$ruleset_file accepts '$context' in place of a template aggregate, but that job is not result-gated (if: always() + needs: + needs.<leaf>.result or verify-ci-results.sh) — GitHub counts a skipped required check as successful, so a non-always() or echo-only rollup launders failing leaves"
+        fi
+    }
+    # Coverage, not exact match: a split-workflow repo satisfies the template's
+    # `verify` with its per-workflow rollups (`build-verify` + `validate-verify`)
+    # and `security` with `security-verify`. Extra required contexts are fine
+    # only when a workflow actually defines that aggregate job — a context no
+    # workflow reports wedges every PR.
+    if has_ruleset_context verify; then
+        # The canonical verify context is an aggregate by design — an
+        # echo-only job named verify outside the audited build workflow must
+        # not satisfy it. (Canonical security is deliberately NOT gated: the
+        # template's security job is a working leaf, not a rollup.)
+        require_result_gated_substitute verify
+    elif has_ruleset_context build-verify && has_ruleset_context validate-verify; then
+        require_result_gated_substitute build-verify
+        require_result_gated_substitute validate-verify
+    else
+        err "$ruleset_file must require 'verify' (or the split 'build-verify' + 'validate-verify'); found: $(printf '%s' "$ruleset_contexts" | tr '\n' ' ')"
     fi
-    if [ "$codeql_required" = true ]; then
-        expected_contexts="$expected_contexts
-codeql-verify"
-        expected_contexts_label="$expected_contexts_label + codeql-verify"
+    if ! has_ruleset_context security; then
+        if has_ruleset_context security-verify; then
+            require_result_gated_substitute security-verify
+        else
+            err "$ruleset_file must require 'security' (or the split 'security-verify'); found: $(printf '%s' "$ruleset_contexts" | tr '\n' ' ')"
+        fi
     fi
-    expected_contexts="$(printf '%s\n' "$expected_contexts" | sort -u)"
-    if [ "$ruleset_contexts" != "$expected_contexts" ]; then
-        err "$ruleset_file required checks must be $expected_contexts_label; found: $(printf '%s' "$ruleset_contexts" | tr '\n' ' ')"
+    if [ "$has_terraform" = true ] && ! has_ruleset_context terraform-verify; then
+        err "$ruleset_file must require 'terraform-verify' when Terraform is present"
     fi
+    if [ "$has_terraform" = false ] && has_ruleset_context terraform-verify; then
+        err "$ruleset_file requires 'terraform-verify' but the repo has no Terraform — the stale check can stop reporting and wedge every PR"
+    fi
+    if [ "$has_terraform" = true ] && has_ruleset_context terraform-verify; then
+        # terraform-verify is an aggregate in the standard (mode-audit: emits
+        # on push/pull_request/merge_group/workflow_dispatch for the trusted
+        # main-apply and manual paths) — existence is not enough.
+        require_result_gated_substitute terraform-verify
+        terraform_events_ok=false
+        for workflow_file in .github/workflows/*.y*ml; do
+            [ -f "$workflow_file" ] || continue
+            grep -qE "^  terraform-verify:[ ]*(#.*)?$" "$workflow_file" || continue
+            if awk '
+                BEGIN { in_on = 0; pr = 0; mg = 0; pu = 0; wd = 0 }
+                {
+                    line = $0
+                    sub(/#.*$/, "", line)
+                }
+                line ~ /^on:/ {
+                    in_on = 1
+                    if (line ~ /pull_request([^_a-z]|$)/) pr = 1
+                    if (line ~ /merge_group([^_a-z]|$)/) mg = 1
+                    if (line ~ /push([^_a-z]|$)/) pu = 1
+                    if (line ~ /workflow_dispatch([^_a-z]|$)/) wd = 1
+                    next
+                }
+                in_on && line ~ /^[A-Za-z_-]+:/ { in_on = 0 }
+                in_on {
+                    if (line ~ /pull_request([^_a-z]|$)/) pr = 1
+                    if (line ~ /merge_group([^_a-z]|$)/) mg = 1
+                    if (line ~ /push([^_a-z]|$)/) pu = 1
+                    if (line ~ /workflow_dispatch([^_a-z]|$)/) wd = 1
+                }
+                END { exit(pr && mg && pu && wd ? 0 : 1) }
+            ' "$workflow_file"; then
+                terraform_events_ok=true
+                break
+            fi
+        done
+        if [ "$terraform_events_ok" = false ]; then
+            err "terraform-verify must emit on push, pull_request, merge_group, and workflow_dispatch (trusted main apply + manual paths) — its workflow is missing one of those triggers"
+        fi
+    fi
+    if [ "$codeql_required" = false ] && has_ruleset_context codeql-verify; then
+        err "$ruleset_file requires 'codeql-verify' but use_codeql is off — the check would never report and wedge every PR"
+    fi
+    if [ "$codeql_required" = true ] && ! has_ruleset_context codeql-verify; then
+        err "$ruleset_file must require 'codeql-verify' when use_codeql is on"
+    fi
+    while IFS= read -r ruleset_context; do
+        [ -n "$ruleset_context" ] || continue
+        context_defined=false
+        context_reports=false
+        for workflow_file in .github/workflows/*.y*ml; do
+            [ -f "$workflow_file" ] || continue
+            # GitHub reports a check under the job-level name: when present,
+            # falling back to the job key — accept either. The name: match is
+            # anchored to the job level (exactly 4-space indent, no list dash)
+            # so a step's `- name:` cannot masquerade as a defined context.
+            if ! grep -qE "^  ${ruleset_context}:[ ]*(#.*)?$" "$workflow_file" &&
+                ! grep -qE "^    name:[[:space:]]*[\"']?${ruleset_context}[\"']?[[:space:]]*(#.*)?$" "$workflow_file"; then
+                continue
+            fi
+            context_defined=true
+            if workflow_reports_on_protected_events "$workflow_file"; then
+                context_reports=true
+                break
+            fi
+        done
+        if [ "$context_defined" = false ]; then
+            err "$ruleset_file requires check '$ruleset_context' but no workflow defines that job — it would never report and wedge every PR"
+        elif [ "$context_reports" = false ]; then
+            err "$ruleset_file requires check '$ruleset_context' but its workflow never triggers on pull_request/merge_group — it would never report and wedge every protected merge"
+        fi
+    done <<<"$ruleset_contexts"
 fi
 
 # ── 3f. CodeQL selection, result truth table, and live capability ──

--- a/.claude/skills/standardize-repo/references/mode-update.md
+++ b/.claude/skills/standardize-repo/references/mode-update.md
@@ -225,6 +225,71 @@ that range even though the file was skipped. Don't assume every renamed file
 needs porting on every update; confirm the delta is non-empty *for this repo's
 answers* before hand-editing.
 
+**Diff the template's script inventory across the range — audit what
+survived the update.** Copier does delete a cleanly-tracked old file when
+the template renames it (delete + add in the re-rendered diff). The orphans
+are the *survivors*: an old copy the repo modified locally, adopted by hand
+(so copier never tracked it), or renamed out of path-match. Any of those
+stays behind silently while every workflow/Taskfile reference to it keeps
+"working" against stale code — so after the update, check each old-side
+inventory entry against the tree and clean up the ones still present:
+
+```bash
+# -r: recurse — shipped subtrees (scripts/foreman/…) hide renames from a
+# top-level listing
+diff <(git -C ~/git/harmon-init ls-tree -r --name-only <old> template/scripts/) \
+     <(git -C ~/git/harmon-init ls-tree -r --name-only <new> template/scripts/)
+```
+
+For each file that disappeared or was renamed: `grep -rn` the repo for
+references, repoint them at the canonical successor, and delete the orphan —
+an intentional repo-owned keeper is the exception, not the default. **Before
+deleting, diff the repo's copy against its own template baseline**
+(`git -C ~/git/harmon-init show <old>:template/<path>` vs the repo file): a
+locally-modified orphan carries repo-specific behavior the canonical
+successor lacks — port that intentional delta to the successor first, the
+same judgment call as any DRIFT.
+
+**The template-side diff cannot see hand-copied ancestors — sweep the
+repo's own inventory too.** A helper the repo adopted by hand (e.g. copied
+from harmon-init's root layer before the template shipped it) was never in
+the `<old>` template tree, so its rename shows up only as the successor's
+*addition* — nothing tells you the old file exists. The five harmon-infra
+orphans were exactly this shape. So, for every script the inventory diff
+ADDS, grep the repo for a predecessor under a different name; and list the
+repo's template-extra scripts outright and judge each one (local keeper vs
+orphan of a new successor):
+
+```bash
+comm -23 <(git ls-files 'scripts/*' | sort) \
+    <(git -C ~/git/harmon-init ls-tree -r --name-only <new> template/scripts/ |
+        sed 's|^template/||' | sort)
+```
+
+Read the output with the gating rule: answer-gated template files appear
+jinja-wrapped in the raw listing (`[% if use_codeql %]…`), so their rendered
+names always show as "repo-extra" here. For each such match, judge by the
+repo's answer — answer ON means the file is canonical (not extra); answer
+OFF (or a feature the template newly gated) means the repo copy is an orphan
+of a disabled feature, exactly the kind this sweep exists to catch. For
+fully repo-local names, decide local keeper vs orphan-of-a-successor as
+above.
+
+Real case (harmon-infra v4.0.0→v4.3.1): five orphans — `shell-quality.sh` (→
+`format-shell.sh` + `lint-shell.sh`), `verify-required-results.sh` (→
+`verify-ci-results.sh`), its truth-table test, and two CodeQL helpers — with
+stale references in two workflows, the Taskfile, and `test-tasks.sh`.
+
+**Answer flips do NOT show in this diff — sweep them explicitly.** A file
+gated on a copier answer (`[% if use_codeql %]…`) exists in the raw template
+tree at *both* refs, so flipping the answer off (e.g. `use_codeql=false`)
+produces an empty inventory diff while still orphaning that feature's
+helpers. Copier deletes the cleanly-tracked rendered copies on the flip, but
+hand-copied or locally-modified ones survive — when an update turns a
+feature answer off, separately `grep -rn` the repo for the disabled
+feature's scripts, workflow steps, Taskfile targets, and doc claims, and
+remove them with the same reference-repoint-then-delete discipline.
+
 ## 3. Reconcile conflicts (in place — no special files)
 
 The three-way merge applies template improvements and keeps the repo's edits when
@@ -302,6 +367,20 @@ git checkout main -- Taskfile.yml   # restore the repo's clean pre-update file
 > `git checkout main -- <file>` + re-applying only the genuinely-new targets is the
 > reliable path (prefer it over `git checkout --ours`, which needs a real merge
 > state a copier conflict may not have).
+
+**Verify the after-side is the same task as the before-side — copier pairs
+hunks positionally, not semantically.** In a heavily-forked file the
+positional neighbor is often a *different* task entirely, so "take the
+template side" — safe-looking for a mechanical hunk — silently swaps or
+deletes repo behavior. Two real cases from one harmon-infra update: a
+conflict paired `security:audit:node` (`npm audit` for the repo's homepage)
+against `./scripts/python-audit.sh` (taking "after" would have replaced the
+Node audit with a duplicate Python audit), and a spanning hunk paired the
+repo's **entire e2e/build/validate task tree** as "before" against one new
+template task block as "after" (taking "after" would have deleted every
+build/validate task in the repo). When the two sides are unrelated, the
+resolution is keep-before **and separately graft** the after-side content at
+its correct location — never a straight take.
 
 **Many near-identical blocks? Rule-resolve them, then hand-do the rest.** A
 heavily-forked repo can surface *dozens* of conflict blocks (harmon-infra: 13

--- a/.skills-sync.yaml
+++ b/.skills-sync.yaml
@@ -8,7 +8,7 @@
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
   # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
-  ref: v0.8.2 # pinned tag — bump deliberately to a released harmon-devkit tag
+  ref: v0.8.4 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
   - repo
 dest: .claude/skills

--- a/template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja
+++ b/template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja
@@ -9,7 +9,7 @@
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
   # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
-  ref: v0.8.2 # pinned tag — bump deliberately to a released harmon-devkit tag
+  ref: v0.8.4 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
 [% for cat in skill_categories %]
   - [[ cat ]]


### PR DESCRIPTION
## What

Devkit pin bump v0.8.2 → v0.8.4 in both layers (root `.skills-sync.yaml` + the template's generated pin), with the mandatory `task sync:skills` re-vendor in the same PR — Renovate can bump the ref but cannot run the re-sync half, and a ref-only change fails `verify:skills`.

The re-vendor delivers the standardize-repo skill fixes from evanharmon1/harmon-devkit#121 + #122 into `.claude/skills/standardize-repo` (verify-applied split-workflow support with the always()-gated rollup and trigger-contract hardening; mode-update orphan-sweep guidance).

## Verification

- `task sync:skills` → vendored 1 skill [repo] @ v0.8.4; `task verify:skills` green
- `task verify` green (full gate incl. render matrix)
- `PR_TITLE=… task guard:release-title` pre-flighted (template/ change ⇒ `fix:`)

## Release note

Suggest merging this **before** the rolling release PR (#359) so v4.4.0 carries the pin bump alongside #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)