### PR TITLE
feat: gate challenge/review on P0+P1 only, defer P2s to the PR stage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,25 +202,32 @@ something to ask permission for.
 - **`task challenge`** — adversarial second-model review. Adjudicate per
   "Second-Model Review" below, fix confirmed findings, re-run `task verify`,
   then **re-run `task challenge`**. The stage passes only when a re-run comes
-  back with **no material findings** — fixing the findings is not the exit
-  condition, a clean pass is. Max **5** challenge → fix → re-challenge
-  rounds; if findings persist, stop and escalate to Evan.
+  back with **no confirmed P0 or P1 findings** — fixing the findings is not
+  the exit condition, a clean pass is. **P2s do not gate this stage**: record
+  them and carry them to the PR. Max **6** challenge → fix → re-challenge
+  rounds; if P0/P1 findings persist, stop and escalate to Evan.
 - **`task review`** — verification-checkpoint review; same adjudication and
-  same clean-pass exit condition, with its own max **4** rounds.
+  same P0/P1 clean-pass exit condition, with its own max **6** rounds.
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
   a clear what/why/verification summary (mind the `template/` → `fix:`/`feat:`
   title rule below).
-- **Shepherd the PR (max 4 rounds).** Opening the PR is not the end. Watch CI
+- **Shepherd the PR (max 5 rounds).** Opening the PR is not the end. Watch CI
   (`gh pr checks <n> --watch`) and incoming bot/human reviews. When a check
   fails or a review lands findings, treat the findings as hypotheses: verify
   them against the code, fix only what's confirmed, explain rejections in a
-  PR comment, push the fix commit, and watch again. Shepherd-round fixes
-  must pass `task verify` before each push; the local challenge/review loops
-  are not re-entered — the post-push cloud/bot review is the second-model
-  check at this stage. This cap is independent of the other loop caps. If
-  checks still fail or material findings remain after 4 rounds, stop and
-  summarize what's unresolved on the PR for Evan.
+  PR comment, push the fix commit, and watch again. **This is where P2s are
+  settled** — the ones deferred from challenge/review plus anything the PR
+  reviewers raise: fix, decline with reasoning, or file as a follow-up issue,
+  but do not leave them unaddressed. Shepherd-round fixes must pass `task
+  verify` before each push; the local challenge/review loops are not
+  re-entered — the post-push cloud/bot review is the second-model check at
+  this stage. This cap is independent of the other loop caps. If checks still
+  fail or findings remain after 5 rounds, stop and summarize what's
+  unresolved on the PR for Evan. Where a **vendored** skill (`/shepherd`)
+  states a different cap or exit condition, **this file wins** — the skills
+  are synced from harmon-devkit on its own release cadence and can lag a
+  policy change made here.
 - **Stop at green.** Report that checks pass, then stop — merging is always a
   human decision.
 
@@ -317,15 +324,32 @@ the cloud run failed.
    appropriate.
 4. Explain why any rejected finding is incorrect or irrelevant.
 5. Re-run `task verify` (and the other relevant gates) after fixes.
-6. Finish with a concise adjudication table: finding → classification →
-   evidence → action taken.
+6. Finish with a concise adjudication table: finding → priority →
+   classification → evidence → action taken.
 
-**Loop cap and exit:** a stage exits only on a **clean re-run** (no material
-findings) — never on "findings fixed" alone — with at most **5** challenge
-iterations and **4** review iterations (challenge → fix → re-challenge, and
-likewise for review). If material disagreement persists at the cap, stop and
-surface it to Evan instead
-of iterating further.
+**Severity gating.** Both tasks ask Codex to label every finding `P0`
+(breaks correctness, security, or data integrity in ordinary use, or breaks
+an existing contract), `P1` (a real defect or materially wrong design
+decision with a plausible trigger), or `P2` (worth knowing, not
+merge-blocking: hardening, unlikely edge cases, maintainability, non-critical
+test gaps). The scale is defined in `scripts/codex-review.sh`, not inherited
+from the Codex CLI's own labels, so the gate keeps its meaning if Codex
+changes its output. **Only P0 and P1 gate the local loops.** Adjudicate P2s
+too — never suppress or ignore one — but carry them to the PR-shepherd stage
+rather than spending a local round on them. A P2 you judge worth fixing
+immediately may of course be fixed in place; it just does not hold the stage
+open.
+
+**Loop cap and exit:** a stage exits only on a **clean re-run** — no
+confirmed P0 or P1 findings — never on "findings fixed" alone, with at most
+**6** challenge iterations and **6** review iterations (challenge → fix →
+re-challenge, and likewise for review). If P0/P1 disagreement persists at the
+cap, stop and surface it to Evan instead of iterating further.
+
+One caveat on the automatic stop-gate: the codex plugin's Stop hook applies
+its **own** notion of a material finding and may BLOCK on something you have
+classified P2. Adjudicate it (fix it, or state the reasoning) — **never**
+disable the gate to get past a BLOCK.
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,8 +203,9 @@ something to ask permission for.
   "Second-Model Review" below, fix confirmed findings, re-run `task verify`,
   then **re-run `task challenge`**. The stage passes only when a re-run comes
   back with **no confirmed P0 or P1 findings** — fixing the findings is not
-  the exit condition, a clean pass is. **P2s do not gate this stage**: record
-  them and carry them to the PR. Max **6** challenge → fix → re-challenge
+  the exit condition, a clean pass is. **P2s do not gate this stage**: carry
+  them to the PR (see "Deferring P2s" below). Max **6** challenge → fix →
+  re-challenge
   rounds; if P0/P1 findings persist, stop and escalate to Evan.
 - **`task review`** — verification-checkpoint review; same adjudication and
   same P0/P1 clean-pass exit condition, with its own max **6** rounds.
@@ -212,12 +213,15 @@ something to ask permission for.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
   a clear what/why/verification summary (mind the `template/` → `fix:`/`feat:`
   title rule below).
-- **Shepherd the PR (max 5 rounds).** Opening the PR is not the end. Watch CI
+- **Shepherd the PR (max 5 rounds).** Opening the PR is not the end. Start by
+  re-reading the **unchecked** entries under `## Deferred findings` in the PR
+  description — those P2s are open work, not a changelog; tick each one off
+  in the body as you settle it. Then watch CI
   (`gh pr checks <n> --watch`) and incoming bot/human reviews. When a check
   fails or a review lands findings, treat the findings as hypotheses: verify
   them against the code, fix only what's confirmed, explain rejections in a
   PR comment, push the fix commit, and watch again. **This is where P2s are
-  settled** — the ones deferred from challenge/review plus anything the PR
+  settled** — the ones the PR description defers here plus anything the PR
   reviewers raise: fix, decline with reasoning, or file as a follow-up issue,
   but do not leave them unaddressed. Shepherd-round fixes must pass `task
   verify` before each push; the local challenge/review loops are not
@@ -339,6 +343,36 @@ too — never suppress or ignore one — but carry them to the PR-shepherd stage
 rather than spending a local round on them. A P2 you judge worth fixing
 immediately may of course be fixed in place; it just does not hold the stage
 open.
+
+**Deferring P2s.** The handoff is the **PR description**: list every deferred
+P2 under a `## Deferred findings` heading as an unchecked task-list item —
+`- [ ] <file:line> — <finding>` — with enough detail to adjudicate it later.
+This is not bookkeeping: `task challenge` and `task review` run locally and
+their output is ephemeral, and the cloud reviewer reposts only high-priority
+findings, so a P2 that is not written into the PR body is simply lost.
+
+Record each one **the moment you defer it**. Challenge and review both run
+before `gh pr create`, so there is usually no PR body to write to yet: append
+it to the file `git rev-parse --git-path deferred-findings.md` names, and
+move the list into the description when you open the PR (then delete the
+file). Terminal scrollback is not a record — a context reset between
+`task challenge` and `gh pr create` would take the findings with it.
+
+That path is not arbitrary. It sits in the **git directory**, so it is
+deterministic (any later session in this checkout finds it the same way, and
+`git rev-parse` resolves it correctly inside a linked worktree) and invisible
+to `git status`. A note in the *worktree* would be worse than none:
+`codex-review.sh` reviews the uncommitted diff whenever the tree is dirty, so
+the note would become the next bare `task challenge`'s entire scope — and the
+change it was supposed to review would get a clean pass it never earned.
+
+The shepherd stage settles every entry and **edits the PR body to tick it**
+(`- [x] … — fixed in <sha>` / `declined: <reason>` / `filed as #<n>`) in the
+same round. The checkbox is the resolution state: an entry left unchecked is
+open work, so a later round — or a different session — can tell at a glance
+what it still owes without re-adjudicating what is done. That obligation is
+stated here and in the Dev Loop above, and holds whether or not the optional
+`/shepherd` skill is installed to automate it.
 
 **Loop cap and exit:** a stage exits only on a **clean re-run** — no
 confirmed P0 or P1 findings — never on "findings fixed" alone, with at most

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,7 +354,7 @@ findings, so a P2 that is not written into the PR body is simply lost.
 Record each one **the moment you defer it**. Challenge and review both run
 before `gh pr create`, so there is usually no PR body to write to yet: append
 it to the file
