### PR TITLE
feat(template): make a generated Terraform repo's CI a requirable gate

### DIFF
--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -272,4 +272,9 @@ if [ -x ./scripts/test-terraform-provider-locks.sh ]; then
     ./scripts/test-terraform-provider-locks.sh
 fi
 
+if [ -x ./scripts/test-terraform-ci.sh ]; then
+    echo "==> Terraform CI keeps plans private and its aggregate result-gated"
+    ./scripts/test-terraform-ci.sh
+fi
+
 echo "==> task targets OK (compile + bootstrap idempotency + path-safe formatting)"

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -932,6 +932,89 @@ else
     ! grep -q 'tflint' Brewfile || err "Brewfile installs tflint but include_terraform=false"
 fi
 
+# ── 9i. Terraform CI aggregate renders per include_terraform ────────
+# terraform-verify is the context branch protection is meant to require, so the
+# workflow behind it must START on every protected-event run (no `paths:`
+# filter — a filtered-out run posts no status and wedges that merge forever)
+# and the aggregate must reject every result it did not explicitly predict.
+# Asserted the way harmon-devkit's verify-applied.sh asserts it, so the two
+# cannot disagree. Gated on the ANSWER, not the profile name.
+if grep -Eq '^include_terraform:[[:space:]]+(true|yes)$' .copier-answers.yml; then
+    tf_workflow=".github/workflows/terraform.yml"
+    [ -f "$tf_workflow" ] || err "$tf_workflow missing (include_terraform=true)"
+    for ci_script in scripts/terraform-ci.sh scripts/terraform-changed.sh scripts/test-terraform-ci.sh; do
+        [ -f "$ci_script" ] || err "$ci_script missing (include_terraform=true)"
+        [ -x "$ci_script" ] || err "$ci_script is not executable"
+    done
+    if have task; then
+        # The CI operations must be reachable by NAME: terraform.yml invokes
+        # `task terraform:ci:*`, so a renamed or missing target is a red CI run
+        # that nothing else in the repo would catch.
+        tf_validate_dry="$(task --color=false --dry terraform:validate 2>&1 || true)"
+        grep -qE 'terraform-ci\.sh[[:space:]]+validate[[:space:]]+[^[:space:]]' <<<"$tf_validate_dry" ||
+            err "task terraform:validate does not reach the shared Terraform CI helper"
+        # `validate` (pre-push + the CI validate job) must route through the same
+        # helper — a bare `terraform validate` fails on an uninitialized root.
+        tf_validate_tier_dry="$(task --color=false --dry validate 2>&1 || true)"
+        grep -qE 'terraform-ci\.sh[[:space:]]+validate[[:space:]]+[^[:space:]]' <<<"$tf_validate_tier_dry" ||
+            err "task validate does not route Terraform validation through the shared CI helper"
+        for ci_operation in plan apply converge; do
+            ci_dry="$(task --color=false --dry "terraform:ci:${ci_operation}" 2>&1 || true)"
+            grep -qE "terraform-ci\.sh[[:space:]]+${ci_operation}[[:space:]]+[^[:space:]]" <<<"$ci_dry" ||
+                err "task terraform:ci:${ci_operation} does not reach the shared Terraform CI helper"
+        done
+    else
+        required task "Terraform CI reachability" || fail=1
+    fi
+    if [ -f "$tf_workflow" ]; then
+        # Triggers: all four protected/manual events, and no trigger filter.
+        tf_on_block="$(
+            awk '
+                /^on:/ { in_on = 1; next }
+                in_on && /^[[:alnum:]_-]+:/ { exit }
+                in_on { print }
+            ' "$tf_workflow"
+        )"
+        for tf_trigger in push pull_request merge_group workflow_dispatch; do
+            grep -Eq "^  ${tf_trigger}:" <<<"$tf_on_block" ||
+                err "terraform.yml does not emit on ${tf_trigger} — a required terraform-verify would not always report"
+        done
+        ! grep -Eq '^ +paths(-ignore)?:' <<<"$tf_on_block" ||
+            err "terraform.yml filters its triggers by path — a required check whose workflow never starts wedges the merge"
+        grep -q 'terraform-changed.sh' "$tf_workflow" ||
+            err "terraform.yml does not scope Terraform work with the internal change detector"
+        # The aggregate: always() + needs + exact result expectations.
+        tf_verify_block="$(
+            awk '
+                $0 == "  terraform-verify:" { in_job = 1; next }
+                in_job && /^  [[:alnum:]_-]+:/ { exit }
+                in_job { print }
+            ' "$tf_workflow"
+        )"
+        [ -n "$tf_verify_block" ] || err "terraform.yml defines no terraform-verify aggregate job"
+        for tf_gate in 'if: always()' 'needs:' 'verify-ci-results.sh' 'expected skipped for an untrusted fork'; do
+            grep -qF -- "$tf_gate" <<<"$tf_verify_block" ||
+                err "terraform-verify is not result-gated (missing '${tf_gate}') — GitHub counts a skipped required check as successful"
+        done
+        # The exact fail-open shape harmon-devkit's catalog rejects by name.
+        ! grep -qF -- '[ "$2" = "success" ] || [ "$2" = "skipped" ]' <<<"$tf_verify_block" ||
+            err "terraform-verify accepts a generic success-or-skipped allowlist — that launders a failing leaf into a green gate"
+    fi
+    # The hermetic regression must ship AND pass: it is what proves saved plans
+    # stay private and run-scoped without touching a cloud or the network.
+    ./scripts/test-terraform-ci.sh >/dev/null 2>&1 ||
+        err "scripts/test-terraform-ci.sh fails its hermetic Terraform CI checks"
+    grep -q 'test-terraform-ci.sh' scripts/test-tasks.sh ||
+        err "test-tasks.sh does not run the Terraform CI regression"
+    grep -Fxq '.terraform-ci/' .gitignore ||
+        err ".gitignore does not ignore the local Terraform CI artifact fallback"
+else
+    for ci_script in scripts/terraform-ci.sh scripts/terraform-changed.sh scripts/test-terraform-ci.sh; do
+        [ ! -f "$ci_script" ] || err "$ci_script rendered but include_terraform=false"
+    done
+    [ ! -f .github/workflows/terraform.yml ] || err "terraform.yml rendered but include_terraform=false"
+fi
+
 # Every `# renovate:` annotation in the rendered composite action must be
 # extractable by one of the rendered repo's own customManagers — an annotation
 # no manager matches (or one missing depName=) looks fine in review and produces

--- a/template/.github/workflows/[% if include_terraform %]terraform.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if include_terraform %]terraform.yml[% endif %].jinja
@@ -3,21 +3,32 @@ name: Terraform
 # standard): PRs produce a plan (the review gate), pushes to main apply, and a
 # post-apply re-plan asserts the state converged.
 #
+# The workflow carries NO `paths:` filter on purpose: terraform-verify is meant
+# to be requirable by branch protection, and a required check whose workflow a
+# filter keeps from starting never posts a status — that merge then waits
+# forever. Scoping lives in the internal `changes` job instead, so an unrelated
+# change is a fast, deliberately-skipped no-op that still reports.
+#
 # The plan/apply job is dormant until remote state exists: configure an
 # S3-compatible backend with native locking (use_lockfile, Terraform >= 1.10 —
 # Cloudflare R2 supports it), add the R2_* backend credentials and provider
 # TF_VAR_* secrets, then set the TERRAFORM_CI_ENABLED repo variable to 'true'.
+#
+# Trust model, stated plainly because enabling that variable is the moment it
+# starts to matter: FORK pull requests are the untrusted boundary and every job
+# here is skipped for them (terraform-verify then requires those skips to be
+# exact). A SAME-REPOSITORY pull request is trusted — planning its Terraform
+# necessarily executes its configuration, its Taskfile, and its scripts with
+# these credentials, which no arrangement of this workflow can avoid. Repo write
+# access is therefore equivalent to access to these secrets; scope collaborators
+# and bot accounts accordingly. A merged change is re-validated regardless: a
+# push to main reconciles unconditionally (see scripts/terraform-changed.sh).
 on:
   push:
     branches: [main]
