### PR TITLE
feat: make terraform-verify reportable on every event

### DIFF
--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -272,4 +272,9 @@ if [ -x ./scripts/test-terraform-provider-locks.sh ]; then
     ./scripts/test-terraform-provider-locks.sh
 fi
 
+if [ -x ./scripts/test-terraform-changed.sh ]; then
+    echo "==> Terraform change detection drives the required terraform-verify check"
+    ./scripts/test-terraform-changed.sh
+fi
+
 echo "==> task targets OK (compile + bootstrap idempotency + path-safe formatting)"

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -903,6 +903,100 @@ if grep -Eq '^include_terraform:[[:space:]]+(true|yes)$' .copier-answers.yml; th
         err "scripts/test-terraform-provider-locks.sh fails its hermetic lock-process checks"
     grep -q 'test-terraform-provider-locks.sh' scripts/test-tasks.sh ||
         err "test-tasks.sh does not run the provider-lock regression"
+
+    # ── The terraform-verify wedge guard ────────────────────────────
+    # terraform-verify is (or is about to become) a REQUIRED status check. A
+    # required check that does not report blocks the merge forever, so the
+    # workflow must NOT filter itself out by path — it has to run on every
+    # event and decide internally. These two assertions are the ones that keep
+    # a future edit from silently re-wedging every PR in a consumer repo.
+    tf_workflow=".github/workflows/terraform.yml"
+    [ -f "$tf_workflow" ] || err "$tf_workflow missing (include_terraform=true)"
+    python3 - "$tf_workflow" <<'PY' || err "the Terraform workflow would wedge a required terraform-verify check (see stderr)"
+import sys, pathlib, re
+
+text = pathlib.Path(sys.argv[1]).read_text()
+# The `on:` block only — a `paths:` key inside a job step is unrelated.
+head = text.split("\njobs:", 1)[0]
+problems = []
+if re.search(r"^\s+paths(-ignore)?:", head, re.M):
+    problems.append(
+        "the `on:` block has a paths filter — the workflow would not report on "
+        "unrelated PRs, and a required check that never reports blocks the merge"
+    )
+for trigger in ("push:", "pull_request:", "merge_group:", "workflow_dispatch:"):
+    if not re.search(r"^\s+%s" % re.escape(trigger), head, re.M):
+        problems.append(f"the `on:` block is missing the {trigger[:-1]} trigger")
+for problem in problems:
+    print(f"  {problem}", file=sys.stderr)
+sys.exit(1 if problems else 0)
+PY
+    grep -qE '^  terraform-verify:' "$tf_workflow" ||
+        err "$tf_workflow has no terraform-verify aggregate job"
+    grep -q 'terraform-changed.sh' "$tf_workflow" ||
+        err "$tf_workflow does not run the change detector — it would do real work on every unrelated PR"
+    for changed_script in scripts/terraform-changed.sh scripts/test-terraform-changed.sh; do
+        [ -f "$changed_script" ] || err "$changed_script missing (include_terraform=true)"
+        [ -x "$changed_script" ] || err "$changed_script is not executable"
+    done
+    ./scripts/test-terraform-changed.sh >/dev/null 2>&1 ||
+        err "scripts/test-terraform-changed.sh fails its own change-detection checks"
+    grep -q 'test-terraform-changed.sh' scripts/test-tasks.sh ||
+        err "test-tasks.sh does not run the change-detection regression"
+    # Applying a re-plan instead of the reviewed one, or disabling state
+    # locking, are the two ways this workflow could damage infrastructure
+    # quietly. Checked with comments stripped and across line continuations —
+    # a naive grep matches the prose warning ABOUT -lock=false, and misses an
+    # apply command wrapped over several lines.
+    python3 - "$tf_workflow" <<'PY' || err "the Terraform workflow's apply path is unsafe (see stderr)"
+import sys, pathlib, re
+
+raw = pathlib.Path(sys.argv[1]).read_text()
+code = "\n".join(re.sub(r"(^|\s)#.*$", "", line) for line in raw.splitlines())
+# Join backslash continuations so a wrapped command reads as one line.
+code = re.sub(r"\\\n\s*", " ", code)
+
+problems = []
+# The credentialed job must stay out of merge_group. A maintainer queuing a
+# FORK pr fires merge_group, where the `pull_request` fork guard does not
+# apply — dropping this predicate hands R2/provider secrets to fork-authored
+# configuration, and the first sign would be a merge-queue run that already had
+# them. Cheap to assert, catastrophic to lose silently.
+plan_apply = re.search(
+    r"^  terraform-plan-apply:\n(.*?)(?=^  \w|\Z)", code, re.M | re.S
+)
+if not plan_apply:
+    problems.append("has no terraform-plan-apply job")
+elif "github.event_name != 'merge_group'" not in plan_apply.group(1):
+    problems.append(
+        "terraform-plan-apply no longer excludes merge_group — a queued fork PR "
+        "would run credentialed Terraform outside the fork trust boundary"
+    )
+if "-lock=false" in code:
+    problems.append("uses -lock=false — a concurrent state write corrupts state")
+if "-lock-timeout" not in code:
+    problems.append("does not bound state-lock waits with -lock-timeout")
+# A real CLI invocation: the word `terraform`, then flags, then the `apply`
+# subcommand. `\bterraform\b.*\bapply\b` would also match job names such as
+# `terraform-plan-apply`, since a hyphen is a word boundary.
+invocation = re.compile(r"(?:^|\s)terraform\s+(?:-\S+\s+)*apply(?:\s|$)")
+# A `name:` key is a human label ("- name: terraform apply"), not a command.
+label = re.compile(r"^\s*-?\s*name:")
+applies = [
+    ln for ln in code.splitlines() if invocation.search(ln) and not label.match(ln)
+]
+if not applies:
+    problems.append("has no terraform apply command at all")
+for ln in applies:
+    if "$TF_PLAN_DIR/tfplan" not in ln:
+        problems.append(
+            f"applies without the saved plan file, so it would apply an "
+            f"unreviewed re-plan: {ln.strip()}"
+        )
+for problem in problems:
+    print(f"  {problem}", file=sys.stderr)
+sys.exit(1 if problems else 0)
+PY
     # The TFLint pin SPECIFICALLY. "Some manager matched something in this file"
     # proves nothing: the shell-variable manager already extracts
     # SHELLCHECK_VERSION= from this same action, so a first-match check passes