-`git rev-parse --git-path "deferred-findings/$(git branch --show-current).md"`
+`git rev-parse --git-path "deferred-findings/$(git branch --show-current)"`
 names (`mkdir -p` its directory first) — but only if that finding is not
 already listed. A stage exits on a *clean re-run*,
 so an unchanged P2 is reported again by design, in every remaining round and
@@ -371,8 +371,11 @@ deterministic (any later session in this checkout finds it the same way, and
 to `git status`. It is keyed by **branch** because an ordinary clone switches
 branches in place: with one shared file, opening branch B's PR would sweep up
 branch A's findings and then delete A's only copy of them. The branch name
-becomes a *path*, not a flattened string — folding `/` to `-` would collide
-`feat/x` with `feat-x` and reintroduce exactly that loss. A note in the *worktree* would be worse than none:
+becomes a *path*, verbatim and without a suffix — folding `/` to `-` would
+collide `feat/x` with `feat-x` and reintroduce exactly that loss, and adding
+an extension would make `foo` (a file) block `foo.md/bar` (needing a
+directory). Used as-is, the mapping is git's own ref namespace, and git
+already forbids one live branch from being a path prefix of another. A note in the *worktree* would be worse than none:
 `codex-review.sh` reviews the uncommitted diff whenever the tree is dirty, so
 the note would become the next bare `task challenge`'s entire scope — and the
 change it was supposed to review would get a clean pass it never earned.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,8 +353,9 @@ findings, so a P2 that is not written into the PR body is simply lost.
 
 Record each one **the moment you defer it**. Challenge and review both run
 before `gh pr create`, so there is usually no PR body to write to yet: append
-it to the file `git rev-parse --git-path deferred-findings.md` names — but
-only if that finding is not already listed. A stage exits on a *clean re-run*,
+it to the file
+`git rev-parse --git-path "deferred-findings-$(git branch --show-current | tr / -).md"`
+names — but only if that finding is not already listed. A stage exits on a *clean re-run*,
 so an unchanged P2 is reported again by design, in every remaining round and
 again by the next stage; appending blindly would hand the shepherd four copies
 of one finding to settle. Match on location plus substance, not exact
@@ -366,7 +367,9 @@ file). Terminal scrollback is not a record — a context reset between
 That path is not arbitrary. It sits in the **git directory**, so it is
 deterministic (any later session in this checkout finds it the same way, and
 `git rev-parse` resolves it correctly inside a linked worktree) and invisible
-to `git status`. A note in the *worktree* would be worse than none:
+to `git status`. It is keyed by **branch** because an ordinary clone switches
+branches in place: with one shared file, opening branch B's PR would sweep up
+branch A's findings and then delete A's only copy of them. A note in the *worktree* would be worse than none:
 `codex-review.sh` reviews the uncommitted diff whenever the tree is dirty, so
 the note would become the next bare `task challenge`'s entire scope — and the
 change it was supposed to review would get a clean pass it never earned.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,8 +354,9 @@ findings, so a P2 that is not written into the PR body is simply lost.
 Record each one **the moment you defer it**. Challenge and review both run
 before `gh pr create`, so there is usually no PR body to write to yet: append
 it to the file
-`git rev-parse --git-path "deferred-findings-$(git branch --show-current | tr / -).md"`
-names — but only if that finding is not already listed. A stage exits on a *clean re-run*,
+`git rev-parse --git-path "deferred-findings/$(git branch --show-current).md"`
+names (`mkdir -p` its directory first) — but only if that finding is not
+already listed. A stage exits on a *clean re-run*,
 so an unchanged P2 is reported again by design, in every remaining round and
 again by the next stage; appending blindly would hand the shepherd four copies
 of one finding to settle. Match on location plus substance, not exact
@@ -369,7 +370,9 @@ deterministic (any later session in this checkout finds it the same way, and
 `git rev-parse` resolves it correctly inside a linked worktree) and invisible
 to `git status`. It is keyed by **branch** because an ordinary clone switches
 branches in place: with one shared file, opening branch B's PR would sweep up
-branch A's findings and then delete A's only copy of them. A note in the *worktree* would be worse than none:
+branch A's findings and then delete A's only copy of them. The branch name
+becomes a *path*, not a flattened string — folding `/` to `-` would collide
+`feat/x` with `feat-x` and reintroduce exactly that loss. A note in the *worktree* would be worse than none:
 `codex-review.sh` reviews the uncommitted diff whenever the tree is dirty, so
 the note would become the next bare `task challenge`'s entire scope — and the
 change it was supposed to review would get a clean pass it never earned.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,7 +353,12 @@ findings, so a P2 that is not written into the PR body is simply lost.
 
 Record each one **the moment you defer it**. Challenge and review both run
 before `gh pr create`, so there is usually no PR body to write to yet: append
-it to the file `git rev-parse --git-path deferred-findings.md` names, and
+it to the file `git rev-parse --git-path deferred-findings.md` names — but
+only if that finding is not already listed. A stage exits on a *clean re-run*,
+so an unchanged P2 is reported again by design, in every remaining round and
+again by the next stage; appending blindly would hand the shepherd four copies
+of one finding to settle. Match on location plus substance, not exact
+wording — the same finding rarely comes back phrased identically. Then
 move the list into the description when you open the PR (then delete the
 file). Terminal scrollback is not a record — a context reset between
 `task challenge` and `gh pr create` would take the findings with it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,15 @@ move the list into the description when you open the PR (then delete the
 file). Terminal scrollback is not a record — a context reset between
 `task challenge` and `gh pr create` would take the findings with it.
 
+**Sweep for orphans when you open the PR.** List the whole tree —
+`ls -R "$(git rev-parse --git-path deferred-findings)"` — and account for
+every file it holds, not just your branch's. Renaming a branch (`git branch
+-m`) or deleting one strands its notes under the old name, where nothing will
+ever look for them again; a rename mid-change is exactly when that happens.
+Adopt an orphan into this PR if it belongs to this work, otherwise leave it
+and say it is there. Listing costs one command; migration logic would cost a
+mechanism that then needs its own correctness argument.
+
 That path is not arbitrary. It sits in the **git directory**, so it is
 deterministic (any later session in this checkout finds it the same way, and
 `git rev-parse` resolves it correctly inside a linked worktree) and invisible

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -138,6 +138,44 @@ to the PR-shepherd stage, where they are fixed, declined with reasoning, or
 filed as follow-up issues. That keeps the expensive local loops focused on
 what actually blocks a merge, without losing the smaller findings.
 
+The deferral needs somewhere to land. These tasks run **locally** — their
+output lives in a terminal and nowhere else — and the cloud reviewer reposts
+only high-priority findings, so a deferred P2 that is not written down is
+gone. Write each one into the **PR description** under a
+`## Deferred findings` heading, as an unchecked task-list item:
+
+```markdown
+## Deferred findings
+
+- [ ] scripts/foo.sh:42 — P2: retry loop has no upper bound
+```
+
+Both tasks run before `gh pr create`, so write each finding down the moment
+you defer it, in the git directory rather than the worktree:
+
+```bash
+cat >>"$(git rev-parse --git-path deferred-findings.md)" <<'DEFERRED'
+- [ ] scripts/foo.sh:42 — P2: retry loop has no upper bound
+DEFERRED
+```
+
+The **quoted** heredoc delimiter is load-bearing: findings routinely quote
+code with backticks or `$(…)`, and inside a double-quoted string the shell
+would run it. Quoting disables expansion, not termination — so pick a
+delimiter the finding text cannot contain.
+
+Move the list into the PR description when you open the PR, then delete the
+file. The location is deterministic, so a later session finds it the same
+way, and `git status` never sees it — a note left in the *worktree* would be
+worse than none, because a dirty tree makes the next bare `task challenge`
+review the note instead of the branch.
+
+The shepherd stage settles every entry and ticks it off in the body as it
+goes, so the checkbox — not anyone's memory — is what says whether a finding
+is still open. The PR is not green while an unchecked entry remains.
+AGENTS.md ("Dev Loop") carries that obligation, so it holds even where the
+optional `/shepherd` skill that automates it is not installed.
+
 Note that the automatic stop-gate is not on this scale — the plugin's Stop
 hook uses its own notion of a material finding and may BLOCK on a P2.
 Adjudicate it; never disable the gate to get past a BLOCK.

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -104,11 +104,11 @@ release plumbing), disable it for routine development.
 task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
