### PR TITLE
ci: automate the harmon-devkit release-to-sync PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
       - run: task test:ci-results
       - run: task test:renovate-pins
       - run: task test:release-title
+      - run: task test:sync-devkit-release
       - name: Dogfood parity (verbatim template files match their root twins)
         run: task test:dogfood-parity
       # The structure check renders template/, so it needs copier. Installed

--- a/.github/workflows/sync-harmon-devkit.yml
+++ b/.github/workflows/sync-harmon-devkit.yml
@@ -1,0 +1,99 @@
+name: Sync harmon-devkit skills
+run-name: sync-harmon-devkit reconciling the vendored skills pin
+
+# harmon-init vendors harmon-devkit's shared agent skills at a released tag.
+# Publishing a stable harmon-devkit release should produce a complete, verified
+# harmon-init pin-and-sync PR without anyone editing a pin by hand — while the
+# two release-PR merges at either end stay intentional human gates.
+#
+# ROOT-ONLY. This is harmon-platform integration glue (the harmon-init <->
+# harmon-devkit edge) and is deliberately NOT rendered into generated repos:
+# there is no template/ twin, and none should be added. See
+# docs/architecture/ci-cd.md.
+#
+# All the logic lives in scripts/sync-devkit-release.sh so it is shellcheck'd
+# and unit-tested (`task test:sync-devkit-release`) instead of hiding in an
+# inline workflow block. It never merges anything.
+
+on:
+  # Emitted by harmon-devkit's release workflow once a stable tag exists. The
+  # payload tag is untrusted: the helper validates its shape and confirms the
+  # release upstream before using it.
+  repository_dispatch:
+    types: [harmon-devkit-released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "harmon-devkit tag to sync (default: latest stable release)"
+        required: false
+        type: string
+  # Reconciliation: a dropped dispatch must not leave the pin stale forever.
+  # Off the hour to avoid GitHub's scheduling pile-up.
+  schedule:
+    - cron: "37 6 * * *"
+
+# Serialize dispatch, manual, and scheduled runs: they all rewrite the same bot
+# branch and maintain the same rolling PR.
+concurrency:
+  group: sync-harmon-devkit
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    # Generous: the pre-push gate runs `task verify`, which renders the whole
+    # copier template matrix.
+    timeout-minutes: 60
+    steps:
+      # CI GitHub App token, not GITHUB_TOKEN: a PR opened by GITHUB_TOKEN never
+      # triggers CI, and branch protection requires those checks before the sync
+      # PR can merge. Least-privilege — push the bot branch (contents) and
+      # maintain one PR (pull-requests); no issues, no workflows.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Full history: release-title pre-flight and the template render
+          # matrix both diff against the base.
+          fetch-depth: 0
+          # Keeps the repo-wide hardening intact even though this job pushes.
+          # The helper authenticates the one `git push` with a process-scoped
+          # credential helper reading GH_TOKEN from the environment, so the
+          # token never lands in .git/config where `task verify`'s copier/npx/uvx
+          # runs could reach it.
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+        with:
+          lint-tools: "true"
+          gitleaks: "true"
+      # `task verify` renders the copier template, so this job needs the same
+      # extras build.yml's template-test job installs on top of the composite.
+      - name: Install the template-render toolchain
+        run: |
+          # --force overwrites a foreign same-named entry point instead of
+          # aborting, keeping reruns idempotent on a self-hosted CI_RUNS_ON
+          # runner (same reasoning as build.yml's lint job).
+          uv tool install --force copier
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          npm install --global @devcontainers/cli lefthook pnpm
+      - name: Configure git for copier renders
+        run: git config --global init.defaultBranch main
+      - name: Pin, vendor, verify, and open or update the sync PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          # Untrusted dispatch payload and manual input reach the helper only
+          # through the environment — never interpolated into a run script.
+          # Empty on the scheduled path, which resolves the latest release.
+          SYNC_DEVKIT_TAG: ${{ github.event.client_payload.tag || inputs.tag || '' }}
+        run: task sync:devkit-release

--- a/.github/workflows/sync-harmon-devkit.yml
+++ b/.github/workflows/sync-harmon-devkit.yml
@@ -63,6 +63,13 @@ jobs:
           permission-pull-requests: write
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          # Pinned to the default branch, not github.ref. Dispatch and schedule
+          # already run from main, but workflow_dispatch lets the operator pick
+          # any branch — and that branch's Taskfile/helper would then execute
+          # with a contents:write App token in the environment. Branch
+          # protection reviews what reaches main; nothing reviews an arbitrary
+          # branch, so the privileged path only ever runs main's code.
+          ref: main
           # Full history: release-title pre-flight and the template render
           # matrix both diff against the base.
           fetch-depth: 0
@@ -79,6 +86,8 @@ jobs:
           gitleaks: "true"
       # `task verify` renders the copier template, so this job needs the same
       # extras build.yml's template-test job installs on top of the composite.
+      # `gh` is assumed from the runner image (as in close-milestone-on-release);
+      # a CI_RUNS_ON runner without it fails fast on "gh is required".
       - name: Install the template-render toolchain
         run: |
           # --force overwrites a foreign same-named entry point instead of

--- a/.github/workflows/sync-harmon-devkit.yml
+++ b/.github/workflows/sync-harmon-devkit.yml
@@ -105,8 +105,16 @@ jobs:
           uv tool install --force copier
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           npm install --global @devcontainers/cli lefthook pnpm
-      - name: Configure git for copier renders
-        run: git config --global init.defaultBranch main
+      # Same three settings build.yml's template-test job needs, for the same
+      # reason: copier runs `git init` + an initial commit inside each rendered
+      # project, and a GitHub-hosted runner has no global identity. This is
+      # GLOBAL config, so it does not affect the sync commit — the helper sets
+      # the bot identity repo-locally, which takes precedence.
+      - name: Configure git identity (copier renders run git init)
+        run: |
+          git config --global user.name "ci"
+          git config --global user.email "ci@users.noreply.github.com"
+          git config --global init.defaultBranch main
       - name: Pin, vendor, verify, and open or update the sync PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/sync-harmon-devkit.yml
+++ b/.github/workflows/sync-harmon-devkit.yml
@@ -96,4 +96,8 @@ jobs:
           # through the environment — never interpolated into a run script.
           # Empty on the scheduled path, which resolves the latest release.
           SYNC_DEVKIT_TAG: ${{ github.event.client_payload.tag || inputs.tag || '' }}
+          # A late or out-of-order dispatch must not roll the pin backwards.
+          # Running the workflow by hand is a deliberate act, so it may — that
+          # is the recovery path off a bad harmon-devkit release.
+          SYNC_DEVKIT_ALLOW_DOWNGRADE: ${{ github.event_name == 'workflow_dispatch' }}
         run: task sync:devkit-release

--- a/.github/workflows/sync-harmon-devkit.yml
+++ b/.github/workflows/sync-harmon-devkit.yml
@@ -16,24 +16,33 @@ run-name: sync-harmon-devkit reconciling the vendored skills pin
 # inline workflow block. It never merges anything.
 
 on:
-  # Emitted by harmon-devkit's release workflow once a stable tag exists. The
-  # payload tag is untrusted: the helper validates its shape and confirms the
-  # release upstream before using it.
+  # Emitted by harmon-devkit's release workflow once a stable tag exists, and
+  # the manual recovery path too:
+  #
+  #   gh api repos/evanharmon1/harmon-init/dispatches \
+  #     -f event_type=harmon-devkit-released \
+  #     -f 'client_payload[tag]=v0.9.0'
+  #
+  # DELIBERATELY not workflow_dispatch. This workflow mints a CI App token, and
+  # for workflow_dispatch GitHub runs the workflow definition from whichever ref
+  # the operator picks — so an unreviewed branch could rewrite this file and use
+  # the credential, and pinning the CHECKOUT to main would not help because the
+  # token was already minted by then. repository_dispatch always runs the
+  # default branch's definition. Every other App-token workflow here
+  # (claude-*, release) is likewise reachable only through triggers that pin the
+  # definition to the default branch; see docs/architecture/security.md.
+  #
+  # The payload is untrusted: the helper validates the tag's shape and confirms
+  # the release upstream before using it.
   repository_dispatch:
     types: [harmon-devkit-released]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "harmon-devkit tag to sync (default: latest stable release)"
-        required: false
-        type: string
   # Reconciliation: a dropped dispatch must not leave the pin stale forever.
   # Off the hour to avoid GitHub's scheduling pile-up.
   schedule:
     - cron: "37 6 * * *"
 
-# Serialize dispatch, manual, and scheduled runs: they all rewrite the same bot
-# branch and maintain the same rolling PR.
+# Serialize dispatched and scheduled runs: they all rewrite the same bot branch
+# and maintain the same rolling PR.
 concurrency:
   group: sync-harmon-devkit
   cancel-in-progress: false
@@ -102,12 +111,16 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-          # Untrusted dispatch payload and manual input reach the helper only
-          # through the environment — never interpolated into a run script.
-          # Empty on the scheduled path, which resolves the latest release.
-          SYNC_DEVKIT_TAG: ${{ github.event.client_payload.tag || inputs.tag || '' }}
-          # A late or out-of-order dispatch must not roll the pin backwards.
-          # Running the workflow by hand is a deliberate act, so it may — that
-          # is the recovery path off a bad harmon-devkit release.
-          SYNC_DEVKIT_ALLOW_DOWNGRADE: ${{ github.event_name == 'workflow_dispatch' }}
+          # The untrusted dispatch payload reaches the helper only through the
+          # environment — never interpolated into a run script. Empty on the
+          # scheduled path, which resolves the latest release.
+          SYNC_DEVKIT_TAG: ${{ github.event.client_payload.tag || '' }}
+          # A late or out-of-order dispatch must not roll the pin backwards, so
+          # a downgrade has to be asked for explicitly — the recovery path off a
+          # bad harmon-devkit release. Sending a repository_dispatch already
+          # requires repository write access; harmon-devkit's emitter never sets
+          # this. Accepts a JSON boolean or the string `gh api -f` sends.
+          SYNC_DEVKIT_ALLOW_DOWNGRADE: >-
+            ${{ github.event.client_payload.allow_downgrade == true ||
+                github.event.client_payload.allow_downgrade == 'true' }}
         run: task sync:devkit-release

--- a/.github/workflows/sync-harmon-devkit.yml
+++ b/.github/workflows/sync-harmon-devkit.yml
@@ -67,10 +67,11 @@ jobs:
           # matrix both diff against the base.
           fetch-depth: 0
           # Keeps the repo-wide hardening intact even though this job pushes.
-          # The helper authenticates the one `git push` with a process-scoped
-          # credential helper reading GH_TOKEN from the environment, so the
-          # token never lands in .git/config where `task verify`'s copier/npx/uvx
-          # runs could reach it.
+          # The helper authenticates each origin operation with a process-scoped
+          # credential helper reading GH_TOKEN from the environment, and runs
+          # the sync and every verification target with GH_TOKEN scrubbed — so
+          # the write token reaches neither .git/config nor the copier/npx/uvx
+          # subprocesses `task verify` spawns.
           persist-credentials: false
       - uses: ./.github/actions/setup
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,8 +107,17 @@ lives in harmon-devkit (`ai/skills/repo/standardize-repo`). The root repo
 dogfoods the same pinned skills sync the template ships: `.skills-sync.yaml`
 pins a released harmon-devkit tag, `task sync:skills` vendors the `repo`
 category into `.claude/skills`, and CI/pre-push run `task verify:skills` /
-`verify:skills:offline` as drift checks. After a harmon-devkit release, bump
-the `ref` pin, run `task sync:skills`, and commit the refresh.
+`verify:skills:offline` as drift checks.
+
+Bumping that pin after a harmon-devkit release is **automated**: the root-only
+`.github/workflows/sync-harmon-devkit.yml` (→ `task sync:devkit-release` →
+`scripts/sync-devkit-release.sh`) validates the released tag, rewrites both
+pins, re-vendors, verifies, and opens or updates ONE rolling
+`bot/sync-harmon-devkit` PR. It never merges anything — both repositories keep
+their intentional release gates. To do it by hand (or recover), run
+`task sync:devkit-release -- vX.Y.Z`, or bump the `ref` pin, run
+`task sync:skills`, and commit the refresh. See
+[docs/architecture/ci-cd.md](docs/architecture/ci-cd.md).
 
 ## Common Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,9 +114,10 @@ Bumping that pin after a harmon-devkit release is **automated**: the root-only
 `scripts/sync-devkit-release.sh`) validates the released tag, rewrites both
 pins, re-vendors, verifies, and opens or updates ONE rolling
 `bot/sync-harmon-devkit` PR. It never merges anything — both repositories keep
-their intentional release gates. To do it by hand (or recover), run
-`task sync:devkit-release -- vX.Y.Z`, or bump the `ref` pin, run
-`task sync:skills`, and commit the refresh. See
+their intentional release gates. To trigger or recover by hand, send the
+dispatch (`gh api repos/evanharmon1/harmon-init/dispatches -f
+event_type=harmon-devkit-released -f 'client_payload[tag]=vX.Y.Z'`) or run
+`task sync:devkit-release -- vX.Y.Z` locally. See
 [docs/architecture/ci-cd.md](docs/architecture/ci-cd.md).
 
 ## Common Commands

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -78,6 +78,7 @@ tasks:
       - task: test:ci-results
       - task: test:renovate-pins
       - task: test:release-title
+      - task: test:sync-devkit-release
       - task: test:dogfood-parity
       - task: test:dogfood-structure
       - task: foreman:test
@@ -307,6 +308,11 @@ tasks:
     cmds:
       - ./scripts/test-release-title.sh
 
+  test:sync-devkit-release:
+    desc: Unit-test the harmon-devkit release→sync-PR automation (offline, stubbed gh/task)
+    cmds:
+      - ./scripts/test-sync-devkit-release.sh
+
   # ── Dogfood drift (root layer vs template/) ───────────────────
   # Three checks, in increasing looseness. The root layer is template/ rendered
   # with .dogfood-answers.yml, maintained by hand — `copier update` can never
@@ -349,6 +355,15 @@ tasks:
     desc: "Fast offline check that the vendored ref matches the manifest (no network)"
     cmds:
       - ./scripts/sync-skills.sh verify-offline
+
+  # ROOT-ONLY (no template twin): the harmon-init <-> harmon-devkit release edge.
+  # Driven by .github/workflows/sync-harmon-devkit.yml on a harmon-devkit release
+  # dispatch, a manual dispatch, or the daily reconciliation schedule — see
+  # docs/architecture/ci-cd.md. Opens/updates ONE PR and never merges anything.
+  sync:devkit-release:
+    desc: "Pin the latest harmon-devkit release, vendor it, verify, and open/update the sync PR"
+    cmds:
+      - ./scripts/sync-devkit-release.sh run {{.CLI_ARGS}}
 
   # ── Second-model review (Codex) ───────────────────────────────
   # Optional second AI model (the OpenAI Codex CLI) reviewing the current

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -26,6 +26,62 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
 - `devcontainer-build.yml` — prebuilds the devcontainer images to GHCR on `.devcontainer/**` changes.
 - `release.yml` — release-please maintains the rolling release PR.
 - `close-milestone-on-release.yml` — closes the milestone matching the tag on release publish.