-    paths:
-      - "terraform/**"
-      - ".github/workflows/terraform.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "terraform/**"
-      - ".github/workflows/terraform.yml"
+  merge_group:
   workflow_dispatch:
 
 # Never cancel an in-flight apply on main — a killed apply can strand
@@ -30,10 +41,40 @@ permissions:
   contents: read
 
 jobs:
-  terraform-validate:
+  changes:
+    # Runs repository code, so it sits behind the same untrusted-fork boundary
+    # as build.yml's jobs: on a fork PR this and every job below are skipped,
+    # and terraform-verify asserts exactly that.
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    timeout-minutes: 10
+    outputs:
+      terraform: ${{ steps.filter.outputs.changed }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          # The detector diffs two commits; a shallow clone may hold neither.
+          fetch-depth: 0
+      - name: Detect Terraform-owned changes
+        id: filter
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGE_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+        run: ./scripts/terraform-changed.sh >> "$GITHUB_OUTPUT"
+
+  terraform-validate:
+    needs: changes
+    if: >-
+      needs.changes.outputs.terraform == 'true' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
     # default; set it to a JSON runner spec to override without a commit.
     runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
@@ -42,24 +83,58 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
-      - name: terraform fmt
-        run: terraform fmt -check -recursive terraform/
-      - name: terraform validate
-        run: |
-          terraform -chdir=terraform init -backend=false -input=false
-          terraform -chdir=terraform validate -no-color
+      - uses: ./.github/actions/setup
+[% if use_node or use_python %]
+        with:
+          # Terraform validation neither installs nor builds the app.
+          install-deps: "false"
+[% if use_node %]
+          cache: "false"
+[% endif %]
+[% endif %]
+      - name: Terraform validate
+        run: task terraform:validate
 
   terraform-plan-apply:
-    # Dormant until TERRAFORM_CI_ENABLED=true (repo variable) — needs remote
-    # state + credentials, see the header comment.
+    # Downstream of validation on purpose: a credentialed plan should never run
+    # against a configuration that does not even validate. Dormant until
+    # TERRAFORM_CI_ENABLED=true (repo variable) — needs remote state +
+    # credentials, see the header comment.
+    #
+    # Never on `merge_group`: a merge group can contain a FORK pull request, and
+    # its ref is checked out and executed here alongside the backend + provider
+    # secrets. The same-repo PR already produced the reviewed plan and the push
+    # to `main` produces the authoritative one, so the queue loses nothing by
+    # staying credential-free. terraform-verify still reports on merge_group —
+    # this skip is one of the results it predicts exactly.
+    needs: [changes, terraform-validate]
     if: >-
+      needs.changes.outputs.terraform == 'true' &&
       vars.TERRAFORM_CI_ENABLED == 'true' &&
+      github.event_name != 'merge_group' &&
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
     runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
-    timeout-minutes: 15
+    # Generous on purpose: this budget covers setup + plan + apply + the
+    # post-apply converge re-plan, and BOTH plans may spend up to their 5m
+    # state-lock wait first. A timeout that fires mid-apply kills the mutation
+    # and strands half-created resources — the exact failure `cancel-in-progress:
+    # false` above exists to prevent. Real applies are the slow part; raise this
+    # further if yours approach it.
+    timeout-minutes: 60
     env:
+      # Saved plans hold sensitive values, so they never live at a shared fixed
+      # path: this directory is scoped to the exact repository/run/attempt under
+      # the runner temp, is created private, and is removed under `if: always()`
+      # — no collisions with a concurrent run, no leftovers for a later one.
+      #
+      # Mode bits are not a trust boundary against a job running as the SAME
+      # Unix user, which is what a persistent self-hosted runner does. If this
+      # job runs anywhere but an ephemeral runner, that isolation has to come
+      # from the runner (one-shot/container-per-job), not from this path.
+      TF_CI_RUN_KEY: terraform-${{ github.repository_id }}-${{ github.run_id }}-${{ github.run_attempt }}
       # The S3-compatible backend (Cloudflare R2) reads AWS-style env vars.
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -71,57 +146,143 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
-      - name: terraform plan
-        run: |
-          terraform -chdir=terraform init -input=false
-          terraform -chdir=terraform plan -no-color -input=false -lock=false \
-            | tee /tmp/tfplan.txt
+      - uses: ./.github/actions/setup
+[% if use_node or use_python %]
+        with:
+          # This job holds backend + provider credentials: it installs no
+          # project dependencies (nothing here builds the app, and an unrelated
+          # lifecycle script should not run next to those secrets)[% if use_node %], and it
+          # never reads the repo-wide Actions cache, which lower-trust PR runs
+          # can write — the composite's own `cache` input documents that rule[% endif %].
+          install-deps: "false"
+[% if use_node %]
+          cache: "false"
+[% endif %]
+[% endif %]
+      - name: Terraform plan
+        run: task terraform:ci:plan
       - name: Plan summary
         if: always()
         run: |
+          # always(), so the plan may have failed before writing anything. Say
+          # so instead of failing this step too and burying the real error.
+          plan_text="${RUNNER_TEMP}/${TF_CI_RUN_KEY}/tfplan.txt"
           {
             echo "## Terraform plan"
-            echo '```'
-            tail -n 100 /tmp/tfplan.txt
-            echo '```'
+            echo '~~~'
+            if [ -f "$plan_text" ]; then
+              tail -n 100 "$plan_text"
+            else
+              echo "(no plan output — see the Terraform plan step)"
+            fi
+            echo '~~~'
           } >> "$GITHUB_STEP_SUMMARY"
-      # Deploy-on-merge: merging the reviewed plan is the approval. Applies
-      # take the state lock (no -lock=false here). workflow_dispatch on main
-      # re-applies — useful to reconcile drift without an empty commit.
-      - name: terraform apply
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        run: terraform -chdir=terraform apply -auto-approve -input=false -no-color
-      # Post-apply smoke: a clean re-plan proves the applied state converged
-      # (exit 2 = unexpected residual diff, exit 1 = plan error).
-      - name: converge check (post-apply re-plan)
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        run: |
-          terraform -chdir=terraform plan -detailed-exitcode -no-color -input=false -lock=false \
-            > /tmp/tfconverge.txt 2>&1 || {
-              echo "Post-apply plan is not clean — state did not converge:"
-              tail -n 60 /tmp/tfconverge.txt
-              exit 1
-            }
-          echo "Converged: post-apply plan reports no changes."
+      # Deploy-on-merge: merging the reviewed plan is the approval. The apply
+      # consumes that exact saved plan and refuses to re-plan if it is missing.
+      # workflow_dispatch on main re-applies — useful to reconcile drift
+      # without an empty commit.
+      - name: Terraform apply
+        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        run: task terraform:ci:apply
+      # Post-apply smoke: a clean re-plan proves the applied state converged.
+      - name: Converge check
+        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        run: task terraform:ci:converge
+      - name: Clean Terraform CI artifacts
+        if: always()
+        run: ./scripts/terraform-ci.sh cleanup
 
   terraform-verify:
+    # The aggregate branch protection can require. `always()` so it reports even
+    # when a leaf fails or is skipped, and every accepted result is derived from
+    # an explicit fork/change/enabled predicate — a `success || skipped`
+    # allowlist would launder a failing leaf into a green gate.
     if: always()
-    needs: [terraform-validate, terraform-plan-apply]
+    needs: [changes, terraform-validate, terraform-plan-apply]
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
     runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    env:
+      IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+      TERRAFORM_CHANGED: ${{ needs.changes.outputs.terraform }}
     steps:
-      - name: Check job results
+      # Never check out or run fork-controlled repository code on this path.
+      - name: Verify deliberate skips at the untrusted-fork boundary
+        if: env.IS_FORK == 'true'
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          VALIDATE_RESULT: ${{ needs.terraform-validate.result }}
+          PLAN_RESULT: ${{ needs.terraform-plan-apply.result }}
         # POSIX single-bracket tests on purpose: bash's double-bracket test
         # syntax collides with this template's jinja delimiters.
         run: |
           fail=0
-          check() {
-            [ "$2" = "success" ] || [ "$2" = "skipped" ] || { echo "Job $1 result: $2"; fail=1; }
+          check_skipped() {
+            if [ "$2" != "skipped" ]; then
+              echo "Job $1 result: $2 (expected skipped for an untrusted fork)"
+              fail=1
+            fi
           }
-          check terraform-validate "${{ needs.terraform-validate.result }}"
-          check terraform-plan-apply "${{ needs.terraform-plan-apply.result }}"
+          check_skipped changes "$CHANGES_RESULT"
+          check_skipped terraform-validate "$VALIDATE_RESULT"
+          check_skipped terraform-plan-apply "$PLAN_RESULT"
           if [ "$fail" -ne 0 ]; then
-            echo "One or more required jobs failed."
             exit 1
           fi
-          echo "All required jobs passed."
+          echo "Untrusted fork trust boundary enforced: all repository-controlled jobs were deliberately skipped."
+      - if: env.IS_FORK != 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      # Every skip below is justified by this job's own decision, so that
+      # decision has to be a real one: an empty or malformed output would
+      # otherwise skip all the Terraform work and still report green.
+      - name: Verify the change detector reached a decision
+        if: env.IS_FORK != 'true'
+        env:
+          EXPECTED_RESULT: success
+          CHANGES_RESULT: ${{ needs.changes.result }}
+        run: |
+          ./scripts/verify-ci-results.sh "changes=${CHANGES_RESULT}"
+          case "${TERRAFORM_CHANGED}" in
+          true | false) ;;
+          *)
+            echo "Invalid Terraform change decision: ${TERRAFORM_CHANGED:-<empty>}" >&2
+            exit 1
+            ;;
+          esac
+      - name: Verify Terraform validation succeeded
+        if: env.IS_FORK != 'true' && needs.changes.outputs.terraform == 'true'
+        env:
+          EXPECTED_RESULT: success
+          VALIDATE_RESULT: ${{ needs.terraform-validate.result }}
+        run: ./scripts/verify-ci-results.sh "terraform-validate=${VALIDATE_RESULT}"
+      - name: Verify the Terraform plan/apply succeeded
+        if: >-
+          env.IS_FORK != 'true' &&
+          needs.changes.outputs.terraform == 'true' &&
+          vars.TERRAFORM_CI_ENABLED == 'true' &&
+          github.event_name != 'merge_group'
+        env:
+          EXPECTED_RESULT: success
+          PLAN_RESULT: ${{ needs.terraform-plan-apply.result }}
+        run: ./scripts/verify-ci-results.sh "terraform-plan-apply=${PLAN_RESULT}"
+      # The exact mirror of the job's own predicate: dormant (no
+      # TERRAFORM_CI_ENABLED) or credential-free by design (merge_group).
+      - name: Verify the credential-free plan/apply was deliberately skipped
+        if: >-
+          env.IS_FORK != 'true' &&
+          needs.changes.outputs.terraform == 'true' &&
+          (vars.TERRAFORM_CI_ENABLED != 'true' ||
+           github.event_name == 'merge_group')
+        env:
+          EXPECTED_RESULT: skipped
+          PLAN_RESULT: ${{ needs.terraform-plan-apply.result }}
+        run: ./scripts/verify-ci-results.sh "terraform-plan-apply=${PLAN_RESULT}"
+      - name: Verify the unrelated-change no-op was deliberately skipped
+        if: env.IS_FORK != 'true' && needs.changes.outputs.terraform != 'true'
+        env:
+          EXPECTED_RESULT: skipped
+          VALIDATE_RESULT: ${{ needs.terraform-validate.result }}
+          PLAN_RESULT: ${{ needs.terraform-plan-apply.result }}
+        run: ./scripts/verify-ci-results.sh "terraform-validate=${VALIDATE_RESULT}" "terraform-plan-apply=${PLAN_RESULT}"

--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -134,6 +134,8 @@ __pycache__/
 # Terraform
 .terraform/
 *.tfplan
+# Local fallback for scripts/terraform-ci.sh artifacts (CI uses runner temp).
+.terraform-ci/
 override.tf
 crash.log
 # State and tfvars can hold secrets — never commit them (only *.tfvars.example).

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -308,7 +308,36 @@ tasks:
   lint:terraform:validate:
     desc: Terraform validate
     cmds:
-      - terraform -chdir=terraform validate -no-color
+      - task: terraform:validate
+
+  terraform:validate:
+    # Routed through the shared CI helper so `task validate`, the pre-push hook,
+    # and the terraform-validate CI job run byte-identical commands. The helper
+    # inits with -backend=false into a throwaway TF_DATA_DIR first: `terraform
+    # validate` on its own fails on an uninitialized root, and a plain init
+    # would rewrite the committed provider lock.
+    desc: Initialize without a backend and validate the Terraform root
+    cmds:
+      - ./scripts/terraform-ci.sh validate terraform
+
+  # The terraform:ci:* targets are the credentialed CI path, invoked by
+  # .github/workflows/terraform.yml. plan saves a private, run-scoped plan;
+  # apply consumes that exact plan and refuses to re-plan without it; converge
+  # re-plans afterwards to prove the applied state has no residual diff.
+  terraform:ci:plan:
+    desc: Create the credentialed Terraform plan used by CI
+    cmds:
+      - ./scripts/terraform-ci.sh plan terraform
+
+  terraform:ci:apply:
+    desc: Apply the exact saved plan generated from reviewed trusted-main configuration
+    cmds:
+      - ./scripts/terraform-ci.sh apply terraform
+
+  terraform:ci:converge:
+    desc: Assert the applied Terraform state has no residual diff
+    cmds:
+      - ./scripts/terraform-ci.sh converge terraform
 [% endif %]
 [% if include_ansible %]
 

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -328,6 +328,29 @@ config, toolchain, devcontainer, and dev environment — against the items below
       *Release Please* → *Run workflow* (main) — the first `wrangler deploy`
       creates it; PR preview uploads work from that point.
 [% endif %]
+[% if include_terraform %]
+
+- [ ] Terraform CI is dormant until state and credentials exist. Configure an
+      S3-compatible backend with native locking (`use_lockfile`, Terraform >=
+      1.10 — Cloudflare R2 works), add the `R2_ACCESS_KEY_ID` /
+      `R2_SECRET_ACCESS_KEY` secrets plus your provider `TF_VAR_*` secrets, then
+      set the `TERRAFORM_CI_ENABLED` repo variable to `true`. Until then
+      `terraform.yml` validates only, and `terraform-plan-apply` is a verified
+      skip
+- [ ] Run the credentialed plan/apply job on an **ephemeral** runner (the
+      default GitHub-hosted one, or one-shot/container-per-job self-hosted). A
+      saved plan can contain secrets; its directory is private and cleaned up,
+      but file modes do not isolate it from another job running as the same
+      Unix user on a persistent runner. `CI_RUNS_ON` sets the runner
+- [ ] Once plan/apply is enabled and has run green, promote the aggregate to a
+      required check: add `terraform-verify` to the ruleset's
+      `required_status_checks` (Settings → Rules → Rulesets). It already emits
+      on every protected event, so requiring it cannot wedge an unrelated merge
+- [ ] If you ever turn `include_terraform` back off, **remove
+      `terraform-verify` from the ruleset first**. `copier update` deletes the
+      workflow, and a required check no workflow reports leaves every later PR
+      pending forever
+[% endif %]
 
 - [ ] For local `.env` needs, use **1Password Environments** (mounts a virtual
       `.env`; secrets never hit disk or git) or `op run`/`op inject`. Commit only

--- a/template/docs/architecture/ci-cd.md.jinja
+++ b/template/docs/architecture/ci-cd.md.jinja
@@ -27,6 +27,16 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
   PR checks, and is not part of branch protection. See
   [security.md](security.md) for quota guidance.
 [% endif %]
+[% if include_terraform %]
+- `terraform.yml` — on push/PR/merge-queue/dispatch: an internal `changes` job
+  scopes the work (the workflow itself carries **no `paths:` filter**, so its
+  aggregate always reports and can safely be required), `terraform-validate`
+  runs `task terraform:validate`, and `terraform-plan-apply` plans on PRs and
+  applies the reviewed plan on `main` before re-planning to prove the state
+  converged. That job stays dormant until the `TERRAFORM_CI_ENABLED` repo
+  variable is `true` — see [../CHECKLIST.md](../CHECKLIST.md). The aggregate is
+  **`terraform-verify`**; it is not in the ruleset's required checks yet.
+[% endif %]
 [% if devcontainer %]
 - `devcontainer-build.yml` — prebuilds the devcontainer images to GHCR on `.devcontainer/**` changes.
 [% endif %]

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -71,9 +71,13 @@ it points here.
 - **Terraform:** `task lint:terraform` aggregates `terraform fmt -check`, TFLint
   (`.tflint.hcl`, bundled ruleset — a cloud ruleset needs `tflint --init` in the
   task and in CI), and Checkov (pinned, via uvx); `terraform validate` runs
-  separately in `task validate` because it needs `terraform init`. Provider
-  tokens are sensitive variables; use `lifecycle.ignore_changes` for mutable
-  fields.
+  separately in `task validate` because it needs `terraform init`. That
+  validation, and the whole CI plan/apply path, go through
+  `scripts/terraform-ci.sh` (`task terraform:validate`, `terraform:ci:plan` /
+  `:apply` / `:converge`) so local runs and `terraform.yml` execute identical
+  commands — saved plans stay in a private, run-scoped directory and apply
+  refuses to re-plan. Provider tokens are sensitive variables; use
+  `lifecycle.ignore_changes` for mutable fields.
 [% endif %]
 [% if include_ansible %]
 - **Ansible:** ansible-lint; idempotency required; roles under `ansible/roles/`,

--- a/template/scripts/[% if include_terraform %]terraform-changed.sh[% endif %]
+++ b/template/scripts/[% if include_terraform %]terraform-changed.sh[% endif %]
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Emit a GitHub Actions output indicating whether Terraform-owned paths changed.
+#
+# terraform.yml carries NO workflow-level `paths:` filter, so the workflow starts
+# on every protected-event run and its terraform-verify aggregate always posts a
+# status — a required check whose workflow never starts wedges that merge
+# forever. Scoping happens here instead: on an unrelated change the Terraform
+# jobs become a deliberate, verified skip and the aggregate still reports.
+set -euo pipefail
+
+event="${GITHUB_EVENT_NAME:-}"
+base=""
+head="${GITHUB_SHA:-HEAD}"
+
+case "$event" in
+push | workflow_dispatch)
+    # Main reconciles UNCONDITIONALLY — it is never scoped.
+    #
+    # A push is the only event whose natural range is incremental
+    # (before..after), and GitHub keeps just one pending run per concurrency
+    # group: while an apply is in flight, a later unrelated push replaces the
+    # pending Terraform push. Scoping by before..after would then compare past
+    # the replaced commit, report "unchanged", and leave a merged Terraform
+    # change permanently unapplied behind a green aggregate. Reconciling every
+    # push costs a plan on unrelated merges and removes that hole entirely;
+    # workflow_dispatch reconciles for the same reason, on purpose.
+    #
+    # Pull requests are not exposed to this: they are compared base..head (the
+    # whole PR), so a superseded run's commits stay inside the next run's range.
+    echo "changed=true"
+    exit 0
+    ;;
+pull_request)
+    base="${PR_BASE_SHA:-}"
+    head="${PR_HEAD_SHA:-$head}"
+    ;;
+merge_group)
+    base="${MERGE_BASE_SHA:-}"
+    head="${MERGE_HEAD_SHA:-$head}"
+    ;;
+*)
+    echo "changed=true"
+    exit 0
+    ;;
+esac
+
+# An establishable comparison range is the precondition for skipping anything,
+# so when there is none the answer is "changed" — never skip a Terraform check
+# whose range could not be computed. On the scoped events this reaches
+# validation and (for a same-repo PR) a plan, never an apply. A genuine
+# `git diff` error is NOT this path: it aborts under `set -e` and fails closed.
+case "$base" in
+"" | 0000000000000000000000000000000000000000)
+    echo "changed=true"
+    exit 0
+    ;;
+esac
+
+# A force-push (or a shallower fetch than the range needs) can leave an endpoint
+# missing from this checkout. `git diff` would abort under `set -e` and fail the
+# gate for a reason that has nothing to do with Terraform, so fail open here too.
+for rev in "$base" "$head"; do
+    if ! git cat-file -e "${rev}^{commit}" 2>/dev/null; then
+        echo "changed=true"
+        exit 0
+    fi
+done
+
+# Everything the Terraform jobs actually execute, including the composite setup
+# action that provisions their toolchain: a change there (a Terraform version
+# bump, a broken installer) has to re-run them, or the required aggregate goes
+# green on a run that never exercised the thing that changed.
+# Three-dot: compare against the MERGE BASE, not the base branch tip. With a
+# two-dot range a branch that is merely behind its target reports the target's
+# own Terraform commits as its own, and an unrelated PR then runs the whole
+# Terraform path — including a credentialed plan it may have no secrets for.
+if git diff --quiet "${base}...${head}" -- \
+    terraform/ \
+    .github/workflows/terraform.yml \
+    .github/actions/setup/action.yml \
+    Taskfile.yml \
+    scripts/terraform-ci.sh \
+    scripts/terraform-changed.sh; then
+    echo "changed=false"
+else
+    echo "changed=true"
+fi

--- a/template/scripts/[% if include_terraform %]terraform-ci.sh[% endif %]
+++ b/template/scripts/[% if include_terraform %]terraform-ci.sh[% endif %]
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Shared Terraform CI operations. Workflows delegate here through Taskfile
+# targets so local verification and CI execute the same commands.
+# Saved plans can contain sensitive values, so artifacts live in a per-run
+# directory created private (or the ignored, repo-scoped local fallback) and
+# cleaned up afterwards — never a shared fixed /tmp path a concurrent or later
+# job could collide with, replace, or leave behind. Note the limit: mode bits
+# stop other Unix users, not another job running as the same user, so a
+# credentialed Terraform job belongs on an ephemeral runner.
+set -euo pipefail
+umask 077
+
+mode="${1:-}"
+shift || true
+
+usage() {
+    echo "Usage: $0 <validate ROOT...|plan ROOT|apply ROOT|converge ROOT|cleanup>" >&2
+    exit 2
+}
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)"
+artifact_dir="${TF_CI_ARTIFACT_DIR:-}"
+if [ -z "$artifact_dir" ]; then
+    if [ -n "${RUNNER_TEMP:-}" ]; then
+        run_key="${TF_CI_RUN_KEY:-terraform-${GITHUB_REPOSITORY_ID:-local}-${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEMPT:-1}}"
+        case "$run_key" in
+        "" | "." | ".." | */*)
+            echo "Invalid Terraform CI run key: ${run_key:-<empty>}" >&2
+            exit 1
+            ;;
+        esac
+        artifact_dir="${RUNNER_TEMP}/${run_key}"
+    else
+        artifact_dir="${repo_root}/.terraform-ci"
+    fi
+fi
+plan_file="${artifact_dir}/tfplan"
+plan_text_file="${artifact_dir}/tfplan.txt"
+converge_text_file="${artifact_dir}/tfconverge.txt"
+# Written when this helper creates the directory. Everything that re-permissions
+# or deletes requires it, so an operator override aimed at a populated directory
+# is refused instead of quietly adopting and pruning it.
+owner_marker="${artifact_dir}/.terraform-ci-owned"
+
+dir_mode() {
+    case "$(uname -s)" in
+    Darwin) stat -f '%Lp' "$1" ;;
+    *) stat -c '%a' "$1" ;;
+    esac
+}
+
+validate_artifact_dir() {
+    # Absolute only: `terraform -chdir=<root> plan -out=<relative>` resolves the
+    # plan path against the ROOT, while this script would create the directory
+    # relative to the caller's cwd — the plan then fails on a path that looks
+    # right in both places.
+    case "$artifact_dir" in
+    /*) ;;
+    *)
+        echo "Terraform CI artifact directory must be an absolute path: ${artifact_dir:-<empty>}" >&2
+        exit 1
+        ;;
+    esac
+    case "$artifact_dir" in
+    "" | "/" | "$repo_root" | */. | */..)
+        echo "Refusing unsafe Terraform CI artifact directory: ${artifact_dir:-<empty>}" >&2
+        exit 1
+        ;;
+    esac
+    if [ -L "$artifact_dir" ]; then
+        echo "Refusing symlinked Terraform CI artifact directory: ${artifact_dir}" >&2
+        exit 1
+    fi
+}
+
+prepare_artifact_dir() {
+    validate_artifact_dir
+    if [ -d "$artifact_dir" ]; then
+        # Reused across plan -> apply -> converge within one run, so an existing
+        # directory is normal — but only OUR directory. TF_CI_ARTIFACT_DIR is an
+        # operator escape hatch, and aiming it at a populated directory must
+        # fail loudly rather than silently re-permission it and delete
+        # plan-shaped files out of it later.
+        if [ ! -f "$owner_marker" ]; then
+            echo "Refusing a Terraform CI artifact directory this helper did not create: ${artifact_dir}" >&2
+            echo "Point TF_CI_ARTIFACT_DIR at a dedicated path, or remove it and let this script create one." >&2
+            exit 1
+        fi
+        existing_mode="$(dir_mode "$artifact_dir")"
+        if [ "$existing_mode" != "700" ]; then
+            echo "Refusing a Terraform CI artifact directory that is not private (mode ${existing_mode}): ${artifact_dir}" >&2
+            exit 1
+        fi
+        return
+    fi
+    # umask 077 already yields 0700; the explicit chmod keeps that true if a
+    # caller relaxed the umask.
+    mkdir -p "$artifact_dir"
+    chmod 700 "$artifact_dir"
+    : >"$owner_marker"
+}
+
+cleanup_artifacts() {
+    validate_artifact_dir
+    # Nothing to do if plan never got far enough to create it. This runs from a
+    # workflow step under `if: always()`, so a missing directory is a normal
+    # outcome, not an error.
+    [ -d "$artifact_dir" ] || return 0
+    if [ ! -f "$owner_marker" ]; then
+        echo "Refusing to clean a Terraform CI artifact directory this helper did not create: ${artifact_dir}" >&2
+        exit 1
+    fi
+    rm -f -- "$plan_file" "$plan_text_file" "$converge_text_file" "$owner_marker"
+    rmdir "$artifact_dir" 2>/dev/null || true
+}
+
+terraform_init() {
+    root="$1"
+    shift
+    if [ -f "${root}/.terraform.lock.hcl" ]; then
+        terraform -chdir="$root" init -lockfile=readonly "$@"
+    else
+        # Fresh scaffolds intentionally have no lock yet. Let init create one
+        # so a developer can review and commit it.
+        terraform -chdir="$root" init "$@"
+    fi
+}
+
+case "$mode" in
+validate)
+    [ "$#" -gt 0 ] || usage
+    data_root="$(mktemp -d)"
+    trap 'rm -rf "$data_root"' EXIT
+    index=0
+    for root in "$@"; do
+        index=$((index + 1))
+        data_dir="${data_root}/${index}"
+        echo "==> terraform validate: ${root}"
+        TF_DATA_DIR="$data_dir" terraform_init "$root" -backend=false -input=false
+        TF_DATA_DIR="$data_dir" terraform -chdir="$root" validate -no-color
+    done
+    ;;
+plan)
+    [ "$#" -eq 1 ] || usage
+    root="$1"
+    prepare_artifact_dir
+    rm -f -- "$plan_file" "$plan_text_file" "$converge_text_file"
+    terraform_init "$root" -input=false
+    # A bounded state-lock wait, never -lock=false: skipping the lock lets a
+    # concurrent apply race this plan against state it no longer describes.
+    terraform -chdir="$root" plan -no-color -input=false -lock-timeout=5m -out="$plan_file" |
+        tee "$plan_text_file"
+    ;;
+apply)
+    [ "$#" -eq 1 ] || usage
+    if [ "${GITHUB_ACTIONS:-}" != "true" ]; then
+        echo "Saved-plan apply is restricted to the trusted GitHub Actions workflow." >&2
+        exit 1
+    fi
+    prepare_artifact_dir
+    [ -f "$plan_file" ] || {
+        echo "Saved plan $plan_file is missing; refusing to re-plan during apply." >&2
+        exit 1
+    }
+    terraform -chdir="$1" apply -input=false -no-color "$plan_file"
+    ;;
+converge)
+    [ "$#" -eq 1 ] || usage
+    root="$1"
+    prepare_artifact_dir
+    rm -f -- "$converge_text_file"
+    trap cleanup_artifacts EXIT
+    if ! terraform -chdir="$root" plan -detailed-exitcode -no-color -input=false -lock-timeout=5m >"$converge_text_file" 2>&1; then
+        echo "Post-apply plan is not clean — state did not converge:"
+        tail -n 60 "$converge_text_file"
+        exit 1
+    fi
+    echo "Converged: post-apply plan reports no changes."
+    ;;
+cleanup)
+    [ "$#" -eq 0 ] || usage
+    cleanup_artifacts
+    ;;
+*)
+    usage
+    ;;
+esac

