### PR TITLE
fix: sync harmon-devkit skills to v0.8.7

### DIFF
--- a/.claude/skills/.SKILLS_PROVENANCE
+++ b/.claude/skills/.SKILLS_PROVENANCE
@@ -1,6 +1,6 @@
 # VENDORED from harmon-devkit — DO NOT EDIT the managed skills here.
 # source: https://github.com/evanharmon1/harmon-devkit.git
-# ref: v0.8.4 (71b445276696d3070da33ca3a2735aedb9a4c658)
+# ref: v0.8.7 (4f9bc054bd4467aa1f2d541a524ffdcb43df034b)
 # path: ai/skills
 # categories: repo
 # managed: standardize-repo

--- a/.claude/skills/standardize-repo/SKILL.md
+++ b/.claude/skills/standardize-repo/SKILL.md
@@ -35,8 +35,11 @@ or widen access to credentials, or weaken a workflow merely to make CI green.
 Verify these before doing anything; stop and tell the user if one is unmet.
 
 - **copier** installed — `copier --version` (needs `>= 9.4.0`, per `_min_copier_version`).
-- **harmon-init** cloned locally at `~/git/harmon-init`. If missing:
+- **harmon-init** cloned locally at `~/git/harmon-init` for **new-repo**,
+  **adopt-existing**, and **update** modes. If missing in one of those modes:
   `git clone https://github.com/evanharmon1/harmon-init ~/git/harmon-init`.
+  **Audit mode does not require a local checkout**; its guarded drift helper
+  snapshots the canonical remote itself.
 - **task** (go-task) on PATH — `task --version` — for the verification gate.
 - **gh** authenticated (`gh auth status`) — only needed for the GitHub side-effect
   steps (remote create, release init). Not required for local scaffolding.
@@ -60,18 +63,27 @@ differently.
 
 These are load-bearing. Full rationale and edge cases in `references/copier-gotchas.md`.
 
-- **Production scaffolds use the canonical GitHub URL at a released ref.** Run
-  `copier copy --trust --vcs-ref=v3.26.1
-  https://github.com/evanharmon1/harmon-init.git <dest> ...` (substitute the
-  reviewed current release). This records durable lineage that another machine
-  can resolve. A local-path `--vcs-ref=HEAD` render is only for a disposable
+- **Production scaffolds use the canonical GitHub URL at a remote-verified
+  release ref.** Select `HARMON_INIT_REF`, verify that exact tag against
+  `origin`, peel it once to `HARMON_INIT_COMMIT`, and pass that immutable commit
+  to Copier using the guarded commands in the applicable mode reference. Update
+  mode must also resolve the recorded `_commit` once, require maintainer-approved
+  recovery when legacy tag-only lineage lacks immutable evidence, and run every
+  trusted render from a read-only offline clone through process-scoped Git URL
+  rewrites.
+  Prove the target descends from the resolved baseline before rendering. This
+  records durable lineage that another machine can resolve without allowing a
+  retag between validation and trusted template execution. A local-path
+  `--vcs-ref=HEAD` render is only for a disposable
   preview/test of unreleased template work. Copier may represent dirty local work
   with a throwaway commit that does not exist on GitHub; never promote that render
   by rewriting only `_src_path`. The recorded `_src_path` and `_commit` are one
   lineage tuple: before changing a local path to the canonical URL, prove the
   recorded commit is reachable from that remote, or re-render/re-adopt from a
-  released remote ref. A normal `copier update` reuses that tuple and takes no
-  `--vcs-ref`. See `copier-gotchas.md` gotchas 1 and 8.
+  released remote ref. An update must reject a non-canonical recorded source and
+  pass the immutable commit derived from the remote-verified `HARMON_INIT_REF`
+  so preview and apply cannot select different releases. See
+  `copier-gotchas.md` gotchas 1 and 8.
 - **Side-effectful answers default to `no`** in `copier.yml` (`github_remote_create`,
   `github_release_init`, `bunch_add`, `obsidian_project_add`, `run_task_install`).
   Leave them off unless the user explicitly asks; only flip them on with confirmation.
@@ -81,9 +93,12 @@ These are load-bearing. Full rationale and edge cases in `references/copier-gotc
 
   ```bash
   copier copy https://github.com/evanharmon1/harmon-init.git ./new-project \
-    --vcs-ref=v3.26.1 --trust \
+    --vcs-ref="$HARMON_INIT_COMMIT" --trust \
     --data project_name="My Project" --data project_type=general --defaults
   ```
+
+  This is only the command shape; run the release-tag validation and derive
+  `HARMON_INIT_COMMIT` in `references/mode-new-repo.md` before executing it.
 
 - **Validate after every apply.** Re-running `copier` or changing answers can churn
   files — confirm the result with the verification step below before committing.
@@ -98,7 +113,7 @@ The asked questions live in `~/git/harmon-init/copier.yml` (e.g. `project_name`,
 [general / web-astro / web-app / iac / docs], `snyk_scan_schedule`
 [off / weekly / daily], `include_terraform`, `include_ansible`, `ci_runner`,
 `license`, `use_codeql`, `codeql_languages`, `use_release_please`, `devcontainer`,
-`git_init`). Read that file to
+`use_codex_review`, `use_coderabbit`, `git_init`). Read that file to
 confirm names/choices/defaults before scaffolding — do not invent answers.
 
 ## Standards catalog

--- a/.claude/skills/standardize-repo/assets/diff-template.sh
+++ b/.claude/skills/standardize-repo/assets/diff-template.sh
@@ -27,7 +27,8 @@
 #
 # Usage: diff-template.sh [-v|--show] [TARGET_DIR]   (default target: .)
 #        Flags and the target dir may appear in any order.
-# Env:   HARMON_INIT   template checkout (default: ~/git/harmon-init)
+# Env:   HARMON_INIT   explicitly prepared template checkout (advanced/test use)
+#        HARMON_INIT_RECORDED_COMMIT immutable commit in that checkout
 #
 # Exit: 0 = no drift, 1 = drift found (for callers that want a signal), 2 = setup error.
 # Portable to macOS bash 3.2 (no mapfile, no grep -P, no associative arrays).
@@ -53,7 +54,13 @@ while [ $# -gt 0 ]; do
     shift
 done
 [ -n "$target" ] || target="."
-template="${HARMON_INIT:-$HOME/git/harmon-init}"
+template_is_explicit=0
+if [ "${HARMON_INIT+x}" = x ]; then
+    template_is_explicit=1
+    template="$HARMON_INIT"
+else
+    template="$HOME/git/harmon-init"
+fi
 here="$(cd "$(dirname "$0")" && pwd)"
 manifest="$here/template-owned-files.txt"
 
@@ -64,10 +71,13 @@ for t in copier yq; do
         exit 2
     }
 done
-[ -d "$template" ] || {
-    echo "FAIL: template not found at $template (set HARMON_INIT)" >&2
-    exit 2
-}
+if [ "$template_is_explicit" -eq 1 ] ||
+    [ -n "${HARMON_INIT_RECORDED_COMMIT:-}" ]; then
+    [ -d "$template" ] || {
+        echo "FAIL: prepared template not found at $template" >&2
+        exit 2
+    }
+fi
 [ -f "$manifest" ] || {
     echo "FAIL: manifest not found at $manifest" >&2
     exit 2
@@ -81,7 +91,7 @@ answers="$target/.copier-answers.yml"
 }
 
 workdir="$(mktemp -d -t harmon-init-render-XXXXXX)"
-trap 'rm -rf "$workdir"' EXIT
+trap 'chmod -R u+w "$workdir" 2>/dev/null || true; rm -rf "$workdir"' EXIT
 render="$workdir/render"
 index_root="$workdir/index-snapshot"
 
@@ -92,6 +102,19 @@ index_root="$workdir/index-snapshot"
 # render for every repo whose answers record it (_commit >= v3.23.0).
 datafile="$workdir/answers-data.yml"
 yq 'with_entries(select((.key | test("^_") | not) and (.value != null)))' "$answers" >"$datafile"
+
+# The fleet policy treats a legacy answer file that predates use_coderabbit as
+# opted out. Its recorded template baseline may still render .coderabbit.yaml
+# unconditionally, so apply that effective answer when interpreting drift
+# rather than telling an agent to restore the intentionally removed file.
+effective_use_coderabbit="$(yq -r '.use_coderabbit // false' "$answers" 2>/dev/null || echo false)"
+case "$effective_use_coderabbit" in
+true | false) ;;
+*)
+    echo "FAIL: use_coderabbit must be true or false in $answers" >&2
+    exit 2
+    ;;
+esac
 
 # Force every side-effect off in the throwaway render (`--data` wins over
 # `--data-file`).
@@ -111,6 +134,109 @@ data_args=(
 # Falls back to HEAD if _commit is somehow absent.
 src_ref="$(yq -r '._commit // "HEAD"' "$answers" 2>/dev/null || echo HEAD)"
 [ -n "$src_ref" ] || src_ref=HEAD
+
+# A normal audit must not trust a mutable tag in the caller's default local
+# harmon-init checkout. Snapshot the canonical remote, freeze the recorded
+# baseline, and render from that no-remote read-only clone. An explicit
+# HARMON_INIT is reserved for callers (such as guarded update mode and hermetic
+# tests) that already prepared their own trust boundary.
+if [ -n "${HARMON_INIT_RECORDED_COMMIT:-}" ]; then
+    case "$HARMON_INIT_RECORDED_COMMIT" in
+    *[!0-9a-fA-F]*)
+        echo "FAIL: HARMON_INIT_RECORDED_COMMIT must be a 40-character commit" >&2
+        exit 2
+        ;;
+    esac
+    [ "${#HARMON_INIT_RECORDED_COMMIT}" -eq 40 ] || {
+        echo "FAIL: HARMON_INIT_RECORDED_COMMIT must be a 40-character commit" >&2
+        exit 2
+    }
+    git -C "$template" cat-file -e "$HARMON_INIT_RECORDED_COMMIT^{commit}" ||
+        {
+            echo "FAIL: prepared template lacks HARMON_INIT_RECORDED_COMMIT" >&2
+            exit 2
+        }
+    src_ref="$HARMON_INIT_RECORDED_COMMIT"
+elif [ "$template_is_explicit" -eq 0 ]; then
+    canonical_source=https://github.com/evanharmon1/harmon-init
+    recorded_source="$(yq -r '._src_path // ""' "$answers")"
+    case "$recorded_source" in
+    "$canonical_source" | "$canonical_source.git") ;;
+    *)
+        echo "FAIL: recorded _src_path is not canonical harmon-init" >&2
+        exit 2
+        ;;
+    esac
+    [ "$src_ref" != HEAD ] || {
+        echo "FAIL: recorded _commit is required for a guarded audit" >&2
+        exit 2
+    }
+    remote_tag_object=""
+    if printf '%s\n' "$src_ref" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+        :
+    elif printf '%s\n' "$src_ref" | grep -Eq '^[0-9a-fA-F]{7,39}$'; then
+        echo "FAIL: abbreviated recorded commits are not accepted" >&2
+        exit 2
+    else
+        [ "${ACCEPT_LEGACY_BASELINE:-}" = true ] || {
+            echo "FAIL: tag-valued baseline needs maintainer-approved ACCEPT_LEGACY_BASELINE=true" >&2
+            exit 2
+        }
+        remote_tag_object="$(
+            git ls-remote --exit-code "$canonical_source" "refs/tags/$src_ref" |
+                awk 'NR == 1 { print $1 }'
+        )" || {
+            echo "FAIL: recorded tag is not present on canonical harmon-init" >&2
+            exit 2
+        }
+        [ -n "$remote_tag_object" ] || {
+            echo "FAIL: canonical recorded tag resolved to no object" >&2
+            exit 2
+        }
+    fi
+    guarded_template="$workdir/guarded-template"
+    git clone --no-checkout "$canonical_source" "$guarded_template" >/dev/null 2>&1 ||
+        {
+            echo "FAIL: cannot snapshot canonical harmon-init" >&2
+            exit 2
+        }
+    if [ -n "$remote_tag_object" ]; then
+        [ "$(git -C "$guarded_template" rev-parse "refs/tags/$src_ref")" = \
+            "$remote_tag_object" ] || {
+            echo "FAIL: recorded tag changed during guarded audit preparation" >&2
+            exit 2
+        }
+    fi
+    recorded_commit="$(git -C "$guarded_template" rev-parse "$src_ref^{commit}")" ||
+        {
+            echo "FAIL: recorded baseline is not a commit in canonical harmon-init" >&2
+            exit 2
+        }
+    git -C "$guarded_template" merge-base --is-ancestor \
+        "$recorded_commit" origin/main || {
+        echo "FAIL: recorded baseline is not on canonical origin/main" >&2
+        exit 2
+    }
+    v3_commit="$(git -C "$guarded_template" rev-parse "v3.0.0^{commit}")" ||
+        {
+            echo "FAIL: cannot resolve the v3 migration boundary" >&2
+            exit 2
+        }
+    git -C "$guarded_template" merge-base --is-ancestor \
+        "$v3_commit" "$recorded_commit" || {
+        echo "FAIL: recorded baseline predates v3; use adoption mode" >&2
+        exit 2
+    }
+    if git -C "$guarded_template" cat-file -e \
+        "$recorded_commit:.gitmodules" 2>/dev/null; then
+        echo "FAIL: guarded audits do not support template submodules" >&2
+        exit 2
+    fi
+    git -C "$guarded_template" remote remove origin
+    chmod -R a-w "$guarded_template"
+    template="$guarded_template"
+    src_ref="$recorded_commit"
+fi
 
 copier copy "$template" "$render" --vcs-ref="$src_ref" --trust --defaults \
     --data-file "$datafile" "${data_args[@]}" >/dev/null 2>&1 || {
@@ -173,6 +299,18 @@ mode_count=0
 missing_count=0
 while IFS= read -r f; do
     case "$f" in '' | \#*) continue ;; esac
+    if [ "$f" = ".coderabbit.yaml" ] && [ "$effective_use_coderabbit" = "false" ]; then
+        checked=$((checked + 1))
+        rv="$(repo_variant "$f")"
+        if [ -n "$rv" ]; then
+            echo "DRIFT    .coderabbit.yaml  (CodeRabbit is disabled by the effective answer)"
+            drift=1
+            drift_count=$((drift_count + 1))
+        else
+            echo "ABSENT   .coderabbit.yaml  (CodeRabbit disabled — expected)"
+        fi
+        continue
+    fi
     [ -f "$render/$f" ] || continue # conditional file not in this profile
     checked=$((checked + 1))
     rv="$(repo_variant "$f")"

--- a/.claude/skills/standardize-repo/references/copier-gotchas.md
+++ b/.claude/skills/standardize-repo/references/copier-gotchas.md
@@ -22,11 +22,20 @@ state with zero warning.
 the **latest git tag**, not your working tree. All uncommitted AND committed-but-
 untagged work is silently ignored.
 
-**Rule:** Production scaffolds use the canonical URL and a released ref, for
-example `copier copy --trust --vcs-ref=v3.26.1
-https://github.com/evanharmon1/harmon-init.git <dest>`. Pass `--vcs-ref=HEAD`
-only when rendering from a local checkout into a disposable preview/test. With
-it, copier auto-includes dirty **and** untracked changes via a
+**Rule:** Production scaffolds use the canonical URL and the remote-verified
+`HARMON_INIT_REF` flow in `mode-new-repo.md`. Update mode additionally resolves
+the target tag once, resolves the recorded `_commit` once, and puts both commits
+in a read-only clone with no remote. Copier may re-describe a commit to a tag,
+but every nested clone then uses the same frozen local tag mapping instead of
+refetching mutable remote state. Process-scoped Git URL rewrites bind Copier's
+canonical source URL to that clone. The destination's ignored
+`.copier-guarded-update/` state directory preserves the original answers and
+checkout identity so interrupted runs remain recoverable.
+Legacy tag-only baselines require the explicit recovery path in
+`mode-update.md`; their original commit cannot be proven retroactively. Pass
+`--vcs-ref=HEAD` only when rendering from a local checkout into a disposable
+preview/test. With it, copier auto-includes
+dirty **and** untracked changes via a
 throwaway `wip` commit in a temporary clone (you'll see a `DirtyLocalWarning`). Your
 real working tree is never touched. `scripts/test-template.sh` always passes
 `--vcs-ref=HEAD` — mirror that for any manual render of work-in-progress.

--- a/.claude/skills/standardize-repo/references/mode-adopt-existing.md
+++ b/.claude/skills/standardize-repo/references/mode-adopt-existing.md
@@ -9,7 +9,8 @@ work on a feature branch the whole time.
 For Copier mechanics (custom `[[ ]]`/`[% %]` jinja delimiters, released production
 refs versus local-preview `--vcs-ref=HEAD`, `--trust`, side-effect answers) see
 [`copier-gotchas.md`](./copier-gotchas.md). For the GitHub-side wiring after the
-files land (branch ruleset import, Renovate/CodeRabbit apps, Actions secrets, etc.)
+files land (branch ruleset import, Renovate and optional CodeRabbit apps, Actions
+secrets, etc.)
 see [`post-generation-checklist.md`](./post-generation-checklist.md).
 
 ---
@@ -75,6 +76,8 @@ Defaults worth knowing so you only override what's wrong (from `copier.yml`):
 - `ci_runner` defaults to `ubuntu-latest` (alt: `self-hosted`).
 - `license` defaults to `mit` (alt: `private`).
 - `use_release_please` and `devcontainer` default to **yes**.
+- `use_coderabbit` defaults to **no**. Keep it false unless this repository is
+  deliberately retaining the CodeRabbit GitHub App.
 - **All side-effect answers must stay `no`** when adopting: `git_init`,
   `github_remote_create`, `github_release_init`, `bunch_add`,
   `obsidian_project_add`, `run_task_install`. The repo already exists and has a
@@ -98,11 +101,13 @@ Defaults worth knowing so you only override what's wrong (from `copier.yml`):
 
 If a `.copier-answers.yml` exists at the repo root, the repo is already linked to
 the template. Update in place; copier performs a three-way merge between the old
-template output, the new template output, and your current files:
+template output, the new template output, and your current files. Follow
+[`mode-update.md`](./mode-update.md) end to end: it remote-verifies and pins the
+target release, collects the CodeRabbit decision (including for legacy answer
+files), and passes the identical reviewed answers to preview and apply.
 
 ```bash
-ls .copier-answers.yml          # present → use update
-copier update --trust --defaults
+ls .copier-answers.yml # present → use mode-update.md
 ```
 
 `--defaults` is **required non-interactively** — without a TTY copier crashes trying
@@ -112,10 +117,10 @@ to prompt (`OSError: [Errno 22]`). See [`mode-update.md`](./mode-update.md) §2.
 `.copier-answers.yml`, whose `_src_path` and `_commit` must form a resolvable
 lineage tuple (see [copier-gotchas.md](./copier-gotchas.md) gotcha 8; never
 normalize only a local path unless the recorded commit is reachable from the
-canonical remote). **Always do a full update to the latest released version** —
-plain `copier update` goes to harmon-init's newest tag and three-way-merges the whole
-delta into your files; don't scope it to a specific intermediate version. Override
-stale answers with `--data key=value` as needed (e.g. a changed `github_org`).
+canonical remote). **Always do a full update to the deliberately selected latest
+release** and pass that same ref to preview and apply. Override stale answers
+with `--data key=value` as needed (e.g. `use_coderabbit` or a changed
+`github_org`).
 (`--vcs-ref=HEAD` is only for a *template developer* testing unreleased local
 changes — never for a normal update.)
 