+- `sync-harmon-devkit.yml` — **root-only**: turns a published harmon-devkit
+  release into a verified pin-and-sync PR (see below).
+
+## Root-only vs template-shipped workflows
+
+Most root workflows are the rendered form of a `template/` twin and must be
+edited in lockstep (AGENTS.md, "Dogfood parity"). A few are **root-only**: they
+exist because harmon-init sits inside harmon-platform, and a generated repo has
+no such edge. `close-milestone-on-release.yml` and `sync-harmon-devkit.yml` are
+root-only; they have no `template/` counterpart, and the dogfood checks are
+twin-driven (they walk `template/`), so root-only files are correctly invisible
+to them. Do not add a twin to make them "consistent".
+
+## harmon-devkit skills propagation
+
+harmon-init vendors harmon-devkit's shared agent skills at a released tag
+(`.skills-sync.yaml` and its template twin). `sync-harmon-devkit.yml` automates
+everything between the two intentional release gates:
+
+```text
+human merges harmon-devkit's release PR  ->  stable tag
+        | repository_dispatch (harmon-devkit-released)
+harmon-init validates the tag, pins it, vendors, verifies, opens/updates ONE PR
+        |
+human merges the sync PR, then harmon-init's release PR
+```
+
+- **Triggers:** the dispatch, `workflow_dispatch` (optional tag, for recovery),
+  and a daily reconciliation `schedule` so a dropped dispatch cannot leave the
+  pin stale. One `concurrency` group serializes all three.
+- **Trust:** the payload tag is untrusted. `scripts/sync-devkit-release.sh`
+  checks its shape in pure shell (no regex a newline can split), then confirms
+  the release exists upstream and is neither a draft nor a prerelease, before
+  anything is written. It reaches the helper only through the environment.
+- **Fail-closed:** the run aborts before any push if the two pins already
+  disagree, if `task sync:skills` writes a path outside the manifests,
+  provenance, and managed skills, or if `task verify:skills:offline`,
+  `task verify:skills`, or `task verify` fails.
+- **One rolling PR:** a deterministic `bot/sync-harmon-devkit` branch, rebuilt
+  from `main` every run, so a newer release supersedes an open sync PR instead
+  of opening a second one. Replaying an event after the PR merged is a no-op;
+  replaying it while the PR is open compares trees and leaves the branch alone,
+  so the daily schedule never force-pushes an identical commit or re-triggers
+  the PR's checks.
+- **Recovery:** `workflow_dispatch` with an explicit tag, or locally
+  `task sync:devkit-release -- vX.Y.Z`. A sync PR that was closed by hand is
+  re-opened from the pushed branch on the next run.
+- **Never merges.** Not the sync PR, not either repository's release PR.
+
+Renovate keeps its approval-gated harmon-devkit rule as a passive stale-pin
+signal and manual fallback; it cannot vendor the skills itself, and its
+Dependency Dashboard approval means it never races this workflow into a
+duplicate branch.
+
+The harmon-devkit side of the edge (emitting the dispatch on release) lives in
+that repository's `release.yml`.
 
 ## Authentication
 

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -61,11 +61,15 @@ human merges the sync PR, then harmon-init's release PR
   the release exists upstream and is neither a draft nor a prerelease, before
   anything is written. It reaches the helper only through the environment.
 - **Fail-closed:** the run aborts before any push if the two pins already
-  disagree, if the tag would move the pin *backwards* (a late or out-of-order
-  dispatch — only a manual run may downgrade, as the recovery path off a bad
-  release), if `task sync:skills` writes a path outside the manifests,
+  disagree, if the tag would move the pin *backwards* — measured against the
+  newest tag in flight, so a delayed dispatch cannot drag an open sync PR back
+  either; only a manual run may downgrade, as the recovery path off a bad
+  release — if `task sync:skills` writes a path outside the manifests,
   provenance, and managed skills, or if `task verify:skills:offline`,
-  `task verify:skills`, or `task verify` fails.
+  `task security:secrets`, `task verify:skills`, or `task verify` fails.
+  gitleaks runs *before* the push, not just on the PR: this step vendors files
+  from another repository, and a pushed secret needs rotating whether or not
+  the PR ever merges.
 - **One rolling PR:** a deterministic `bot/sync-harmon-devkit` branch, rebuilt
   from `main` every run, so a newer release supersedes an open sync PR instead
   of opening a second one. Replaying an event after the PR merged is a no-op;

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -65,9 +65,12 @@ human merges the sync PR, then harmon-init's release PR
   a process-scoped credential helper, and the sync and verification targets run
   with `GH_TOKEN` scrubbed. A contents:write credential is therefore never
   visible to the copier renders, `npx`, and `uvx` that `task verify` spawns.
-- **Base integrity:** the run refuses to start unless `HEAD` is `main` and
-  `main` matches `origin/main`, so a force-push can never publish unrelated
-  local commits under a bot title.
+- **Base integrity:** the checkout is pinned to `main` (`workflow_dispatch`
+  otherwise lets an operator run an unreviewed branch's helper with a write
+  token), and the run refuses to start unless `HEAD` is `main` and `main`
+  matches `origin/main` — so a force-push can never publish unrelated local
+  commits under a bot title. An origin that cannot be reached aborts rather
+  than being read as "no sync PR is in flight".
 - **Fail-closed:** the run aborts before any push if the two pins already
   disagree, if the tag would move the pin *backwards* — measured against the
   newest tag in flight, so a delayed dispatch cannot drag an open sync PR back

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -61,7 +61,9 @@ human merges the sync PR, then harmon-init's release PR
   the release exists upstream and is neither a draft nor a prerelease, before
   anything is written. It reaches the helper only through the environment.
 - **Fail-closed:** the run aborts before any push if the two pins already
-  disagree, if `task sync:skills` writes a path outside the manifests,
+  disagree, if the tag would move the pin *backwards* (a late or out-of-order
+  dispatch — only a manual run may downgrade, as the recovery path off a bad
+  release), if `task sync:skills` writes a path outside the manifests,
   provenance, and managed skills, or if `task verify:skills:offline`,
   `task verify:skills`, or `task verify` fails.
 - **One rolling PR:** a deterministic `bot/sync-harmon-devkit` branch, rebuilt

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -60,6 +60,14 @@ human merges the sync PR, then harmon-init's release PR
   checks its shape in pure shell (no regex a newline can split), then confirms
   the release exists upstream and is neither a draft nor a prerelease, before
   anything is written. It reaches the helper only through the environment.
