### PR TITLE
feat: seed Domain and Layer across the GitHub issue-field, project-field, and label taxonomy

### DIFF
--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -147,9 +147,12 @@ this comment. -->
       `evanharmon1 Project`) and idempotently sync its `Status` pipeline and
       `Size` number field — see
       [project-management.md](project-management.md).
-      On a personal account it also creates Priority/Product/Agent/Size as
-      project fields (issue fields are org-only); status automation is a separate
-      follow-up — the board is set up, but issue/PR status isn't auto-synced yet.
+      On a personal account it also creates Priority/Product/Agent/Domain/Layer/
+      Size as project fields (issue fields are org-only); status automation is a
+      separate follow-up — the board is set up, but issue/PR status isn't
+      auto-synced yet. `Domain` is seeded with `auth`/`billing`/`platform` only —
+      add this product's real domains in the Project UI, and matching `domain:`
+      labels in `scripts/setup-github-labels.sh`.
 - [ ] Labels: run `task setup:github-labels` to seed this repo's starter label
       families (concerns/source/workflow/layer/domain — see
       [project-management.md](project-management.md)). Labels are per-repo, so run

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -179,9 +179,34 @@ The work-metadata fields:
 - **Product** — which product/area it belongs to (free text)
 - **Agent** — which agent should implement it (Claude Code, Codex, Gemini CLI,
   Qwen Code, DeepSeek, Kimi K2, GLM, GitHub Copilot) and how (effort level, model)
+- **Domain** — which part of the *product* it belongs to. Ships as a starter
+  single-select (`auth`, `billing`, `platform`); the real vocabulary comes from
+  your ERD entities — add options as the product grows
+- **Layer** — which slice of the *stack* it changes: `ui` (components, styling,
+  interaction, tokens, a11y — no data change), `logic` (business rules,
+  handlers, calculation), `data` (schema, indexes, validators, migrations),
+  `integration` (external boundary: webhooks, API clients, credentials)
+
+Domain and Layer are orthogonal to each other and to `Type`/`Status`: an issue
+normally carries one of each — *what part of the product* × *what slice of the
+stack*. They ship with the same option lists as the `domain:` / `layer:` label
+families below, so both surfaces start from one vocabulary — but nothing keeps
+them in step afterwards. Two things to know before you extend either:
+
+- **Nothing syncs an individual issue's label to its field value**, so an issue
+  can carry `domain:auth` and `Domain=billing` at once. **Pick one surface as the
+  source of truth** — the fields if you work the board, the labels if you live in
+  `gh issue list` — and treat the other as optional. Dual-entering both by hand is
+  how they end up contradicting each other.
+- **Adding a starter value is not symmetric.** `task setup:github-labels` creates
+  *or updates*, so a new starter label lands on a re-run; the field scripts only
+  create a field that is **missing** and never touch an existing one's options. So
+  when you (or a later harmon-init release) add a value, add the field option by
+  hand in the org's issue-field settings / the Project UI. That is deliberate —
+  it's what keeps your own customizations safe from a re-run.
 
 On a personal account there are no issue fields, so `task setup:github-project`
-creates **Priority, Product, Agent, and Size** as project fields.
+creates **Priority, Product, Agent, Domain, Layer, and Size** as project fields.
 
 TODO: finalize each field's options/values.
 
@@ -197,15 +222,23 @@ families, color-coded by family; the starter set is created by
 - **Workflow** — `needs-triage`, `needs-requirements`, `blocked`, `waiting`,
   `needs-decision`, `needs-response`, `needs-communication` (transient triage
   states; `blocked` is the non-issue-blocker flag described above)
