### PR TITLE
fix(template): stop a merged Terraform change from going unapplied

### DIFF
--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -973,11 +973,69 @@ sys.exit(1 if problems else 0)
 PY
     grep -qE '^  terraform-verify:' "$tf_workflow" ||
         err "$tf_workflow has no terraform-verify aggregate job"
+    # A push to main must NOT be scoped by an incremental before..after range.
+    # GitHub keeps one pending run per concurrency group, so while an apply is
+    # in flight a later unrelated push replaces the pending Terraform push; a
+    # before..after comparison then steps over the replaced commit, reports
+    # "unchanged", and leaves a merged Terraform change unapplied behind a green
+    # required check. Pull requests and merge groups compare endpoints and keep
+    # their scoping — this asserts only that `push` reconciles.
+    ! grep -q "github.event_name == 'push' && github.event.before" "$tf_workflow" ||
+        err "$tf_workflow scopes pushes by github.event.before — concurrency replacement can then drop a merged Terraform change with terraform-verify still green"
+    if have python3; then
+        python3 - "$tf_workflow" <<'PY' || err "the Terraform change detector does not reconcile unconditionally on push (see stderr)"
+import sys, pathlib, re
+
+text = pathlib.Path(sys.argv[1]).read_text()
+match = re.search(r"^\s+BASE_SHA:.*?(?=^\s+HEAD_SHA:)", text, re.M | re.S)
+if not match:
+    print("  no BASE_SHA expression found in the change-detection job", file=sys.stderr)
+    sys.exit(1)
+if "push" in match.group(0):
+    print(
+        "  BASE_SHA derives a range for `push`; main must reconcile instead "
+        "(an incremental range can be stepped over by concurrency replacement)",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+PY
+    fi
     # A required context with no job to emit it never reports, and a check that
     # never reports blocks the merge forever. Assert the ruleset and the
     # workflow agree, in BOTH directions.
     grep -q '"context": "terraform-verify"' '.github/Branch Protection Ruleset - Protect Main.json' ||
         err "ruleset does not require terraform-verify (include_terraform=true)"
+    # The job that runs `terraform apply` needs a budget that covers init + plan
+    # + apply + converge, each able to spend its full lock timeout first. A
+    # timeout firing mid-apply strands half-created resources, which is the
+    # failure `cancel-in-progress: false` exists to prevent — so the apply job
+    # must not sit on the same short budget as the validate-only jobs.
+    if have python3; then
+        python3 - "$tf_workflow" <<'PY' || err "the Terraform apply job's timeout is too short to be safe (see stderr)"
+import sys, pathlib, re
+
+text = pathlib.Path(sys.argv[1]).read_text()
+jobs = re.split(r"^(?=  [A-Za-z0-9_-]+:$)", text, flags=re.M)
+for job in jobs:
+    if "terraform apply" not in job and "terraform:ci:apply" not in job:
+        continue
+    found = re.search(r"^\s+timeout-minutes:\s*(\d+)", job, re.M)
+    if not found:
+        print("  the apply job has no timeout-minutes at all", file=sys.stderr)
+        sys.exit(1)
+    minutes = int(found.group(1))
+    if minutes < 30:
+        print(
+            f"  the apply job's timeout-minutes is {minutes}; a timeout during "
+            "`terraform apply` strands half-created resources",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    sys.exit(0)
+print("  no job running `terraform apply` was found", file=sys.stderr)
+sys.exit(1)
+PY
+    fi
     # Every doc that tells a consumer WHEN to import the ruleset must name
     # terraform.yml as a prerequisite. Importing a required check before its
     # workflow is on main wedges the repo, and the instruction is the only thing

--- a/template/.github/workflows/[% if include_terraform %]terraform.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if include_terraform %]terraform.yml[% endif %].jinja
@@ -55,13 +55,26 @@ jobs:
       - name: Detect Terraform changes
         id: detect
         env:
-          # workflow_dispatch has no range — a human asked for this run, so it
-          # always counts as changed (that is how drift is reconciled without
-          # an empty commit).
+          # Two events deliberately pass NO range, so the detector reconciles:
+          #
+          #   workflow_dispatch — has no range at all; a human asked for this
+          #   run, which is how drift is reconciled without an empty commit.
+          #
+          #   push — its only natural range is INCREMENTAL (before..after), and
+          #   that is not safe here. GitHub keeps a single *pending* run per
+          #   concurrency group, so while an apply is in flight a later
+          #   unrelated push REPLACES the pending Terraform push. Comparing
+          #   before..after would then step straight over the replaced commit,
+          #   answer "unchanged", skip every leaf — and terraform-verify would
+          #   go green over a merged Terraform change that was never applied.
+          #   Main reconciles instead; the cost is a plan on unrelated merges.
+          #
+          # pull_request and merge_group are compared endpoint-to-endpoint, so a
+          # superseded run's commits stay inside the next run's range. They keep
+          # their scoping, which is where it pays off anyway.
           BASE_SHA: >-
             ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha
             || github.event_name == 'merge_group' && github.event.merge_group.base_sha
-            || github.event_name == 'push' && github.event.before
             || '' }}
           HEAD_SHA: >-
             ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha
