### PR TITLE
fix(template): step back when review rounds start attacking their own fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,6 +379,12 @@ in the adjudication table *and* in the message of the commit that removes the
 code — the table is scrollback, but the commit is why the code is gone, and it
 is the record a later round or a different session can still find.
 
+One endpoint is worth knowing: if the deletion empties the change *entirely*,
+there is no clean pass to reach — `codex-review.sh` refuses an empty scope
+non-zero by design, so the stage cannot pass and re-running will not change
+that. Treat it as the answer rather than a failure to work around: a change
+that has become empty is abandoned, not reviewed clean.
+
 **Severity gating.** Both tasks ask Codex to label every finding `P0`
 (breaks correctness, security, or data integrity in ordinary use, or breaks
 an existing contract), `P1` (a real defect or materially wrong design

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,6 +356,29 @@ the cloud run failed.
 6. Finish with a concise adjudication table: finding → priority →
    classification → evidence → action taken.
 
+**Between rounds, check what the findings are about.** Those six steps are all
+*per-finding*, so a reviewer can be right every round while the loop as a whole
+diverges: each fix adds surface, the next round attacks that surface, and the
+findings stay individually defensible right up to the cap. Before starting a
+round's fixes, ask where they *live* — in the change you set out to make, or in
+code that exists only because an earlier round asked for it. **A round whose
+findings are all about the previous round's fix is the tell**, and it is
+visible in round 2 — the first round that can show it. Do not wait for the
+pattern to be unmistakable in round 4.
+
+**Deleting the added code is a legitimate way to reach a clean pass.** When a
+round's findings are about scaffolding rather than the change, weigh removing
+that scaffolding against hardening it once more — a remediation can be correct
+in the abstract and wrong for the artifact. A documentation guide that has
+grown a hand-rolled process supervisor earns real, defensible P1s about per-run
+state, process-group supervision, and PID reuse; every one of them becomes moot
+when the recipe is deleted instead of hardened. That is not giving up on the
+findings: the stage exits on a **clean re-run**, and a re-run does not care
+whether a finding was answered or made inapplicable. Name the mooted findings
+in the adjudication table *and* in the message of the commit that removes the
+code — the table is scrollback, but the commit is why the code is gone, and it
+is the record a later round or a different session can still find.
+
 **Severity gating.** Both tasks ask Codex to label every finding `P0`
 (breaks correctness, security, or data integrity in ordinary use, or breaks
 an existing contract), `P1` (a real defect or materially wrong design

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -249,6 +249,29 @@ never resolves means the cloud run failed.
 6. Finish with a concise adjudication table: finding → priority →
    classification → evidence → action taken.
 
+**Between rounds, check what the findings are about.** Those six steps are all
+*per-finding*, so a reviewer can be right every round while the loop as a whole
+diverges: each fix adds surface, the next round attacks that surface, and the
+findings stay individually defensible right up to the cap. Before starting a
+round's fixes, ask where they *live* — in the change you set out to make, or in
+code that exists only because an earlier round asked for it. **A round whose
+findings are all about the previous round's fix is the tell**, and it is
+visible in round 2 — the first round that can show it. Do not wait for the
+pattern to be unmistakable in round 4.
+
+**Deleting the added code is a legitimate way to reach a clean pass.** When a
+round's findings are about scaffolding rather than the change, weigh removing
+that scaffolding against hardening it once more — a remediation can be correct
+in the abstract and wrong for the artifact. A documentation guide that has
+grown a hand-rolled process supervisor earns real, defensible P1s about per-run
+state, process-group supervision, and PID reuse; every one of them becomes moot
+when the recipe is deleted instead of hardened. That is not giving up on the
+findings: the stage exits on a **clean re-run**, and a re-run does not care
+whether a finding was answered or made inapplicable. Name the mooted findings
+in the adjudication table *and* in the message of the commit that removes the
+code — the table is scrollback, but the commit is why the code is gone, and it
+is the record a later round or a different session can still find.
+
 **Severity gating.** Both tasks ask Codex to label every finding `P0`
 (breaks correctness, security, or data integrity in ordinary use, or breaks
 an existing contract), `P1` (a real defect or materially wrong design

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -272,6 +272,12 @@ in the adjudication table *and* in the message of the commit that removes the
 code — the table is scrollback, but the commit is why the code is gone, and it
 is the record a later round or a different session can still find.
 
+One endpoint is worth knowing: if the deletion empties the change *entirely*,
+there is no clean pass to reach — `codex-review.sh` refuses an empty scope
+non-zero by design, so the stage cannot pass and re-running will not change
+that. Treat it as the answer rather than a failure to work around: a change
+that has become empty is abandoned, not reviewed clean.
+
 **Severity gating.** Both tasks ask Codex to label every finding `P0`
 (breaks correctness, security, or data integrity in ordinary use, or breaks
 an existing contract), `P1` (a real defect or materially wrong design


### PR DESCRIPTION
Closes #456

## What

Adds a between-rounds check to the Codex adjudication protocol, in both
AGENTS.md layers:

- **Names the tell** — a round whose findings are all about the *previous*
  round's fix. That is observable in round 2, the first round that can show
  it, rather than in round 4 once the pattern is unmistakable.
- **Says deletion is a legitimate clean pass**, not a concession: the stage
  exits on a clean re-run, and a re-run does not care whether a finding was
  answered or made inapplicable.
- **Gives the rationale a durable home** — mooted findings are named in the
  message of the commit that removes the code, not only in the adjudication
  table, which is scrollback.

## Why

The protocol's six steps are all *per-finding*, so a reviewer can be right
every round while the loop as a whole diverges: each fix adds surface, the
next round attacks that surface, and the findings stay individually
defensible right up to the cap. Nothing prompted the operator to reconsider.
On #453 that took until round 4 — three rounds of hardening a hand-rolled
process supervisor that a documentation guide had grown, ended in one round
by deleting it.

Note for the issue record: the issue body also cites "#180 records the same
pathology on #171". Neither resolves — #180 is "create skill and prompt for
nightly docs sync routine", #171 is a copier-question request, and there are
no PRs at those numbers. The #453 evidence is real and is what this change
rests on.

## Verification

- `task verify` — green
- `task challenge` — round 1 clean (no P0/P1, 2 P2s fixed in place); round 2
  clean (no P0/P1, 1 P2 deferred below)
- `task review` — round 1 clean, no findings
- `task ci` — green
- `PR_TITLE=… BASE_SHA=main task guard:release-title` — releasing type, ok
- Root and template paragraphs verified byte-identical; `test:dogfood-parity`
  and `test:dogfood-structure` pass

The two P2s fixed in place were both about the new text: "two consecutive
rounds" is first observable in round 3, contradicting the round-2 detection
the issue asks for (now one round); and the adjudication table has no durable
destination, which this same file elsewhere calls out as not-a-record (now
the commit message).

## Deferred findings

- [x] `AGENTS.md` / `template/AGENTS.md.jinja` ("Deleting the added code…"
      paragraph) — if the deletion removes the *entire* net branch change,
      `task challenge` cannot produce the promised clean re-run:
      `codex-review.sh`'s empty-scope guard refuses non-zero before invoking
      Codex. **Fixed in `81faad8`** — the paragraph now names the endpoint and
      says an emptied change is abandoned, not reviewed clean. The Codex cloud
      reviewer raised the same finding independently; verified against
      `refuse_empty_scope` and answered in-thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