@@ -132,14 +137,34 @@ write `.copier-answers.yml` so future runs can use `copier update`:
 ```bash
 ls .copier-answers.yml          # absent → adopt fresh
 : "${USE_CODEQL:?set USE_CODEQL=true or false after the capability review}"
-copier copy --trust https://github.com/evanharmon1/harmon-init.git . \
-  --vcs-ref=v3.26.1 --defaults --overwrite \
+: "${HARMON_INIT_REF:?set to a released harmon-init tag whose copier.yml defines use_coderabbit}"
+HARMON_INIT_SOURCE=https://github.com/evanharmon1/harmon-init
+git -C ~/git/harmon-init fetch "$HARMON_INIT_SOURCE" \
+  '+refs/heads/main:refs/remotes/origin/main' --tags ||
+  { echo "failed to refresh harmon-init from origin" >&2; exit 1; }
+REMOTE_TAG_OBJECT="$(
+  git -C ~/git/harmon-init ls-remote --exit-code "$HARMON_INIT_SOURCE" \
+    "refs/tags/$HARMON_INIT_REF" |
+    awk 'NR == 1 { print $1 }'
+)" ||
+  { echo "HARMON_INIT_REF is not a tag published by origin" >&2; exit 1; }
+test -n "$REMOTE_TAG_OBJECT" &&
+  test "$(git -C ~/git/harmon-init rev-parse "refs/tags/$HARMON_INIT_REF")" = "$REMOTE_TAG_OBJECT" &&
+  git -C ~/git/harmon-init merge-base --is-ancestor "$HARMON_INIT_REF^{commit}" origin/main ||
+  { echo "HARMON_INIT_REF must exactly match a release tag on origin/main" >&2; exit 1; }
+HARMON_INIT_COMMIT="$(git -C ~/git/harmon-init rev-parse "$HARMON_INIT_REF^{commit}")"
+git -C ~/git/harmon-init show "$HARMON_INIT_COMMIT":copier.yml |
+  grep -q '^use_coderabbit:' ||
+  { echo "HARMON_INIT_REF does not support the CodeRabbit choice" >&2; exit 1; }
+copier copy --trust "$HARMON_INIT_SOURCE" . \
+  --vcs-ref="$HARMON_INIT_COMMIT" --defaults --overwrite \
   --data project_type="$PROJECT_TYPE" \
   --data project_name="<Formal Project Name>" \
   --data project_slug="$(basename "$(pwd)")" \
   --data github_org="<org-or-user>" \
   --data use_codeql="$USE_CODEQL" \
   --data codeql_languages="$CODEQL_LANGUAGES" \
+  --data use_coderabbit=false \
   --data git_init=false \
   --data github_remote_create=false --data github_release_init=false \
   --data bunch_add=false --data obsidian_project_add=false --data run_task_install=false
@@ -147,10 +172,16 @@ copier copy --trust https://github.com/evanharmon1/harmon-init.git . \
   #   defaults from the stale .copier-answers.yml, so they do NOT "default to no".
 ```
 
-`v3.26.1` is the current reviewed release example; deliberately select a newer
-released ref when appropriate. Local `--vcs-ref=HEAD` adoption is for a disposable
-preview only, never the production apply: dirty local renders can record a
-throwaway `_commit` that no later remote update can resolve.
+The `use_coderabbit` answer is introduced by the companion harmon-init change.
+Release this skill first so harmon-init can refresh its pinned vendored copy,
+then merge and release harmon-init. Until that supporting template release
+exists, the guard above intentionally blocks adoption. Older releases (including
+v4.4.0 and v3.26.1) render CodeRabbit unconditionally. Local `--vcs-ref=HEAD`
+adoption is for a disposable preview only, never the production apply: dirty
+local renders can record a throwaway `_commit` that no later remote update can
+resolve. Production adoption passes the peeled `HARMON_INIT_COMMIT` derived from
+the remote-verified tag, preventing a retag between validation and Copier's
+trusted template checkout from changing which tasks execute.
 
 Set `USE_CODEQL` and `CODEQL_LANGUAGES` deliberately before rendering. Use
 `true` only when supported first-party JS/TS or Python source is present and Code
@@ -293,13 +324,10 @@ after the copier run:
    docs with real content — fold them into the standard locations.
 
 3. **Leave YAML extensions alone.** Do not rename `.yaml`↔`.yml`. Each tool