--- a/template/scripts/[% if include_terraform %]test-terraform-ci.sh[% endif %]
+++ b/template/scripts/[% if include_terraform %]test-terraform-ci.sh[% endif %]
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# Hermetic regression for the Terraform CI path: scripts/terraform-ci.sh is
+# exercised against a fake `terraform` (no network, no cloud, no state), and
+# .github/workflows/terraform.yml is checked for the contract that makes
+# terraform-verify safe to require — always-emitting triggers, work scoped by
+# the internal change detector, private run-scoped plan artifacts, and exact
+# result expectations rather than a fail-open success-or-skipped allowlist.
+set -euo pipefail
+
+repo="$(git rev-parse --show-toplevel)"
+cd "$repo"
+
+workflow=".github/workflows/terraform.yml"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+fake_bin="${tmp}/bin"
+runner_temp="${tmp}/runner-temp"
+run_key="terraform-123-456-1"
+artifact_dir="${runner_temp}/${run_key}"
+apply_marker="${tmp}/apply-called"
+init_log="${tmp}/terraform-init.log"
+locked_root="${tmp}/locked-root"
+fresh_root="${tmp}/fresh-root"
+lock_snapshot="${tmp}/committed-lock.snapshot"
+mkdir -p "$fake_bin" "$runner_temp" "$locked_root" "$fresh_root"
+printf '%s\n' "committed provider lock" >"${locked_root}/.terraform.lock.hcl"
+cp "${locked_root}/.terraform.lock.hcl" "$lock_snapshot"
+
+cat >"${fake_bin}/terraform" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode=""
+root=""
+lockfile_readonly=0
+for arg in "$@"; do
+    case "$arg" in
+    -chdir=*) root="${arg#-chdir=}" ;;
+    -lockfile=readonly) lockfile_readonly=1 ;;
+    init | validate | plan | apply)
+        mode="$arg"
+        ;;
+    esac
+done
+
+case "$mode" in
+init)
+    [ -n "$root" ] || exit 95
+    if [ -f "${root}/.terraform.lock.hcl" ]; then
+        if [ "$lockfile_readonly" -eq 1 ]; then
+            printf 'readonly %s\n' "$root" >>"${TF_INIT_LOG:?}"
+        else
+            printf '%s\n' "rewritten provider lock" >"${root}/.terraform.lock.hcl"
+            printf 'writable-existing %s\n' "$root" >>"${TF_INIT_LOG:?}"
+        fi
+    else
+        [ "$lockfile_readonly" -eq 0 ] || exit 96
+        printf '%s\n' "generated provider lock" >"${root}/.terraform.lock.hcl"
+        printf 'writable-new %s\n' "$root" >>"${TF_INIT_LOG:?}"
+    fi
+    ;;
+validate) ;;
+plan)
+    plan_path=""
+    for arg in "$@"; do
+        case "$arg" in
+        -out=*) plan_path="${arg#-out=}" ;;
+        esac
+    done
+    if [ -n "$plan_path" ]; then
+        printf '%s\n' "saved plan" >"$plan_path"
+        printf '%s\n' "plan summary"
+    fi
+    ;;
+apply)
+    plan_path=""
+    for arg in "$@"; do
+        plan_path="$arg"
+    done
+    [ -f "$plan_path" ] || exit 97
+    : >"${TF_APPLY_MARKER:?}"
+    ;;
+*)
+    exit 98
+    ;;
+esac
+EOF
+chmod +x "${fake_bin}/terraform"
+
+run_ci() {
+    PATH="${fake_bin}:${PATH}" \
+        RUNNER_TEMP="$runner_temp" \
+        TF_CI_RUN_KEY="$run_key" \
+        TF_APPLY_MARKER="$apply_marker" \
+        TF_INIT_LOG="$init_log" \
+        GITHUB_ACTIONS="${GITHUB_ACTIONS:-}" \
+        ./scripts/terraform-ci.sh "$@"
+}
+
+file_mode() {
+    case "$(uname -s)" in
+    Darwin) stat -f '%Lp' "$1" ;;
+    *) stat -c '%a' "$1" ;;
+    esac
+}
+
+# Extract one top-level job block from the workflow.
+job_block() {
+    awk -v job="  $1:" '
+        $0 == job { in_job = 1; next }
+        in_job && /^  [[:alnum:]_-]+:/ { exit }
+        in_job { print }
+    ' "$workflow"
+}
+
+run_ci validate "$locked_root" "$fresh_root" >/dev/null
+cmp -s "$lock_snapshot" "${locked_root}/.terraform.lock.hcl" ||
+    fail "backend-free validate rewrote a committed provider lock"
+[ -f "${fresh_root}/.terraform.lock.hcl" ] ||
+    fail "fresh scaffold init did not preserve the provider-lock creation path"
+grep -Fxq "readonly ${locked_root}" "$init_log" ||
+    fail "backend-free validate did not make the tracked lock readonly"
+grep -Fxq "writable-new ${fresh_root}" "$init_log" ||
+    fail "fresh scaffold init unexpectedly required a pre-existing lock"
+
+run_ci plan "$locked_root" >/dev/null
+cmp -s "$lock_snapshot" "${locked_root}/.terraform.lock.hcl" ||
+    fail "credentialed plan init rewrote a committed provider lock"
+readonly_count=$(grep -Fxc "readonly ${locked_root}" "$init_log" || true)
+[ "$readonly_count" -eq 2 ] ||
+    fail "tracked locks must be readonly for both validate and plan init"
+[ -f "${artifact_dir}/tfplan" ] || fail "plan was not saved under the run-scoped directory"
+[ -f "${artifact_dir}/tfplan.txt" ] || fail "plan summary was not saved under the run-scoped directory"
+[ "$(file_mode "$artifact_dir")" = "700" ] || fail "artifact directory is not private"
+[ "$(file_mode "${artifact_dir}/tfplan")" = "600" ] || fail "saved plan is not private"
+[ "$(file_mode "${artifact_dir}/tfplan.txt")" = "600" ] || fail "plan summary is not private"
+
+if GITHUB_ACTIONS=false run_ci apply "$locked_root" >/dev/null 2>&1; then
+    fail "local execution bypassed the GitHub Actions apply guard"
+fi
+[ ! -e "$apply_marker" ] ||
+    fail "local execution reached terraform apply before it was refused"
+
+GITHUB_ACTIONS=true run_ci apply "$locked_root" >/dev/null
+[ -e "$apply_marker" ] || fail "apply did not consume the saved run-scoped plan"
+[ -f "${artifact_dir}/tfplan" ] || fail "apply removed the plan before converge"
+
+run_ci converge "$locked_root" >/dev/null
+[ ! -e "$artifact_dir" ] || fail "converge did not clean Terraform CI artifacts"
+
+# An operator override must never adopt (and re-permission, and delete files
+# out of) a directory this script did not create.
+shared_dir="${tmp}/shared"
+mkdir -p "$shared_dir"
+chmod 755 "$shared_dir"
+printf '%s\n' 'unrelated' >"${shared_dir}/tfplan"
+if TF_CI_ARTIFACT_DIR="$shared_dir" run_ci plan "$locked_root" >/dev/null 2>&1; then
+    fail "a non-private pre-existing artifact directory was adopted instead of refused"
+fi
+[ "$(file_mode "$shared_dir")" = "755" ] ||
+    fail "a pre-existing artifact directory was re-permissioned by the override path"
+# Private but not ours: mode alone must not authorize adoption or deletion.
+private_dir="${tmp}/private-not-ours"
+mkdir -p "$private_dir"
+chmod 700 "$private_dir"
+printf '%s\n' 'unrelated' >"${private_dir}/tfplan"
+if TF_CI_ARTIFACT_DIR="$private_dir" run_ci plan "$locked_root" >/dev/null 2>&1; then
+    fail "a private directory this helper did not create was adopted"
+fi
+if TF_CI_ARTIFACT_DIR="$private_dir" run_ci cleanup >/dev/null 2>&1; then
+    fail "cleanup ran in a directory this helper did not create"
+fi
+[ -f "${private_dir}/tfplan" ] ||
+    fail "cleanup deleted a plan-shaped file out of a directory it does not own"
+for unsafe_dir in "/" "$repo" "${tmp}/." "relative/artifacts"; do
+    if TF_CI_ARTIFACT_DIR="$unsafe_dir" run_ci plan "$locked_root" >/dev/null 2>&1; then
+        fail "unsafe artifact directory was accepted: $unsafe_dir"
+    fi
+done
+
+# State-lock waits must be bounded, never disabled: skipping the lock lets a
+# concurrent apply race a plan against state it no longer describes. Comments
+# are stripped first so prose explaining the rule cannot trip it.
+terraform_ci_code="$(grep -v '^[[:space:]]*#' scripts/terraform-ci.sh)"
+grep -q -- '-lock-timeout=' <<<"$terraform_ci_code" ||
+    fail "Terraform CI plan/converge do not bound the state-lock wait"
+if grep -q -- '-lock=false' <<<"$terraform_ci_code"; then
+    fail "Terraform CI disables state locking instead of bounding the wait"
+fi
+
+# Main is never scoped. GitHub keeps only ONE pending run per concurrency
+# group, so while an apply is in flight a later unrelated push replaces the
+# pending Terraform push; an incremental before..after comparison would then
+# skip past the replaced commit and leave a merged Terraform change unapplied
+# behind a green aggregate. Pull requests ARE scoped — they compare base..head,
+# so a superseded run's commits stay inside the next run's range.
+head_sha="$(git rev-parse HEAD)"
+# PUSH_BEFORE_SHA is deliberately a VALID, empty-diff range here: an
+# implementation that scopes pushes by before..after answers "changed=false"
+# for it, so this assertion fails on exactly the regression it guards. Passing
+# an empty/unset value instead would pass either way via the fail-open path.
+for reconciling_event in push workflow_dispatch; do
+    decision="$(GITHUB_EVENT_NAME="$reconciling_event" GITHUB_SHA="$head_sha" \
+        PUSH_BEFORE_SHA="$head_sha" ./scripts/terraform-changed.sh)"
+    [ "$decision" = "changed=true" ] ||
+        fail "${reconciling_event} must reconcile unconditionally, got: ${decision}"
+done
+pr_decision="$(GITHUB_EVENT_NAME=pull_request PR_BASE_SHA="$head_sha" \
+    PR_HEAD_SHA="$head_sha" GITHUB_SHA="$head_sha" ./scripts/terraform-changed.sh)"
+[ "$pr_decision" = "changed=false" ] ||
+    fail "an empty pull-request range must scope Terraform work out, got: ${pr_decision}"
+new_branch_decision="$(GITHUB_EVENT_NAME=pull_request PR_BASE_SHA="" \
+    PR_HEAD_SHA="$head_sha" GITHUB_SHA="$head_sha" ./scripts/terraform-changed.sh)"
+[ "$new_branch_decision" = "changed=true" ] ||
+    fail "an unestablishable range must fail open into validation, got: ${new_branch_decision}"
+
+# A PR branch that is merely BEHIND a target which gained Terraform commits
+# must still scope out: comparing endpoints instead of the merge base blames a
+# branch for its target's changes and drags unrelated PRs through the whole
+# Terraform path. Built as a throwaway history so the assertion is exact.
+branch_repo="${tmp}/branch-repo"
+mkdir -p "${branch_repo}/scripts" "${branch_repo}/terraform"
+cp scripts/terraform-changed.sh "${branch_repo}/scripts/terraform-changed.sh"
+git -C "$branch_repo" init -q
+git -C "$branch_repo" config user.email test@example.com
+git -C "$branch_repo" config user.name test
+printf '%s\n' 'terraform {}' >"${branch_repo}/terraform/main.tf"
+printf '%s\n' 'base' >"${branch_repo}/README.md"
+git -C "$branch_repo" add -A
+git -C "$branch_repo" commit -qm base
+fork_point="$(git -C "$branch_repo" rev-parse HEAD)"
+printf '%s\n' 'unrelated branch work' >>"${branch_repo}/README.md"
+git -C "$branch_repo" commit -qam branch-work
+branch_head="$(git -C "$branch_repo" rev-parse HEAD)"
+git -C "$branch_repo" checkout -q "$fork_point"
+printf '%s\n' 'variable "added_on_target" {}' >>"${branch_repo}/terraform/main.tf"
+git -C "$branch_repo" commit -qam target-terraform-work
+target_head="$(git -C "$branch_repo" rev-parse HEAD)"
+stale_branch_decision="$(
+    cd "$branch_repo" &&
+        GITHUB_EVENT_NAME=pull_request PR_BASE_SHA="$target_head" \
+            PR_HEAD_SHA="$branch_head" GITHUB_SHA="$branch_head" \
+            ./scripts/terraform-changed.sh
+)"
+[ "$stale_branch_decision" = "changed=false" ] ||
+    fail "a branch behind a Terraform-changing target must not inherit those changes, got: ${stale_branch_decision}"
+
+grep -Fxq '.terraform-ci/' .gitignore || fail "local Terraform CI artifact fallback is not ignored"
+if grep -Eq '/tmp/tf(plan|converge)' scripts/terraform-ci.sh "$workflow"; then
+    fail "fixed global Terraform plan paths remain"
+fi
+grep -Fq 'TF_CI_RUN_KEY: terraform-${{ github.repository_id }}-${{ github.run_id }}-${{ github.run_attempt }}' \
+    "$workflow" || fail "workflow run key is not repository/run scoped"
+grep -Fq './scripts/terraform-ci.sh cleanup' "$workflow" ||
+    fail "workflow does not clean Terraform CI artifacts on completion"
+for ci_operation in plan apply converge; do
+    grep -Fq "task terraform:ci:${ci_operation}" "$workflow" ||
+        fail "workflow does not use the namespaced Terraform CI ${ci_operation} target"
+done
+
+# terraform-verify is meant to be requirable by branch protection, so the
+# workflow must start on every protected-event run. A `paths:` filter would stop
+# it from starting at all on an out-of-scope change — and a required check that
+# posts no status wedges that merge forever. The scoping lives in the `changes`
+# job instead.
+trigger_block="$(
+    awk '
+        /^on:/ { in_on = 1; next }
+        in_on && /^[[:alnum:]_-]+:/ { exit }
+        in_on { print }
+    ' "$workflow"
+)"
+for trigger in push pull_request merge_group workflow_dispatch; do
+    grep -Eq "^  ${trigger}:" <<<"$trigger_block" ||
+        fail "terraform.yml does not emit on ${trigger} — a required terraform-verify would not always report"
+done
+if grep -Eq '^ +paths(-ignore)?:' <<<"$trigger_block"; then
+    fail "terraform.yml filters its triggers by path — scope the work in the changes job, not the trigger"
+fi
+grep -Fq './scripts/terraform-changed.sh' "$workflow" ||
+    fail "workflow does not scope Terraform work with the internal change detector"
+
+terraform_validate_block="$(job_block terraform-validate)"
+case "$terraform_validate_block" in
+*"github.event_name != 'pull_request'"*"github.event.pull_request.head.repo.full_name == github.repository"*) ;;
+*) fail "terraform-validate can run fork code on a configurable self-hosted runner" ;;
+esac
+
+terraform_plan_block="$(job_block terraform-plan-apply)"
+case "$terraform_plan_block" in
+*"needs: [changes, terraform-validate]"*) ;;
+*) fail "terraform-plan-apply can run before terraform-validate succeeds" ;;
+esac
+# A merge group can carry a fork PR's code, and this job holds the backend and
+# provider secrets — it must not run there.
+case "$terraform_plan_block" in
+*"github.event_name != 'merge_group'"*) ;;
+*) fail "terraform-plan-apply runs credentialed on merge_group, where a fork PR's code can be in the merge ref" ;;
+esac
+
+terraform_verify_block="$(job_block terraform-verify)"
+case "$terraform_verify_block" in
+*"if: always()"*) ;;
+*) fail "terraform-verify is not if: always() — a skipped required check counts as successful" ;;
+esac
+for verify_contract in \
+    "IS_FORK:" \
+    "TERRAFORM_CHANGED:" \
+    "expected skipped for an untrusted fork" \
+    "EXPECTED_RESULT: success" \
+    "EXPECTED_RESULT: skipped" \
+    "verify-ci-results.sh"; do
+    case "$terraform_verify_block" in
+    *"$verify_contract"*) ;;
+    *) fail "terraform-verify does not derive exact expected results from workflow intent (missing: ${verify_contract})" ;;
+    esac
+done
+case "$terraform_verify_block" in
+*'[ "$2" = "success" ] || [ "$2" = "skipped" ]'*)
+    fail "terraform-verify still accepts unexpected skips and terminal states"
+    ;;
+*) ;;
+esac
+# The fork diagnostic must not check out repository code: on an untrusted fork
+# PR the aggregate is the one job that still runs, so anything it executes from
+# the checkout is fork-controlled.
+awk '
+    /uses: actions\/checkout/ {
+        if (prev !~ /IS_FORK != .true./) exit 1
+    }
+    /[^[:space:]]/ { prev = $0 }
+' <<<"$terraform_verify_block" ||
+    fail "terraform-verify checks out repository code without excluding the untrusted-fork path"
+
+echo "==> Terraform CI artifacts, triggers, and result gating OK"

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -272,4 +272,9 @@ if [ -x ./scripts/test-terraform-provider-locks.sh ]; then
     ./scripts/test-terraform-provider-locks.sh
 fi
 
