### PR TITLE
fix: time-box the devcontainer config check so a wedged container runtime cannot stall task verify

### DIFF
--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -29,6 +29,19 @@ trap 'rm -rf "$dest"' EXIT
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
+# GNU timeout, named `gtimeout` when Homebrew's coreutils is installed without
+# the gnubin shim. Same resolver as scripts/devcontainer-smoke.sh, but absence
+# is not fatal here: that script is an opt-in task, whereas this one runs inside
+# `task verify`, so a missing coreutils goes through `required` (skip locally,
+# fail in CI) rather than aborting the gate on every macOS box without it.
+if have timeout; then
+    timeout_bin="timeout"
+elif have gtimeout; then
+    timeout_bin="gtimeout"
+else
+    timeout_bin=""
+fi
+
 # In CI every tool must be present; locally, missing tools downgrade to a skip.
 required() {
     if [ -n "${GITHUB_ACTIONS:-}" ]; then
@@ -608,13 +621,29 @@ done < <(find . -name '*.json' -not -path './.git/*' -not -path './node_modules/
 [ "$json_fail" -eq 0 ] && echo "JSON: all rendered .json files parse"
 
 # ── 8. Devcontainer configs are readable by the devcontainers CLI ───
+# This check only needs the static JSONC, but `read-configuration` 0.87+ shells
+# out to the docker binary anyway (probing for an existing container). Pointing
+# it at a no-op keeps the check daemon-independent, the same trick and reasoning
+# as scripts/devcontainer-assert.sh's unit mode: a stopped or wedged runtime
+# cannot stall it, and — unlike the daemon probe this replaced — it no longer
+# has to skip the check to stay safe. The timeout is a backstop on the CLI
+# itself; `true` cannot hang, so it should never fire.
+#
+# `true` is passed bare rather than as /usr/bin/true (which is what the assert
+# script hardcodes): the CLI resolves the name on PATH, and a distro that keeps
+# coreutils outside /usr/bin — NixOS, say — would otherwise fail every
+# devcontainer-enabled profile here, on a check that used to pass.
 if [ -d .devcontainer ]; then
-    if ! have devcontainer || ! docker info >/dev/null 2>&1; then
-        echo "SKIP: devcontainer CLI or docker daemon unavailable — skipping devcontainer config check"
+    if ! have devcontainer; then
+        required devcontainer "devcontainer config check" || fail=1
+    elif [ -z "$timeout_bin" ]; then
+        required timeout "devcontainer config check" || fail=1
     else
         for cfg in .devcontainer/devcontainer.json .devcontainer/dev/devcontainer.json; do
             [ -f "$cfg" ] || continue
-            devcontainer read-configuration --workspace-folder . --config "$cfg" >/dev/null ||
+            "$timeout_bin" -k 5 60 devcontainer read-configuration \
+                --docker-path true \
+                --workspace-folder . --config "$cfg" >/dev/null ||
                 err "devcontainer read-configuration failed for $cfg"
         done
     fi


### PR DESCRIPTION
## What

`scripts/test-template.sh`'s devcontainer config check (section 8) guarded itself
with a bare `docker info`. The intent was already right — an unavailable daemon
should skip — but `docker info` is unbounded, so a **stopped or wedged** runtime
made it hang rather than exit non-zero. The guard never evaluated, the skip never
happened, and `task verify` stalled with no output (~80 minutes, observed
2026-07-28). `devcontainer read-configuration` on the next line talks to the
daemon too, so bounding the probe alone would not have been enough.

This replaces the daemon probe with a **no-op docker path**, the same trick and
reasoning as `scripts/devcontainer-assert.sh`'s unit mode: `read-configuration`
only needs the static JSONC, but 0.87+ shells out to the docker binary anyway to
probe for an existing container. Pointing it at `true` makes the check
daemon-*independent* rather than merely bounded — so it no longer has to skip to
stay safe, which is strictly **more** coverage than before.

## Why this shape

- **`--docker-path true`, not a timeout on `docker info`.** The issue proposed
  time-boxing both calls. Bounding is the weaker fix: it converts an 80-minute
  stall into a 20-second one and still skips the check. Removing the daemon
  dependency means the check simply runs. A `timeout` remains as a backstop on
  the CLI itself, but `true` cannot hang, so it should never fire.
- **`true` bare, not `/usr/bin/true`.** The CLI resolves the name on `PATH`
  (verified: `let M=A||"docker"` is passed straight to the spawn helper). A
  distro that keeps coreutils outside `/usr/bin` — NixOS, say — would otherwise
  fail every devcontainer-enabled profile, on a check that used to pass. Caught
  by `task challenge`.
- **`required()`, not a bespoke skip.** A missing `devcontainer` CLI or GNU
  `timeout` now routes through the script's existing helper, which fails under
  `GITHUB_ACTIONS` and skips locally — so a wedged/absent runtime cannot
  silently pass in CI, where the tooling is expected to be present.
- **Missing `timeout` is not fatal.** `devcontainer-smoke.sh` exits 1 in that
  case, which is right for an opt-in task; this script runs inside `task verify`,
  so aborting the gate on every macOS box without coreutils would be a
  regression. Same resolver shape, non-fatal outcome.

## Verification

The issue's repro calls for stopping the container runtime. Reproduced **without**
touching OrbStack, by shadowing `docker` on `PATH` with a stub that `sleep 3000`s —
a strictly harsher simulation than a stopped daemon:

| run | code | result |
|---|---|---|
| `test-template.sh full`, wedged docker, **before** | — | stalled at the line before section 8; killed at 600s; **0** CLI invocations |
| `test-template.sh full`, wedged docker, **after** | 0 | `PASS`, **2** `read-configuration` invocations (bot + dev) |

The invocation count is the load-bearing part: it proves the check *ran* rather
than being skipped.

Also confirmed:

- `read-configuration` output is **byte-identical** with a real docker path vs.
  `true` (3078 bytes both) — no degraded parsing.
- Passing a `--docker-path` that hangs makes the CLI hang (exit 124), proving it
  really does shell out, so the no-op path is what does the work.
- `grep -n 'docker info' scripts/test-template.sh` → no hits.
- All 13 `task verify` gates pass; `task ci` green; `task challenge` and
  `task review` both return a clean pass with no P0/P1.

## Acceptance criteria

- [x] Every `docker info` probe is time-bounded — there are now none; the probe
      is gone entirely, which is why nothing can hang on it.
- [x] `devcontainer read-configuration` is bounded too (and made
      daemon-independent, so a daemon that answers `info` then wedges is a
      non-issue).
- [x] A wedged daemon does not stall, and cannot silently pass in CI — the
      CLI/`timeout` absence paths go through `required()` (fail under
      `GITHUB_ACTIONS`, skip locally).
- [x] `task verify` completes with the container runtime unavailable (verified
      via the hanging-`docker` shim above).
- [x] Decide whether `scripts/devcontainer-assert.sh`'s unbounded `docker exec`
      needs the same treatment — **decision: no change.** Those calls live only
      in `assert_container`, reachable solely from `devcontainer-smoke.sh:85` via
      `task test:devcontainer:root`/`:dev`. Neither is in `verify` or `ci`
      (`ci` runs `devcontainer-assert.sh unit`; `build.yml` runs only
      `task test:devcontainer:permissions`), so they sit outside this issue's
      invariant. `devcontainer-smoke.sh` also already gates on a bounded
      `docker info` before any container starts. Avoiding the edit also keeps a
      verbatim two-layer twin out of contention with Renovate PR #405.

## Notes

- **Root-only change.** `scripts/test-template.sh` has no `template/` twin, so
  this is not a dogfood-parity change and ships nothing to generated repos.
- The issue's repro command is slightly off: `task test:template:minimal` cannot
  reproduce the hang, because the `minimal` profile sets `devcontainer=false` and
  never reaches section 8. Any devcontainer-enabled profile (e.g. `full`) does.

## Deferred findings

- [x] **filed as #436** — `scripts/devcontainer-assert.sh:141` (+ its verbatim template twin) —
      hardcodes `--docker-path /usr/bin/true`, the same portability trap removed
      here. Pre-existing, not a regression, but the two call sites now spell the
      same trick differently. Decide: align it to bare `true`, or document why
      the absolute path is deliberate. Touches a verbatim two-layer twin
      currently contended by #405.
- [x] **filed as #437** — `scripts/test-template.sh:644` — no regression coverage for the
      daemon-independent path. The matrix normally runs where Docker is healthy,
      so deleting `--docker-path true` would silently reintroduce the hang.
      Cheap guard proven while writing this PR: prepend a dir containing an
      executable `docker` that `sleep 3000`s, run `read-configuration
      --docker-path true` against the root repo's own `.devcontainer` under a
      `timeout`, assert exit 0 (~0.1s). Costs a new root-only script + Taskfile
      target + `verify` wiring, which is why it is not in this PR.

Closes #424
