### PR TITLE
docs: describe the real check/verify/ci tiers in conventions.md

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -32,7 +32,14 @@ it points here.
   `install:hooks`, `status:git`. **Never action-first** (`typescript:lint`,
   `yaml:lint`).
 - Pipeline order is **`check → build → validate → test → security`**, with
-  `verify` (local gate) and `ci` (full) as the aggregates.
+  `verify` and `ci` as the aggregates. `check` is the fast inner-loop/hook gate
+  (lint only). `verify` is the definition-of-done gate — `check` + the
+  Taskfile/hook/dogfood guards + this repo's test tier, which renders the whole
+  template via `test:template` and is therefore heavier than a generated repo's.
+  `ci` is the full CI mirror — `verify` + the network skills-drift check
+  (`verify:skills`) + the devcontainer permission assert + `security`. A check
+  the build workflow **gates on** and that can run locally belongs in `ci` too,
+  or the mirror quietly stops being one.
 - **`lint:*` and `check` are read-only gates** — they report and fail, never
   modify files. All auto-fixing lives in **`task format`**, **`task format:file
   -- <path>`**, and **`task fix`** (= format then lint). Pre-commit hooks run the


### PR DESCRIPTION
## What

`docs/conventions.md`'s "Pipeline order" bullet said only:

> `verify` (local gate) and `ci` (full) as the aggregates.

Accurate but uninformative — and terser than the same bullet in `template/docs/conventions.md.jinja`, which now explains the tiers.

## Adapted, not copied

The template's wording describes a **generated** repo, where `verify` = check + validate + test and `ci` = verify + security. Neither matches this repo:

| | this repo |
|---|---|
| `check` | lint only — the fast inner-loop/hook gate |
| `verify` | `check` + the Taskfile/hook/dogfood guards + the full `test:template` render matrix |
| `ci` | `verify` + `verify:skills` (network) + the devcontainer permission assert + `security` |

Copying the template verbatim would have documented a pipeline harmon-init doesn't have — the exact failure mode the dogfood tooling from #382 exists to prevent, so it seemed worth not committing it in the same breath.

Also carries over the invariant added to `AGENTS.md` in #378, so it lives with the conventions catalog too: *a check the build workflow gates on and that can run locally belongs in `ci`.*

## Verification

Every claim cross-checked against the Taskfile rather than read off task descriptions:

```
check -> lint only?        yes (deps: lint)
ci includes verify:skills? yes
ci includes devcontainer?  yes
ci includes security?      yes
verify includes template?  yes
```

`task verify` green (re-run after rebasing onto #383). markdownlint clean. Root-only, so `docs:` is the correct type — guard pre-flighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yVCkTcXvs5F6o8HLGy1N8
