### PR TITLE
chore: add root<->template drift tooling for jinja twins

### DIFF
--- a/.dogfood-answers.yml
+++ b/.dogfood-answers.yml
@@ -1,0 +1,60 @@
+# .dogfood-answers.yml — the copier answers harmon-init's ROOT layer is the
+# render of. Consumed by `task audit:dogfood` and `task test:dogfood-structure`
+# (scripts/audit-dogfood.sh, scripts/test-dogfood-structure.sh).
+#
+# This is NOT a .copier-answers.yml: harmon-init IS the template, so it has no
+# copier operation of its own and `copier update` can never target it. The root
+# layer is a HAND-MAINTAINED render of template/, and these are the answers it
+# is maintained against. Recording them turns "render the template the way the
+# root is supposed to look" from tribal knowledge into one command.
+#
+# Keep in sync with reality: when the root layer adopts a new template option
+# (or drops one), change the answer here in the same PR, or the drift tooling
+# reports noise instead of drift. Answers that only fire side effects
+# (github_remote_create, run_task_install, ...) are forced off by the scripts,
+# not recorded here.
+project_name: Harmon Init
+project_slug: harmon-init
+project_description: >-
+  Copier project template that scaffolds repos with pre-configured DevOps
+  tooling, CI/CD, linting, security checks, git hooks, and task runners
+project_type: general
+
+github_org: evanharmon1
+code_owner: evanharmon1
+claude_authorized_members: evanharmon1
+
+license: mit
+ci_runner: ubuntu-latest
+
+# Releases are intentional via release-please; `template/` is the release-worthy
+# path, so a PR touching it must carry a fix:/feat: title (release-content-guard).
+use_release_please: true
+release_content_paths: template
+
+# Vendors the `repo` category (the standardize-repo skill) from harmon-devkit.
+use_skills_sync: true
+skill_categories:
+  - repo
+
+use_foreman: true
+
+# Public repo -> CodeQL is free. foreman is the first-party Python.
+use_codeql: true
+codeql_languages:
+  - python
+
+# This repo dogfoods the Codex second-model review; CodeRabbit stays off.
+use_codex_review: true
+use_coderabbit: false
+
+devcontainer: true
+
+# Root ships docs/project-management.md plus setup:github-project / -labels.
+project_management: github
+
+# Snyk stays manual/local (public-repo posture: CodeQL + Dependabot + gitleaks).
+snyk_scan_schedule: "off"
+
+include_terraform: false
+include_ansible: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,16 @@ jobs:
       - run: task test:release-title
       - name: Dogfood parity (verbatim template files match their root twins)
         run: task test:dogfood-parity
+      # The structure check renders template/, so it needs copier. Installed
+      # explicitly rather than via scripts/install-copier.sh: that script no-ops
+      # when brew is present, and GitHub's ubuntu images ship linuxbrew — it
+      # would leave copier missing here. uv comes from the composite action.
+      - name: Install copier (dogfood structure check renders the template)
+        run: |
+          uv tool install copier
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Dogfood structure (template sections/tasks exist in the root layer)
+        run: task test:dogfood-structure
       - run: task foreman:test
       - name: Skills drift check (vendored skills vs pinned harmon-devkit ref)
         run: task verify:skills

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,11 @@ jobs:
       # would leave copier missing here. uv comes from the composite action.
       - name: Install copier (dogfood structure check renders the template)
         run: |
-          uv tool install copier
+          # --force for the same reason scripts/install-copier.sh uses it: it
+          # overwrites a foreign same-named entry point (e.g. a stale pipx shim)
+          # instead of aborting, keeping reruns idempotent on a persistent
+          # self-hosted CI_RUNS_ON runner.
+          uv tool install --force copier
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Dogfood structure (template sections/tasks exist in the root layer)
         run: task test:dogfood-structure