-- **Layer** — `layer:frontend`, `layer:backend`, `layer:infra`, …
-- **Domain** — start with `domain:auth`, `domain:billing`; grow from your ERD
-  entities
+- **Layer** — `layer:ui`, `layer:logic`, `layer:data`, `layer:integration`
+- **Domain** — start with `domain:auth`, `domain:billing`, `domain:platform`;
+  grow from your ERD entities
+
+The `layer:` and `domain:` families offer the same options as the **Layer** and
+**Domain** fields above — same names, same meanings, but no per-issue sync (see
+Fields). Use the label when you want it on the issue list and in
+`gh issue list --label`, the field when you want to group a board view by it, and
+extend both together so the option sets stay identical.
 
 GitHub labels live per-repository (there's no shared org label pool).
 `setup-github-labels` seeds the set into one repo — run it in each, or set the
 org's **default labels** (org Settings → Repository, UI-only) to seed *new* repos
 (it won't change existing ones). It never deletes labels, so GitHub's defaults
-remain until you prune them.
+remain until you prune them — including a pre-`ui`/`logic`/`data`/`integration`
+repo's `layer:frontend`, `layer:backend`, and `layer:infra`, which you re-map and
+delete by hand.
 
 ## Milestones
 
@@ -427,7 +460,8 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   expect rough edges.
 - **Slice the board** — rather than separate per-product / per-layer / per-agent
   saved views, slice the one board: by **`Product`** when you go multi-product, by
-  **`layer:`** to focus a system layer, by **`Agent`** to see the split. One
+  **`Domain`** to focus a product area, by **`Layer`** to focus a slice of the
+  stack, by **`Agent`** to see the split. One
   board, many lenses — and how multiple products stay legible in one aggregating
   project instead of fragmenting into project-per-product.
 

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -3,11 +3,19 @@
 # set (docs/project-management.md). Colors are grouped by family (concerns=purple,
 # source=pink, workflow=orange, layer=blue, domain=yellow).
 #
+# The `layer:` and `domain:` families deliberately mirror the Layer and Domain
+# single-select fields created by setup-github-issue-fields.sh (org) /
+# setup-github-project.sh (personal account) — same vocabulary, so a label and a
+# field value never disagree. Keep the three lists in step when you extend them.
+#
 # Labels are REPO-level in GitHub — there's no shared org label pool. Run this in
 # each repo; org "default labels" (Settings → Repository, UI-only, no API) only
 # seed NEW repos and don't touch existing ones. Non-destructive: `--force`
 # creates-or-updates and it never deletes labels, so GitHub's defaults stay unless
-# you prune them yourself.
+# you prune them yourself. That cuts both ways: a repo seeded before the layer
+# family became ui/logic/data/integration keeps its old `layer:frontend`,
+# `layer:backend`, and `layer:infra` labels — re-map the issues and delete those
+# three by hand if you want the one vocabulary.
 #
 # Usage: setup-github-labels.sh --repo <owner/repo>
 # Needs: gh authed with repo write.
@@ -57,11 +65,13 @@ waiting|E36209|Waiting on an external party
 needs-decision|E36209|Needs a decision before it can proceed
 needs-response|E36209|Awaiting a response
 needs-communication|E36209|An update needs to be communicated out
-layer:frontend|1D76DB|Frontend
-layer:backend|1D76DB|Backend
-layer:infra|1D76DB|Infrastructure
+layer:ui|1D76DB|Components, styling, interaction, tokens, a11y. No data change
+layer:logic|1D76DB|Business rules, handlers, calculation
+layer:data|1D76DB|Schema, indexes, validators, migrations
+layer:integration|1D76DB|External boundary: webhooks, API clients, credentials
 domain:auth|FBCA04|Authentication and authorization
 domain:billing|FBCA04|Billing and payments
+domain:platform|FBCA04|CI, build, test infra, and tooling in this repo
 "
 
 printf '%s\n' "$labels" | while IFS='|' read -r name color desc; do

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -6,9 +6,9 @@
 # because only project number fields sum in view group headers (issue-field
 # columns can group/filter/sort, not sum). The other metadata on an ORGANIZATION
 # are org-level ISSUE fields (Priority/Effort are GitHub built-ins, left at
-# their defaults; setup-github-issue-fields.sh adds Product + Agent); on a
-# personal account (no org issue fields) this script creates
-# Priority/Product/Agent as project fields too.
+# their defaults; setup-github-issue-fields.sh adds Product, Agent, Domain, and
+# Layer); on a personal account (no org issue fields) this script creates
+# Priority/Product/Agent/Domain/Layer as project fields too.
 #
 # Safe to re-run and safe to run from every repo the owner controls: it looks the
 # project up by title, so the first run creates it and later runs just reconcile
@@ -142,12 +142,46 @@ else
 fi
 
 # ── Snapshot current fields (one read; reused for existence checks) ──
-fields_json=$(gh api graphql -f query='query($p:ID!){node(id:$p){... on ProjectV2{fields(first:50){nodes{... on ProjectV2FieldCommon{id name} ... on ProjectV2SingleSelectField{options{name color description}}}}}}}' \
+fields_json=$(gh api graphql -f query='query($p:ID!){node(id:$p){... on ProjectV2{fields(first:50){nodes{... on ProjectV2FieldCommon{id name dataType} ... on ProjectV2SingleSelectField{options{name color description}}}}}}}' \
     -f p="$project_id")
 
 field_id() {
     printf '%s' "$fields_json" |
         jq -r --arg n "$1" '.data.node.fields.nodes[] | select(.name==$n) | .id' | head -n1
+}
+
+field_type() {
+    printf '%s' "$fields_json" |
+        jq -r --arg n "$1" '.data.node.fields.nodes[] | select(.name==$n) | .dataType' | head -n1
+}
+
+# A reused project may already carry a field with one of these names — of the
+# wrong data type. GitHub cannot change a project field's data type in place, so
+# its intended options are unavailable until it is renamed or deleted. Warn (and
+# repeat it in the summary) rather than exit non-zero: this script is a
+# create-if-missing reconciler that never edits what the owner already has, and
+# one pre-existing field is no reason to abort the rest.
+incompatible=""
+
+# field_exists NAME EXPECTED_DATATYPE — 0 when a field of that name is already
+# there (so the caller skips creation), recording a data-type mismatch on the way.
+field_exists() {
+    [ -n "$(field_id "$1")" ] || return 1
+    etype="$(field_type "$1")"
+    if [ -n "$etype" ] && [ "$etype" != "null" ] && [ "$etype" != "$2" ]; then
+        echo "    WARNING: field '$1' already exists as $etype, not $2 — its intended options are NOT available" >&2
+        incompatible="${incompatible}${incompatible:+, }$1 (is $etype, wanted $2)"
+    else
+        echo "    Field '$1' already exists — leaving it as-is"
+    fi
+    return 0
+}
+
+report_incompatible() {
+    [ -n "$incompatible" ] || return 0
+    echo "==> WARNING — these project fields already exist with a different data type: $incompatible" >&2
+    echo "    GitHub cannot change a project field's data type in place. Rename or delete each one in the" >&2
+    echo "    Project UI and re-run this script to get the intended options." >&2
 }
 
 # ── Status field: full pipeline on a new project; preserve + append on an
@@ -180,8 +214,7 @@ fi
 create_single_select() {
     name="$1"
     options_json="$2"
-    if [ -n "$(field_id "$name")" ]; then
-        echo "    Field '$name' already exists — leaving it as-is"
+    if field_exists "$name" SINGLE_SELECT; then
         return 0
     fi
     echo "    Creating single-select field '$name'"
@@ -193,8 +226,7 @@ create_single_select() {
 
 create_text() {
     name="$1"
-    if [ -n "$(field_id "$name")" ]; then
-        echo "    Field '$name' already exists — leaving it as-is"
+    if field_exists "$name" TEXT; then
         return 0
     fi
     echo "    Creating text field '$name'"
@@ -205,8 +237,7 @@ create_text() {
 
 create_number() {
     name="$1"
-    if [ -n "$(field_id "$name")" ]; then
-        echo "    Field '$name' already exists — leaving it as-is"
+    if field_exists "$name" NUMBER; then
         return 0
     fi
     echo "    Creating number field '$name'"
@@ -228,10 +259,12 @@ create_number "Size"
 # Other metadata: on an ORGANIZATION these are org-level ISSUE fields (durable —
 # the value is on the issue, shared across every project; see
 # docs/project-management.md). Priority is a GitHub built-in;
-# setup-github-issue-fields.sh adds Product + Agent. A personal account has no org
-# issue fields, so fall back to creating them as project fields here.
+# setup-github-issue-fields.sh adds Product, Agent, Domain, and Layer. A personal
+# account has no org issue fields, so fall back to creating them as project
+# fields here.
 if [ "$owner_type" = "Organization" ]; then
-    echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product/Agent)"
+    echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product/Agent/Domain/Layer)"
+    report_incompatible
     echo "==> Done — project #$project_number: $title"
     exit 0
 fi
@@ -254,5 +287,22 @@ create_single_select "Agent" '[
   {"name":"GLM","color":"PINK","description":""},
   {"name":"GitHub Copilot","color":"GRAY","description":""}
 ]'
+# Domain (what part of the product) and Layer (which slice of the stack) mirror
+# the `domain:` / `layer:` label families in setup-github-labels.sh — keep the
+# lists in step. Domain is a starter set; real domains come from your product's
+# entities, and create_single_select leaves an existing field alone, so options
+# you add in the Project UI survive every re-run.
+create_single_select "Domain" '[
+  {"name":"auth","color":"PURPLE","description":"Authentication and authorization"},
+  {"name":"billing","color":"GREEN","description":"Billing and payments"},
+  {"name":"platform","color":"GRAY","description":"CI, build, test infra, and tooling in this repo"}
+]'
+create_single_select "Layer" '[
+  {"name":"ui","color":"BLUE","description":"Components, styling, interaction, tokens, a11y. No data change"},
+  {"name":"logic","color":"GREEN","description":"Business rules, handlers, calculation"},
+  {"name":"data","color":"YELLOW","description":"Schema, indexes, validators, migrations"},
+  {"name":"integration","color":"ORANGE","description":"External boundary: webhooks, API clients, credentials"}
+]'
 
+report_incompatible
 echo "==> Done — project #$project_number: $title"

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -452,8 +452,13 @@ if [[ "${SECTION}" == "setup" ]]; then
             # PM setup surface — audit the results of the setup:github-* tasks the
             # repo actually ships (each script is the marker it opted in).
             if [ -f scripts/setup-github-labels.sh ]; then
-                (run_timeout "${NETWORK_TIMEOUT}" gh label list -R "${OWNER}/${REPO}" --json name \
-                    >"${d}/labels.json" 2>/dev/null || echo '[]' >"${d}/labels.json") &
+                # The REST endpoint with --paginate, not `gh label list`: the
+                # check below compares against the WHOLE starter set, so any
+                # fixed page cap (gh's default 30, or any --limit) can drop a
+                # real label on a label-heavy repo and report it as missing.
+                # One name per line — --paginate emits a document per page.
+                (run_timeout "${NETWORK_TIMEOUT}" gh api "repos/${OWNER}/${REPO}/labels" --paginate --jq '.[].name' \
+                    >"${d}/labels.txt" 2>/dev/null || : >"${d}/labels.txt") &
             fi
             if [ -f scripts/setup-github-issue-types.sh ]; then
                 (run_timeout "${NETWORK_TIMEOUT}" gh api "orgs/${OWNER}/issue-types" --paginate \
@@ -663,10 +668,26 @@ if [[ "${SECTION}" == "setup" ]]; then
                     checkline unknown "GitHub Project linked" "needs read:project scope"
                 fi
                 if [ -f scripts/setup-github-labels.sh ]; then
-                    if jq -e 'any(.[]?; .name == "needs-triage")' "${d}/labels.json" >/dev/null 2>&1; then
-                        checkline ok "Starter labels" "seeded"
-                    else
+                    # The expected set is read out of the setup script's own
+                    # `name|color|description` table rather than probed with one
+                    # sentinel label: a repo seeded before the set grew (a new
+                    # layer:/domain: value, say) has the sentinel and is missing
+                    # the rest, and a single probe would call that green.
+                    want_labels="$(sed -n -E 's/^([A-Za-z0-9:._-]+)\|[0-9A-Fa-f]{6}\|.*/\1/p' scripts/setup-github-labels.sh)"
+                    have_labels="$(cat "${d}/labels.txt" 2>/dev/null || true)"
+                    want_count=0
+                    missing_count=0
+                    for want in ${want_labels}; do
+                        want_count=$((want_count + 1))
+                        printf '%s\n' "${have_labels}" | grep -qxF "${want}" ||
+                            missing_count=$((missing_count + 1))
+                    done
+                    if [ -z "${have_labels}" ] || [ "${want_count}" -eq 0 ]; then
                         checkline no "Starter labels" "run task setup:github-labels"
+                    elif [ "${missing_count}" -eq 0 ]; then
+                        checkline ok "Starter labels" "all ${want_count} seeded"
+                    else
+                        checkline no "Starter labels" "${missing_count}/${want_count} missing — run task setup:github-labels"
                     fi
                 fi
                 if [ -f scripts/setup-github-issue-types.sh ]; then
@@ -680,13 +701,38 @@ if [[ "${SECTION}" == "setup" ]]; then
                     fi
                 fi
                 if [ -f scripts/setup-github-issue-fields.sh ]; then
-                    field_names="$(jq -r '(if type == "object" then (.issue_fields // []) elif type == "array" then . else [] end) | map(.name) | join(",")' "${d}/issue-fields.json" 2>/dev/null || echo "")"
-                    if [ -z "${field_names}" ]; then
+                    # One `name<TAB>data_type` per line, not a joined string:
+                    # `gh api --paginate` writes one JSON document per page, so jq
+                    # runs per page and any single-line delimiter trick breaks at a
+                    # page boundary.
+                    field_rows="$(jq -r '(if type == "object" then (.issue_fields // []) elif type == "array" then . else [] end) | .[] | "\(.name)\t\(.data_type // "")"' "${d}/issue-fields.json" 2>/dev/null || echo "")"
+                    # Every non-built-in field setup-github-issue-fields.sh creates
+                    # must be present AND of the right type: an org set up before
+                    # Domain and Layer joined the set already has Product + Agent,
+                    # and one that happens to own a text field named `Domain` can
+                    # never get the taxonomy options (GitHub cannot change a
+                    # field's data type in place). Reporting either as done would
+                    # hide exactly what the setup script warns about.
+                    missing_fields=""
+                    wrong_fields=""
+                    for want in Product:text Agent:single_select Domain:single_select Layer:single_select; do
+                        wname="${want%%:*}"
+                        wtype="${want##*:}"
+                        htype="$(printf '%s\n' "${field_rows}" | awk -F'\t' -v n="${wname}" '$1 == n { print $2; exit }')"
+                        if ! printf '%s\n' "${field_rows}" | cut -f1 | grep -qxF "${wname}"; then
+                            missing_fields="${missing_fields}${missing_fields:+, }${wname}"
+                        elif [ -n "${htype}" ] && [ "${htype}" != "${wtype}" ]; then
+                            wrong_fields="${wrong_fields}${wrong_fields:+, }${wname} is ${htype}"
+                        fi
+                    done
+                    if [ -z "${field_rows}" ]; then
                         checkline unknown "Org issue fields" "needs admin:org (public preview)"
-                    elif printf '%s' "${field_names}" | grep -q 'Agent'; then
-                        checkline ok "Org issue fields" "Product + Agent"
+                    elif [ -n "${wrong_fields}" ]; then
+                        checkline no "Org issue fields" "wrong type: ${wrong_fields} — rename/delete, then re-run task setup:github-issue-fields"
+                    elif [ -z "${missing_fields}" ]; then
+                        checkline ok "Org issue fields" "Product + Agent + Domain + Layer"
                     else
-                        checkline no "Org issue fields" "run task setup:github-issue-fields"
+                        checkline no "Org issue fields" "missing ${missing_fields} — run task setup:github-issue-fields"
                     fi
                 fi
                 if [ "${has_release_wf}" = 1 ]; then

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -45,6 +45,26 @@ err() {
     fail=1
 }
 
+# opt_names FILE START_REGEX — the `"name":"…"` values of one single-select
+# option block, sorted and deduped. The block opens on the line matching
+# START_REGEX and closes on the next line starting with `]`, so options are read
+# from the field they actually belong to rather than from anywhere in the file.
+# Any non-quote name matches: a name this misses would be silently absent from
+# the set comparison below, turning a drift failure into a false pass.
+opt_names() {
+    awk -v start="$2" '
+        $0 ~ start { inblock = 1; next }
+        inblock && /^\]/ { inblock = 0 }
+        inblock {
+            line = $0
+            while (match(line, /"name":"[^"]+"/)) {
+                print substr(line, RSTART + 8, RLENGTH - 9)
+                line = substr(line, RSTART + RLENGTH)
+            }
+        }
+    ' "$1" | sort -u
+}
+
 # Answers shared by every profile. Side-effectful answers are forced off so
 # this is safe to run anywhere (no gh repo create, no iCloud moves). The meta
 # profile re-enables bunch/obsidian but renders with --skip-tasks.
@@ -622,6 +642,31 @@ full) # project_management=github; github_org=test-org (an org repo)
     # org + github → the org issue-fields + issue-types scripts render too
     [ -f scripts/setup-github-issue-fields.sh ] || err "scripts/setup-github-issue-fields.sh did not render for github+org"
     [ -f scripts/setup-github-issue-types.sh ] || err "org-gated scripts/setup-github-issue-types.sh did not render"
+    # The Layer/Domain taxonomy is seeded in three places — the `layer:`/`domain:`
+    # label families, the org issue fields, and the personal-account project
+    # fields. They are meant to be one vocabulary per family, so compare each
+    # family's option SET across all three, exactly (not just membership
+    # somewhere in the file: `auth` living under Domain must not satisfy a
+    # `layer:auth` label) and in both directions (a field option with no label is
+    # drift too).
+    for pair in layer:Layer domain:Domain; do
+        fam="${pair%%:*}"
+        field="${pair##*:}"
+        # Each source's option set for this family, one name per line, sorted.
+        # Name charset is deliberately permissive: a domain like `oauth2` or
+        # `saas_billing` must land in the compared set, not be silently dropped
+        # (which would make an "exact set" comparison quietly pass on drift).
+        lbl_set="$(sed -n -E "s/^${fam}:([^|]+)\|.*/\1/p" scripts/setup-github-labels.sh | sort -u)"
+        # `<fam>_opts='[ … ]'` in the org script; `create_single_select "<Field>" '[ … ]'`
+        # in the project script. Both blocks end on a line starting with `]`.
+        fld_set="$(opt_names scripts/setup-github-issue-fields.sh "^${fam}_opts='")"
+        prj_set="$(opt_names scripts/setup-github-project.sh "^create_single_select \"${field}\" '")"
+        [ -n "$lbl_set" ] || err "no ${fam}: labels found in setup-github-labels.sh"
+        [ "$lbl_set" = "$fld_set" ] ||
+            err "${fam} vocabulary drift: labels [$(echo "$lbl_set" | tr '\n' ' ')] != issue-field options [$(echo "$fld_set" | tr '\n' ' ')]"
+        [ "$lbl_set" = "$prj_set" ] ||
+            err "${fam} vocabulary drift: labels [$(echo "$lbl_set" | tr '\n' ' ')] != project-field options [$(echo "$prj_set" | tr '\n' ' ')]"
+    done
     ;;
 meta) # project_management=linear
     [ -f docs/project-management.md ] || err "Linear project-management.md missing from docs/"

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -919,10 +919,10 @@ tasks:
 
   setup:github-issue-fields:
     desc: >-
-      Idempotently add the org's Product + Agent issue fields (Priority/Effort
-      are GitHub built-ins, left at defaults; the numeric Size estimate is a
-      project field via setup:github-project). Requires `gh` with the admin:org
-      scope.
+      Idempotently add the org's Product + Agent + Domain + Layer issue fields
+      (Priority/Effort are GitHub built-ins, left at defaults; the numeric Size
+      estimate is a project field via setup:github-project). Creates only what is
+      missing, org-wide. Requires `gh` with the admin:org scope.
     cmds:
       - ./scripts/setup-github-issue-fields.sh --org "[[ github_org ]]"
 [% endif %]

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -167,16 +167,26 @@ config, toolchain, devcontainer, and dev environment — against the items below
       project-automation.yml and the claude-* workflows read (they fall back to
       the project title).
 - [ ] Org issue fields: run `task setup:github-issue-fields` (needs `gh` with the
-      `admin:org` scope) to add the org's **Product** and **Agent** issue fields.
+      `admin:org` scope) to add the org's **Product**, **Agent**, **Domain**, and
+      **Layer** issue fields.
       Priority/Effort (and the date fields) are GitHub built-in issue fields, left
       at their defaults — tune options in the org's issue-field settings if you
       like. **The numeric estimate is the `Size` project number field** (created
       by `task setup:github-project`; only project number fields sum in view
       group headers). Idempotent and non-destructive.