+if [ -x ./scripts/test-terraform-ci.sh ]; then
+    echo "==> Terraform CI keeps plans private and its aggregate result-gated"
+    ./scripts/test-terraform-ci.sh
+fi
+
 echo "==> task targets OK (compile + bootstrap idempotency + path-safe formatting)"


### PR DESCRIPTION
Third and last part of #385 — raising the template to the Terraform standard
harmon-devkit's `standardize-repo` skill enforces. #391 shipped TFLint +
Checkov; #395 shipped provider-lock discipline. This is the CI-aggregate half,
ported from harmon-infra's live implementation so its own reconciliation diff
lands near zero and the other two infra repos gain the tooling.

## ⚠️ The ruleset item is deliberately excluded

Item 4 of #385 — adding `terraform-verify` to
`template/.github/Branch Protection Ruleset - Protect Main.json.jinja` — is
**not** in this PR. It changes required status checks for every repo generated
with `include_terraform=true`, which is a security-relevant settings change
that shouldn't ride along inside a large diff. Approved to defer.

**Consequence:** `verify-applied.sh` will still report
`must require 'terraform-verify' when Terraform is present` until it lands.
Everything else in the Terraform contract is now satisfied.

The sequencing is the safe one regardless: this PR is what *makes*
`terraform-verify` safe to require. Requiring it while the workflow still had
`paths:` filters would have wedged every out-of-scope merge.

