### PR TITLE
feat: give the dev container the host Claude Code status line

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -392,8 +392,13 @@ RUN install -d -m 0755 /home/vscode/.config/zellij \
 # Hook scripts referenced from managed-settings.json are installed alongside
 # at /etc/claude-code/hooks/ so they share the same image-baked, volume-proof
 # location. Source of truth: .devcontainer/config/claude-hooks/ (checked into git).
+#
+# statusline.sh lands here for the same reason: ~/.claude is a volume mount at
+# runtime, so a status line script shipped inside it would vanish on a volume
+# wipe. The `statusLine` key in claude-user-defaults.json points at this path.
 RUN install -d -m 0755 /etc/claude-code /etc/claude-code/hooks \
     && install -m 0644 /usr/local/share/devcontainer-config/claude-settings.json /etc/claude-code/managed-settings.json \
+    && install -m 0755 /usr/local/share/devcontainer-config/claude-statusline.sh /etc/claude-code/statusline.sh \
     && install -m 0755 /usr/local/share/devcontainer-config/claude-hooks/post-edit-format.sh             /etc/claude-code/hooks/post-edit-format.sh \
     && install -m 0755 /usr/local/share/devcontainer-config/claude-hooks/protect-files.sh               /etc/claude-code/hooks/protect-files.sh \
     && install -m 0755 /usr/local/share/devcontainer-config/claude-hooks/block-no-verify.sh             /etc/claude-code/hooks/block-no-verify.sh \

