### PR TITLE
fix: guard that both skills-sync manifests pin the same tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
       - run: task test:renovate-pins
       - run: task test:release-title
       - run: task test:sync-devkit-release
+      - run: task test:skills-pin-parity
       - name: Dogfood parity (verbatim template files match their root twins)
         run: task test:dogfood-parity
       # The structure check renders template/, so it needs copier. Installed

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -79,6 +79,7 @@ tasks:
       - task: test:renovate-pins
       - task: test:release-title
       - task: test:sync-devkit-release
+      - task: test:skills-pin-parity
       - task: test:dogfood-parity
       - task: test:dogfood-structure
       - task: foreman:test
@@ -312,6 +313,18 @@ tasks:
     desc: Unit-test the harmon-devkit release→sync-PR automation (offline, stubbed gh/task)
     cmds:
       - ./scripts/test-sync-devkit-release.sh
+
+  # ROOT-ONLY (a generated repo has ONE skills-sync manifest, so it has nothing
+  # to compare). Closes a real hole: `verify:skills*` both read only the ROOT
+  # manifest, so a pin edited in the template twin alone leaves the root pin and
+  # the provenance agreeing, passes every other gate, and ships a stale pin to
+  # generated repos — surfacing only when the next automated sync aborts. The
+  # comparison already exists as sync-devkit-release.sh's `pinned` (offline: no
+  # gh, no network); this just runs it as a gate.
+  test:skills-pin-parity:
+    desc: "Guard: the root and template skills-sync manifests pin the same harmon-devkit tag"
+    cmds:
+      - ./scripts/sync-devkit-release.sh pinned
 
   # ── Dogfood drift (root layer vs template/) ───────────────────
   # Three checks, in increasing looseness. The root layer is template/ rendered

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -47,9 +47,13 @@ this comment. -->
       just that one leaves the template shipping the old pin to generated repos
       — and the next automated run aborts with `pin disagreement` until someone
       reconciles them by hand. Only this fully manual route has that trap: the
-      workflow and `task sync:devkit-release` both write both manifests. A
-      ref-only commit (either manifest, without the re-sync) fails the
-      `verify:skills` drift check in CI and pre-push. Renovate's harmon-devkit
+      workflow and `task sync:devkit-release` both write both manifests.
+      **The two mistakes fail very differently.** Editing the *root* manifest
+      without re-syncing fails `verify:skills` in CI and `verify:skills:offline`
+      pre-push, immediately. Editing *only the template* manifest passes every
+      gate — both drift checks read the root manifest, whose pin still matches
+      the provenance — so it surfaces only when the next automated run aborts.
+      Check that one by eye. Renovate's harmon-devkit
       rule is kept only as a passive stale-pin signal: it is Dependency
       Dashboard-gated, so it never opens a pin PR unattended. **Leave it
       unapproved while the sync workflow is healthy** — approving it opens a

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -48,12 +48,13 @@ this comment. -->
       — and the next automated run aborts with `pin disagreement` until someone
       reconciles them by hand. Only this fully manual route has that trap: the
       workflow and `task sync:devkit-release` both write both manifests.
-      **The two mistakes fail very differently.** Editing the *root* manifest
-      without re-syncing fails `verify:skills` in CI and `verify:skills:offline`
-      pre-push, immediately. Editing *only the template* manifest passes every
-      gate — both drift checks read the root manifest, whose pin still matches
-      the provenance — so it surfaces only when the next automated run aborts.
-      Check that one by eye. Renovate's harmon-devkit
+      **Both mistakes are caught, by different gates.** Editing the *root*
+      manifest without re-syncing fails `verify:skills` in CI and
+      `verify:skills:offline` pre-push. Editing *only the template* manifest is
+      invisible to those two — they read the root manifest, whose pin still
+      matches the provenance — so `task test:skills-pin-parity` (in `verify` and
+      CI) compares the two pins directly and fails on disagreement.
+      Renovate's harmon-devkit
       rule is kept only as a passive stale-pin signal: it is Dependency
       Dashboard-gated, so it never opens a pin PR unattended. **Leave it
       unapproved while the sync workflow is healthy** — approving it opens a

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -43,9 +43,12 @@ this comment. -->
       `.skills-sync.yaml`, then run `task sync:skills` and commit the refreshed
       `.claude/skills/` in the same PR — a ref-only commit fails the
       `verify:skills` drift check in CI and pre-push. Renovate's harmon-devkit
