### PR TITLE
fix(devcontainer): install task from a pinned release instead of the go-task Feature

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,6 +8,8 @@ ARG TARGETARCH
 # can auto-PR new releases. See renovate.json for the regex manager config.
 # NODE_MAJOR is intentionally unmanaged — Node major bumps are deliberate.
 ARG NODE_MAJOR=24
+# renovate: datasource=github-releases depName=go-task/task extractVersion=^v?(?<version>.+)$
+ARG TASK_VERSION=3.52.0
 # renovate: datasource=github-releases depName=mvdan/sh extractVersion=^v?(?<version>.+)$
 ARG SHFMT_VERSION=3.13.1
 # renovate: datasource=github-releases depName=hadolint/hadolint extractVersion=^v?(?<version>.+)$
@@ -187,6 +189,21 @@ RUN install -d -m 0755 /etc/apt/keyrings \
 
 # Suppress Corepack's interactive download prompt so pnpm installs silently.
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
+# ---------- task runner ----------
+# Pinned release rather than the go-task devcontainer Feature: with no `version`
+# option the Feature resolves "latest" through the ANONYMOUS GitHub API from
+# inside the build, and GitHub-hosted runners share egress IPs against a 60
+# req/hour/IP limit — so the required devcontainer build check 403s at random
+# (harmon-init#427). Every other release-downloaded tool here is pinned the same
+# way for the same reason.
+RUN case "${TARGETARCH}" in \
+        "amd64") export TASK_ARCH="amd64" ;; \
+        "arm64") export TASK_ARCH="arm64" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/go-task/task/releases/download/v${TASK_VERSION}/task_linux_${TASK_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin task
 
 # ---------- code-quality linters ----------
 RUN case "${TARGETARCH}" in \

--- a/.devcontainer/dev/devcontainer.json
+++ b/.devcontainer/dev/devcontainer.json
@@ -36,7 +36,6 @@
     },
     "ghcr.io/tailscale/codespace/tailscale": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers-extra/features/go-task:1": {},
     "ghcr.io/itsmechlark/features/1password:1.5.0": {}
   },
   "mounts": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,11 +34,10 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "dockerDashComposeVersion": "v2"
     },
-    "ghcr.io/devcontainers/features/github-cli:1": {},
     // No 1Password CLI in the bot profile — this container must hold no path
     // to production secrets (docs/guides/devcontainers.md). The human dev
     // profile (.devcontainer/dev/) keeps its own op feature.
-    "ghcr.io/devcontainers-extra/features/go-task:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "mounts": [
     "source=claude-code-config-evanharmon1-harmon-init,target=/home/vscode/.claude,type=volume",

--- a/docs/guides/devcontainer-incidents.md
+++ b/docs/guides/devcontainer-incidents.md
@@ -8,6 +8,38 @@ you can tell quickly whether the guard failed or you have found something new.
 For everyday problems see [troubleshooting.md](troubleshooting.md); this file is
 the deep end.
 