-                # until a CLEAN pass (no material findings), ≤5 rounds
-task review     # verification checkpoint — same clean-pass exit, ≤4 rounds
+                # until a CLEAN pass (no P0/P1 findings), ≤6 rounds
+task review     # verification checkpoint — same clean-pass exit, ≤6 rounds
 task ci         # full CI mirror
-# → open the PR, then shepherd it: watch CI + reviews, adjudicate → fix →
-#   push, ≤4 rounds (independent of the loops above)
+# → open the PR, then shepherd it: watch CI + reviews, settle the deferred
+#   P2s, adjudicate → fix → push, ≤5 rounds (independent of the loops above)
 # → merging stays a human decision
 ```
 
@@ -116,6 +116,31 @@ The full staged loop — including the PR-shepherding rounds — is defined in
 AGENTS.md ("Dev Loop"). If Codex cloud review is connected to the repo, PRs
 get a cloud pass too: inline comments only for high-priority findings, a
 bare 👍 reaction as the clean pass.
+
+## Finding priorities
+
+Both modes ask Codex to label every finding, and the local loops gate on that
+label:
+
+| Priority | Meaning | Gates `challenge`/`review`? |
+| --- | --- | --- |
+| `P0` | Breaks correctness, security, or data integrity in ordinary use, or breaks an existing contract | Yes |
+| `P1` | A real defect or materially wrong design decision with a plausible trigger | Yes |
+| `P2` | Worth knowing, not merge-blocking: hardening, unlikely edge cases, maintainability, non-critical test gaps | No |
+
+The scale lives in the prompt that `scripts/codex-review.sh` builds — not in
+the Codex CLI's own priority labels, which are an undocumented convention
+that can change. Keeping the definition local means the gate still means what
+it says when Codex's output format moves.
+
+P2s are **reported, adjudicated, and deferred**, never suppressed: they carry
+to the PR-shepherd stage, where they are fixed, declined with reasoning, or
+filed as follow-up issues. That keeps the expensive local loops focused on
+what actually blocks a merge, without losing the smaller findings.
+
+Note that the automatic stop-gate is not on this scale — the plugin's Stop
+hook uses its own notion of a material finding and may BLOCK on a P2.
+Adjudicate it; never disable the gate to get past a BLOCK.
 
 ## Troubleshooting
 

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -155,7 +155,8 @@ you defer it, in the git directory rather than the worktree:
 
 ```bash
 note="$(git rev-parse --git-path \
-  "deferred-findings-$(git branch --show-current | tr / -).md")"
+  "deferred-findings/$(git branch --show-current).md")"
+mkdir -p "$(dirname "$note")"
 cat >>"$note" <<'DEFERRED'
 - [ ] scripts/foo.sh:42 — P2: retry loop has no upper bound
 DEFERRED
@@ -163,7 +164,8 @@ DEFERRED
 
 One file **per branch**: an ordinary clone switches branches in place, so a
 single shared sidecar would let branch B's PR absorb branch A's findings — and
-then delete A's only copy when it clears the file.
+then delete A's only copy when it clears the file. The branch name is used as
+a path rather than flattened, so `feat/x` and `feat-x` stay distinct.
 
 The **quoted** heredoc delimiter is load-bearing: findings routinely quote
 code with backticks or `$(…)`, and inside a double-quoted string the shell

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -155,7 +155,7 @@ you defer it, in the git directory rather than the worktree:
 
 ```bash
 note="$(git rev-parse --git-path \
-  "deferred-findings/$(git branch --show-current).md")"
+  "deferred-findings/$(git branch --show-current)")"
 mkdir -p "$(dirname "$note")"
 cat >>"$note" <<'DEFERRED'
 - [ ] scripts/foo.sh:42 — P2: retry loop has no upper bound
@@ -165,7 +165,10 @@ DEFERRED
 One file **per branch**: an ordinary clone switches branches in place, so a
 single shared sidecar would let branch B's PR absorb branch A's findings — and
 then delete A's only copy when it clears the file. The branch name is used as
-a path rather than flattened, so `feat/x` and `feat-x` stay distinct.
+a path rather than flattened, so `feat/x` and `feat-x` stay distinct — and
+without an extension, so `foo` cannot block `foo.md/bar`. That makes the
+sidecar tree mirror git's ref namespace, which already forbids one live
+branch from being a path prefix of another.
 
 The **quoted** heredoc delimiter is load-bearing: findings routinely quote
 code with backticks or `$(…)`, and inside a double-quoted string the shell

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -164,6 +164,10 @@ code with backticks or `$(…)`, and inside a double-quoted string the shell
 would run it. Quoting disables expansion, not termination — so pick a
 delimiter the finding text cannot contain.
 
+Check the file before appending: a stage only exits on a *clean re-run*, so an
+unchanged P2 comes back every remaining round and again in the next stage. Add
+it once, matching on location and substance rather than exact wording.
+
 Move the list into the PR description when you open the PR, then delete the
 file. The location is deterministic, so a later session finds it the same
 way, and `git status` never sees it — a note left in the *worktree* would be

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -154,10 +154,16 @@ Both tasks run before `gh pr create`, so write each finding down the moment
 you defer it, in the git directory rather than the worktree:
 
 ```bash
