### PR TITLE
fix(template): route agents into /shepherd and mark checks-green non-terminal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,8 +215,11 @@ something to ask permission for.
   title rule below).
 - **Shepherd the PR (`/shepherd`, max 5 rounds).** `gh pr create` returning is
   the trigger for this stage, not the end of the work — enter it deliberately
-  (invoke the `/shepherd` skill wherever it is installed) instead of judging
-  for yourself when the PR is finished. Start by
+  instead of judging for yourself when the PR is finished. `/shepherd` is the
+  procedure, and it is **user-invocable only**
+  (`disable-model-invocation: true`): an agent enters the stage by reading
+  `.claude/skills/shepherd/SKILL.md` and following it, not by calling a slash
+  command it cannot call. Start by
   re-reading the **unchecked** entries under `## Deferred findings` in the PR
   description — those P2s are open work, not a changelog; tick each one off
   in the body as you settle it. Then watch CI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,7 +213,10 @@ something to ask permission for.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
   a clear what/why/verification summary (mind the `template/` → `fix:`/`feat:`
   title rule below).
-- **Shepherd the PR (max 5 rounds).** Opening the PR is not the end. Start by
+- **Shepherd the PR (`/shepherd`, max 5 rounds).** `gh pr create` returning is
+  the trigger for this stage, not the end of the work — enter it deliberately
+  (invoke the `/shepherd` skill wherever it is installed) instead of judging
+  for yourself when the PR is finished. Start by
   re-reading the **unchecked** entries under `## Deferred findings` in the PR
   description — those P2s are open work, not a changelog; tick each one off
   in the body as you settle it. Then watch CI
@@ -232,8 +235,17 @@ something to ask permission for.
   states a different cap or exit condition, **this file wins** — the skills
   are synced from harmon-devkit on its own release cadence and can lag a
   policy change made here.
-- **Stop at green.** Report that checks pass, then stop — merging is always a
-  human decision.
+- **Checks green is a non-terminal state.** Reporting "all checks pass"
+  without having polled reviews and inline comments is not a handoff — it is
+  the middle of the shepherd stage. Bot and human reviews land *after* checks
+  settle, so `gh pr checks --watch` returns at exactly the moment the review
+  has not run yet: an empty comment list read at that instant means "not
+  reviewed yet", not "nothing to answer". Wait for **both** signals — let
+  every check conclude, then give the reviewer a bounded window (~10–15
+  minutes) on the current head, and proceed on CI alone only if nothing lands
+  in it.
+- **Stop at green.** Once checks pass *and* no review findings are unresolved,
+  report that and stop — merging is always a human decision.
 
 ## Critical Copier Gotchas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,8 +277,9 @@ something to ask permission for.
   `verify` + `security` + `codeql-verify` status checks.
 - **Agents never merge to main** — no `gh pr merge`, `git merge`, or push to
   `main` without Evan's explicit, per-merge approval, even when CI is green and
