### PR TITLE
fix(template): stop trailing block tags from joining the next rendered line

### DIFF
--- a/template/.github/github-app-manifest.json.jinja
+++ b/template/.github/github-app-manifest.json.jinja
@@ -15,6 +15,6 @@
     "metadata": "read"[% if github_org != author_git_provider_username %],
     "actions": "read",
     "members": "read",
-    "organization_projects": "write"[% endif %]
+    "organization_projects": "write"[% endif +%]
   }
 }

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -445,7 +445,7 @@ provider accounts, and machines. The standard:
   <org>` holding `Account ID`) so identifiers have one home too.
 - **SSH keys use the 1Password SSH key type** (fields: `public key`,
   `fingerprint`, `private key`, `passphrase`).
-- Repos consume credentials only through references[% if use_python %]
+- Repos consume credentials only through references[% if use_python +%]
   (`.envrc.tpl` → `op inject`, see
   [../guides/local-secrets.md](../guides/local-secrets.md))[% endif %] or CI
   secrets fed from these items (`op read "…" | gh secret set …`) — never by

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -17,7 +17,7 @@ it points here.
   major bump.
 - **Feature branches only.** Direct commits to `main` are blocked by the
   `guard:no-commit-to-main` pre-commit hook and the branch ruleset. Land changes
-  via a PR; code-owner review and the `verify` + `security`[% if use_codeql %] + `codeql-verify`[% endif %]
+  via a PR; code-owner review and the `verify` + `security`[% if use_codeql %] + `codeql-verify`[% endif +%]
   checks are required.
 - **Never bypass hooks** (`--no-verify` is forbidden) — fix the underlying issue.
 [% if devcontainer %]

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -73,7 +73,7 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\n\\s*\\w+_version:\\s*\"(?<currentValue>[^\"]+)\""
       ]
-    }[% endif %]
+    }[% endif +%]
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## What

Four rendered files carried a whitespace defect that shipped to generated repos.

`_envops` sets `trim_blocks`, which strips the newline immediately after a block tag. A `[% endif %]` (or `[% if %]`) sitting at **end of line** therefore swallows the line break and welds the next line onto it:

| Rendered file | Damage | Reaches |
|---|---|---|
| `renovate.json` | `}  ],` where the managers array closes | every generated repo |
| `docs/conventions.md` | ``…`codeql-verify`  checks are required.`` | every repo with CodeQL |
| `.github/github-app-manifest.json` | `"organization_projects": "write"  }` | every **org-owned** repo |
| `docs/architecture/security.md` | ``…through references  (`.envrc.tpl` …`` | every Python/iac repo |

All four are cosmetic — the JSON stays valid and the markdown still renders — but they're in consumers' checked-in config.

## Fix

Jinja's per-tag whitespace control, `+%]`, which disables `trim_blocks` for that tag only.

**This is not a new idiom here.** `renovate.json.jinja:142` and `build.yml.jinja:41` already use `+%]` for exactly this reason — these four were simply missed. I verified the syntax works with this repo's custom `%]` delimiter before relying on it.

## Deliberately left alone

`build.yml.jinja:302` also ends on a block tag, but the comment directly beneath it shows that's intentional — a literal final line so `trim_blocks` doesn't eat the workflow's EOF newline. Changing it would reintroduce the bug that comment prevents.

## How this was found

`task audit:dogfood` from #382. I'd spotted the first two by eye while diffing during #378 and deliberately left them (fixing `template/` would have changed that PR's release semantics). Rather than fix just those two, I scanned for the whole bug class — `grep` for lines ending in a block tag with content before them — which surfaced the other two, both in branches my earlier renders never exercised.

## Verification

Rendered **both** branches of every affected conditional — `use_codeql` on/off, org vs personal `github_org`, `use_python` on/off:

- Each artifact is gone when the branch is taken.
- Each negative branch still renders as one correct sentence/object (e.g. `…only through references or CI secrets…`).
- `github-app-manifest.json` parses as JSON in both branches.
- No root twin carried these — they're render-only defects, so the root layer needed no matching change; `task audit:dogfood` confirms.
- `task verify` and `task ci` green. `task challenge` and `task review` (Codex) both clean on first pass.

`fix:` title is required and correct: this changes `template/`, so consumers only receive it via `copier update` to a released tag. Guard pre-flighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yVCkTcXvs5F6o8HLGy1N8