@@ -110,7 +123,14 @@ jobs:
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
-    timeout-minutes: 15
+    # Generous on purpose, and NOT the 15 minutes the other jobs use: this one
+    # budget covers init + plan + apply + the post-apply converge re-plan, and
+    # each of those three Terraform commands may first spend its full
+    # TF_LOCK_TIMEOUT waiting on state. A timeout that fires mid-apply kills the
+    # mutation and strands half-created resources — the exact failure
+    # `cancel-in-progress: false` above exists to prevent. Raise it further if
+    # real applies get close.
+    timeout-minutes: 60
     env:
       # The S3-compatible backend (Cloudflare R2) reads AWS-style env vars.
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/template/scripts/[% if include_terraform %]terraform-changed.sh[% endif %]
+++ b/template/scripts/[% if include_terraform %]terraform-changed.sh[% endif %]
@@ -44,10 +44,14 @@ emit() {
     exit 0
 }
 
-# All-zero sha = branch creation / no previous commit; empty = caller had none.
+# No base to compare against. Three ways to get here, all answering `true`:
+# branch creation (all-zero sha), an event with no range (workflow_dispatch),
+# and an event that reconciles BY DESIGN — a push to the deploy branch, where an
+# incremental before..after range can be stepped over by concurrency
+# replacement (see the BASE_SHA comment in .github/workflows/terraform.yml).
 case "$base" in
 "" | 0000000000000000000000000000000000000000)
-    echo "terraform-changed: no usable base ($base) — assuming changed" >&2
+    echo "terraform-changed: no comparison range (base='${base}') — reconciling" >&2
     emit true
     ;;
 esac


### PR DESCRIPTION
Two defects in the Terraform CI path shipped by #397 / #399, both in the job
that mutates real infrastructure. Small, independent, and on top of current
`main` (25342f1).

## 1. A merged Terraform change can go unapplied behind a green required check

`terraform.yml` scoped `push` by `github.event.before`. GitHub keeps a single
**pending** run per concurrency group, so while an apply is in flight a later
unrelated push *replaces* the pending Terraform push. The `before..after` range
then steps straight over the replaced commit:

1. Push A changes `terraform/` → its run starts an apply.
2. Push B (docs only) queues behind it — pending.
3. Push C (docs only) arrives → **B is cancelled**, C queues.
4. C compares `B..C` → no Terraform files → `changed=false`.
5. Every leaf is a *predicted* skip, so `terraform-verify` is **green**.

B's Terraform change is never applied, and nothing anywhere reports a problem.
This is the failure mode the detector's fail-safe design is meant to exclude —
it just doesn't reach this path, because the range is perfectly usable, only
wrong.

**Fix:** `push` reconciles unconditionally, exactly like `workflow_dispatch`.
`push` is the only event whose natural range is *incremental*; `pull_request`
and `merge_group` compare endpoints, so a superseded run's commits stay inside
the next run's range — they keep their scoping, which is where it pays off
anyway. The cost is a plan on unrelated merges to `main`.

## 2. The apply job's 15-minute timeout can kill an in-flight apply

`terraform-plan-apply` sat on the same `timeout-minutes: 15` as the
validate-only jobs, but its budget now covers `init` + `plan` + `apply` + the
converge re-plan — and each of those three commands may first spend its full
`TF_LOCK_TIMEOUT` (5m) waiting on state. A timeout firing mid-`apply` kills the
mutation and strands half-created resources, which is the exact failure
`cancel-in-progress: false` exists to prevent.

**Fix:** 60 minutes, with the reasoning recorded next to it.

## Verification

- `task ci` green; all six `test-template` profiles pass.
- Both fixes are asserted in `test-template.sh` section 9h, next to the existing
  wedge guards.
- **Both assertions were confirmed to fail against the previous code**, not
  merely to pass against the new — I reverted each defect in turn and checked
  the diagnostic:
  - `…scopes pushes by github.event.before — concurrency replacement can then drop a merged Terraform change with terraform-verify still green`
  - `the apply job's timeout-minutes is 15; a timeout during 'terraform apply' strands half-created resources`

## Provenance

These came out of an independent implementation of #385 item 3 (#398, now
redundant since #397 landed the same scope). #398 is duplicate work and should
be closed — this PR is the part of it that is still worth having. Everything
else it contained is either already on `main` via #397/#399 or a design
difference I did not want to relitigate against merged code.