-cat >>"$(git rev-parse --git-path deferred-findings.md)" <<'DEFERRED'
+note="$(git rev-parse --git-path \
+  "deferred-findings-$(git branch --show-current | tr / -).md")"
+cat >>"$note" <<'DEFERRED'
 - [ ] scripts/foo.sh:42 — P2: retry loop has no upper bound
 DEFERRED
 ```
+
+One file **per branch**: an ordinary clone switches branches in place, so a
+single shared sidecar would let branch B's PR absorb branch A's findings — and
+then delete A's only copy when it clears the file.
 
 The **quoted** heredoc delimiter is load-bearing: findings routinely quote
 code with backticks or `$(…)`, and inside a double-quoted string the shell

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -180,7 +180,17 @@ unchanged P2 comes back every remaining round and again in the next stage. Add
 it once, matching on location and substance rather than exact wording.
 
 Move the list into the PR description when you open the PR, then delete the
-file. The location is deterministic, so a later session finds it the same
+file — and sweep the tree for strays while you are there:
+
+```bash
+ls -R "$(git rev-parse --git-path deferred-findings)"
+```
+
+Renaming or deleting a branch strands its notes under the old name, where
+nothing looks for them again. Account for every file the sweep shows: adopt an
+orphan if it belongs to this work, otherwise leave it and mention it. One
+command beats rename-migration logic that would need its own correctness
+argument. The location is deterministic, so a later session finds it the same
 way, and `git status` never sees it — a note left in the *worktree* would be
 worse than none, because a dirty tree makes the next bare `task challenge`
 review the note instead of the branch.

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -199,8 +199,10 @@ Label EVERY finding with a priority, as the first token of the finding:
 Only P0 and P1 decide whether this review passes. Still report P2s in full —
 they are triaged later, once the pull request is open — but do not let them
 hold the stage open. Do not inflate a P2 to P1 to make it heard, and do not
-withhold or soften a P2 because it is non-gating. If there are no P0 or P1
-findings, say so explicitly and in those terms."
+withhold or soften a P2 because it is non-gating: a P2 reported here is
+carried into the pull request description, so an unreported one is lost
+outright. If there are no P0 or P1 findings, say so explicitly and in those
+terms."
 
 if [ -n "$focus" ]; then
     instructions="${instructions}

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -18,7 +18,9 @@
 # so the resolved scope is written INTO the instructions instead.
 # Codex reviews read-only; findings are advisory hypotheses for the primary
 # agent/human to adjudicate (AGENTS.md "Second-Model Review") — this is never
-# part of `verify`/`ci`. Requires an authenticated Codex CLI (`codex login`);
+# part of `verify`/`ci`. Both modes ask for P0/P1/P2-labelled findings; only
+# P0/P1 gate the local loop, P2s are reported and deferred to the PR stage.
+# Requires an authenticated Codex CLI (`codex login`);
 # see docs/guides/codex-review.md.
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -178,6 +180,27 @@ tests for anything it fixes). Flag docs the change should have updated.
 Report only material, defensible findings tied to concrete files and lines —
 no style nits. If the change holds up, say so directly."
 fi
+
+# Severity is defined HERE rather than inherited from the Codex CLI's own
+# review output: its priority labels are an undocumented convention that can
+# change under us, and the local dev loop gates on this scale (AGENTS.md
+# "Second-Model Review"). Stating it in the prompt keeps the gate meaningful.
+instructions="${instructions}
+
+Label EVERY finding with a priority, as the first token of the finding:
+
+  P0 — a defect that breaks correctness, security, or data integrity in
+       ordinary use, or that breaks an existing contract. Merge-blocking.
+  P1 — a real defect or materially wrong design decision with a plausible
+       trigger. Merge-blocking unless argued down with evidence.
+  P2 — worth knowing, but not merge-blocking: hardening, edge cases behind
+       unlikely preconditions, maintainability, non-critical test gaps.
+
+Only P0 and P1 decide whether this review passes. Still report P2s in full —
+they are triaged later, once the pull request is open — but do not let them
+hold the stage open. Do not inflate a P2 to P1 to make it heard, and do not
+withhold or soften a P2 because it is non-gating. If there are no P0 or P1
+findings, say so explicitly and in those terms."
 
 if [ -n "$focus" ]; then
     instructions="${instructions}

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -70,6 +70,10 @@ echo "$out" | grep -q "STUB-ARGS:exec review" || fail "codex exec review not inv
 echo "$out" | grep -q "base branch 'origin/develop'" || fail "remote-qualified fallback base missing: $out"
 echo "$out" | grep -q "ADVERSARIAL" || fail "challenge mode instructions missing: $out"
 echo "$out" | grep -q "feature.txt" || fail "changed-file manifest missing from branch-scope prompt: $out"
+# The gate is only meaningful if the scale it gates on is defined in the
+# prompt — Codex's own priority labels are an undocumented convention.
+echo "$out" | grep -q "Only P0 and P1 decide" || fail "challenge prompt missing the P0/P1 gating rule: $out"
+echo "$out" | grep -q "Still report P2s" || fail "challenge prompt missing the report-P2s instruction: $out"
 
 echo "==> origin/HEAD outranks a stray local main"
 git branch -q main "$(git rev-list --max-parents=0 HEAD)"
@@ -90,6 +94,7 @@ out="$(run review --base origin/develop watch the hooks)" || fail "review --base
 echo "$out" | grep -q "base branch 'origin/develop'" || fail "--base not honored: $out"
 echo "$out" | grep -q "VERIFICATION-CHECKPOINT" || fail "review mode instructions missing: $out"
 echo "$out" | grep -q "watch the hooks" || fail "focus text missing from prompt: $out"
+echo "$out" | grep -q "Only P0 and P1 decide" || fail "review prompt missing the P0/P1 gating rule: $out"
 
 echo "==> dirty tree auto-selects uncommitted scope and enumerates untracked dirs"
 echo x >dirty.txt

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -74,6 +74,9 @@ echo "$out" | grep -q "feature.txt" || fail "changed-file manifest missing from 
 # prompt — Codex's own priority labels are an undocumented convention.
 echo "$out" | grep -q "Only P0 and P1 decide" || fail "challenge prompt missing the P0/P1 gating rule: $out"
 echo "$out" | grep -q "Still report P2s" || fail "challenge prompt missing the report-P2s instruction: $out"
+# An unreported P2 never reaches the PR body, so the handoff clause is what
+# makes "reported but non-gating" different from "ignored".
+echo "$out" | grep -q "carried into the pull request description" || fail "challenge prompt missing the P2 handoff clause: $out"
 
 echo "==> origin/HEAD outranks a stray local main"
 git branch -q main "$(git rev-list --max-parents=0 HEAD)"
@@ -95,6 +98,7 @@ echo "$out" | grep -q "base branch 'origin/develop'" || fail "--base not honored
 echo "$out" | grep -q "VERIFICATION-CHECKPOINT" || fail "review mode instructions missing: $out"
 echo "$out" | grep -q "watch the hooks" || fail "focus text missing from prompt: $out"
 echo "$out" | grep -q "Only P0 and P1 decide" || fail "review prompt missing the P0/P1 gating rule: $out"
+echo "$out" | grep -q "carried into the pull request description" || fail "review prompt missing the P2 handoff clause: $out"
 
 echo "==> dirty tree auto-selects uncommitted scope and enumerates untracked dirs"
 echo x >dirty.txt

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -113,8 +113,9 @@ something to ask permission for.
   "Second-Model Review" below, fix confirmed findings, re-run `task verify`,
   then **re-run `task challenge`**. The stage passes only when a re-run comes
   back with **no confirmed P0 or P1 findings** — fixing the findings is not
-  the exit condition, a clean pass is. **P2s do not gate this stage**: record
-  them and carry them to the PR. Max **6** challenge → fix → re-challenge
+  the exit condition, a clean pass is. **P2s do not gate this stage**: carry
+  them to the PR (see "Deferring P2s" below). Max **6** challenge → fix →
+  re-challenge
   rounds; if P0/P1 findings persist, stop and escalate to the maintainer.
 - **`task review`** — verification-checkpoint review; same adjudication and
   same P0/P1 clean-pass exit condition, with its own max **6** rounds.
@@ -122,14 +123,17 @@ something to ask permission for.
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
   a clear what/why/verification summary.
-- **Shepherd the PR (max 5 rounds).** Opening the PR is not the end. Watch CI
+- **Shepherd the PR (max 5 rounds).** Opening the PR is not the end. Start by
+  re-reading any **unsettled** findings the PR description defers to this
+  stage — they are open work, not a changelog; mark each one off in the body
+  as you settle it. Then watch CI
   (`gh pr checks <n> --watch`) and incoming bot/human reviews. When a check
   fails or a review lands findings, treat the findings as hypotheses: verify
   them against the code, fix only what's confirmed, explain rejections in a
   PR comment, push the fix commit, and watch again. **This is where
-  lower-priority findings are settled** — those deferred from the earlier
-  review stages plus anything the PR reviewers raise: fix, decline with
-  reasoning, or file as a follow-up issue, but do not leave them unaddressed.
+  lower-priority findings are settled** — those the PR description defers
+  here plus anything the PR reviewers raise: fix, decline with reasoning, or
+  file as a follow-up issue, but do not leave them unaddressed.
   Shepherd-round fixes must pass `task verify` before each push; the local
   challenge/review loops are not re-entered — the post-push cloud/bot review
   is the second-model check at this stage. This cap is independent of the
@@ -231,6 +235,36 @@ too — never suppress or ignore one — but carry them to the PR-shepherd stage
 rather than spending a local round on them. A P2 you judge worth fixing
 immediately may of course be fixed in place; it just does not hold the stage
 open.
+
+**Deferring P2s.** The handoff is the **PR description**: list every deferred
+P2 under a `## Deferred findings` heading as an unchecked task-list item —
+`- [ ] <file:line> — <finding>` — with enough detail to adjudicate it later.
+This is not bookkeeping: `task challenge` and `task review` run locally and
+their output is ephemeral, and the cloud reviewer reposts only high-priority
+findings, so a P2 that is not written into the PR body is simply lost.
+
+Record each one **the moment you defer it**. Challenge and review both run
+before `gh pr create`, so there is usually no PR body to write to yet: append
+it to the file `git rev-parse --git-path deferred-findings.md` names, and
+move the list into the description when you open the PR (then delete the
+file). Terminal scrollback is not a record — a context reset between
+`task challenge` and `gh pr create` would take the findings with it.
+
+That path is not arbitrary. It sits in the **git directory**, so it is
+deterministic (any later session in this checkout finds it the same way, and
+`git rev-parse` resolves it correctly inside a linked worktree) and invisible
+to `git status`. A note in the *worktree* would be worse than none:
+`codex-review.sh` reviews the uncommitted diff whenever the tree is dirty, so
+the note would become the next bare `task challenge`'s entire scope — and the
+change it was supposed to review would get a clean pass it never earned.
+
+The shepherd stage settles every entry and **edits the PR body to tick it**
+(`- [x] … — fixed in <sha>` / `declined: <reason>` / `filed as #<n>`) in the
+same round. The checkbox is the resolution state: an entry left unchecked is
+open work, so a later round — or a different session — can tell at a glance
+what it still owes without re-adjudicating what is done. That obligation is
+stated here and in the Dev Loop above, and holds whether or not the optional
+`/shepherd` skill is installed to automate it.
 
 **Loop cap and exit:** a stage exits only on a **clean re-run** — no
 confirmed P0 or P1 findings — never on "findings fixed" alone, with at most

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -257,6 +257,15 @@ move the list into the description when you open the PR (then delete the
 file). Terminal scrollback is not a record — a context reset between
 `task challenge` and `gh pr create` would take the findings with it.
 
