### PR TITLE
fix: mark generated checklists as human maintained

### DIFF
--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -1,5 +1,15 @@
 # Post-Generation Checklist — Harmon Init
 
+<!--
+AI AGENTS: This checklist is a human-maintained record for humans to check off.
+Do not check, uncheck, rewrite, remove, reorder, normalize, reconcile, or
+otherwise update its items based on repository state. Do not try to keep it
+consistent with code, configuration, tags, releases, or external services.
+Read-only inspection and reporting are allowed when requested, but never mutate
+checklist state based on the findings. Only edit a checklist item when the human
+user clearly and explicitly asks for that specific checklist update.
+-->
+
 Work through this after generating the repo from harmon-init. Delete items
 that don't apply, then keep this file as a record of what was configured.
 

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -1,5 +1,15 @@
 # Post-Generation Checklist — [[ project_name ]]
 
+<!--
+AI AGENTS: This checklist is a human-maintained record for humans to check off.
+Do not check, uncheck, rewrite, remove, reorder, normalize, reconcile, or
+otherwise update its items based on repository state. Do not try to keep it
+consistent with code, configuration, tags, releases, or external services.
+Read-only inspection and reporting are allowed when requested, but never mutate
+checklist state based on the findings. Only edit a checklist item when the human
+user clearly and explicitly asks for that specific checklist update.
+-->
+
 Work through this after generating the repo from harmon-init. Delete items
 that don't apply, then keep this file as a record of what was configured.
 


### PR DESCRIPTION
## Summary

- mark the root post-generation checklist as a human-maintained record
- add the identical instruction to the generated checklist template
- prohibit agents from mutating checklist state based on inferred repository or external-service state
- preserve requested read-only inspection and reporting

## Why

Checklist markers record the human maintainer's decisions. Agents must not check, uncheck, normalize, reconcile, or otherwise rewrite them unless the user clearly and explicitly requests a specific checklist edit.

## Verification

- `task check`
- `task verify`
- `task challenge -- --uncommitted ...` (clean rerun)
- `task review -- --uncommitted ...` (clean)
- `task ci`
- `PR_TITLE="fix: mark generated checklists as human maintained" BASE_SHA=main task guard:release-title`
- pre-push minimal template render and gitleaks scan

## Review adjudication

| Finding | Classification | Evidence | Action |
| --- | --- | --- | --- |
| Initial wording could prohibit the existing read-only setup-status workflow | Confirmed | `task status:setup` inspects checklist/repository state without editing the checklist | Clarified that requested read-only inspection and reporting are allowed, while mutation based on findings remains prohibited |