### PR TITLE
fix: warn instead of aborting when a reused board's Status field is not a single-select

### DIFF
--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -142,6 +142,14 @@ fi
 # that project-automation.yml + the claude-* workflows read (preferred over a
 # title lookup). Personal accounts have no org-level variable scope, and their
 # status automation is a separate follow-up, so skip it there.
+#
+# This deliberately runs BEFORE field reconciliation. The variable answers "which
+# board", and by this point the board exists, so pointing at it is correct even
+# if a later step cannot finish. Deferring the write until after reconciliation
+# would not protect anything: a run that died in between would leave no variable
+# at all, and the workflows' title-lookup fallback resolves to that same
+# half-reconciled board. Reconciliation is additive and re-runnable, so the
+# remedy for a partial run is to re-run this script either way.
 if [ "$owner_type" = "Organization" ]; then
     echo "==> Recording project id in the ORG_PROJECT_ID org variable"
     if ! gh variable set ORG_PROJECT_ID --org "$owner" --visibility all --body "$project_id"; then
@@ -286,22 +294,36 @@ append_options() {
 }
 
 # ── Status field: full pipeline on a new project; preserve + append on an
-#    existing one so items already assigned to an option are never orphaned ──
-status_field_id=$(field_id "Status")
-if [ -z "$status_field_id" ]; then
+#    existing one so items already assigned to an option are never orphaned.
+#
+#    Status goes through field_exists — the SAME data-type guard as the custom
+#    fields below — rather than a bare name lookup. A reused board can carry a
+#    field named `Status` that is not a single-select, and handing that to
+#    append_options reaches existing_options, whose jq iterates a null
+#    `.options` and exits 5; under `set -euo pipefail` that aborts the entire
+#    run rather than warning, leaving a half-reconciled project (on an org,
+#    after ORG_PROJECT_ID has already been repointed above). ──
+if field_exists "Status" SINGLE_SELECT; then
+    # A data-type mismatch already warned and is repeated by report_incompatible;
+    # options cannot be added to such a field, so skip it and carry on.
+    if [ "$field_matched" = "1" ]; then
+        if [ "$created" = "1" ]; then
+            # A project GitHub just created for us carries its default Status
+            # options and nothing is assigned to them yet, so replacing the list
+            # wholesale is safe.
+            echo "==> Setting Status to the full pipeline (new project)"
+            set_options "$(field_id "Status")" "$(printf '%s' "$status_pipeline" | jq -c .)"
+        else
+            echo "==> Syncing Status (keeping existing options, appending any missing)"
+            append_options "Status" "$status_pipeline"
+        fi
+    fi
+else
     echo "==> Creating the Status field with the full pipeline"
     frag=$(printf '%s' "$status_pipeline" | jq -r "$opts_to_graphql")
     gh api graphql -f p="$project_id" \
         -f query="mutation(\$p:ID!){createProjectV2Field(input:{projectId:\$p,dataType:SINGLE_SELECT,name:\"Status\",singleSelectOptions:[$frag]}){projectV2Field{... on ProjectV2SingleSelectField{id}}}}" \
         >/dev/null
-elif [ "$created" = "1" ]; then
-    # A project GitHub just created for us carries its default Status options and
-    # nothing is assigned to them yet, so replacing the list wholesale is safe.
-    echo "==> Setting Status to the full pipeline (new project)"
-    set_options "$status_field_id" "$(printf '%s' "$status_pipeline" | jq -c .)"
-else
-    echo "==> Syncing Status (keeping existing options, appending any missing)"
-    append_options "Status" "$status_pipeline"
 fi
 
 # ── Custom fields: create if missing; an existing single-select is reconciled by

--- a/scripts/test-setup-github-project.sh
+++ b/scripts/test-setup-github-project.sh
@@ -158,6 +158,23 @@ run_with "$wrong"
 [ "$(updates)" = 0 ] || fail "a wrong-typed field must not receive an option update"
 grep -q "already exists as TEXT" "$tmp/out" || fail "expected a data-type warning for Domain"
 