+**Sweep for orphans when you open the PR.** List the whole tree —
+`ls -R "$(git rev-parse --git-path deferred-findings)"` — and account for
+every file it holds, not just your branch's. Renaming a branch (`git branch
+-m`) or deleting one strands its notes under the old name, where nothing will
+ever look for them again; a rename mid-change is exactly when that happens.
+Adopt an orphan into this PR if it belongs to this work, otherwise leave it
+and say it is there. Listing costs one command; migration logic would cost a
+mechanism that then needs its own correctness argument.
+
 That path is not arbitrary. It sits in the **git directory**, so it is
 deterministic (any later session in this checkout finds it the same way, and
 `git rev-parse` resolves it correctly inside a linked worktree) and invisible

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -245,7 +245,12 @@ findings, so a P2 that is not written into the PR body is simply lost.
 
 Record each one **the moment you defer it**. Challenge and review both run
 before `gh pr create`, so there is usually no PR body to write to yet: append
-it to the file `git rev-parse --git-path deferred-findings.md` names, and
+it to the file `git rev-parse --git-path deferred-findings.md` names — but
+only if that finding is not already listed. A stage exits on a *clean re-run*,
+so an unchanged P2 is reported again by design, in every remaining round and
+again by the next stage; appending blindly would hand the shepherd four copies
+of one finding to settle. Match on location plus substance, not exact
+wording — the same finding rarely comes back phrased identically. Then
 move the list into the description when you open the PR (then delete the
 file). Terminal scrollback is not a record — a context reset between
 `task challenge` and `gh pr create` would take the findings with it.

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -246,8 +246,9 @@ findings, so a P2 that is not written into the PR body is simply lost.
 Record each one **the moment you defer it**. Challenge and review both run
 before `gh pr create`, so there is usually no PR body to write to yet: append
 it to the file
-`git rev-parse --git-path "deferred-findings-$(git branch --show-current | tr / -).md"`
-names — but only if that finding is not already listed. A stage exits on a *clean re-run*,
+`git rev-parse --git-path "deferred-findings/$(git branch --show-current).md"`
+names (`mkdir -p` its directory first) — but only if that finding is not
+already listed. A stage exits on a *clean re-run*,
 so an unchanged P2 is reported again by design, in every remaining round and
 again by the next stage; appending blindly would hand the shepherd four copies
 of one finding to settle. Match on location plus substance, not exact
@@ -261,7 +262,9 @@ deterministic (any later session in this checkout finds it the same way, and
 `git rev-parse` resolves it correctly inside a linked worktree) and invisible
 to `git status`. It is keyed by **branch** because an ordinary clone switches
 branches in place: with one shared file, opening branch B's PR would sweep up
-branch A's findings and then delete A's only copy of them. A note in the *worktree* would be worse than none:
+branch A's findings and then delete A's only copy of them. The branch name
+becomes a *path*, not a flattened string — folding `/` to `-` would collide
+`feat/x` with `feat-x` and reintroduce exactly that loss. A note in the *worktree* would be worse than none:
 `codex-review.sh` reviews the uncommitted diff whenever the tree is dirty, so
 the note would become the next bare `task challenge`'s entire scope — and the
 change it was supposed to review would get a clean pass it never earned.

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -112,25 +112,32 @@ something to ask permission for.
 - **`task challenge`** — adversarial second-model review. Adjudicate per
   "Second-Model Review" below, fix confirmed findings, re-run `task verify`,
   then **re-run `task challenge`**. The stage passes only when a re-run comes
-  back with **no material findings** — fixing the findings is not the exit
-  condition, a clean pass is. Max **5** challenge → fix → re-challenge
-  rounds; if findings persist, stop and escalate to the maintainer.
+  back with **no confirmed P0 or P1 findings** — fixing the findings is not
+  the exit condition, a clean pass is. **P2s do not gate this stage**: record
+  them and carry them to the PR. Max **6** challenge → fix → re-challenge
+  rounds; if P0/P1 findings persist, stop and escalate to the maintainer.
 - **`task review`** — verification-checkpoint review; same adjudication and
-  same clean-pass exit condition, with its own max **4** rounds.
+  same P0/P1 clean-pass exit condition, with its own max **6** rounds.
 [% endif %]
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
   a clear what/why/verification summary.
-- **Shepherd the PR (max 4 rounds).** Opening the PR is not the end. Watch CI
+- **Shepherd the PR (max 5 rounds).** Opening the PR is not the end. Watch CI
   (`gh pr checks <n> --watch`) and incoming bot/human reviews. When a check
   fails or a review lands findings, treat the findings as hypotheses: verify
   them against the code, fix only what's confirmed, explain rejections in a
-  PR comment, push the fix commit, and watch again. Shepherd-round fixes
-  must pass `task verify` before each push; the local challenge/review loops
-  are not re-entered — the post-push cloud/bot review is the second-model
-  check at this stage. This cap is independent of the other loop caps. If
-  checks still fail or material findings remain after 4 rounds, stop and
-  summarize what's unresolved on the PR for the maintainer.
+  PR comment, push the fix commit, and watch again. **This is where
+  lower-priority findings are settled** — those deferred from the earlier
+  review stages plus anything the PR reviewers raise: fix, decline with
+  reasoning, or file as a follow-up issue, but do not leave them unaddressed.
+  Shepherd-round fixes must pass `task verify` before each push; the local
+  challenge/review loops are not re-entered — the post-push cloud/bot review
+  is the second-model check at this stage. This cap is independent of the
+  other loop caps. If checks still fail or findings remain after 5 rounds,
+  stop and summarize what's unresolved on the PR for the maintainer. Where a
+  **vendored** skill (`/shepherd`) states a different cap or exit condition,
+  **this file wins** — vendored skills are synced on their own release
+  cadence and can lag a policy change made here.
 - **Stop at green.** Report that checks pass, then stop — merging is always a
   human decision.
 
@@ -209,15 +216,32 @@ never resolves means the cloud run failed.
    appropriate.
 4. Explain why any rejected finding is incorrect or irrelevant.
 5. Re-run `task verify` (and the other relevant gates) after fixes.
-6. Finish with a concise adjudication table: finding → classification →
-   evidence → action taken.
+6. Finish with a concise adjudication table: finding → priority →
+   classification → evidence → action taken.
 
-**Loop cap and exit:** a stage exits only on a **clean re-run** (no material
-findings) — never on "findings fixed" alone — with at most **5** challenge
-iterations and **4** review iterations (challenge → fix → re-challenge, and
-likewise for review). If material disagreement persists at the cap, stop and
-surface it to the
-maintainer instead of iterating further.
+**Severity gating.** Both tasks ask Codex to label every finding `P0`
+(breaks correctness, security, or data integrity in ordinary use, or breaks
+an existing contract), `P1` (a real defect or materially wrong design
+decision with a plausible trigger), or `P2` (worth knowing, not
+merge-blocking: hardening, unlikely edge cases, maintainability, non-critical
+test gaps). The scale is defined in `scripts/codex-review.sh`, not inherited
+from the Codex CLI's own labels, so the gate keeps its meaning if Codex
+changes its output. **Only P0 and P1 gate the local loops.** Adjudicate P2s
+too — never suppress or ignore one — but carry them to the PR-shepherd stage
+rather than spending a local round on them. A P2 you judge worth fixing
+immediately may of course be fixed in place; it just does not hold the stage
+open.
+
+**Loop cap and exit:** a stage exits only on a **clean re-run** — no
+confirmed P0 or P1 findings — never on "findings fixed" alone, with at most
+**6** challenge iterations and **6** review iterations (challenge → fix →
+re-challenge, and likewise for review). If P0/P1 disagreement persists at the
+cap, stop and surface it to the maintainer instead of iterating further.
+
+One caveat on the automatic stop-gate: the codex plugin's Stop hook applies
+its **own** notion of a material finding and may BLOCK on something you have
+classified P2. Adjudicate it (fix it, or state the reasoning) — **never**
+disable the gate to get past a BLOCK.
 
 [% endif %]
 ## Conventions

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -245,8 +245,9 @@ findings, so a P2 that is not written into the PR body is simply lost.
 
 Record each one **the moment you defer it**. Challenge and review both run
 before `gh pr create`, so there is usually no PR body to write to yet: append
-it to the file `git rev-parse --git-path deferred-findings.md` names — but
-only if that finding is not already listed. A stage exits on a *clean re-run*,
+it to the file
+`git rev-parse --git-path "deferred-findings-$(git branch --show-current | tr / -).md"`
+names — but only if that finding is not already listed. A stage exits on a *clean re-run*,
 so an unchanged P2 is reported again by design, in every remaining round and
 again by the next stage; appending blindly would hand the shepherd four copies
 of one finding to settle. Match on location plus substance, not exact
@@ -258,7 +259,9 @@ file). Terminal scrollback is not a record — a context reset between
 That path is not arbitrary. It sits in the **git directory**, so it is
 deterministic (any later session in this checkout finds it the same way, and
 `git rev-parse` resolves it correctly inside a linked worktree) and invisible
-to `git status`. A note in the *worktree* would be worse than none:
+to `git status`. It is keyed by **branch** because an ordinary clone switches
+branches in place: with one shared file, opening branch B's PR would sweep up
+branch A's findings and then delete A's only copy of them. A note in the *worktree* would be worse than none:
 `codex-review.sh` reviews the uncommitted diff whenever the tree is dirty, so
 the note would become the next bare `task challenge`'s entire scope — and the
 change it was supposed to review would get a clean pass it never earned.

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -246,7 +246,7 @@ findings, so a P2 that is not written into the PR body is simply lost.
 Record each one **the moment you defer it**. Challenge and review both run
 before `gh pr create`, so there is usually no PR body to write to yet: append
 it to the file
-`git rev-parse --git-path "deferred-findings/$(git branch --show-current).md"`
+`git rev-parse --git-path "deferred-findings/$(git branch --show-current)"`
 names (`mkdir -p` its directory first) — but only if that finding is not
 already listed. A stage exits on a *clean re-run*,
 so an unchanged P2 is reported again by design, in every remaining round and
@@ -263,8 +263,11 @@ deterministic (any later session in this checkout finds it the same way, and
 to `git status`. It is keyed by **branch** because an ordinary clone switches
 branches in place: with one shared file, opening branch B's PR would sweep up
 branch A's findings and then delete A's only copy of them. The branch name
-becomes a *path*, not a flattened string — folding `/` to `-` would collide
-`feat/x` with `feat-x` and reintroduce exactly that loss. A note in the *worktree* would be worse than none:
+becomes a *path*, verbatim and without a suffix — folding `/` to `-` would
+collide `feat/x` with `feat-x` and reintroduce exactly that loss, and adding
+an extension would make `foo` (a file) block `foo.md/bar` (needing a
+directory). Used as-is, the mapping is git's own ref namespace, and git
+already forbids one live branch from being a path prefix of another. A note in the *worktree* would be worse than none:
 `codex-review.sh` reviews the uncommitted diff whenever the tree is dirty, so
 the note would become the next bare `task challenge`'s entire scope — and the
 change it was supposed to review would get a clean pass it never earned.

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -138,6 +138,44 @@ to the PR-shepherd stage, where they are fixed, declined with reasoning, or
 filed as follow-up issues. That keeps the expensive local loops focused on
 what actually blocks a merge, without losing the smaller findings.
 
+The deferral needs somewhere to land. These tasks run **locally** — their
+output lives in a terminal and nowhere else — and the cloud reviewer reposts
+only high-priority findings, so a deferred P2 that is not written down is
+gone. Write each one into the **PR description** under a
+`## Deferred findings` heading, as an unchecked task-list item:
+
+```markdown
+## Deferred findings
+
+- [ ] scripts/foo.sh:42 — P2: retry loop has no upper bound
+```
+
+Both tasks run before `gh pr create`, so write each finding down the moment
+you defer it, in the git directory rather than the worktree:
+
+```bash
+cat >>"$(git rev-parse --git-path deferred-findings.md)" <<'DEFERRED'
+- [ ] scripts/foo.sh:42 — P2: retry loop has no upper bound
+DEFERRED
+```
+
+The **quoted** heredoc delimiter is load-bearing: findings routinely quote
+code with backticks or `$(…)`, and inside a double-quoted string the shell
+would run it. Quoting disables expansion, not termination — so pick a
+delimiter the finding text cannot contain.
+
+Move the list into the PR description when you open the PR, then delete the
+file. The location is deterministic, so a later session finds it the same
+way, and `git status` never sees it — a note left in the *worktree* would be
+worse than none, because a dirty tree makes the next bare `task challenge`
+review the note instead of the branch.
+
+The shepherd stage settles every entry and ticks it off in the body as it
+goes, so the checkbox — not anyone's memory — is what says whether a finding
+is still open. The PR is not green while an unchecked entry remains.
+AGENTS.md ("Dev Loop") carries that obligation, so it holds even where the
+optional `/shepherd` skill that automates it is not installed.
+
 Note that the automatic stop-gate is not on this scale — the plugin's Stop
 hook uses its own notion of a material finding and may BLOCK on a P2.
 Adjudicate it; never disable the gate to get past a BLOCK.

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -104,11 +104,11 @@ release plumbing), disable it for routine development.
 task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
