### PR TITLE
fix: install file in the devcontainer and fail loudly without it

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -95,6 +95,7 @@ RUN apt-get update \
         eza \
         fd-find \
         ffmpeg \
+        file \
         fzf \
         git-crypt \
         git-delta \

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -46,10 +46,9 @@ runs:
         # rather than silently scanning binaries as text. GitHub-hosted images
         # ship it, but a self-hosted CI_RUNS_ON runner may not — the same
         # reasoning as the explicit yq install in build.yml's template-test.
-        command -v file >/dev/null 2>&1 || {
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends file
-        }
+        # The helper probes for a package manager: `self-hosted` implies only
+        # the `linux` label, so apt-get cannot be assumed.
+        ./scripts/ensure-file.sh
         # renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.+)$
         SHELLCHECK_VERSION=0.10.0
         curl -fsSL --retry 3 -o /tmp/shellcheck.tar.xz \

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -38,10 +38,18 @@ runs:
         # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
         version: 3.51.1
         repo-token: ${{ github.token }}
-    - name: Install lint tools (shellcheck, shfmt, actionlint, yamllint, yq)
+    - name: Install lint tools (file, shellcheck, shfmt, actionlint, yamllint, yq)
       if: inputs.lint-tools == 'true'
       shell: bash
       run: |
+        # `file` backs lint-hygiene.sh's binary detection, which fails closed
+        # rather than silently scanning binaries as text. GitHub-hosted images
+        # ship it, but a self-hosted CI_RUNS_ON runner may not — the same
+        # reasoning as the explicit yq install in build.yml's template-test.
+        command -v file >/dev/null 2>&1 || {
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends file
+        }
         # renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.+)$
         SHELLCHECK_VERSION=0.10.0
         curl -fsSL --retry 3 -o /tmp/shellcheck.tar.xz \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,15 @@ jobs:
           curl -fsSL --retry 3 -o /tmp/yq \
             "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
           sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+          # `file` backs the rendered lint-hygiene.sh's binary detection, which
+          # fails closed. test-template.sh runs that rendered script directly, so
+          # a runner without `file` would abort every profile before validation.
+          # This job does not use .github/actions/setup, so installing it there
+          # does not cover this path. Same self-hosted reasoning as yq above.
+          command -v file >/dev/null 2>&1 || {
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends file
+          }
       - name: Configure git identity (copier renders run git init)
         run: |
           git config --global user.name "ci"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,10 +149,7 @@ jobs:
           # a runner without `file` would abort every profile before validation.
           # This job does not use .github/actions/setup, so installing it there
           # does not cover this path. Same self-hosted reasoning as yq above.
-          command -v file >/dev/null 2>&1 || {
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends file
-          }
+          ./scripts/ensure-file.sh
       - name: Configure git identity (copier renders run git init)
         run: |
           git config --global user.name "ci"

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,12 @@
 # Brewfile for harmon-init (template maintenance tooling)
 # Install with: task install  (brew bundle --file=Brewfile)
+#
+# Base-OS prerequisite, deliberately not a brew entry: `file(1)`, which
+# scripts/lint-hygiene.sh requires. macOS ships /usr/bin/file and every
+# mainstream Linux distro installs it in the base system, so a brew formula
+# would shadow the system binary to no benefit. CI provisions it explicitly via
+# scripts/ensure-file.sh; if it is somehow absent locally, lint-hygiene.sh says
+# so by name and exits rather than misreporting binaries as text.
 
 # Template engine. On a Homebrew host this is copier's source (installed on PATH
 # by brew); the brew-less devcontainer installs it via uv instead (see