+## The image build fails with `403: rate limit exceeded`
+
+**Symptom.** A devcontainer build fails part-way through a Feature install, and
+a rerun of the identical commit succeeds. The log carries:
+
+```text
+urllib.error.HTTPError: HTTP Error 403: rate limit exceeded
+nanolayer.utils.invoker.Invoker.InvokerException: … VERSION="latest" … ./install.sh' failed
+ERROR: Feature "…" failed to install!
+```
+
+**Cause.** A devcontainer Feature given no `version` option resolves `latest` by
+calling `api.github.com` **from inside the build**. Unauthenticated, that API
+allows 60 requests/hour/IP, and GitHub-hosted runners share egress IPs — so the
+call fails unpredictably regardless of your own usage. The build is fine; the
+lookup is not.
+
+The tell is that it is **flaky rather than deterministic**, and that a rerun
+with no code change goes green. Do not go looking for a defect in the diff.
+
+Shipped fix: tools are installed in the `Dockerfile` from pinned
+`https://github.com/<owner>/<repo>/releases/download/v${FOO_VERSION}/…` URLs
+carrying `# renovate: datasource=github-releases` annotations, not from
+Features that resolve a version at build time. `task` was the last holdout
+(harmon-init#427); `scripts/devcontainer-assert.sh unit` — which `task ci`
+runs — now fails if the Feature returns or the pin goes missing.
+
+**Generalize this one.** Any build-time call to an unauthenticated public API
+is a flake waiting to happen. Pinning the Feature's own version does *not* fix
+it: the lookup happens inside the Feature's install script whichever version of
+it runs. Remove the lookup, don't version it.
+
 ## The conductor and Telegram bridge do not start
 
 **Symptom.** After launching the container, the agent-deck conductor reports

--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -52,6 +52,34 @@ assert_unit() {
     [ -f "$bot_config" ] || fail "bot devcontainer.json not found at ${bot_config}"
     [ -f "$dev_config" ] || fail "dev devcontainer.json not found at ${dev_config}"
 
+    # `task` must come from the Dockerfile's PINNED release, never a
+    # devcontainer Feature: the Feature resolved "latest" through the anonymous
+    # GitHub API from inside the build, and GitHub-hosted runners share egress
+    # IPs against a 60 req/hour/IP limit, so the required build check 403'd at
+    # random (harmon-init#427). Asserted here, in unit mode, because this is the
+    # gated path — `task ci` runs it with no container. The container-mode check
+    # below proves the binary actually landed, but it needs a built image and so
+    # runs only from the manual smoke tasks.
+    local dockerfile cfg
+    dockerfile="${repo_root}/.devcontainer/Dockerfile"
+    [ -f "$dockerfile" ] || fail "devcontainer Dockerfile not found at ${dockerfile}"
+    for cfg in "$bot_config" "$dev_config"; do
+        if grep -q 'features/go-task' "$cfg"; then
+            fail "${cfg} installs task via a devcontainer Feature — pin it in the Dockerfile instead (harmon-init#427)"
+        fi
+    done
+    grep -q '^ARG TASK_VERSION=' "$dockerfile" ||
+        fail "no 'ARG TASK_VERSION=' pin found in ${dockerfile}"
+    grep -q '# renovate: datasource=github-releases depName=go-task/task' "$dockerfile" ||
+        fail "the TASK_VERSION pin in ${dockerfile} carries no '# renovate:' annotation, so it would never be bumped"
+    # Match the URL through `v${TASK_VERSION}` (fixed-string, so the literal
+    # shell expansion in the Dockerfile is compared verbatim): a URL that merely
+    # mentions go-task would also be satisfied by a hardcoded version or a
+    # "latest" path, which is the exact failure being fixed — and would leave
+    # Renovate dutifully bumping an ARG that nothing reads.
+    grep -qF 'go-task/task/releases/download/v${TASK_VERSION}/task_linux_' "$dockerfile" ||
+        fail "${dockerfile} does not install task from the pinned \${TASK_VERSION} release URL"
+
     # Run from a non-repo temp dir so `git rev-parse --is-inside-work-tree`
     # inside init-env.sh is false and the rebuild `git pull` never fires.
     local work_dir env_file
@@ -176,6 +204,33 @@ assert_container() {
         fail "could not read git user.name in container"
     git_email="$(docker exec -u vscode "$container_id" git config --global user.email)" ||
         fail "could not read git user.email in container"
+
+    # `task` ships from the Dockerfile's pinned release, NOT a devcontainer
+    # Feature: the Feature resolved "latest" through the anonymous GitHub API
+    # from inside the build and 403'd at random on shared runner IPs. With the
+    # Feature gone, nothing else would notice if that RUN block were dropped —
+    # the image would silently lose the one binary every task target runs
+    # through. The expected version is read from the Dockerfile rather than
+    # hardcoded here: a Renovate bump then moves the pin and this assertion's
+    # source of truth in ONE file, so it cannot split across a twin.
+    local script_dir repo_root pinned_task actual_task
+    script_dir="$(cd "$(dirname "$0")" && pwd)"
+    repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+    pinned_task="$(sed -n 's/^ARG TASK_VERSION=//p' "${repo_root}/.devcontainer/Dockerfile")"
+    [ -n "$pinned_task" ] ||
+        fail "no 'ARG TASK_VERSION=' pin found in ${repo_root}/.devcontainer/Dockerfile"
+    actual_task="$(docker exec -u vscode "$container_id" sh -c 'task --version' 2>/dev/null)" ||
+        fail "task is not runnable in the ${profile} container"
+    # Compare EXACTLY, not as a substring: `*3.5.2*` also matches the output
+    # "3.5.20", which would wave through a binary that is not the pinned one.
+    # `task --version` prints a bare "3.52.0"; older builds printed
+    # "Task version: v3.52.0" — reduce both shapes to the bare version first.
+    local actual_version
+    actual_version="$(printf '%s' "$actual_task" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+    [ -n "$actual_version" ] ||
+        fail "could not parse a version out of 'task --version' output '${actual_task}' in the ${profile} container"
+    [ "$actual_version" = "$pinned_task" ] ||
+        fail "task version '${actual_version}' in the ${profile} container does not match the pin '${pinned_task}'"
 
     if [ "$profile" = "bot" ]; then
         # Assert the bot identity RELATIONSHIP, not literal values, so the

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -853,6 +853,24 @@ else
     [ -x scripts/devcontainer-assert.sh ] || err "scripts/devcontainer-assert.sh missing or not executable"
     [ -x scripts/devcontainer-smoke.sh ] || err "scripts/devcontainer-smoke.sh missing or not executable"
     grep -q -- '- task: test:devcontainer:permissions' Taskfile.yml || err "ci task is missing the devcontainer permission assertion"
+
+    # `task` must reach the RENDERED repo from a pinned release, never from the
+    # go-task Feature — the Feature resolved "latest" through the anonymous
+    # GitHub API at build time and flaked the required build check
+    # (harmon-init#427). Asserted on the rendered output, not the root layer:
+    # the devcontainer.json twins are jinja, so test:dogfood-parity cannot
+    # byte-compare them, and template/ could reintroduce the Feature while the
+    # root copy stays correct — shipping the flake to every consumer with
+    # nothing here failing.
+    for dc_cfg in .devcontainer/devcontainer.json .devcontainer/dev/devcontainer.json; do
+        [ -f "$dc_cfg" ] || continue
+        ! grep -q 'features/go-task' "$dc_cfg" ||
+            err "rendered $dc_cfg installs task via a devcontainer Feature (harmon-init#427)"
+    done
+    grep -q '^ARG TASK_VERSION=' .devcontainer/Dockerfile ||
+        err "rendered .devcontainer/Dockerfile has no 'ARG TASK_VERSION=' pin"
+    grep -qF 'go-task/task/releases/download/v${TASK_VERSION}/task_linux_' .devcontainer/Dockerfile ||
+        err "rendered .devcontainer/Dockerfile does not install task from the pinned release URL"
 fi
 
 # ── 9f. .prettierignore: web-app-only entries are gated by project type ──

--- a/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile
@@ -8,6 +8,8 @@ ARG TARGETARCH
 # can auto-PR new releases. See renovate.json for the regex manager config.
 # NODE_MAJOR is intentionally unmanaged — Node major bumps are deliberate.
 ARG NODE_MAJOR=24
+# renovate: datasource=github-releases depName=go-task/task extractVersion=^v?(?<version>.+)$
+ARG TASK_VERSION=3.52.0
 # renovate: datasource=github-releases depName=mvdan/sh extractVersion=^v?(?<version>.+)$
 ARG SHFMT_VERSION=3.13.1
 # renovate: datasource=github-releases depName=hadolint/hadolint extractVersion=^v?(?<version>.+)$
@@ -187,6 +189,21 @@ RUN install -d -m 0755 /etc/apt/keyrings \
 
 # Suppress Corepack's interactive download prompt so pnpm installs silently.
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
+# ---------- task runner ----------
+# Pinned release rather than the go-task devcontainer Feature: with no `version`
+# option the Feature resolves "latest" through the ANONYMOUS GitHub API from
+# inside the build, and GitHub-hosted runners share egress IPs against a 60
+# req/hour/IP limit — so the required devcontainer build check 403s at random
+# (harmon-init#427). Every other release-downloaded tool here is pinned the same
+# way for the same reason.
+RUN case "${TARGETARCH}" in \
+        "amd64") export TASK_ARCH="amd64" ;; \
+        "arm64") export TASK_ARCH="arm64" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/go-task/task/releases/download/v${TASK_VERSION}/task_linux_${TASK_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin task
 
 # ---------- code-quality linters ----------
 RUN case "${TARGETARCH}" in \

--- a/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
@@ -42,7 +42,6 @@
     },
     "ghcr.io/tailscale/codespace/tailscale": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers-extra/features/go-task:1": {},
     "ghcr.io/itsmechlark/features/1password:1.5.0": {}
   },
   "mounts": [

--- a/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
@@ -40,11 +40,10 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "dockerDashComposeVersion": "v2"
     },