--- a/.github/workflows/close-milestone-on-release.yml
+++ b/.github/workflows/close-milestone-on-release.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   close-milestone:
     name: Close matching milestone
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
     runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
     timeout-minutes: 10
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,12 +73,33 @@ itself, not against the root copy). The root form is the template rendered with
 harmon-init's own answers (e.g. `[[ ci_runner_labels ]]` → `[ "ubuntu-latest" ]`),
 and template-only logic (`[% if … %]`, `${VERSION}` arg substitution) collapses to
 its concrete value. When you touch a templated file, grep for the sibling and edit
-both. For **verbatim** twins — template files *without* a `.jinja` suffix, copied
-byte-for-byte into generated repos — `task test:dogfood-parity` (part of `task
-verify`) enforces byte-equality with the root copy, so a fix applied to only one
-side fails the gate instead of silently shipping stale content downstream
-(intentional root-only divergences are allowlisted in
-`scripts/test-dogfood-parity.sh`).
+both.
+
+**The answers the root layer is a render of are checked in** at
+`.dogfood-answers.yml`. It is NOT a `.copier-answers.yml` — harmon-init is the
+template, so it has no copier operation of its own and `copier update` can never
+target it. When the root adopts (or drops) a template option, change that file in
+the same PR, or the drift tooling below reports noise instead of drift.
+
+Three checks cover the two layers, in increasing looseness:
+
+| Check | Scope | Gate? |
+|---|---|---|
+| `task test:dogfood-parity` | **verbatim** twins (no `.jinja`) — byte-equality | yes (`verify` + CI) |
+| `task test:dogfood-structure` | **jinja** twins — every rendered heading/task exists in the root copy | yes (`verify` + CI) |
+| `task audit:dogfood` | **jinja** twins — full text diff | no, a report |
+
+Verbatim twins are copied into generated repos byte-for-byte, so a fix applied to
+only one side fails the parity gate instead of silently shipping stale content
+downstream. Jinja twins can't be byte-compared — the root copy is a render and
+legitimately diverges in prose — so the gate is narrowed to *structure*: if the
+template grows a section or a task, the root should have gained one too. That
+catches the direction drift actually travels (you edit `template/` to ship a fix
+to consumers, and nothing fails when the root copy is forgotten); it does **not**
+catch changes inside a task body or paragraph. For those, run `task
+audit:dogfood` — before a release, or whenever a change spans both layers — and
+read the diff. Intentional divergences are allowlisted, **with reasons**, in each
+script.
 
 The **standardize-repo skill** is vendored at `.claude/skills/standardize-repo`
 (so the devcontainer and cloud claude-* workflows can use it); the canonical copy
@@ -111,6 +132,10 @@ task fix
 # Render the template into a temp dir and validate the output
 task test          # = task test:template (all profiles)
 task test:template
+
+# Report root<->template drift for jinja twins (a report, not a gate)
+task audit:dogfood              # full diffs
+task audit:dogfood -- --summary # filenames + diff sizes only
 
 # Free security baseline (Semgrep CE + gitleaks + dependency audit)
 task security

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -79,6 +79,7 @@ tasks:
       - task: test:renovate-pins
       - task: test:release-title
       - task: test:dogfood-parity
+      - task: test:dogfood-structure
       - task: foreman:test
       - task: test:hooks
       - task: test:codex-review
@@ -306,10 +307,24 @@ tasks:
     cmds:
       - ./scripts/test-release-title.sh
 
+  # ── Dogfood drift (root layer vs template/) ───────────────────
+  # Three checks, in increasing looseness. The root layer is template/ rendered
+  # with .dogfood-answers.yml, maintained by hand — `copier update` can never
+  # target it, because harmon-init IS the template.
   test:dogfood-parity:
     desc: Verbatim (non-jinja) template files must byte-match their root twins
     cmds:
       - ./scripts/test-dogfood-parity.sh