## What changed

**Three scripts** under `include_terraform` (the five names harmon-devkit's
`template-owned-files.txt` expects are now all present):

| script | role |
|---|---|
| `terraform-ci.sh` | validate / plan / apply / converge; private run-scoped plan artifacts; apply refuses to re-plan without the saved plan |
| `terraform-changed.sh` | the internal change detector |
| `test-terraform-ci.sh` | hermetic regression — fake `terraform`, no network, no cloud |

**Taskfile:** `terraform:validate` (and `lint:terraform:validate` now routes
through it — a bare `terraform validate` fails on an uninitialized root), plus
`terraform:ci:plan` / `:apply` / `:converge`.

**terraform.yml**, the four problems from #385:

1. **`paths:` filters dropped, `merge_group` added.** A required check whose
   workflow a filter keeps from starting never posts a status, and branch
   protection blocks that merge forever.
2. **Work scoped instead of the trigger**, via an internal `changes` job —
   unrelated PRs are a fast no-op that still reports.
3. **The fail-open aggregate is gone.** `[ "$2" = "success" ] || [ "$2" =
   "skipped" ]` is replaced by build.yml's exact contract: fork PRs require
   every suppressed leaf to be exactly `skipped`, checked inline without
   checking out repository code; trusted events require `success` via
   `verify-ci-results.sh`. Every accepted `skipped` is tied to an explicit
   change / enabled / merge_group predicate.