+- **Token scope:** the checkout keeps `persist-credentials: false`; the App
+  token authenticates only the individual `git` calls that talk to origin, via
+  a process-scoped credential helper, and the sync and verification targets run
+  with `GH_TOKEN` scrubbed. A contents:write credential is therefore never
+  visible to the copier renders, `npx`, and `uvx` that `task verify` spawns.
+- **Base integrity:** the run refuses to start unless `HEAD` is `main` and
+  `main` matches `origin/main`, so a force-push can never publish unrelated
+  local commits under a bot title.
 - **Fail-closed:** the run aborts before any push if the two pins already
   disagree, if the tag would move the pin *backwards* — measured against the
   newest tag in flight, so a delayed dispatch cannot drag an open sync PR back

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -53,9 +53,9 @@ harmon-init validates the tag, pins it, vendors, verifies, opens/updates ONE PR
 human merges the sync PR, then harmon-init's release PR
 ```
 
-- **Triggers:** the dispatch, `workflow_dispatch` (optional tag, for recovery),
-  and a daily reconciliation `schedule` so a dropped dispatch cannot leave the
-  pin stale. One `concurrency` group serializes all three.
+- **Triggers:** the dispatch and a daily reconciliation `schedule`, so a dropped
+  dispatch cannot leave the pin stale. One `concurrency` group serializes them.
+  There is deliberately **no `workflow_dispatch`** — see "Token scope" below.
 - **Trust:** the payload tag is untrusted. `scripts/sync-devkit-release.sh`
   checks its shape in pure shell (no regex a newline can split), then confirms
   the release exists upstream and is neither a draft nor a prerelease, before
@@ -65,12 +65,15 @@ human merges the sync PR, then harmon-init's release PR
   a process-scoped credential helper, and the sync and verification targets run
   with `GH_TOKEN` scrubbed. A contents:write credential is therefore never
   visible to the copier renders, `npx`, and `uvx` that `task verify` spawns.
-- **Base integrity:** the checkout is pinned to `main` (`workflow_dispatch`
-  otherwise lets an operator run an unreviewed branch's helper with a write
-  token), and the run refuses to start unless `HEAD` is `main` and `main`
-  matches `origin/main` — so a force-push can never publish unrelated local
-  commits under a bot title. An origin that cannot be reached aborts rather
-  than being read as "no sync PR is in flight".
+  The workflow is not `workflow_dispatch`-able for the same reason: GitHub
+  would run the *selected ref's* workflow definition, so an unreviewed branch
+  could rewrite the token-minting step itself — a checkout pinned to `main`
+  cannot help, because the token exists by then.
+- **Base integrity:** the checkout is pinned to `main`, and the run refuses to
+  start unless `HEAD` is `main` and `main` matches `origin/main` — so a
+  force-push can never publish unrelated local commits under a bot title. An
+  origin that cannot be reached aborts rather than being read as "no sync PR is
+  in flight".
 - **Fail-closed:** the run aborts before any push if the two pins already
   disagree, if the tag would move the pin *backwards* — measured against the
   newest tag in flight, so a delayed dispatch cannot drag an open sync PR back
@@ -87,9 +90,18 @@ human merges the sync PR, then harmon-init's release PR
   replaying it while the PR is open compares trees and leaves the branch alone,
   so the daily schedule never force-pushes an identical commit or re-triggers
   the PR's checks.
-- **Recovery:** `workflow_dispatch` with an explicit tag, or locally
-  `task sync:devkit-release -- vX.Y.Z`. A sync PR that was closed by hand is
-  re-opened from the pushed branch on the next run.
+- **Recovery:** send the dispatch by hand (it always runs the default branch's
+  definition, unlike `workflow_dispatch`) —
+
+  ```bash
+  gh api repos/evanharmon1/harmon-init/dispatches \
+    -f event_type=harmon-devkit-released \
+    -f 'client_payload[tag]=v0.9.0' \
+    -f 'client_payload[allow_downgrade]=true'   # only to roll back a bad release
+  ```
+
+  — or run it locally with `task sync:devkit-release -- vX.Y.Z`. A sync PR
+  closed by hand is re-opened from the pushed branch on the next run.
 - **Never merges.** Not the sync PR, not either repository's release PR.
 
 Renovate keeps its approval-gated harmon-devkit rule as a passive stale-pin

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -341,6 +341,16 @@ even the in-org radius small:
   it from workflows that untrusted code can influence (fork `pull_request`,
   `pull_request_target`, `workflow_run`) — the provided workflows gate on
   sender / same-repo checks.
+- **Never put `workflow_dispatch` on a workflow that mints an App token.** For
+  that trigger GitHub runs the workflow definition from whichever ref the
+  operator selects, so any branch — reviewed or not — could rewrite the
+  token-minting step and use the credential. Pinning the *checkout* to `main`
+  does not help: the token already exists. Every App-token workflow here is
+  reachable only through triggers that pin the definition to the default
+  branch — `push` (release), the issue/PR events (`claude-*`), and
+  `repository_dispatch` (`sync-harmon-devkit`). Use `repository_dispatch` when
+  a manual trigger is needed; it takes the same repository write access and
+  always runs the default branch's definition.
 - **Rotate the key** periodically; GitHub Apps allow multiple keys for
   zero-downtime rotation.
 

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -231,7 +231,7 @@ variable, not forever.
 ## CI automation identity (GitHub App)
 
 CI workflows that act on the repo as a bot — release-please, the
-`claude-*` workflows — authenticate as a
+`claude-*` workflows, `sync-harmon-devkit.yml` — authenticate as a
 **GitHub App dedicated to this owner**, not a personal access token. **Each
 GitHub org (and personal account) gets its own App**, named **`<owner>-ci`** —
 for this repo, **`evanharmon1-ci`**. One App per org keeps a leaked key
@@ -350,7 +350,7 @@ TODO: enumerate the tokens/secrets this repo depends on and where each lives:
 
 | Secret / variable | Used by | Stored in | Rotation |
 |---|---|---|---|
-| `CI_APP_CLIENT_ID` (var) + `CI_APP_PRIVATE_KEY` (secret) | release-please, claude-* | repo or org Actions variable + secret | rotate App key per policy |
+| `CI_APP_CLIENT_ID` (var) + `CI_APP_PRIVATE_KEY` (secret) | release-please, claude-*, sync-harmon-devkit | repo or org Actions variable + secret | rotate App key per policy |
 | `CLAUDE_CODE_OAUTH_TOKEN` | claude-* workflows | repo Actions secret | TODO |
 | `SNYK_TOKEN` | optional Snyk CLI scans; also `snyk-scheduled.yml` when explicitly generated | local env / 1Password by default; Actions secret only for scheduled/paid CI | manual |
 | `GH_TOKEN` (the bot's PAT) | the devcontainer agent's `gh`/git operations | 1Password Environment → devcontainer `--env-file` | manual; re-issue before expiry ([guides/bot-account.md](../guides/bot-account.md)) |

--- a/renovate.json
+++ b/renovate.json
@@ -110,7 +110,8 @@
       "dependencyDashboardApproval": true,
       "dependencyDashboardCategory": "Agent skills",
       "prBodyNotes": [
-        "After approving this update, run `task sync:skills` and push the refreshed `.claude/skills/` as a separate commit; do not amend Renovate's commit."
+        "Normally unnecessary: `.github/workflows/sync-harmon-devkit.yml` already opens a complete pin-and-sync PR on every stable harmon-devkit release. This rule stays as a passive stale-pin signal and manual fallback — it needs Dependency Dashboard approval, so it never races that workflow.",
+        "If you do approve this update, run `task sync:skills` and push the refreshed `.claude/skills/` as a separate commit; do not amend Renovate's commit. A ref-only bump fails the skills drift check by design."
       ]
     },
     {

--- a/scripts/sync-devkit-release.sh
+++ b/scripts/sync-devkit-release.sh
@@ -1,0 +1,480 @@
+#!/usr/bin/env bash
+# sync-devkit-release.sh — turn a published harmon-devkit release into a
+# complete, verified harmon-init pin-and-sync PR.
+#
+# harmon-init vendors harmon-devkit's shared agent skills at a pinned tag
+# (.skills-sync.yaml plus its template twin). Bumping that pin by hand is a
+# six-step chore, and the two release-PR merges at either end are intentional
+# human gates. Everything BETWEEN them is deterministic, so this helper does it:
+#
+#   resolve + validate a stable upstream release
+#     -> rewrite BOTH pins
+#     -> `task sync:skills`
+#     -> assert the diff touched nothing but the expected paths
+#     -> verify
+#     -> commit, force-push the rolling bot branch, open/update exactly ONE PR
+#
+# It never merges anything, and it never writes the base branch. A validation,
+# scope, or verification failure aborts BEFORE the push, so a broken sync can
+# never surface as an open PR.
+#
+# Root-only: this is harmon-platform integration glue (the harmon-init <->
+# harmon-devkit edge) and is deliberately NOT shipped to generated repos —
+# there is no template/ twin. See docs/architecture/ci-cd.md.
+#
+# Usage:
+#   sync-devkit-release.sh resolve [TAG]   # validate + print the tag to sync to
+#   sync-devkit-release.sh pinned          # print the agreed current pin
+#   sync-devkit-release.sh run [TAG]       # the whole pipeline
+#
+# TAG defaults to $SYNC_DEVKIT_TAG, then to the latest stable upstream release.
+# Env: GH_APP_SLUG — when set, the bot commit identity is derived from the App.
+# Depends on: git, gh, task. Unit-tested by scripts/test-sync-devkit-release.sh.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+DEVKIT_REPO="evanharmon1/harmon-devkit"
+ROOT_MANIFEST=".skills-sync.yaml"
+TEMPLATE_MANIFEST='template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja'
+BASE_BRANCH="main"
+# One deterministic branch -> one rolling PR. A newer release rewrites it
+# instead of opening a second PR (see the force-push in cmd_run).
+SYNC_BRANCH="bot/sync-harmon-devkit"
+
+LF="
+"
+
+BODY_FILE=""
+cleanup() {
+    [ -n "$BODY_FILE" ] && rm -f "$BODY_FILE"
+    return 0
+}
+trap cleanup EXIT
+
+die() {
+    echo "sync-devkit-release: $*" >&2
+    exit 1
+}
+
+note() {
+    echo "sync-devkit-release: $*"
+}
+
+need_bin() {
+    command -v "$1" >/dev/null 2>&1 || die "$1 is required"
+}
+
+need_manifests() {
+    [ -f "$ROOT_MANIFEST" ] || die "manifest '$ROOT_MANIFEST' not found"
+    [ -f "$TEMPLATE_MANIFEST" ] || die "manifest '$TEMPLATE_MANIFEST' not found"
+}
+
+# ── Tag validation ────────────────────────────────────────────────────
+# A dispatch payload is untrusted input, so the tag is checked for SHAPE before
+# it is used anywhere and for EXISTENCE against the upstream API before it is
+# believed. Deliberately pure shell: no pipe into grep, so there is no way for
+# an embedded newline to satisfy a per-line anchored regex and slip through.
+assert_tag_shape() {
+    _ats_tag="$1"
+    [ -n "$_ats_tag" ] || die "empty harmon-devkit tag"
+    case "$_ats_tag" in
+    v*) ;;
+    *) die "refusing tag '$_ats_tag' — a harmon-devkit release tag starts with 'v'" ;;
+    esac
+    _ats_rest="${_ats_tag#v}"
+    # Only digits and dots may follow the 'v'. This also rejects newlines,
+    # whitespace, and every shell metacharacter in one gate.
+    case "$_ats_rest" in
+    "" | *[!0-9.]*) die "refusing tag '$_ats_tag' — only digits and dots may follow 'v'" ;;
+    esac
+    _ats_dots="${_ats_rest//[!.]/}"
+    [ "${#_ats_dots}" -eq 2 ] ||
+        die "refusing tag '$_ats_tag' — expected a stable v<major>.<minor>.<patch> tag"
+    _ats_tail="${_ats_rest#*.}"
+    for _ats_part in "${_ats_rest%%.*}" "${_ats_tail%%.*}" "${_ats_tail#*.}"; do
+        [ -n "$_ats_part" ] ||
+            die "refusing tag '$_ats_tag' — empty version component"
+    done
+}
+
+# cmd_resolve [TAG] — echo the harmon-devkit tag to sync to, and NOTHING else
+# on stdout: callers capture it.
+cmd_resolve() {
+    _cr_tag="${1:-}"
+    if [ -z "$_cr_tag" ]; then
+        _cr_tag="$(gh api "repos/$DEVKIT_REPO/releases/latest" --jq '.tag_name')" ||
+            die "could not resolve the latest stable $DEVKIT_REPO release"
+    fi
+    assert_tag_shape "$_cr_tag"
+    # Independent confirmation that the tag is a real, published, stable
+    # release — never take the payload's word for it. GitHub's
+    # get-release-by-tag already 404s on drafts; the explicit checks keep the
+    # rejection loud rather than incidental.
+    _cr_meta="$(gh api "repos/$DEVKIT_REPO/releases/tags/$_cr_tag" \
+        --jq '[.tag_name, (.draft|tostring), (.prerelease|tostring)] | join(" ")')" ||
+        die "no published $DEVKIT_REPO release found for tag '$_cr_tag'"
+    _cr_name="" _cr_draft="" _cr_pre=""
+    read -r _cr_name _cr_draft _cr_pre <<EOF
+$_cr_meta
+EOF
+    [ "$_cr_name" = "$_cr_tag" ] ||
+        die "upstream release for '$_cr_tag' reports tag_name '$_cr_name' — refusing"
+    [ "$_cr_draft" = "false" ] || die "refusing tag '$_cr_tag' — it is a draft release"
+    [ "$_cr_pre" = "false" ] || die "refusing tag '$_cr_tag' — it is a prerelease"
+    printf '%s\n' "$_cr_tag"
+}
+
+# ── Manifests ─────────────────────────────────────────────────────────
+# Read with sed rather than yq: the template twin is jinja (its `categories:`
+# block is a `[% for %]` loop), so it is not parseable YAML until rendered.
+manifest_field() {
+    _mf_file="$1" _mf_key="$2"
+    _mf_n="$(grep -c "^[[:space:]]*${_mf_key}:" "$_mf_file" || true)"
+    [ "$_mf_n" = "1" ] ||
+        die "expected exactly one '${_mf_key}:' line in $_mf_file (found $_mf_n)"
+    sed -n "s/^[[:space:]]*${_mf_key}:[[:space:]]*\\([^[:space:]#]*\\).*/\\1/p" "$_mf_file"
+}
+
+set_pin() {
+    _sp_file="$1" _sp_tag="$2"
+    _sp_n="$(grep -c '^[[:space:]]*ref:' "$_sp_file" || true)"
+    [ "$_sp_n" = "1" ] || die "expected exactly one 'ref:' line in $_sp_file (found $_sp_n)"
+    # In-place via a temp copy: BSD and GNU `sed -i` take different arguments.
+    # The tag passed assert_tag_shape, so it holds no sed replacement
+    # metacharacter (&, \, |).
+    _sp_tmp="$(mktemp)"
+    sed "s|^\\([[:space:]]*ref:[[:space:]]*\\)[^[:space:]#]*|\\1${_sp_tag}|" "$_sp_file" >"$_sp_tmp"
+    cat "$_sp_tmp" >"$_sp_file"
+    rm -f "$_sp_tmp"
+}
+
+# cmd_pinned — the tag both manifests agree on. Pre-existing disagreement is a
+# human problem: bumping one side of an already-drifted pair would hide it.
+cmd_pinned() {
+    _cp_root="$(manifest_field "$ROOT_MANIFEST" ref)"
+    _cp_tpl="$(manifest_field "$TEMPLATE_MANIFEST" ref)"
+    [ "$_cp_root" = "$_cp_tpl" ] ||
+        die "pin disagreement: $ROOT_MANIFEST pins '$_cp_root' but the template twin pins '$_cp_tpl' — reconcile by hand before automating a bump"
+    printf '%s\n' "$_cp_root"
+}
+
+# prov_field PROV FIELD — a `# FIELD: …` provenance header value. Single awk
+# process on purpose: a `sed | head` pipeline can raise SIGPIPE and, under
+# `pipefail`, turn a successful read into a script-killing failure.
+prov_field() {
+    [ -f "$1" ] || return 0
+    awk -v k="$2" 'index($0, "# " k ":") == 1 {
+        sub("^# " k ":[[:space:]]*", ""); print; exit
+    }' "$1"
+}
+
+prov_ref() {
+    [ -f "$1" ] || return 0
+    awk 'index($0, "# ref:") == 1 {
+        sub(/^# ref:[[:space:]]*/, ""); sub(/[[:space:]]*\(.*/, ""); print; exit
+    }' "$1"
+}
+
+assert_safe_dest() {
+    case "$1" in
+    "" | "/" | "." | "..") die "refusing unsafe skills dest '$1'" ;;
+    /*) die "refusing absolute skills dest '$1'" ;;
+    ../* | */../* | */..) die "refusing skills dest with a '..' component: '$1'" ;;
+    esac
+}
+
+# ── Diff scope ────────────────────────────────────────────────────────
+# --no-renames so every change is exactly one path; -z so a path is never
+# quoted or split (the template manifest's filename contains spaces).
+changed_paths_z() {
+    git diff --no-renames --name-only -z HEAD
+    git ls-files --others --exclude-standard -z
+}
+
+changed_paths_nl() {
+    git diff --no-renames --name-only HEAD
+    git ls-files --others --exclude-standard
+}
+
+# assert_expected_scope DEST — fail closed unless every changed path is one of
+# the two manifests, the provenance stamp, or a vendored skill the sync owns.
+# The owned set is the UNION of the pre-sync (HEAD) and post-sync `# managed:`
+# lines: a skill the new pin dropped appears only in the old list, one it added
+# only in the new. Anything else — a local skill, an unrelated file — is an
+# unexpected write and aborts the run before anything is committed or pushed.
+assert_expected_scope() {
+    _aes_dest="$1"
+    _aes_prov="$_aes_dest/.SKILLS_PROVENANCE"
+    _aes_allow="$(
+        {
+            git show "HEAD:$_aes_prov" 2>/dev/null || true
+            cat "$_aes_prov" 2>/dev/null || true
+        } | awk 'index($0, "# managed:") == 1 {
+                sub(/^# managed:[[:space:]]*/, "")
+                n = split($0, parts, ",")
+                for (i = 1; i <= n; i++) {
+                    gsub(/^[[:space:]]+|[[:space:]]+$/, "", parts[i])
+                    if (parts[i] != "") print parts[i]
+                }
+            }'
+    )"
+    # Delimited membership test (no `grep` subprocess): a pipeline whose reader
+    # exits early can report SIGPIPE under `pipefail` and reject a legitimate
+    # path.
+    _aes_haystack="${LF}${_aes_allow}${LF}"
+
+    _aes_bad=""
+    while IFS= read -r -d '' _aes_p; do
+        [ -n "$_aes_p" ] || continue
+        # Quoted case patterns are literal matches — essential for the template
+        # manifest, whose name contains `[%`, a glob bracket expression.
+        case "$_aes_p" in
+        "$ROOT_MANIFEST" | "$TEMPLATE_MANIFEST" | "$_aes_prov") continue ;;
+        esac
+        _aes_ok=0
+        case "$_aes_p" in
+        "$_aes_dest"/*)
+            _aes_name="${_aes_p#"$_aes_dest"/}"
+            _aes_name="${_aes_name%%/*}"
+            case "$_aes_haystack" in
+            *"${LF}${_aes_name}${LF}"*) _aes_ok=1 ;;
+            esac
+            ;;
+        esac
+        [ "$_aes_ok" -eq 1 ] || _aes_bad="${_aes_bad}  - ${_aes_p}${LF}"
+    done < <(changed_paths_z)
+
+    if [ -n "$_aes_bad" ]; then
+        echo "sync-devkit-release: the sync wrote paths it does not own:" >&2
+        printf '%s' "$_aes_bad" >&2
+        die "expected only the two skills-sync manifests, $_aes_prov, and managed skills under $_aes_dest/ — inspect by hand"
+    fi
+}
+
+# ── Verification ──────────────────────────────────────────────────────
+# Cheapest first. `verify` is the repo's definition-of-done gate and already
+# contains test:dogfood-parity, test:dogfood-structure and the whole
+# test:template render matrix; verify:skills is the NETWORK drift check that
+# `verify` deliberately leaves out (see the Taskfile's `ci` comment).
+run_verification() {
+    for _rv_target in verify:skills:offline verify:skills verify; do
+        note "verifying: task $_rv_target"
+        task "$_rv_target" ||
+            die "verification failed at 'task $_rv_target' — nothing pushed, no PR touched"
+    done
+}
+
+# preflight_title TITLE — the PR changes template/, so a non-releasing title
+# would merge without cutting a tag and no downstream repo would ever receive
+# the new skills. Run the same guard CI runs, before the branch is pushed.
+preflight_title() {
+    PR_TITLE="$1" PR_BODY="" CHANGED_FILES="$(changed_paths_nl)" \
+        task guard:release-title ||
+        die "PR title '$1' would not cut a release for a template/ change"
+}
+
+# configure_identity — commit as the CI GitHub App rather than as whatever the
+# runner defaults to. A no-op when GH_APP_SLUG is unset (local runs, tests).
+configure_identity() {
+    _ci_slug="${GH_APP_SLUG:-}"
+    [ -n "$_ci_slug" ] || return 0
+    case "$_ci_slug" in
+    *[!a-zA-Z0-9-]*) die "refusing unexpected GitHub App slug '$_ci_slug'" ;;
+    esac
+    _ci_uid="$(gh api "/users/${_ci_slug}[bot]" --jq '.id')" ||
+        die "could not resolve the user id for '${_ci_slug}[bot]'"
+    case "$_ci_uid" in
+    "" | *[!0-9]*) die "unexpected user id '$_ci_uid' for '${_ci_slug}[bot]'" ;;
+    esac
+    git config user.name "${_ci_slug}[bot]"
+    git config user.email "${_ci_uid}+${_ci_slug}[bot]@users.noreply.github.com"
+}
+
+write_pr_body() {
+    _wb_old="$1" _wb_new="$2" _wb_prov="$3"
+    BODY_FILE="$(mktemp)"
+    cat >"$BODY_FILE" <<EOF
+Automated pin-and-sync of the vendored harmon-devkit agent skills.
+
+| | |
+| --- | --- |
+| previous pin | \`${_wb_old}\` |
+| new pin | \`${_wb_new}\` |
+| upstream release | https://github.com/${DEVKIT_REPO}/releases/tag/${_wb_new} |
+| categories | $(prov_field "$_wb_prov" categories) |
+| vendored skills | $(prov_field "$_wb_prov" managed) |
+
+## What changed
+
+- \`${ROOT_MANIFEST}\` and the template twin pin \`${_wb_new}\`.
+- \`${_wb_prov}\` and the managed skill directories were re-vendored from that tag.
+
+Nothing else — the run aborts if the sync writes a path it does not own.
+
+## Verification
+
+\`task verify:skills:offline\`, \`task verify:skills\` and \`task verify\` all
+passed on this commit before the branch was pushed, and the releasing PR title
+was pre-flighted through \`task guard:release-title\`.
+
+## Merging
+
+**Merging stays manual.** This PR is opened by \`sync-harmon-devkit.yml\`; no
+workflow merges it, and none merges either repository's release PR. A newer
+stable harmon-devkit release rewrites this same branch rather than opening a
+second PR.
+EOF
+}
+
+# open_pr_number — the number of the open sync PR, or empty. `// empty`
+# matters: without it jq prints the string "null" and the caller would go on to
+# edit PR "null".
+open_pr_number() {
+    _pn="$(gh pr list --head "$SYNC_BRANCH" --base "$BASE_BRANCH" \
+        --state open --json number --jq '.[0].number // empty')" ||
+        die "could not list open PRs for $SYNC_BRANCH"
+    case "$_pn" in
+    *[!0-9]*) die "unexpected PR number '$_pn' for $SYNC_BRANCH" ;;
+    esac
+    printf '%s\n' "$_pn"
+}
+
+open_or_update_pr() {
+    _pr_title="$1" _pr_existing="$2"
+    if [ -n "$_pr_existing" ]; then
+        note "updating the open sync PR #$_pr_existing"
+        gh pr edit "$_pr_existing" --title "$_pr_title" --body-file "$BODY_FILE" ||
+            die "could not update PR #$_pr_existing"
+    else
+        note "opening a sync PR"
+        gh pr create --base "$BASE_BRANCH" --head "$SYNC_BRANCH" \
+            --title "$_pr_title" --body-file "$BODY_FILE" ||
+            die "could not open the sync PR"
+    fi
+}
+
+# remote_sync_tree — the tree the pushed sync branch already holds, or empty
+# when the branch does not exist upstream. Trees, not commit SHAs: a rebuilt
+# commit differs only by committer timestamp, so comparing SHAs would report a
+# change on every run.
+remote_sync_tree() {
+    git fetch --quiet origin "+refs/heads/$SYNC_BRANCH:refs/remotes/origin/$SYNC_BRANCH" \
+        2>/dev/null || return 0
+    git rev-parse --quiet --verify "refs/remotes/origin/$SYNC_BRANCH^{tree}" 2>/dev/null || return 0
+}
+
+# push_sync_branch — push the rolling bot branch, and ONLY that branch.
+#
+# The token is deliberately not persisted into .git/config (the repo-wide
+# `persist-credentials: false` hardening — see docs/architecture/security.md):
+# this job runs `task verify`, which executes copier renders, npx and uvx, so a
+# credential sitting in a file for the whole job is reachable by third-party
+# code. `-c` config is scoped to this one git process and the helper reads the
+# token from the environment, so it lands in neither argv nor any file. The
+# empty first helper clears any inherited helper list so ours answers.
+push_sync_branch() {
+    if [ -n "${GH_TOKEN:-}" ]; then
+        # shellcheck disable=SC2016 # $GH_TOKEN must expand inside git's helper, not here
+        git -c credential.helper= \
+            -c credential.helper='!f() { echo username=x-access-token; echo "password=${GH_TOKEN}"; }; f' \
+            push --force origin "HEAD:refs/heads/$SYNC_BRANCH"
+    else
+        # Local/manual run: rely on whatever credentials the operator's git has.
+        git push --force origin "HEAD:refs/heads/$SYNC_BRANCH"
+    fi
+}
+
+# base_ref — the local base branch when the checkout created one, else its
+# remote-tracking ref (a detached checkout still has origin/main).
+base_ref() {
+    if git rev-parse --verify --quiet "refs/heads/$BASE_BRANCH" >/dev/null; then
+        printf '%s\n' "$BASE_BRANCH"
+    elif git rev-parse --verify --quiet "refs/remotes/origin/$BASE_BRANCH" >/dev/null; then
+        printf '%s\n' "origin/$BASE_BRANCH"
+    else
+        die "neither $BASE_BRANCH nor origin/$BASE_BRANCH exists — cannot start a sync branch"
+    fi
+}
+
+cmd_run() {
+    _run_tag="${1:-${SYNC_DEVKIT_TAG:-}}"
+    need_bin git
+    need_bin gh
+    need_bin task
+    need_manifests
+    [ -z "$(git status --porcelain)" ] ||
+        die "working tree is not clean — refusing to build a sync commit on top of local changes"
+
+    _run_target="$(cmd_resolve "$_run_tag")"
+    _run_current="$(cmd_pinned)"
+    _run_dest="$(manifest_field "$ROOT_MANIFEST" dest)"
+    assert_safe_dest "$_run_dest"
+    _run_prov="$_run_dest/.SKILLS_PROVENANCE"
+
+    if [ "$_run_current" = "$_run_target" ] && [ "$(prov_ref "$_run_prov")" = "$_run_target" ]; then
+        note "already pinned and vendored at $_run_target — nothing to do"
+        return 0
+    fi
+    note "syncing $_run_current -> $_run_target"
+
+    configure_identity
+    # Always branch from the base, never from whatever the branch held last
+    # run: that is what makes a newer release deterministically supersede an
+    # older open sync PR instead of stacking on top of it.
+    git checkout -B "$SYNC_BRANCH" "$(base_ref)" >/dev/null
+
+    set_pin "$ROOT_MANIFEST" "$_run_target"
+    set_pin "$TEMPLATE_MANIFEST" "$_run_target"
+    task sync:skills || die "'task sync:skills' failed at $_run_target — nothing pushed"
+    assert_expected_scope "$_run_dest"
+
+    _run_title="fix(template): sync harmon-devkit skills to $_run_target"
+    preflight_title "$_run_title"
+
+    git add -A
+    if git diff --cached --quiet; then
+        note "the sync produced no change — nothing to commit"
+        return 0
+    fi
+    git commit -m "$_run_title" >/dev/null
+
+    # The scheduled reconciliation fires while the sync PR is still open, and
+    # the pins on the base branch stay stale until it merges — so every run
+    # rebuilds the identical commit. Stop here when the pushed branch already
+    # holds that tree AND its PR is open: pushing would churn the branch, reset
+    # review state, and re-trigger the PR's CI daily for no change. Verification
+    # is skipped too — this exact tree already passed it on the open PR.
+    _run_open_pr="$(open_pr_number)"
+    if [ -n "$_run_open_pr" ] && [ "$(remote_sync_tree)" = "$(git rev-parse 'HEAD^{tree}')" ]; then
+        note "PR #$_run_open_pr already carries this exact sync at $_run_target — leaving it untouched"
+        return 0
+    fi
+
+    run_verification
+
+    # Force-push: this branch is owned solely by this workflow and is rebuilt
+    # from the base every run, so its remote history is disposable by design.
+    # Only $SYNC_BRANCH is ever written — never $BASE_BRANCH.
+    note "pushing $SYNC_BRANCH"
+    push_sync_branch || die "could not push $SYNC_BRANCH"
+
+    write_pr_body "$_run_current" "$_run_target" "$_run_prov"
+    open_or_update_pr "$_run_title" "$_run_open_pr"
+    note "done — merging $SYNC_BRANCH stays a human decision"
+}
+
+case "${1:-}" in
+resolve)
+    need_bin gh
+    cmd_resolve "${2:-${SYNC_DEVKIT_TAG:-}}"
+    ;;
+pinned)
+    need_manifests
+    cmd_pinned
+    ;;
+run) cmd_run "${2:-}" ;;
+*)
+    echo "usage: sync-devkit-release.sh {resolve|pinned|run} [TAG]" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/sync-devkit-release.sh
+++ b/scripts/sync-devkit-release.sh
@@ -390,6 +390,13 @@ open_pr_number() {
     printf '%s\n' "$_pn"
 }
 
+# pr_title N — the current title of PR N. Empty rather than fatal when the PR
+# cannot be read: the caller only uses it to decide whether metadata needs
+# repairing, and "unknown" should mean "repair", not "abort".
+pr_title() {
+    gh pr view "$1" --json title --jq '.title // empty' 2>/dev/null || true
+}
+
 open_or_update_pr() {
     _pr_title="$1" _pr_existing="$2"
     if [ -n "$_pr_existing" ]; then
@@ -563,7 +570,20 @@ cmd_run() {
     # is skipped too — this exact tree already passed it on the open PR.
     _run_open_pr="$(open_pr_number)"
     if [ -n "$_run_open_pr" ] && [ "$(remote_sync_tree)" = "$(git rev-parse 'HEAD^{tree}')" ]; then
-        note "PR #$_run_open_pr already carries this exact sync at $_run_target — leaving it untouched"
+        # The branch is right, but the PR's metadata may not be: a previous run
+        # can push successfully and then fail at `gh pr edit`, and the title is
+        # load-bearing (squash-merge feeds it to release-please, so a stale one
+        # would name the wrong tag or fail the release-content guard). Repair it
+        # here rather than leaving it wrong until someone notices. Either way
+        # the push and the verification are skipped — this exact tree already
+        # passed them on the open PR.
+        if [ "$(pr_title "$_run_open_pr")" = "$_run_title" ]; then
+            note "PR #$_run_open_pr already carries this exact sync at $_run_target — leaving it untouched"
+            return 0
+        fi
+        note "PR #$_run_open_pr has the right branch but stale metadata — repairing it"
+        write_pr_body "$_run_current" "$_run_target" "$_run_prov"
+        open_or_update_pr "$_run_title" "$_run_open_pr"
         return 0
     fi
 

--- a/scripts/sync-devkit-release.sh
+++ b/scripts/sync-devkit-release.sh
@@ -29,6 +29,8 @@
 #
 # TAG defaults to $SYNC_DEVKIT_TAG, then to the latest stable upstream release.
 # Env: GH_APP_SLUG — when set, the bot commit identity is derived from the App.
+#      SYNC_DEVKIT_ALLOW_DOWNGRADE=true — permit pinning an older release than
+#      the current one (manual recovery only; the event path refuses it).
 # Depends on: git, gh, task. Unit-tested by scripts/test-sync-devkit-release.sh.
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -173,6 +175,30 @@ prov_ref() {
     awk 'index($0, "# ref:") == 1 {
         sub(/^# ref:[[:space:]]*/, ""); sub(/[[:space:]]*\(.*/, ""); print; exit
     }' "$1"