--- a/scripts/ensure-file.sh
+++ b/scripts/ensure-file.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# ensure-file.sh — make sure `file(1)` is available for scripts/lint-hygiene.sh.
+#
+# lint-hygiene.sh uses `file --mime-encoding` to tell binaries from text and now
+# fails closed when it is missing, so CI has to provision it rather than inherit
+# it. GitHub-hosted images ship `file`; a self-hosted runner selected via
+# `ci_runner=self-hosted` / `CI_RUNS_ON` may not, and `self-hosted` implies only
+# the `linux` label — not a Debian/Ubuntu host. So probe for a package manager
+# instead of assuming apt-get, and fail with an actionable message when none of
+# them matches rather than dying on `apt-get: command not found`.
+#
+# Nothing here runs on a host that already has `file`, which is the overwhelming
+# majority: it is a base-OS utility on every mainstream distro and on macOS.
+set -euo pipefail
+
+if command -v file >/dev/null 2>&1; then
+    exit 0
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y --no-install-recommends file
+elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y file
+elif command -v yum >/dev/null 2>&1; then
+    sudo yum install -y file
+elif command -v zypper >/dev/null 2>&1; then
+    sudo zypper --non-interactive install file
+elif command -v pacman >/dev/null 2>&1; then
+    sudo pacman -Sy --noconfirm file
+elif command -v apk >/dev/null 2>&1; then
+    sudo apk add --no-cache file
+else
+    echo "ensure-file: 'file' is missing and no supported package manager was found." >&2
+    echo "  scripts/lint-hygiene.sh requires it to distinguish binaries from text." >&2
+    echo "  Preinstall it on this runner (it is a base-OS package on every" >&2
+    echo "  mainstream distro) and re-run." >&2
+    exit 1
+fi
+
+command -v file >/dev/null 2>&1 || {
+    echo "ensure-file: install reported success but 'file' is still not on PATH" >&2
+    exit 1
+}

--- a/scripts/lint-hygiene.sh
+++ b/scripts/lint-hygiene.sh
@@ -16,6 +16,18 @@
 # general lint escape hatch.
 set -euo pipefail
 