4. `if: always()` retained.

## Deliberate divergences from harmon-infra

These files are template-owned, so this version becomes canonical and
harmon-infra picks them up on its next `copier update`:

- **Pushes to main reconcile unconditionally.** GitHub keeps only one *pending*
  run per concurrency group, so while an apply is in flight a later unrelated
  push replaces the pending Terraform push — an incremental `before..after`
  comparison would skip past the replaced commit and leave a merged Terraform
  change permanently unapplied behind a green aggregate. PRs stay scoped
  (compared `base...head`, immune to that replacement).
- **`terraform-plan-apply` never runs on `merge_group`.** A merge group can
  carry a fork PR's code, and that job holds the backend/provider secrets. The
  same-repo PR already produced the reviewed plan and the push to main produces
  the authoritative one.
- **PR scoping uses the merge base** (`base...head`), so a branch merely behind
  its target doesn't inherit the target's Terraform commits.
- `install-deps: "false"` (and `cache: "false"` for Node) on both jobs — the
  composite action's own docs say the cache must be off for credential-holding
  jobs.
- Plan/apply timeout **15 → 60 min**: the old budget covered a plan; it now has
  to cover setup + plan + apply + converge with two possible 5-minute lock
  waits, and a timeout firing mid-apply strands half-created resources.
