### PR TITLE
feat(template): ship Terraform provider-lock discipline

### DIFF
--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -267,4 +267,9 @@ for category in SSH_KEY SSHKEY; do
     fi
 done
 
+if [ -x ./scripts/test-terraform-provider-locks.sh ]; then
+    echo "==> Terraform provider locks cover developer and CI platforms"
+    ./scripts/test-terraform-provider-locks.sh
+fi
+
 echo "==> task targets OK (compile + bootstrap idempotency + path-safe formatting)"

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -872,9 +872,37 @@ if grep -Eq '^include_terraform:[[:space:]]+(true|yes)$' .copier-answers.yml; th
                     err "task ${tf_task} does not reach the Terraform contract '${tf_contract}'"
             done
         done
+        # The provider-lock check must be reachable from `check`, not just
+        # `validate`: an iac repo has no `build-test` job, so nothing in CI runs
+        # `task validate` and a lock check there would never gate a PR.
+        for lock_entry in lint:terraform check; do
+            lock_dry="$(task --color=false --dry "$lock_entry" 2>&1 || true)"
+            grep -qE 'terraform-provider-locks\.sh[[:space:]]+check[[:space:]]+[^[:space:]]' \
+                <<<"$lock_dry" ||
+                err "task ${lock_entry} does not reach the Terraform provider-lock check helper"
+        done
+        lock_update_dry="$(task --color=false --dry terraform:providers:lock 2>&1 || true)"
+        grep -qE 'terraform-provider-locks\.sh[[:space:]]+update[[:space:]]+[^[:space:]]' \
+            <<<"$lock_update_dry" ||
+            err "task terraform:providers:lock does not reach the explicit lock update helper"
     else
         required task "Terraform lint reachability" || fail=1
     fi
+    # The lock helper and its hermetic regression must ship, be executable, and
+    # actually establish both platforms — a committed lock file proves nothing
+    # about which platforms it covers.
+    for lock_script in scripts/terraform-provider-locks.sh scripts/test-terraform-provider-locks.sh; do
+        [ -f "$lock_script" ] || err "$lock_script missing (include_terraform=true)"
+        [ -x "$lock_script" ] || err "$lock_script is not executable"
+    done
+    for lock_contract in 'providers lock' '-platform=darwin_arm64' '-platform=linux_amd64'; do
+        grep -qF -- "$lock_contract" scripts/terraform-provider-locks.sh ||
+            err "scripts/terraform-provider-locks.sh does not establish '$lock_contract'"
+    done
+    ./scripts/test-terraform-provider-locks.sh >/dev/null 2>&1 ||
+        err "scripts/test-terraform-provider-locks.sh fails its hermetic lock-process checks"
+    grep -q 'test-terraform-provider-locks.sh' scripts/test-tasks.sh ||
+        err "test-tasks.sh does not run the provider-lock regression"
     # The TFLint pin SPECIFICALLY. "Some manager matched something in this file"
     # proves nothing: the shell-variable manager already extracts
     # SHELLCHECK_VERSION= from this same action, so a first-match check passes

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -249,14 +249,17 @@ tasks:
 
   # Aggregate reached by `check` (and the pre-commit hook), so the local gate and
   # CI can never enforce different Terraform rules. `lint:terraform:validate`
-  # deliberately stays OUT of it: validate needs `terraform init`, which wants
-  # network + provider downloads, so it runs in `validate` (pre-push + CI).
+  # deliberately stays OUT of it: a full validate wants a backend-shaped init
+  # per root, so it runs in `validate` (pre-push + CI). The lock CHECK is in,
+  # despite also running `terraform init`: it is the only CI-reachable place for
+  # it on an iac repo, which has no `build-test` job to run `task validate`.
   lint:terraform:
-    desc: Terraform lint (fmt + TFLint + Checkov)
+    desc: Terraform lint (fmt + TFLint + Checkov + provider locks)
     cmds:
       - task: lint:terraform:fmt
       - task: lint:terraform:tflint
       - task: lint:terraform:security