-   keeps its own conventional extension (`Taskfile.yml`, `.coderabbit.yaml`,
+   keeps its own conventional extension (`Taskfile.yml`, `.yamllint.yml`;
    GitHub Actions accepts either) — homogenizing extensions across the repo is
-   not a goal.
-
-   (Note `.coderabbit.yaml` is intentionally `.yaml` — leave it.) After renaming,
-   update any branch-ruleset required-check contexts that referenced the old job
-   names (see `post-generation-checklist.md`).
+   not a goal. After renaming, update any branch-ruleset required-check contexts
+   that referenced the old job names (see `post-generation-checklist.md`).
 
 4. **Add `# renovate:` annotations to tool pins.** Inline tool-version pins in
    workflows must carry a renovate annotation so updates are automated and pins

--- a/.claude/skills/standardize-repo/references/mode-audit.md
+++ b/.claude/skills/standardize-repo/references/mode-audit.md
@@ -38,11 +38,12 @@ TEMPLATE=~/git/harmon-init           # source of truth
      canonical remote (a real finding — see
      [copier-gotchas.md](./copier-gotchas.md) gotcha 8 / [mode-update.md](./mode-update.md) §2).
    - Absent → it was never templated (or was adopted by a raw `copier copy`).
-     Reconciling the templated bits means a fresh adopt:
-     `copier copy --trust --vcs-ref=v3.26.1
-     https://github.com/evanharmon1/harmon-init.git .` (substitute the reviewed
-     current release; see §4). Treat
-     every catalog area as hand-verifiable rather than diff-against-answers.
+     Reconciling the templated bits means a fresh adopt, but only from a released
+     harmon-init tag whose `copier.yml` defines `use_coderabbit`. Use the
+     `HARMON_INIT_REF` guard and explicit answer in
+     [mode-adopt-existing.md](./mode-adopt-existing.md), Path B; older releases
+     render CodeRabbit unconditionally. Treat every catalog area as
+     hand-verifiable rather than diff-against-answers.
 
 2. **Walk each catalog area against the target.** For every area in
    `standards-catalog.md`, do the three-way check:
@@ -197,7 +198,7 @@ the devcontainer job and align CI job names to the rendered required-check set.
 Severity: **blocker** (wrong contexts mean the gate is unenforced or unsatisfiable).
 
 **E. YAML file extensions — NOT drift; do not flag.** `.yml` vs `.yaml` is left
-to each tool's own convention (`Taskfile.yml`, `.coderabbit.yaml`, GitHub Actions
+to each tool's own convention (`Taskfile.yml`, `.yamllint.yml`; GitHub Actions
 accepts either). Never rename a tool's file to homogenize extensions across the
 repo. Severity: **none** (listed only so audits don't wrongly raise it).
 
@@ -237,6 +238,18 @@ protection. Flag an Actions `SNYK_TOKEN` when no scheduled or deliberately paid
 Snyk workflow consumes it, and flag legacy Snyk PR/push jobs as policy drift.
 Severity: **should** (blocker if an unintended required check makes PRs
 unsatisfiable).
+
+**G3. CodeRabbit selection drift.** Read `use_coderabbit` from
+`.copier-answers.yml`; for legacy answers that omit it, apply the current
+fleet default of `false` unless the maintainer explicitly reviews and retains
+the integration. When true, `.coderabbit.yaml`, the conditional setup
+instructions, and `coderabbitai[bot]` trust must all be present. When false,
+all three must be absent. Also require a human-verifiable checklist item to
+remove the repository from the CodeRabbit GitHub App installation: repository
+files cannot prove or revoke external App access, so record that live access
+check as `?` until a human confirms it. Stale local config/trust is a
+**should** finding; an omitted App-access confirmation is a **should** manual
+finding.
 
 **H. lint-hygiene script portability to macOS bash 3.2.** `scripts/lint-hygiene.sh`
 must be portable: **no `mapfile`, no `grep -P`** (both Linux/bash-4-only), and it
@@ -315,7 +328,17 @@ assets/diff-template.sh "$TARGET"
 # --show to see the per-file diff
 ```
 
-It renders harmon-init **at the repo's own `_commit`** (from its
+Do not set `HARMON_INIT` for a normal audit. The helper verifies the recorded
+source is canonical, snapshots that remote, removes its remote, rejects
+submodules, and renders the full recorded commit from the read-only clone. A
+legacy tag-valued `_commit` has no immutable historical proof, so show the
+maintainer the current canonical tag mapping and obtain approval before running
+with `ACCEPT_LEGACY_BASELINE=true`; a full commit needs no recovery approval.
+An explicit `HARMON_INIT` is only for a caller that already built an equivalent
+guarded clone (update mode passes `HARMON_INIT_RECORDED_COMMIT`) or for a
+disposable hermetic test.
+
+The helper renders harmon-init **at the repo's own frozen `_commit`** (from its
 `.copier-answers.yml`) and reports both content **`DRIFT`** in the curated set and
 **`MISSING`** template files the repo lacks entirely (mapping `.yml`↔`.yaml`). The
 `MISSING` scan walks the whole render and is **manifest-independent**, so a file the
@@ -480,22 +503,19 @@ Apply fixes on a branch, prefer re-templating for files copier owns, then verify
      rather than hand-porting:
      - Generated from the template (has `.copier-answers.yml`):
 
-       ```bash
-       ( cd "$TARGET" && copier update --trust )
-       ```
+       Follow [`mode-update.md`](./mode-update.md) end to end so the release and
+       explicit CodeRabbit choice are identical in preview and apply.
 
      - Never templated / adopting fresh:
 
-       ```bash
-       ( cd "$TARGET" && copier copy --trust --vcs-ref=v3.26.1 \
-           https://github.com/evanharmon1/harmon-init.git . )
-       ```
+       Follow Path B in
+       [`mode-adopt-existing.md`](./mode-adopt-existing.md), including its
+       remote-tag validation and explicit `use_coderabbit` answer.
 
-     Replace `v3.26.1` only with a deliberately selected newer release. A local
-     `--vcs-ref=HEAD` render is appropriate for a disposable pre-release preview,
-     not the production adoption, because dirty work can record an unreachable
-     throwaway commit. Answer the questions to match the repo, and keep all
-     side-effectful answers
+     A local `--vcs-ref=HEAD` render is appropriate for a disposable pre-release
+     preview, not the production adoption, because dirty work can record an
+     unreachable throwaway commit. Answer the questions to match the repo, and
+     keep all side-effectful answers
      (`github_remote_create`, `github_release_init`, `bunch_add`,
      `obsidian_project_add`, `run_task_install`) at their **no** defaults so the
      adopt has no side effects. Review the resulting diff carefully and discard

--- a/.claude/skills/standardize-repo/references/mode-new-repo.md
+++ b/.claude/skills/standardize-repo/references/mode-new-repo.md
@@ -16,8 +16,9 @@ Verify before running anything:
       `git`, and — if you will create the remote or release — `gh` (GitHub CLI,
       authenticated: `gh auth status`).
 - [ ] **Released template ref chosen.** Production scaffolds use the canonical
-      GitHub source and a reviewed release such as `v3.26.1`. A local checkout is
-      needed only to inspect source or preview unreleased work.
+      GitHub source and a deliberately selected release tag whose template
+      defines `use_coderabbit`. A local checkout is needed only to inspect source
+      or preview unreleased work.
 - [ ] **Destination does not already exist / is empty.** Copier writes into
       `<dest>`; pick a path that is free.
 - [ ] **Hidden author/org defaults are correct for you.** Identity, org info,
@@ -34,12 +35,34 @@ The `--trust` flag is required: it allows copier to run the `_tasks` (git init,
 commit, etc.) defined in `copier.yml`.
 
 ```bash
-copier copy https://github.com/evanharmon1/harmon-init.git <dest> \
-  --trust --vcs-ref=v3.26.1
+: "${HARMON_INIT_REF:?set to a released harmon-init tag whose copier.yml defines use_coderabbit}"
+HARMON_INIT_SOURCE=https://github.com/evanharmon1/harmon-init
+git -C ~/git/harmon-init fetch "$HARMON_INIT_SOURCE" \
+  '+refs/heads/main:refs/remotes/origin/main' --tags ||
+  { echo "failed to refresh harmon-init from origin" >&2; exit 1; }
+REMOTE_TAG_OBJECT="$(
+  git -C ~/git/harmon-init ls-remote --exit-code "$HARMON_INIT_SOURCE" \
+    "refs/tags/$HARMON_INIT_REF" |
+    awk 'NR == 1 { print $1 }'
+)" ||
+  { echo "HARMON_INIT_REF is not a tag published by origin" >&2; exit 1; }
+test -n "$REMOTE_TAG_OBJECT" &&
+  test "$(git -C ~/git/harmon-init rev-parse "refs/tags/$HARMON_INIT_REF")" = "$REMOTE_TAG_OBJECT" &&
+  git -C ~/git/harmon-init merge-base --is-ancestor "$HARMON_INIT_REF^{commit}" origin/main ||
+  { echo "HARMON_INIT_REF must exactly match a release tag on origin/main" >&2; exit 1; }
+HARMON_INIT_COMMIT="$(git -C ~/git/harmon-init rev-parse "$HARMON_INIT_REF^{commit}")"
+git -C ~/git/harmon-init show "$HARMON_INIT_COMMIT":copier.yml |
+  grep -q '^use_coderabbit:' ||
+  { echo "HARMON_INIT_REF does not support the CodeRabbit choice" >&2; exit 1; }
+copier copy "$HARMON_INIT_SOURCE" <dest> \
+  --trust --vcs-ref="$HARMON_INIT_COMMIT"
 ```
 
-`v3.26.1` is the current reviewed example; replace it when a newer release has
-been deliberately selected. Do not use a moving branch for production lineage.
+Choose `use_coderabbit=false` at the prompt unless this repository is
+deliberately retaining the CodeRabbit App. Do not use a moving branch for
+production lineage. The guard resolves the remote-verified release tag to
+`HARMON_INIT_COMMIT` before Copier runs, so a later retag cannot change which
+trusted template tasks execute.
 For an unreleased template preview only, a developer may render a local checkout
 with `--vcs-ref=HEAD` into a disposable destination. That preview can contain a
 Copier-created throwaway commit and must not be promoted as a production scaffold.
@@ -54,8 +77,27 @@ questions all default to `no`, so omitting them is safe in CI. Add `--defaults`
 to accept the default for any key you do not pass.
 
 ```bash
-copier copy https://github.com/evanharmon1/harmon-init.git <dest> \
-  --trust --vcs-ref=v3.26.1 --defaults \
+: "${HARMON_INIT_REF:?set to a released harmon-init tag whose copier.yml defines use_coderabbit}"
+HARMON_INIT_SOURCE=https://github.com/evanharmon1/harmon-init
+git -C ~/git/harmon-init fetch "$HARMON_INIT_SOURCE" \
+  '+refs/heads/main:refs/remotes/origin/main' --tags ||
+  { echo "failed to refresh harmon-init from origin" >&2; exit 1; }
+REMOTE_TAG_OBJECT="$(
+  git -C ~/git/harmon-init ls-remote --exit-code "$HARMON_INIT_SOURCE" \
+    "refs/tags/$HARMON_INIT_REF" |
+    awk 'NR == 1 { print $1 }'
+)" ||
+  { echo "HARMON_INIT_REF is not a tag published by origin" >&2; exit 1; }
+test -n "$REMOTE_TAG_OBJECT" &&
+  test "$(git -C ~/git/harmon-init rev-parse "refs/tags/$HARMON_INIT_REF")" = "$REMOTE_TAG_OBJECT" &&
+  git -C ~/git/harmon-init merge-base --is-ancestor "$HARMON_INIT_REF^{commit}" origin/main ||
+  { echo "HARMON_INIT_REF must exactly match a release tag on origin/main" >&2; exit 1; }
+HARMON_INIT_COMMIT="$(git -C ~/git/harmon-init rev-parse "$HARMON_INIT_REF^{commit}")"
+git -C ~/git/harmon-init show "$HARMON_INIT_COMMIT":copier.yml |
+  grep -q '^use_coderabbit:' ||
+  { echo "HARMON_INIT_REF does not support the CodeRabbit choice" >&2; exit 1; }
+copier copy "$HARMON_INIT_SOURCE" <dest> \
+  --trust --vcs-ref="$HARMON_INIT_COMMIT" --defaults \
   --data project_name="My Project" \
   --data project_slug="my-project" \
   --data project_description="One-line description of the project" \
@@ -64,6 +106,7 @@ copier copy https://github.com/evanharmon1/harmon-init.git <dest> \
   --data include_terraform=false \
   --data include_ansible=false \
   --data use_codeql=false \
+  --data use_coderabbit=false \
   --data ci_runner="ubuntu-latest" \
   --data license="mit" \
   --data use_release_please=true \