--- a/template/.github/workflows/[% if include_terraform %]terraform.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if include_terraform %]terraform.yml[% endif %].jinja
@@ -1,39 +1,80 @@
 name: Terraform
 # GitOps deploy-on-merge (harmonops/harmon-infra ADR-0006, the shared infra
-# standard): PRs produce a plan (the review gate), pushes to main apply, and a
-# post-apply re-plan asserts the state converged.
+# standard): PRs produce a plan (the review gate), pushes to main apply that
+# exact plan, and a post-apply re-plan asserts the state converged.
 #
 # The plan/apply job is dormant until remote state exists: configure an
 # S3-compatible backend with native locking (use_lockfile, Terraform >= 1.10 —
 # Cloudflare R2 supports it), add the R2_* backend credentials and provider
 # TF_VAR_* secrets, then set the TERRAFORM_CI_ENABLED repo variable to 'true'.
+#
+# NOTE the deliberate absence of top-level `paths:` filters. `terraform-verify`
+# is a REQUIRED status check, and a path-filtered workflow simply never reports
+# on an unrelated PR — a required check that never reports blocks the merge
+# forever. So this always runs and decides internally: `terraform-changes` makes
+# unrelated changes a cheap, explicit no-op that still reports.
 on:
   push:
     branches: [main]