-      rule is kept only as a passive stale-pin signal; it needs Dependency
-      Dashboard approval, so it never races the workflow, and it cannot do the
-      re-sync itself.
+      rule is kept only as a passive stale-pin signal: it is Dependency
+      Dashboard-gated, so it never opens a pin PR unattended. **Leave it
+      unapproved while the sync workflow is healthy** — approving it opens a
+      second, ref-only PR for a bump the automation is already handling, and
+      Renovate cannot do the re-sync, so that PR fails `verify:skills` until
+      someone finishes it by hand.
 - [ ] Verify `harmon-init.code-workspace` opens the repo's folder in VS Code and has a unique VS Code Workspace color. Then add any other related repos (e.g. other org repos) to the `folders` list in the workspace file so you have quick access to those repos
 - [ ] Extend `.gitignore` for your stack — the template ships a base; add stack-specific entries via [gitignore.io](https://www.toptal.com/developers/gitignore)
 - [ ] macOS: add a Raycast quicklink/alias that opens the `harmon-init.code-workspace`

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -21,16 +21,31 @@ config, toolchain, devcontainer, and dev environment — against the items below
 
 - [ ] `task install` — Brewfile deps, and lefthook git hooks
 - [ ] `task verify` passes locally
+<!-- Diverges from template/docs/CHECKLIST.md.jinja ON PURPOSE — do not
+"reconcile" it. sync-harmon-devkit.yml is root-only harmon-platform glue with no
+template twin, so a generated repo really does the manual two-step the template
+describes, while harmon-init's bump is automated. Note that NOTHING will tell you
+this: the parity gate skips jinja twins, the structure gate checks headings and
+tasks rather than prose, and this file is on audit-dogfood.sh's SKIP list. Hence
+this comment. -->
 - [ ] **Vendored agent skills stay pinned**: `.skills-sync.yaml` pins which
       harmon-devkit skill categories this repo vendors into `.claude/skills/`.
-      **Pin bumps are a two-step:** edit `ref` in `.skills-sync.yaml`, then run
-      `task sync:skills` and commit the refreshed `.claude/skills/` in the same
-      PR. Renovate surfaces a new
+      **In this repo the bump is automated** — publishing a stable
       [harmon-devkit release](https://github.com/evanharmon1/harmon-devkit/releases)
-      in the Dependency Dashboard; approve it there to open the pin PR, then run
-      the sync and push its output as a separate commit (do not amend Renovate's
-      commit). Renovate cannot do the re-sync, so a ref-only commit fails the
-      `verify:skills` drift check in CI and pre-push.
+      opens or updates one rolling `bot/sync-harmon-devkit` PR with both
+      manifests, the provenance, and the vendored skills already moved in
+      lockstep and verified. Review and merge it like any other PR; nothing
+      auto-merges. See
+      [architecture/ci-cd.md](architecture/ci-cd.md#harmon-devkit-skills-propagation).
+      To bump by hand — or to recover a missed dispatch — run
+      `task sync:devkit-release -- vX.Y.Z`, which does the same work locally.
+      **The fully manual fallback is still a two-step:** edit `ref` in
+      `.skills-sync.yaml`, then run `task sync:skills` and commit the refreshed
+      `.claude/skills/` in the same PR — a ref-only commit fails the
+      `verify:skills` drift check in CI and pre-push. Renovate's harmon-devkit
+      rule is kept only as a passive stale-pin signal; it needs Dependency
+      Dashboard approval, so it never races the workflow, and it cannot do the
+      re-sync itself.
 - [ ] Verify `harmon-init.code-workspace` opens the repo's folder in VS Code and has a unique VS Code Workspace color. Then add any other related repos (e.g. other org repos) to the `folders` list in the workspace file so you have quick access to those repos
 - [ ] Extend `.gitignore` for your stack — the template ships a base; add stack-specific entries via [gitignore.io](https://www.toptal.com/developers/gitignore)
 - [ ] macOS: add a Raycast quicklink/alias that opens the `harmon-init.code-workspace`

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -39,9 +39,16 @@ this comment. -->
       [architecture/ci-cd.md](architecture/ci-cd.md#harmon-devkit-skills-propagation).
       To bump by hand — or to recover a missed dispatch — run
       `task sync:devkit-release -- vX.Y.Z`, which does the same work locally.
-      **The fully manual fallback is still a two-step:** edit `ref` in
-      `.skills-sync.yaml`, then run `task sync:skills` and commit the refreshed
-      `.claude/skills/` in the same PR — a ref-only commit fails the
+      **The fully manual fallback is a two-step, and this repo has TWO
+      manifests:** edit `ref` in both `.skills-sync.yaml` **and**
+      `template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja`,
+      then run `task sync:skills` and commit the refreshed `.claude/skills/` in
+      the same PR. `task sync:skills` reads only the root manifest, so editing
+      just that one leaves the template shipping the old pin to generated repos
+      — and the next automated run aborts with `pin disagreement` until someone
+      reconciles them by hand. Only this fully manual route has that trap: the
+      workflow and `task sync:devkit-release` both write both manifests. A
+      ref-only commit (either manifest, without the re-sync) fails the
       `verify:skills` drift check in CI and pre-push. Renovate's harmon-devkit
       rule is kept only as a passive stale-pin signal: it is Dependency
       Dashboard-gated, so it never opens a pin PR unattended. **Leave it

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -105,9 +105,15 @@ human merges the sync PR, then harmon-init's release PR
 - **Never merges.** Not the sync PR, not either repository's release PR.
 
 Renovate keeps its approval-gated harmon-devkit rule as a passive stale-pin
-signal and manual fallback; it cannot vendor the skills itself, and its
-Dependency Dashboard approval means it never races this workflow into a
-duplicate branch.
+signal and manual fallback. Being Dependency Dashboard-gated, it never opens a
+pin PR unattended — but that is not mutual exclusion, and nothing enforces one:
+the workflow's `concurrency` group serializes only its own runs, and the helper
+looks only for `bot/sync-harmon-devkit`. **Approving the dashboard item while
+the automation is healthy therefore produces two PRs for the same bump.** The
+duplicate is not silently wrong — Renovate cannot vendor the skills, so a
+ref-only pin change fails `verify:skills` until a human finishes it — but the
+operational rule is to leave the item unapproved unless the automation is
+broken and you are deliberately falling back to the manual route.
 
 The harmon-devkit side of the edge (emitting the dispatch on release) lives in
 that repository's `release.yml`.

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -74,6 +74,12 @@ human merges the sync PR, then harmon-init's release PR
   force-push can never publish unrelated local commits under a bot title. An
   origin that cannot be reached aborts rather than being read as "no sync PR is
   in flight".
+- **Pin parity:** `task test:skills-pin-parity` (in `verify` and CI) fails when
+  the root and template manifests pin different tags. The `verify:skills*` drift
+  checks cannot see this — both read only the root manifest — so a pin edited in
+  the template twin alone would otherwise ship a stale pin to generated repos
+  and surface only when the next sync run aborts. Root-only: a generated repo
+  has one manifest and nothing to compare.
 - **Fail-closed:** the run aborts before any push if the two pins already
   disagree, if the tag would move the pin *backwards* — measured against the
   newest tag in flight, so a delayed dispatch cannot drag an open sync PR back

--- a/renovate.json
+++ b/renovate.json
@@ -110,7 +110,7 @@
       "dependencyDashboardApproval": true,
       "dependencyDashboardCategory": "Agent skills",
       "prBodyNotes": [
-        "Normally unnecessary: `.github/workflows/sync-harmon-devkit.yml` already opens a complete pin-and-sync PR on every stable harmon-devkit release. This rule stays as a passive stale-pin signal and manual fallback — it needs Dependency Dashboard approval, so it never races that workflow.",
+        "Normally unnecessary: `.github/workflows/sync-harmon-devkit.yml` already opens a complete pin-and-sync PR on every stable harmon-devkit release. This rule stays as a passive stale-pin signal and manual fallback: dashboard-gating means it never opens a pin PR unattended, but approving it while the automation is healthy produces a SECOND PR for the same bump. Leave it unapproved unless the workflow is broken and you are deliberately falling back to the manual route.",
         "If you do approve this update, run `task sync:skills` and push the refreshed `.claude/skills/` as a separate commit; do not amend Renovate's commit. A ref-only bump fails the skills drift check by design."
       ]
     },

--- a/scripts/test-sync-devkit-release.sh
+++ b/scripts/test-sync-devkit-release.sh
@@ -611,4 +611,16 @@ rc="$(run_helper "$fix" pinned)"
 rc="$(run_helper "$fix" bogus)"
 [ "$rc" = 2 ] || fail "an unknown subcommand should be a usage error (got $rc)"
 
+start "pinned fails on drift — the contract task:skills-pin-parity gates on"
+# `task test:skills-pin-parity` is exactly `sync-devkit-release.sh pinned`, so
+# the guard is only as good as this subcommand's exit code. Both manifests
+# agreeing must exit 0; disagreeing must exit non-zero. Asserted directly rather
+# than only through `run`, because that is how the gate invokes it.
+fix="$(new_fixture pin_parity_ok)"
+[ "$(run_helper "$fix" pinned)" = 0 ] || fail "matching pins did not pass the parity guard"
+fix="$(new_fixture pin_parity_drift v0.9.0 v0.8.7)"
+rc="$(run_helper "$fix" pinned)"
+[ "$rc" != 0 ] || fail "the parity guard passed a template twin pinned to an older tag"
+grep -q "pin disagreement" "$LAST_OUT" || fail "drift was not reported: $(cat "$LAST_OUT")"
+
 echo "sync-devkit-release: all ${cases} cases passed"


### PR DESCRIPTION
Closes #413.

`docs/CHECKLIST.md` still told harmon-init to bump the harmon-devkit skills pin by
hand through Renovate. That stopped being the primary path when #403 landed the
sync workflow — AGENTS.md, `docs/architecture/ci-cd.md`,
`docs/architecture/security.md` and `renovate.json` were all updated then, and
this file was missed.

## What changed

Root `docs/CHECKLIST.md` only. The bullet now leads with the automated rolling
`bot/sync-harmon-devkit` PR, keeps `task sync:devkit-release -- vX.Y.Z` as the
manual/recovery route, and retains the fully manual two-step as the last-resort
fallback (still accurate, still enforced by the `verify:skills` drift check).
Renovate's role is restated as a passive stale-pin signal.

## The template twin is deliberately untouched

`template/docs/CHECKLIST.md.jinja` keeps describing the manual two-step, because
that is exactly right for generated repos: `sync-harmon-devkit.yml` is root-only
harmon-platform glue with no template twin, so a generated repo has no automation
to describe.

An inline HTML comment records the divergence, because **nothing else would**:

- `test:dogfood-parity` only covers verbatim (non-`.jinja`) twins — this is a jinja twin
- `test:dogfood-structure` checks that headings and tasks exist, not prose
- `docs/CHECKLIST.md` is on `scripts/audit-dogfood.sh`'s `SKIP` list

I had originally written that comment claiming `task audit:dogfood` would report
the divergence. It does not — I checked, found the file on the SKIP list, and
corrected both the comment and #413. That absence is the whole reason the inline
note earns its place: a future maintainer "reconciling" the two copies would get
no signal from any gate.

## Verification

`task verify` passes. `task lint:markdown`, `test:dogfood-parity` (105 twins) and
`test:dogfood-structure` (197 sections/tasks) all green. The `architecture/ci-cd.md#harmon-devkit-skills-propagation`
anchor was checked against the actual heading. `task challenge` returned a clean
pass. Title pre-flighted: `docs:` is correct since no `template/` path is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