+# Binary detection below shells out to `file`. Without it that test silently
+# never matches, so every tracked binary is scanned as text and reports bogus
+# trailing-whitespace/EOF-newline failures — hundreds of them in a repo with
+# committed assets, with nothing pointing at the real cause. Fail loudly here
+# instead of degrading into noise.
+if ! command -v file >/dev/null 2>&1; then
+    echo "lint-hygiene: required tool 'file' not found on PATH" >&2
+    echo "  needed to tell binary files from text before hygiene checks" >&2
+    echo "  install it (Debian/Ubuntu: apt-get install file) and re-run" >&2
+    exit 1
+fi
+
 errors=0
 warn() {
     echo "FAIL: $*" >&2

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -156,8 +156,9 @@ fi
 # of its merge gate. Running it here catches defects the other validators miss
 # because they live in the SOURCE files, not the rendered structure — e.g. a
 # `.jinja` whose whitespace-control strips the trailing newline (the LICENSE
-# bug) or a shell script committed without its EOF newline. Pure bash + git, so
-# no `task install` is needed; runs against the freshly-rendered tree.
+# bug) or a shell script committed without its EOF newline. Needs only bash, git
+# and `file` (which the job installs explicitly), so no `task install` is
+# needed; runs against the freshly-rendered tree.
 if [ -x scripts/lint-hygiene.sh ]; then
     ./scripts/lint-hygiene.sh || err "rendered output fails its own lint:hygiene gate"
 fi

--- a/template/.github/actions/setup/action.yml.jinja
+++ b/template/.github/actions/setup/action.yml.jinja
@@ -69,11 +69,9 @@ runs:
       run: |
         # `file` backs lint-hygiene.sh's binary detection, which fails closed
         # rather than silently scanning binaries as text. GitHub-hosted images
-        # ship it, but a self-hosted CI_RUNS_ON runner may not.
-        command -v file >/dev/null 2>&1 || {
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends file
-        }
+        # ship it, but a self-hosted CI_RUNS_ON runner may not. The helper
+        # probes for a package manager rather than assuming apt-get.
+        ./scripts/ensure-file.sh
         # renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.+)$
         SHELLCHECK_VERSION=0.10.0
         curl -fsSL --retry 3 -o /tmp/shellcheck.tar.xz \

--- a/template/.github/actions/setup/action.yml.jinja
+++ b/template/.github/actions/setup/action.yml.jinja
@@ -63,10 +63,17 @@ runs:
         # renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
         version: 3.51.1
         repo-token: ${{ github.token }}
-    - name: Install lint tools (shellcheck, shfmt, actionlint, yamllint[% if use_skills_sync %], yq[% endif %])
+    - name: Install lint tools (file, shellcheck, shfmt, actionlint, yamllint[% if use_skills_sync %], yq[% endif %])
       if: inputs.lint-tools == 'true'
       shell: bash
       run: |
+        # `file` backs lint-hygiene.sh's binary detection, which fails closed
+        # rather than silently scanning binaries as text. GitHub-hosted images
+        # ship it, but a self-hosted CI_RUNS_ON runner may not.
+        command -v file >/dev/null 2>&1 || {
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends file
+        }
         # renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.+)$
         SHELLCHECK_VERSION=0.10.0
         curl -fsSL --retry 3 -o /tmp/shellcheck.tar.xz \

--- a/template/Brewfile.jinja
+++ b/template/Brewfile.jinja
@@ -1,5 +1,12 @@
 # Brewfile for [[ project_name ]]
 # Install with: task install  (brew bundle --file=Brewfile)
+#
+# Base-OS prerequisite, deliberately not a brew entry: `file(1)`, which
+# scripts/lint-hygiene.sh requires. macOS ships /usr/bin/file and every
+# mainstream Linux distro installs it in the base system, so a brew formula
+# would shadow the system binary to no benefit. CI provisions it explicitly via
+# scripts/ensure-file.sh; if it is somehow absent locally, lint-hygiene.sh says
+# so by name and exits rather than misreporting binaries as text.
 
 # Task runner + git hooks
 brew "go-task"

--- a/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile
@@ -95,6 +95,7 @@ RUN apt-get update \
         eza \
         fd-find \
         ffmpeg \
+        file \
         fzf \
         git-crypt \
         git-delta \

--- a/template/scripts/ensure-file.sh
+++ b/template/scripts/ensure-file.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# ensure-file.sh — make sure `file(1)` is available for scripts/lint-hygiene.sh.
+#
+# lint-hygiene.sh uses `file --mime-encoding` to tell binaries from text and now
+# fails closed when it is missing, so CI has to provision it rather than inherit
+# it. GitHub-hosted images ship `file`; a self-hosted runner selected via
+# `ci_runner=self-hosted` / `CI_RUNS_ON` may not, and `self-hosted` implies only
+# the `linux` label — not a Debian/Ubuntu host. So probe for a package manager
+# instead of assuming apt-get, and fail with an actionable message when none of
+# them matches rather than dying on `apt-get: command not found`.
+#
+# Nothing here runs on a host that already has `file`, which is the overwhelming
+# majority: it is a base-OS utility on every mainstream distro and on macOS.
+set -euo pipefail
+
+if command -v file >/dev/null 2>&1; then
+    exit 0
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y --no-install-recommends file
+elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y file
+elif command -v yum >/dev/null 2>&1; then
+    sudo yum install -y file
+elif command -v zypper >/dev/null 2>&1; then
+    sudo zypper --non-interactive install file
+elif command -v pacman >/dev/null 2>&1; then
+    sudo pacman -Sy --noconfirm file
+elif command -v apk >/dev/null 2>&1; then
+    sudo apk add --no-cache file
+else
+    echo "ensure-file: 'file' is missing and no supported package manager was found." >&2
+    echo "  scripts/lint-hygiene.sh requires it to distinguish binaries from text." >&2
+    echo "  Preinstall it on this runner (it is a base-OS package on every" >&2
+    echo "  mainstream distro) and re-run." >&2
+    exit 1
+fi
+
+command -v file >/dev/null 2>&1 || {
+    echo "ensure-file: install reported success but 'file' is still not on PATH" >&2
+    exit 1
+}

--- a/template/scripts/lint-hygiene.sh
+++ b/template/scripts/lint-hygiene.sh
@@ -16,6 +16,18 @@
 # general lint escape hatch.
 set -euo pipefail
 
+# Binary detection below shells out to `file`. Without it that test silently
+# never matches, so every tracked binary is scanned as text and reports bogus
+# trailing-whitespace/EOF-newline failures — hundreds of them in a repo with
+# committed assets, with nothing pointing at the real cause. Fail loudly here
+# instead of degrading into noise.
+if ! command -v file >/dev/null 2>&1; then
+    echo "lint-hygiene: required tool 'file' not found on PATH" >&2
+    echo "  needed to tell binary files from text before hygiene checks" >&2
+    echo "  install it (Debian/Ubuntu: apt-get install file) and re-run" >&2
+    exit 1
+fi
+
 errors=0
 warn() {
     echo "FAIL: $*" >&2


### PR DESCRIPTION
## What

`scripts/lint-hygiene.sh` tells binaries from text by shelling out to `file`,
with stderr suppressed. The devcontainer never installed it. Two halves, both
needed:

- **Add `file` to the devcontainer apt list** — the base image does not ship it.
- **Preflight the dependency in `lint-hygiene.sh`** and exit 1 with an actionable
  message when it is absent, instead of degrading into noise.

Root dogfood and template copies updated together; both pairs remain identical.

## Why

Without `file` on PATH the binary test silently never matches, so every tracked
binary is scanned as text and reports bogus trailing-whitespace and
EOF-newline failures — with nothing in the output pointing at the real cause.
The symptom names the wrong problem, so diagnosing it means reading the script.

Observed downstream in **harmon-devkit**, where 95 tracked AppleScript binaries
(`.icns` / `.strings` / `.scpt` — extensions outside the script's static skip
list) produced **172 false failures** and made `task check` fail on a clean
checkout of `main`. The static extension skip list is what covers the common
cases; `file` is the catch-all, and it was the catch-all that was missing.

A missing tool should fail like a missing tool.

## Verification

Behavior proven both directions, using a PATH shim with `file` removed:

| Condition | Before | After |
| --- | --- | --- |
| `file` present | runs clean | runs clean |
| `file` absent, binary input | `FAIL: asset.dat: trailing whitespace detected`<br>`FAIL: asset.dat: no newline at end of file` | `lint-hygiene: required tool 'file' not found on PATH`<br>(+ what it's for, + how to install), exit 1 |

Gates:

- `task check` — pass
- `task verify` — pass
- `task ci` — pass
- `task challenge -- --base main` — clean, no material findings
- `task review -- --base main` — clean, no material findings
- `PR_TITLE=… BASE_SHA=main task guard:release-title` — pass

## Notes

The preflight keeps the script's portability contract — `command -v`, no
`mapfile`, no `grep -P` (macOS bash 3.2 / BSD grep). macOS ships `file`
preinstalled, so nothing changes there; this only affects Linux devcontainers,
which is exactly where it was breaking.

### Related, not fixed here

`copier` has the same shape of problem but a different scope, so it is not in
this PR. It is deliberately **root-only** in this repo — `task install` covers
the brew-less devcontainer via `scripts/install-copier.sh`, and the comment there
is explicit that generated repos don't render templates, so copier is absent from
`template/Taskfile.yml.jinja` and `template/Brewfile.jinja`. That reasoning holds
for every generated repo **except harmon-devkit**, which hosts the
`standardize-repo` skill and renders templates in its own tests. Handling that
downstream in harmon-devkit rather than pushing copier into every generated repo.

Separately worth a look later: the template ships bare
`brew bundle --file=…` in `task install`, while this repo's root Taskfile uses
`scripts/install-brewfile.sh` (a graceful no-op without Homebrew). Any generated
repo in a brew-less devcontainer therefore hard-fails `task install` — the
root fix was never pushed into the template. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