-    paths:
-      - "terraform/**"
-      - ".github/workflows/terraform.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "terraform/**"
-      - ".github/workflows/terraform.yml"
+  merge_group:
   workflow_dispatch:
 
 # Never cancel an in-flight apply on main — a killed apply can strand
 # half-created resources; PR runs are plan-only and safe to cancel.
 concurrency:
-  group: terraform-${{ github.ref }}
+  group: terraform-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
 
 jobs:
-  terraform-validate:
+  terraform-changes:
+    # Skipped for untrusted forks along with every other repository-controlled
+    # job. `actions/checkout` on a fork PR fetches the CONTRIBUTOR's version of
+    # scripts/terraform-changed.sh, so running it here would execute untrusted
+    # shell on the runner — and let that shell dictate the `changed` output the
+    # jobs below branch on. Forks need no answer: everything downstream is
+    # already skipped for them, and terraform-verify asserts exactly that.
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    timeout-minutes: 5
+    outputs:
+      changed: ${{ steps.detect.outputs.changed }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          # Both endpoints of the comparison must be present locally; a shallow
+          # clone would make the detector fail safe to "changed" on every run.
+          fetch-depth: 0
+      - name: Detect Terraform changes
+        id: detect
+        env:
+          # workflow_dispatch has no range — a human asked for this run, so it
+          # always counts as changed (that is how drift is reconciled without
+          # an empty commit).
+          BASE_SHA: >-
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha
+            || github.event_name == 'merge_group' && github.event.merge_group.base_sha
+            || github.event_name == 'push' && github.event.before
+            || '' }}
+          HEAD_SHA: >-
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha
+            || github.event_name == 'merge_group' && github.event.merge_group.head_sha
+            || github.sha }}
+        run: ./scripts/terraform-changed.sh "$BASE_SHA" "$HEAD_SHA"
+
+  terraform-validate:
+    needs: [terraform-changes]
+    if: >-
+      needs.terraform-changes.outputs.changed == 'true' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
     # default; set it to a JSON runner spec to override without a commit.
     runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
@@ -51,10 +92,21 @@ jobs:
           terraform -chdir=terraform validate -no-color
 
   terraform-plan-apply:
-    # Dormant until TERRAFORM_CI_ENABLED=true (repo variable) — needs remote
-    # state + credentials, see the header comment.
+    # Downstream of successful validation: never plan (let alone apply) a
+    # configuration that has not been validated. Dormant until
+    # TERRAFORM_CI_ENABLED=true — it needs remote state + credentials.
+    #
+    # merge_group is excluded deliberately, and it is a TRUST boundary, not a
+    # preference: a fork PR that a maintainer queues produces a merge_group
+    # event, where `github.event_name != 'pull_request'` is true and the fork
+    # check below would wave it through — handing R2 and provider secrets to
+    # fork-authored configuration before it ever lands on main. Validation still
+    # runs in the queue; only the credentialed half stands down.
+    needs: [terraform-changes, terraform-validate]
     if: >-
+      needs.terraform-changes.outputs.changed == 'true' &&
       vars.TERRAFORM_CI_ENABLED == 'true' &&
+      github.event_name != 'merge_group' &&
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
@@ -64,6 +116,9 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       TF_IN_AUTOMATION: "true"
+      # Wait for a state lock rather than stealing it — a forced unlock during a
+      # concurrent write corrupts state.
+      TF_LOCK_TIMEOUT: 5m
       # Add provider credentials as TF_VAR_* secrets here, e.g.:
       # TF_VAR_cloudflare_api_token: ${{ secrets.TF_VAR_CLOUDFLARE_API_TOKEN }}
       # TF_VAR_cloudflare_account_id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
@@ -72,56 +127,141 @@ jobs:
         with:
           persist-credentials: false
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+      # Run-scoped and private to this runner: the saved plan names real
+      # infrastructure, so it never goes to a shared path or an uploaded
+      # artifact. run_id + run_attempt keeps a re-run from colliding with
+      # itself. Set here rather than in job `env:` because RUNNER_TEMP is a
+      # runtime environment variable, not an expression context.
+      - name: Scope the plan directory to this run
+        run: |
+          echo "TF_PLAN_DIR=${RUNNER_TEMP}/tfplan-${{ github.run_id }}-${{ github.run_attempt }}" \
+            >> "$GITHUB_ENV"
       - name: terraform plan
         run: |
-          terraform -chdir=terraform init -input=false
-          terraform -chdir=terraform plan -no-color -input=false -lock=false \
-            | tee /tmp/tfplan.txt
+          mkdir -p "$TF_PLAN_DIR"
+          chmod 700 "$TF_PLAN_DIR"
+          # -lockfile=readonly: CI consumes the committed lock, never rewrites
+          # it. A provider bump is a reviewed commit (task
+          # terraform:providers:lock), not a silent side effect of a CI run.
+          terraform -chdir=terraform init -input=false -lockfile=readonly \
+            -lock-timeout="$TF_LOCK_TIMEOUT"
+          terraform -chdir=terraform plan -no-color -input=false \
+            -lock-timeout="$TF_LOCK_TIMEOUT" \
+            -out="$TF_PLAN_DIR/tfplan"
       - name: Plan summary
-        if: always()
+        # Render the SAVED plan, so the summary reviewers read describes the
+        # artifact that gets applied — not a second plan that could differ.
         run: |
+          terraform -chdir=terraform show -no-color "$TF_PLAN_DIR/tfplan" \
+            >"$TF_PLAN_DIR/tfplan.txt"
           {
             echo "## Terraform plan"
             echo '```'
-            tail -n 100 /tmp/tfplan.txt
+            tail -n 100 "$TF_PLAN_DIR/tfplan.txt"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-      # Deploy-on-merge: merging the reviewed plan is the approval. Applies
-      # take the state lock (no -lock=false here). workflow_dispatch on main
-      # re-applies — useful to reconcile drift without an empty commit.
+      # Deploy-on-merge: merging the reviewed plan is the approval. Applies take
+      # the state lock. workflow_dispatch on main re-applies — useful to
+      # reconcile drift without an empty commit.
+      #
+      # Applies the SAVED plan file: re-planning at apply time would apply
+      # something no human ever reviewed.
       - name: terraform apply
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        run: terraform -chdir=terraform apply -auto-approve -input=false -no-color
+        if: >-
+          github.ref == 'refs/heads/main' &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        run: |
+          terraform -chdir=terraform apply -input=false -no-color \
+            -lock-timeout="$TF_LOCK_TIMEOUT" \
+            "$TF_PLAN_DIR/tfplan"
       # Post-apply smoke: a clean re-plan proves the applied state converged
       # (exit 2 = unexpected residual diff, exit 1 = plan error).
       - name: converge check (post-apply re-plan)
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        if: >-
+          github.ref == 'refs/heads/main' &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
-          terraform -chdir=terraform plan -detailed-exitcode -no-color -input=false -lock=false \
-            > /tmp/tfconverge.txt 2>&1 || {
+          terraform -chdir=terraform plan -detailed-exitcode -no-color -input=false \
+            -lock-timeout="$TF_LOCK_TIMEOUT" \
+            > "$TF_PLAN_DIR/converge.txt" 2>&1 || {
               echo "Post-apply plan is not clean — state did not converge:"
-              tail -n 60 /tmp/tfconverge.txt
+              tail -n 60 "$TF_PLAN_DIR/converge.txt"
               exit 1
             }
           echo "Converged: post-apply plan reports no changes."
+      # The plan names real infrastructure; never leave it on the runner, and
+      # clean up even when an earlier step failed.
+      - name: Remove the saved plan
+        if: always()
+        run: rm -rf "$TF_PLAN_DIR"
 
   terraform-verify:
+    # The REQUIRED status check. `if: always()` so it reports on every event —
+    # including the unrelated-path runs that used to be filtered away, which is
+    # what lets it be required at all.
     if: always()
-    needs: [terraform-validate, terraform-plan-apply]
+    needs: [terraform-changes, terraform-validate, terraform-plan-apply]
     runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    env:
+      IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+      CHANGED: ${{ needs.terraform-changes.outputs.changed }}
+      CHANGES_RESULT: ${{ needs.terraform-changes.result }}
+      VALIDATE_RESULT: ${{ needs.terraform-validate.result }}
+      PLAN_APPLY_RESULT: ${{ needs.terraform-plan-apply.result }}
     steps:
-      - name: Check job results
-        # POSIX single-bracket tests on purpose: bash's double-bracket test
-        # syntax collides with this template's jinja delimiters.
+      # Never check out or run fork-controlled repository code on this path.
+      - name: Verify deliberate skips at the untrusted-fork boundary
+        if: env.IS_FORK == 'true'
         run: |
           fail=0
-          check() {
-            [ "$2" = "success" ] || [ "$2" = "skipped" ] || { echo "Job $1 result: $2"; fail=1; }
+          check_skipped() {
+            if [ "$2" != "skipped" ]; then
+              echo "Job $1 result: $2 (expected skipped for an untrusted fork)"
+              fail=1
+            fi
           }
-          check terraform-validate "${{ needs.terraform-validate.result }}"
-          check terraform-plan-apply "${{ needs.terraform-plan-apply.result }}"
+          check_skipped terraform-changes "$CHANGES_RESULT"
+          check_skipped terraform-validate "$VALIDATE_RESULT"
+          check_skipped terraform-plan-apply "$PLAN_APPLY_RESULT"
           if [ "$fail" -ne 0 ]; then
-            echo "One or more required jobs failed."
             exit 1
           fi
-          echo "All required jobs passed."
+          echo "Untrusted fork trust boundary enforced: no repository-controlled job ran."
+      - if: env.IS_FORK != 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      # The detector itself must always run: if IT was skipped or failed, the
+      # `changed` answer below is not trustworthy and nothing may be excused.
+      - name: Verify the change detector ran
+        if: env.IS_FORK != 'true'
+        env:
+          EXPECTED_RESULT: success
+        run: ./scripts/verify-ci-results.sh "terraform-changes=${CHANGES_RESULT}"
+      # `skipped` is accepted below ONLY where a predicate proves it deliberate:
+      # here, that the range contains no Terraform changes.
+      - name: Verify deliberate no-op (no Terraform changes)
+        if: env.IS_FORK != 'true' && env.CHANGED == 'false'
+        env:
+          EXPECTED_RESULT: skipped
+        run: |
+          ./scripts/verify-ci-results.sh \
+            "terraform-validate=${VALIDATE_RESULT}" \
+            "terraform-plan-apply=${PLAN_APPLY_RESULT}"
+          echo "No Terraform changes in this range — the Terraform jobs were deliberately skipped."
+      - name: Verify validation succeeded
+        if: env.IS_FORK != 'true' && env.CHANGED != 'false'
+        env:
+          EXPECTED_RESULT: success
+        run: ./scripts/verify-ci-results.sh "terraform-validate=${VALIDATE_RESULT}"
+      # plan/apply is legitimately absent in two cases — TERRAFORM_CI_ENABLED is
+      # not set, or this is a merge_group run, where the credentialed half
+      # stands down at the fork trust boundary. Its expected result is derived
+      # from those same predicates, so `skipped` is never merely tolerated.
+      - name: Verify plan/apply matched its predicates
+        if: env.IS_FORK != 'true' && env.CHANGED != 'false'
+        env:
+          EXPECTED_RESULT: >-
+            ${{ (vars.TERRAFORM_CI_ENABLED == 'true' && github.event_name != 'merge_group')
+            && 'success' || 'skipped' }}
+        run: ./scripts/verify-ci-results.sh "terraform-plan-apply=${PLAN_APPLY_RESULT}"

--- a/template/scripts/[% if include_terraform %]terraform-changed.sh[% endif %]
+++ b/template/scripts/[% if include_terraform %]terraform-changed.sh[% endif %]
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# terraform-changed.sh — decide whether a range of commits touches Terraform.
+#
+# The Terraform workflow deliberately carries NO top-level `paths:` filter,
+# because `terraform-verify` is a required status check: a filtered workflow
+# never reports on unrelated PRs, and a required check that never reports blocks
+# the merge forever. So the workflow always runs and decides internally, and
+# this is that decision.
+#
+# usage: terraform-changed.sh <base_sha> <head_sha>
+#   prints `true` or `false` (also written to $GITHUB_OUTPUT as changed=...)
+#
+# Fails SAFE: anything it cannot determine — a missing/unknown sha, a shallow
+# clone, the very first push — answers `true`. A wrong `true` costs one CI run;
+# a wrong `false` waves an unvalidated infrastructure change straight through.
+set -euo pipefail
+
+base="${1:-}"
+head="${2:-HEAD}"
+
+# Paths whose change means Terraform must be re-validated:
+#
+#   terraform/**            the root itself, including non-.tf assets
+#   **/*.tf, **/*.tf.json   configuration ANYWHERE — a root may reference a
+#                           local module outside its own directory
+#                           (`source = "../modules/dns"`), and a change there
+#                           changes the plan just as much
+#   **/*.tfvars(.json)      variable values feed the plan
+#   **/.terraform.lock.hcl  provider selection
+#   the workflow itself     it decides how, and whether, infra gets applied
+#
+# Known limit: an asset that is not Terraform syntax and lives OUTSIDE
+# terraform/ — say a modules/dns/zone.tpl pulled in via templatefile() — is not
+# matched. Keep such files under terraform/, or add their path here.
+matches_terraform() {
+    grep -qE '(^terraform/|^\.github/workflows/terraform\.yml$|\.tf$|\.tf\.json$|\.tfvars$|\.tfvars\.json$|(^|/)\.terraform\.lock\.hcl$)'
+}
+
+emit() {
+    echo "$1"
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+        echo "changed=$1" >>"$GITHUB_OUTPUT"
+    fi
+    exit 0
+}
+
+# All-zero sha = branch creation / no previous commit; empty = caller had none.
+case "$base" in
+"" | 0000000000000000000000000000000000000000)
+    echo "terraform-changed: no usable base ($base) — assuming changed" >&2
+    emit true
+    ;;
+esac
+
+if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+    echo "terraform-changed: base $base is not in this clone — assuming changed" >&2
+    emit true
+fi
+if ! git cat-file -e "${head}^{commit}" 2>/dev/null; then
+    echo "terraform-changed: head $head is not in this clone — assuming changed" >&2
+    emit true
+fi
+
+# `git diff` (two dots) rather than a merge-base range: the question is which
+# files differ between what is deployed and what is proposed, not which commits
+# are unique to the branch.
+#
+# --no-renames is load-bearing. With rename detection on (the default), moving
+# terraform/main.tf to docs/main.tf reports ONLY the destination path, so
+# deleting the entire Terraform configuration by moving it out would look like
+# "no Terraform change" and skip validation. --no-renames reports both sides.
+if ! changed_files="$(git diff --name-only --no-renames "$base" "$head" 2>/dev/null)"; then
+    echo "terraform-changed: could not diff $base..$head — assuming changed" >&2
+    emit true
+fi
+
+if printf '%s\n' "$changed_files" | matches_terraform; then
+    emit true
+fi
+
+emit false