-                # until a CLEAN pass (no material findings), ≤5 rounds
-task review     # verification checkpoint — same clean-pass exit, ≤4 rounds
+                # until a CLEAN pass (no P0/P1 findings), ≤6 rounds
+task review     # verification checkpoint — same clean-pass exit, ≤6 rounds
 task ci         # full CI mirror
-# → open the PR, then shepherd it: watch CI + reviews, adjudicate → fix →
-#   push, ≤4 rounds (independent of the loops above)
+# → open the PR, then shepherd it: watch CI + reviews, settle the deferred
+#   P2s, adjudicate → fix → push, ≤5 rounds (independent of the loops above)
 # → merging stays a human decision
 ```
 
@@ -116,6 +116,31 @@ The full staged loop — including the PR-shepherding rounds — is defined in
 AGENTS.md ("Dev Loop"). If Codex cloud review is connected to the repo, PRs
 get a cloud pass too: inline comments only for high-priority findings, a
 bare 👍 reaction as the clean pass.
+
+## Finding priorities
+
+Both modes ask Codex to label every finding, and the local loops gate on that
+label:
+
+| Priority | Meaning | Gates `challenge`/`review`? |
+| --- | --- | --- |
+| `P0` | Breaks correctness, security, or data integrity in ordinary use, or breaks an existing contract | Yes |
+| `P1` | A real defect or materially wrong design decision with a plausible trigger | Yes |
+| `P2` | Worth knowing, not merge-blocking: hardening, unlikely edge cases, maintainability, non-critical test gaps | No |
+
+The scale lives in the prompt that `scripts/codex-review.sh` builds — not in
+the Codex CLI's own priority labels, which are an undocumented convention
+that can change. Keeping the definition local means the gate still means what
+it says when Codex's output format moves.
+
+P2s are **reported, adjudicated, and deferred**, never suppressed: they carry
+to the PR-shepherd stage, where they are fixed, declined with reasoning, or
+filed as follow-up issues. That keeps the expensive local loops focused on
+what actually blocks a merge, without losing the smaller findings.
+
+Note that the automatic stop-gate is not on this scale — the plugin's Stop
+hook uses its own notion of a material finding and may BLOCK on a P2.
+Adjudicate it; never disable the gate to get past a BLOCK.
 
 ## Troubleshooting
 

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -155,7 +155,8 @@ you defer it, in the git directory rather than the worktree:
 
 ```bash
 note="$(git rev-parse --git-path \
-  "deferred-findings-$(git branch --show-current | tr / -).md")"
+  "deferred-findings/$(git branch --show-current).md")"
+mkdir -p "$(dirname "$note")"
 cat >>"$note" <<'DEFERRED'
 - [ ] scripts/foo.sh:42 — P2: retry loop has no upper bound
 DEFERRED