+      - task: lint:terraform:locks
 
   lint:terraform:fmt:
     desc: Terraform format check
@@ -283,6 +286,24 @@ tasks:
       CHECKOV_VERSION: 3.3.8
     cmds:
       - uvx --from "checkov=={{.CHECKOV_VERSION}}" checkov -d terraform --quiet --compact
+
+  terraform:providers:lock:
+    # The ONLY task that mutates the committed lock file; the lint check above
+    # calls the same helper in `check` mode, which leaves the checkout clean.
+    desc: Update provider locks for macOS arm64 and Linux amd64
+    cmds:
+      - ./scripts/terraform-provider-locks.sh update terraform
+
+  lint:terraform:locks:
+    # In the aggregate, not the validate tier: for an iac repo `use_node` is
+    # false, so build.yml ships no `build-test` job and NOTHING in CI runs
+    # `task validate` — a lock check there would be locally enforced and
+    # CI-blind. `check` runs in the lint job on every profile. It costs a
+    # `terraform init` in a scratch copy, which is why the aggregate comment
+    # above no longer claims to be network-free.
+    desc: Check provider locks cover macOS arm64 and Linux amd64
+    cmds:
+      - ./scripts/terraform-provider-locks.sh check terraform
 
   lint:terraform:validate:
     desc: Terraform validate