-    "ghcr.io/devcontainers/features/github-cli:1": {},
     // No 1Password CLI in the bot profile — this container must hold no path
     // to production secrets (docs/guides/devcontainers.md). The human dev
     // profile (.devcontainer/dev/) keeps its own op feature.
-    "ghcr.io/devcontainers-extra/features/go-task:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "mounts": [
     [% if use_python %]

--- a/template/docs/guides/[% if devcontainer %]devcontainer-incidents.md[% endif %]
+++ b/template/docs/guides/[% if devcontainer %]devcontainer-incidents.md[% endif %]
@@ -8,6 +8,38 @@ you can tell quickly whether the guard failed or you have found something new.
 For everyday problems see [troubleshooting.md](troubleshooting.md); this file is
 the deep end.
 
+## The image build fails with `403: rate limit exceeded`
+
+**Symptom.** A devcontainer build fails part-way through a Feature install, and
+a rerun of the identical commit succeeds. The log carries:
+
+```text
+urllib.error.HTTPError: HTTP Error 403: rate limit exceeded
+nanolayer.utils.invoker.Invoker.InvokerException: … VERSION="latest" … ./install.sh' failed
+ERROR: Feature "…" failed to install!
+```
+
+**Cause.** A devcontainer Feature given no `version` option resolves `latest` by
+calling `api.github.com` **from inside the build**. Unauthenticated, that API
+allows 60 requests/hour/IP, and GitHub-hosted runners share egress IPs — so the
+call fails unpredictably regardless of your own usage. The build is fine; the
+lookup is not.
+
+The tell is that it is **flaky rather than deterministic**, and that a rerun
+with no code change goes green. Do not go looking for a defect in the diff.
+
+Shipped fix: tools are installed in the `Dockerfile` from pinned
+`https://github.com/<owner>/<repo>/releases/download/v${FOO_VERSION}/…` URLs
+carrying `# renovate: datasource=github-releases` annotations, not from
+Features that resolve a version at build time. `task` was the last holdout
+(harmon-init#427); `scripts/devcontainer-assert.sh unit` — which `task ci`
+runs — now fails if the Feature returns or the pin goes missing.
+
+**Generalize this one.** Any build-time call to an unauthenticated public API
+is a flake waiting to happen. Pinning the Feature's own version does *not* fix
+it: the lookup happens inside the Feature's install script whichever version of
+it runs. Remove the lookup, don't version it.
+
 ## The conductor and Telegram bridge do not start
 
 **Symptom.** After launching the container, the agent-deck conductor reports

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -52,6 +52,34 @@ assert_unit() {
     [ -f "$bot_config" ] || fail "bot devcontainer.json not found at ${bot_config}"
     [ -f "$dev_config" ] || fail "dev devcontainer.json not found at ${dev_config}"
 
+    # `task` must come from the Dockerfile's PINNED release, never a
+    # devcontainer Feature: the Feature resolved "latest" through the anonymous
+    # GitHub API from inside the build, and GitHub-hosted runners share egress
+    # IPs against a 60 req/hour/IP limit, so the required build check 403'd at
+    # random (harmon-init#427). Asserted here, in unit mode, because this is the
+    # gated path — `task ci` runs it with no container. The container-mode check
+    # below proves the binary actually landed, but it needs a built image and so
+    # runs only from the manual smoke tasks.
+    local dockerfile cfg
+    dockerfile="${repo_root}/.devcontainer/Dockerfile"
+    [ -f "$dockerfile" ] || fail "devcontainer Dockerfile not found at ${dockerfile}"
+    for cfg in "$bot_config" "$dev_config"; do
+        if grep -q 'features/go-task' "$cfg"; then
+            fail "${cfg} installs task via a devcontainer Feature — pin it in the Dockerfile instead (harmon-init#427)"
+        fi
+    done
+    grep -q '^ARG TASK_VERSION=' "$dockerfile" ||
+        fail "no 'ARG TASK_VERSION=' pin found in ${dockerfile}"
+    grep -q '# renovate: datasource=github-releases depName=go-task/task' "$dockerfile" ||
+        fail "the TASK_VERSION pin in ${dockerfile} carries no '# renovate:' annotation, so it would never be bumped"
+    # Match the URL through `v${TASK_VERSION}` (fixed-string, so the literal
+    # shell expansion in the Dockerfile is compared verbatim): a URL that merely
+    # mentions go-task would also be satisfied by a hardcoded version or a
+    # "latest" path, which is the exact failure being fixed — and would leave
+    # Renovate dutifully bumping an ARG that nothing reads.
+    grep -qF 'go-task/task/releases/download/v${TASK_VERSION}/task_linux_' "$dockerfile" ||
+        fail "${dockerfile} does not install task from the pinned \${TASK_VERSION} release URL"
+
     # Run from a non-repo temp dir so `git rev-parse --is-inside-work-tree`
     # inside init-env.sh is false and the rebuild `git pull` never fires.
     local work_dir env_file
@@ -176,6 +204,33 @@ assert_container() {
         fail "could not read git user.name in container"
     git_email="$(docker exec -u vscode "$container_id" git config --global user.email)" ||
         fail "could not read git user.email in container"
+
+    # `task` ships from the Dockerfile's pinned release, NOT a devcontainer
+    # Feature: the Feature resolved "latest" through the anonymous GitHub API
+    # from inside the build and 403'd at random on shared runner IPs. With the
+    # Feature gone, nothing else would notice if that RUN block were dropped —
+    # the image would silently lose the one binary every task target runs
+    # through. The expected version is read from the Dockerfile rather than
+    # hardcoded here: a Renovate bump then moves the pin and this assertion's
+    # source of truth in ONE file, so it cannot split across a twin.
+    local script_dir repo_root pinned_task actual_task
+    script_dir="$(cd "$(dirname "$0")" && pwd)"
+    repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+    pinned_task="$(sed -n 's/^ARG TASK_VERSION=//p' "${repo_root}/.devcontainer/Dockerfile")"
+    [ -n "$pinned_task" ] ||
+        fail "no 'ARG TASK_VERSION=' pin found in ${repo_root}/.devcontainer/Dockerfile"
+    actual_task="$(docker exec -u vscode "$container_id" sh -c 'task --version' 2>/dev/null)" ||
+        fail "task is not runnable in the ${profile} container"
+    # Compare EXACTLY, not as a substring: `*3.5.2*` also matches the output
+    # "3.5.20", which would wave through a binary that is not the pinned one.
+    # `task --version` prints a bare "3.52.0"; older builds printed
+    # "Task version: v3.52.0" — reduce both shapes to the bare version first.
+    local actual_version
+    actual_version="$(printf '%s' "$actual_task" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+    [ -n "$actual_version" ] ||
+        fail "could not parse a version out of 'task --version' output '${actual_task}' in the ${profile} container"
+    [ "$actual_version" = "$pinned_task" ] ||
+        fail "task version '${actual_version}' in the ${profile} container does not match the pin '${pinned_task}'"
 
     if [ "$profile" = "bot" ]; then
         # Assert the bot identity RELATIONSHIP, not literal values, so the


### PR DESCRIPTION
## What

Removes `ghcr.io/devcontainers-extra/features/go-task:1` from all four
`devcontainer.json` files (bot + dev profiles × root + `template/` layers) and
installs `task` in the Dockerfile from a pinned `go-task/task` release, the way
every other release-downloaded tool there is installed.

## Why

The Feature carried no `version` option, so its install script resolved
`latest` by calling `api.github.com` **from inside the image build**.
Unauthenticated, that API allows 60 requests/hour/IP and GitHub-hosted runners
share egress IPs — so the required `devcontainer-verify` check failed at
random:

```text
urllib.error.HTTPError: HTTP Error 403: rate limit exceeded
nanolayer…InvokerException: … REPO="go-task/task" … VERSION="latest" … ./install.sh' failed
```

Two of the four profile builds on #420 failed this way and both went green on a
rerun with no code change — a required check flaking ~50% on first attempt, on a
four-line diff.

Pinning the *Feature's* version (the approach in #412) would **not** fix this:
the lookup happens inside the Feature's install script whichever version of it
runs. Removing the Feature is what removes the call — and it shrinks #412's
surface by one row.

## How it's guarded

Dropping the Feature also drops the only thing that guaranteed `task` was in the
image at all, so the invariant is asserted three ways:

| Where | Runs in | Catches |
|---|---|---|
| `devcontainer-assert.sh unit` | `task ci` (no container) | Feature reintroduced; missing pin, `# renovate:` annotation, or `v${TASK_VERSION}` URL |
| `test-template.sh` | `task verify` / `template-test` | the same, on the **rendered** output |
| `devcontainer-assert.sh container` | smoke tasks | running image reports exactly the pinned version |

The rendered check matters because the `devcontainer.json` twins are jinja:
`test:dogfood-parity` cannot byte-compare them, so `template/` could rot while
the root copy stays correct — shipping the flake to every consumer with nothing
failing locally.

## Verification

- `task verify` ✅ · `task ci` ✅ (includes `security`, skills drift, devcontainer permission assert)
- `task test:dogfood-parity` ✅ — 105 verbatim twins identical
- **Both profile images built and `task --version` → `3.52.0`**, matching the pin
- Both release assets resolve: `task_linux_amd64.tar.gz` and `task_linux_arm64.tar.gz` → HTTP 200
- Renovate extraction proven directly — both twins yield `go-task/task = 3.52.0`, and both resolve to the **Devcontainer** group, so the bump stays atomic. `scripts/test-renovate-pins.sh` green; no `renovate.json` change needed.
- Every new assertion mutation-tested (Feature re-added, pin removed, annotation removed, URL hardcoded, template twin regressed) — all fail correctly and revert clean.
- `task challenge` and `task review` both exit clean: no P0/P1, and no P2s remaining.

## Notes

- **`task test:devcontainer:root` / `:dev` cannot complete from a linked git worktree** — `post-create.sh` dies on `fatal: not a git repository: …/.git/worktrees/…` because the worktree's `.git` file points outside the mounted workspace. Pre-existing and unrelated to this diff (`post-create.sh` is untouched). The images themselves built fine; `task --version` was verified by running the built images directly. Worth a follow-up, since this repo dispatches agents into worktrees.
- **Tailscale checked, as the issue asked:** `ghcr.io/tailscale/codespace/tailscale` downloads from `pkgs.tailscale.com`, **not** `api.github.com` — it does *not* carry this exposure. It is still an entirely unpinned Feature reference (no version at all), which remains #412's scope.
- The vendored `standardize-repo` skill still lists go-task as a devcontainer Feature (`standards-catalog.md:313-315`). It is vendored, so it must be fixed in harmon-devkit and re-pinned rather than hand-edited here.

Refs #427 — all six acceptance criteria are met; leaving it open only because the checkboxes are unticked (this repo's convention blocks a closing keyword until they are).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