--- a/template/scripts/[% if include_terraform %]test-terraform-changed.sh[% endif %]
+++ b/template/scripts/[% if include_terraform %]test-terraform-changed.sh[% endif %]
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# test-terraform-changed.sh — regression for the Terraform change detector.
+#
+# Every case here is a way the required `terraform-verify` check could go wrong:
+# a false `false` skips validation on a real infrastructure change, and a
+# detector that errors out wedges the check entirely.
+set -euo pipefail
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+helper="$repo_root/scripts/terraform-changed.sh"
+
+tmp="$(mktemp -d -t test-terraform-changed-XXXXXX)"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+repo="$tmp/repo"
+mkdir -p "$repo/terraform" "$repo/src" "$repo/.github/workflows"
+cd "$repo"
+git init -q .
+git config user.email test@example.com
+git config user.name Test
+
+printf '%s\n' 'terraform {}' >terraform/main.tf
+printf '%s\n' 'x' >src/app.js
+printf '%s\n' 'name: Terraform' >.github/workflows/terraform.yml
+git add -A
+git commit -qm base
+base="$(git rev-parse HEAD)"
+
+# ── an unrelated change is a no-op ──────────────────────────────────
+printf '%s\n' 'y' >src/app.js
+git commit -qam "unrelated"
+[ "$("$helper" "$base" HEAD)" = false ] ||
+    fail "a change touching only src/ was reported as a Terraform change"
+
+# ── a terraform/ change counts ──────────────────────────────────────
+prev="$(git rev-parse HEAD)"
+printf '%s\n' 'terraform { backend "s3" {} }' >terraform/main.tf
+git commit -qam "terraform"
+[ "$("$helper" "$prev" HEAD)" = true ] ||
+    fail "a change under terraform/ was not detected"
+
+# ── a nested terraform/ change counts ───────────────────────────────
+prev="$(git rev-parse HEAD)"
+mkdir -p terraform/modules/vpc
+printf '%s\n' 'variable "n" {}' >terraform/modules/vpc/main.tf
+git add -A
+git commit -qm "nested"
+[ "$("$helper" "$prev" HEAD)" = true ] ||
+    fail "a change under terraform/modules/ was not detected"
+
+# ── editing the workflow counts: it decides how infra is applied ────
+prev="$(git rev-parse HEAD)"
+printf '%s\n' '# edited' >>.github/workflows/terraform.yml
+git commit -qam "workflow"
+[ "$("$helper" "$prev" HEAD)" = true ] ||
+    fail "a change to the Terraform workflow itself was not detected"
+
+# ── a local module OUTSIDE terraform/ counts ────────────────────────
+# `module "dns" { source = "../modules/dns" }` is a supported layout (the
+# provider-lock helper mirrors the whole checkout for exactly this reason), so a
+# change under modules/ changes the plan even though terraform/ is untouched.
+prev="$(git rev-parse HEAD)"
+mkdir -p modules/dns
+printf '%s\n' 'variable "zone" {}' >modules/dns/main.tf
+git add -A
+git commit -qm "sibling module"
+[ "$("$helper" "$prev" HEAD)" = true ] ||
+    fail "a change to a local module outside terraform/ was not detected"
+
+# ── tfvars and lock files count wherever they live ──────────────────
+prev="$(git rev-parse HEAD)"
+printf '%s\n' 'zone = "example.com"' >modules/dns/dev.tfvars
+git add -A
+git commit -qm "tfvars"
+[ "$("$helper" "$prev" HEAD)" = true ] ||
+    fail "a .tfvars change was not detected"
+
+prev="$(git rev-parse HEAD)"
+printf '%s\n' '# lock' >modules/dns/.terraform.lock.hcl
+git add -A
+git commit -qm "lock"
+[ "$("$helper" "$prev" HEAD)" = true ] ||
+    fail "a .terraform.lock.hcl change was not detected"
+
+# ── a path that merely starts with the same letters does NOT ────────
+# `terraform-docs.md` must not match the `terraform/` prefix.
+prev="$(git rev-parse HEAD)"
+printf '%s\n' 'docs' >terraform-notes.md
+git add -A
+git commit -qm "lookalike"
+[ "$("$helper" "$prev" HEAD)" = false ] ||
+    fail "a path merely prefixed 'terraform' was treated as a Terraform change"
+
+# ── moving a file OUT of terraform/ counts ──────────────────────────
+# Rename detection reports only the DESTINATION path, so moving a file out of
+# terraform/ can hide the fact that terraform/ lost it. Only `--no-renames`
+# makes the source side visible.
+#
+# The moved file is deliberately NOT a .tf: a .tf destination is matched by the
+# "Terraform syntax anywhere" rule wherever it lands, so this case would pass
+# with --no-renames reverted and prove nothing. A .tpl matches only via its
+# old terraform/ path.
+prev="$(git rev-parse HEAD)"
+mkdir -p docs
+printf '%s\n' 'zone content' >terraform/zone.tpl
+git add -A
+git commit -qm "add template asset"
+prev="$(git rev-parse HEAD)"
+git mv terraform/zone.tpl docs/zone.tpl
+git commit -qm "move out"
+[ "$("$helper" "$prev" HEAD)" = true ] ||
+    fail "moving a file OUT of terraform/ was not detected (rename hid the source path)"
+git mv docs/zone.tpl terraform/zone.tpl
+git commit -qm "move back"
+
+# ── deletions count as changes ──────────────────────────────────────
+prev="$(git rev-parse HEAD)"
+git rm -q terraform/modules/vpc/main.tf
+git commit -qm "delete"
+[ "$("$helper" "$prev" HEAD)" = true ] ||
+    fail "deleting a Terraform file was not detected"
+
+# ── fail-safe: unusable input must answer true, never false ─────────
+[ "$("$helper" "" HEAD 2>/dev/null)" = true ] ||
+    fail "an empty base must fail safe to changed=true"
+[ "$("$helper" 0000000000000000000000000000000000000000 HEAD 2>/dev/null)" = true ] ||
+    fail "an all-zero base (branch creation) must fail safe to changed=true"
+[ "$("$helper" deadbeefdeadbeefdeadbeefdeadbeefdeadbeef HEAD 2>/dev/null)" = true ] ||
+    fail "a base missing from the clone must fail safe to changed=true"
+[ "$("$helper" "$base" deadbeefdeadbeefdeadbeefdeadbeefdeadbeef 2>/dev/null)" = true ] ||
+    fail "a head missing from the clone must fail safe to changed=true"
+
+# ── the workflow reads this from $GITHUB_OUTPUT, not stdout ─────────
+out="$tmp/gh-output"
+: >"$out"
+GITHUB_OUTPUT="$out" "$helper" "$base" HEAD >/dev/null
+grep -q '^changed=true$' "$out" ||
+    fail "changed= was not written to \$GITHUB_OUTPUT"
+
+echo "Terraform change-detection regression: PASS"

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -272,4 +272,9 @@ if [ -x ./scripts/test-terraform-provider-locks.sh ]; then
     ./scripts/test-terraform-provider-locks.sh
 fi
 