@@ -75,6 +118,13 @@ copier copy https://github.com/evanharmon1/harmon-init.git <dest> \
   --data obsidian_project_add=false \
   --data run_task_install=false
 ```
+
+The `use_coderabbit` answer is introduced by the companion harmon-init change.
+Release this skill first so harmon-init can refresh its pinned vendored copy,
+then merge and release the harmon-init change. Until that supporting template
+release exists, this command intentionally stops at the guard above. Do not
+substitute an older release (including v4.4.0 or v3.26.1): those templates
+predate the question and render CodeRabbit unconditionally.
 
 ### Answerable questions (from `copier.yml`)
 
@@ -89,6 +139,8 @@ copier copy https://github.com/evanharmon1/harmon-init.git <dest> \
 | `include_ansible` | bool | `true` iff `project_type == 'iac'` | Adds `ansible/` skeleton + ansible linting. |
 | `use_codeql` | bool | `true` for `web-astro` / `web-app`; otherwise `false` | Includes CodeQL SAST. Public repositories have Code Security by default; for a private/internal repo, enable GitHub Code Security first or answer `false`. |
 | `codeql_languages` | multiselect | JS/TS for web; Python for supported Python/IaC selections when CodeQL is enabled | Exact CodeQL matrix; must be nonempty when `use_codeql=true` and should match real first-party source. |
+| `use_codex_review` | bool | `false` | Adds local, advisory Codex review/challenge tasks and the optional Claude → Codex stop-gate. |
+| `use_coderabbit` | bool | `false` | Adds `.coderabbit.yaml`, App setup instructions, and CodeRabbit bot trust. Requires an account/App install; public OSS hosted reviews are free with rate limits, while private hosted code reviews require a paid plan after the trial. |
 | `ci_runner` | str | `ubuntu-latest` | `ubuntu-latest` \| `self-hosted`. |
 | `license` | str | `mit` | `mit` \| `private`. |
 | `use_release_please` | bool | `true` | release-please rolling release PR + auto CHANGELOG. |
@@ -195,7 +247,8 @@ companion reference:
 - In the new repo: work through `docs/CHECKLIST.md` (rendered from
   `template/docs/CHECKLIST.md.jinja`). It covers, in order: local setup → GitHub
   repo settings (branch ruleset import via the GitHub UI, Dependabot
-  alerts + private vulnerability reporting, Renovate app, CodeRabbit app, Actions
+  alerts + private vulnerability reporting, Renovate app, optional CodeRabbit app
+  only when `use_coderabbit=true`, Actions
   secrets/variables, the CI GitHub App, GHCR publishing) → framework scaffolding
   for the chosen `project_type` → secrets/env → docs/meta (fill `TODO:` markers,
   confirm badges, optional `task release:init`).

--- a/.claude/skills/standardize-repo/references/mode-update.md
+++ b/.claude/skills/standardize-repo/references/mode-update.md
@@ -6,8 +6,10 @@ the newest harmon-init changes into this repo," not initial setup.
 
 Routing:
 
-- **v3+ repo** (`.copier-answers.yml` present, `_commit: v3.x` or later) → this mode
-  (`copier update`).
+- **v3+ repo** (`.copier-answers.yml` present, with `_commit` either a `v3.x` or
+  later release ref or the 40-character commit recorded by a guarded update) →
+  this mode (`copier update`). For an unfamiliar full hash, resolve it against
+  the canonical harmon-init remote and confirm it descends from `v3.0.0`.
 - **v2 repo or never templated** → [`mode-adopt-existing.md`](./mode-adopt-existing.md)
   (v2→v3 was a breaking redesign; re-template via its Path B).
 - **Just want a drift report, no changes** → run §1 and stop, or see
@@ -40,12 +42,12 @@ already exists locally as a leftover from a prior run whose PR was
 the PR. (Deleting the stale local branch also works, but is destructive — prefer
 the versioned name.)
 
-## 1. See what's missing (read-only)
+## 1. Verify and freeze both template inputs
 
-```bash
-assets/diff-template.sh .
-# add --show to print the full per-file diff
-```
+Do not run `diff-template.sh` or any other trusted Copier render until the
+guarded source and answers file below exist. The ordinary drift command trusts
+the repo's recorded `_commit`; when that value is a tag, running it first would
+reintroduce the mutable-baseline gap this preflight closes.
 
 This renders harmon-init from the repo's own `.copier-answers.yml` and reports
 the following result classes (mapping `.yml`↔`.yaml`):
@@ -73,17 +75,230 @@ the following result classes (mapping `.yml`↔`.yaml`):
   log intentionally replaces a generated seed path. This is informational and
   does not fail the comparison.
 
-Together these are your reconciliation worklist for §3.
-
 ### Preview the release and review new answers
 
 Before accepting `--defaults`, identify both the target release and any Copier
 questions added since the repo's recorded `_commit`:
 
 ```bash
-copier check-update --output-format json .
-git -C ~/git/harmon-init diff "$(yq -r '._commit' .copier-answers.yml)"..v<TARGET> -- copier.yml
+: "${HARMON_INIT_REF:?set to the deliberately selected latest harmon-init release tag}"
+HARMON_INIT_SOURCE=https://github.com/evanharmon1/harmon-init
+RECORDED_SOURCE="$(yq -r '._src_path // ""' .copier-answers.yml)"
+RECORDED_REF="$(yq -r '._commit // ""' .copier-answers.yml)"
+case "$RECORDED_SOURCE" in
+"$HARMON_INIT_SOURCE" | "$HARMON_INIT_SOURCE.git") ;;
+*)
+  echo "_src_path must be the canonical harmon-init URL before update" >&2
+  exit 1
+  ;;
+esac
+git -C ~/git/harmon-init fetch "$HARMON_INIT_SOURCE" \
+  '+refs/heads/main:refs/remotes/origin/main' --tags ||
+  { echo "failed to refresh harmon-init from origin" >&2; exit 1; }
+test -n "$RECORDED_REF" ||
+  { echo "_commit must name the recorded harmon-init baseline" >&2; exit 1; }
+if printf '%s\n' "$RECORDED_REF" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+  RECORDED_COMMIT="$(git -C ~/git/harmon-init rev-parse "$RECORDED_REF^{commit}")"
+else
+  # Legacy Copier answers normally contain `git describe` output (usually a
+  # release tag), which is not immutable evidence of the commit originally used.
+  # An agent must not accept the current mapping silently.
+  : "${ACCEPT_LEGACY_BASELINE:?obtain maintainer approval for the legacy baseline recovery}"
+  test "$ACCEPT_LEGACY_BASELINE" = true ||
+    { echo "ACCEPT_LEGACY_BASELINE must be exactly true" >&2; exit 1; }
+  RELEASE_TARGET="$(
+    gh api "repos/evanharmon1/harmon-init/releases/tags/$RECORDED_REF" \
+      --jq '.target_commitish'
+  )" ||
+    { echo "recorded tag has no matching GitHub release" >&2; exit 1; }
+  RECORDED_COMMIT="$(git -C ~/git/harmon-init rev-parse "$RECORDED_REF^{commit}")"
+  case "$RELEASE_TARGET" in
+  "$RECORDED_COMMIT") ;;
+  main)
+    git -C ~/git/harmon-init merge-base --is-ancestor \
+      "$RECORDED_COMMIT" origin/main ||
+      { echo "recorded tag is not on the release target branch" >&2; exit 1; }
+    ;;
+  *)
+    echo "GitHub release target must be the recorded commit or main" >&2
+    exit 1
+    ;;
+  esac
+fi
+git -C ~/git/harmon-init merge-base --is-ancestor "$RECORDED_COMMIT" origin/main ||
+  { echo "recorded _commit must resolve to a commit on origin/main" >&2; exit 1; }
+V3_TAG_OBJECT="$(
+  git -C ~/git/harmon-init ls-remote --exit-code "$HARMON_INIT_SOURCE" \
+    "refs/tags/v3.0.0" |
+    awk 'NR == 1 { print $1 }'
+)" ||
+  { echo "cannot verify the v3 migration boundary on origin" >&2; exit 1; }
+test -n "$V3_TAG_OBJECT" &&
+  test "$(git -C ~/git/harmon-init rev-parse refs/tags/v3.0.0)" = \
+    "$V3_TAG_OBJECT" ||
+  { echo "local v3.0.0 tag does not match origin" >&2; exit 1; }
+V3_BASELINE_COMMIT="$(git -C ~/git/harmon-init rev-parse "v3.0.0^{commit}")"
+git -C ~/git/harmon-init merge-base --is-ancestor \
+  "$V3_BASELINE_COMMIT" "$RECORDED_COMMIT" ||
+  {
+    echo "recorded baseline predates v3; use mode-adopt-existing.md" >&2
+    exit 1
+  }
+REMOTE_TAG_OBJECT="$(
+  git -C ~/git/harmon-init ls-remote --exit-code "$HARMON_INIT_SOURCE" \
+    "refs/tags/$HARMON_INIT_REF" |
+    awk 'NR == 1 { print $1 }'
+)" ||
+  { echo "HARMON_INIT_REF is not a tag published by origin" >&2; exit 1; }
+test -n "$REMOTE_TAG_OBJECT" &&
+  test "$(git -C ~/git/harmon-init rev-parse "refs/tags/$HARMON_INIT_REF")" = "$REMOTE_TAG_OBJECT" &&
+  git -C ~/git/harmon-init merge-base --is-ancestor "$HARMON_INIT_REF^{commit}" origin/main ||
+  { echo "HARMON_INIT_REF must exactly match a release tag on origin/main" >&2; exit 1; }
+HARMON_INIT_COMMIT="$(git -C ~/git/harmon-init rev-parse "$HARMON_INIT_REF^{commit}")"
+git -C ~/git/harmon-init merge-base --is-ancestor \
+  "$RECORDED_COMMIT" "$HARMON_INIT_COMMIT" ||
+  { echo "target release must descend from the recorded baseline" >&2; exit 1; }
+git -C ~/git/harmon-init show "$HARMON_INIT_COMMIT":copier.yml |
+  grep -q '^use_coderabbit:' ||
+  { echo "latest harmon-init release does not support the CodeRabbit choice" >&2; exit 1; }
+git -C ~/git/harmon-init diff \
+  "$RECORDED_COMMIT".."$HARMON_INIT_COMMIT" -- copier.yml
 ```
+
+Stop before previewing or applying when that guard fails. Requiring the recorded
+source to be canonical binds Copier's actual update source to the remote that was
+validated. `RECORDED_COMMIT` and `HARMON_INIT_COMMIT` freeze the old and new
+template inputs and the ancestry check rejects a downgrade or unrelated target.
+
+For a legacy tag-valued `_commit`, the original commit cannot be reconstructed
+cryptographically after the fact. `ACCEPT_LEGACY_BASELINE=true` is an explicit
+recovery decision, not a default: show the maintainer the current tag commit, the
+GitHub release target, and relevant repository history, then obtain approval
+before setting it. Record that decision in the eventual PR.
+
+Create a read-only offline clone containing the validated baseline and target,
+then bind Copier's canonical Git URL to that clone for each guarded subprocess:
+
+```bash
+GUARDED_TEMPLATE="$(mktemp -d -t harmon-init-guarded-XXXXXX)"
+GUARDED_COPIER_CACHE="$(mktemp -d -t copier-guarded-cache-XXXXXX)"
+git clone --no-checkout "$HARMON_INIT_SOURCE" "$GUARDED_TEMPLATE" ||
+  { echo "failed to snapshot harmon-init from the canonical remote" >&2; exit 1; }
+git -C "$GUARDED_TEMPLATE" remote remove origin
+test "$(git -C "$GUARDED_TEMPLATE" rev-parse "$RECORDED_COMMIT^{commit}")" = \
+  "$RECORDED_COMMIT" &&
+  test "$(git -C "$GUARDED_TEMPLATE" rev-parse "$HARMON_INIT_COMMIT^{commit}")" = \
+    "$HARMON_INIT_COMMIT" ||
+  { echo "guarded template does not contain the validated commits" >&2; exit 1; }
+test "$(git -C "$GUARDED_TEMPLATE" rev-parse "$HARMON_INIT_REF^{commit}")" = \
+  "$HARMON_INIT_COMMIT" ||
+  { echo "guarded target tag mapping changed during snapshot creation" >&2; exit 1; }
+if ! printf '%s\n' "$RECORDED_REF" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+  test "$(git -C "$GUARDED_TEMPLATE" rev-parse "$RECORDED_REF^{commit}")" = \
+    "$RECORDED_COMMIT" ||
+    { echo "guarded baseline tag mapping changed during snapshot creation" >&2; exit 1; }
+fi
+for GUARDED_COMMIT in "$RECORDED_COMMIT" "$HARMON_INIT_COMMIT"; do
+  if git -C "$GUARDED_TEMPLATE" cat-file -e \
+    "$GUARDED_COMMIT:.gitmodules" 2>/dev/null; then
+    echo "guarded updates do not support template commits with submodules" >&2
+    exit 1
+  fi
+done
+chmod -R a-w "$GUARDED_TEMPLATE"
+GUARDED_STATE=.copier-guarded-update
+guarded_checkout_id() {
+  if GUARDED_BRANCH="$(git symbolic-ref --quiet --short HEAD)"; then
+    printf 'branch:%s\n' "$GUARDED_BRANCH"
+  else
+    printf '%s\n' detached
+  fi
+}
+GIT_EXCLUDE="$(git rev-parse --path-format=absolute --git-path info/exclude)"
+grep -qxF "/$GUARDED_STATE/" "$GIT_EXCLUDE" ||
+  printf '%s\n' "/$GUARDED_STATE/" >>"$GIT_EXCLUDE" ||
+  { echo "failed to ignore guarded update state" >&2; exit 1; }
+mkdir "$GUARDED_STATE" ||
+  {
+    echo "$GUARDED_STATE already exists; recover or remove it before retrying" >&2
+    exit 1
+  }
+git rev-parse HEAD >"$GUARDED_STATE/start-head" &&
+  guarded_checkout_id >"$GUARDED_STATE/start-checkout" &&
+  git hash-object .copier-answers.yml >"$GUARDED_STATE/canonical-answers-oid" &&
+  printf '%s\n' "$HARMON_INIT_COMMIT" >"$GUARDED_STATE/target-commit" &&
+  printf '%s\n' "$GUARDED_TEMPLATE" >"$GUARDED_STATE/template-path" &&
+  printf '%s\n' "$GUARDED_COPIER_CACHE" >"$GUARDED_STATE/cache-path" &&
+  cp .copier-answers.yml "$GUARDED_STATE/original-answers.yml" ||
+  { echo "failed to initialize guarded update state" >&2; exit 1; }
+git -C "$GUARDED_TEMPLATE" show "$RECORDED_COMMIT":copier.yml |
+  yq -r 'keys | .[] | select(test("^_") | not)' |
+  LC_ALL=C sort -u >"$GUARDED_STATE/baseline-questions" &&
+  git -C "$GUARDED_TEMPLATE" show "$HARMON_INIT_COMMIT":copier.yml |
+    yq -r 'keys | .[] | select(test("^_") | not)' |
+    LC_ALL=C sort -u >"$GUARDED_STATE/target-questions" &&
+  comm -13 \
+    "$GUARDED_STATE/baseline-questions" \
+    "$GUARDED_STATE/target-questions" \
+    >"$GUARDED_STATE/new-question-candidates" ||
+  { echo "failed to derive new question candidates" >&2; exit 1; }
+test -z "$(git status --porcelain)" ||
+  { echo "guarded preparation must leave the worktree clean" >&2; exit 1; }
+run_guarded_copier() {
+  env \
+    "COPIER_CACHE_DIR=$GUARDED_COPIER_CACHE" \
+    GIT_CONFIG_COUNT=2 \
+    "GIT_CONFIG_KEY_0=url.$GUARDED_TEMPLATE.insteadOf" \
+    "GIT_CONFIG_VALUE_0=$HARMON_INIT_SOURCE.git" \
+    "GIT_CONFIG_KEY_1=url.$GUARDED_TEMPLATE.insteadOf" \
+    "GIT_CONFIG_VALUE_1=$HARMON_INIT_SOURCE" \
+    copier "$@"
+}
+HARMON_INIT="$GUARDED_TEMPLATE" \
+  HARMON_INIT_RECORDED_COMMIT="$RECORDED_COMMIT" \
+  assets/diff-template.sh .
+# add --show to print the full per-file diff
+run_guarded_copier check-update --output-format json .
+```
+
+The guarded clone has no remote, is read-only, and is rejected if either
+selected commit contains `.gitmodules`; Copier clones templates recursively, so
+allowing a submodule URL would break the offline trust boundary. This matters
+because Copier 9.16 checks out the recorded hash, then internally runs
+`git describe --tags --always` and reuses that description for its old render.
+Its nested clone now resolves that description against the same frozen local tag
+mapping instead of a freshly fetched remote. Keeping the tags also preserves the
+PEP 440 versions Copier requires for update ordering. Cloning the snapshot from
+the canonical remote prevents local-only tags in `~/git/harmon-init` from
+affecting `git describe`; both selected tag mappings are revalidated after the
+clone to catch a concurrent retag. `run_guarded_copier`
+defines two process-scoped Git `insteadOf` mappings so both accepted canonical
+URL spellings clone the offline snapshot; the longer `.git` spelling wins when
+applicable. Its isolated temporary mirror cache prevents a pre-existing
+canonical-URL cache from bypassing the snapshot. Copier continues reading and
+writing its canonical answers path, so harmon-init's fixed answers template and
+Copier agree on the same file.
+
+The worktree-root state directory is ignored through Git's resolved local
+exclude file, so it works in both ordinary and linked worktrees. Its atomic
+`mkdir` acts as a per-worktree lock and recovery marker. If preparation, preview,
+update, or promotion is interrupted, do not rerun preparation or remove that
+directory blindly: inspect the backed-up `original-answers.yml`, recorded
+`start-head`, `start-checkout`, `canonical-answers-oid`, `target-commit`,
+`template-path`, `cache-path`, reviewed/discovery data, and the ignored-path
+backup plus its recorded object IDs
+alongside the working-tree diff. Restore the validated variables and
+`run_guarded_copier` definition from that state when resuming, then run the
+context checks below. Either finish the update and promotion or explicitly
+discard the failed run. A concurrent or accidental rerun must stop at the
+existing-directory error instead of overwriting recovery state.
+
+The drift output is your reconciliation worklist for §3.
+
+The companion harmon-init change must not be released until this skill is
+published and its new tag is pinned into harmon-init. After that pin refresh,
+release harmon-init; until then, older template releases render CodeRabbit
+unconditionally and cannot satisfy a reviewed false answer.
 
 Every newly introduced question needs an explicit decision. This is especially
 important for a feature with a material footprint or an external capability:
@@ -92,6 +307,11 @@ important for a feature with a material footprint or an external capability:
   documentation, and tests. It was default-on when introduced in v3.26.1;
   current template source defaults it off. Update mode must still decide whether
   the target should opt in.
+- `use_coderabbit` adds a third-party GitHub App integration and defaults off.
+  Pass `--data use_coderabbit=false` unless the repository is deliberately
+  retaining CodeRabbit. The false path removes `.coderabbit.yaml` and bot trust,
+  but a human must also remove the repository from the CodeRabbit App
+  installation because deleting repository files does not revoke App access.
 - `use_codeql` includes CodeQL only when the matrix corresponds to planned/actual
   first-party JS/TS/Python source. `use_node` / `use_python` are tooling flags,
   not source evidence; review and persist the explicit `codeql_languages`
@@ -129,23 +349,322 @@ important for a feature with a material footprint or an external capability:
   check-mode initialization must omit it. Do not accept a pre-existing
   `.terraform.lock.hcl` as proof of that process.
 
-Pass each reviewed answer with `--data`, even when the decision happens to match
-the current default.
+Pass the complete reviewed answer map with `--data-file`, even when a decision
+happens to match the current default. The guarded preparation first finds raw
+questions added between the frozen baseline and target, then performs a
+task-free target render to retain only questions Copier considers active and
+recordable under this repository's answers. It adds the four active
+repository-capability questions that always require reconsideration.
 
 Preview the exact answer set before the real update:
 
 ```bash