- The artifact directory carries an ownership marker; the helper refuses to
  adopt, re-permission, or clean a directory it did not create.
- The detector also watches `.github/actions/setup/action.yml`, since both jobs
  now depend on it.

harmon-infra's two open `terraform-provider-locks.sh` bugs
(harmonops/harmon-infra#461) did not come along — that script is unchanged
here, and #395 already carried the fix for the first one.

## Verification

- `task ci` green; all six `test-template` profiles pass.
- New `test-template.sh` **section 9i** asserts the same contract
  `verify-applied.sh` checks (triggers, no path filters, result-gating, no
  fail-open allowlist), gated on the answer rather than the profile name.
- **Every new assertion was proven to fail on the defect it guards** —
  path filter, missing `merge_group`, the `success || skipped` allowlist,
  unguarded checkout in the aggregate, plan not downstream of validate,
  credentialed `merge_group`, two-dot PR comparison, scoped push, relative and
  unowned artifact directories, and the artifact-privacy/apply-guard behaviors.
  One assertion was found to be vacuous this way and fixed.
- `task challenge` ran 5 rounds (its cap), `task review` exited clean.

## Adjudication

| # | Finding | Class | Action |
|---|---|---|---|
| 1 | Detector ignores the composite setup action both jobs use | confirmed | Added to the diff paths |
| 2 | Credentialed job inherits `install-deps`/`cache` defaults | confirmed | `install-deps: "false"` + `cache: "false"` |
| 3 | No safe removal path if `include_terraform` is turned off | confirmed | CHECKLIST: drop the required check *first* |
| 4 | Fail-open range → unintended apply on main | rejected | Ruleset's `non_fast_forward` prevents a dangling `before` on a protected main; a real `git diff` error fails *closed* under `set -e`. Comment corrected where it understated the consequence |
| 5 | `merge_group` runs credentialed fork code | confirmed | Plan/apply excluded from `merge_group`; aggregate predicts the skip exactly |
| 6 | `TF_CI_ARTIFACT_DIR` could re-permission/prune a shared dir | confirmed | Absolute-path requirement + ownership marker; refuses to adopt or clean what it didn't create |
| 7 | Concurrency replacement can drop a Terraform push | confirmed | Pushes reconcile unconditionally (the divergence above) |
| 8 | 15-min timeout can kill an in-flight apply | confirmed | Raised to 60 |
| 9 | Job-level secrets visible to the setup action's steps | rejected | Would triple the "add your provider secrets here" block downstream repos must edit — a partially-updated set is the likelier real failure. Steps are SHA-pinned actions with `install-deps` off |
| 10 | Mode bits aren't a co-tenant boundary on a persistent runner | confirmed (as overclaim) | Claim corrected in code + a CHECKLIST item to run this job on an ephemeral runner |
| 11 | PR-controlled helpers run with deploy credentials | rejected | Inherent to plan-on-PR: planning a PR's Terraform executes that PR's config. Fork PRs are the untrusted boundary and are excluded; same-repo authors already have write access. Now stated explicitly in the workflow header |
| 12 | A PR could edit the detector to skip its own gate | rejected | Requires an approved PR containing a visible edit to the detector, and pushes to main reconcile unconditionally — main re-validates immediately after merge |
| 13 | PR comparison blames a branch for its target's changes | confirmed | Three-dot merge-base comparison |

Closes #385 except for the ruleset item, which stays open for a separate,
explicitly-approved change.
