### PR TITLE
fix(codex-review): warn that challenge/review rounds outrun agent tool timeouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,8 +207,15 @@ something to ask permission for.
   them to the PR (see "Deferring P2s" below). Max **6** challenge → fix →
   re-challenge
   rounds; if P0/P1 findings persist, stop and escalate to Evan.
-- **`task review`** — verification-checkpoint review; same adjudication and
-  same P0/P1 clean-pass exit condition, with its own max **6** rounds.
+  A `task challenge` round is long — 5–15 minutes is ordinary, past most
+  agents' tool-call timeouts — so **run it in the background and poll**
+  instead of blocking one call on it. Growing output means running, not hung;
+  relaunching a live run only doubles the cost. Details:
+  [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
+  backgrounding").
+- **`task review`** — verification-checkpoint review; same adjudication, same
+  P0/P1 clean-pass exit condition, and the same background-and-poll handling,
+  with its own max **6** rounds.
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
   a clear what/why/verification summary (mind the `template/` → `fix:`/`feat:`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,9 @@ something to ask permission for.
   A `task challenge` round is long — 5–15 minutes is ordinary, past most
   agents' tool-call timeouts — so **run it in the background and poll**
   instead of blocking one call on it. Growing output means running, not hung;
-  relaunching a live run only doubles the cost. Details:
+  relaunching a live run only doubles the cost. Commit each round's fixes
+  before re-challenging, or the re-run scopes to the fix alone instead of the
+  whole change. Details:
   [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
   backgrounding").
 - **`task review`** — verification-checkpoint review; same adjudication, same

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -40,7 +40,7 @@ Review").
 Both accept an explicit target and free-text focus after `--`:
 
 ```bash
-task challenge                                     # auto: dirty tree → uncommitted; clean → --base main
+task challenge                                     # auto: dirty tree → uncommitted; clean → origin/HEAD, else local main/master
 task challenge -- --base main                      # branch vs main explicitly
 task review -- --uncommitted                       # staged + unstaged + untracked only
 task challenge -- --base main focus on the update/migration path
@@ -51,6 +51,60 @@ equivalents: `/codex:review` and
 `/codex:adversarial-review --base main --background` (with extra focus text
 allowed after the flags), plus `/codex:status` / `/codex:result` for
 background runs.
+
+### Duration and backgrounding
+
+A round is **minutes, not seconds** — 5–15 is ordinary and passing ten is not
+unusual. The cost tracks how much the reviewer *reads*, not how large the diff
+is: it re-reads AGENTS.md, this guide, and whatever those point at on every
+round, so a three-line docs change can run as long as a feature branch.
+
+That is longer than a typical agent's tool-call timeout (Claude Code's Bash
+tool caps at 600s), so an agent must **start these tasks in the background and
+poll** rather than blocking one call on them — otherwise an ordinary round
+surfaces as a timeout and reads like a hang. Use the harness's own background
+execution (in Claude Code, the Bash tool's background option): it owns the
+process, reports completion, and can cancel the run and its children. Where a
+harness has no such primitive, run the task in a terminal you can watch —
+do not hand-roll a supervisor around it in the shell, which trades a ten-minute
+wait for orphaned processes, races over shared log files, and a completion
+signal that the reviewed diff can spoof.
+
+Two things not to change when backgrounding:
+
+- **The target.** Bare `task challenge` keeps the auto-selection above — dirty
+  tree → uncommitted, clean tree → `origin/HEAD`. At this point in the loop
+  the tree is normally dirty, so a hardcoded `-- --base main` would review the
+  committed branch and silently skip the very work being challenged (and name
+  the wrong base in a repo that does not use `main`). Add a target flag only
+  when you mean to override. Note `origin/HEAD` is a *cached* ref: if the
+  remote's default branch moved, refresh it with
+  `git remote set-head origin --auto`, or the auto-selected base is silently
+  the old one.
+- **The runner.** Background `task challenge` itself, not
+  `/codex:adversarial-review --background`: the slash command calls Codex
+  directly, so it never receives the P0/P1/P2 scale that
+  `scripts/codex-review.sh` writes into the prompt. Fine for an interactive
+  spot-check; it cannot establish the clean pass this loop gates on.
+
+**Then leave the tree alone until it finishes.** `codex-review.sh` captures the
+file manifest at launch, but Codex collects the diffs itself as it runs — so
+editing, staging, or committing mid-review has it read a repository that no
+longer matches the manifest, and committing an initially dirty tree empties the
+`--uncommitted` scope outright. Backgrounding buys polling, not parallel edits:
+if there is other work to do, do it after the verdict. Should you capture the
+output to a file, keep it under `git rev-parse --git-path` rather than in the
+worktree — for the same reason the deferred-findings sidecar lives there, a
+stray worktree file becomes the next bare `task challenge`'s entire scope.
+
+**Still running is not hung.** `codex exec` streams events as it works, so
+growing output is the liveness signal — poll it instead of inferring. Long
+gaps between events are normal, and relaunching never resumes a run, it starts
+a fresh one, so re-running a live review doubles both the wall clock and the
+Codex usage the first one already spent. Bound the patience rather than the
+run: if the output has been static for **~20 minutes** — well past any normal
+gap — treat it as wedged on a stalled API call rather than thinking, cancel it
+through the harness that started it, and only then start over.
 
 ## The automatic stop-gate
 

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -81,6 +81,13 @@ Two things not to change when backgrounding:
   remote's default branch moved, refresh it with
   `git remote set-head origin --auto`, or the auto-selected base is silently
   the old one.
+
+  The scopes do not overlap: `--uncommitted` reads the worktree,
+  `--base` diffs commits, and **neither covers both**. A dirty tree always wins
+  the auto-selection, so once the branch has commits, an uncommitted fix
+  narrows the re-run to just that fix — and the clean pass then attests to the
+  fix rather than to the whole change. **Commit each round's fixes before
+  re-running**, so the branch diff is the whole change again.
 - **The runner.** Background `task challenge` itself, not
   `/codex:adversarial-review --background`: the slash command calls Codex
   directly, so it never receives the P0/P1/P2 scale that

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -120,7 +120,9 @@ something to ask permission for.
   A `task challenge` round is long — 5–15 minutes is ordinary, past most
   agents' tool-call timeouts — so **run it in the background and poll**
   instead of blocking one call on it. Growing output means running, not hung;
-  relaunching a live run only doubles the cost. Details:
+  relaunching a live run only doubles the cost. Commit each round's fixes
+  before re-challenging, or the re-run scopes to the fix alone instead of the
+  whole change. Details:
   [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
   backgrounding").
 - **`task review`** — verification-checkpoint review; same adjudication, same

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -117,8 +117,15 @@ something to ask permission for.
   them to the PR (see "Deferring P2s" below). Max **6** challenge → fix →
   re-challenge
   rounds; if P0/P1 findings persist, stop and escalate to the maintainer.
-- **`task review`** — verification-checkpoint review; same adjudication and
-  same P0/P1 clean-pass exit condition, with its own max **6** rounds.
+  A `task challenge` round is long — 5–15 minutes is ordinary, past most
+  agents' tool-call timeouts — so **run it in the background and poll**
+  instead of blocking one call on it. Growing output means running, not hung;
+  relaunching a live run only doubles the cost. Details:
+  [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
+  backgrounding").
+- **`task review`** — verification-checkpoint review; same adjudication, same
+  P0/P1 clean-pass exit condition, and the same background-and-poll handling,
+  with its own max **6** rounds.
 [% endif %]
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -40,7 +40,7 @@ Review").
 Both accept an explicit target and free-text focus after `--`:
 
 ```bash
-task challenge                                     # auto: dirty tree → uncommitted; clean → --base main
+task challenge                                     # auto: dirty tree → uncommitted; clean → origin/HEAD, else local main/master
 task challenge -- --base main                      # branch vs main explicitly
 task review -- --uncommitted                       # staged + unstaged + untracked only
 task challenge -- --base main focus on the update/migration path
@@ -51,6 +51,60 @@ equivalents: `/codex:review` and
 `/codex:adversarial-review --base main --background` (with extra focus text
 allowed after the flags), plus `/codex:status` / `/codex:result` for
 background runs.
+
+### Duration and backgrounding
+
+A round is **minutes, not seconds** — 5–15 is ordinary and passing ten is not
+unusual. The cost tracks how much the reviewer *reads*, not how large the diff
+is: it re-reads AGENTS.md, this guide, and whatever those point at on every
+round, so a three-line docs change can run as long as a feature branch.
+
+That is longer than a typical agent's tool-call timeout (Claude Code's Bash
+tool caps at 600s), so an agent must **start these tasks in the background and
+poll** rather than blocking one call on them — otherwise an ordinary round
+surfaces as a timeout and reads like a hang. Use the harness's own background
+execution (in Claude Code, the Bash tool's background option): it owns the
+process, reports completion, and can cancel the run and its children. Where a
+harness has no such primitive, run the task in a terminal you can watch —
+do not hand-roll a supervisor around it in the shell, which trades a ten-minute
+wait for orphaned processes, races over shared log files, and a completion
+signal that the reviewed diff can spoof.
+
+Two things not to change when backgrounding:
+
+- **The target.** Bare `task challenge` keeps the auto-selection above — dirty
+  tree → uncommitted, clean tree → `origin/HEAD`. At this point in the loop
+  the tree is normally dirty, so a hardcoded `-- --base main` would review the
+  committed branch and silently skip the very work being challenged (and name
+  the wrong base in a repo that does not use `main`). Add a target flag only
+  when you mean to override. Note `origin/HEAD` is a *cached* ref: if the
+  remote's default branch moved, refresh it with
+  `git remote set-head origin --auto`, or the auto-selected base is silently
+  the old one.
+- **The runner.** Background `task challenge` itself, not
+  `/codex:adversarial-review --background`: the slash command calls Codex
+  directly, so it never receives the P0/P1/P2 scale that
+  `scripts/codex-review.sh` writes into the prompt. Fine for an interactive
+  spot-check; it cannot establish the clean pass this loop gates on.
+
+**Then leave the tree alone until it finishes.** `codex-review.sh` captures the
+file manifest at launch, but Codex collects the diffs itself as it runs — so
+editing, staging, or committing mid-review has it read a repository that no
+longer matches the manifest, and committing an initially dirty tree empties the
+`--uncommitted` scope outright. Backgrounding buys polling, not parallel edits:
+if there is other work to do, do it after the verdict. Should you capture the
+output to a file, keep it under `git rev-parse --git-path` rather than in the
+worktree — for the same reason the deferred-findings sidecar lives there, a
+stray worktree file becomes the next bare `task challenge`'s entire scope.
+
+**Still running is not hung.** `codex exec` streams events as it works, so
+growing output is the liveness signal — poll it instead of inferring. Long
+gaps between events are normal, and relaunching never resumes a run, it starts
+a fresh one, so re-running a live review doubles both the wall clock and the
+Codex usage the first one already spent. Bound the patience rather than the
+run: if the output has been static for **~20 minutes** — well past any normal
+gap — treat it as wedged on a stalled API call rather than thinking, cancel it
+through the harness that started it, and only then start over.
 
 ## The automatic stop-gate
 

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -81,6 +81,13 @@ Two things not to change when backgrounding:
   remote's default branch moved, refresh it with
   `git remote set-head origin --auto`, or the auto-selected base is silently
   the old one.
+
+  The scopes do not overlap: `--uncommitted` reads the worktree,
+  `--base` diffs commits, and **neither covers both**. A dirty tree always wins
+  the auto-selection, so once the branch has commits, an uncommitted fix
+  narrows the re-run to just that fix — and the clean pass then attests to the
+  fix rather than to the whole change. **Commit each round's fixes before
+  re-running**, so the branch diff is the whole change again.
 - **The runner.** Background `task challenge` itself, not
   `/codex:adversarial-review --background`: the slash command calls Codex
   directly, so it never receives the P0/P1/P2 scale that


### PR DESCRIPTION
## What

Adds a **"Duration and backgrounding"** section to `docs/guides/codex-review.md`
and a matching note in the AGENTS.md Dev Loop where `task challenge` is
introduced. Root and template twins stay byte-identical.

## Why

A `task challenge` round routinely runs **5–15 minutes** because the reviewer
re-reads AGENTS.md, this guide, and everything they reference on every round —
cost tracks *reading*, not diff size, so a three-line docs change can run as
long as a feature branch. That is longer than a typical agent tool-call timeout
(Claude Code's Bash tool caps at 600s), and nothing said so at the point of use:

- the guide's only `--background` mentions were about the `/codex:` slash
  commands, not `task challenge` / `task review`
- the Dev Loop introduced `task challenge` with no duration at all

The default reading — run it and wait — stalls for ten minutes, then surfaces as
a timeout that reads like a hang and invites a relaunch, doubling the cost. This
was observed across a five-round loop on evanharmon1/harmon-devkit#175, where two
rounds blew the 600s timeout and had to be moved to the background mid-run.

## What the guidance says

- **Background the task, not the slash command.**
  `/codex:adversarial-review --background` calls Codex directly, so it never
  receives the P0/P1/P2 scale that `codex-review.sh` writes into the prompt —
  it cannot establish the clean pass the loop gates on.
- **Keep the auto-selected target.** A hardcoded `--base main` reviews the
  committed branch and skips the uncommitted work being challenged.
- **Leave the tree alone until it finishes.** The manifest is captured at
  launch but Codex collects diffs as it runs; committing a dirty tree empties
  the `--uncommitted` scope outright.
- **Growing output means running, not hung** — bounded by a ~20 minute
  no-progress ceiling. Relaunching restarts rather than resumes.
- Explicitly *don't* hand-roll a shell supervisor around it — that trades a
  ten-minute wait for orphaned processes, log races, and a completion signal
  the reviewed diff can spoof.

Also corrects the auto-target comment, which claimed `clean → --base main`
where `codex-review.sh` prefers `origin/HEAD` and falls back to local
`main`/`master`, and notes that `origin/HEAD` is a *cached* ref that goes stale
when the remote's default branch moves.

## Verification

- `task verify` and `task ci` green (full render matrix, dogfood parity,
  Semgrep 0 findings, gitleaks clean)
- `task challenge` — clean pass at round 5/6; 8 confirmed P1s fixed in rounds
  1–4, all in an earlier shell-fallback recipe that this PR ultimately removes
  rather than hardens
- `task review` — clean pass at round 3/6, final round reporting zero findings
  at any priority
- `PR_TITLE=… BASE_SHA=main task guard:release-title` — ok (releasing type,
  required because this touches `template/`)

Two findings were confirmed by direct experiment rather than reading: killing a
backgrounded wrapper leaves its descendants reparented to init and running, and
a sentinel token written into the review log is spoofable by the reviewed diff —
this guide's own text tripped it.

## Delivery

`Refs` rather than `Closes`: the issue is in another repo, and its acceptance
criteria name **harmon-devkit's** copies of these files, which stay unchanged
until this reaches them via `copier update` (tracked in
evanharmon1/harmon-devkit#180).

Refs evanharmon1/harmon-devkit#178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