--- a/template/scripts/[% if include_terraform %]terraform-provider-locks.sh[% endif %]
+++ b/template/scripts/[% if include_terraform %]terraform-provider-locks.sh[% endif %]
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# terraform-provider-locks.sh — update or verify reproducible provider locks for
+# the developer (darwin_arm64) and CI (linux_amd64) platforms.
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <check|update> <terraform-root> [terraform-root ...]" >&2
+    exit 2
+}
+
+[ "$#" -ge 2 ] || usage
+mode="$1"
+shift
+case "$mode" in
+check | update) ;;
+*) usage ;;
+esac
+
+terraform_bin="${TERRAFORM_BIN:-terraform}"
+if ! command -v "$terraform_bin" >/dev/null 2>&1; then
+    echo "Terraform executable not found: $terraform_bin" >&2
+    exit 1
+fi
+
+scratch=""
+cleanup() {
+    if [ -n "$scratch" ]; then
+        rm -rf "$scratch"
+    fi
+}
+trap cleanup EXIT HUP INT TERM
+
+for root in "$@"; do
+    if [ ! -d "$root" ]; then
+        echo "Terraform root does not exist: $root" >&2
+        exit 1
+    fi
+
+    root_abs="$(cd "$root" && pwd -P)"
+    scratch="$(mktemp -d -t terraform-provider-locks-XXXXXX)"
+    mkdir "$scratch/repo"
+
+    # Copy the whole Git checkout (tracked + relevant untracked files), not just
+    # the selected root. This preserves relative local-module sources such as
+    # ../../modules/dns while excluding ignored caches and .terraform trees.
+    if repo_top="$(git -C "$root_abs" rev-parse --show-toplevel 2>/dev/null)"; then
+        repo_top="$(cd "$repo_top" && pwd -P)"
+        case "$root_abs" in
+        "$repo_top") root_rel=. ;;
+        "$repo_top"/*) root_rel="${root_abs#"$repo_top"/}" ;;
+        *)
+            echo "Terraform root is outside its Git checkout: $root" >&2
+            exit 1
+            ;;
+        esac
+        file_list="$scratch/repo-files"
+        # Filter to paths that still exist: `--cached` keeps listing a tracked
+        # file whose deletion is not staged yet, and `tar` aborts on the first
+        # missing entry — so one unrelated unstaged deletion anywhere in the
+        # repo would break `task validate` before Terraform even runs.
+        git -C "$repo_top" ls-files --cached --others --exclude-standard |
+            while IFS= read -r repo_file; do
+                if [ -e "$repo_top/$repo_file" ] || [ -L "$repo_top/$repo_file" ]; then
+                    printf '%s\n' "$repo_file"
+                fi
+            done >"$file_list"
+        (cd "$repo_top" && tar -cf - -T "$file_list") |
+            (cd "$scratch/repo" && tar -xf -)
+        scratch_root="$scratch/repo/$root_rel"
+    else
+        # Also support a standalone root before its first git init.
+        mkdir "$scratch/repo/root"
+        cp -R "$root_abs/." "$scratch/repo/root/"
+        scratch_root="$scratch/repo/root"
+    fi
+
+    # Prove clean-checkout behavior even when the caller has initialized this
+    # root locally. All module/provider discovery happens in the scratch copy.
+    rm -rf "$scratch_root/.terraform"
+    init_args=(-backend=false -input=false)
+    if [ "$mode" = update ]; then
+        # Permit intentional provider constraint/version changes. Check mode
+        # must keep selecting from the committed lock and remain read-only.
+        init_args+=(-upgrade)
+    fi
+    if ! "$terraform_bin" "-chdir=$scratch_root" init "${init_args[@]}" >/dev/null; then
+        echo "Could not initialize Terraform modules/providers in $root" >&2
+        exit 1
+    fi
+
+    lock_file="$root/.terraform.lock.hcl"
+    if ! "$terraform_bin" "-chdir=$scratch_root" providers lock \
+        -platform=darwin_arm64 \
+        -platform=linux_amd64 >/dev/null; then
+        echo "Could not verify Terraform provider locks in $root" >&2
+        exit 1
+    fi
+    scratch_lock="$scratch_root/.terraform.lock.hcl"
+
+    # `terraform providers` demands backend initialization for configurations
+    # with remote backends, even after `init -backend=false`. The lock command
+    # does not, and a provider-free fresh root simply produces no lockfile.
+    if [ ! -f "$scratch_lock" ]; then
+        echo "Terraform provider locks: no providers in $root; skipping"
+        cleanup
+        scratch=""
+        continue
+    fi
+
+    if [ "$mode" = update ]; then
+        cp "$scratch_lock" "$lock_file"
+        cleanup
+        scratch=""
+        echo "Terraform provider locks updated: $lock_file"
+        continue
+    fi
+
+    if [ ! -f "$lock_file" ]; then
+        echo "Terraform provider lock missing: $lock_file" >&2
+        echo "Run: task terraform:providers:lock" >&2
+        exit 1
+    fi
+
+    if ! cmp -s "$lock_file" "$scratch_lock"; then
+        echo "Terraform provider lock is not current for the configuration and required platforms: $lock_file" >&2
+        echo "Run: task terraform:providers:lock" >&2
+        exit 1
+    fi
+
+    cleanup
+    scratch=""
+    echo "Terraform provider locks complete: $lock_file"
+done

--- a/template/scripts/[% if include_terraform %]test-terraform-provider-locks.sh[% endif %]
+++ b/template/scripts/[% if include_terraform %]test-terraform-provider-locks.sh[% endif %]
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# test-terraform-provider-locks.sh — hermetic regression for provider-lock
+# update/check behavior. A fake Terraform binary avoids registry access.
+set -euo pipefail
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+tmp="$(mktemp -d -t test-terraform-provider-locks-XXXXXX)"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+fake_terraform="$tmp/terraform"
+
+cat >"$fake_terraform" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+-chdir=*) root="${1#-chdir=}" ;;
+*) exit 2 ;;
+esac
+shift
+
+case "${1:-}" in
+init)
+    upgrade=false
+    for arg in "$@"; do
+        if [ "$arg" = -upgrade ]; then
+            upgrade=true
+        fi
+    done
+    if [ -f "$root/expect-init-upgrade.fixture" ] && [ "$upgrade" != true ]; then
+        echo "update init omitted -upgrade" >&2
+        exit 8
+    fi
+    if [ -f "$root/forbid-init-upgrade.fixture" ] && [ "$upgrade" = true ]; then
+        echo "check init unexpectedly used -upgrade" >&2
+        exit 8
+    fi
+    if [ -f "$root/local-module.fixture" ] &&
+        [ ! -f "$root/../../modules/example/main.tf" ]; then
+        echo "local module was not copied" >&2
+        exit 9
+    fi
+    ;;
+providers)
+    shift
+    [ "${1:-}" = lock ] || exit 2
+    [ -f "$root/required-provider.fixture" ] || exit 0
+    lock="$root/.terraform.lock.hcl"
+    touch "$lock"
+    grep -Fq '# platform: darwin_arm64' "$lock" ||
+        printf '%s\n' '# platform: darwin_arm64' >>"$lock"
+    grep -Fq '# platform: linux_amd64' "$lock" ||
+        printf '%s\n' '# platform: linux_amd64' >>"$lock"
+    ;;
+*) exit 2 ;;
+esac
+EOF
+chmod +x "$fake_terraform"
+
+helper=./scripts/terraform-provider-locks.sh
+
+empty_root="$tmp/empty"
+mkdir "$empty_root"
+printf '%s\n' 'terraform {}' >"$empty_root/main.tf"
+TERRAFORM_BIN="$fake_terraform" "$helper" check "$empty_root" >/dev/null ||
+    fail "provider-free root did not skip cleanly"
+[ ! -e "$empty_root/.terraform.lock.hcl" ] ||
+    fail "provider-free check created a lockfile"
+
+incomplete_root="$tmp/incomplete"
+mkdir "$incomplete_root"
+: >"$incomplete_root/required-provider.fixture"
+printf '%s\n' '# platform: darwin_arm64' >"$incomplete_root/.terraform.lock.hcl"
+before="$(cksum "$incomplete_root/.terraform.lock.hcl")"
+if TERRAFORM_BIN="$fake_terraform" "$helper" check "$incomplete_root" >/dev/null 2>&1; then
+    fail "incomplete multi-platform lock passed"
+fi
+after="$(cksum "$incomplete_root/.terraform.lock.hcl")"
+[ "$before" = "$after" ] || fail "lock check mutated the checkout"
+
+complete_root="$tmp/complete"
+mkdir "$complete_root"
+: >"$complete_root/required-provider.fixture"
+: >"$complete_root/forbid-init-upgrade.fixture"
+printf '%s\n' \
+    '# platform: darwin_arm64' \
+    '# platform: linux_amd64' >"$complete_root/.terraform.lock.hcl"
+TERRAFORM_BIN="$fake_terraform" "$helper" check "$complete_root" >/dev/null ||
+    fail "complete multi-platform lock failed"
+
+update_root="$tmp/update"
+mkdir "$update_root"
+: >"$update_root/required-provider.fixture"
+: >"$update_root/expect-init-upgrade.fixture"
+printf '%s\n' '# stale provider selection' >"$update_root/.terraform.lock.hcl"
+TERRAFORM_BIN="$fake_terraform" "$helper" update "$update_root" >/dev/null ||
+    fail "provider-lock update failed"
+grep -Fq '# platform: darwin_arm64' "$update_root/.terraform.lock.hcl" ||
+    fail "update omitted darwin_arm64"
+grep -Fq '# platform: linux_amd64' "$update_root/.terraform.lock.hcl" ||
+    fail "update omitted linux_amd64"
+
+module_repo="$tmp/module repo"
+module_root="$module_repo/terraform/environments/production env"
+mkdir -p "$module_root" "$module_repo/terraform/modules/example"
+git -C "$module_repo" init -q
+: >"$module_root/required-provider.fixture"
+: >"$module_root/local-module.fixture"
+printf '%s\n' \
+    '# platform: darwin_arm64' \
+    '# platform: linux_amd64' >"$module_root/.terraform.lock.hcl"
+printf '%s\n' 'module "example" { source = "../../modules/example" }' >"$module_root/main.tf"
+printf '%s\n' 'terraform {}' >"$module_repo/terraform/modules/example/main.tf"
+git -C "$module_repo" add .
+module_status_before="$(git -C "$module_repo" status --porcelain)"
+TERRAFORM_BIN="$fake_terraform" "$helper" check "$module_root" >/dev/null ||
+    fail "uninitialized local-module root failed in the scratch checkout"
+module_status_after="$(git -C "$module_repo" status --porcelain)"
+[ "$module_status_before" = "$module_status_after" ] ||
+    fail "local-module lock check mutated the checkout"
+
+echo "Terraform provider-lock regression: PASS"

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -267,4 +267,9 @@ for category in SSH_KEY SSHKEY; do
     fi
 done
 
+if [ -x ./scripts/test-terraform-provider-locks.sh ]; then
+    echo "==> Terraform provider locks cover developer and CI platforms"
+    ./scripts/test-terraform-provider-locks.sh
+fi
+
 echo "==> task targets OK (compile + bootstrap idempotency + path-safe formatting)"


### PR DESCRIPTION
Refs #385 — the "raise the template" direction.

## What

#391 gave the template TFLint and pinned Checkov. This adds the **provider-lock** half, so a generated Terraform repo satisfies the lock contract harmon-devkit's `verify-applied.sh` enforces instead of failing it out of the box.

- ports harmon-infra's `terraform-provider-locks.sh` + its hermetic regression into `template/scripts/`, gated on `include_terraform`
- adds `lint:terraform:locks` and the mutating `terraform:providers:lock`
- runs the regression from `test-tasks.sh`, guarded on the helper being present so it stays a no-op for non-Terraform repos (including this one — the root twin is updated in lockstep for the parity gate)

## The placement decision, and why it changed mid-PR

I first put the lock check in the `validate` tier, matching the template's deliberate "keep `terraform init` out of the fast gate" rule. `task challenge` showed that is **CI-blind on exactly the profile that has Terraform**:

- `task validate` runs only in build.yml's `build-test` job (L87)
- `build-test` is gated `[% if use_node %]`
- an **iac** repo has `use_node=false` → no `build-test` → nothing in CI runs `task validate`
- `terraform.yml` runs raw terraform commands, never a `task` target

So the lock check would have been enforced on developer machines and never on a PR. It now lives in the `lint:terraform` aggregate, which `check` reaches and the `lint` job runs on every profile. The aggregate's comment no longer claims to be network-free — that trade is now explicit rather than silently untrue.

**Worth your call:** this puts a scratch-copy `terraform init` in the pre-commit gate for Terraform repos. The alternative is to keep it in `validate` and have `terraform.yml` run `task lint:terraform:locks` — fast gate stays fast, but it diverges from harmon-devkit's verifier, which specifically requires `task check` to reach the helper. I took the standard-conformant option since #385 was decided as "raise the template".

## Bug fixed in the port

The harmon-infra original builds its scratch copy from `git ls-files --cached`, so a tracked file with an **unstaged deletion** made `tar` abort — taking `task check` down before Terraform ran, for a deletion anywhere in the repo. The file list is now filtered to paths that still exist. harmon-infra has the same bug in its copy.

## Verification

- `task verify` green; **all six** `test-template` profiles pass.
- The new assertions were confirmed to actually execute by mutation: breaking the platform contract string makes `test-template (iac)` fail with the expected diagnostic. (A green assertion that never runs proves nothing.)

## Adjudicated, not fixed

- **Configurable lock platforms** — rejected. `darwin_arm64` + `linux_amd64` *is* the standard: harmon-devkit's catalog specifies exactly those two and its verifier asserts both literals. Changing it means changing the standard.
- **Multi-root partial write** — real, but unreachable as shipped: the template has a single `terraform` root. It matters in harmon-infra, which uses several; better filed there than diverging the two copies.

## Still open on #385

The CI-aggregate half: `terraform-ci.sh` / `terraform-changed.sh` / `test-terraform-ci.sh`, `terraform.yml` restructuring (internal change detector instead of `paths:` filters, `merge_group`, a result-gated `terraform-verify`), and adding `terraform-verify` to the shipped ruleset. That last one changes required checks for every generated repo, so I'm not folding it in without you saying so explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)