-: "${USE_CODEQL:?set USE_CODEQL=true or false after the capability review}"
-copier update --trust --defaults --pretend \
-  --data use_foreman=false \
-  --data use_codeql="$USE_CODEQL"
+REVIEWED_DATA="$GUARDED_STATE/reviewed-data.yml"
+ORIGINAL_DATA="$GUARDED_STATE/original-data.yml"
+yq 'with_entries(select(.key | test("^_") | not))' \
+  "$GUARDED_STATE/original-answers.yml" >"$ORIGINAL_DATA" ||
+  { echo "failed to prepare recorded answers for discovery" >&2; exit 1; }
+if test -e "$REVIEWED_DATA"; then
+  yq -e \
+    'tag == "!!map" and
+     ([.[] | select(. == "__REVIEW_REQUIRED__")] | length == 0)' \
+    "$REVIEWED_DATA" >/dev/null ||
+    {
+      echo "review every existing entry and replace all __REVIEW_REQUIRED__ values" >&2
+      exit 1
+    }
+  USE_FOREMAN="$(yq -r '.use_foreman' "$REVIEWED_DATA")"
+  USE_CODERABBIT="$(yq -r '.use_coderabbit' "$REVIEWED_DATA")"
+  USE_CODEQL="$(yq -r '.use_codeql' "$REVIEWED_DATA")"
+  CODEQL_LANGUAGES="$(yq -o=json -I=0 '.codeql_languages' "$REVIEWED_DATA")"
+else
+  : "${USE_CODEQL:?set USE_CODEQL=true or false after the capability review}"
+  : "${CODEQL_LANGUAGES:=$(yq -o=json -I=0 '.codeql_languages // []' .copier-answers.yml)}"
+  : "${USE_FOREMAN:=$(yq -r '.use_foreman // false' .copier-answers.yml)}"
+  : "${USE_CODERABBIT:=$(yq -r '.use_coderabbit // false' .copier-answers.yml)}"
+fi
+case "$USE_FOREMAN" in true | false) ;; *) echo "USE_FOREMAN must be true or false" >&2; exit 1 ;; esac
+case "$USE_CODERABBIT" in true | false) ;; *) echo "USE_CODERABBIT must be true or false" >&2; exit 1 ;; esac
+if [ "$USE_CODEQL" = "false" ]; then
+  CODEQL_LANGUAGES='[]'
+elif [ "$USE_CODEQL" != "true" ] ||
+  ! printf '%s\n' "$CODEQL_LANGUAGES" |
+    yq -e '(tag == "!!seq") and (length > 0) and
+      ([.[] | select(. != "javascript-typescript" and . != "python")] | length == 0)' - >/dev/null; then
+  echo "CODEQL_LANGUAGES must be a nonempty YAML list of supported first-party languages" >&2
+  exit 1
+fi
+CODEQL_LANGUAGES="$(
+  printf '%s\n' "$CODEQL_LANGUAGES" | yq -o=json -I=0 '.'
+)"
+DISCOVERY_DATA="$GUARDED_STATE/discovery-data.yml"
+: >"$GUARDED_STATE/active-target-questions"
+DISCOVERY_STABLE=false
+for DISCOVERY_ROUND in 1 2 3 4 5 6 7 8 9 10; do
+  ACTIVE_REVIEWED="$GUARDED_STATE/active-reviewed-data.yml"
+  printf '%s\n' '{}' >"$ACTIVE_REVIEWED" ||
+    { echo "failed to initialize active reviewed data" >&2; exit 1; }
+  if test -e "$REVIEWED_DATA"; then
+    while IFS= read -r ACTIVE_KEY; do
+      if ACTIVE_KEY="$ACTIVE_KEY" \
+        yq -e 'has(strenv(ACTIVE_KEY))' "$REVIEWED_DATA" >/dev/null; then
+        ACTIVE_VALUE="$(
+          ACTIVE_KEY="$ACTIVE_KEY" \
+            yq -o=json -I=0 '.[strenv(ACTIVE_KEY)]' "$REVIEWED_DATA"
+        )" &&
+          ACTIVE_KEY="$ACTIVE_KEY" ACTIVE_VALUE="$ACTIVE_VALUE" \
+            yq -i \
+              '.[strenv(ACTIVE_KEY)] = (strenv(ACTIVE_VALUE) | from_json)' \
+              "$ACTIVE_REVIEWED" ||
+          { echo "failed to select active reviewed value" >&2; exit 1; }
+      fi
+    done <"$GUARDED_STATE/active-target-questions"
+  fi
+  DISCOVERY_CANDIDATE="$(mktemp "$GUARDED_STATE/discovery-data.XXXXXX")" ||
+    { echo "failed to create discovery-data candidate" >&2; exit 1; }
+  yq eval-all \
+    'select(fileIndex == 0) * select(fileIndex == 1)' \
+    "$ORIGINAL_DATA" "$ACTIVE_REVIEWED" >"$DISCOVERY_CANDIDATE" ||
+    {
+      rm -f "$DISCOVERY_CANDIDATE"
+      echo "failed to merge discovery answers" >&2
+      exit 1
+    }
+  mv "$DISCOVERY_CANDIDATE" "$DISCOVERY_DATA" ||
+    {
+      rm -f "$DISCOVERY_CANDIDATE"
+      echo "failed to publish discovery answers" >&2
+      exit 1
+    }
+  TARGET_DISCOVERY="$(mktemp -d -t copier-target-discovery-XXXXXX)" ||
+    { echo "failed to create target discovery directory" >&2; exit 1; }
+  run_guarded_copier copy --trust --defaults --skip-tasks \
+    --vcs-ref="$HARMON_INIT_COMMIT" \
+    --data-file="$DISCOVERY_DATA" \
+    "$HARMON_INIT_SOURCE" "$TARGET_DISCOVERY" ||
+    { echo "target question discovery failed" >&2; exit 1; }
+  yq -r 'keys | .[] | select(test("^_") | not)' \
+    "$TARGET_DISCOVERY/.copier-answers.yml" |
+    LC_ALL=C sort -u >"$GUARDED_STATE/active-target-questions.next" ||
+    { echo "failed to derive active target questions" >&2; exit 1; }
+  if cmp -s \
+    "$GUARDED_STATE/active-target-questions" \
+    "$GUARDED_STATE/active-target-questions.next"; then
+    rm -f "$GUARDED_STATE/active-target-questions.next"
+    DISCOVERY_STABLE=true
+    break
+  fi
+  mv \
+    "$GUARDED_STATE/active-target-questions.next" \
+    "$GUARDED_STATE/active-target-questions" ||
+    { echo "failed to advance active question discovery" >&2; exit 1; }
+done
+test "$DISCOVERY_STABLE" = true ||
+  { echo "active question discovery did not converge in 10 rounds" >&2; exit 1; }
+comm -12 \
+  "$GUARDED_STATE/new-question-candidates" \
+  "$GUARDED_STATE/active-target-questions" \
+  >"$GUARDED_STATE/active-new-questions" ||
+  { echo "failed to derive active new questions" >&2; exit 1; }
+{
+  cat "$GUARDED_STATE/active-new-questions"
+  printf '%s\n' use_foreman use_coderabbit use_codeql codeql_languages
+} |
+  LC_ALL=C sort -u |
+  comm -12 - "$GUARDED_STATE/active-target-questions" \
+    >"$GUARDED_STATE/reviewed-keys" ||
+  { echo "failed to derive the complete active review set" >&2; exit 1; }
+for CAPABILITY_KEY in \
+  use_foreman use_coderabbit use_codeql codeql_languages; do
+  grep -qxF "$CAPABILITY_KEY" "$GUARDED_STATE/reviewed-keys" ||
+    {
+      echo "required capability question is not active: $CAPABILITY_KEY" >&2
+      exit 1
+    }
+done
+find "$TARGET_DISCOVERY" \( -type f -o -type l \) -print |
+  sed "s#^$TARGET_DISCOVERY/##" |
+  LC_ALL=C sort -u >"$GUARDED_STATE/target-managed-paths" ||
+  { echo "failed to inventory target render paths" >&2; exit 1; }
+REVIEWED_KEYSET_OID="$(
+  test -e "$REVIEWED_DATA" &&
+    yq -r 'keys | .[]' "$REVIEWED_DATA" |
+      LC_ALL=C sort -u |
+      git hash-object --stdin
+)"
+REQUIRED_KEYSET_OID="$(
+  git hash-object "$GUARDED_STATE/reviewed-keys"
+)"
+if ! test -e "$REVIEWED_DATA" ||
+  test "$REVIEWED_KEYSET_OID" != "$REQUIRED_KEYSET_OID"; then
+  REVIEWED_CANDIDATE="$(mktemp "$GUARDED_STATE/reviewed-data.XXXXXX")" ||
+    { echo "failed to create reviewed-data candidate" >&2; exit 1; }
+  printf '%s\n' '{}' >"$REVIEWED_CANDIDATE" ||
+    {
+      rm -f "$REVIEWED_CANDIDATE"
+      echo "failed to initialize reviewed-data candidate" >&2
+      exit 1
+    }
+  while IFS= read -r REVIEWED_KEY; do
+    if ! REVIEWED_KEY="$REVIEWED_KEY" yq -i \
+      '.[strenv(REVIEWED_KEY)] = "__REVIEW_REQUIRED__"' \
+      "$REVIEWED_CANDIDATE"; then
+      rm -f "$REVIEWED_CANDIDATE"
+      echo "failed to seed reviewed question: $REVIEWED_KEY" >&2
+      exit 1
+    fi
+  done <"$GUARDED_STATE/reviewed-keys"
+  if ! USE_FOREMAN="$USE_FOREMAN" \
+    USE_CODERABBIT="$USE_CODERABBIT" \
+    USE_CODEQL="$USE_CODEQL" \
+    CODEQL_LANGUAGES="$CODEQL_LANGUAGES" \
+    yq -i \
+      '.use_foreman = (strenv(USE_FOREMAN) == "true") |
+       .use_coderabbit = (strenv(USE_CODERABBIT) == "true") |
+       .use_codeql = (strenv(USE_CODEQL) == "true") |
+       .codeql_languages = (strenv(CODEQL_LANGUAGES) | from_json)' \
+      "$REVIEWED_CANDIDATE"; then
+    rm -f "$REVIEWED_CANDIDATE"
+    echo "failed to seed reviewed capability answers" >&2
+    exit 1
+  fi
+  mv "$REVIEWED_CANDIDATE" "$REVIEWED_DATA" ||
+    {
+      rm -f "$REVIEWED_CANDIDATE"
+      echo "failed to publish reviewed data" >&2
+      exit 1
+    }
+  echo "the active question set changed; review every key in $REVIEWED_DATA, replace all __REVIEW_REQUIRED__ values, then rerun discovery" >&2
+  exit 1
+fi
+while IFS= read -r REVIEWED_KEY; do
+  REVIEWED_KEY="$REVIEWED_KEY" yq -e \
+    'has(strenv(REVIEWED_KEY)) and
+     .[strenv(REVIEWED_KEY)] != "__REVIEW_REQUIRED__"' \
+    "$REVIEWED_DATA" >/dev/null ||
+    {
+      echo "missing explicit reviewed value for $REVIEWED_KEY" >&2
+      exit 1
+    }
+done <"$GUARDED_STATE/reviewed-keys"
+USE_FOREMAN="$(yq -r '.use_foreman' "$REVIEWED_DATA")"
+USE_CODERABBIT="$(yq -r '.use_coderabbit' "$REVIEWED_DATA")"
+USE_CODEQL="$(yq -r '.use_codeql' "$REVIEWED_DATA")"
+CODEQL_LANGUAGES="$(yq -o=json -I=0 '.codeql_languages' "$REVIEWED_DATA")"
+case "$USE_FOREMAN" in true | false) ;; *) echo "reviewed use_foreman must be boolean" >&2; exit 1 ;; esac
+case "$USE_CODERABBIT" in true | false) ;; *) echo "reviewed use_coderabbit must be boolean" >&2; exit 1 ;; esac
+case "$USE_CODEQL" in true | false) ;; *) echo "reviewed use_codeql must be boolean" >&2; exit 1 ;; esac
+if ! test -e "$GUARDED_STATE/ignored-snapshot-ready"; then
+  BASELINE_DISCOVERY="$(mktemp -d -t copier-baseline-discovery-XXXXXX)" ||
+    { echo "failed to create baseline discovery directory" >&2; exit 1; }
+  run_guarded_copier copy --trust --defaults --skip-tasks \
+    --vcs-ref="$RECORDED_COMMIT" \
+    --data-file="$ORIGINAL_DATA" \
+    "$HARMON_INIT_SOURCE" "$BASELINE_DISCOVERY" ||
+    { echo "baseline path discovery failed" >&2; exit 1; }
+  find "$BASELINE_DISCOVERY" \( -type f -o -type l \) -print |
+    sed "s#^$BASELINE_DISCOVERY/##" |
+    LC_ALL=C sort -u >"$GUARDED_STATE/baseline-managed-paths" ||
+    { echo "failed to inventory baseline render paths" >&2; exit 1; }
+  cat \
+    "$GUARDED_STATE/baseline-managed-paths" \
+    "$GUARDED_STATE/target-managed-paths" |
+    LC_ALL=C sort -u >"$GUARDED_STATE/managed-paths" ||
+    { echo "failed to inventory guarded render paths" >&2; exit 1; }
+  : >"$GUARDED_STATE/ignored-managed-paths"
+  : >"$GUARDED_STATE/ignored-existing-paths"
+  : >"$GUARDED_STATE/ignored-absent-paths"
+  while IFS= read -r MANAGED_PATH; do
+    case "$MANAGED_PATH" in
+    "" | /* | ../* | */../*)
+      echo "unsafe managed path: $MANAGED_PATH" >&2
+      exit 1
+      ;;
+    esac
+    if git check-ignore -q -- "$MANAGED_PATH"; then
+      printf '%s\n' "$MANAGED_PATH" \
+        >>"$GUARDED_STATE/ignored-managed-paths"
+      if test -e "$MANAGED_PATH" || test -L "$MANAGED_PATH"; then
+        test ! -d "$MANAGED_PATH" || test -L "$MANAGED_PATH" ||
+          {
+            echo "ignored managed path is an unsupported directory: $MANAGED_PATH" >&2
+            exit 1
+          }
+        printf '%s\n' "$MANAGED_PATH" \
+          >>"$GUARDED_STATE/ignored-existing-paths"
+      else
+        printf '%s\n' "$MANAGED_PATH" \
+          >>"$GUARDED_STATE/ignored-absent-paths"
+      fi
+    fi
+  done <"$GUARDED_STATE/managed-paths"
+  tar -cf "$GUARDED_STATE/ignored-backup.tar" \
+    -T "$GUARDED_STATE/ignored-existing-paths" ||
+    { echo "failed to back up ignored managed paths" >&2; exit 1; }
+  git hash-object "$GUARDED_STATE/ignored-backup.tar" \
+    >"$GUARDED_STATE/ignored-backup-oid" &&
+    git hash-object "$GUARDED_STATE/ignored-managed-paths" \
+      >"$GUARDED_STATE/ignored-managed-paths-oid" &&
+    printf '%s\n' ready >"$GUARDED_STATE/ignored-snapshot-ready" ||
+    { echo "failed to freeze ignored-path recovery state" >&2; exit 1; }
+fi
+REVIEWED_DATA_OID="$(git hash-object "$REVIEWED_DATA")"
+if test -e "$GUARDED_STATE/reviewed-data-oid"; then
+  test "$(cat "$GUARDED_STATE/reviewed-data-oid")" = "$REVIEWED_DATA_OID" ||
+    {
+      echo "reviewed data changed after preview; explicitly restart the guarded run" >&2
+      exit 1
+    }
+else
+  printf '%s\n' "$REVIEWED_DATA_OID" >"$GUARDED_STATE/reviewed-data-oid" ||
+    { echo "failed to freeze reviewed data" >&2; exit 1; }
+fi
+run_guarded_copier update --trust --defaults --pretend \
+  --vcs-ref="$HARMON_INIT_COMMIT" \
+  --data-file="$REVIEWED_DATA"
 ```
 
-`--pretend` confirms rendering succeeds but its output can be terse. For a heavily
-customized or high-impact repo, make a disposable clone under a temporary directory,
-run the same update there without `--pretend`, and inspect its full `git diff` before
-touching the working branch. A preview complements the pinned-baseline drift report;
-neither replaces the post-update reconciliation in §3.
+The existing Foreman answer is the starting point, not an instruction to retain
+it blindly. Review that substantial per-repo choice and override `USE_FOREMAN`
+deliberately when the repository should change posture. The existing CodeRabbit
+answer is handled the same way; legacy omission starts at the fleet's `false`
+default, while an explicit opt-in stays true unless the maintainer deliberately
+opts out. `CODEQL_LANGUAGES` is a serialized YAML list such as
+`["javascript-typescript","python"]`; the existing matrix is only a starting
+point and must be reviewed against actual first-party source. Disabling CodeQL
+records an empty matrix.
+
+The reviewed payload is written atomically before preview. The first run stops
+after generating it: inspect every entry, replace every
+`__REVIEW_REQUIRED__` sentinel, and rerun discovery. A reviewed choice may
+activate another conditional new question; when that happens, discovery
+regenerates the exact active keyset and stops for another explicit review.
+Continue until the bounded discovery loop reaches a fixed point with no
+sentinel. Each pass supplies only reviewed keys that Copier marked active on
+the prior pass, so a stale value from a newly inactive question cannot affect
+later conditions. Hidden `when: false` values and inactive conditional
+questions are never passed as user data. On recovery, load the complete map
+instead of recomputing defaults:
+
+```bash
+REVIEWED_DATA="$GUARDED_STATE/reviewed-data.yml"
+USE_FOREMAN="$(yq -r '.use_foreman' "$REVIEWED_DATA")"
+USE_CODERABBIT="$(yq -r '.use_coderabbit' "$REVIEWED_DATA")"
+USE_CODEQL="$(yq -r '.use_codeql' "$REVIEWED_DATA")"
+CODEQL_LANGUAGES="$(
+  yq -o=json -I=0 '.codeql_languages' "$REVIEWED_DATA"
+)"
+```
+
+The frozen Git object ID refuses to preview or apply a different payload over
+recovery state from an interrupted run.
+
+`--pretend` confirms rendering succeeds but its output can be terse. For a
+heavily customized or high-impact repo, make a disposable clone under a
+temporary directory, repeat the guarded-source preparation there, run the same
+update without `--pretend`, and inspect its full `git diff` before touching the
+working branch. A preview complements the guarded-baseline drift report; neither
+replaces the post-update reconciliation in §3.
 
 ## 2. Run the update
 
@@ -166,9 +685,247 @@ otherwise unreachable, do not fabricate lineage by swapping only the path or
 commit; re-adopt from the canonical GitHub URL at a reviewed released ref.
 
 ```bash
-copier update --trust --defaults \
-  --data <new-question>=<reviewed-answer>
+test "$(cat "$GUARDED_STATE/start-head")" = "$(git rev-parse HEAD)" &&
+  test "$(cat "$GUARDED_STATE/start-checkout")" = "$(guarded_checkout_id)" &&
+  test "$(cat "$GUARDED_STATE/canonical-answers-oid")" = \
+    "$(git hash-object .copier-answers.yml)" &&
+  test "$(cat "$GUARDED_STATE/target-commit")" = "$HARMON_INIT_COMMIT" &&
+  test "$(cat "$GUARDED_STATE/template-path")" = "$GUARDED_TEMPLATE" &&
+  test "$(cat "$GUARDED_STATE/cache-path")" = "$GUARDED_COPIER_CACHE" &&
+  test "$(cat "$GUARDED_STATE/reviewed-data-oid")" = \
+    "$(git hash-object "$REVIEWED_DATA")" &&
+  test "$(cat "$GUARDED_STATE/ignored-snapshot-ready")" = ready &&
+  test "$(cat "$GUARDED_STATE/ignored-backup-oid")" = \
+    "$(git hash-object "$GUARDED_STATE/ignored-backup.tar")" &&
+  test "$(cat "$GUARDED_STATE/ignored-managed-paths-oid")" = \
+    "$(git hash-object "$GUARDED_STATE/ignored-managed-paths")" &&
+  test -z "$(git status --porcelain)" ||
+  { echo "working checkout no longer matches guarded update state" >&2; exit 1; }
+tar -cf "$GUARDED_STATE/ignored-preapply.tar" \
+  -T "$GUARDED_STATE/ignored-existing-paths" ||
+  { echo "failed to verify ignored paths before apply" >&2; exit 1; }
+test "$(git hash-object "$GUARDED_STATE/ignored-preapply.tar")" = \
+  "$(cat "$GUARDED_STATE/ignored-backup-oid")" ||
+  { echo "an ignored managed path changed after preparation" >&2; exit 1; }
+rm -f "$GUARDED_STATE/ignored-preapply.tar"
+while IFS= read -r ABSENT_IGNORED_PATH; do
+  if test -e "$ABSENT_IGNORED_PATH" || test -L "$ABSENT_IGNORED_PATH"; then
+    echo "an ignored managed path appeared after preparation: $ABSENT_IGNORED_PATH" >&2
+    exit 1
+  fi
+done <"$GUARDED_STATE/ignored-absent-paths"
+test ! -e "$GUARDED_STATE/apply-phase" ||
+  {
+    echo "apply already started; do not rerun Copier—continue with applied-state validation" >&2
+    exit 1
+  }
+write_guarded_phase() {
+  GUARDED_PHASE="$1"
+  GUARDED_PHASE_CANDIDATE="$(
+    mktemp "$GUARDED_STATE/apply-phase.XXXXXX"
+  )" ||
+    { echo "failed to create apply-phase candidate" >&2; return 1; }
+  if printf '%s\n' "$GUARDED_PHASE" >"$GUARDED_PHASE_CANDIDATE" &&
+    mv "$GUARDED_PHASE_CANDIDATE" "$GUARDED_STATE/apply-phase"; then
+    return 0
+  fi
+  rm -f "$GUARDED_PHASE_CANDIDATE"
+  echo "failed to persist guarded apply phase" >&2
+  return 1
+}
+write_guarded_phase applying ||
+  { echo "Copier was not started" >&2; exit 1; }
+if run_guarded_copier update --trust --defaults \
+  --vcs-ref="$HARMON_INIT_COMMIT" \
+  --data-file="$REVIEWED_DATA"; then
+  write_guarded_phase applied ||
+    {
+      echo "Copier returned success but phase recording failed; validate the applied state" >&2
+      exit 1
+    }
+else
+  echo "guarded Copier update failed; preserve the applying phase and recovery state" >&2
+  exit 1
+fi
 ```
+
+Use the same frozen reviewed-data file in the preview and real invocation; do
+not retype or omit answers between those two steps. The `applying` phase is
+atomically recorded before Copier can mutate the worktree. `applied` records a
+normal return, but promotion does not trust either phase by itself: it validates
+the complete resulting state below. After a crash or nonzero return, never
+blindly rerun Copier.
+
+Copier can return success while leaving merge conflicts. Reconcile those as
+described in §3 before promotion. Then prove that the canonical answers record
+the applied target and promote its lineage to the canonical URL plus full target
+commit:
+
+```bash
+test "$(cat "$GUARDED_STATE/start-head")" = "$(git rev-parse HEAD)" &&
+  test "$(cat "$GUARDED_STATE/start-checkout")" = "$(guarded_checkout_id)" &&
+  test "$(cat "$GUARDED_STATE/canonical-answers-oid")" = \
+    "$(git hash-object "$GUARDED_STATE/original-answers.yml")" &&
+  test "$(cat "$GUARDED_STATE/target-commit")" = "$HARMON_INIT_COMMIT" &&
+  test "$(cat "$GUARDED_STATE/template-path")" = "$GUARDED_TEMPLATE" &&
+  test "$(cat "$GUARDED_STATE/cache-path")" = "$GUARDED_COPIER_CACHE" &&
+  test "$(cat "$GUARDED_STATE/reviewed-data-oid")" = \
+    "$(git hash-object "$REVIEWED_DATA")" &&
+  test "$(cat "$GUARDED_STATE/ignored-snapshot-ready")" = ready &&
+  test "$(cat "$GUARDED_STATE/ignored-backup-oid")" = \
+    "$(git hash-object "$GUARDED_STATE/ignored-backup.tar")" &&
+  test "$(cat "$GUARDED_STATE/ignored-managed-paths-oid")" = \
+    "$(git hash-object "$GUARDED_STATE/ignored-managed-paths")" ||
+  { echo "working checkout no longer matches guarded update state" >&2; exit 1; }
+APPLY_PHASE="$(cat "$GUARDED_STATE/apply-phase")" ||
+  { echo "guarded apply has not started" >&2; exit 1; }
+case "$APPLY_PHASE" in
+applied) ;;
+applying)
+  echo "Copier did not record a normal return; validate for diagnosis, then use the rollback path" >&2
+  exit 1
+  ;;
+*) echo "invalid guarded apply phase" >&2; exit 1 ;;
+esac
+test -z "$(git diff --name-only --diff-filter=U)" ||
+  { echo "resolve every Copier merge conflict before promotion" >&2; exit 1; }
+APPLIED_REF="$(yq -r '._commit // ""' .copier-answers.yml)" &&
+  APPLIED_SOURCE="$(yq -r '._src_path // ""' .copier-answers.yml)" ||
+  { echo "applied canonical answers are not valid YAML" >&2; exit 1; }
+APPLIED_COMMIT="$(
+  git -C "$GUARDED_TEMPLATE" rev-parse "$APPLIED_REF^{commit}"
+)" ||
+  { echo "applied answers do not record a resolvable commit" >&2; exit 1; }
+case "$APPLIED_SOURCE" in
+"$HARMON_INIT_SOURCE" | "$HARMON_INIT_SOURCE.git") ;;
+*) echo "applied answers no longer name canonical harmon-init" >&2; exit 1 ;;
+esac
+test "$APPLIED_COMMIT" = "$HARMON_INIT_COMMIT" ||
+  { echo "guarded update did not apply the validated target" >&2; exit 1; }
+while IFS= read -r REVIEWED_KEY; do
+  REVIEWED_KEY="$REVIEWED_KEY" yq -e \
+    'has(strenv(REVIEWED_KEY))' .copier-answers.yml >/dev/null ||
+    {
+      echo "applied answers omit reviewed key: $REVIEWED_KEY" >&2
+      exit 1
+    }
+  ACTUAL_REVIEWED_VALUE="$(
+    REVIEWED_KEY="$REVIEWED_KEY" \
+      yq -o=json -I=0 '.[strenv(REVIEWED_KEY)]' .copier-answers.yml
+  )" &&
+    EXPECTED_REVIEWED_VALUE="$(
+      REVIEWED_KEY="$REVIEWED_KEY" \
+        yq -o=json -I=0 '.[strenv(REVIEWED_KEY)]' "$REVIEWED_DATA"
+    )" &&
+    test "$ACTUAL_REVIEWED_VALUE" = "$EXPECTED_REVIEWED_VALUE" ||
+    {
+      echo "applied answer differs from reviewed value: $REVIEWED_KEY" >&2
+      exit 1
+    }
+done <"$GUARDED_STATE/reviewed-keys"
+PROMOTED_ANSWERS="$(mktemp .copier-answers.yml.promote.XXXXXX)" ||
+  { echo "failed to create answers promotion file" >&2; exit 1; }
+if cp .copier-answers.yml "$PROMOTED_ANSWERS" &&
+  HARMON_INIT_SOURCE="$HARMON_INIT_SOURCE" \
+    HARMON_INIT_COMMIT="$HARMON_INIT_COMMIT" \
+    yq -i \
+      '._src_path = strenv(HARMON_INIT_SOURCE) |
+       ._commit = strenv(HARMON_INIT_COMMIT)' \
+      "$PROMOTED_ANSWERS"; then
+  mv "$PROMOTED_ANSWERS" .copier-answers.yml ||
+    { echo "failed to atomically promote canonical answers" >&2; exit 1; }
+  git add -- .copier-answers.yml ||
+    { echo "failed to stage promoted canonical answers" >&2; exit 1; }
+  test "$GUARDED_STATE" = .copier-guarded-update &&
+    test -d "$GUARDED_STATE" &&
+    test ! -L "$GUARDED_STATE" &&
+    rm -rf -- "$GUARDED_STATE" ||
+    { echo "canonical answers promoted, but guarded state cleanup failed" >&2; exit 1; }
+else
+  echo "answers promotion failed; canonical answers and recovery state remain" >&2
+  exit 1
+fi
+git diff -- .copier-answers.yml # canonical URL + full HARMON_INIT_COMMIT
+```
+
+Do not normalize only one field. The successful guarded update may have changed
+other answers, so copy its complete result first, then replace `_src_path` and
+`_commit` together with the already-validated canonical values. The temporary
+file is renamed over the canonical answers only after both edits succeed; if
+promotion fails, preserve it and recovery state for diagnosis. Promotion is
+allowed only when the checkout and original answers still match preparation and
+the `applied` phase proves Copier returned normally, the reviewed-data object is
+unchanged, and the applied canonical answers resolve to the validated target
+commit in the offline clone with every reviewed value intact. An `applying`
+state is never promotable: Copier writes the target answers before its full
+three-way merge is complete, so the answers alone cannot prove that a
+mid-process crash left a complete update.
+
+If an interrupted `applying` state fails that validation, preserve it for
+diagnosis. To abandon it, first verify the recorded branch and HEAD still match,
+inspect `git diff`, and obtain explicit maintainer approval to discard **all**
+worktree changes made since preparation. The deterministic rollback is:
+
+```bash
+test "$(cat "$GUARDED_STATE/start-head")" = "$(git rev-parse HEAD)" &&
+  test "$(cat "$GUARDED_STATE/start-checkout")" = "$(guarded_checkout_id)" &&
+  test "$(cat "$GUARDED_STATE/canonical-answers-oid")" = \
+    "$(git hash-object "$GUARDED_STATE/original-answers.yml")" &&
+  test "$(cat "$GUARDED_STATE/ignored-snapshot-ready")" = ready &&
+  test "$(cat "$GUARDED_STATE/ignored-backup-oid")" = \
+    "$(git hash-object "$GUARDED_STATE/ignored-backup.tar")" &&
+  test "$(cat "$GUARDED_STATE/ignored-managed-paths-oid")" = \
+    "$(git hash-object "$GUARDED_STATE/ignored-managed-paths")" ||
+  { echo "rollback context no longer matches guarded preparation" >&2; exit 1; }
+git diff HEAD --stat
+git clean -nd
+tar -tvf "$GUARDED_STATE/ignored-backup.tar"
+cat "$GUARDED_STATE/ignored-absent-paths"
+: "${APPROVE_GUARDED_ROLLBACK:?obtain maintainer approval after reviewing all four outputs}"
+test "$APPROVE_GUARDED_ROLLBACK" = true ||
+  { echo "APPROVE_GUARDED_ROLLBACK must be exactly true" >&2; exit 1; }
+git restore \
+  --source="$(cat "$GUARDED_STATE/start-head")" \
+  --staged --worktree -- .
+git clean -fd
+while IFS= read -r ABSENT_IGNORED_PATH; do
+  rm -f -- "$ABSENT_IGNORED_PATH" ||
+    { echo "failed to remove new ignored path: $ABSENT_IGNORED_PATH" >&2; exit 1; }
+done <"$GUARDED_STATE/ignored-absent-paths"
+tar -xf "$GUARDED_STATE/ignored-backup.tar" ||
+  { echo "failed to restore ignored managed paths" >&2; exit 1; }
+tar -cf "$GUARDED_STATE/ignored-verify.tar" \
+  -T "$GUARDED_STATE/ignored-existing-paths" ||
+  { echo "failed to verify ignored managed paths" >&2; exit 1; }
+test "$(git hash-object .copier-answers.yml)" = \
+  "$(cat "$GUARDED_STATE/canonical-answers-oid")" &&
+  test "$(git hash-object "$GUARDED_STATE/ignored-verify.tar")" = \
+    "$(cat "$GUARDED_STATE/ignored-backup-oid")" &&
+  test -z "$(git status --porcelain)" ||
+  { echo "rollback did not restore the prepared worktree" >&2; exit 1; }
+while IFS= read -r ABSENT_IGNORED_PATH; do
+  if test -e "$ABSENT_IGNORED_PATH" || test -L "$ABSENT_IGNORED_PATH"; then
+    echo "rollback left a newly-created ignored path: $ABSENT_IGNORED_PATH" >&2
+    exit 1
+  fi
+done <"$GUARDED_STATE/ignored-absent-paths"
+rm -f "$GUARDED_STATE/ignored-verify.tar"
+test "$GUARDED_STATE" = .copier-guarded-update &&
+  test -d "$GUARDED_STATE" &&
+  test ! -L "$GUARDED_STATE" &&
+  rm -rf -- "$GUARDED_STATE" ||
+  { echo "rollback succeeded, but guarded state cleanup failed" >&2; exit 1; }
+```
+
+Run `git clean -fd` only if its preview contains exclusively Copier-created
+paths; the ignored guarded state survives that command. The prepared tar archive
+restores pre-existing ignored template paths, and the absent-path list removes
+ignored paths that Copier created. This rollback is destructive and must never
+be inferred from a failed validation.
+
+Stage the promoted file immediately because §3 may already have staged Copier's
+tag-valued version. Leave the guarded template and Copier cache directories in
+the system temporary area until the PR is verified; the OS can clean them later.
 
 **`--defaults` is mandatory when running non-interactively (agents have no TTY),
 but it is not permission to accept newly introduced behavior.** Review and pass
@@ -176,15 +933,19 @@ new answers explicitly as described above. Without `--defaults`, Copier tries to
 prompt for answers and crashes with
 `OSError: [Errno 22] Invalid argument` (prompt_toolkit can't attach to a missing
 terminal). It reuses the stored answers and accepts defaults for any new questions
-the template added since `_commit`; explicit `--data` values override those
-defaults and are recorded in `.copier-answers.yml`.
+the template added since `_commit`; the generated `--data-file` explicitly
+authorizes every one of those new questions, while `--defaults` supplies only
+unchanged existing answers and noninteractive prompt behavior.
 
-**Always do a full update to the latest released version.** Plain `copier update`
-goes to harmon-init's newest **tag** and three-way-merges the *entire* delta from the
-repo's recorded `_commit` up to that tag, preserving local edits. Don't get fancy
-scoping the update to a specific intermediate version (no `--vcs-ref vX.Y.Z`, no
-hand-picking which template changes to take) — pull all the way to latest and
-reconcile in §3. First-run `_tasks` are guarded on `_copier_operation == 'copy'`, so
+**Always do a full update to the deliberately selected latest released
+version.** Derive `HARMON_INIT_COMMIT` once from the remote-verified
+`HARMON_INIT_REF`, resolve `RECORDED_COMMIT` once, place both in the read-only
+offline clone, and pass the immutable target commit to both preview and apply
+through `run_guarded_copier`. Copier three-way-merges the *entire* delta from that
+immutable recorded baseline up to the release commit, preserving local edits.
+Do not hand-pick which template changes to take—select the current release and
+reconcile the full result in §3.
+First-run `_tasks` are guarded on `_copier_operation == 'copy'`, so
 update will **not** make a scaffold commit, re-init git, or re-cut a release. Only
 `CHANGELOG.md` is frozen (`_skip_if_exists`); every other template improvement
 (README, AGENTS.md, docs, scripts, …) flows in through the merge.

--- a/.claude/skills/standardize-repo/references/post-generation-checklist.md
+++ b/.claude/skills/standardize-repo/references/post-generation-checklist.md
@@ -70,13 +70,23 @@ push so the remote exists.
   gh api "repos/<org>/<repo>/private-vulnerability-reporting" --method PUT
   ```
 
-- [ ] **[human-only]** Install the **Renovate** GitHub App on the repo —
-      <https://github.com/apps/renovate> (the generated `renovate.json` is
-      pre-configured). App installation goes through GitHub's UI consent flow.
+- [ ] **[human-only]** Install and activate the **Renovate** GitHub App —
+      install <https://github.com/apps/renovate> for **Only select
+      repositories** and select this repo. In the Mend Developer Portal choose
+      the **Renovate** product and **Scan and Alert** mode. **Scan Only** is
+      silent mode: it scans without checks, issues (including the Dependency
+      Dashboard), or update/remediation PRs. Keep the generated
+      `renovate.json`; do not replace it with a generic onboarding config.
 
-- [ ] **[human-only]** Install the **CodeRabbit** GitHub App on the repo —
-      <https://github.com/apps/coderabbitai> (the generated `.coderabbit.yaml` is
-      pre-configured). UI consent flow.
+- [ ] **[human-only; only when `use_coderabbit=true`]** Install the
+      **CodeRabbit** GitHub App — <https://github.com/apps/coderabbitai>. The
+      generated `.coderabbit.yaml` is pre-configured.
+
+- [ ] **[human-only; default `use_coderabbit=false`]** Confirm CodeRabbit has no
+      access to this repository. For a repository that previously used it,
+      remove the repo from the CodeRabbit GitHub App installation after Copier
+      removes `.coderabbit.yaml`; deleting the config alone does not revoke App
+      access.
 
 - [ ] **[human-only]** Set Actions **secret** `CLAUDE_CODE_OAUTH_TOKEN`
       (consumed by `claude-plan.yml`, `claude-implement.yml`,

--- a/.claude/skills/standardize-repo/references/standards-catalog.md
+++ b/.claude/skills/standardize-repo/references/standards-catalog.md
@@ -162,7 +162,10 @@ are check-only by design.
 `status:setup` is a **setup-completeness audit** (run by hand, not part of the
 default dashboard): it checks the repo against `docs/CHECKLIST.md` and reports
 ✓/✗/?/– per item across GitHub config (ruleset, Dependabot alerts, private vuln
-reporting, visibility-appropriate SAST route, Renovate/CodeRabbit apps, Actions
+reporting, visibility-appropriate SAST route, Renovate and the optional
+CodeRabbit app when configured. When CodeRabbit is off, `status:setup` must show
+a manual `?` until App access is confirmed removed; account-level installation
+metadata cannot prove repository selection. It also checks Actions
 secrets/variables by name only, GHCR image, linked Project, release), toolchain
 (`brew bundle check`), devcontainer profiles, and dev environment (1Password
 CLI, direnv). Useful as a quick first pass when auditing an already-standardized
@@ -209,8 +212,8 @@ Notable command bodies (for an auditor checking they match):
   `DESIGN.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`,
   `LICENSE`, `CHECKLIST.md`. **[copier]**
 - **YAML extensions follow each tool's own convention** — no repo-wide
-  `.yml`-vs-`.yaml` normalization (go-task → `Taskfile.yml`, CodeRabbit →
-  `.coderabbit.yaml`). Don't rename a tool's file to homogenize extensions.
+  `.yml`-vs-`.yaml` normalization (go-task → `Taskfile.yml`, yamllint →
+  `.yamllint.yml`). Don't rename a tool's file to homogenize extensions.
 - **Feature branches only.** Direct commits to `main` are blocked by the
   `guard:no-commit-to-main` pre-commit hook AND the branch ruleset. **[copier]**
   for the hook/ruleset file; **[manual]** to import the ruleset to GitHub.
@@ -693,7 +696,8 @@ install the Renovate GitHub App on the repo. Conventions:
   to main.** **[manual]** to actually cut a release.
 - Other root files: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE`
   (mit/private), `<slug>.code-workspace`, `.vscode/{settings,extensions}.json`,
-  `.coderabbit.yaml` (CodeRabbit reviews — [manual] install the app),
+  `.coderabbit.yaml` only when `use_coderabbit=true` (CodeRabbit reviews —
+  [manual] install the app),
   `.github/PULL_REQUEST_TEMPLATE.md`, the `.github/ISSUE_TEMPLATE/` YAML **Issue
   Forms** (`{bug,feature,task,research}.yml` and `config.yml`, always generated —
   see §1.13 for the `type:`/assignee behavior), `.dockerignore`. **[copier]**

--- a/.skills-sync.yaml
+++ b/.skills-sync.yaml
@@ -8,7 +8,7 @@
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
   # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
-  ref: v0.8.4 # pinned tag — bump deliberately to a released harmon-devkit tag
+  ref: v0.8.7 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
   - repo
 dest: .claude/skills

--- a/template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja
+++ b/template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja
@@ -9,7 +9,7 @@
 source:
   repo: https://github.com/evanharmon1/harmon-devkit.git
   # renovate: datasource=github-releases depName=evanharmon1/harmon-devkit
-  ref: v0.8.4 # pinned tag — bump deliberately to a released harmon-devkit tag
+  ref: v0.8.7 # pinned tag — bump deliberately to a released harmon-devkit tag
 categories:
 [% for cat in skill_categories %]
   - [[ cat ]]


### PR DESCRIPTION
## What

Bumps the pinned harmon-devkit ref from **v0.8.4 → v0.8.7** and re-vendors
`.claude/skills` from the new tag.

- `.skills-sync.yaml` — `ref: v0.8.4` → `v0.8.7`
- `template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja` — same bump (dogfood parity twin)
- `.claude/skills/standardize-repo/**` — re-vendored via `task sync:skills` (9 files, upstream content unmodified)

## Why

harmon-devkit is the single source of truth for shared agent skills and had cut
three releases since the pin (v0.8.5, v0.8.6, v0.8.7). Per AGENTS.md, after a
harmon-devkit release the flow is: bump the `ref` pin, run `task sync:skills`,
commit the refresh.

Upstream changes picked up (all `standardize-repo`):
- `fix(standardize-repo): freeze Copier update baselines` (#131)
- `fix(standardize-repo): freeze verified Copier commits` (#129)
- `fix(standardize-repo): make CodeRabbit opt-in` (#128)

## Verification

- `task verify` — pass
- `task ci` — pass
- `task verify:skills` (network) — `✓ vendored skills in sync with v0.8.7`
- `task verify:skills:offline` — `✓ vendored ref matches manifest (v0.8.7)`
- `PR_TITLE=… BASE_SHA=main task guard:release-title` — pass (`fix:` title, `template/` touched)
- All 14 CI checks green, including required `verify` / `security` / `codeql-verify`

## Second-model review — adjudication

Local Codex (2× `challenge`, 1× `review`) plus the Codex cloud review surfaced
**four** P2s across three distinct defects. All were verified against source and
**all are confirmed** — and all live in **vendored upstream content**, not in
anything this PR authors.

| # | Finding | Location | Verdict | Evidence |
| --- | --- | --- | --- | --- |
| 1 | Legacy baseline recovery requires authenticated `gh`, contradicting SKILL.md prereqs | `references/mode-update.md:111` | **Confirmed** | SKILL.md:44-45 scopes `gh` to side-effect steps; 3/3 platform repos have tag-valued `_commit`, so this is the default path, not an edge case |
| 2 | Audit mode declared checkout-free, but `mode-audit.md` still needs `$TEMPLATE` | `SKILL.md:42` | **Confirmed — regression** | v0.8.4's precondition was unconditional; v0.8.7 added the exemption while `mode-audit.md` still reads `$TEMPLATE` at lines 7, 27, 52, 172, 259 |
| 3 | `_commit` stays tag-valued after scaffold, so lineage isn't peeled | `references/mode-new-repo.md:58` | **Confirmed** | `copier/_template.py:286` sets `_commit` from `git describe --tags --always`, which wins over `--vcs-ref=<sha>` |

Partially rejected on #1: Codex offered "either do this without `gh`, or require `gh`."
The first option is not viable — the check exists to detect a **moved tag**, and
`git fetch --tags` re-fetches whatever origin currently claims, so git remote data
structurally cannot detect that tampering. The GitHub release record is independent
evidence and carries real signal here (`target_commitish` returns actual commits,
not `main`). Only the "declare `gh` a prerequisite" half is correct.

Added beyond Codex on #1: `mode-update.md:112-113` funnels *every* `gh` failure
(absent, unauthenticated, rate-limited, network, 5xx) into the single message
`"recorded tag has no matching GitHub release"` — a misleading diagnosis on the
default update path.

**No fixes applied here by design.** These files are vendored byte-for-byte from
harmon-devkit v0.8.7 and drift-checked by `task verify:skills`; editing them in
this repo fails CI. All three belong upstream in
`harmon-devkit → ai/skills/repo/standardize-repo/`. Per-thread replies with full
reasoning are on each inline comment.

**Reviewer note:** finding #2 is a regression *introduced by* v0.8.7, so merging
this bump vendors a self-contradicting precondition into the skill agents read.
Worth deciding whether to land this now and fast-follow with a devkit v0.8.8, or
hold the pin until upstream is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