+
+  test:dogfood-structure:
+    desc: Every section/task the rendered template ships must exist in the root layer
+    cmds:
+      - ./scripts/test-dogfood-structure.sh
+
+  audit:dogfood:
+    desc: "Report root<->template drift for jinja twins (report, not a gate; --summary for names only)"
+    cmds:
+      - ./scripts/audit-dogfood.sh {{.CLI_ARGS}}
 
   test:codex-review:
     desc: Unit-test codex-review.sh target selection (offline, stubbed codex)

--- a/scripts/audit-dogfood.sh
+++ b/scripts/audit-dogfood.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# audit-dogfood.sh — REPORT root<->template drift for jinja twins.
+#
+# `task test:dogfood-parity` byte-compares VERBATIM twins (template files with no
+# .jinja suffix). That leaves the jinja twins — AGENTS.md, Taskfile.yml, the
+# workflows, docs — completely unchecked, and that is exactly where drift lands:
+# you edit template/ to ship a fix to consumers, nothing fails, and the root copy
+# silently falls behind.
+#
+# This renders template/ at HEAD with .dogfood-answers.yml (the answers the root
+# layer is maintained against) and diffs each rendered file against its root twin.
+#
+# It is a REPORT, NOT A GATE, and exits 0 even when it finds differences. The root
+# legitimately diverges in prose (harmon-init-specific sections, root-only tooling,
+# template/ lint exclusions), so a hard gate here would fail constantly and train
+# everyone to ignore it. Read the output; reconcile what is real drift. The
+# structural subset that CAN be gated lives in test-dogfood-structure.sh.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Git hooks export GIT_DIR/GIT_WORK_TREE; left set, copier's `git init` in the
+# temp render re-targets THIS repo. Same sanitation as test-template.sh.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+# Wholly root-owned files: the root copy is not a render of the template copy at
+# all, so a diff is 100% noise rather than signal. Keep this list SHORT. Files
+# with PARTIAL divergence (AGENTS.md, Taskfile.yml, .gitignore, build.yml, ...)
+# are deliberately NOT here — they are where drift actually hides, so they must
+# be reported even though their diffs always contain some intentional lines.
+SKIP="
+CHANGELOG.md
+README.md
+DESIGN.md
+LICENSE
+.release-please-manifest.json
+.copier-answers.yml
+todo.md
+.github/CODEOWNERS
+.github/SECURITY.md
+docs/README.md
+docs/CHECKLIST.md
+docs/project-management.md
+docs/architecture/README.md
+docs/architecture/branch-protection.md
+docs/architecture/ci-cd.md
+docs/architecture/security.md
+docs/architecture/tests.md
+docs/guides/README.md
+docs/guides/bot-account.md
+.devcontainer/related-repos.txt
+"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+if ! have copier; then
+    echo "SKIP: copier is not installed — cannot render the template." >&2
+    exit 0
+fi
+
+dest="$(mktemp -d -t harmon-init-dogfood-XXXXXX)"
+trap 'rm -rf "$dest"' EXIT
+
+# --vcs-ref=HEAD is load-bearing: without it copier renders the latest TAG and
+# every uncommitted/untagged change is invisible (see AGENTS.md).
+copier copy . "$dest" --trust --vcs-ref=HEAD --defaults --quiet \
+    --data-file .dogfood-answers.yml \
+    --data git_init=false \
+    --data github_remote_create=false \
+    --data github_release_init=false \
+    --data run_task_install=false \
+    --data bunch_add=false \
+    --data obsidian_project_add=false >/dev/null 2>&1
+
+only_summary=0
+[ "${1:-}" = "--summary" ] && only_summary=1
+
+differ=0
+same=0
+skipped=0
+missing=0
+report=""
+
+while IFS= read -r rendered; do
+    rel="${rendered#"$dest"/}"
+    case "
+$SKIP
+" in *"
+$rel
+"*)
+        skipped=$((skipped + 1))
+        continue
+        ;;
+    esac
+    # *.code-workspace is generated once then owned by the consumer; the root
+    # gitignores it entirely. Same for the .meta scratch dir.
+    case "$rel" in *.code-workspace | .meta/*) skipped=$((skipped + 1)) && continue ;; esac
+
+    if [ ! -e "$rel" ]; then
+        missing=$((missing + 1))
+        report="${report}
+ABSENT AT ROOT  ${rel}"
+        continue
+    fi
+    if diff -q "$rendered" "$rel" >/dev/null 2>&1; then
+        same=$((same + 1))
+    else
+        differ=$((differ + 1))
+        n=$(diff -u "$rel" "$rendered" | grep -cE '^[+-][^+-]' || true)
+        report="${report}
+DIFFERS (${n} lines)  ${rel}"
+    fi
+done < <(find "$dest" -type f ! -path "$dest/.git/*" | sort)
+
+echo "── dogfood audit (root vs template rendered with .dogfood-answers.yml) ──"
+echo "identical: ${same}   differing: ${differ}   absent at root: ${missing}   skipped (root-owned): ${skipped}"
+[ -n "$report" ] && printf '%s\n' "$report"
+
+if [ "$only_summary" -eq 0 ] && [ "$differ" -gt 0 ]; then
+    echo
+    echo "── diffs (left = root, right = rendered template) ──"
+    while IFS= read -r line; do
+        case "$line" in "DIFFERS "*)
+            f="${line##*)  }"
+            echo
+            echo "═══ $f ═══"
+            diff -u "$f" "$dest/$f" || true
+            ;;
+        esac
+    done <<EOF
+$report
+EOF
+fi
+
+echo
+echo "Report only — differences here are NOT automatically failures. The root"
+echo "layer intentionally diverges (harmon-init-specific content, root-only"
+echo "tooling, template/ lint exclusions). Reconcile what is real drift, and"
+echo "edit BOTH layers in lockstep (AGENTS.md)."

--- a/scripts/test-dogfood-structure.sh
+++ b/scripts/test-dogfood-structure.sh
@@ -149,7 +149,12 @@ if [ -f "$dest/Taskfile.yml" ] && [ -f Taskfile.yml ]; then
     while IFS= read -r task; do
         [ -n "$task" ] || continue
         checked=$((checked + 1))
-        if ! grep -qE "^  ${task}:" Taskfile.yml; then
+        # Whole-line fixed-string match. An unanchored regex ("^  ${task}:")
+        # prefix-matches namespaced siblings — a missing `security:` would be
+        # satisfied by `  security:audit:` — so a dropped group-name task would
+        # pass silently. -x anchors both ends; -F avoids treating the name as a
+        # pattern.
+        if ! grep -qxF "  ${task}:" Taskfile.yml; then
             allowed "Taskfile.yml" "$task" && continue
             echo "FAIL: Taskfile.yml is missing a task the rendered template has: '${task}'" >&2
             fail=1

--- a/scripts/test-dogfood-structure.sh
+++ b/scripts/test-dogfood-structure.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# test-dogfood-structure.sh — GATE the structural subset of root<->template drift.
+#
+# The three dogfood checks, in increasing looseness:
+#   test-dogfood-parity.sh    byte-equality for VERBATIM twins        (hard gate)
+#   this script               structure only, for JINJA twins         (hard gate)
+#   audit-dogfood.sh          full diff of jinja twins                (report)
+#
+# Prose in a jinja twin legitimately differs (the root has harmon-init-specific
+# sections and root-only tooling), so full-text equality can never be gated. But
+# STRUCTURE can: if the rendered template grows a section or a task, the root copy
+# should have gained one too. That catches the commonest drift — "template gained
+# X, the root never got it" — which is the direction drift actually travels, since
+# you edit template/ to ship a fix to consumers and nothing fails when the root
+# copy is forgotten.
+#
+# Checked:
+#   - every `##`..`######` heading in a rendered markdown twin exists in the root twin
+#   - every top-level task name in the rendered Taskfile exists in the root Taskfile
+#
+# NOT checked: anything inside a section or task body. A rewritten task body or a
+# changed step still needs `task audit:dogfood` and human eyes.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Git hooks export GIT_DIR/GIT_WORK_TREE; left set, copier's `git init` in the
+# temp render re-targets THIS repo. Same sanitation as test-template.sh.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+# Files whose root copy is NOT a render of the template copy — comparing their
+# structure is meaningless. Same rationale (and largely the same list) as the
+# SKIP block in audit-dogfood.sh.
+SKIP_FILES="
+CHANGELOG.md
+README.md
+DESIGN.md
+docs/README.md
+docs/CHECKLIST.md
+docs/project-management.md
+docs/architecture/README.md
+docs/architecture/branch-protection.md
+docs/architecture/ci-cd.md
+docs/architecture/security.md
+docs/architecture/tests.md
+docs/guides/README.md
+docs/guides/bot-account.md
+"
+
+# Structural elements the root DELIBERATELY does not mirror, as `path|element`.
+# Every entry needs a reason. Keep this list short: each one is a place the gate
+# has been told to look away.
+#   AGENTS.md|## Commands
+#       Root titles the section "## Common Commands" (it documents copier and the
+#       template-render tasks, which no generated repo has).
+#   AGENTS.md|## Definition of Done
+#       Root folds these rules into "## Development Workflow", alongside the
+#       two-layer rules (release-title guard, dogfood parity) that only apply here.
+#   Taskfile.yml|validate
+#       The template ships a placeholder echo. harmon-init's real validation is
+#       the test:template render matrix, so a stub claiming "no validate steps"
+#       would be actively wrong. See PR #378.
+ALLOW="
+AGENTS.md|## Commands
+AGENTS.md|## Definition of Done
+Taskfile.yml|validate
+"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+if ! have copier; then
+    # In CI a missing tool must FAIL, never skip: this is a gate, and a silent
+    # skip reports green while checking nothing. Same rule as test-template.sh.
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+        echo "FAIL: copier is required in CI — the workflow must install it before this step." >&2
+        exit 1
+    fi
+    echo "SKIP: copier is not installed — cannot render the template."
+    exit 0
+fi
+
+dest="$(mktemp -d -t harmon-init-structure-XXXXXX)"
+trap 'rm -rf "$dest"' EXIT
+
+# --vcs-ref=HEAD is load-bearing: without it copier renders the latest TAG.
+copier copy . "$dest" --trust --vcs-ref=HEAD --defaults --quiet \
+    --data-file .dogfood-answers.yml \
+    --data git_init=false \
+    --data github_remote_create=false \
+    --data github_release_init=false \
+    --data run_task_install=false \
+    --data bunch_add=false \
+    --data obsidian_project_add=false >/dev/null 2>&1
+
+allowed() {
+    case "
+$ALLOW
+" in *"
+$1|$2
+"*) return 0 ;; esac
+    return 1
+}
+
+fail=0
+checked=0
+
+# ── markdown headings ────────────────────────────────────────────────
+while IFS= read -r rel; do
+    [ -e "$rel" ] || continue
+    # CLAUDE.md / GEMINI.md / copilot-instructions.md are symlinks to AGENTS.md;
+    # checking them just reports every AGENTS.md finding four times.
+    [ -L "$rel" ] && continue
+    case "
+$SKIP_FILES
+" in *"
+$rel
+"*) continue ;; esac
+
+    while IFS= read -r heading; do
+        [ -n "$heading" ] || continue
+        checked=$((checked + 1))
+        if ! grep -qxF "$heading" "$rel"; then
+            allowed "$rel" "$heading" && continue
+            echo "FAIL: ${rel} is missing a section the rendered template has: '${heading}'" >&2
+            fail=1
+        fi
+    done < <(grep -E '^#{2,6} ' "$dest/$rel" 2>/dev/null || true)
+done < <(cd "$dest" && find . -name '*.md' ! -path './.git/*' | sed 's|^\./||' | sort)
+
+# ── Taskfile task names ──────────────────────────────────────────────
+if [ -f "$dest/Taskfile.yml" ] && [ -f Taskfile.yml ]; then
+    while IFS= read -r task; do
+        [ -n "$task" ] || continue
+        checked=$((checked + 1))
+        if ! grep -qE "^  ${task}:" Taskfile.yml; then
+            allowed "Taskfile.yml" "$task" && continue
+            echo "FAIL: Taskfile.yml is missing a task the rendered template has: '${task}'" >&2
+            fail=1
+        fi
+    done < <(sed -nE 's/^  ([a-z][a-z0-9:_-]*):$/\1/p' "$dest/Taskfile.yml" | sort -u)
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "dogfood structure: the root layer is missing structure the template ships." >&2
+    echo "Edit both layers in lockstep (AGENTS.md). If the omission is deliberate," >&2
+    echo "add it to ALLOW in scripts/test-dogfood-structure.sh WITH a reason." >&2
+    echo "Run 'task audit:dogfood' to see the full root<->template diff." >&2
+    exit 1
+fi
+echo "dogfood structure OK: ${checked} rendered sections/tasks all present in the root layer"

--- a/scripts/test-dogfood-structure.sh
+++ b/scripts/test-dogfood-structure.sh
@@ -59,10 +59,15 @@ docs/guides/bot-account.md
 #       The template ships a placeholder echo. harmon-init's real validation is
 #       the test:template render matrix, so a stub claiming "no validate steps"
 #       would be actively wrong. See PR #378.
+#   todo.md|<absent>
+#       Per-project scratch file. The root gitignores it (`/todo.md`), so the
+#       root layer having no copy is correct. `<absent>` is the sentinel for
+#       "this rendered file is allowed to have no root twin at all".
 ALLOW="
 AGENTS.md|## Commands
 AGENTS.md|## Definition of Done
 Taskfile.yml|validate
+todo.md|<absent>
 "
 
 have() { command -v "$1" >/dev/null 2>&1; }
@@ -104,15 +109,29 @@ checked=0
 
 # ── markdown headings ────────────────────────────────────────────────
 while IFS= read -r rel; do
-    [ -e "$rel" ] || continue
     # CLAUDE.md / GEMINI.md / copilot-instructions.md are symlinks to AGENTS.md;
-    # checking them just reports every AGENTS.md finding four times.
+    # checking them just reports every AGENTS.md finding four times. Tested
+    # before the existence check below, since a symlink whose target is present
+    # is not a missing file.
     [ -L "$rel" ] && continue
     case "
 $SKIP_FILES
 " in *"
 $rel
 "*) continue ;; esac
+
+    # A rendered doc with NO root copy is the WORST case, not a skippable one:
+    # the template gained a whole dogfooded file and the root never got it. An
+    # early `continue` here would report green over exactly the drift this gate
+    # exists to catch.
+    if [ ! -e "$rel" ]; then
+        checked=$((checked + 1))
+        if ! allowed "$rel" "<absent>"; then
+            echo "FAIL: ${rel} is rendered by the template but does not exist in the root layer" >&2
+            fail=1
+        fi
+        continue
+    fi
 
     while IFS= read -r heading; do
         [ -n "$heading" ] || continue


### PR DESCRIPTION
## What

Closes the hole #378 exposed: **the root↔template dogfood had no check covering jinja twins.**

`task test:dogfood-parity` byte-compares the 130 **verbatim** template files and reported a confident `133/133 OK` the entire time the root was materially behind. That gate covers the easy half. The 65 **jinja** twins with a root counterpart — `AGENTS.md`, `Taskfile.yml`, the workflows, docs — were checked by nothing at all, and **every one of the 13 files #378 had to fix was a jinja twin.**

The drift is also directional: you edit `template/` to ship a fix to consumers (the release-content guard even *forces* you to think about `template/` at PR time), nothing fails, and the root copy is the afterthought. There was a CI check pushing attention toward the template and nothing pulling it back.

## Three pieces

**1. `.dogfood-answers.yml`** — the copier answers the root layer is the render of, previously implicit and reconstructed by hand each time.

Not a `.copier-answers.yml`: harmon-init *is* the template, so it has no copier operation of its own and `copier update` can never target it. Verified by rendering with it — the file set matches root exactly, except the three files root deliberately gitignores (`.copier-answers.yml`, `*.code-workspace`, `todo.md`).

**2. `task audit:dogfood`** — renders `template/` at HEAD with those answers and diffs every jinja twin against its root copy.

A **report, not a gate**; exits 0 even with differences. The root legitimately diverges in prose, and a check that always fails is a check everyone learns to ignore. `-- --summary` for names and diff sizes. Currently **134 identical / 16 differing / 0 absent / 21 skipped**.

**3. `task test:dogfood-structure`** — the gateable subset, wired into `verify` and the CI lint job.

Full text can't be gated; structure can. Every heading in a rendered markdown twin and every task name in the rendered Taskfile must exist in the root copy — catching "template gained X, root never got it." **196 elements checked, 4 allowlisted omissions, each with its reason recorded.** It does *not* catch changes inside a task body or paragraph; that's what `audit:dogfood` and human eyes are for.

I pitched this expecting the allowlist to balloon and the gate to catch maybe 2 of 13 findings. Measured, it needed 3 entries (a 4th was added for `todo.md` during review).

## The tooling immediately found real drift

`close-milestone-on-release.yml` was missing the `CI_RUNS_ON` runner-switch comment added to the other four workflows in #378. It was invisible then because that ad-hoc render guessed `project_management=none`, so the file never rendered — which is precisely the argument for checking the answers in. Fixed here.

## Gate-integrity fixes made while building

Four defects, each of which would have left a decorative check. Two I caught while wiring, two came from `task review` (Codex) — all reproduced before fixing:

| Defect | Why it mattered |
|---|---|
| Script exited 0 when copier was absent | CI's lint job has no copier — green while checking nothing. Now fails under `GITHUB_ACTIONS`, skips only locally |
| Nearly used `scripts/install-copier.sh` in CI | It no-ops when `brew` exists, and GitHub's ubuntu images ship linuxbrew — copier would have stayed missing |
| Rendered file with **no** root twin was skipped | A whole new dogfooded doc could go missing and pass. Reproduced: gate said `OK: 195 ... all present`, exit 0 |
| `grep -qE "^  ${task}:"` prefix-matched | A missing bare `security:` was satisfied by `security:audit:`. Reproduced: renamed the task, gate still exit 0 |

## Verification

- `task verify` and `task ci` green.
- **Negative-tested rather than trusting green** — the gate must be able to fail:
  - remove `## Conventions` from AGENTS.md → exit 1
  - rename the `sync:skills` task → exit 1
  - add a template doc with no root twin → exit 1
  - remove the bare `security:` task → exit 1
  - clean tree → exit 0
- `task challenge` clean; `task review` clean on re-run (3 findings fixed across 4 rounds).
- Release guard pre-flighted: `chore:` is correct — this is root-only tooling (like `test-template.sh`), nothing ships to `template/`. Generated repos have `copier update` for this.

## Note on scope

This is deliberately **not** in the standardize-repo skill. That skill states its own scope — *"how an agent **consumes** that template"* — and its remediation is `copier update`. harmon-init's root is the source, not a consumer: no answers file, `copier update` can't target it, and its expected divergence is substantial rather than near-zero. Full reasoning is in the thread on this PR's sibling discussion.

Follow-up #379 (Lighthouse CI-mirror gap) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yVCkTcXvs5F6o8HLGy1N8