+- [ ] `Domain` options: the script seeds `auth`/`billing`/`platform` only — add
+      this product's real domains (from your ERD entities) in the org's
+      issue-field settings, and add matching `domain:` labels in
+      `scripts/setup-github-labels.sh`. `Layer` (`ui`/`logic`/`data`/
+      `integration`) is product-independent and normally needs no edits. See
+      [project-management.md](project-management.md).
 [% else %]
-      On a personal account it also creates Priority/Product/Agent/Size as
-      project fields (issue fields are org-only); status automation is a separate
-      follow-up — the board is set up, but issue/PR status isn't auto-synced yet.
+      On a personal account it also creates Priority/Product/Agent/Domain/Layer/
+      Size as project fields (issue fields are org-only); status automation is a
+      separate follow-up — the board is set up, but issue/PR status isn't
+      auto-synced yet. `Domain` is seeded with `auth`/`billing`/`platform` only —
+      add this product's real domains in the Project UI, and matching `domain:`
+      labels in `scripts/setup-github-labels.sh`.
 [% endif %]
 - [ ] Labels: run `task setup:github-labels` to seed this repo's starter label
       families (concerns/source/workflow/layer/domain — see

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -185,14 +185,44 @@ The work-metadata fields:
 - **Product** — which product/area it belongs to (free text)
 - **Agent** — which agent should implement it (Claude Code, Codex, Gemini CLI,
   Qwen Code, DeepSeek, Kimi K2, GLM, GitHub Copilot) and how (effort level, model)
+- **Domain** — which part of the *product* it belongs to. Ships as a starter
+  single-select (`auth`, `billing`, `platform`); the real vocabulary comes from
+  your ERD entities — add options as the product grows
+- **Layer** — which slice of the *stack* it changes: `ui` (components, styling,
+  interaction, tokens, a11y — no data change), `logic` (business rules,
+  handlers, calculation), `data` (schema, indexes, validators, migrations),
+  `integration` (external boundary: webhooks, API clients, credentials)
+
+Domain and Layer are orthogonal to each other and to `Type`/`Status`: an issue
+normally carries one of each — *what part of the product* × *what slice of the
+stack*. They ship with the same option lists as the `domain:` / `layer:` label
+families below, so both surfaces start from one vocabulary — but nothing keeps
+them in step afterwards. Two things to know before you extend either:
+
+- **Nothing syncs an individual issue's label to its field value**, so an issue
+  can carry `domain:auth` and `Domain=billing` at once. **Pick one surface as the
+  source of truth** — the fields if you work the board, the labels if you live in
+  `gh issue list` — and treat the other as optional. Dual-entering both by hand is
+  how they end up contradicting each other.
+- **Adding a starter value is not symmetric.** `task setup:github-labels` creates
+  *or updates*, so a new starter label lands on a re-run; the field scripts only
+  create a field that is **missing** and never touch an existing one's options. So
+  when you (or a later harmon-init release) add a value, add the field option by
+  hand in the org's issue-field settings / the Project UI. That is deliberate —
+  it's what keeps your own customizations safe from a re-run.
 
 [% if github_org != author_git_provider_username %]
-**Priority, Product, and Agent are org issue fields**: org-level, defined once,
-and — unlike a project field — the value lives on the **issue**, stays consistent
-across every project the issue belongs to, and shows in the issue timeline. GitHub
-ships **Priority** and **Effort** (plus **Start date** / **Target date**) built
-in, left at their defaults, so `task setup:github-issue-fields` only adds
-**Product** and **Agent**.
+**Priority, Product, Agent, Domain, and Layer are org issue fields**: org-level,
+defined once, and — unlike a project field — the value lives on the **issue**,
+stays consistent across every project the issue belongs to, and shows in the issue
+timeline. GitHub ships **Priority** and **Effort** (plus **Start date** /
+**Target date**) built in, left at their defaults, so
+`task setup:github-issue-fields` only adds **Product**, **Agent**, **Domain**,
+and **Layer**.
+
+Because issue fields are org-level, `Domain`'s option list is shared by every
+repo in the org — expect it to accumulate the union of your products' domains.
+`Product` is what disambiguates them; scope a board view by filtering on both.
 
 **Size is the exception — a project number field** (created by
 `task setup:github-project`): project views can group, filter, and sort by
@@ -204,7 +234,7 @@ its default (a coarse gut-check) and put points in `Size`.
 
 [% else %]
 On a personal account there are no issue fields, so `task setup:github-project`
-creates **Priority, Product, Agent, and Size** as project fields.
+creates **Priority, Product, Agent, Domain, Layer, and Size** as project fields.
 
 [% endif %]
 TODO: finalize each field's options/values.
@@ -242,15 +272,23 @@ families, color-coded by family; the starter set is created by
 - **Workflow** — `needs-triage`, `needs-requirements`, `blocked`, `waiting`,
   `needs-decision`, `needs-response`, `needs-communication` (transient triage
   states; `blocked` is the non-issue-blocker flag described above)
-- **Layer** — `layer:frontend`, `layer:backend`, `layer:infra`, …
-- **Domain** — start with `domain:auth`, `domain:billing`; grow from your ERD
-  entities
+- **Layer** — `layer:ui`, `layer:logic`, `layer:data`, `layer:integration`
+- **Domain** — start with `domain:auth`, `domain:billing`, `domain:platform`;
+  grow from your ERD entities
+
+The `layer:` and `domain:` families offer the same options as the **Layer** and
+**Domain** fields above — same names, same meanings, but no per-issue sync (see
+Fields). Use the label when you want it on the issue list and in
+`gh issue list --label`, the field when you want to group a board view by it, and
+extend both together so the option sets stay identical.
 
 GitHub labels live per-repository (there's no shared org label pool).
 `setup-github-labels` seeds the set into one repo — run it in each, or set the
 org's **default labels** (org Settings → Repository, UI-only) to seed *new* repos
 (it won't change existing ones). It never deletes labels, so GitHub's defaults
-remain until you prune them.
+remain until you prune them — including a pre-`ui`/`logic`/`data`/`integration`
+repo's `layer:frontend`, `layer:backend`, and `layer:infra`, which you re-map and
+delete by hand.
 
 ## Milestones
 
@@ -472,7 +510,8 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   expect rough edges.
 - **Slice the board** — rather than separate per-product / per-layer / per-agent
   saved views, slice the one board: by **`Product`** when you go multi-product, by
-  **`layer:`** to focus a system layer, by **`Agent`** to see the split. One
+  **`Domain`** to focus a product area, by **`Layer`** to focus a slice of the
+  stack, by **`Agent`** to see the split. One
   board, many lenses — and how multiple products stay legible in one aggregating
   project instead of fragmenting into project-per-product.
 

--- a/template/scripts/[% if project_management == 'github' %]setup-github-labels.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-labels.sh[% endif %]
@@ -3,11 +3,19 @@
 # set (docs/project-management.md). Colors are grouped by family (concerns=purple,
 # source=pink, workflow=orange, layer=blue, domain=yellow).
 #
+# The `layer:` and `domain:` families deliberately mirror the Layer and Domain
+# single-select fields created by setup-github-issue-fields.sh (org) /
+# setup-github-project.sh (personal account) — same vocabulary, so a label and a
+# field value never disagree. Keep the three lists in step when you extend them.
+#
 # Labels are REPO-level in GitHub — there's no shared org label pool. Run this in
 # each repo; org "default labels" (Settings → Repository, UI-only, no API) only
 # seed NEW repos and don't touch existing ones. Non-destructive: `--force`
 # creates-or-updates and it never deletes labels, so GitHub's defaults stay unless
-# you prune them yourself.
+# you prune them yourself. That cuts both ways: a repo seeded before the layer
+# family became ui/logic/data/integration keeps its old `layer:frontend`,
+# `layer:backend`, and `layer:infra` labels — re-map the issues and delete those
+# three by hand if you want the one vocabulary.
 #
 # Usage: setup-github-labels.sh --repo <owner/repo>
 # Needs: gh authed with repo write.
@@ -57,11 +65,13 @@ waiting|E36209|Waiting on an external party
 needs-decision|E36209|Needs a decision before it can proceed
 needs-response|E36209|Awaiting a response
 needs-communication|E36209|An update needs to be communicated out
-layer:frontend|1D76DB|Frontend
-layer:backend|1D76DB|Backend
-layer:infra|1D76DB|Infrastructure
+layer:ui|1D76DB|Components, styling, interaction, tokens, a11y. No data change
+layer:logic|1D76DB|Business rules, handlers, calculation
+layer:data|1D76DB|Schema, indexes, validators, migrations
+layer:integration|1D76DB|External boundary: webhooks, API clients, credentials
 domain:auth|FBCA04|Authentication and authorization
 domain:billing|FBCA04|Billing and payments
+domain:platform|FBCA04|CI, build, test infra, and tooling in this repo
 "
 
 printf '%s\n' "$labels" | while IFS='|' read -r name color desc; do

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -6,9 +6,9 @@
 # because only project number fields sum in view group headers (issue-field
 # columns can group/filter/sort, not sum). The other metadata on an ORGANIZATION
 # are org-level ISSUE fields (Priority/Effort are GitHub built-ins, left at
-# their defaults; setup-github-issue-fields.sh adds Product + Agent); on a
-# personal account (no org issue fields) this script creates
-# Priority/Product/Agent as project fields too.
+# their defaults; setup-github-issue-fields.sh adds Product, Agent, Domain, and
+# Layer); on a personal account (no org issue fields) this script creates
+# Priority/Product/Agent/Domain/Layer as project fields too.
 #
 # Safe to re-run and safe to run from every repo the owner controls: it looks the
 # project up by title, so the first run creates it and later runs just reconcile
@@ -142,12 +142,46 @@ else
 fi
 
 # ── Snapshot current fields (one read; reused for existence checks) ──
-fields_json=$(gh api graphql -f query='query($p:ID!){node(id:$p){... on ProjectV2{fields(first:50){nodes{... on ProjectV2FieldCommon{id name} ... on ProjectV2SingleSelectField{options{name color description}}}}}}}' \
+fields_json=$(gh api graphql -f query='query($p:ID!){node(id:$p){... on ProjectV2{fields(first:50){nodes{... on ProjectV2FieldCommon{id name dataType} ... on ProjectV2SingleSelectField{options{name color description}}}}}}}' \
     -f p="$project_id")
 
 field_id() {
     printf '%s' "$fields_json" |
         jq -r --arg n "$1" '.data.node.fields.nodes[] | select(.name==$n) | .id' | head -n1
+}
+
+field_type() {
+    printf '%s' "$fields_json" |
+        jq -r --arg n "$1" '.data.node.fields.nodes[] | select(.name==$n) | .dataType' | head -n1
+}
+
+# A reused project may already carry a field with one of these names — of the
+# wrong data type. GitHub cannot change a project field's data type in place, so
+# its intended options are unavailable until it is renamed or deleted. Warn (and
+# repeat it in the summary) rather than exit non-zero: this script is a
+# create-if-missing reconciler that never edits what the owner already has, and
+# one pre-existing field is no reason to abort the rest.
+incompatible=""
+
+# field_exists NAME EXPECTED_DATATYPE — 0 when a field of that name is already
+# there (so the caller skips creation), recording a data-type mismatch on the way.
+field_exists() {
+    [ -n "$(field_id "$1")" ] || return 1
+    etype="$(field_type "$1")"
+    if [ -n "$etype" ] && [ "$etype" != "null" ] && [ "$etype" != "$2" ]; then
+        echo "    WARNING: field '$1' already exists as $etype, not $2 — its intended options are NOT available" >&2
+        incompatible="${incompatible}${incompatible:+, }$1 (is $etype, wanted $2)"
+    else
+        echo "    Field '$1' already exists — leaving it as-is"
+    fi
+    return 0
+}
+
+report_incompatible() {
+    [ -n "$incompatible" ] || return 0
+    echo "==> WARNING — these project fields already exist with a different data type: $incompatible" >&2
+    echo "    GitHub cannot change a project field's data type in place. Rename or delete each one in the" >&2
+    echo "    Project UI and re-run this script to get the intended options." >&2
 }
 
 # ── Status field: full pipeline on a new project; preserve + append on an
@@ -180,8 +214,7 @@ fi
 create_single_select() {
     name="$1"
     options_json="$2"
-    if [ -n "$(field_id "$name")" ]; then
-        echo "    Field '$name' already exists — leaving it as-is"
+    if field_exists "$name" SINGLE_SELECT; then
         return 0
     fi
     echo "    Creating single-select field '$name'"
@@ -193,8 +226,7 @@ create_single_select() {
 
 create_text() {
     name="$1"
-    if [ -n "$(field_id "$name")" ]; then
-        echo "    Field '$name' already exists — leaving it as-is"
+    if field_exists "$name" TEXT; then
         return 0
     fi
     echo "    Creating text field '$name'"
@@ -205,8 +237,7 @@ create_text() {
 
 create_number() {
     name="$1"
-    if [ -n "$(field_id "$name")" ]; then
-        echo "    Field '$name' already exists — leaving it as-is"
+    if field_exists "$name" NUMBER; then
         return 0
     fi
     echo "    Creating number field '$name'"
@@ -228,10 +259,12 @@ create_number "Size"
 # Other metadata: on an ORGANIZATION these are org-level ISSUE fields (durable —
 # the value is on the issue, shared across every project; see
 # docs/project-management.md). Priority is a GitHub built-in;
-# setup-github-issue-fields.sh adds Product + Agent. A personal account has no org
-# issue fields, so fall back to creating them as project fields here.
+# setup-github-issue-fields.sh adds Product, Agent, Domain, and Layer. A personal
+# account has no org issue fields, so fall back to creating them as project
+# fields here.
 if [ "$owner_type" = "Organization" ]; then
-    echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product/Agent)"
+    echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product/Agent/Domain/Layer)"
+    report_incompatible
     echo "==> Done — project #$project_number: $title"
     exit 0
 fi
@@ -254,5 +287,22 @@ create_single_select "Agent" '[
   {"name":"GLM","color":"PINK","description":""},
   {"name":"GitHub Copilot","color":"GRAY","description":""}
 ]'
+# Domain (what part of the product) and Layer (which slice of the stack) mirror
+# the `domain:` / `layer:` label families in setup-github-labels.sh — keep the
+# lists in step. Domain is a starter set; real domains come from your product's
+# entities, and create_single_select leaves an existing field alone, so options
+# you add in the Project UI survive every re-run.
+create_single_select "Domain" '[
+  {"name":"auth","color":"PURPLE","description":"Authentication and authorization"},
+  {"name":"billing","color":"GREEN","description":"Billing and payments"},
+  {"name":"platform","color":"GRAY","description":"CI, build, test infra, and tooling in this repo"}
+]'
+create_single_select "Layer" '[
+  {"name":"ui","color":"BLUE","description":"Components, styling, interaction, tokens, a11y. No data change"},
+  {"name":"logic","color":"GREEN","description":"Business rules, handlers, calculation"},
+  {"name":"data","color":"YELLOW","description":"Schema, indexes, validators, migrations"},
+  {"name":"integration","color":"ORANGE","description":"External boundary: webhooks, API clients, credentials"}
+]'
 
+report_incompatible
 echo "==> Done — project #$project_number: $title"

--- a/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # setup-github-issue-fields.sh — idempotently add the org ISSUE FIELDS that are
-# NOT GitHub built-ins: Product and Agent. GitHub already ships Priority, Effort,
-# Start date, and Target date as built-in issue fields, and we never recreate or
-# modify those (leave them at their defaults). Create-if-missing only; it never
-# edits or deletes a field.
+# NOT GitHub built-ins: Product, Agent, Domain, and Layer. GitHub already ships
+# Priority, Effort, Start date, and Target date as built-in issue fields, and we
+# never recreate or modify those (leave them at their defaults).
+# Create-if-missing only; it never edits or deletes a field — so the starter
+# Domain/Layer options below are a floor, and per-product options you add later
+# in the org's issue-field settings survive every re-run.
 #
 # NB: the numeric, summable estimate is NOT an issue field — it is the Size
 # project NUMBER field (setup-github-project.sh), because only project number
@@ -70,6 +72,27 @@ agent_opts='[
   {"name":"GitHub Copilot","color":"gray","description":"","priority":8}
 ]'
 
+# Domain (what part of the product) and Layer (which slice of the stack) are
+# orthogonal to each other and to Type/Status — an issue normally carries one of
+# each. Both mirror the `domain:` / `layer:` label families in
+# setup-github-labels.sh; keep the two lists in step.
+#
+# Domain is a STARTER set only: real domains come from your product's entities
+# (crm, invoicing, scheduling, …). Add them in the org's issue-field settings —
+# this script never edits an existing field, so they survive.
+domain_opts='[
+  {"name":"auth","color":"purple","description":"Authentication and authorization","priority":1},
+  {"name":"billing","color":"green","description":"Billing and payments","priority":2},
+  {"name":"platform","color":"gray","description":"CI, build, test infra, and tooling in this repo","priority":3}
+]'
+
+layer_opts='[
+  {"name":"ui","color":"blue","description":"Components, styling, interaction, tokens, a11y. No data change","priority":1},
+  {"name":"logic","color":"green","description":"Business rules, handlers, calculation","priority":2},
+  {"name":"data","color":"yellow","description":"Schema, indexes, validators, migrations","priority":3},
+  {"name":"integration","color":"orange","description":"External boundary: webhooks, API clients, credentials","priority":4}
+]'
+
 echo "==> Reading existing issue fields for '$org'"
 existing=$(gh api "orgs/$org/issue-fields" -H "X-GitHub-Api-Version: $api_version" --paginate 2>/dev/null || true)
 if [ -z "$existing" ]; then
@@ -77,11 +100,24 @@ if [ -z "$existing" ]; then
     exit 1
 fi
 
-# The list endpoint returns a bare array; tolerate an {"issue_fields":[...]} wrapper too.
-existing_names=$(printf '%s' "$existing" |
-    jq -r 'if type == "object" then (.issue_fields // []) else . end | .[].name' 2>/dev/null || true)
+# One `name<TAB>data_type` per line. The list endpoint returns a bare array;
+# tolerate an {"issue_fields":[...]} wrapper too. Reading names line-wise (not as
+# one joined string) also keeps this correct across `--paginate`'s multiple
+# documents.
+existing_fields=$(printf '%s' "$existing" |
+    jq -r 'if type == "object" then (.issue_fields // []) else . end | .[] | "\(.name)\t\(.data_type // "")"' 2>/dev/null || true)
 
-field_present() { printf '%s\n' "$existing_names" | grep -Fxq "$1"; }
+field_present() { printf '%s\n' "$existing_fields" | cut -f1 | grep -Fxq "$1"; }
+field_type() { printf '%s\n' "$existing_fields" | awk -F'\t' -v n="$1" '$1 == n { print $2; exit }'; }
+
+# Names like `Domain` and `Layer` are generic enough that an adopting org may
+# already have one — of the wrong data type. GitHub cannot change an issue
+# field's data type in place, so the intended options are simply unavailable
+# until that field is renamed or deleted. Warn (loudly, and again in the summary)
+# rather than exit non-zero: this script's contract is create-if-missing and
+# never-edit, and a pre-existing field the org owns is not a reason to abort the
+# fields that *can* still be created.
+incompatible=""
 
 # create_field NAME DATA_TYPE DESCRIPTION [OPTIONS_JSON]
 create_field() {
@@ -90,7 +126,13 @@ create_field() {
     desc="$3"
     opts="${4:-}"
     if field_present "$name"; then
-        echo "    Issue field '$name' already exists — leaving it as-is"
+        etype="$(field_type "$name")"
+        if [ -n "$etype" ] && [ "$etype" != "$dtype" ]; then
+            echo "    WARNING: issue field '$name' already exists as '$etype', not '$dtype' — its intended options are NOT available" >&2
+            incompatible="${incompatible}${incompatible:+, }${name} (is '$etype', wanted '$dtype')"
+        else
+            echo "    Issue field '$name' already exists — leaving it as-is"
+        fi
         return 0
     fi
     echo "    Creating $dtype issue field '$name'"
@@ -108,5 +150,13 @@ create_field() {
 
 create_field "Product" "text" "Which product/area it belongs to"
 create_field "Agent" "single_select" "Which agent should implement it" "$agent_opts"
+create_field "Domain" "single_select" "Which part of the product it belongs to" "$domain_opts"
+create_field "Layer" "single_select" "Which slice of the stack it changes" "$layer_opts"
 
-echo "==> Done — added issue fields on '$org': Product, Agent (Priority/Effort/dates are GitHub built-ins)"
+if [ -n "$incompatible" ]; then
+    echo "==> Done, WITH WARNINGS — these fields already exist with a different data type: $incompatible" >&2
+    echo "    GitHub cannot change an issue field's data type in place. Rename or delete each one in the org's" >&2
+    echo "    issue-field settings and re-run this script to get the intended options." >&2
+else
+    echo "==> Done — added issue fields on '$org': Product, Agent, Domain, Layer (Priority/Effort/dates are GitHub built-ins)"
+fi

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -452,8 +452,13 @@ if [[ "${SECTION}" == "setup" ]]; then
             # PM setup surface — audit the results of the setup:github-* tasks the
             # repo actually ships (each script is the marker it opted in).
             if [ -f scripts/setup-github-labels.sh ]; then
-                (run_timeout "${NETWORK_TIMEOUT}" gh label list -R "${OWNER}/${REPO}" --json name \
-                    >"${d}/labels.json" 2>/dev/null || echo '[]' >"${d}/labels.json") &
+                # The REST endpoint with --paginate, not `gh label list`: the
+                # check below compares against the WHOLE starter set, so any
+                # fixed page cap (gh's default 30, or any --limit) can drop a
+                # real label on a label-heavy repo and report it as missing.
+                # One name per line — --paginate emits a document per page.
+                (run_timeout "${NETWORK_TIMEOUT}" gh api "repos/${OWNER}/${REPO}/labels" --paginate --jq '.[].name' \
+                    >"${d}/labels.txt" 2>/dev/null || : >"${d}/labels.txt") &
             fi
             if [ -f scripts/setup-github-issue-types.sh ]; then
                 (run_timeout "${NETWORK_TIMEOUT}" gh api "orgs/${OWNER}/issue-types" --paginate \
@@ -663,10 +668,26 @@ if [[ "${SECTION}" == "setup" ]]; then
                     checkline unknown "GitHub Project linked" "needs read:project scope"
                 fi
                 if [ -f scripts/setup-github-labels.sh ]; then
-                    if jq -e 'any(.[]?; .name == "needs-triage")' "${d}/labels.json" >/dev/null 2>&1; then
-                        checkline ok "Starter labels" "seeded"
-                    else
+                    # The expected set is read out of the setup script's own
+                    # `name|color|description` table rather than probed with one
+                    # sentinel label: a repo seeded before the set grew (a new
+                    # layer:/domain: value, say) has the sentinel and is missing
+                    # the rest, and a single probe would call that green.
+                    want_labels="$(sed -n -E 's/^([A-Za-z0-9:._-]+)\|[0-9A-Fa-f]{6}\|.*/\1/p' scripts/setup-github-labels.sh)"
+                    have_labels="$(cat "${d}/labels.txt" 2>/dev/null || true)"
+                    want_count=0
+                    missing_count=0
+                    for want in ${want_labels}; do
+                        want_count=$((want_count + 1))
+                        printf '%s\n' "${have_labels}" | grep -qxF "${want}" ||
+                            missing_count=$((missing_count + 1))
+                    done
+                    if [ -z "${have_labels}" ] || [ "${want_count}" -eq 0 ]; then
                         checkline no "Starter labels" "run task setup:github-labels"
+                    elif [ "${missing_count}" -eq 0 ]; then
+                        checkline ok "Starter labels" "all ${want_count} seeded"
+                    else
+                        checkline no "Starter labels" "${missing_count}/${want_count} missing — run task setup:github-labels"
                     fi
                 fi
                 if [ -f scripts/setup-github-issue-types.sh ]; then
@@ -680,13 +701,38 @@ if [[ "${SECTION}" == "setup" ]]; then
                     fi
                 fi
                 if [ -f scripts/setup-github-issue-fields.sh ]; then
-                    field_names="$(jq -r '(if type == "object" then (.issue_fields // []) elif type == "array" then . else [] end) | map(.name) | join(",")' "${d}/issue-fields.json" 2>/dev/null || echo "")"
-                    if [ -z "${field_names}" ]; then
+                    # One `name<TAB>data_type` per line, not a joined string:
+                    # `gh api --paginate` writes one JSON document per page, so jq
+                    # runs per page and any single-line delimiter trick breaks at a
+                    # page boundary.
+                    field_rows="$(jq -r '(if type == "object" then (.issue_fields // []) elif type == "array" then . else [] end) | .[] | "\(.name)\t\(.data_type // "")"' "${d}/issue-fields.json" 2>/dev/null || echo "")"
+                    # Every non-built-in field setup-github-issue-fields.sh creates
+                    # must be present AND of the right type: an org set up before
+                    # Domain and Layer joined the set already has Product + Agent,
+                    # and one that happens to own a text field named `Domain` can
+                    # never get the taxonomy options (GitHub cannot change a
+                    # field's data type in place). Reporting either as done would
+                    # hide exactly what the setup script warns about.
+                    missing_fields=""
+                    wrong_fields=""
+                    for want in Product:text Agent:single_select Domain:single_select Layer:single_select; do
+                        wname="${want%%:*}"
+                        wtype="${want##*:}"
+                        htype="$(printf '%s\n' "${field_rows}" | awk -F'\t' -v n="${wname}" '$1 == n { print $2; exit }')"
+                        if ! printf '%s\n' "${field_rows}" | cut -f1 | grep -qxF "${wname}"; then
+                            missing_fields="${missing_fields}${missing_fields:+, }${wname}"
+                        elif [ -n "${htype}" ] && [ "${htype}" != "${wtype}" ]; then
+                            wrong_fields="${wrong_fields}${wrong_fields:+, }${wname} is ${htype}"
+                        fi
+                    done
+                    if [ -z "${field_rows}" ]; then
                         checkline unknown "Org issue fields" "needs admin:org (public preview)"
-                    elif printf '%s' "${field_names}" | grep -q 'Agent'; then
-                        checkline ok "Org issue fields" "Product + Agent"
+                    elif [ -n "${wrong_fields}" ]; then
+                        checkline no "Org issue fields" "wrong type: ${wrong_fields} — rename/delete, then re-run task setup:github-issue-fields"
+                    elif [ -z "${missing_fields}" ]; then
+                        checkline ok "Org issue fields" "Product + Agent + Domain + Layer"
                     else
-                        checkline no "Org issue fields" "run task setup:github-issue-fields"
+                        checkline no "Org issue fields" "missing ${missing_fields} — run task setup:github-issue-fields"
                     fi
                 fi
                 if [ "${has_release_wf}" = 1 ]; then


### PR DESCRIPTION
## What

Adds **Domain** (what part of the product) and **Layer** (which slice of the stack)
to the GitHub setup + project automation, as two orthogonal dimensions alongside
`Type` and `Status`.

- **Org issue fields** — `setup-github-issue-fields.sh` now creates `Domain` and
  `Layer` single-selects alongside `Product` and `Agent`.
- **Personal-account project fields** — `setup-github-project.sh` creates the same
  two as project fields on the no-org fallback path, so personal repos stay at
  parity.
- **Labels** — the `layer:` family moves to the issue's vocabulary
  (`ui`/`logic`/`data`/`integration`, replacing `frontend`/`backend`/`infra`) and
  `domain:platform` joins `auth`/`billing`, so the label families and the field
  option lists are one vocabulary.

`Domain` ships as a **starter set only** (`auth`, `billing`, `platform`) — the real
domains come from each product's entities. The scripts stay create-if-missing, so
options added downstream survive every re-run; the CHECKLIST tells a new repo to
add its own.

## Why

Closes #365. The issue lists a product's actual domains and layers; harmon-init
can't hardcode Lawnomator's `crm`/`invoicing`/`quoting`, so the template
establishes the *fields* with a product-neutral starter vocabulary and documents
how to grow it. `Layer` is product-independent and ships complete.

## Also fixed (found while wiring this up)

The new fields made two `status.sh` checks stale or wrong; both are corrected here:

- **Starter labels** were probed with a single sentinel (`needs-triage`), so a repo
  seeded before the taxonomy grew reported green while missing every new label.
  Now compared against the full expected set, read out of
  `setup-github-labels.sh`'s own table so it can't go stale again — and fetched
  with `gh api --paginate` rather than a capped `gh label list`.
- **Org issue fields** were probed by name only. Now every field
  (`Product`/`Agent`/`Domain`/`Layer`) must be present *and* of the expected
  `data_type`, read line-wise so `--paginate`'s per-page documents can't split a
  name across the check.

Both setup scripts also now warn when a field of the right name already exists
with the **wrong data type** — GitHub can't change a field's type in place, so the
intended options are silently unavailable. They warn and continue rather than
abort: the scripts' contract is create-if-missing / never-edit.

## Verification

- `task verify` green (includes the full 6-profile render matrix + dogfood
  parity/structure).
- New drift guard in `test-template.sh` (`full` profile) compares each family's
  option **set** across all three scripts — exactly, per family, in both
  directions. Negative-tested against wrong-family (`layer:auth`), label-only,
  field-only, and digit/underscore (`domain:oauth2`) drift.
- The `status.sh` and setup-script logic changes were unit-tested against canned
  single-page, multi-page, and wrong-type API payloads.
- `task challenge` and `task review` both end on a clean pass.

## Follow-up (not in this PR)

The vendored `standardize-repo` catalog
(`.claude/skills/standardize-repo/references/standards-catalog.md`) still describes
`setup:github-issue-fields` as "Product + Agent" and the personal project fields as
"Priority/Effort/Product/Agent". That file is vendored from harmon-devkit and must
not be hand-edited here — it needs a harmon-devkit change plus a pin bump.
