### PR TITLE
fix(template): refuse an empty-diff codex review instead of passing it off as clean

### DIFF
--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -46,6 +46,14 @@ task review -- --uncommitted                       # staged + unstaged + untrack
 task challenge -- --base main focus on the update/migration path
 ```
 
+Whichever target you pick, an empty one is refused before Codex is invoked,
+with a non-zero exit. An empty scope has no correct outcome — the model either
+invents one or declines, and a decline reads exactly like a clean pass, so a
+capped challenge/review round would be spent banking a review that never
+happened. `--base` on a dirty tree also says so on stderr: it reviews
+committed history only, and the uncommitted work it excludes is often the very
+change you meant to review.
+
 Inside Claude Code the plugin's slash commands are the interactive
 equivalents: `/codex:review` and
 `/codex:adversarial-review --base main --background` (with extra focus text
@@ -220,6 +228,9 @@ Adjudicate it; never disable the gate to get past a BLOCK.
 - **Gate enabled but nothing happens** — `task codex:gate:status`; remember
   the flag is per workspace path (worktrees toggle separately) and fails open
   when Codex is unavailable.
-- **Nothing to review** — a clean tree with no commits beyond the base exits
-  early; pass `--base <ref>`, `--uncommitted`, or `--commit <sha>` to pick
-  the target explicitly.
+- **Nothing to review** — the resolved target is empty, so the run refuses
+  (exit 1) instead of asking Codex to review nothing; the message names the
+  condition and the way out. Reaching it from `task challenge` with no flags
+  means a clean tree with no commits beyond the base. Reaching it from
+  `--base <ref>` usually means the work is still uncommitted — use
+  `--uncommitted`, or commit first.

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -20,6 +20,8 @@
 # agent/human to adjudicate (AGENTS.md "Second-Model Review") — this is never
 # part of `verify`/`ci`. Both modes ask for P0/P1/P2-labelled findings; only
 # P0/P1 gate the local loop, P2s are reported and deferred to the PR stage.
+# No target path may invoke Codex with an empty scope; every one of them
+# refuses and exits non-zero instead (see refuse_empty_scope).
 # Requires an authenticated Codex CLI (`codex login`);
 # see docs/guides/codex-review.md.
 set -euo pipefail
@@ -52,9 +54,52 @@ cap_manifest() {
     awk 'NR <= 200 { print } NR == 201 { print "... (manifest truncated at 200 entries; re-enumerate with git for the full set)" }'
 }
 
+# Every manifest and dirty-check goes through these, so no call site can forget
+# the flags. Both spell out git's own defaults and therefore change nothing on
+# a default config; they exist to neutralize repo/user settings that would
+# otherwise hide real changes and make a non-empty target look empty —
+# `status.showUntrackedFiles=no` (a tree whose only work is untracked reads
+# clean) and `diff.ignoreSubmodules=all` / `submodule.<name>.ignore=all` (a
+# commit that only bumps a submodule gitlink reads as no change at all).
+git_status_porcelain() {
+    git status --porcelain --untracked-files=all --ignore-submodules=none "$@"
+}
+git_diff_name_status() {
+    git diff --name-status --ignore-submodules=none "$@"
+}
+
+# An empty scope has no correct outcome, so no target path may reach Codex
+# with one. The model either invents a scope (reviewing whatever it can see)
+# or declines — and a decline is textually indistinguishable from a clean
+# pass, which is exactly what the local loop's exit condition reads. Refuse
+# before spending the model call, and exit NON-ZERO: a capped challenge/review
+# loop reads exit status, so a zero here would be banked as the clean pass the
+# stage exits on.
+refuse_empty_scope() {
+    # $1 — the condition, $2 — how to fix it
+    echo "Nothing to review: $1" >&2
+    echo "$2" >&2
+    exit 1
+}
+
+# --base reviews committed history only, so uncommitted work is silently out
+# of scope. Say so — the surprise compounds when the working tree holds
+# exactly the change the operator meant to review. Not applied to --commit:
+# naming a specific sha already says the target is not "my current work".
+warn_if_dirty() {
+    [ -n "$(git_status_porcelain)" ] || return 0
+    echo "Note: the working tree is dirty, and --base reviews committed history only." >&2
+    echo "      Uncommitted changes are NOT in scope; use --uncommitted for those." >&2
+}
+
 scope=""
 manifest=""
 focus=""
+# Which explicit target flag was given, plus the wording its empty-scope
+# refusal should use. Resolved during parsing, acted on after it.
+target_kind=""
+empty_desc=""
+empty_hint=""
 require_single_target() {
     if [ -n "$scope" ]; then
         echo "conflicting target flags: --base, --uncommitted, and --commit are mutually exclusive." >&2
@@ -80,7 +125,13 @@ while [ $# -gt 0 ]; do
             exit 2
         fi
         scope="Review the changes on the current branch relative to base branch '$2' (the merge-base diff $2...HEAD)."
-        manifest="$(git diff --name-status "$2...HEAD" 2>/dev/null | cap_manifest || true)"
+        manifest="$(git_diff_name_status "$2...HEAD" 2>/dev/null | cap_manifest || true)"
+        target_kind="base"
+        empty_desc="the merge-base diff $2...HEAD is empty — HEAD changes no files beyond '$2'."
+        # --commit belongs here too: a branch whose commits net out to no change
+        # (an add and its revert) is already committed and has a clean tree, so
+        # both of the other two remedies would be dead ends.
+        empty_hint="Pass --uncommitted for working-tree changes, --commit <sha> for a single commit, or commit your work first."
         shift 2
         ;;
     --commit)
@@ -98,16 +149,22 @@ while [ $# -gt 0 ]; do
         # emit each merge parent's diff, pulling pre-merge mainline files into
         # the "authoritative" manifest. --root covers parentless root commits.
         if git rev-parse --verify --quiet "$2^" >/dev/null; then
-            manifest="$(git diff --name-status "$2^" "$2" 2>/dev/null | cap_manifest || true)"
+            manifest="$(git_diff_name_status "$2^" "$2" 2>/dev/null | cap_manifest || true)"
         else
-            manifest="$(git diff-tree --no-commit-id --name-status -r --root "$2" 2>/dev/null | cap_manifest || true)"
+            manifest="$(git diff-tree --no-commit-id --name-status -r --root --ignore-submodules=none "$2" 2>/dev/null | cap_manifest || true)"
         fi
+        target_kind="commit"
+        empty_desc="commit $2 changes no files (an empty commit, or a merge with no first-parent change)."
+        empty_hint="Pass --base <ref> for a branch-scoped review, or name a commit that touches files."
         shift 2
         ;;
     --uncommitted)
         require_single_target
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
-        manifest="$(git status --porcelain --untracked-files=all | cap_manifest || true)"
+        manifest="$(git_status_porcelain | cap_manifest || true)"
+        target_kind="uncommitted"
+        empty_desc="the working tree is clean — there is no staged, unstaged, or untracked work."
+        empty_hint="Pass --base <ref> to review the branch's commits instead."
         shift
         ;;
     *)
@@ -117,10 +174,24 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+# Checked after the parse loop, not inside it: an empty diff is a property of
+# a fully-resolved target, so reporting it mid-parse would mask a genuine
+# argument error (e.g. `--base <ref> --uncommitted` must still be rejected as
+# conflicting flags, whatever that base's diff contains).
+if [ "$target_kind" = "base" ]; then
+    warn_if_dirty
+fi
+if [ -n "$target_kind" ] && [ -z "$manifest" ]; then
+    refuse_empty_scope "$empty_desc" "$empty_hint"
+fi
+
 if [ -z "$scope" ]; then
-    if [ -n "$(git status --porcelain)" ]; then
+    # Same helper as the manifest built from it two lines down, so the tree
+    # cannot test clean here and then yield a non-empty manifest (or vice
+    # versa) because the two calls disagreed about what counts as a change.
+    if [ -n "$(git_status_porcelain)" ]; then
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
-        manifest="$(git status --porcelain --untracked-files=all | cap_manifest || true)"
+        manifest="$(git_status_porcelain | cap_manifest || true)"
         echo "==> Reviewing uncommitted work (dirty tree; pass --base <ref> to review the branch instead)"
     else
         # origin/HEAD (the remote's actual default branch) outranks local
@@ -146,13 +217,32 @@ if [ -z "$scope" ]; then
             exit 2
         fi
         if [ "$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)" -eq 0 ]; then
-            echo "Nothing to review: the working tree is clean and HEAD has no commits beyond ${base}."
-            exit 0
+            refuse_empty_scope \
+                "the working tree is clean and HEAD has no commits beyond ${base}." \
+                "Pass --base <ref> or --commit <sha> to name a target explicitly."
         fi
         scope="Review the changes on the current branch relative to base branch '${base}' (the merge-base diff ${base}...HEAD)."
-        manifest="$(git diff --name-status "${base}...HEAD" | cap_manifest || true)"
+        manifest="$(git_diff_name_status "${base}...HEAD" | cap_manifest || true)"
+        # Commits beyond the base do not guarantee a non-empty diff: an empty
+        # commit, or one later reverted, leaves nothing for Codex to read.
+        if [ -z "$manifest" ]; then
+            refuse_empty_scope \
+                "the merge-base diff ${base}...HEAD is empty — the commits beyond ${base} change no files." \
+                "Pass --commit <sha> to review a specific commit, or --uncommitted for working-tree changes."
+        fi
         echo "==> Reviewing branch changes against ${base}"
     fi
+fi
+
+# Backstop for every path, so the invariant does not depend on each one
+# remembering it. The auto dirty-tree path in particular decides on one
+# `git status` and builds its manifest from a second: a tree cleaned between
+# the two calls — or a call that failed into `|| true` — would otherwise still
+# reach the model with nothing to review.
+if [ -z "$manifest" ]; then
+    refuse_empty_scope \
+        "the resolved target contains no changed files." \
+        "Name a target explicitly with --base <ref>, --commit <sha>, or --uncommitted."
 fi
 
 if [ "$MODE" = "challenge" ]; then
@@ -213,16 +303,16 @@ fi
 # Custom review instructions bypass the CLI's native diff-target modes (the
 # two are mutually exclusive), leaving diff collection to the model. Anchor it
 # with an authoritative, git-generated file manifest so nothing in scope —
-# untracked files included — can be silently skipped.
-if [ -n "$manifest" ]; then
-    instructions="${instructions}
+# untracked files included — can be silently skipped. Unconditional: the
+# backstop above guarantees a non-empty manifest, so a "if we have one" test
+# here would be dead code implying an empty-manifest run is reachable.
+instructions="${instructions}
 
 Authoritative changed-file manifest from git for this scope (status + path;
 cover EVERY entry, including untracked files, collecting the diffs yourself
 with git):
 
 ${manifest}"
-fi
 
 # Feed the prompt through stdin (`review -`): a single argv element is
 # capped (~128 KiB per arg on Linux), and cap_manifest bounds entry count,

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -5,7 +5,9 @@
 # regression a real adversarial review caught: with no local main/master and
 # origin/HEAD pointing at another default branch, the base fallback used to
 # strip `origin/` into a nonexistent local ref and silently report nothing
-# to review. Run via `task test:codex-review`.
+# to review, and the one a real --base run caught: an empty scope reached
+# Codex, whose "that diff is empty" reply exited 0 and read as the clean pass
+# a capped review loop exits on. Run via `task test:codex-review`.
 set -euo pipefail
 
 repo="$(git rev-parse --show-toplevel)"
@@ -123,11 +125,68 @@ echo "$out" | grep -q "STUB-ARGS:exec review" || fail "codex not invoked on larg
 echo "$out" | grep -q "manifest truncated at 200 entries" || fail "truncation marker missing on >200-entry manifest: $out"
 rm -f bulk_f*.txt
 
-echo "==> clean tree at the base tip reports nothing to review"
+echo "==> clean tree at the base tip refuses, non-zero, without invoking codex"
 git checkout -q -b tipcheck origin/develop
-out="$(run review)" || fail "nothing-to-review case exited non-zero: $out"
+# Non-zero is the point: a capped review loop reads exit status, so a zero
+# here would be banked as the clean pass the stage exits on.
+if out="$(run review)"; then
+    fail "nothing-to-review case exited zero (reads as a clean pass): $out"
+fi
 echo "$out" | grep -q "Nothing to review" || fail "expected nothing-to-review message: $out"
 echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite nothing to review: $out"
+
+echo "==> --base level with its base refuses, non-zero, without invoking codex"
+# The reported bug: an explicit --base built an empty manifest and shipped a
+# scope string anyway, and Codex's "that diff is empty" reply exited 0 and
+# consumed a round of a capped loop.
+if out="$(run challenge --base origin/develop)"; then
+    fail "--base with an empty diff was accepted: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite an empty --base diff: $out"
+echo "$out" | grep -q "Nothing to review" || fail "missing empty--base refusal message: $out"
+echo "$out" | grep -q -- "--uncommitted" || fail "empty --base refusal does not name the fix: $out"
+
+echo "==> --base on a dirty tree says the uncommitted work is out of scope"
+echo scratch >scratch.txt
+if out="$(run challenge --base origin/develop)"; then
+    fail "--base with an empty diff was accepted on a dirty tree: $out"
+fi
+echo "$out" | grep -q "working tree is dirty" || fail "no dirty-tree note on --base: $out"
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite an empty --base diff: $out"
+
+echo "==> --uncommitted on a clean tree refuses, non-zero, without invoking codex"
+rm -f scratch.txt
+if out="$(run review --uncommitted)"; then
+    fail "--uncommitted on a clean tree was accepted: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite a clean tree: $out"
+echo "$out" | grep -q "Nothing to review" || fail "missing empty--uncommitted refusal message: $out"
+
+echo "==> status.showUntrackedFiles=no cannot hide an untracked-only tree"
+# Both the auto dirty-tree test and the --base warning read `git status`; with
+# the default untracked mode, this config makes a tree holding only untracked
+# work look clean, so the auto path would review the branch instead of the
+# work, and --base would skip its warning.
+git_t config status.showUntrackedFiles no
+echo hidden >hidden.txt
+out="$(run review)" || fail "untracked-only tree with showUntrackedFiles=no exited non-zero: $out"
+echo "$out" | grep -q "uncommitted work" || fail "untracked-only tree was not seen as dirty: $out"
+echo "$out" | grep -q "hidden.txt" || fail "untracked file missing from manifest: $out"
+if out="$(run challenge --base origin/develop)"; then
+    fail "--base with an empty diff was accepted: $out"
+fi
+echo "$out" | grep -q "working tree is dirty" || fail "dirty-tree note suppressed by showUntrackedFiles=no: $out"
+rm -f hidden.txt
+git_t config --unset status.showUntrackedFiles
+
+echo "==> --commit on an empty commit refuses, non-zero, without invoking codex"
+git_t commit -q --allow-empty -m "empty commit"
+if out="$(run review --commit HEAD)"; then
+    fail "--commit on an empty commit was accepted: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite an empty commit diff: $out"
+echo "$out" | grep -q "Nothing to review" || fail "missing empty--commit refusal message: $out"
+git_t reset -q --hard HEAD~1
 
 echo "==> bad mode is rejected"
 if out="$(run bogus 2>&1)"; then
@@ -168,6 +227,29 @@ merge_sha="$(git rev-parse HEAD)"
 out="$(run review --commit "$merge_sha")" || fail "merge-commit review exited non-zero: $out"
 echo "$out" | grep -q "side.txt" || fail "merge commit manifest missing first-parent change: $out"
 echo "$out" | grep -q "feature.txt" && fail "merge manifest includes pre-merge mainline files (diff-tree -m regression): $out"
+
+echo "==> a submodule-only change is not misread as empty under diff.ignoreSubmodules=all"
+# The empty-scope guard turns "no files changed" into a hard refusal, so a
+# config that hides a real change from `git diff` would block a legitimate
+# review. Both helpers pass git's defaults explicitly to prevent that.
+git init -q "${test_tmp}/submod"
+(
+    cd "${test_tmp}/submod"
+    git_t commit -q --allow-empty -m one
+    git_t commit -q --allow-empty -m two
+)
+git checkout -q -b submodtest feature
+# protocol.file.allow: git >=2.38 refuses file:// submodules by default.
+git -c protocol.file.allow=always submodule add -q "${test_tmp}/submod" vendored
+git_t commit -q -m "add submodule"
+submod_base="$(git rev-parse HEAD)"
+(cd vendored && git checkout -q HEAD~1)
+git add vendored
+git_t commit -q -m "bump submodule pointer only"
+git_t config diff.ignoreSubmodules all
+out="$(run review --base "$submod_base")" || fail "submodule-only diff refused as empty: $out"
+echo "$out" | grep -q "vendored" || fail "submodule gitlink missing from manifest: $out"
+git_t config --unset diff.ignoreSubmodules
 
 echo "==> gate: another repo's project-scoped plugin install is not accepted"
 fake_claude="${test_tmp}/claude-config"
@@ -266,4 +348,4 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (18 cases)"
+echo "codex-review + codex-gate guards OK (24 cases)"

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -46,6 +46,14 @@ task review -- --uncommitted                       # staged + unstaged + untrack
 task challenge -- --base main focus on the update/migration path
 ```
 
