### PR TITLE
feat: default dev containers to Claude Opus 5

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,7 +25,7 @@ ARG WORKMUX_VERSION=0.1.212
 # renovate: datasource=github-releases depName=njbrake/agent-of-empires extractVersion=^v?(?<version>.+)$
 ARG AOE_VERSION=1.10.1
 # renovate: datasource=npm depName=@anthropic-ai/claude-code
-ARG CLAUDE_CODE_VERSION=2.1.167
+ARG CLAUDE_CODE_VERSION=2.1.220
 # renovate: datasource=npm depName=@openai/codex
 ARG CODEX_VERSION=0.137.0
 # renovate: datasource=npm depName=@google/gemini-cli

--- a/.devcontainer/config/claude-user-defaults.json
+++ b/.devcontainer/config/claude-user-defaults.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-4-8",
+  "model": "claude-opus-5",
   "statusLine": {
     "type": "command",
     "command": "/etc/claude-code/statusline.sh",

--- a/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile
@@ -25,7 +25,7 @@ ARG WORKMUX_VERSION=0.1.212
 # renovate: datasource=github-releases depName=njbrake/agent-of-empires extractVersion=^v?(?<version>.+)$
 ARG AOE_VERSION=1.10.1
 # renovate: datasource=npm depName=@anthropic-ai/claude-code
-ARG CLAUDE_CODE_VERSION=2.1.167
+ARG CLAUDE_CODE_VERSION=2.1.220
 # renovate: datasource=npm depName=@openai/codex
 ARG CODEX_VERSION=0.137.0
 # renovate: datasource=npm depName=@google/gemini-cli

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-user-defaults.json
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-user-defaults.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-4-8",
+  "model": "claude-opus-5",
   "statusLine": {
     "type": "command",
     "command": "/etc/claude-code/statusline.sh",


### PR DESCRIPTION
## What

- `.devcontainer/config/claude-user-defaults.json` and its `template/` twin: seed model `claude-opus-4-8` → `claude-opus-5`.
- `.devcontainer/Dockerfile` and its `template/` twin: `CLAUDE_CODE_VERSION` 2.1.167 → 2.1.220.

## Why

Closes #372 — Opus 5 becomes the default model for every dev container, at the root (dogfood) layer and for generated repos.

The CLI bump is load-bearing, not incidental housekeeping: `claude-opus-5` was added in Claude Code **2.1.219**. On the old 2.1.167 pin, `post-create-common.sh` would seed `~/.claude/settings.json` with a model the bundled client predates, so a fresh (or wiped-volume) container would start on an unknown model. Caught by `task challenge` and verified against the upstream changelog.

This is a seed default the user can still override with `/model`; it only applies on a `~/.claude` volume that has no `settings.json` yet.

## Verification

- `task verify` — green (includes `test:dogfood-parity`; both twin pairs stay byte-identical).
- `task ci` — green (skills drift, devcontainer permission assert, security).
- `task challenge` — clean re-run, no material findings (the first round raised the CLI-pin P2 fixed here).
- `task review` — clean pass.
- The PR touches `.devcontainer/**`, so `devcontainer-build.yml` builds both profiles against the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)