+if [ -x ./scripts/test-terraform-changed.sh ]; then
+    echo "==> Terraform change detection drives the required terraform-verify check"
+    ./scripts/test-terraform-changed.sh
+fi
+
 echo "==> task targets OK (compile + bootstrap idempotency + path-safe formatting)"


### PR DESCRIPTION
## What

Step 3 of 4 on #385. Makes `terraform-verify` safe to require **before** step 4
actually requires it — that ordering is the point, not incidental.

## Why it could not be required as written

The workflow carried top-level `paths:` filters, so on a PR that did not touch
`terraform/` it never ran and therefore **never reported**. A required check
that never reports blocks the merge forever. Simply deleting the filters would
run real Terraform work on every unrelated PR, so the decision moves inside the
workflow instead:

- no `paths:` filters; adds `merge_group` so queued entries report rather than
  hang until the check times out
- a credential-free `terraform-changes` job answers "does this range touch
  Terraform?" via `scripts/terraform-changed.sh`
- `terraform-verify` now reuses the repo's fail-closed `verify-ci-results.sh`.
  The old aggregate accepted `success` **or** `skipped` for everything, which
  passes essentially whatever happens; `skipped` is now accepted only where a
  predicate proves it deliberate — no changes in range, plan/apply not enabled,
  merge_group, or an untrusted fork.