+Whichever target you pick, an empty one is refused before Codex is invoked,
+with a non-zero exit. An empty scope has no correct outcome — the model either
+invents one or declines, and a decline reads exactly like a clean pass, so a
+capped challenge/review round would be spent banking a review that never
+happened. `--base` on a dirty tree also says so on stderr: it reviews
+committed history only, and the uncommitted work it excludes is often the very
+change you meant to review.
+
 Inside Claude Code the plugin's slash commands are the interactive
 equivalents: `/codex:review` and
 `/codex:adversarial-review --base main --background` (with extra focus text
@@ -220,6 +228,9 @@ Adjudicate it; never disable the gate to get past a BLOCK.
 - **Gate enabled but nothing happens** — `task codex:gate:status`; remember
   the flag is per workspace path (worktrees toggle separately) and fails open
   when Codex is unavailable.
-- **Nothing to review** — a clean tree with no commits beyond the base exits
-  early; pass `--base <ref>`, `--uncommitted`, or `--commit <sha>` to pick
-  the target explicitly.
+- **Nothing to review** — the resolved target is empty, so the run refuses
+  (exit 1) instead of asking Codex to review nothing; the message names the
+  condition and the way out. Reaching it from `task challenge` with no flags
+  means a clean tree with no commits beyond the base. Reaching it from
+  `--base <ref>` usually means the work is still uncommitted — use
+  `--uncommitted`, or commit first.

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -20,6 +20,8 @@
 # agent/human to adjudicate (AGENTS.md "Second-Model Review") — this is never
 # part of `verify`/`ci`. Both modes ask for P0/P1/P2-labelled findings; only
 # P0/P1 gate the local loop, P2s are reported and deferred to the PR stage.
+# No target path may invoke Codex with an empty scope; every one of them
+# refuses and exits non-zero instead (see refuse_empty_scope).
 # Requires an authenticated Codex CLI (`codex login`);
 # see docs/guides/codex-review.md.
 set -euo pipefail
@@ -52,9 +54,52 @@ cap_manifest() {
     awk 'NR <= 200 { print } NR == 201 { print "... (manifest truncated at 200 entries; re-enumerate with git for the full set)" }'
 }
 
+# Every manifest and dirty-check goes through these, so no call site can forget
+# the flags. Both spell out git's own defaults and therefore change nothing on
+# a default config; they exist to neutralize repo/user settings that would
+# otherwise hide real changes and make a non-empty target look empty —
+# `status.showUntrackedFiles=no` (a tree whose only work is untracked reads
+# clean) and `diff.ignoreSubmodules=all` / `submodule.<name>.ignore=all` (a
+# commit that only bumps a submodule gitlink reads as no change at all).
+git_status_porcelain() {
+    git status --porcelain --untracked-files=all --ignore-submodules=none "$@"
+}
+git_diff_name_status() {
+    git diff --name-status --ignore-submodules=none "$@"
+}
+
+# An empty scope has no correct outcome, so no target path may reach Codex
+# with one. The model either invents a scope (reviewing whatever it can see)
+# or declines — and a decline is textually indistinguishable from a clean
+# pass, which is exactly what the local loop's exit condition reads. Refuse
+# before spending the model call, and exit NON-ZERO: a capped challenge/review
+# loop reads exit status, so a zero here would be banked as the clean pass the
+# stage exits on.
+refuse_empty_scope() {
+    # $1 — the condition, $2 — how to fix it
+    echo "Nothing to review: $1" >&2
+    echo "$2" >&2
+    exit 1
+}
+
+# --base reviews committed history only, so uncommitted work is silently out
+# of scope. Say so — the surprise compounds when the working tree holds
+# exactly the change the operator meant to review. Not applied to --commit:
+# naming a specific sha already says the target is not "my current work".
+warn_if_dirty() {
+    [ -n "$(git_status_porcelain)" ] || return 0
+    echo "Note: the working tree is dirty, and --base reviews committed history only." >&2
+    echo "      Uncommitted changes are NOT in scope; use --uncommitted for those." >&2
+}
+
 scope=""
 manifest=""
 focus=""
+# Which explicit target flag was given, plus the wording its empty-scope
+# refusal should use. Resolved during parsing, acted on after it.
+target_kind=""
+empty_desc=""
+empty_hint=""
 require_single_target() {
     if [ -n "$scope" ]; then
         echo "conflicting target flags: --base, --uncommitted, and --commit are mutually exclusive." >&2
@@ -80,7 +125,13 @@ while [ $# -gt 0 ]; do
             exit 2
         fi
         scope="Review the changes on the current branch relative to base branch '$2' (the merge-base diff $2...HEAD)."
-        manifest="$(git diff --name-status "$2...HEAD" 2>/dev/null | cap_manifest || true)"
+        manifest="$(git_diff_name_status "$2...HEAD" 2>/dev/null | cap_manifest || true)"
+        target_kind="base"
+        empty_desc="the merge-base diff $2...HEAD is empty — HEAD changes no files beyond '$2'."
+        # --commit belongs here too: a branch whose commits net out to no change
+        # (an add and its revert) is already committed and has a clean tree, so
+        # both of the other two remedies would be dead ends.
+        empty_hint="Pass --uncommitted for working-tree changes, --commit <sha> for a single commit, or commit your work first."
         shift 2
         ;;
     --commit)
@@ -98,16 +149,22 @@ while [ $# -gt 0 ]; do
         # emit each merge parent's diff, pulling pre-merge mainline files into
         # the "authoritative" manifest. --root covers parentless root commits.
         if git rev-parse --verify --quiet "$2^" >/dev/null; then
-            manifest="$(git diff --name-status "$2^" "$2" 2>/dev/null | cap_manifest || true)"
+            manifest="$(git_diff_name_status "$2^" "$2" 2>/dev/null | cap_manifest || true)"
         else
-            manifest="$(git diff-tree --no-commit-id --name-status -r --root "$2" 2>/dev/null | cap_manifest || true)"
+            manifest="$(git diff-tree --no-commit-id --name-status -r --root --ignore-submodules=none "$2" 2>/dev/null | cap_manifest || true)"
         fi
+        target_kind="commit"
+        empty_desc="commit $2 changes no files (an empty commit, or a merge with no first-parent change)."
+        empty_hint="Pass --base <ref> for a branch-scoped review, or name a commit that touches files."
         shift 2
         ;;
     --uncommitted)
         require_single_target
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
-        manifest="$(git status --porcelain --untracked-files=all | cap_manifest || true)"
+        manifest="$(git_status_porcelain | cap_manifest || true)"
+        target_kind="uncommitted"
+        empty_desc="the working tree is clean — there is no staged, unstaged, or untracked work."
+        empty_hint="Pass --base <ref> to review the branch's commits instead."
         shift
         ;;
     *)
@@ -117,10 +174,24 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+# Checked after the parse loop, not inside it: an empty diff is a property of
+# a fully-resolved target, so reporting it mid-parse would mask a genuine
+# argument error (e.g. `--base <ref> --uncommitted` must still be rejected as
+# conflicting flags, whatever that base's diff contains).
+if [ "$target_kind" = "base" ]; then
+    warn_if_dirty
+fi
+if [ -n "$target_kind" ] && [ -z "$manifest" ]; then
+    refuse_empty_scope "$empty_desc" "$empty_hint"
+fi
+
 if [ -z "$scope" ]; then
-    if [ -n "$(git status --porcelain)" ]; then
+    # Same helper as the manifest built from it two lines down, so the tree
+    # cannot test clean here and then yield a non-empty manifest (or vice
+    # versa) because the two calls disagreed about what counts as a change.
+    if [ -n "$(git_status_porcelain)" ]; then
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
-        manifest="$(git status --porcelain --untracked-files=all | cap_manifest || true)"
+        manifest="$(git_status_porcelain | cap_manifest || true)"
         echo "==> Reviewing uncommitted work (dirty tree; pass --base <ref> to review the branch instead)"
     else
         # origin/HEAD (the remote's actual default branch) outranks local
@@ -146,13 +217,32 @@ if [ -z "$scope" ]; then
             exit 2
         fi
         if [ "$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)" -eq 0 ]; then
-            echo "Nothing to review: the working tree is clean and HEAD has no commits beyond ${base}."
-            exit 0
+            refuse_empty_scope \
+                "the working tree is clean and HEAD has no commits beyond ${base}." \
+                "Pass --base <ref> or --commit <sha> to name a target explicitly."
         fi
         scope="Review the changes on the current branch relative to base branch '${base}' (the merge-base diff ${base}...HEAD)."
-        manifest="$(git diff --name-status "${base}...HEAD" | cap_manifest || true)"
+        manifest="$(git_diff_name_status "${base}...HEAD" | cap_manifest || true)"
+        # Commits beyond the base do not guarantee a non-empty diff: an empty
+        # commit, or one later reverted, leaves nothing for Codex to read.
+        if [ -z "$manifest" ]; then
+            refuse_empty_scope \
+                "the merge-base diff ${base}...HEAD is empty — the commits beyond ${base} change no files." \
+                "Pass --commit <sha> to review a specific commit, or --uncommitted for working-tree changes."
+        fi
         echo "==> Reviewing branch changes against ${base}"
     fi
+fi
+
+# Backstop for every path, so the invariant does not depend on each one
+# remembering it. The auto dirty-tree path in particular decides on one
+# `git status` and builds its manifest from a second: a tree cleaned between
+# the two calls — or a call that failed into `|| true` — would otherwise still
+# reach the model with nothing to review.
+if [ -z "$manifest" ]; then
+    refuse_empty_scope \
+        "the resolved target contains no changed files." \
+        "Name a target explicitly with --base <ref>, --commit <sha>, or --uncommitted."
 fi
 
 if [ "$MODE" = "challenge" ]; then
@@ -213,16 +303,16 @@ fi
 # Custom review instructions bypass the CLI's native diff-target modes (the
 # two are mutually exclusive), leaving diff collection to the model. Anchor it
 # with an authoritative, git-generated file manifest so nothing in scope —
-# untracked files included — can be silently skipped.
-if [ -n "$manifest" ]; then
-    instructions="${instructions}
+# untracked files included — can be silently skipped. Unconditional: the
+# backstop above guarantees a non-empty manifest, so a "if we have one" test
+# here would be dead code implying an empty-manifest run is reachable.
+instructions="${instructions}
 
 Authoritative changed-file manifest from git for this scope (status + path;
 cover EVERY entry, including untracked files, collecting the diffs yourself
 with git):
 
 ${manifest}"
-fi
 
 # Feed the prompt through stdin (`review -`): a single argv element is
 # capped (~128 KiB per arg on Linux), and cap_manifest bounds entry count,

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -5,7 +5,9 @@
 # regression a real adversarial review caught: with no local main/master and
 # origin/HEAD pointing at another default branch, the base fallback used to
 # strip `origin/` into a nonexistent local ref and silently report nothing
-# to review. Run via `task test:codex-review`.
+# to review, and the one a real --base run caught: an empty scope reached
+# Codex, whose "that diff is empty" reply exited 0 and read as the clean pass
+# a capped review loop exits on. Run via `task test:codex-review`.
 set -euo pipefail
 
 repo="$(git rev-parse --show-toplevel)"
@@ -123,11 +125,68 @@ echo "$out" | grep -q "STUB-ARGS:exec review" || fail "codex not invoked on larg
 echo "$out" | grep -q "manifest truncated at 200 entries" || fail "truncation marker missing on >200-entry manifest: $out"
 rm -f bulk_f*.txt
 
-echo "==> clean tree at the base tip reports nothing to review"
+echo "==> clean tree at the base tip refuses, non-zero, without invoking codex"
 git checkout -q -b tipcheck origin/develop
-out="$(run review)" || fail "nothing-to-review case exited non-zero: $out"
+# Non-zero is the point: a capped review loop reads exit status, so a zero
+# here would be banked as the clean pass the stage exits on.
+if out="$(run review)"; then
+    fail "nothing-to-review case exited zero (reads as a clean pass): $out"
+fi
 echo "$out" | grep -q "Nothing to review" || fail "expected nothing-to-review message: $out"
 echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite nothing to review: $out"
+
+echo "==> --base level with its base refuses, non-zero, without invoking codex"
+# The reported bug: an explicit --base built an empty manifest and shipped a
+# scope string anyway, and Codex's "that diff is empty" reply exited 0 and
+# consumed a round of a capped loop.
+if out="$(run challenge --base origin/develop)"; then
+    fail "--base with an empty diff was accepted: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite an empty --base diff: $out"
+echo "$out" | grep -q "Nothing to review" || fail "missing empty--base refusal message: $out"
+echo "$out" | grep -q -- "--uncommitted" || fail "empty --base refusal does not name the fix: $out"
+
+echo "==> --base on a dirty tree says the uncommitted work is out of scope"
+echo scratch >scratch.txt
+if out="$(run challenge --base origin/develop)"; then
+    fail "--base with an empty diff was accepted on a dirty tree: $out"
+fi
+echo "$out" | grep -q "working tree is dirty" || fail "no dirty-tree note on --base: $out"
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite an empty --base diff: $out"
+
+echo "==> --uncommitted on a clean tree refuses, non-zero, without invoking codex"
+rm -f scratch.txt
+if out="$(run review --uncommitted)"; then
+    fail "--uncommitted on a clean tree was accepted: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite a clean tree: $out"
+echo "$out" | grep -q "Nothing to review" || fail "missing empty--uncommitted refusal message: $out"
+
+echo "==> status.showUntrackedFiles=no cannot hide an untracked-only tree"
+# Both the auto dirty-tree test and the --base warning read `git status`; with
+# the default untracked mode, this config makes a tree holding only untracked
+# work look clean, so the auto path would review the branch instead of the
+# work, and --base would skip its warning.
+git_t config status.showUntrackedFiles no
+echo hidden >hidden.txt
+out="$(run review)" || fail "untracked-only tree with showUntrackedFiles=no exited non-zero: $out"
+echo "$out" | grep -q "uncommitted work" || fail "untracked-only tree was not seen as dirty: $out"
+echo "$out" | grep -q "hidden.txt" || fail "untracked file missing from manifest: $out"
+if out="$(run challenge --base origin/develop)"; then
+    fail "--base with an empty diff was accepted: $out"
+fi
+echo "$out" | grep -q "working tree is dirty" || fail "dirty-tree note suppressed by showUntrackedFiles=no: $out"
+rm -f hidden.txt
+git_t config --unset status.showUntrackedFiles
+
+echo "==> --commit on an empty commit refuses, non-zero, without invoking codex"
+git_t commit -q --allow-empty -m "empty commit"
+if out="$(run review --commit HEAD)"; then
+    fail "--commit on an empty commit was accepted: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite an empty commit diff: $out"
+echo "$out" | grep -q "Nothing to review" || fail "missing empty--commit refusal message: $out"
+git_t reset -q --hard HEAD~1
 
 echo "==> bad mode is rejected"
 if out="$(run bogus 2>&1)"; then
@@ -168,6 +227,29 @@ merge_sha="$(git rev-parse HEAD)"
 out="$(run review --commit "$merge_sha")" || fail "merge-commit review exited non-zero: $out"
 echo "$out" | grep -q "side.txt" || fail "merge commit manifest missing first-parent change: $out"
 echo "$out" | grep -q "feature.txt" && fail "merge manifest includes pre-merge mainline files (diff-tree -m regression): $out"
+
+echo "==> a submodule-only change is not misread as empty under diff.ignoreSubmodules=all"
+# The empty-scope guard turns "no files changed" into a hard refusal, so a
+# config that hides a real change from `git diff` would block a legitimate
+# review. Both helpers pass git's defaults explicitly to prevent that.
+git init -q "${test_tmp}/submod"
+(
+    cd "${test_tmp}/submod"
+    git_t commit -q --allow-empty -m one
+    git_t commit -q --allow-empty -m two
+)
+git checkout -q -b submodtest feature
+# protocol.file.allow: git >=2.38 refuses file:// submodules by default.
+git -c protocol.file.allow=always submodule add -q "${test_tmp}/submod" vendored
+git_t commit -q -m "add submodule"
+submod_base="$(git rev-parse HEAD)"
+(cd vendored && git checkout -q HEAD~1)
+git add vendored
+git_t commit -q -m "bump submodule pointer only"
+git_t config diff.ignoreSubmodules all
+out="$(run review --base "$submod_base")" || fail "submodule-only diff refused as empty: $out"
+echo "$out" | grep -q "vendored" || fail "submodule gitlink missing from manifest: $out"
+git_t config --unset diff.ignoreSubmodules
 
 echo "==> gate: another repo's project-scoped plugin install is not accepted"
 fake_claude="${test_tmp}/claude-config"
@@ -266,4 +348,4 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (18 cases)"
+echo "codex-review + codex-gate guards OK (24 cases)"


### PR DESCRIPTION
Closes #448

## What

`codex-review.sh` guarded only its auto-detected-base path against an empty scope. `--base`, `--commit`, and `--uncommitted` each built a manifest and invoked Codex regardless. Every target path now refuses an empty scope before spending the model call, and every refusal exits **non-zero**.

| Path | Before | After |
|---|---|---|
| auto (clean tree, no commits beyond base) | message, **exit 0** | message, **exit 1** |
| auto (commits beyond base, but empty diff) | Codex invoked, no manifest | refuses, exit 1 |
| `--base <ref>` (empty `ref...HEAD`) | Codex invoked, no manifest | refuses, exit 1 |
| `--commit <sha>` (empty commit diff) | Codex invoked, no manifest | refuses, exit 1 |
| `--uncommitted` (clean tree) | Codex invoked, no manifest | refuses, exit 1 |

## Why

An empty scope has no correct outcome: the model either invents one (reviewing whatever it can see) or declines — and a decline is textually indistinguishable from a clean pass, which is exactly what the local loop's exit condition reads. The issue records this happening live: one of five identical `task challenge -- --base main` invocations returned *"the requested diff is empty"*, no findings, exit 0. That consumed a round of a capped challenge loop, and the substantial uncommitted change it declined to read went unreviewed.

Non-zero is the load-bearing half. A capped loop reads exit status, so a zero is banked as the clean pass the stage exits on.

## Decisions beyond the ACs as written

Both were raised in the issue thread before implementation:

- **The auto path's exit code changed from 0 to 1.** AC3 asks only that the new refusals exit non-zero, but the auto path reaches the same condition without a flag and had the same hazard. Leaving it would mean one condition returning two exit codes depending on whether a flag was passed. This updates documented behavior (`docs/guides/codex-review.md`) and flips one existing test assertion.
- **`--uncommitted` is guarded too**, though the ACs name only `--base` and `--commit`. On a clean tree it built an empty manifest and invoked Codex — the same invariant violation.

AC5 ("consider whether `--base` on a dirty tree should say so") is implemented as a **stderr note, not a refusal**: `--base` reviews committed history only, and the uncommitted work it excludes is often the very change the operator meant to review — but refusing would break reviewing a branch while unrelated scratch edits are present.

## Config-sensitivity, found by the adversarial review

The guard turns "no files changed" into a hard refusal, so a config that hides a real change from git would now *block* a legitimate review rather than merely produce a bogus one. All `git status` / `git diff` calls go through two helpers that pass `--untracked-files=all --ignore-submodules=none`. Both spell out git's own defaults and change nothing on a default config; they exist so that

- `status.showUntrackedFiles=no` cannot make an untracked-only tree read clean, and
- `diff.ignoreSubmodules=all` / `submodule.<name>.ignore=all` cannot make a commit that only bumps a submodule gitlink read as no change at all.

Both were reproduced against real fixtures before fixing, and both are covered by tests.

## Verification

- `task ci` green (includes `verify` → `test:codex-review`, `test:dogfood-parity`, `test:template`).
- `test-codex-review.sh`: **18 → 24 cases**. New coverage for each empty target with the non-zero exit asserted, the dirty-tree note, `status.showUntrackedFiles=no`, and a real submodule fixture under `diff.ignoreSubmodules=all`.
- Each new guard was **mutation-tested**: reverting it individually makes its own test fail, and only that test.
- `task challenge` and `task review` both reached a clean re-run with zero findings (challenge: 3 rounds, review: 2). Every P2 raised was fixed in place; none deferred.
- All six files are byte-identical verbatim root/template twins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