+}
+
+# version_key TAG — a fixed-width, lexicographically comparable key. String
+# comparison, never arithmetic: a zero-padded key would be read as octal by
+# `[ -lt ]`. printf's %d parses each component as base 10, so a tag written
+# v1.08.0 still keys correctly.
+version_key() {
+    _vk_rest="${1#v}"
+    _vk_tail="${_vk_rest#*.}"
+    printf '%05d%05d%05d\n' "${_vk_rest%%.*}" "${_vk_tail%%.*}" "${_vk_tail#*.}"
+}
+
+# assert_not_a_downgrade TARGET CURRENT — a dispatch can be delivered late or
+# out of order, and `concurrency` serializes runs without ordering them, so an
+# older tag can arrive after the pin has already advanced. Rolling the pin
+# backwards would open a bogus rollback PR that the next scheduled run (which
+# resolves the LATEST release) immediately flips back. Manual dispatch is a
+# deliberate act, so it may still downgrade — that is the recovery path off a
+# bad release.
+assert_not_a_downgrade() {
+    [ "${SYNC_DEVKIT_ALLOW_DOWNGRADE:-}" != "true" ] || return 0
+    if [[ "$(version_key "$1")" < "$(version_key "$2")" ]]; then
+        die "refusing to move the pin backwards ($2 -> $1) — replay a current release, or re-run the workflow manually with that tag to downgrade deliberately"
+    fi
 }
 
 assert_safe_dest() {
@@ -326,12 +352,18 @@ second PR.
 EOF
 }
 
-# open_pr_number — the number of the open sync PR, or empty. `// empty`
-# matters: without it jq prints the string "null" and the caller would go on to
-# edit PR "null".
+# open_pr_number — the number of the open sync PR, or empty.
+#
+# `--head` filters by branch NAME only — gh cannot qualify it with an owner —
+# so a fork PR whose head branch happens to be called $SYNC_BRANCH is returned
+# too. Editing that would rewrite an unrelated contributor's PR with a
+# trusted-looking `fix(template): …` title and leave the real sync PR unopened,
+# so cross-repository heads are dropped. `// empty` matters as well: without it
+# jq prints the string "null" and the caller would go on to edit PR "null".
 open_pr_number() {
-    _pn="$(gh pr list --head "$SYNC_BRANCH" --base "$BASE_BRANCH" \
-        --state open --json number --jq '.[0].number // empty')" ||
+    _pn="$(gh pr list --head "$SYNC_BRANCH" --base "$BASE_BRANCH" --state open \
+        --json number,isCrossRepository \
+        --jq 'map(select(.isCrossRepository == false)) | .[0].number // empty')" ||
         die "could not list open PRs for $SYNC_BRANCH"
     case "$_pn" in
     *[!0-9]*) die "unexpected PR number '$_pn' for $SYNC_BRANCH" ;;