@@ -163,7 +164,8 @@ DEFERRED
 
 One file **per branch**: an ordinary clone switches branches in place, so a
 single shared sidecar would let branch B's PR absorb branch A's findings — and
-then delete A's only copy when it clears the file.
+then delete A's only copy when it clears the file. The branch name is used as
+a path rather than flattened, so `feat/x` and `feat-x` stay distinct.
 
 The **quoted** heredoc delimiter is load-bearing: findings routinely quote
 code with backticks or `$(…)`, and inside a double-quoted string the shell

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -155,7 +155,7 @@ you defer it, in the git directory rather than the worktree:
 
 ```bash
 note="$(git rev-parse --git-path \
-  "deferred-findings/$(git branch --show-current).md")"
+  "deferred-findings/$(git branch --show-current)")"
 mkdir -p "$(dirname "$note")"
 cat >>"$note" <<'DEFERRED'
 - [ ] scripts/foo.sh:42 — P2: retry loop has no upper bound
@@ -165,7 +165,10 @@ DEFERRED
 One file **per branch**: an ordinary clone switches branches in place, so a
 single shared sidecar would let branch B's PR absorb branch A's findings — and
 then delete A's only copy when it clears the file. The branch name is used as
-a path rather than flattened, so `feat/x` and `feat-x` stay distinct.
+a path rather than flattened, so `feat/x` and `feat-x` stay distinct — and
+without an extension, so `foo` cannot block `foo.md/bar`. That makes the
+sidecar tree mirror git's ref namespace, which already forbids one live
+branch from being a path prefix of another.
 
 The **quoted** heredoc delimiter is load-bearing: findings routinely quote
 code with backticks or `$(…)`, and inside a double-quoted string the shell

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -164,6 +164,10 @@ code with backticks or `$(…)`, and inside a double-quoted string the shell
 would run it. Quoting disables expansion, not termination — so pick a
 delimiter the finding text cannot contain.
 
+Check the file before appending: a stage only exits on a *clean re-run*, so an
+unchanged P2 comes back every remaining round and again in the next stage. Add
+it once, matching on location and substance rather than exact wording.
+
 Move the list into the PR description when you open the PR, then delete the
 file. The location is deterministic, so a later session finds it the same
 way, and `git status` never sees it — a note left in the *worktree* would be

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -154,10 +154,16 @@ Both tasks run before `gh pr create`, so write each finding down the moment
 you defer it, in the git directory rather than the worktree:
 
 ```bash