+echo "==> a non-single-select Status warns and is skipped, never aborting the run"
+# Status is reconciled by its own call site rather than create_single_select, so
+# it needs its own coverage: without the field_exists guard there, existing_options
+# runs `.options[]` over a field that has none, jq exits 5, and `set -euo pipefail`
+# kills the whole run — a stack trace instead of the warning this script promises,
+# and on an org it happens after ORG_PROJECT_ID was already repointed. run_with
+# fails the test on any non-zero exit, so the exit-0 half of this is implicit.
+wrong_status=$(printf '%s' "$complete" | jq -c '
+    .data.node.fields.nodes |= map(
+        if .name == "Status" then {id: .id, name: .name, dataType: "TEXT"} else . end)')
+run_with "$wrong_status"
+[ "$(updates)" = 0 ] || fail "a wrong-typed Status must not receive an option update"
+grep -q "field 'Status' already exists as TEXT" "$tmp/out" ||
+    fail "expected a data-type warning naming Status and its actual type"
+grep -q "Status (is TEXT, wanted SINGLE_SELECT)" "$tmp/out" ||
+    fail "expected Status in the end-of-run incompatible summary"
+
 echo "==> a field at the option cap warns instead of attempting an oversized write"
 capped=$(printf '%s' "$complete" | jq -c '
     .data.node.fields.nodes |= map(

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -142,6 +142,14 @@ fi
 # that project-automation.yml + the claude-* workflows read (preferred over a
 # title lookup). Personal accounts have no org-level variable scope, and their
 # status automation is a separate follow-up, so skip it there.
+#
+# This deliberately runs BEFORE field reconciliation. The variable answers "which
+# board", and by this point the board exists, so pointing at it is correct even
+# if a later step cannot finish. Deferring the write until after reconciliation
+# would not protect anything: a run that died in between would leave no variable
+# at all, and the workflows' title-lookup fallback resolves to that same
+# half-reconciled board. Reconciliation is additive and re-runnable, so the
+# remedy for a partial run is to re-run this script either way.
 if [ "$owner_type" = "Organization" ]; then
     echo "==> Recording project id in the ORG_PROJECT_ID org variable"
     if ! gh variable set ORG_PROJECT_ID --org "$owner" --visibility all --body "$project_id"; then
@@ -286,22 +294,36 @@ append_options() {
 }
 
 # ── Status field: full pipeline on a new project; preserve + append on an
-#    existing one so items already assigned to an option are never orphaned ──
-status_field_id=$(field_id "Status")
-if [ -z "$status_field_id" ]; then
+#    existing one so items already assigned to an option are never orphaned.
+#
+#    Status goes through field_exists — the SAME data-type guard as the custom
+#    fields below — rather than a bare name lookup. A reused board can carry a
+#    field named `Status` that is not a single-select, and handing that to
+#    append_options reaches existing_options, whose jq iterates a null
+#    `.options` and exits 5; under `set -euo pipefail` that aborts the entire
+#    run rather than warning, leaving a half-reconciled project (on an org,
+#    after ORG_PROJECT_ID has already been repointed above). ──
+if field_exists "Status" SINGLE_SELECT; then
+    # A data-type mismatch already warned and is repeated by report_incompatible;
+    # options cannot be added to such a field, so skip it and carry on.
+    if [ "$field_matched" = "1" ]; then
+        if [ "$created" = "1" ]; then
+            # A project GitHub just created for us carries its default Status
+            # options and nothing is assigned to them yet, so replacing the list
+            # wholesale is safe.
+            echo "==> Setting Status to the full pipeline (new project)"
+            set_options "$(field_id "Status")" "$(printf '%s' "$status_pipeline" | jq -c .)"
+        else
+            echo "==> Syncing Status (keeping existing options, appending any missing)"
+            append_options "Status" "$status_pipeline"
+        fi
+    fi
+else
     echo "==> Creating the Status field with the full pipeline"
     frag=$(printf '%s' "$status_pipeline" | jq -r "$opts_to_graphql")
     gh api graphql -f p="$project_id" \
         -f query="mutation(\$p:ID!){createProjectV2Field(input:{projectId:\$p,dataType:SINGLE_SELECT,name:\"Status\",singleSelectOptions:[$frag]}){projectV2Field{... on ProjectV2SingleSelectField{id}}}}" \
         >/dev/null
-elif [ "$created" = "1" ]; then
-    # A project GitHub just created for us carries its default Status options and
-    # nothing is assigned to them yet, so replacing the list wholesale is safe.
-    echo "==> Setting Status to the full pipeline (new project)"
-    set_options "$status_field_id" "$(printf '%s' "$status_pipeline" | jq -c .)"
-else
-    echo "==> Syncing Status (keeping existing options, appending any missing)"
-    append_options "Status" "$status_pipeline"
 fi
 
 # ── Custom fields: create if missing; an existing single-select is reconciled by

--- a/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
@@ -158,6 +158,23 @@ run_with "$wrong"
 [ "$(updates)" = 0 ] || fail "a wrong-typed field must not receive an option update"
 grep -q "already exists as TEXT" "$tmp/out" || fail "expected a data-type warning for Domain"
 
+echo "==> a non-single-select Status warns and is skipped, never aborting the run"
+# Status is reconciled by its own call site rather than create_single_select, so
+# it needs its own coverage: without the field_exists guard there, existing_options
+# runs `.options[]` over a field that has none, jq exits 5, and `set -euo pipefail`
+# kills the whole run — a stack trace instead of the warning this script promises,
+# and on an org it happens after ORG_PROJECT_ID was already repointed. run_with
+# fails the test on any non-zero exit, so the exit-0 half of this is implicit.
+wrong_status=$(printf '%s' "$complete" | jq -c '
+    .data.node.fields.nodes |= map(
+        if .name == "Status" then {id: .id, name: .name, dataType: "TEXT"} else . end)')
+run_with "$wrong_status"
+[ "$(updates)" = 0 ] || fail "a wrong-typed Status must not receive an option update"
+grep -q "field 'Status' already exists as TEXT" "$tmp/out" ||
+    fail "expected a data-type warning naming Status and its actual type"
+grep -q "Status (is TEXT, wanted SINGLE_SELECT)" "$tmp/out" ||
+    fail "expected Status in the end-of-run incompatible summary"
+
 echo "==> a field at the option cap warns instead of attempting an oversized write"
 capped=$(printf '%s' "$complete" | jq -c '
     .data.node.fields.nodes |= map(


### PR DESCRIPTION
Closes #447

## What

`setup-github-project.sh` resolved the `Status` field with a name-only
`field_id "Status"` lookup and called `append_options "Status"` directly, while
every **custom** field went through `field_exists NAME EXPECTED_DATATYPE` — the
data-type guard that records a mismatch, warns, and skips the append.

This routes the `Status` call site through that same guard, mirroring
`create_single_select`'s shape.

## Why

The script is documented as idempotent and **warn-and-continue** — its own
comment says a pre-existing field it cannot reconcile is "no reason to abort the
rest." `Status` broke that promise.

A reused board carrying a field named `Status` of any non-single-select type
reached `existing_options`, whose jq runs `.options[]` over a field that has
none:

```
jq: error (at <stdin>:0): Cannot iterate over null (null)
```

jq exits 5; under `set -euo pipefail` the assignment aborted the whole task. So
the operator got a stack trace instead of the promised WARNING, no summary line
naming the field, and a half-reconciled project — and on an organization the run
died **after** `ORG_PROJECT_ID` had already been repointed. The path is reachable
in the ordinary case the script exists for: adopting harmon-init project
management onto an owner's existing board.

`created=1` is not a second instance of the bug — that branch is only reachable
for a project GitHub just created, whose `Status` is always a single-select — but
it now sits inside the guard too, so all three outcomes are handled in one shape.

## Acceptance criteria

- [x] `Status` is routed through the same data-type guard as the custom fields, so a non-single-select `Status` warns and is skipped instead of aborting.
- [x] The mismatch appears in the end-of-run summary (the `incompatible` list) like any other wrong-typed field, naming `Status` and its actual type.
- [x] `test-setup-github-project.sh` gains a case for a pre-existing non-single-select `Status`, asserting the run exits 0 and warns.
- [x] Considered the ordering — see below.

### On AC 4 (ORG_PROJECT_ID ordering)

Left where it is, with the reasoning now recorded in a comment at the write
site. The variable answers *which board*, and by that point the board exists, so
pointing at it is correct even if a later step cannot finish. Deferring the write
until after reconciliation protects nothing: a run that died in between would
leave **no** variable at all, and the workflows' title-lookup fallback resolves
to the same half-reconciled board. Reconciliation is additive and re-runnable, so
the remedy for a partial run is to re-run the script either way.

## Verification

- `task verify` — exit 0
- `task ci` — exit 0 (full mirror: verify + skills drift + devcontainer assert + security; Semgrep 173 rules / 211 files, 0 findings; gitleaks no leaks)
- `task test:setup-github-project` — passes, including the new case
- **Mutation-checked**: the new test case fails against the pre-fix script with exactly the reported `jq: Cannot iterate over null` abort, so it is a real regression guard rather than a test that passes either way.
- `task challenge` (Codex adversarial) — no P0/P1 findings
- `task review` (Codex verification) — no P0/P1, no material P2
- `PR_TITLE=… BASE_SHA=main task guard:release-title` — releasing type, ok
- The issue's own grep now shows `append_options "Status"` inside a `field_exists "Status" SINGLE_SELECT` guard, alongside the three custom-field guards.

## Dogfood parity

Both files are **verbatim** twins; the root and `template/` copies were updated in
lockstep and are byte-identical (`task test:dogfood-parity` gates this).

## Follow-up (other repo, not this PR)

harmon-devkit #177 (merged ~1 min before #447 was filed) documents this as a
**hard stop** in the standardize-repo catalog §1.13. Once this ships and the
skills pin bumps, that entry should be softened to "warns and skips".

## Deferred findings

None — both Codex stages came back clean on the first pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