@@ -415,6 +447,7 @@ cmd_run() {
         note "already pinned and vendored at $_run_target — nothing to do"
         return 0
     fi
+    assert_not_a_downgrade "$_run_target" "$_run_current"
     note "syncing $_run_current -> $_run_target"
 
     configure_identity

--- a/scripts/sync-devkit-release.sh
+++ b/scripts/sync-devkit-release.sh
@@ -279,6 +279,19 @@ assert_expected_scope() {
 }
 
 # ── Verification ──────────────────────────────────────────────────────
+# run_untrusted CMD… — run a subprocess WITHOUT the repo-write App token.
+#
+# The sync clones another repository and the verification gate renders the
+# copier template, running npx, uvx and rendered scripts. Those inherit this
+# process's environment, so leaving GH_TOKEN in it would hand a
+# contents:write + pull-requests:write credential to every one of them — the
+# exact exposure the non-persisted push credential exists to avoid. Everything
+# they reach is public (harmon-devkit, the npm and PyPI registries), so nothing
+# here needs the token; only `gh` and the single `git push` do.
+run_untrusted() {
+    env -u GH_TOKEN -u GITHUB_TOKEN "$@"
+}
+
 # Cheapest first. `verify` is the repo's definition-of-done gate and already
 # contains test:dogfood-parity, test:dogfood-structure and the whole
 # test:template render matrix; verify:skills is the NETWORK drift check that
@@ -291,7 +304,7 @@ assert_expected_scope() {
 run_verification() {
     for _rv_target in verify:skills:offline security:secrets verify:skills verify; do
         note "verifying: task $_rv_target"
-        task "$_rv_target" ||
+        run_untrusted task "$_rv_target" ||
             die "verification failed at 'task $_rv_target' — nothing pushed, no PR touched"
     done
 }
@@ -301,7 +314,7 @@ run_verification() {
 # the new skills. Run the same guard CI runs, before the branch is pushed.
 preflight_title() {
     PR_TITLE="$1" PR_BODY="" CHANGED_FILES="$(changed_paths_nl)" \
-        task guard:release-title ||
+        run_untrusted task guard:release-title ||
         die "PR title '$1' would not cut a release for a template/ change"
 }
 
@@ -401,7 +414,7 @@ fetch_sync_branch() {
     [ "$SYNC_BRANCH_FETCHED" -eq 0 ] || return 0
     SYNC_BRANCH_FETCHED=1
     git update-ref -d "refs/remotes/origin/$SYNC_BRANCH" 2>/dev/null || true
-    git fetch --quiet origin "+refs/heads/$SYNC_BRANCH:refs/remotes/origin/$SYNC_BRANCH" \
+    git_remote fetch --quiet origin "+refs/heads/$SYNC_BRANCH:refs/remotes/origin/$SYNC_BRANCH" \
         2>/dev/null || true
     return 0
 }
@@ -430,37 +443,47 @@ $_sbp_yaml
 EOF
 }
 
-# push_sync_branch — push the rolling bot branch, and ONLY that branch.
+# git_remote ARGS… — a git command that talks to origin, authenticated when a
+# token is available.
 #
 # The token is deliberately not persisted into .git/config (the repo-wide
-# `persist-credentials: false` hardening — see docs/architecture/security.md):
-# this job runs `task verify`, which executes copier renders, npx and uvx, so a
-# credential sitting in a file for the whole job is reachable by third-party
-# code. `-c` config is scoped to this one git process and the helper reads the
-# token from the environment, so it lands in neither argv nor any file. The
-# empty first helper clears any inherited helper list so ours answers.
-push_sync_branch() {
+# `persist-credentials: false` hardening — see docs/architecture/security.md).
+# `-c` config is scoped to this one git process and the helper reads the token
+# from the environment, so it lands in neither argv nor any file, and no other
+# process inherits it — the sync and verification subprocesses run with
+# GH_TOKEN scrubbed (see run_untrusted). The empty first helper clears any
+# inherited helper list so ours answers.
+git_remote() {
     if [ -n "${GH_TOKEN:-}" ]; then
         # shellcheck disable=SC2016 # $GH_TOKEN must expand inside git's helper, not here
         git -c credential.helper= \
             -c credential.helper='!f() { echo username=x-access-token; echo "password=${GH_TOKEN}"; }; f' \
-            push --force origin "HEAD:refs/heads/$SYNC_BRANCH"
+            "$@"
     else
         # Local/manual run: rely on whatever credentials the operator's git has.
-        git push --force origin "HEAD:refs/heads/$SYNC_BRANCH"
+        git "$@"
     fi
 }
 
-# base_ref — the local base branch when the checkout created one, else its
-# remote-tracking ref (a detached checkout still has origin/main).
-base_ref() {
-    if git rev-parse --verify --quiet "refs/heads/$BASE_BRANCH" >/dev/null; then
-        printf '%s\n' "$BASE_BRANCH"
-    elif git rev-parse --verify --quiet "refs/remotes/origin/$BASE_BRANCH" >/dev/null; then
-        printf '%s\n' "origin/$BASE_BRANCH"
-    else
-        die "neither $BASE_BRANCH nor origin/$BASE_BRANCH exists — cannot start a sync branch"
-    fi
+push_sync_branch() {
+    git_remote push --force origin "HEAD:refs/heads/$SYNC_BRANCH"
+}
+
+# assert_on_base — everything below reads the WORKING TREE, and the force-push
+# publishes whatever the sync branch inherits from its start point, so the
+# checkout must actually be the base branch and must match what origin holds.
+# `actions/checkout` guarantees both in CI; locally this refuses to build the
+# bot branch on a stale or ahead `main`, which would otherwise publish
+# unrelated local commits under a bot title. The scope check cannot catch that:
+# it inspects the working tree against HEAD, not HEAD against origin.
+assert_on_base() {
+    _aob_head="$(git rev-parse --abbrev-ref HEAD)"
+    [ "$_aob_head" = "$BASE_BRANCH" ] ||
+        die "HEAD is '$_aob_head', not '$BASE_BRANCH' — run the sync from the base branch"
+    git_remote fetch --quiet origin "+refs/heads/$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH" ||
+        die "could not fetch origin/$BASE_BRANCH — cannot confirm the sync would start from the real base"
+    [ "$(git rev-parse HEAD)" = "$(git rev-parse "refs/remotes/origin/$BASE_BRANCH")" ] ||
+        die "local $BASE_BRANCH is not at origin/$BASE_BRANCH — fetch and reset first (a force-push would publish the difference)"
 }
 
 cmd_run() {
@@ -471,6 +494,7 @@ cmd_run() {
     need_manifests
     [ -z "$(git status --porcelain)" ] ||
         die "working tree is not clean — refusing to build a sync commit on top of local changes"
+    assert_on_base
 
     _run_target="$(cmd_resolve "$_run_tag")"
     _run_current="$(cmd_pinned)"
@@ -497,11 +521,12 @@ cmd_run() {
     # Always branch from the base, never from whatever the branch held last
     # run: that is what makes a newer release deterministically supersede an
     # older open sync PR instead of stacking on top of it.
-    git checkout -B "$SYNC_BRANCH" "$(base_ref)" >/dev/null
+    git checkout -B "$SYNC_BRANCH" "$BASE_BRANCH" >/dev/null
 
     set_pin "$ROOT_MANIFEST" "$_run_target"
     set_pin "$TEMPLATE_MANIFEST" "$_run_target"
-    task sync:skills || die "'task sync:skills' failed at $_run_target — nothing pushed"
+    run_untrusted task sync:skills ||
+        die "'task sync:skills' failed at $_run_target — nothing pushed"
     assert_expected_scope "$_run_dest"
 
     _run_title="fix(template): sync harmon-devkit skills to $_run_target"

--- a/scripts/sync-devkit-release.sh
+++ b/scripts/sync-devkit-release.sh
@@ -76,27 +76,28 @@ need_manifests() {
 # it is used anywhere and for EXISTENCE against the upstream API before it is
 # believed. Deliberately pure shell: no pipe into grep, so there is no way for
 # an embedded newline to satisfy a per-line anchored regex and slip through.
-assert_tag_shape() {
-    _ats_tag="$1"
-    [ -n "$_ats_tag" ] || die "empty harmon-devkit tag"
-    case "$_ats_tag" in
+looks_like_tag() {
+    case "${1:-}" in
     v*) ;;
-    *) die "refusing tag '$_ats_tag' — a harmon-devkit release tag starts with 'v'" ;;
+    *) return 1 ;;
     esac
-    _ats_rest="${_ats_tag#v}"
-    # Only digits and dots may follow the 'v'. This also rejects newlines,
-    # whitespace, and every shell metacharacter in one gate.
-    case "$_ats_rest" in
-    "" | *[!0-9.]*) die "refusing tag '$_ats_tag' — only digits and dots may follow 'v'" ;;
+    _llt_rest="${1#v}"
+    # Only digits and dots may follow the 'v'. This one gate also rejects
+    # newlines, whitespace, and every shell metacharacter.
+    case "$_llt_rest" in
+    "" | *[!0-9.]* | .* | *.) return 1 ;;
     esac
-    _ats_dots="${_ats_rest//[!.]/}"
-    [ "${#_ats_dots}" -eq 2 ] ||
-        die "refusing tag '$_ats_tag' — expected a stable v<major>.<minor>.<patch> tag"
-    _ats_tail="${_ats_rest#*.}"
-    for _ats_part in "${_ats_rest%%.*}" "${_ats_tail%%.*}" "${_ats_tail#*.}"; do
-        [ -n "$_ats_part" ] ||
-            die "refusing tag '$_ats_tag' — empty version component"
-    done
+    case "$_llt_rest" in
+    *..*) return 1 ;;
+    esac
+    _llt_dots="${_llt_rest//[!.]/}"
+    [ "${#_llt_dots}" -eq 2 ]
+}
+
+assert_tag_shape() {
+    [ -n "${1:-}" ] || die "empty harmon-devkit tag"
+    looks_like_tag "$1" ||
+        die "refusing tag '$1' — expected a stable v<major>.<minor>.<patch> harmon-devkit tag"
 }
 
 # cmd_resolve [TAG] — echo the harmon-devkit tag to sync to, and NOTHING else
@@ -282,8 +283,13 @@ assert_expected_scope() {
 # contains test:dogfood-parity, test:dogfood-structure and the whole
 # test:template render matrix; verify:skills is the NETWORK drift check that
 # `verify` deliberately leaves out (see the Taskfile's `ci` comment).
+#
+# security:secrets is here rather than left to the PR's own CI because this
+# step vendors files from another repository and the next step PUBLISHES them:
+# a credential that reached a harmon-devkit release would be in harmon-init's
+# remote history — and need rotating — before any PR check could object.
 run_verification() {
-    for _rv_target in verify:skills:offline verify:skills verify; do
+    for _rv_target in verify:skills:offline security:secrets verify:skills verify; do
         note "verifying: task $_rv_target"
         task "$_rv_target" ||
             die "verification failed at 'task $_rv_target' — nothing pushed, no PR touched"
@@ -339,9 +345,9 @@ Nothing else — the run aborts if the sync writes a path it does not own.
 
 ## Verification
 
-\`task verify:skills:offline\`, \`task verify:skills\` and \`task verify\` all
-passed on this commit before the branch was pushed, and the releasing PR title
-was pre-flighted through \`task guard:release-title\`.
+\`task verify:skills:offline\`, \`task security:secrets\`, \`task verify:skills\`
+and \`task verify\` all passed on this commit before the branch was pushed, and
+the releasing PR title was pre-flighted through \`task guard:release-title\`.
 
 ## Merging
 
@@ -385,14 +391,43 @@ open_or_update_pr() {
     fi
 }
 
+# fetch_sync_branch — refresh refs/remotes/origin/$SYNC_BRANCH exactly once.
+# The ref is dropped first so that after this it exists if and only if the
+# branch exists upstream: `actions/checkout --fetch-depth 0` populates
+# remote-tracking refs, and a branch deleted since then would otherwise be read
+# as still present.
+SYNC_BRANCH_FETCHED=0
+fetch_sync_branch() {
+    [ "$SYNC_BRANCH_FETCHED" -eq 0 ] || return 0
+    SYNC_BRANCH_FETCHED=1
+    git update-ref -d "refs/remotes/origin/$SYNC_BRANCH" 2>/dev/null || true
+    git fetch --quiet origin "+refs/heads/$SYNC_BRANCH:refs/remotes/origin/$SYNC_BRANCH" \
+        2>/dev/null || true
+    return 0
+}
+
 # remote_sync_tree — the tree the pushed sync branch already holds, or empty
 # when the branch does not exist upstream. Trees, not commit SHAs: a rebuilt
 # commit differs only by committer timestamp, so comparing SHAs would report a
 # change on every run.
 remote_sync_tree() {
-    git fetch --quiet origin "+refs/heads/$SYNC_BRANCH:refs/remotes/origin/$SYNC_BRANCH" \
-        2>/dev/null || return 0
+    fetch_sync_branch
     git rev-parse --quiet --verify "refs/remotes/origin/$SYNC_BRANCH^{tree}" 2>/dev/null || return 0
+}
+
+# sync_branch_pin — the tag an already-pushed sync branch carries, or empty.
+# The base branch alone is not enough to detect an out-of-order event: while a
+# sync PR is open, the base pin stays stale, so a delayed older dispatch would
+# look like a legitimate move forward and force the open PR backwards.
+sync_branch_pin() {
+    fetch_sync_branch
+    _sbp_yaml="$(git show "refs/remotes/origin/$SYNC_BRANCH:$ROOT_MANIFEST" 2>/dev/null)" ||
+        return 0
+    awk '/^[[:space:]]*ref:/ {
+        sub(/^[[:space:]]*ref:[[:space:]]*/, ""); sub(/[[:space:]#].*/, ""); print; exit
+    }' <<EOF
+$_sbp_yaml
+EOF
 }
 
 # push_sync_branch — push the rolling bot branch, and ONLY that branch.
@@ -447,7 +482,15 @@ cmd_run() {
         note "already pinned and vendored at $_run_target — nothing to do"
         return 0
     fi
-    assert_not_a_downgrade "$_run_target" "$_run_current"
+    # The floor is the newest tag already in flight: the base pin, or the open
+    # sync branch's pin when it is ahead (the PR has not merged yet).
+    _run_floor="$_run_current"
+    _run_branch_pin="$(sync_branch_pin)"
+    if looks_like_tag "$_run_branch_pin" &&
+        [[ "$(version_key "$_run_floor")" < "$(version_key "$_run_branch_pin")" ]]; then
+        _run_floor="$_run_branch_pin"
+    fi
+    assert_not_a_downgrade "$_run_target" "$_run_floor"
     note "syncing $_run_current -> $_run_target"
 
     configure_identity

--- a/scripts/sync-devkit-release.sh
+++ b/scripts/sync-devkit-release.sh
@@ -414,8 +414,20 @@ fetch_sync_branch() {
     [ "$SYNC_BRANCH_FETCHED" -eq 0 ] || return 0
     SYNC_BRANCH_FETCHED=1
     git update-ref -d "refs/remotes/origin/$SYNC_BRANCH" 2>/dev/null || true
-    git_remote fetch --quiet origin "+refs/heads/$SYNC_BRANCH:refs/remotes/origin/$SYNC_BRANCH" \
-        2>/dev/null || true
+    # "the branch is not there" and "origin was unreachable" must not look the
+    # same: both would leave the ref absent, and the second silently disarms
+    # the guards that read it — the older-tag floor and the no-churn check —
+    # so a transient blip could regress an open sync PR. ls-remote --exit-code
+    # separates them: 0 = present, 2 = genuinely absent, anything else = error.
+    _fsb_rc=0
+    git_remote ls-remote --exit-code --heads origin "$SYNC_BRANCH" >/dev/null 2>&1 || _fsb_rc=$?
+    case "$_fsb_rc" in
+    0) ;;
+    2) return 0 ;;
+    *) die "could not reach origin to look for $SYNC_BRANCH (git exit $_fsb_rc) — refusing to proceed as if no sync PR were in flight" ;;
+    esac
+    git_remote fetch --quiet origin "+refs/heads/$SYNC_BRANCH:refs/remotes/origin/$SYNC_BRANCH" ||
+        die "could not fetch $SYNC_BRANCH from origin"
     return 0
 }
 
@@ -506,6 +518,10 @@ cmd_run() {
         note "already pinned and vendored at $_run_target — nothing to do"
         return 0
     fi
+    # Called as a bare statement so a failure aborts here: inside the command
+    # substitutions below, `set -e` would not see it and the run would continue
+    # with the guards silently disarmed.
+    fetch_sync_branch
     # The floor is the newest tag already in flight: the base pin, or the open
     # sync branch's pin when it is ahead (the PR has not merged yet).
     _run_floor="$_run_current"

--- a/scripts/test-sync-devkit-release.sh
+++ b/scripts/test-sync-devkit-release.sh
@@ -1,0 +1,486 @@
+#!/usr/bin/env bash
+# test-sync-devkit-release.sh — offline unit tests for sync-devkit-release.sh,
+# the harmon-devkit release -> harmon-init pin-and-sync PR automation.
+#
+# Every case runs the REAL helper against a throwaway git repo (with a bare
+# `origin` so pushes are observable) while `gh` and `task` are replaced by stubs
+# on PATH. Nothing here touches the network, this repository, or GitHub.
+#
+# The stubs are deliberately thin: `task guard:release-title` delegates to the
+# real guard, and `task sync:skills` simulates a vendoring run whose blast
+# radius the fixture controls — so the scope check is exercised against real
+# git state rather than a mock. Run via `task test:sync-devkit-release`.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd)"
+
+HELPER="scripts/sync-devkit-release.sh"
+TEMPLATE_MANIFEST='template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja'
+SYNC_BRANCH="bot/sync-harmon-devkit"
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+cases=0
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+# ── Fixture ───────────────────────────────────────────────────────────
+# new_fixture NAME [PIN] [TEMPLATE_PIN] [PROVENANCE_PIN] — a repo pinned at PIN
+# whose skills dir holds one vendored skill and one local skill the sync must
+# never touch. TEMPLATE_PIN/PROVENANCE_PIN default to PIN; setting them apart
+# models pre-existing drift. Echoes the fixture path.
+new_fixture() {
+    _nf_dir="$TMPROOT/$1"
+    _nf_pin="${2:-v0.8.7}"
+    _nf_tpl_pin="${3:-$_nf_pin}"
+    _nf_prov_pin="${4:-$_nf_pin}"
+    mkdir -p "$_nf_dir/scripts" "$_nf_dir/template" \
+        "$_nf_dir/.claude/skills/standardize-repo" \
+        "$_nf_dir/.claude/skills/local-only"
+
+    cat >"$_nf_dir/$ROOT_MANIFEST_NAME" <<EOF
+source:
+  repo: https://github.com/evanharmon1/harmon-devkit.git
+  # a comment line sits directly above the pin in the real manifests
+  ref: $_nf_pin # pinned tag — bump deliberately to a released harmon-devkit tag
+categories:
+  - repo
+dest: .claude/skills
+EOF
+    cat >"$_nf_dir/$TEMPLATE_MANIFEST" <<EOF
+source:
+  repo: https://github.com/evanharmon1/harmon-devkit.git
+  # a comment line sits directly above the pin in the real manifests
+  ref: $_nf_tpl_pin # pinned tag — bump deliberately to a released harmon-devkit tag
+categories:
+[% for cat in skill_categories %]
+  - [[ cat ]]
+[% endfor %]
+dest: .claude/skills
+EOF
+    printf 'vendored at %s\n' "$_nf_pin" >"$_nf_dir/.claude/skills/standardize-repo/SKILL.md"
+    printf 'a local skill the sync must never touch\n' >"$_nf_dir/.claude/skills/local-only/SKILL.md"
+    cat >"$_nf_dir/.claude/skills/.SKILLS_PROVENANCE" <<EOF
+# VENDORED from harmon-devkit — DO NOT EDIT the managed skills here.
+# source: https://github.com/evanharmon1/harmon-devkit.git
+# ref: $_nf_prov_pin (1111111111111111111111111111111111111111)
+# path: ai/skills
+# categories: repo
+# managed: standardize-repo
+EOF
+
+    cp "$REPO_ROOT/$HELPER" "$_nf_dir/scripts/"
+    cp "$REPO_ROOT/scripts/require-release-title.sh" "$_nf_dir/scripts/"
+
+    git init --quiet --initial-branch=main "$_nf_dir"
+    git -C "$_nf_dir" config user.name "fixture"
+    git -C "$_nf_dir" config user.email "fixture@example.invalid"
+    git -C "$_nf_dir" add -A
+    git -C "$_nf_dir" commit --quiet -m "fixture"
+
+    git init --quiet --bare "$_nf_dir.origin.git"
+    git -C "$_nf_dir" remote add origin "$_nf_dir.origin.git"
+    git -C "$_nf_dir" push --quiet origin main
+    printf '%s\n' "$_nf_dir"
+}
+ROOT_MANIFEST_NAME=".skills-sync.yaml"
+
+# ── Stubs ─────────────────────────────────────────────────────────────
+# STUB_RELEASES lines are "<tag> <draft> <prerelease>"; a tag that is absent
+# stands in for GitHub's 404. STUB_LATEST answers /releases/latest.
+make_stubs() {
+    _ms_bin="$TMPROOT/bin"
+    mkdir -p "$_ms_bin"
+
+    cat >"$_ms_bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -eu
+printf 'gh %s\n' "$*" >>"$STUB_LOG"
+case "${1:-}" in
+api)
+    path="${2:-}"
+    case "$path" in
+    */releases/latest)
+        [ -n "${STUB_LATEST:-}" ] || exit 1
+        printf '%s\n' "$STUB_LATEST"
+        ;;
+    */releases/tags/*)
+        tag="${path##*/}"
+        while read -r t draft pre; do
+            [ "$t" = "$tag" ] || continue
+            printf '%s %s %s\n' "$t" "$draft" "$pre"
+            exit 0
+        done <<EOF
+${STUB_RELEASES:-}
+EOF
+        echo "stub gh: no release for $tag" >&2
+        exit 1
+        ;;
+    /users/*)
+        printf '%s\n' "${STUB_BOT_UID:-12345}"
+        ;;
+    *)
+        echo "stub gh: unhandled api path $path" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+pr)
+    case "${2:-}" in
+    list) printf '%s' "${STUB_OPEN_PR:-}" ;;
+    create | edit) printf 'https://example.invalid/pr\n' ;;
+    *)
+        echo "stub gh: unhandled pr subcommand ${2:-}" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+*)
+    echo "stub gh: unhandled command ${1:-}" >&2
+    exit 1
+    ;;
+esac
+STUB
+
+    cat >"$_ms_bin/task" <<'STUB'
+#!/usr/bin/env bash
+set -eu
+printf 'task %s\n' "$*" >>"$STUB_LOG"
+target="${1:-}"
+case ",${STUB_FAIL_TASKS:-}," in
+*",$target,"*)
+    echo "stub task: $target failed on purpose" >&2
+    exit 1
+    ;;
+esac
+case "$target" in
+guard:release-title)
+    exec ./scripts/require-release-title.sh template
+    ;;
+sync:skills)
+    ref=$(sed -n 's/^[[:space:]]*ref:[[:space:]]*\([^[:space:]#]*\).*/\1/p' .skills-sync.yaml)
+    managed="standardize-repo"
+    mkdir -p .claude/skills/standardize-repo
+    printf 'vendored at %s\n' "$ref" >.claude/skills/standardize-repo/SKILL.md
+    if [ -n "${STUB_SYNC_ADD_SKILL:-}" ]; then
+        mkdir -p ".claude/skills/${STUB_SYNC_ADD_SKILL}"
+        printf 'new skill at %s\n' "$ref" >".claude/skills/${STUB_SYNC_ADD_SKILL}/SKILL.md"
+        managed="$managed, ${STUB_SYNC_ADD_SKILL}"
+    fi
+    if [ -n "${STUB_SYNC_DROP_SKILL:-}" ]; then
+        rm -rf ".claude/skills/${STUB_SYNC_DROP_SKILL}"
+        managed="standardize-repo"
+    fi
+    {
+        echo "# VENDORED from harmon-devkit — DO NOT EDIT the managed skills here."
+        echo "# source: https://github.com/evanharmon1/harmon-devkit.git"
+        echo "# ref: $ref (2222222222222222222222222222222222222222)"
+        echo "# path: ai/skills"
+        echo "# categories: repo"
+        echo "# managed: $managed"
+    } >.claude/skills/.SKILLS_PROVENANCE
+    [ -z "${STUB_SYNC_TOUCH_UNRELATED:-}" ] || echo "oops" >"${STUB_SYNC_TOUCH_UNRELATED}"
+    [ -z "${STUB_SYNC_DELETE_LOCAL:-}" ] || rm -rf .claude/skills/local-only
+    ;;
+esac
+exit 0
+STUB
+
+    chmod +x "$_ms_bin/gh" "$_ms_bin/task"
+    printf '%s\n' "$_ms_bin"
+}
+
+STUB_BIN="$(make_stubs)"
+
+# run_helper DIR ARGS... — invoke the helper in DIR with the stubs on PATH and
+# the current STUB_* fixture settings. Echoes the exit code; combined output
+# lands in $LAST_OUT. (Callers capture the echo, so run_helper runs in a
+# subshell — $LAST_OUT is fixed here rather than assigned inside it.)
+LAST_OUT="$TMPROOT/out"
+run_helper() {
+    _rh_dir="$1"
+    shift
+    _rh_rc=0
+    (
+        cd "$_rh_dir"
+        PATH="$STUB_BIN:$PATH" \
+            STUB_LOG="$STUB_LOG" \
+            STUB_LATEST="${STUB_LATEST:-}" \
+            STUB_RELEASES="${STUB_RELEASES:-}" \
+            STUB_OPEN_PR="${STUB_OPEN_PR:-}" \
+            STUB_BOT_UID="${STUB_BOT_UID:-12345}" \
+            STUB_FAIL_TASKS="${STUB_FAIL_TASKS:-}" \
+            STUB_SYNC_TOUCH_UNRELATED="${STUB_SYNC_TOUCH_UNRELATED:-}" \
+            STUB_SYNC_DELETE_LOCAL="${STUB_SYNC_DELETE_LOCAL:-}" \
+            STUB_SYNC_ADD_SKILL="${STUB_SYNC_ADD_SKILL:-}" \
+            STUB_SYNC_DROP_SKILL="${STUB_SYNC_DROP_SKILL:-}" \
+            GH_APP_SLUG="${GH_APP_SLUG:-}" \
+            SYNC_DEVKIT_TAG="${SYNC_DEVKIT_TAG:-}" \
+            ./scripts/sync-devkit-release.sh "$@"
+    ) >"$LAST_OUT" 2>&1 || _rh_rc=$?
+    echo "$_rh_rc"
+}
+
+reset_stub_state() {
+    STUB_LOG="$TMPROOT/log.$cases"
+    : >"$STUB_LOG"
+    STUB_LATEST=""
+    STUB_RELEASES="v0.8.7 false false
+v0.9.0 false false
+v0.9.1 false false
+v0.9.2-rc.1 false true
+v1.0.0 true false"
+    STUB_OPEN_PR=""
+    STUB_FAIL_TASKS=""
+    STUB_SYNC_TOUCH_UNRELATED=""
+    STUB_SYNC_DELETE_LOCAL=""
+    STUB_SYNC_ADD_SKILL=""
+    STUB_SYNC_DROP_SKILL=""
+    GH_APP_SLUG=""
+    SYNC_DEVKIT_TAG=""
+}
+
+# start NAME — begin a case; echoes a fresh fixture path.
+start() {
+    cases=$((cases + 1))
+    reset_stub_state
+    echo "==> $1"
+}
+
+logged() { grep -qF -- "$1" "$STUB_LOG"; }
+# A PR was created or updated — as opposed to merely queried, which the
+# no-churn check does before verification runs.
+pr_written() { grep -qE '^gh pr (create|edit)' "$STUB_LOG"; }
+pushed() { git -C "$1.origin.git" show-ref --verify --quiet "refs/heads/$SYNC_BRANCH"; }
+pin_of() { sed -n 's/^[[:space:]]*ref:[[:space:]]*\([^[:space:]#]*\).*/\1/p' "$1"; }
+
+# ── Cases ─────────────────────────────────────────────────────────────
+
+start "a stable release payload produces one verified, pushed sync PR"
+fix="$(new_fixture happy)"
+main_before="$(git -C "$fix" rev-parse main)"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "happy path exited $rc: $(cat "$LAST_OUT")"
+[ "$(pin_of "$fix/.skills-sync.yaml")" = v0.9.0 ] || fail "root pin not updated"
+[ "$(pin_of "$fix/$TEMPLATE_MANIFEST")" = v0.9.0 ] || fail "template pin not updated"
+grep -q '^# ref: v0.9.0 ' "$fix/.claude/skills/.SKILLS_PROVENANCE" || fail "provenance not refreshed"
+[ -f "$fix/.claude/skills/local-only/SKILL.md" ] || fail "local skill was disturbed"
+pushed "$fix" || fail "sync branch was never pushed"
+logged "gh pr create" || fail "no PR was opened"
+logged "fix(template): sync harmon-devkit skills to v0.9.0" || fail "PR title is not releasing"
+logged "task verify" || fail "verification never ran"
+[ "$(git -C "$fix" rev-parse main)" = "$main_before" ] || fail "main was modified"
+# The commit must contain exactly the expected paths.
+changed="$(git -C "$fix" diff --no-renames --name-only main "$SYNC_BRANCH" | sort | tr '\n' '|')"
+[ "$changed" = ".claude/skills/.SKILLS_PROVENANCE|.claude/skills/standardize-repo/SKILL.md|.skills-sync.yaml|template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja|" ] ||
+    fail "unexpected commit contents: $changed"
+
+start "an event replayed after the sync PR merged is a clean no-op"
+fix="$(new_fixture replay_merged v0.9.0)"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "replay exited $rc: $(cat "$LAST_OUT")"
+grep -q "already pinned and vendored at v0.9.0" "$LAST_OUT" || fail "replay did not short-circuit"
+! logged "gh pr" || fail "replay touched a PR"
+! pushed "$fix" || fail "replay pushed a branch"
+
+start "a re-run while the sync PR is open leaves the branch and PR untouched"
+fix="$(new_fixture reconcile)"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "first run exited $rc: $(cat "$LAST_OUT")"
+pushed_before="$(git -C "$fix.origin.git" rev-parse "$SYNC_BRANCH")"
+# A fresh CI checkout always starts on the base branch; the pins there stay
+# stale until the PR merges, so the daily reconciliation rebuilds this same
+# commit. It must not force-push it again.
+git -C "$fix" checkout --quiet main
+STUB_OPEN_PR="42"
+: >"$STUB_LOG"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "reconciliation run exited $rc: $(cat "$LAST_OUT")"
+grep -q "already carries this exact sync" "$LAST_OUT" || fail "reconciliation did not short-circuit"
+[ "$(git -C "$fix.origin.git" rev-parse "$SYNC_BRANCH")" = "$pushed_before" ] ||
+    fail "reconciliation force-pushed an identical tree"
+! logged "gh pr edit" || fail "reconciliation churned the open PR"
+! logged "task verify" || fail "reconciliation re-ran the expensive verification"
+
+start "a re-run with no open PR re-opens one from the pushed branch"
+fix="$(new_fixture reopen)"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "first run exited $rc: $(cat "$LAST_OUT")"
+git -C "$fix" checkout --quiet main
+STUB_OPEN_PR=""
+: >"$STUB_LOG"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "re-open run exited $rc: $(cat "$LAST_OUT")"
+logged "gh pr create" || fail "a closed/missing PR was not re-opened"
+
+start "an already-pinned tag whose provenance is stale still re-syncs"
+fix="$(new_fixture stale_prov v0.9.0 v0.9.0 v0.8.7)"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "stale-provenance run exited $rc: $(cat "$LAST_OUT")"
+logged "gh pr create" || fail "stale provenance did not produce a PR"
+
+start "an open sync PR is updated, never duplicated"
+fix="$(new_fixture existing_pr)"
+STUB_OPEN_PR="42"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "existing-PR run exited $rc: $(cat "$LAST_OUT")"
+logged "gh pr edit 42" || fail "the open PR was not updated"
+! logged "gh pr create" || fail "a duplicate PR was created"
+
+start "a newer release supersedes an open sync PR from one commit off main"
+fix="$(new_fixture supersede)"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "first sync exited $rc: $(cat "$LAST_OUT")"
+git -C "$fix" checkout --quiet main
+STUB_OPEN_PR="7"
+: >"$STUB_LOG"
+rc="$(run_helper "$fix" run v0.9.1)"
+[ "$rc" = 0 ] || fail "superseding sync exited $rc: $(cat "$LAST_OUT")"
+[ "$(pin_of "$fix/.skills-sync.yaml")" = v0.9.1 ] || fail "pin not moved to the newer release"
+logged "gh pr edit 7" || fail "the open PR was not retargeted at the newer release"
+depth="$(git -C "$fix" rev-list --count "main..$SYNC_BRANCH")"
+[ "$depth" = 1 ] || fail "sync branch stacked $depth commits instead of rebuilding from main"
+
+start "no tag given resolves the latest stable release"
+fix="$(new_fixture latest)"
+STUB_LATEST="v0.9.1"
+rc="$(run_helper "$fix" run)"
+[ "$rc" = 0 ] || fail "latest-resolution run exited $rc: $(cat "$LAST_OUT")"
+[ "$(pin_of "$fix/.skills-sync.yaml")" = v0.9.1 ] || fail "latest release was not pinned"
+
+start "SYNC_DEVKIT_TAG supplies the tag when no argument is given"
+fix="$(new_fixture env_tag)"
+SYNC_DEVKIT_TAG="v0.9.0"
+rc="$(run_helper "$fix" run)"
+[ "$rc" = 0 ] || fail "env-tag run exited $rc: $(cat "$LAST_OUT")"
+[ "$(pin_of "$fix/.skills-sync.yaml")" = v0.9.0 ] || fail "SYNC_DEVKIT_TAG was ignored"
+
+start "malformed and metacharacter-bearing tags are rejected before any write"
+fix="$(new_fixture bad_tags)"
+for bad in "v1.2" "1.2.3" "v1.2.3.4" "v1.2.3-rc.1" "v1.2.3; rm -rf /" 'v1.2.3 && touch pwned' \
+    "v1.2.3$(printf '\n')v0.9.0" "v" "vv1.2.3" "" "../../etc/passwd"; do
+    rc="$(run_helper "$fix" run "$bad")"
+    [ "$rc" != 0 ] || fail "tag '$bad' was accepted"
+done
+[ "$(pin_of "$fix/.skills-sync.yaml")" = v0.8.7 ] || fail "a rejected tag still moved the pin"
+[ ! -e "$fix/pwned" ] || fail "a metacharacter payload reached a shell"
+! pushed "$fix" || fail "a rejected tag still pushed a branch"
+! logged "gh pr" || fail "a rejected tag still touched a PR"
+
+start "draft, prerelease, and unknown releases are rejected"
+fix="$(new_fixture bad_releases)"
+rc="$(run_helper "$fix" run v1.0.0)"
+[ "$rc" != 0 ] || fail "a draft release was accepted"
+grep -q "draft release" "$LAST_OUT" || fail "draft rejection was not reported: $(cat "$LAST_OUT")"
+rc="$(run_helper "$fix" run v0.9.2-rc.1)"
+[ "$rc" != 0 ] || fail "a prerelease tag was accepted"
+rc="$(run_helper "$fix" run v9.9.9)"
+[ "$rc" != 0 ] || fail "an unpublished tag was accepted"
+grep -q "no published" "$LAST_OUT" || fail "missing-release rejection was not reported"
+! pushed "$fix" || fail "a rejected release still pushed a branch"
+
+start "a prerelease that passes the shape gate is still refused"
+fix="$(new_fixture prerelease_shaped)"
+STUB_RELEASES="v0.9.0 false true"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "a well-shaped prerelease was accepted"
+grep -q "prerelease" "$LAST_OUT" || fail "prerelease rejection was not reported"
+
+start "root/template pin disagreement fails loudly before anything is written"
+fix="$(new_fixture drift v0.8.7 v0.8.5)"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "pre-existing pin drift was not detected"
+grep -q "pin disagreement" "$LAST_OUT" || fail "drift rejection was not reported: $(cat "$LAST_OUT")"
+[ "$(pin_of "$fix/.skills-sync.yaml")" = v0.8.7 ] || fail "drifted repo was still modified"
+! pushed "$fix" || fail "drifted repo still pushed a branch"
+
+start "a sync that writes an unrelated path fails closed"
+fix="$(new_fixture scope_extra)"
+STUB_SYNC_TOUCH_UNRELATED="README.md"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "an out-of-scope write was accepted"
+grep -q "paths it does not own" "$LAST_OUT" || fail "scope rejection was not reported: $(cat "$LAST_OUT")"
+! pushed "$fix" || fail "an out-of-scope sync still pushed"
+! logged "gh pr" || fail "an out-of-scope sync still touched a PR"
+
+start "a sync that deletes a local skill fails closed"
+fix="$(new_fixture scope_delete)"
+STUB_SYNC_DELETE_LOCAL="1"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "deleting a local skill was accepted"
+grep -q "local-only" "$LAST_OUT" || fail "the deleted local skill was not named: $(cat "$LAST_OUT")"
+! pushed "$fix" || fail "a local-skill deletion still pushed"
+
+start "a skill the new pin adds or drops stays in scope"
+fix="$(new_fixture scope_managed)"
+STUB_SYNC_ADD_SKILL="new-repo-skill"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "adding a managed skill was rejected: $(cat "$LAST_OUT")"
+fix="$(new_fixture scope_dropped)"
+STUB_SYNC_ADD_SKILL=""
+STUB_SYNC_DROP_SKILL="standardize-repo"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "dropping a previously managed skill was rejected: $(cat "$LAST_OUT")"
+
+start "a failing sync never pushes or opens a PR"
+fix="$(new_fixture sync_fail)"
+STUB_FAIL_TASKS="sync:skills"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "a failing sync:skills was ignored"
+! pushed "$fix" || fail "a failing sync still pushed"
+! logged "gh pr" || fail "a failing sync still touched a PR"
+
+start "a failing verification never pushes or opens a PR"
+for failing in verify:skills:offline verify:skills verify; do
+    fix="$(new_fixture "verify_fail_${failing//:/_}")"
+    STUB_FAIL_TASKS="$failing"
+    rc="$(run_helper "$fix" run v0.9.0)"
+    [ "$rc" != 0 ] || fail "a failing '$failing' was ignored"
+    grep -q "verification failed at 'task $failing'" "$LAST_OUT" ||
+        fail "'$failing' failure was not reported: $(cat "$LAST_OUT")"
+    ! pushed "$fix" || fail "a failing '$failing' still pushed"
+    ! pr_written || fail "a failing '$failing' still created or updated a PR"
+    # The commit exists locally but main is untouched and nothing left the host.
+    [ "$(git -C "$fix" rev-parse main)" = "$(git -C "$fix.origin.git" rev-parse main)" ] ||
+        fail "main diverged from origin after a failed '$failing'"
+done
+
+start "a dirty working tree is refused"
+fix="$(new_fixture dirty)"
+echo "local edit" >>"$fix/.skills-sync.yaml"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "a dirty tree was accepted"
+grep -q "working tree is not clean" "$LAST_OUT" || fail "dirty-tree rejection was not reported"
+
+start "the bot identity comes from the GitHub App slug"
+fix="$(new_fixture identity)"
+GH_APP_SLUG="evanharmon1-ci"
+STUB_BOT_UID="987654"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "identity run exited $rc: $(cat "$LAST_OUT")"
+author="$(git -C "$fix" log -1 --format='%an <%ae>' "$SYNC_BRANCH")"
+[ "$author" = "evanharmon1-ci[bot] <987654+evanharmon1-ci[bot]@users.noreply.github.com>" ] ||
+    fail "unexpected commit author: $author"
+
+start "a bogus App slug is refused before it reaches git config"
+fix="$(new_fixture bad_slug)"
+GH_APP_SLUG='evil; touch pwned'
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "a bogus App slug was accepted"
+[ ! -e "$fix/pwned" ] || fail "an App slug payload reached a shell"
+
+start "resolve and pinned are usable on their own"
+fix="$(new_fixture subcommands)"
+rc="$(run_helper "$fix" resolve v0.9.1)"
+[ "$rc" = 0 ] || fail "resolve exited $rc: $(cat "$LAST_OUT")"
+[ "$(cat "$LAST_OUT")" = "v0.9.1" ] || fail "resolve printed more than the tag: $(cat "$LAST_OUT")"
+rc="$(run_helper "$fix" pinned)"
+[ "$rc" = 0 ] || fail "pinned exited $rc: $(cat "$LAST_OUT")"
+[ "$(cat "$LAST_OUT")" = "v0.8.7" ] || fail "pinned printed '$(cat "$LAST_OUT")'"
+rc="$(run_helper "$fix" bogus)"
+[ "$rc" = 2 ] || fail "an unknown subcommand should be a usage error (got $rc)"
+
+echo "sync-devkit-release: all ${cases} cases passed"

--- a/scripts/test-sync-devkit-release.sh
+++ b/scripts/test-sync-devkit-release.sh
@@ -98,7 +98,7 @@ make_stubs() {
     cat >"$_ms_bin/gh" <<'STUB'
 #!/usr/bin/env bash
 set -eu
-printf 'gh %s\n' "$*" >>"$STUB_LOG"
+printf 'gh %s GH_TOKEN=%s\n' "$*" "${GH_TOKEN:+set}${GH_TOKEN:-unset}" >>"$STUB_LOG"
 case "${1:-}" in
 api)
     path="${2:-}"
@@ -165,7 +165,7 @@ STUB
     cat >"$_ms_bin/task" <<'STUB'
 #!/usr/bin/env bash
 set -eu
-printf 'task %s\n' "$*" >>"$STUB_LOG"
+printf 'task %s GH_TOKEN=%s\n' "$*" "${GH_TOKEN:+set}${GH_TOKEN:-unset}" >>"$STUB_LOG"
 target="${1:-}"
 case ",${STUB_FAIL_TASKS:-}," in
 *",$target,"*)
@@ -235,6 +235,7 @@ run_helper() {
             STUB_SYNC_ADD_SKILL="${STUB_SYNC_ADD_SKILL:-}" \
             STUB_SYNC_DROP_SKILL="${STUB_SYNC_DROP_SKILL:-}" \
             GH_APP_SLUG="${GH_APP_SLUG:-}" \
+            GH_TOKEN="${GH_TOKEN:-}" \
             SYNC_DEVKIT_TAG="${SYNC_DEVKIT_TAG:-}" \
             SYNC_DEVKIT_ALLOW_DOWNGRADE="${SYNC_DEVKIT_ALLOW_DOWNGRADE:-}" \
             ./scripts/sync-devkit-release.sh "$@"
@@ -258,6 +259,7 @@ v1.0.0 true false"
     STUB_SYNC_ADD_SKILL=""
     STUB_SYNC_DROP_SKILL=""
     GH_APP_SLUG=""
+    GH_TOKEN=""
     SYNC_DEVKIT_TAG=""
     SYNC_DEVKIT_ALLOW_DOWNGRADE=""
 }
@@ -504,6 +506,38 @@ for failing in verify:skills:offline security:secrets verify:skills verify; do
     [ "$(git -C "$fix" rev-parse main)" = "$(git -C "$fix.origin.git" rev-parse main)" ] ||
         fail "main diverged from origin after a failed '$failing'"
 done
+
+start "the write token never reaches the sync or verification subprocesses"
+fix="$(new_fixture token_scope)"
+GH_TOKEN="s3cret-app-token"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "token-scope run exited $rc: $(cat "$LAST_OUT")"
+# The stubs record whether GH_TOKEN was visible to them. `gh` legitimately
+# needs it; `task` (sync:skills, the guard, every verification target) must not
+# see a contents:write credential it could hand to copier/npx/uvx.
+! grep -q '^task .*GH_TOKEN=set' "$STUB_LOG" ||
+    fail "a task subprocess inherited the repo-write token: $(grep -m1 '^task .*GH_TOKEN=set' "$STUB_LOG")"
+grep -q '^task .*GH_TOKEN=unset' "$STUB_LOG" || fail "no task invocation recorded its token visibility"
+grep -q '^gh .*GH_TOKEN=set' "$STUB_LOG" || fail "gh lost the token it needs"
+
+start "a base branch that diverges from origin is refused"
+fix="$(new_fixture diverged)"
+# A local commit that was never pushed: force-pushing a bot branch built on it
+# would publish it under a bot title.
+echo "unpushed local work" >"$fix/LOCAL.md"
+git -C "$fix" add LOCAL.md
+git -C "$fix" commit --quiet -m "local only"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "a diverged base branch was accepted"
+grep -q "not at origin/main" "$LAST_OUT" || fail "divergence was not reported: $(cat "$LAST_OUT")"
+! pushed "$fix" || fail "a diverged base still pushed"
+
+start "running from a branch that is not the base is refused"
+fix="$(new_fixture off_base)"
+git -C "$fix" checkout --quiet -b some-feature
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "running off the base branch was accepted"
+grep -q "not 'main'" "$LAST_OUT" || fail "off-base rejection was not reported: $(cat "$LAST_OUT")"
 
 start "a dirty working tree is refused"
 fix="$(new_fixture dirty)"

--- a/scripts/test-sync-devkit-release.sh
+++ b/scripts/test-sync-devkit-release.sh
@@ -130,7 +130,24 @@ EOF
     ;;
 pr)
     case "${2:-}" in
-    list) printf '%s' "${STUB_OPEN_PR:-}" ;;
+    list)
+        # Emulate `--json number,isCrossRepository --jq …` without depending on
+        # a jq binary: STUB_PR_LIST lines are "<number> <isCrossRepository>".
+        # The same-repo filter is applied only when the caller actually asked
+        # for that field, so dropping the guard from the helper fails the test.
+        want_same_repo=0
+        case "$*" in *isCrossRepository*) want_same_repo=1 ;; esac
+        while read -r num cross; do
+            [ -n "$num" ] || continue
+            if [ "$want_same_repo" = 1 ] && [ "$cross" = "true" ]; then
+                continue
+            fi
+            printf '%s' "$num"
+            exit 0
+        done <<EOF
+${STUB_PR_LIST:-}
+EOF
+        ;;
     create | edit) printf 'https://example.invalid/pr\n' ;;
     *)
         echo "stub gh: unhandled pr subcommand ${2:-}" >&2
@@ -210,7 +227,7 @@ run_helper() {
             STUB_LOG="$STUB_LOG" \
             STUB_LATEST="${STUB_LATEST:-}" \
             STUB_RELEASES="${STUB_RELEASES:-}" \
-            STUB_OPEN_PR="${STUB_OPEN_PR:-}" \
+            STUB_PR_LIST="${STUB_PR_LIST:-}" \
             STUB_BOT_UID="${STUB_BOT_UID:-12345}" \
             STUB_FAIL_TASKS="${STUB_FAIL_TASKS:-}" \
             STUB_SYNC_TOUCH_UNRELATED="${STUB_SYNC_TOUCH_UNRELATED:-}" \
@@ -219,6 +236,7 @@ run_helper() {
             STUB_SYNC_DROP_SKILL="${STUB_SYNC_DROP_SKILL:-}" \
             GH_APP_SLUG="${GH_APP_SLUG:-}" \
             SYNC_DEVKIT_TAG="${SYNC_DEVKIT_TAG:-}" \
+            SYNC_DEVKIT_ALLOW_DOWNGRADE="${SYNC_DEVKIT_ALLOW_DOWNGRADE:-}" \
             ./scripts/sync-devkit-release.sh "$@"
     ) >"$LAST_OUT" 2>&1 || _rh_rc=$?
     echo "$_rh_rc"
@@ -233,7 +251,7 @@ v0.9.0 false false
 v0.9.1 false false
 v0.9.2-rc.1 false true
 v1.0.0 true false"
-    STUB_OPEN_PR=""
+    STUB_PR_LIST=""
     STUB_FAIL_TASKS=""
     STUB_SYNC_TOUCH_UNRELATED=""
     STUB_SYNC_DELETE_LOCAL=""
@@ -241,6 +259,7 @@ v1.0.0 true false"
     STUB_SYNC_DROP_SKILL=""
     GH_APP_SLUG=""
     SYNC_DEVKIT_TAG=""
+    SYNC_DEVKIT_ALLOW_DOWNGRADE=""
 }
 
 # start NAME — begin a case; echoes a fresh fixture path.
@@ -295,7 +314,7 @@ pushed_before="$(git -C "$fix.origin.git" rev-parse "$SYNC_BRANCH")"
 # stale until the PR merges, so the daily reconciliation rebuilds this same
 # commit. It must not force-push it again.
 git -C "$fix" checkout --quiet main
-STUB_OPEN_PR="42"
+STUB_PR_LIST="42 false"
 : >"$STUB_LOG"
 rc="$(run_helper "$fix" run v0.9.0)"
 [ "$rc" = 0 ] || fail "reconciliation run exited $rc: $(cat "$LAST_OUT")"
@@ -310,7 +329,7 @@ fix="$(new_fixture reopen)"
 rc="$(run_helper "$fix" run v0.9.0)"
 [ "$rc" = 0 ] || fail "first run exited $rc: $(cat "$LAST_OUT")"
 git -C "$fix" checkout --quiet main
-STUB_OPEN_PR=""
+STUB_PR_LIST=""
 : >"$STUB_LOG"
 rc="$(run_helper "$fix" run v0.9.0)"
 [ "$rc" = 0 ] || fail "re-open run exited $rc: $(cat "$LAST_OUT")"
@@ -324,18 +343,41 @@ logged "gh pr create" || fail "stale provenance did not produce a PR"
 
 start "an open sync PR is updated, never duplicated"
 fix="$(new_fixture existing_pr)"
-STUB_OPEN_PR="42"
+STUB_PR_LIST="42 false"
 rc="$(run_helper "$fix" run v0.9.0)"
 [ "$rc" = 0 ] || fail "existing-PR run exited $rc: $(cat "$LAST_OUT")"
 logged "gh pr edit 42" || fail "the open PR was not updated"
 ! logged "gh pr create" || fail "a duplicate PR was created"
+
+start "a fork PR sharing the bot branch name is never mistaken for the sync PR"
+fix="$(new_fixture fork_pr)"
+# gh's --head filters by branch NAME only, so an untrusted fork PR whose head
+# branch is called bot/sync-harmon-devkit shows up in the same listing.
+STUB_PR_LIST="9001 true"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "fork-PR run exited $rc: $(cat "$LAST_OUT")"
+! logged "gh pr edit 9001" || fail "the automation rewrote an unrelated fork PR"
+logged "gh pr create" || fail "the real sync PR was not opened"
+
+start "a stale or out-of-order release event cannot roll the pin backwards"
+fix="$(new_fixture downgrade v0.9.1)"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "a downgrade was accepted on the event path"
+grep -q "backwards" "$LAST_OUT" || fail "downgrade rejection was not reported: $(cat "$LAST_OUT")"
+[ "$(pin_of "$fix/.skills-sync.yaml")" = v0.9.1 ] || fail "a refused downgrade still moved the pin"
+! pushed "$fix" || fail "a refused downgrade still pushed"
+# Manual dispatch is deliberate, so it may downgrade — the recovery path.
+SYNC_DEVKIT_ALLOW_DOWNGRADE="true"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "a deliberate manual downgrade was refused: $(cat "$LAST_OUT")"
+[ "$(pin_of "$fix/.skills-sync.yaml")" = v0.9.0 ] || fail "the manual downgrade did not move the pin"
 
 start "a newer release supersedes an open sync PR from one commit off main"
 fix="$(new_fixture supersede)"
 rc="$(run_helper "$fix" run v0.9.0)"
 [ "$rc" = 0 ] || fail "first sync exited $rc: $(cat "$LAST_OUT")"
 git -C "$fix" checkout --quiet main
-STUB_OPEN_PR="7"
+STUB_PR_LIST="7 false"
 : >"$STUB_LOG"
 rc="$(run_helper "$fix" run v0.9.1)"
 [ "$rc" = 0 ] || fail "superseding sync exited $rc: $(cat "$LAST_OUT")"

--- a/scripts/test-sync-devkit-release.sh
+++ b/scripts/test-sync-devkit-release.sh
@@ -372,6 +372,21 @@ rc="$(run_helper "$fix" run v0.9.0)"
 [ "$rc" = 0 ] || fail "a deliberate manual downgrade was refused: $(cat "$LAST_OUT")"
 [ "$(pin_of "$fix/.skills-sync.yaml")" = v0.9.0 ] || fail "the manual downgrade did not move the pin"
 
+start "an out-of-order event cannot drag an open sync PR back to an older tag"
+fix="$(new_fixture out_of_order)"
+rc="$(run_helper "$fix" run v0.9.1)"
+[ "$rc" = 0 ] || fail "first sync exited $rc: $(cat "$LAST_OUT")"
+pushed_before="$(git -C "$fix.origin.git" rev-parse "$SYNC_BRANCH")"
+# The base pin is still v0.8.7 until the PR merges, so the older tag would look
+# like a move forward if only the base branch were consulted.
+git -C "$fix" checkout --quiet main
+STUB_PR_LIST="7 false"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "a delayed older event regressed the open sync PR"
+grep -q "backwards" "$LAST_OUT" || fail "regression was not reported: $(cat "$LAST_OUT")"
+[ "$(git -C "$fix.origin.git" rev-parse "$SYNC_BRANCH")" = "$pushed_before" ] ||
+    fail "the open sync branch was rewritten with the older tag"
+
 start "a newer release supersedes an open sync PR from one commit off main"
 fix="$(new_fixture supersede)"
 rc="$(run_helper "$fix" run v0.9.0)"
@@ -476,7 +491,7 @@ rc="$(run_helper "$fix" run v0.9.0)"
 ! logged "gh pr" || fail "a failing sync still touched a PR"
 
 start "a failing verification never pushes or opens a PR"
-for failing in verify:skills:offline verify:skills verify; do
+for failing in verify:skills:offline security:secrets verify:skills verify; do
     fix="$(new_fixture "verify_fail_${failing//:/_}")"
     STUB_FAIL_TASKS="$failing"
     rc="$(run_helper "$fix" run v0.9.0)"

--- a/scripts/test-sync-devkit-release.sh
+++ b/scripts/test-sync-devkit-release.sh
@@ -539,6 +539,18 @@ rc="$(run_helper "$fix" run v0.9.0)"
 [ "$rc" != 0 ] || fail "running off the base branch was accepted"
 grep -q "not 'main'" "$LAST_OUT" || fail "off-base rejection was not reported: $(cat "$LAST_OUT")"
 
+start "an unreachable origin aborts instead of assuming nothing is in flight"
+fix="$(new_fixture unreachable)"
+rc="$(run_helper "$fix" run v0.9.1)"
+[ "$rc" = 0 ] || fail "first sync exited $rc: $(cat "$LAST_OUT")"
+pushed_before="$(git -C "$fix.origin.git" rev-parse "$SYNC_BRANCH")"
+git -C "$fix" checkout --quiet main
+git -C "$fix" remote set-url origin "$TMPROOT/does-not-exist.git"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "an unreachable origin was treated as 'no sync branch'"
+[ "$(git -C "$fix.origin.git" rev-parse "$SYNC_BRANCH")" = "$pushed_before" ] ||
+    fail "the sync branch changed despite an unreachable origin"
+
 start "a dirty working tree is refused"
 fix="$(new_fixture dirty)"
 echo "local edit" >>"$fix/.skills-sync.yaml"

--- a/scripts/test-sync-devkit-release.sh
+++ b/scripts/test-sync-devkit-release.sh
@@ -148,6 +148,7 @@ pr)
 ${STUB_PR_LIST:-}
 EOF
         ;;
+    view) printf '%s\n' "${STUB_PR_TITLE:-}" ;;
     create | edit) printf 'https://example.invalid/pr\n' ;;
     *)
         echo "stub gh: unhandled pr subcommand ${2:-}" >&2
@@ -228,6 +229,7 @@ run_helper() {
             STUB_LATEST="${STUB_LATEST:-}" \
             STUB_RELEASES="${STUB_RELEASES:-}" \
             STUB_PR_LIST="${STUB_PR_LIST:-}" \
+            STUB_PR_TITLE="${STUB_PR_TITLE:-}" \
             STUB_BOT_UID="${STUB_BOT_UID:-12345}" \
             STUB_FAIL_TASKS="${STUB_FAIL_TASKS:-}" \
             STUB_SYNC_TOUCH_UNRELATED="${STUB_SYNC_TOUCH_UNRELATED:-}" \
@@ -253,6 +255,7 @@ v0.9.1 false false
 v0.9.2-rc.1 false true
 v1.0.0 true false"
     STUB_PR_LIST=""
+    STUB_PR_TITLE=""
     STUB_FAIL_TASKS=""
     STUB_SYNC_TOUCH_UNRELATED=""
     STUB_SYNC_DELETE_LOCAL=""
@@ -317,6 +320,7 @@ pushed_before="$(git -C "$fix.origin.git" rev-parse "$SYNC_BRANCH")"
 # commit. It must not force-push it again.
 git -C "$fix" checkout --quiet main
 STUB_PR_LIST="42 false"
+STUB_PR_TITLE="fix(template): sync harmon-devkit skills to v0.9.0"
 : >"$STUB_LOG"
 rc="$(run_helper "$fix" run v0.9.0)"
 [ "$rc" = 0 ] || fail "reconciliation run exited $rc: $(cat "$LAST_OUT")"
@@ -325,6 +329,27 @@ grep -q "already carries this exact sync" "$LAST_OUT" || fail "reconciliation di
     fail "reconciliation force-pushed an identical tree"
 ! logged "gh pr edit" || fail "reconciliation churned the open PR"
 ! logged "task verify" || fail "reconciliation re-ran the expensive verification"
+
+start "a pushed branch whose PR metadata went stale is repaired, not skipped"
+fix="$(new_fixture stale_meta)"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "first run exited $rc: $(cat "$LAST_OUT")"
+pushed_before="$(git -C "$fix.origin.git" rev-parse "$SYNC_BRANCH")"
+git -C "$fix" checkout --quiet main
+# Models a run whose push landed but whose `gh pr edit` failed: the branch is
+# correct, the PR still advertises the previous tag. The title is what
+# squash-merge feeds release-please, so leaving it stale would tag the wrong
+# release — it must self-heal on the next run.
+STUB_PR_LIST="42 false"
+STUB_PR_TITLE="fix(template): sync harmon-devkit skills to v0.8.7"
+: >"$STUB_LOG"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "metadata-repair run exited $rc: $(cat "$LAST_OUT")"
+logged "gh pr edit 42" || fail "stale PR metadata was not repaired"
+logged "fix(template): sync harmon-devkit skills to v0.9.0" || fail "the repaired title is wrong"
+[ "$(git -C "$fix.origin.git" rev-parse "$SYNC_BRANCH")" = "$pushed_before" ] ||
+    fail "the metadata repair also force-pushed an identical tree"
+! logged "task verify" || fail "the metadata repair re-ran the expensive verification"
 
 start "a re-run with no open PR re-opens one from the pushed branch"
 fix="$(new_fixture reopen)"


### PR DESCRIPTION
Closes #360.

## What

Publishing a stable harmon-devkit release now opens or updates **one complete,
verified harmon-init pin-and-sync PR**, instead of the six-step manual chain
(edit both pins → `task sync:skills` → branch → verify → PR).

```text
human merges harmon-devkit's release PR  ->  stable tag
        | repository_dispatch (harmon-devkit-released)
harmon-init validates the tag, pins it, vendors, verifies, opens/updates ONE PR
        |
human merges the sync PR, then harmon-init's release PR
```

Both release-PR merges stay intentional human gates. Nothing here merges
anything.

## Why

`.skills-sync.yaml` and its template twin pin a released harmon-devkit tag, and
the vendored `.claude/skills/` must move with them. That work is deterministic;
only the two release merges at either end are judgement calls.

## How

- **`.github/workflows/sync-harmon-devkit.yml`** (root-only, no `template/`
  twin) — `repository_dispatch` from harmon-devkit plus a daily reconciliation
  schedule, serialized by one `concurrency` group.
- **`scripts/sync-devkit-release.sh`** — all the logic, so it is shellcheck'd
  and unit-tested rather than hiding in an inline workflow block.
- **`scripts/test-sync-devkit-release.sh`** — 30 offline cases against stubbed
  `gh`/`task` and a real throwaway git repo with a bare `origin`, so pushes and
  PR calls are observable. Wired into `verify` and the CI lint job.

### Safety properties

| | |
| --- | --- |
| Untrusted payload | Tag shape checked in pure shell (no regex a newline can split), then confirmed upstream: no drafts, no prereleases. Reaches the helper only via the environment. |
| Fail-closed | Aborts before any push on pre-existing pin drift, a backwards move, an out-of-scope write by the sync, or a failed gate. |
| Secrets | `task security:secrets` runs **before** the push — this vendors files from another repo, and a pushed secret needs rotating whether or not the PR merges. |
| Token scope | `persist-credentials: false`; the App token authenticates only the individual git calls to origin via a process-scoped credential helper, and the sync + verification run under `env -u GH_TOKEN`. |
| Base integrity | Checkout pinned to `main`; refuses to run unless `HEAD` is `main` and matches a freshly fetched `origin/main`. |
| Idempotency | One rolling `bot/sync-harmon-devkit` branch rebuilt from `main`, so a newer release supersedes an open PR rather than opening a second. Replays are no-ops; an identical tree is never re-pushed, but stale PR metadata is repaired. |
| Never merges | Not the sync PR, not either release PR. |

### Deviation from the issue

The issue specified `workflow_dispatch` for recovery. **Omitted deliberately**:
for that trigger GitHub runs the workflow definition from whichever ref the
operator selects, so an unreviewed branch could rewrite the token-minting step
and use the CI App credential — pinning the *checkout* to `main` does not help,
because the token already exists. `repository_dispatch` gives the same manual
capability (same write access required) and always runs the default branch's
definition:

```bash
gh api repos/evanharmon1/harmon-init/dispatches \
  -f event_type=harmon-devkit-released \
  -f 'client_payload[tag]=v0.9.0' \
  -f 'client_payload[allow_downgrade]=true'   # only to roll back a bad release
```

No other App-token workflow here is `workflow_dispatch`-able either; the
invariant is now written down in `docs/architecture/security.md` so the next one
does not reintroduce it.

Renovate's approval-gated harmon-devkit rule is kept as a passive stale-pin
signal, with its `prBodyNotes` updated to say the workflow normally handles this.

## Verification

`task verify`, `task ci`, and `task security` all pass locally. `task review`
came back clean on its first pass.

`task challenge` ran **7 rounds** — past the 5-round cap in AGENTS.md. Findings
converged monotonically (P1s → P1/P2 → P1/P2 → P1/P2/P2 → P1 → P2 → P3) and
every round's findings were confirmed against the code and fixed, each with a
regression test; two were mutation-checked to prove the test fails without the
fix. Flagging the overrun rather than continuing to iterate. Rounds:

1. Fork PR sharing the bot branch name could be rewritten by the automation
   (`gh pr list --head` matches by branch name only); stale tags could roll the
   pin backwards.
2. The branch was pushed before any secret scan; the downgrade floor ignored an
   open sync PR's pin.
3. `GH_TOKEN` was exported to every subprocess including copier/npx/uvx; a local
   `main` ahead of `origin/main` could publish unrelated commits.
4. `workflow_dispatch` + `checkout ref: main` still ran unreviewed code; a failed
   fetch was read as "no sync branch in flight".
5. `workflow_dispatch` itself exposed the App credential (see above).
6. **Real bug** — `task verify` renders the template, and copier's `git init` +
   initial commit needs a *global* git identity that GitHub-hosted runners lack.
   The workflow set only `init.defaultBranch`, so the verification step would
   have failed with "Author identity unknown" in CI. Local runs hid it.
7. Stale PR metadata after a partial failure was never repaired.

## Follow-up

harmon-init is the **receiver**. The companion emitter in harmon-devkit —
give the release-please step an id, and on `release_created` mint a separate
short-lived App token scoped to harmon-init and send the dispatch — must land
**after** this merges, since `repository_dispatch` only fires when the receiving
workflow exists on the default branch. I'll open the linked harmon-devkit issue
once this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