-cat >>"$(git rev-parse --git-path deferred-findings.md)" <<'DEFERRED'
+note="$(git rev-parse --git-path \
+  "deferred-findings-$(git branch --show-current | tr / -).md")"
+cat >>"$note" <<'DEFERRED'
 - [ ] scripts/foo.sh:42 — P2: retry loop has no upper bound
 DEFERRED
 ```
+
+One file **per branch**: an ordinary clone switches branches in place, so a
+single shared sidecar would let branch B's PR absorb branch A's findings — and
+then delete A's only copy when it clears the file.
 
 The **quoted** heredoc delimiter is load-bearing: findings routinely quote
 code with backticks or `$(…)`, and inside a double-quoted string the shell

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -180,7 +180,17 @@ unchanged P2 comes back every remaining round and again in the next stage. Add
 it once, matching on location and substance rather than exact wording.
 
 Move the list into the PR description when you open the PR, then delete the
-file. The location is deterministic, so a later session finds it the same
+file — and sweep the tree for strays while you are there:
+
+```bash
+ls -R "$(git rev-parse --git-path deferred-findings)"
+```
+
+Renaming or deleting a branch strands its notes under the old name, where
+nothing looks for them again. Account for every file the sweep shows: adopt an
+orphan if it belongs to this work, otherwise leave it and mention it. One
+command beats rename-migration logic that would need its own correctness
+argument. The location is deterministic, so a later session finds it the same
 way, and `git status` never sees it — a note left in the *worktree* would be
 worse than none, because a dirty tree makes the next bare `task challenge`
 review the note instead of the branch.

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -199,8 +199,10 @@ Label EVERY finding with a priority, as the first token of the finding:
 Only P0 and P1 decide whether this review passes. Still report P2s in full —
 they are triaged later, once the pull request is open — but do not let them
 hold the stage open. Do not inflate a P2 to P1 to make it heard, and do not
-withhold or soften a P2 because it is non-gating. If there are no P0 or P1
-findings, say so explicitly and in those terms."
+withhold or soften a P2 because it is non-gating: a P2 reported here is
+carried into the pull request description, so an unreported one is lost
+outright. If there are no P0 or P1 findings, say so explicitly and in those
+terms."
 
 if [ -n "$focus" ]; then
     instructions="${instructions}

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -18,7 +18,9 @@
 # so the resolved scope is written INTO the instructions instead.
 # Codex reviews read-only; findings are advisory hypotheses for the primary
 # agent/human to adjudicate (AGENTS.md "Second-Model Review") — this is never
-# part of `verify`/`ci`. Requires an authenticated Codex CLI (`codex login`);
+# part of `verify`/`ci`. Both modes ask for P0/P1/P2-labelled findings; only
+# P0/P1 gate the local loop, P2s are reported and deferred to the PR stage.
+# Requires an authenticated Codex CLI (`codex login`);
 # see docs/guides/codex-review.md.
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -178,6 +180,27 @@ tests for anything it fixes). Flag docs the change should have updated.
 Report only material, defensible findings tied to concrete files and lines —
 no style nits. If the change holds up, say so directly."
 fi
+
+# Severity is defined HERE rather than inherited from the Codex CLI's own
+# review output: its priority labels are an undocumented convention that can
+# change under us, and the local dev loop gates on this scale (AGENTS.md
+# "Second-Model Review"). Stating it in the prompt keeps the gate meaningful.
+instructions="${instructions}
+
+Label EVERY finding with a priority, as the first token of the finding:
+
+  P0 — a defect that breaks correctness, security, or data integrity in
+       ordinary use, or that breaks an existing contract. Merge-blocking.
+  P1 — a real defect or materially wrong design decision with a plausible
+       trigger. Merge-blocking unless argued down with evidence.
+  P2 — worth knowing, but not merge-blocking: hardening, edge cases behind
+       unlikely preconditions, maintainability, non-critical test gaps.
+
+Only P0 and P1 decide whether this review passes. Still report P2s in full —
+they are triaged later, once the pull request is open — but do not let them
+hold the stage open. Do not inflate a P2 to P1 to make it heard, and do not
+withhold or soften a P2 because it is non-gating. If there are no P0 or P1
+findings, say so explicitly and in those terms."
 
 if [ -n "$focus" ]; then
     instructions="${instructions}

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -70,6 +70,10 @@ echo "$out" | grep -q "STUB-ARGS:exec review" || fail "codex exec review not inv
 echo "$out" | grep -q "base branch 'origin/develop'" || fail "remote-qualified fallback base missing: $out"
 echo "$out" | grep -q "ADVERSARIAL" || fail "challenge mode instructions missing: $out"
 echo "$out" | grep -q "feature.txt" || fail "changed-file manifest missing from branch-scope prompt: $out"
+# The gate is only meaningful if the scale it gates on is defined in the
+# prompt — Codex's own priority labels are an undocumented convention.
+echo "$out" | grep -q "Only P0 and P1 decide" || fail "challenge prompt missing the P0/P1 gating rule: $out"
+echo "$out" | grep -q "Still report P2s" || fail "challenge prompt missing the report-P2s instruction: $out"
 
 echo "==> origin/HEAD outranks a stray local main"
 git branch -q main "$(git rev-list --max-parents=0 HEAD)"
@@ -90,6 +94,7 @@ out="$(run review --base origin/develop watch the hooks)" || fail "review --base
 echo "$out" | grep -q "base branch 'origin/develop'" || fail "--base not honored: $out"
 echo "$out" | grep -q "VERIFICATION-CHECKPOINT" || fail "review mode instructions missing: $out"
 echo "$out" | grep -q "watch the hooks" || fail "focus text missing from prompt: $out"
+echo "$out" | grep -q "Only P0 and P1 decide" || fail "review prompt missing the P0/P1 gating rule: $out"
 
 echo "==> dirty tree auto-selects uncommitted scope and enumerates untracked dirs"
 echo x >dirty.txt

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -74,6 +74,9 @@ echo "$out" | grep -q "feature.txt" || fail "changed-file manifest missing from 
 # prompt — Codex's own priority labels are an undocumented convention.
 echo "$out" | grep -q "Only P0 and P1 decide" || fail "challenge prompt missing the P0/P1 gating rule: $out"
 echo "$out" | grep -q "Still report P2s" || fail "challenge prompt missing the report-P2s instruction: $out"
+# An unreported P2 never reaches the PR body, so the handoff clause is what
+# makes "reported but non-gating" different from "ignored".
+echo "$out" | grep -q "carried into the pull request description" || fail "challenge prompt missing the P2 handoff clause: $out"
 
 echo "==> origin/HEAD outranks a stray local main"
 git branch -q main "$(git rev-list --max-parents=0 HEAD)"
@@ -95,6 +98,7 @@ echo "$out" | grep -q "base branch 'origin/develop'" || fail "--base not honored
 echo "$out" | grep -q "VERIFICATION-CHECKPOINT" || fail "review mode instructions missing: $out"
 echo "$out" | grep -q "watch the hooks" || fail "focus text missing from prompt: $out"
 echo "$out" | grep -q "Only P0 and P1 decide" || fail "review prompt missing the P0/P1 gating rule: $out"
+echo "$out" | grep -q "carried into the pull request description" || fail "review prompt missing the P2 handoff clause: $out"
 
 echo "==> dirty tree auto-selects uncommitted scope and enumerates untracked dirs"
 echo x >dirty.txt


### PR DESCRIPTION
Closes #376

## What

The local second-model loops (`task challenge` / `task review`) treated every
"material finding" as blocking, so a P2 nit could hold a stage open for a full
adjudicate → fix → re-run round. This focuses those loops on merge-blockers.

- **Both Codex modes now ask for `P0`/`P1`/`P2`-labelled findings**, and only
  P0/P1 decide whether a stage passes. P2s are still reported and adjudicated
  in full — the prompt explicitly forbids withholding or softening one — but
  they carry to the PR-shepherd stage instead of costing a local round.
- **Caps move**: challenge 5 → **6**, review 4 → **6**, shepherd 4 → **5**
  (the stage that now absorbs the deferred P2s).
- **The severity scale is defined in the prompt** that `scripts/codex-review.sh`
  builds, not inherited from the Codex CLI's own priority labels. Those labels
  are an undocumented convention; a gate keyed on them would quietly stop
  meaning what it says if the output format changed.
- **AGENTS.md now outranks a vendored skill's round caps** where they differ.

## Why the precedence rule

`.claude/skills/shepherd/SKILL.md` is vendored from harmon-devkit (`v0.10.0`)
and still states 4 rounds with a "material findings" exit — it cannot be edited
here, only upstream. The adversarial review caught the resulting contradiction
as a P1. A companion harmon-devkit PR follows; until it releases and the pin
bumps, the precedence rule keeps the interim unambiguous instead of leaving two
live documents in conflict.

## Files

Two-layer twins, edited in lockstep:

| Root | Template twin | Gate |
| --- | --- | --- |
| `scripts/codex-review.sh` | verbatim | `test:dogfood-parity` |
| `scripts/test-codex-review.sh` | verbatim | `test:dogfood-parity` |
| `docs/guides/codex-review.md` | verbatim | `test:dogfood-parity` |
| `AGENTS.md` | `template/AGENTS.md.jinja` | `test:dogfood-structure` |

The template's shepherd bullet says "lower-priority findings" rather than "P2s"
because that bullet sits outside the `use_codex_review` conditional and must
read correctly for repos generated without Codex.

## Verification

- `task verify` — green (exit 0)
- `task ci` — green (exit 0); Semgrep 173 rules / 210 files, 0 findings
- `scripts/test-codex-review.sh` — 18 cases pass, including three new
  assertions that both modes carry the gating rule into the prompt
- `task test:dogfood-parity` — 105 verbatim twins identical
- `task test:dogfood-structure` — 198 rendered sections present in the root
- `task challenge` — round 1 found the P1 above (fixed); **round 2 clean**
- `task review` — **clean**, no P0/P1 and no material P2
- `PR_TITLE=… BASE_SHA=main task guard:release-title` — releasing type ok

Both Codex stages used the new P0/P1/P2 vocabulary in their verdicts, which
exercises the prompt change end to end.

## Deferred findings

Non-gating P2s, recorded here per the policy this PR introduces. The devkit
items belong to the companion PR (harmon-devkit#164) and are tracked there too.

- [x] `docs/guides/codex-review.md` — in a non-worktree clone the sidecar path
  was repo-global, so switching branches before the first PR mixed two
  branches' findings — and worse, opening B's PR would delete A's only copy.
  **Fixed in 98b7bc1**: the sidecar is keyed by branch.
- [x] `.claude/skills/shepherd/SKILL.md` still states 4 rounds and "material
  findings" — **declined**: it is vendored from harmon-devkit and cannot be
  edited here. harmon-devkit#164 fixes it; the AGENTS.md precedence rule added
  in this PR makes AGENTS.md authoritative in the meantime.

- [x] `docs/guides/codex-review.md` — renaming a branch after deferring a P2
  but before opening its PR orphans that branch's sidecar. **Fixed in 73a1f7e**
  (decline reversed): opening the PR now sweeps
  `ls -R "$(git rev-parse --git-path deferred-findings)"` and accounts for
  every file, not just the current branch's. Discovery, not migration.
- [x] Sidecar survives a *deleted* branch and could collide with a later
  prefix-shaped branch name. **Fixed in 73a1f7e** by the same sweep — the
  stranded note is surfaced rather than sitting there invisibly. The narrow
  collision itself remains possible; the finding-loss risk does not.

## Review log

Six challenge rounds and three review rounds, each finding exposed by fixing
the previous one:

| Stage | Finding | Outcome |
| --- | --- | --- |
| challenge 1 | P1 — vendored `/shepherd` contradicts the new caps | precedence rule |
| challenge 3 | P1 — nothing carried a deferred P2 to the PR | `## Deferred findings` handoff |
| challenge 3 | P1 — prose assumed `/shepherd` reads the PR body | obligation moved into AGENTS.md |
| challenge 4 | P1 — entries had no resolution state | task-list checkboxes |
| challenge 5 | P1 — no record existed before the PR did | sidecar written at deferral time |
| challenge 6 | P1 — a note in the worktree hijacks the next review scope | sidecar lives in the git dir |
| review 1 | P1 — "outside the worktree" was not discoverable | `git rev-parse --git-path` |
| review 2 | P1 — documented `echo "…"` executes finding text | quoted heredoc |
| challenge 6, review 3 | **clean** | — |

The scope-hijack one is the sharpest: `codex-review.sh:118-122` selects the
uncommitted diff on a dirty tree, so an untracked note would have become the
entire scope of the next `task challenge` — handing the real change a clean
pass it never earned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