-  the ruleset would allow it. Open the PR, report that checks pass, then stop;
-  merging is always a human decision. (`.claude/settings.json` backstops this
+  the ruleset would allow it. Open the PR and shepherd it — checks green with
+  reviews unpolled is not the stopping point — then report and stop; merging
+  is always a human decision. (`.claude/settings.json` backstops this
   with `permissions.ask` rules on merge commands.)
 - **Reply to every inline PR review comment in its own thread** — bot
   reviewers and humans alike. Treat findings as

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -123,7 +123,10 @@ something to ask permission for.
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
   a clear what/why/verification summary.
-- **Shepherd the PR (max 5 rounds).** Opening the PR is not the end. Start by
+- **Shepherd the PR (`/shepherd`, max 5 rounds).** `gh pr create` returning is
+  the trigger for this stage, not the end of the work — enter it deliberately
+  (invoke the `/shepherd` skill wherever it is installed) instead of judging
+  for yourself when the PR is finished. Start by
   re-reading any **unsettled** findings the PR description defers to this
   stage — they are open work, not a changelog; mark each one off in the body
   as you settle it. Then watch CI
@@ -142,8 +145,17 @@ something to ask permission for.
   **vendored** skill (`/shepherd`) states a different cap or exit condition,
   **this file wins** — vendored skills are synced on their own release
   cadence and can lag a policy change made here.
-- **Stop at green.** Report that checks pass, then stop — merging is always a
-  human decision.
+- **Checks green is a non-terminal state.** Reporting "all checks pass"
+  without having polled reviews and inline comments is not a handoff — it is
+  the middle of the shepherd stage. Bot and human reviews land *after* checks
+  settle, so `gh pr checks --watch` returns at exactly the moment the review
+  has not run yet: an empty comment list read at that instant means "not
+  reviewed yet", not "nothing to answer". Wait for **both** signals — let
+  every check conclude, then give the reviewer a bounded window (~10–15
+  minutes) on the current head, and proceed on CI alone only if nothing lands
+  in it.
+- **Stop at green.** Once checks pass *and* no review findings are unresolved,
+  report that and stop — merging is always a human decision.
 
 ## Definition of Done
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -125,8 +125,12 @@ something to ask permission for.
   a clear what/why/verification summary.
 - **Shepherd the PR (`/shepherd`, max 5 rounds).** `gh pr create` returning is
   the trigger for this stage, not the end of the work — enter it deliberately
-  (invoke the `/shepherd` skill wherever it is installed) instead of judging
-  for yourself when the PR is finished. Start by
+  instead of judging for yourself when the PR is finished. Where the optional
+  `/shepherd` skill is vendored it is the procedure, and it is **user-invocable
+  only** (`disable-model-invocation: true`): an agent enters the stage by
+  reading `.claude/skills/shepherd/SKILL.md` and following it, not by calling a
+  slash command it cannot call. Where it is not vendored, this bullet is the
+  procedure. Start by
   re-reading any **unsettled** findings the PR description defers to this
   stage — they are open work, not a changelog; mark each one off in the body
   as you settle it. Then watch CI

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -170,8 +170,9 @@ something to ask permission for.
 - Work on a feature branch; direct commits to `main` are blocked.
 - **Never merge to main yourself** — no `gh pr merge`, `git merge`, or push to
   `main` without the maintainer's explicit, per-merge approval, even when CI is
-  green and the ruleset would allow it. Open the PR, report that checks pass,
-  then stop; merging is always a human decision.
+  green and the ruleset would allow it. Open the PR and shepherd it — checks
+  green with reviews unpolled is not the stopping point — then report and
+  stop; merging is always a human decision.
 - **Reply to every inline PR review comment in its own thread** — bot
   reviewers and humans alike. Treat findings as
   hypotheses: verify each against the code, fix what's confirmed, and post the


### PR DESCRIPTION
## What

Two Dev Loop changes, applied in lockstep to the root dogfood twin
(`AGENTS.md`) and `template/AGENTS.md.jinja`:

- **Route into the shepherd stage.** `gh pr create` returning is now stated as
  the *trigger* for the stage, not the end of the work. The bullet names
  `/shepherd` as the procedure and says how an agent actually enters it —
  by reading `.claude/skills/shepherd/SKILL.md` and following it, because the
  skill sets `disable-model-invocation: true` and cannot be called via the
  Skill tool. The template wording also covers repos where the optional skill
  is not vendored: there, the bullet itself is the procedure.
- **Checks green is a non-terminal state.** A new bullet says that reporting
  "all checks pass" without having polled reviews and inline comments is the
  middle of the stage, not a handoff, and carries the timing reason: bot and
  human reviews land *after* checks settle, so `gh pr checks --watch` returns
  at the exact moment the review has not run yet — an empty comment list read
  then means "not reviewed yet", not "nothing to answer". `Stop at green` now
  requires both signals.

The 5-round cap was already correct here and is unchanged.

## Why

Observed downstream: an agent ran `gh pr checks --watch`, saw everything
green, reported "all checks green, merging is yours" and stopped. The Codex
cloud reviewer posted an inline P2 two minutes later; it sat unanswered until
the maintainer asked. The guidance was already correct in prose — what was
missing was anything that makes stopping at green *hard*, and any statement of
how an agent enters the stage at all.

Reported as evanharmon1/harmon-devkit#179, fixed downstream in
evanharmon1/harmon-devkit (AGENTS.md, the shepherd skill, and the codex-review
guide) — this is the upstream half so a `copier update` does not re-open it.

## Verification

- `task check`, `task verify`, `task ci` — all pass.
- `task audit:dogfood` — no new root↔template drift on the changed bullets.
- `task challenge` → clean pass (round 2; round 1's P1 is fixed in `f7ea519`,
  see below).
- `task review` → clean pass, no P0/P1, no material P2.

### Adjudication

| Finding | Class | Action |
| --- | --- | --- |
| P1: agents cannot invoke `/shepherd` — the skill sets `disable-model-invocation: true` | **Confirmed** | Fixed in `f7ea519`: route through the skill *file*. Codex's proposed remedy (make the skill model-invocable and rebump the pin) was **rejected** — shepherd pushes commits and posts PR comments, and the whole `/start`–`/close` session suite is deliberately user-driven; only `track-work` is model-invocable. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