The detector **fails safe**: an unknown sha, a shallow clone, or an unusable
range answers "changed". A wrong "changed" costs one CI run; a wrong "unchanged"
waves an unvalidated infrastructure change straight through.

## Apply-path hardening

This is the workflow that mutates real infrastructure, so:

- applies the **saved** plan file — re-planning at apply time would apply
  something no human reviewed — and the step summary renders that same artifact
- plan lives in a run-scoped `0700` dir under `RUNNER_TEMP` (keyed by
  `run_id` + `run_attempt`), removed under `if: always()`, never uploaded
- `-lock-timeout` everywhere, never `-lock=false`; `init -lockfile=readonly` so
  CI consumes the committed provider lock rather than rewriting it
- plan/apply is downstream of successful validation

## Trust boundary

| job | fork guard | excluded from merge_group |
| --- | --- | --- |
| `terraform-changes` | yes | no (uncredentialed) |
| `terraform-validate` | yes | no (uncredentialed) |
| `terraform-plan-apply` | yes | **yes** |

A maintainer queuing a **fork** PR fires `merge_group`, where
`event_name != 'pull_request'` is true — so the ordinary fork guard does not
apply there. The credentialed job stands down for that event; validation still
runs in the queue.

## Review adjudication (2 challenge + 1 review round)