--- a/.devcontainer/config/claude-statusline.sh
+++ b/.devcontainer/config/claude-statusline.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# claude-statusline.sh — Claude Code `statusLine` renderer for the dev container.
+#
+# Gives a container session the same two-line status line as a host session:
+#
+#   📁 ~/git/harmon-init  🌿 main  🤖 Opus 5  📟 v2.1.220  🎨 default
+#   🧠 Context Remaining: 60% [======----]
+#
+# Claude Code pipes the session JSON on stdin and renders whatever we print.
+# Baked into the image at /etc/claude-code/statusline.sh (see the Dockerfile) so
+# it survives the ~/.claude volume mount, and wired up via the `statusLine` key
+# in config/claude-user-defaults.json — a seed default the user can override.
+#
+# `set -e` is deliberately omitted: this runs on every render, so a single
+# failing probe (no git repo, a field a newer payload no longer emits) must
+# degrade to a shorter line rather than blank the status line entirely.
+set -uo pipefail
+
+input=$(cat)
+
+# ---- colors (256-color palette; honors NO_COLOR) ----
+if [ -n "${NO_COLOR:-}" ]; then
+    color() { :; }
+    reset() { :; }
+else
+    color() { printf '\033[38;5;%sm' "$1"; }
+    reset() { printf '\033[0m'; }
+fi
+
+COLOR_DIR=117     # sky blue
+COLOR_GIT=150     # soft green
+COLOR_MODEL=147   # light purple
+COLOR_VERSION=249 # light gray
+COLOR_STYLE=245   # gray
+
+# Claude Code renders our stdout as ANSI, and a directory name may legally
+# contain ESC or a newline — so every value that reaches the terminal is
+# stripped of control bytes first. Without this, a checkout under a crafted
+# path could inject escape sequences (OSC 52 clipboard writes, extra status
+# lines) on every refresh.
+sanitize() { printf '%s' "$1" | tr -d '[:cntrl:]'; }
+
+# field <emoji> <color> <text> — one "  <emoji> <colored text>" segment.
+field() {
+    printf '  %s %s%s%s' "$1" "$(color "$2")" "$(sanitize "$3")" "$(reset)"
+}
+
+# jq is baked into the image. Without it there is no payload to read, so fall
+# back to the one thing we can still resolve locally.
+if ! command -v jq >/dev/null 2>&1; then
+    printf '📁 %s\n' "$(sanitize "$PWD")"
+    exit 0
+fi
+
+json() { printf '%s' "$input" | jq -r "$1" 2>/dev/null; }
+
+current_dir=$(json '.workspace.current_dir // .cwd // ""')
+model_name=$(json '.model.display_name // ""')
+cc_version=$(json '.version // ""')
+output_style=$(json '.output_style.name // ""')
+
+# jq exits nonzero (and prints nothing) on an unparseable payload, so the
+# fallbacks belong here rather than in the filters above.
+[ -n "$model_name" ] || model_name="Claude"
+
+# ---- git branch (resolved in the session's directory, not ours) ----
+git_branch=""
+if [ -n "$current_dir" ] && cd "$current_dir" 2>/dev/null; then
+    if git rev-parse --git-dir >/dev/null 2>&1; then
+        git_branch=$(git branch --show-current 2>/dev/null)
+        [ -n "$git_branch" ] || git_branch=$(git rev-parse --short HEAD 2>/dev/null)
+    fi
+fi
+
+# ---- display path (~ for $HOME, matching the host status line) ----
+display_dir="${current_dir:-unknown}"
+case "$display_dir" in
+"$HOME") display_dir="~" ;;
+"$HOME"/*) display_dir="~${display_dir#"$HOME"}" ;;
+esac
+
+# ---- context window ----
+# Claude Code already reports `remaining_percentage`; prefer it so the bar never
+# disagrees with the figure the CLI itself shows (its rounding is not ours, and
+# it accounts for reserved output tokens). The token sum is a fallback for
+# payloads that predate the field.
+context_pct=""
+context_bar=""
+context_color=158 # mint green
+remaining=$(json '.context_window.remaining_percentage // empty')
+if ! [[ "$remaining" =~ ^[0-9]+$ ]]; then
+    remaining=""
+    context_size=$(json '.context_window.context_window_size // 0')
+    context_used=$(json '(.context_window.current_usage // {})
+        | (.input_tokens // 0)
+        + (.cache_creation_input_tokens // 0)
+        + (.cache_read_input_tokens // 0)')
+    if [[ "$context_size" =~ ^[0-9]+$ ]] && [[ "$context_used" =~ ^[0-9]+$ ]] &&
+        [ "$context_size" -gt 0 ] && [ "$context_used" -gt 0 ]; then
+        remaining=$((100 - context_used * 100 / context_size))
+    fi
+fi
+
+if [ -n "$remaining" ]; then
+    ((remaining < 0)) && remaining=0
+    ((remaining > 100)) && remaining=100
+
+    if [ "$remaining" -le 20 ]; then
+        context_color=203 # coral red
+    elif [ "$remaining" -le 40 ]; then
+        context_color=215 # peach
+    fi
+
+    filled=$((remaining / 10))
+    context_bar=$(printf '%*s' "$filled" '' | tr ' ' '=')
+    context_bar+=$(printf '%*s' "$((10 - filled))" '' | tr ' ' '-')
+    context_pct="${remaining}%"
+fi
+
+# ---- render ----
+printf '📁 %s%s%s' "$(color "$COLOR_DIR")" "$(sanitize "$display_dir")" "$(reset)"
+[ -n "$git_branch" ] && field '🌿' "$COLOR_GIT" "$git_branch"
+field '🤖' "$COLOR_MODEL" "$model_name"
+[ -n "$cc_version" ] && field '📟' "$COLOR_VERSION" "v${cc_version}"
+[ -n "$output_style" ] && field '🎨' "$COLOR_STYLE" "$output_style"
+
+if [ -n "$context_pct" ]; then
+    printf '\n🧠 %sContext Remaining: %s [%s]%s' \
+        "$(color "$context_color")" "$context_pct" "$context_bar" "$(reset)"
+else
+    printf '\n🧠 %sContext Remaining: TBD%s' "$(color "$context_color")" "$(reset)"
+fi
+printf '\n'

--- a/.devcontainer/config/claude-user-defaults.json
+++ b/.devcontainer/config/claude-user-defaults.json
@@ -1,3 +1,8 @@
 {
-  "model": "claude-opus-4-8"
+  "model": "claude-opus-4-8",
+  "statusLine": {
+    "type": "command",
+    "command": "/etc/claude-code/statusline.sh",
+    "padding": 0
+  }
 }

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -108,10 +108,11 @@ fi
 #
 #   2. ~/.claude/settings.json (user level) — seed-merged below from
 #      claude-user-defaults.json. Provides defaults the user CAN override
-#      (currently: model). Existing values in ~/.claude/settings.json always
-#      win on conflict, so /model and other in-app changes stick across
-#      post-create runs. On a fresh volume the defaults are populated; on a
-#      volume wipe + rebuild they come back automatically.
+#      (currently: model, plus the statusLine renderer baked at
+#      /etc/claude-code/statusline.sh). Existing values in ~/.claude/
+#      settings.json always win on conflict, so /model and other in-app changes
+#      stick across post-create runs. On a fresh volume the defaults are
+#      populated; on a volume wipe + rebuild they come back automatically.
 CLAUDE_DEFAULTS_SRC=/usr/local/share/devcontainer-config/claude-user-defaults.json
 CLAUDE_USER_SETTINGS="$HOME/.claude/settings.json"
 if [ -d "$HOME/.claude" ] && [ -f "$CLAUDE_DEFAULTS_SRC" ]; then

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -32,19 +32,22 @@ is fast. A cache miss is non-fatal — it just rebuilds from the `Dockerfile`.
 
 ## Claude Code settings in the container
 
-Two layers, both owned by the container — never the `~/.claude` volume, which a
-rebuild or volume wipe can empty:
+Everything is sourced from `.devcontainer/config/` and baked into the **image**,
+so a volume wipe can never leave the container without its policy, hooks, or
+status line:
 
-| Layer | Baked at | Source | Overridable |
+| What | Lives at | Source | Overridable |
 |---|---|---|---|
-| Managed settings | `/etc/claude-code/managed-settings.json` | `config/claude-settings.json` | no (policy) |
-| Hook scripts | `/etc/claude-code/hooks/` | `config/claude-hooks/` | no |
-| Status line | `/etc/claude-code/statusline.sh` | `config/claude-statusline.sh` | yes |
-| User defaults | `~/.claude/settings.json` | `config/claude-user-defaults.json` | yes |
+| Managed settings | `/etc/claude-code/managed-settings.json` (image) | `config/claude-settings.json` | no (policy) |
+| Hook scripts | `/etc/claude-code/hooks/` (image) | `config/claude-hooks/` | no |
+| Status line | `/etc/claude-code/statusline.sh` (image) | `config/claude-statusline.sh` | yes |
+| User defaults | `~/.claude/settings.json` (**volume**) | `config/claude-user-defaults.json` | yes |
 
-User defaults are **seed-merged** into `~/.claude/settings.json` by
-`post-create-common.sh` — existing values win, so `/model` and other in-app
-changes survive a rebuild, and a fresh volume gets the defaults back.
+The last row is the one exception, and deliberately so: `~/.claude/settings.json`
+is volume-backed because Claude Code writes your in-app changes there. Every
+`post-create` **seed-merges** the image copy into it — existing values win, so
+`/model` and friends stick, and a wiped volume gets the defaults back. What the
+volume never holds is the code those settings point at.
 
 `config/claude-statusline.sh` renders the same two-line status line as a host
 session, so a container session reads identically:

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -30,6 +30,33 @@ Prebuilt images are pulled from GHCR as a build cache
 (`ghcr.io/evanharmon1/harmon-init-devcontainer` / `ghcr.io/evanharmon1/harmon-init-devcontainer-dev`), so a warm rebuild
 is fast. A cache miss is non-fatal — it just rebuilds from the `Dockerfile`.
 
+## Claude Code settings in the container
+
+Two layers, both owned by the container — never the `~/.claude` volume, which a
+rebuild or volume wipe can empty:
+
+| Layer | Baked at | Source | Overridable |
+|---|---|---|---|
+| Managed settings | `/etc/claude-code/managed-settings.json` | `config/claude-settings.json` | no (policy) |
+| Hook scripts | `/etc/claude-code/hooks/` | `config/claude-hooks/` | no |
+| Status line | `/etc/claude-code/statusline.sh` | `config/claude-statusline.sh` | yes |
+| User defaults | `~/.claude/settings.json` | `config/claude-user-defaults.json` | yes |
+
+User defaults are **seed-merged** into `~/.claude/settings.json` by
+`post-create-common.sh` — existing values win, so `/model` and other in-app
+changes survive a rebuild, and a fresh volume gets the defaults back.
+
+`config/claude-statusline.sh` renders the same two-line status line as a host
+session, so a container session reads identically:
+
+```text
+📁 ~/git/harmon-init  🌿 main  🤖 Opus 5  📟 v2.1.220  🎨 default
+🧠 Context Remaining: 60% [======----]
+```
+
+To use your own instead, point `statusLine.command` in `~/.claude/settings.json`
+at it — the seed merge will not overwrite it.
+
 ## Secrets — 1Password Environments (the standard)
 
 Don't hand-write or copy `devcontainer.env`. The standard is **1Password

--- a/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile
@@ -392,8 +392,13 @@ RUN install -d -m 0755 /home/vscode/.config/zellij \
 # Hook scripts referenced from managed-settings.json are installed alongside
 # at /etc/claude-code/hooks/ so they share the same image-baked, volume-proof
 # location. Source of truth: .devcontainer/config/claude-hooks/ (checked into git).
+#
+# statusline.sh lands here for the same reason: ~/.claude is a volume mount at
+# runtime, so a status line script shipped inside it would vanish on a volume
+# wipe. The `statusLine` key in claude-user-defaults.json points at this path.
 RUN install -d -m 0755 /etc/claude-code /etc/claude-code/hooks \
     && install -m 0644 /usr/local/share/devcontainer-config/claude-settings.json /etc/claude-code/managed-settings.json \
+    && install -m 0755 /usr/local/share/devcontainer-config/claude-statusline.sh /etc/claude-code/statusline.sh \
     && install -m 0755 /usr/local/share/devcontainer-config/claude-hooks/post-edit-format.sh             /etc/claude-code/hooks/post-edit-format.sh \
     && install -m 0755 /usr/local/share/devcontainer-config/claude-hooks/protect-files.sh               /etc/claude-code/hooks/protect-files.sh \
     && install -m 0755 /usr/local/share/devcontainer-config/claude-hooks/block-no-verify.sh             /etc/claude-code/hooks/block-no-verify.sh \

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-statusline.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-statusline.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# claude-statusline.sh — Claude Code `statusLine` renderer for the dev container.
+#
+# Gives a container session the same two-line status line as a host session:
+#
+#   📁 ~/git/harmon-init  🌿 main  🤖 Opus 5  📟 v2.1.220  🎨 default
+#   🧠 Context Remaining: 60% [======----]
+#
+# Claude Code pipes the session JSON on stdin and renders whatever we print.
+# Baked into the image at /etc/claude-code/statusline.sh (see the Dockerfile) so
+# it survives the ~/.claude volume mount, and wired up via the `statusLine` key
+# in config/claude-user-defaults.json — a seed default the user can override.
+#
+# `set -e` is deliberately omitted: this runs on every render, so a single
+# failing probe (no git repo, a field a newer payload no longer emits) must
+# degrade to a shorter line rather than blank the status line entirely.
+set -uo pipefail
+
+input=$(cat)
+
+# ---- colors (256-color palette; honors NO_COLOR) ----
+if [ -n "${NO_COLOR:-}" ]; then
+    color() { :; }
+    reset() { :; }
+else
+    color() { printf '\033[38;5;%sm' "$1"; }
+    reset() { printf '\033[0m'; }
+fi
+
+COLOR_DIR=117     # sky blue
+COLOR_GIT=150     # soft green
+COLOR_MODEL=147   # light purple
+COLOR_VERSION=249 # light gray
+COLOR_STYLE=245   # gray
+
+# Claude Code renders our stdout as ANSI, and a directory name may legally
+# contain ESC or a newline — so every value that reaches the terminal is
+# stripped of control bytes first. Without this, a checkout under a crafted
+# path could inject escape sequences (OSC 52 clipboard writes, extra status
+# lines) on every refresh.
+sanitize() { printf '%s' "$1" | tr -d '[:cntrl:]'; }
+
+# field <emoji> <color> <text> — one "  <emoji> <colored text>" segment.
+field() {
+    printf '  %s %s%s%s' "$1" "$(color "$2")" "$(sanitize "$3")" "$(reset)"
+}
+
+# jq is baked into the image. Without it there is no payload to read, so fall
+# back to the one thing we can still resolve locally.
+if ! command -v jq >/dev/null 2>&1; then
+    printf '📁 %s\n' "$(sanitize "$PWD")"
+    exit 0
+fi
+
+json() { printf '%s' "$input" | jq -r "$1" 2>/dev/null; }
+
+current_dir=$(json '.workspace.current_dir // .cwd // ""')
+model_name=$(json '.model.display_name // ""')
+cc_version=$(json '.version // ""')
+output_style=$(json '.output_style.name // ""')
+
+# jq exits nonzero (and prints nothing) on an unparseable payload, so the
+# fallbacks belong here rather than in the filters above.
+[ -n "$model_name" ] || model_name="Claude"
+
+# ---- git branch (resolved in the session's directory, not ours) ----
+git_branch=""
+if [ -n "$current_dir" ] && cd "$current_dir" 2>/dev/null; then
+    if git rev-parse --git-dir >/dev/null 2>&1; then
+        git_branch=$(git branch --show-current 2>/dev/null)
+        [ -n "$git_branch" ] || git_branch=$(git rev-parse --short HEAD 2>/dev/null)
+    fi
+fi
+
+# ---- display path (~ for $HOME, matching the host status line) ----
+display_dir="${current_dir:-unknown}"
+case "$display_dir" in
+"$HOME") display_dir="~" ;;
+"$HOME"/*) display_dir="~${display_dir#"$HOME"}" ;;
+esac
+
+# ---- context window ----
+# Claude Code already reports `remaining_percentage`; prefer it so the bar never
+# disagrees with the figure the CLI itself shows (its rounding is not ours, and
+# it accounts for reserved output tokens). The token sum is a fallback for
+# payloads that predate the field.
+context_pct=""
+context_bar=""
+context_color=158 # mint green
+remaining=$(json '.context_window.remaining_percentage // empty')
+if ! [[ "$remaining" =~ ^[0-9]+$ ]]; then
+    remaining=""
+    context_size=$(json '.context_window.context_window_size // 0')
+    context_used=$(json '(.context_window.current_usage // {})
+        | (.input_tokens // 0)
+        + (.cache_creation_input_tokens // 0)
+        + (.cache_read_input_tokens // 0)')
+    if [[ "$context_size" =~ ^[0-9]+$ ]] && [[ "$context_used" =~ ^[0-9]+$ ]] &&
+        [ "$context_size" -gt 0 ] && [ "$context_used" -gt 0 ]; then
+        remaining=$((100 - context_used * 100 / context_size))
+    fi
+fi
+
+if [ -n "$remaining" ]; then
+    ((remaining < 0)) && remaining=0
+    ((remaining > 100)) && remaining=100
+
+    if [ "$remaining" -le 20 ]; then
+        context_color=203 # coral red
+    elif [ "$remaining" -le 40 ]; then
+        context_color=215 # peach
+    fi
+
+    filled=$((remaining / 10))
+    context_bar=$(printf '%*s' "$filled" '' | tr ' ' '=')
+    context_bar+=$(printf '%*s' "$((10 - filled))" '' | tr ' ' '-')
+    context_pct="${remaining}%"
+fi
+
+# ---- render ----
+printf '📁 %s%s%s' "$(color "$COLOR_DIR")" "$(sanitize "$display_dir")" "$(reset)"
+[ -n "$git_branch" ] && field '🌿' "$COLOR_GIT" "$git_branch"
+field '🤖' "$COLOR_MODEL" "$model_name"
+[ -n "$cc_version" ] && field '📟' "$COLOR_VERSION" "v${cc_version}"
+[ -n "$output_style" ] && field '🎨' "$COLOR_STYLE" "$output_style"
+
+if [ -n "$context_pct" ]; then
+    printf '\n🧠 %sContext Remaining: %s [%s]%s' \
+        "$(color "$context_color")" "$context_pct" "$context_bar" "$(reset)"
+else
+    printf '\n🧠 %sContext Remaining: TBD%s' "$(color "$context_color")" "$(reset)"
+fi
+printf '\n'

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-user-defaults.json
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-user-defaults.json
@@ -1,3 +1,8 @@
 {
-  "model": "claude-opus-4-8"
+  "model": "claude-opus-4-8",
+  "statusLine": {
+    "type": "command",
+    "command": "/etc/claude-code/statusline.sh",
+    "padding": 0
+  }
 }

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -108,10 +108,11 @@ fi
 #
 #   2. ~/.claude/settings.json (user level) — seed-merged below from
 #      claude-user-defaults.json. Provides defaults the user CAN override
-#      (currently: model). Existing values in ~/.claude/settings.json always
-#      win on conflict, so /model and other in-app changes stick across
-#      post-create runs. On a fresh volume the defaults are populated; on a
-#      volume wipe + rebuild they come back automatically.
+#      (currently: model, plus the statusLine renderer baked at
+#      /etc/claude-code/statusline.sh). Existing values in ~/.claude/
+#      settings.json always win on conflict, so /model and other in-app changes
+#      stick across post-create runs. On a fresh volume the defaults are
+#      populated; on a volume wipe + rebuild they come back automatically.
 CLAUDE_DEFAULTS_SRC=/usr/local/share/devcontainer-config/claude-user-defaults.json
 CLAUDE_USER_SETTINGS="$HOME/.claude/settings.json"
 if [ -d "$HOME/.claude" ] && [ -f "$CLAUDE_DEFAULTS_SRC" ]; then

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -32,19 +32,22 @@ is fast. A cache miss is non-fatal — it just rebuilds from the `Dockerfile`.
 
 ## Claude Code settings in the container
 
-Two layers, both owned by the container — never the `~/.claude` volume, which a
-rebuild or volume wipe can empty:
+Everything is sourced from `.devcontainer/config/` and baked into the **image**,
+so a volume wipe can never leave the container without its policy, hooks, or
+status line:
 
-| Layer | Baked at | Source | Overridable |
+| What | Lives at | Source | Overridable |
 |---|---|---|---|
-| Managed settings | `/etc/claude-code/managed-settings.json` | `config/claude-settings.json` | no (policy) |
-| Hook scripts | `/etc/claude-code/hooks/` | `config/claude-hooks/` | no |
-| Status line | `/etc/claude-code/statusline.sh` | `config/claude-statusline.sh` | yes |
-| User defaults | `~/.claude/settings.json` | `config/claude-user-defaults.json` | yes |
+| Managed settings | `/etc/claude-code/managed-settings.json` (image) | `config/claude-settings.json` | no (policy) |
+| Hook scripts | `/etc/claude-code/hooks/` (image) | `config/claude-hooks/` | no |
+| Status line | `/etc/claude-code/statusline.sh` (image) | `config/claude-statusline.sh` | yes |
+| User defaults | `~/.claude/settings.json` (**volume**) | `config/claude-user-defaults.json` | yes |
 
-User defaults are **seed-merged** into `~/.claude/settings.json` by
-`post-create-common.sh` — existing values win, so `/model` and other in-app
-changes survive a rebuild, and a fresh volume gets the defaults back.
+The last row is the one exception, and deliberately so: `~/.claude/settings.json`
+is volume-backed because Claude Code writes your in-app changes there. Every
+`post-create` **seed-merges** the image copy into it — existing values win, so
+`/model` and friends stick, and a wiped volume gets the defaults back. What the
+volume never holds is the code those settings point at.
 
 `config/claude-statusline.sh` renders a two-line status line matching the one a
 host session shows:

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -30,6 +30,33 @@ Prebuilt images are pulled from GHCR as a build cache
 (`[[ devcontainer_image ]]` / `[[ devcontainer_image ]]-dev`), so a warm rebuild
 is fast. A cache miss is non-fatal — it just rebuilds from the `Dockerfile`.
 
+## Claude Code settings in the container
+
+Two layers, both owned by the container — never the `~/.claude` volume, which a
+rebuild or volume wipe can empty:
+
+| Layer | Baked at | Source | Overridable |
+|---|---|---|---|
+| Managed settings | `/etc/claude-code/managed-settings.json` | `config/claude-settings.json` | no (policy) |
+| Hook scripts | `/etc/claude-code/hooks/` | `config/claude-hooks/` | no |
+| Status line | `/etc/claude-code/statusline.sh` | `config/claude-statusline.sh` | yes |
+| User defaults | `~/.claude/settings.json` | `config/claude-user-defaults.json` | yes |
+
+User defaults are **seed-merged** into `~/.claude/settings.json` by
+`post-create-common.sh` — existing values win, so `/model` and other in-app
+changes survive a rebuild, and a fresh volume gets the defaults back.
+
+`config/claude-statusline.sh` renders a two-line status line matching the one a
+host session shows:
+
+```text
+📁 ~/git/[[ project_slug ]]  🌿 main  🤖 Opus 5  📟 v2.1.220  🎨 default
+🧠 Context Remaining: 60% [======----]
+```
+
+To use your own instead, point `statusLine.command` in `~/.claude/settings.json`
+at it — the seed merge will not overwrite it.
+
 ## Secrets — 1Password Environments (the standard)
 
 Don't hand-write or copy `devcontainer.env`. The standard is **1Password


### PR DESCRIPTION
Closes #386.

## What

A Claude session inside the dev container showed the bare default status line
while the host shows a two-line one. This ships that status line to the
container — and to every repo generated from the template.

```text
📁 ~/git/harmon-init  🌿 main  🤖 Opus 5 (1M context)  📟 v2.1.220  🎨 default
🧠 Context Remaining: 60% [======----]
```

- `config/claude-statusline.sh` — the renderer, baked to
  `/etc/claude-code/statusline.sh` by the `Dockerfile`, alongside the managed
  settings and hooks. It lives in the image and not in `~/.claude` because that
  path is a volume mount, so anything written there dies with the volume.
- `config/claude-user-defaults.json` — gains the matching `statusLine` key, so
  it arrives through the **existing seed-merge** in `post-create-common.sh`.
  Existing values win, so a user who sets their own `statusLine.command` keeps
  it, and a wiped volume gets the default back.
- `docs/guides/devcontainers.md` — new "Claude Code settings in the container"
  section mapping each layer to its image path, source, and whether it can be
  overridden.

Both layers edited in lockstep — the `Dockerfile`, `post-create-common.sh`, and
both config files are verbatim twins; the guide is a jinja twin.

## Why it isn't a copy of the host script

The host's `~/.claude/statusline.sh` is generated by `cc-statusline`. The
version here renders the same two lines but:

- **drops the per-render logging.** The host script appends the full session
  JSON to a log file on every refresh; that log is currently **128 MB**.
- **drops the dead branches** — the cost/token/burn-rate line references
  variables the script never assigns, so it can never render.
- **prefers `context_window.remaining_percentage`** over recomputing from the
  token counts. Claude Code emits the field directly, and the host script's
  hand-rolled arithmetic disagrees with it (89% where the CLI says 88%).
- **strips control bytes from every value it prints.** Directory names may
  legally contain `ESC`; without this, a checkout under a crafted path injects
  terminal escape sequences (verified: an OSC 52 clipboard-write in a directory
  name reached the terminal before the fix, and is inert after it).

## Verification

- `task verify` and `task ci` green.
- `task test:dogfood-parity` (105 verbatim twins) and `task test:dogfood-structure` green.
- Rendered the template and confirmed the script ships with mode `0755`, the
  `Dockerfile` install line, and the docs section.
- Ran the renderer **inside a Linux container** at its real image path
  (`/etc/claude-code/statusline.sh`) against a captured live payload — correct
  output, `~` substitution, and git-branch detection.
- Exercised: live payload, legacy payload without `remaining_percentage`,
  `remaining_percentage: 0`, absent `context_window`, unparseable stdin, absent
  `jq`, `NO_COLOR`, non-ASCII text, and the escape-injection repro.
- Simulated the `jq` seed-merge for all three cases: fresh volume, existing
  settings without `statusLine`, and a user-supplied `statusLine` (wins).
- `task challenge` and `task review` both exit on a **clean re-run**. Codex
  found three material issues along the way — the `remaining_percentage`
  mismatch, the escape-injection path, and a docs contradiction about what the
  volume holds — all confirmed and fixed. Its "add `statusLine.refreshIntervalMs`"
  finding was declined: the setting exists, but the host config does not set it,
  and the point of this change is to match the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)