| Finding | Verdict | Action |
| --- | --- | --- |
| Renames hide the source path | **Confirmed** | `git mv terraform/main.tf docs/main.tf` reports *only* the destination, so deleting the config by moving it out read as "no change". Now `--no-renames`. |
| merge_group bypasses the fork guard for credentialed plan/apply | **Confirmed** | Excluded, per the table above |
| Detector executed fork-controlled shell | **Confirmed** | `terraform-changes` skips for untrusted forks; the aggregate asserts it skipped |
| Local modules outside `terraform/` undetected | **Confirmed** | `source = "../modules/dns"` is a layout #395's lock helper supports. Detection now covers Terraform syntax anywhere, plus `terraform/**` and the workflow |
| Rename regression was **vacuous** | **Confirmed** | Widening the patterns silently defeated it — the `.tf` destination matched wherever it landed. Now moves a `.tpl`, whose destination matches nothing |
| No render guard on the merge_group credential boundary | **Confirmed** | Added; dropping the predicate now fails the render test |
| merge_group runs fork-controlled scripts (generally) | **Rejected — pre-existing, by design** | See below |

Every guard and regression here is **mutation-tested** — each was confirmed to
fail when the behaviour it protects is reverted. That is how the vacuous rename
test was caught.

## One rejected finding, for your call

A reviewer flagged that on `merge_group` the workflow checks out and runs
repository scripts from the queued merge commit, which for a queued fork PR is
fork-authored. Accurate — but it describes the **template's existing CI
architecture**, not this PR: `build.yml` has triggered on `merge_group` and run
`task check` + `verify-ci-results.sh` on the queued commit since long before
this work. Executing queued code is what a merge queue is for; the control is
that a maintainer must approve and queue it.

I did not build a bespoke guard for `terraform.yml` alone — it would be
inconsistent with the primary gate and offer false comfort. Flagging it as a
repo-wide question worth its own decision. Note the credentialed job is already
out of merge_group regardless, so **secrets** are not exposed either way.

## Verification

- `task verify` and `task ci` green (all 6 render profiles)
- rendered YAML parsed to confirm the folded `EXPECTED_RESULT` expression
  collapses to one correct line and all four triggers survive
- render guards: `paths:` filter, missing trigger, `-lock=false`, applying a
  re-plan, and dropping the merge_group exclusion each fail the render test

## Not in scope

Step 4: adding `terraform-verify` to the rendered ruleset. It must come after
this — requiring the check while `paths:` filters remained would wedge every
out-of-scope PR in all three infra consumers.

Refs #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)
