### PR TITLE
fix(codex-review): review commits and uncommitted work in one scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,9 +210,11 @@ something to ask permission for.
   A `task challenge` round is long — 5–15 minutes is ordinary, past most
   agents' tool-call timeouts — so **run it in the background and poll**
   instead of blocking one call on it. Growing output means running, not hung;
-  relaunching a live run only doubles the cost. Commit each round's fixes
-  before re-challenging, or the re-run scopes to the fix alone instead of the
-  whole change. Details:
+  relaunching a live run only doubles the cost. Re-challenge with a bare
+  `task challenge` — it covers the branch's commits *and* the working tree,
+  so an uncommitted fix cannot narrow the re-run to itself; an explicit
+  `--base`/`--uncommitted` reviews one half only. Committing each round's
+  fixes first is still tidier, not load-bearing. Details:
   [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
   backgrounding").
 - **`task review`** — verification-checkpoint review; same adjudication, same
@@ -410,9 +412,10 @@ collide `feat/x` with `feat-x` and reintroduce exactly that loss, and adding
 an extension would make `foo` (a file) block `foo.md/bar` (needing a
 directory). Used as-is, the mapping is git's own ref namespace, and git
 already forbids one live branch from being a path prefix of another. A note in the *worktree* would be worse than none:
-`codex-review.sh` reviews the uncommitted diff whenever the tree is dirty, so
-the note would become the next bare `task challenge`'s entire scope — and the
-change it was supposed to review would get a clean pass it never earned.
+`codex-review.sh` puts uncommitted files in scope whenever the tree is dirty,
+so the note would be handed to the next bare `task challenge` as part of the
+change under review — a file of open findings, presented to the reviewer as
+work to adjudicate.
 
 The shepherd stage settles every entry and **edits the PR body to tick it**
 (`- [x] … — fixed in <sha>` / `declined: <reason>` / `filed as #<n>`) in the

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -51,10 +51,12 @@ beyond the auto-detected base (`origin/HEAD`, else a local `main`/`master`)
 *and* the working tree. When both exist the prompt carries one manifest split
 into a `Committed changes` and an `Uncommitted changes` section, so the
 reviewer knows which diff to collect for each path; when only one exists it is
-reviewed on its own. The explicit flags stay narrow deliberately — `--base` is
-committed history only and `--uncommitted` is the worktree only — so they
-remain escapes you opt into rather than a default that quietly drops half the
-change.
+reviewed on its own. If the base cannot be resolved at all, the run refuses
+(exit 2) rather than falling back to the worktree half — a partial review that
+exits 0 is indistinguishable from a clean pass. The explicit flags stay narrow
+deliberately — `--base` is committed history only and `--uncommitted` is the
+worktree only — so they remain escapes you opt into rather than a default that
+quietly drops half the change.
 
 Whichever target you pick, an empty one is refused before Codex is invoked,
 with a non-zero exit. An empty scope has no correct outcome — the model either
@@ -275,8 +277,9 @@ orphan if it belongs to this work, otherwise leave it and mention it. One
 command beats rename-migration logic that would need its own correctness
 argument. The location is deterministic, so a later session finds it the same
 way, and `git status` never sees it — a note left in the *worktree* would be
-worse than none, because a dirty tree makes the next bare `task challenge`
-review the note instead of the branch.
+worse than none, because a dirty tree puts it in the next bare
+`task challenge`'s scope: a file of open findings, handed to the reviewer as
+part of the change to adjudicate.
 
 The shepherd stage settles every entry and ticks it off in the body as it
 goes, so the checkbox — not anyone's memory — is what says whether a finding
@@ -309,9 +312,11 @@ Adjudicate it; never disable the gate to get past a BLOCK.
   means a clean tree with no commits beyond the base. Reaching it from
   `--base <ref>` usually means the work is still uncommitted — drop the flag
   to review both halves, or use `--uncommitted`.
-- **Could not resolve a review target** — no `origin/HEAD` and no local
-  `main`/`master`, or the detected base shares no history with `HEAD`, on a
-  clean tree (exit 2). With a dirty tree the same condition is only a note:
-  the run continues over the working tree alone and says the commits are out
-  of scope. Either name a base with `--base <ref>` or fix the cached ref
-  (`git remote set-head origin --auto`).
+- **Could not resolve a base to review this branch against** — no
+  `origin/HEAD` and no local `main`/`master`, or the detected base shares no
+  history with `HEAD` (exit 2). It refuses on a dirty tree too, rather than
+  quietly reviewing the worktree alone: which commits are missing is exactly
+  what cannot be determined, and a partial review that exits 0 reads as a
+  clean pass. Fix the cached ref (`git remote set-head origin --auto`), name a
+  base with `--base <ref>`, or say the worktree really is the whole target
+  with `--uncommitted`.

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -40,11 +40,21 @@ Review").
 Both accept an explicit target and free-text focus after `--`:
 
 ```bash
-task challenge                                     # auto: dirty tree → uncommitted; clean → origin/HEAD, else local main/master
-task challenge -- --base main                      # branch vs main explicitly
+task challenge                                     # auto: commits beyond the base AND uncommitted work — whatever exists
+task challenge -- --base main                      # committed history only, vs main explicitly
 task review -- --uncommitted                       # staged + unstaged + untracked only
 task challenge -- --base main focus on the update/migration path
 ```
+
+With no target flag, **both halves of the change are in scope**: the commits
+beyond the auto-detected base (`origin/HEAD`, else a local `main`/`master`)
+*and* the working tree. When both exist the prompt carries one manifest split
+into a `Committed changes` and an `Uncommitted changes` section, so the
+reviewer knows which diff to collect for each path; when only one exists it is
+reviewed on its own. The explicit flags stay narrow deliberately — `--base` is
+committed history only and `--uncommitted` is the worktree only — so they
+remain escapes you opt into rather than a default that quietly drops half the
+change.
 
 Whichever target you pick, an empty one is refused before Codex is invoked,
 with a non-zero exit. An empty scope has no correct outcome — the model either
@@ -80,22 +90,25 @@ signal that the reviewed diff can spoof.
 
 Two things not to change when backgrounding:
 
-- **The target.** Bare `task challenge` keeps the auto-selection above — dirty
-  tree → uncommitted, clean tree → `origin/HEAD`. At this point in the loop
-  the tree is normally dirty, so a hardcoded `-- --base main` would review the
-  committed branch and silently skip the very work being challenged (and name
-  the wrong base in a repo that does not use `main`). Add a target flag only
-  when you mean to override. Note `origin/HEAD` is a *cached* ref: if the
-  remote's default branch moved, refresh it with
-  `git remote set-head origin --auto`, or the auto-selected base is silently
-  the old one.
+- **The target.** Bare `task challenge` keeps the auto-selection above — the
+  branch's commits and the working tree, whichever exist. At this point in the
+  loop the tree is normally dirty *and* the branch has commits, so a hardcoded
+  `-- --base main` would review the committed branch and silently skip the
+  very work being challenged (and name the wrong base in a repo that does not
+  use `main`). Add a target flag only when you mean to narrow. Note
+  `origin/HEAD` is a *cached* ref: if the remote's default branch moved,
+  refresh it with `git remote set-head origin --auto`, or the auto-selected
+  base is silently the old one.
 
-  The scopes do not overlap: `--uncommitted` reads the worktree,
-  `--base` diffs commits, and **neither covers both**. A dirty tree always wins
-  the auto-selection, so once the branch has commits, an uncommitted fix
-  narrows the re-run to just that fix — and the clean pass then attests to the
-  fix rather than to the whole change. **Commit each round's fixes before
-  re-running**, so the branch diff is the whole change again.
+  The explicit scopes do not overlap: `--uncommitted` reads the worktree,
+  `--base` diffs commits, and **neither covers both**. That is why passing one
+  mid-loop is risky — an uncommitted fix under `--uncommitted` narrows the
+  re-run to just that fix, and the clean pass then attests to the fix rather
+  than to the whole change. Bare `task challenge` covers both halves, so it is
+  the right thing to re-run. Committing each round's fixes first is still
+  tidier (it keeps the committed half authoritative and shrinks what Codex has
+  to reconcile), but the loop's exit condition no longer depends on your
+  remembering to.
 - **The runner.** Background `task challenge` itself, not
   `/codex:adversarial-review --background`: the slash command calls Codex
   directly, so it never receives the P0/P1/P2 scale that
@@ -105,12 +118,13 @@ Two things not to change when backgrounding:
 **Then leave the tree alone until it finishes.** `codex-review.sh` captures the
 file manifest at launch, but Codex collects the diffs itself as it runs — so
 editing, staging, or committing mid-review has it read a repository that no
-longer matches the manifest, and committing an initially dirty tree empties the
-`--uncommitted` scope outright. Backgrounding buys polling, not parallel edits:
-if there is other work to do, do it after the verdict. Should you capture the
-output to a file, keep it under `git rev-parse --git-path` rather than in the
-worktree — for the same reason the deferred-findings sidecar lives there, a
-stray worktree file becomes the next bare `task challenge`'s entire scope.
+longer matches the manifest, and committing an initially dirty tree empties an
+explicit `--uncommitted` scope outright. Backgrounding buys polling, not
+parallel edits: if there is other work to do, do it after the verdict. Should
+you capture the output to a file, keep it under `git rev-parse --git-path`
+rather than in the worktree — for the same reason the deferred-findings
+sidecar lives there, a stray worktree file lands in the next bare
+`task challenge`'s scope as part of the change under review.
 
 **Still running is not hung.** `codex exec` streams events as it works, so
 growing output is the liveness signal — poll it instead of inferring. Long
@@ -293,5 +307,11 @@ Adjudicate it; never disable the gate to get past a BLOCK.
   (exit 1) instead of asking Codex to review nothing; the message names the
   condition and the way out. Reaching it from `task challenge` with no flags
   means a clean tree with no commits beyond the base. Reaching it from
-  `--base <ref>` usually means the work is still uncommitted — use
-  `--uncommitted`, or commit first.
+  `--base <ref>` usually means the work is still uncommitted — drop the flag
+  to review both halves, or use `--uncommitted`.
+- **Could not resolve a review target** — no `origin/HEAD` and no local
+  `main`/`master`, or the detected base shares no history with `HEAD`, on a
+  clean tree (exit 2). With a dirty tree the same condition is only a note:
+  the run continues over the working tree alone and says the commits are out
+  of scope. Either name a base with `--base <ref>` or fix the cached ref
+  (`git remote set-head origin --auto`).

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -295,10 +295,10 @@ ${dirty_manifest}"
 fi
 
 # Backstop for every path, so the invariant does not depend on each one
-# remembering it. Every manifest above is built through `|| true`, so a git
-# call that failed rather than returning nothing would otherwise reach the
-# model with an empty scope — and a new target path added later inherits the
-# guard for free instead of having to re-derive it.
+# remembering it. The explicit target flags build their manifest through
+# `|| true`, so a git call that failed rather than returning nothing arrives
+# here as an empty one — and a new target path added later inherits the guard
+# for free instead of having to re-derive it.
 if [ -z "$manifest" ]; then
     refuse_empty_scope \
         "the resolved target contains no changed files." \

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -204,7 +204,17 @@ if [ -z "$scope" ]; then
     # One `git status` call feeds both the choice and the manifest, so a tree
     # cleaned between two calls cannot make the run pick a scope it then fails
     # to enumerate.
-    dirty_manifest="$(git_status_porcelain | cap_manifest || true)"
+    #
+    # No `|| true` on either half here, unlike the explicit target flags above:
+    # those refuse when their one manifest comes back empty, so a failed git
+    # call there still fails closed. This path composes two halves, so a failure
+    # swallowed into "" would leave the OTHER half non-empty, satisfy the guard,
+    # and ship a partial review that exits 0 — the precise shape of the bug this
+    # path exists to close.
+    if ! dirty_manifest="$(git_status_porcelain | cap_manifest)"; then
+        echo "git status failed; refusing rather than reading an unreadable worktree as clean." >&2
+        exit 2
+    fi
 
     # origin/HEAD (the remote's actual default branch) outranks local
     # branch-name guesses: a stray local `main` in a develop-default repo must
@@ -220,20 +230,37 @@ if [ -z "$scope" ]; then
             fi
         done
     fi
-    # An unresolvable base is fatal only when there is nothing else to review.
-    # With a dirty tree the worktree half is still a real scope, so degrade to
-    # it with a warning rather than refusing a run that has something to say.
-    base_manifest=""
+    # An unresolvable base is fatal, on a dirty tree as much as a clean one.
+    # Degrading to the worktree half would be the old bug in a new place: the
+    # run would review a fraction of the change and still exit 0, and the
+    # stage's exit condition reads the status, not the stderr warning. Which
+    # commits are missing is exactly what cannot be determined here, so there
+    # is no honest partial scope to fall back to — make the narrowing an
+    # explicit act instead. `--uncommitted` is the one-flag way to say "the
+    # worktree really is all I want reviewed".
     base_problem=""
     if [ -z "$base" ] || ! git rev-parse --verify --quiet "$base" >/dev/null; then
         base_problem="no base branch could be detected (no origin/HEAD, no local main or master)"
     elif ! git merge-base "$base" HEAD >/dev/null 2>&1; then
         base_problem="the auto-detected base '${base}' shares no merge base with HEAD"
-    else
-        # Commits beyond the base do not guarantee a non-empty diff (an empty
-        # commit, or one later reverted), and an empty diff is indistinguish-
-        # able from no commits at all here — both simply leave this half out.
-        base_manifest="$(git_diff_name_status "${base}...HEAD" | cap_manifest || true)"
+    fi
+    if [ -n "$base_problem" ]; then
+        # Not refuse_empty_scope: nothing was resolved to be empty. This is a
+        # repository/argument problem, and it keeps the usage exit code (2)
+        # the explicit target flags use for the same class of failure.
+        echo "Could not resolve a base to review this branch against: ${base_problem}." >&2
+        echo "Refusing rather than reviewing the working tree alone — a partial review that" >&2
+        echo "exits 0 reads as the clean pass a challenge/review stage exits on." >&2
+        echo "Name a target explicitly: --base <ref>, --uncommitted, or --commit <sha>." >&2
+        exit 2
+    fi
+    # Commits beyond the base do not guarantee a non-empty diff (an empty
+    # commit, or one later reverted), and an empty diff is indistinguishable
+    # from no commits at all here — both simply leave this half out.
+    if ! base_manifest="$(git_diff_name_status "${base}...HEAD" | cap_manifest)"; then
+        echo "git diff ${base}...HEAD failed; refusing rather than reading an unreadable" >&2
+        echo "branch diff as an empty half (a partial clone missing objects, for one)." >&2
+        exit 2
     fi
 
     if [ -n "$base_manifest" ] && [ -n "$dirty_manifest" ]; then
@@ -251,24 +278,11 @@ ${dirty_manifest}"
     elif [ -n "$dirty_manifest" ]; then
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
         manifest="$dirty_manifest"
-        if [ -n "$base_problem" ]; then
-            echo "Note: ${base_problem}, so this run covers the working tree only." >&2
-            echo "      Pass --base <ref> to bring this branch's commits into scope." >&2
-            echo "==> Reviewing uncommitted work (no base branch resolved)"
-        else
-            echo "==> Reviewing uncommitted work (HEAD changes no files beyond ${base})"
-        fi
+        echo "==> Reviewing uncommitted work (HEAD changes no files beyond ${base})"
     elif [ -n "$base_manifest" ]; then
         scope="Review the changes on the current branch relative to base branch '${base}' (the merge-base diff ${base}...HEAD)."
         manifest="$base_manifest"
         echo "==> Reviewing branch changes against ${base} (clean working tree)"
-    elif [ -n "$base_problem" ]; then
-        # Not refuse_empty_scope: nothing was resolved to be empty. This is a
-        # repository/argument problem, and it keeps the usage exit code (2)
-        # the explicit target flags use for the same class of failure.
-        echo "Could not resolve a review target: ${base_problem}." >&2
-        echo "Pass --base <ref> or --commit <sha> to name one explicitly." >&2
-        exit 2
     elif [ "$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)" -eq 0 ]; then
         refuse_empty_scope \
             "the working tree is clean and HEAD has no commits beyond ${base}." \

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -10,9 +10,11 @@
 #
 # Usage: codex-review.sh <review|challenge> [--base <ref>|--uncommitted|--commit <sha>] [focus text ...]
 #
-# Target selection when no explicit flag is given (mirrors the Codex Claude
-# Code plugin's auto scope): a dirty working tree reviews staged + unstaged +
-# untracked work; a clean tree reviews the branch against the default base.
+# Target selection when no explicit flag is given: whatever exists is in
+# scope. Commits beyond the default base AND a dirty working tree are reviewed
+# together as one change; either alone is reviewed on its own. The explicit
+# flags stay narrow on purpose — --base is committed history only, and
+# --uncommitted is the worktree only — so they remain escapes you opt into.
 # The CLI's --base/--uncommitted/--commit flags are mutually exclusive with
 # custom instructions ("custom review instructions" is its own review mode),
 # so the resolved scope is written INTO the instructions instead.
@@ -89,7 +91,9 @@ refuse_empty_scope() {
 warn_if_dirty() {
     [ -n "$(git_status_porcelain)" ] || return 0
     echo "Note: the working tree is dirty, and --base reviews committed history only." >&2
-    echo "      Uncommitted changes are NOT in scope; use --uncommitted for those." >&2
+    echo "      Uncommitted changes are NOT in scope; drop the flag to review the" >&2
+    echo "      commits and the working tree together, or pass --uncommitted for" >&2
+    echo "      the working tree alone." >&2
 }
 
 scope=""
@@ -131,7 +135,7 @@ while [ $# -gt 0 ]; do
         # --commit belongs here too: a branch whose commits net out to no change
         # (an add and its revert) is already committed and has a clean tree, so
         # both of the other two remedies would be dead ends.
-        empty_hint="Pass --uncommitted for working-tree changes, --commit <sha> for a single commit, or commit your work first."
+        empty_hint="Drop --base to review the commits and the working tree together, pass --uncommitted for working-tree changes only, or --commit <sha> for a single commit."
         shift 2
         ;;
     --commit)
@@ -186,59 +190,101 @@ if [ -n "$target_kind" ] && [ -z "$manifest" ]; then
 fi
 
 if [ -z "$scope" ]; then
-    # Same helper as the manifest built from it two lines down, so the tree
-    # cannot test clean here and then yield a non-empty manifest (or vice
-    # versa) because the two calls disagreed about what counts as a change.
-    if [ -n "$(git_status_porcelain)" ]; then
-        scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
-        manifest="$(git_status_porcelain | cap_manifest || true)"
-        echo "==> Reviewing uncommitted work (dirty tree; pass --base <ref> to review the branch instead)"
+    # BOTH halves are resolved before either is chosen, because a branch
+    # carrying commits AND uncommitted work is the ordinary state mid-loop —
+    # fixes are not committed until the PR stage — and the two scopes are
+    # disjoint: `git status` sees the worktree, `${base}...HEAD` sees the
+    # commits. Choosing one used to silently drop the other, so a re-run after
+    # an uncommitted fix reviewed that fix alone and reported the clean pass
+    # the challenge/review stage exits on: the pass attested to the fix rather
+    # than to the change. Resolving both and reviewing both is what keeps the
+    # exit condition honest without relying on the operator remembering to
+    # commit between rounds.
+    #
+    # One `git status` call feeds both the choice and the manifest, so a tree
+    # cleaned between two calls cannot make the run pick a scope it then fails
+    # to enumerate.
+    dirty_manifest="$(git_status_porcelain | cap_manifest || true)"
+
+    # origin/HEAD (the remote's actual default branch) outranks local
+    # branch-name guesses: a stray local `main` in a develop-default repo must
+    # not silently become the comparison base. The remote-qualified ref is
+    # kept as-is — stripping origin/ could name a branch that does not exist
+    # locally. Name guesses only apply to remoteless repos.
+    base="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+    if [ -z "$base" ]; then
+        for candidate in main master; do
+            if git rev-parse --verify --quiet "$candidate" >/dev/null; then
+                base="$candidate"
+                break
+            fi
+        done
+    fi
+    # An unresolvable base is fatal only when there is nothing else to review.
+    # With a dirty tree the worktree half is still a real scope, so degrade to
+    # it with a warning rather than refusing a run that has something to say.
+    base_manifest=""
+    base_problem=""
+    if [ -z "$base" ] || ! git rev-parse --verify --quiet "$base" >/dev/null; then
+        base_problem="no base branch could be detected (no origin/HEAD, no local main or master)"
+    elif ! git merge-base "$base" HEAD >/dev/null 2>&1; then
+        base_problem="the auto-detected base '${base}' shares no merge base with HEAD"
     else
-        # origin/HEAD (the remote's actual default branch) outranks local
-        # branch-name guesses: a stray local `main` in a develop-default repo
-        # must not silently become the comparison base. The remote-qualified
-        # ref is kept as-is — stripping origin/ could name a branch that does
-        # not exist locally. Name guesses only apply to remoteless repos.
-        base="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"
-        if [ -z "$base" ]; then
-            for candidate in main master; do
-                if git rev-parse --verify --quiet "$candidate" >/dev/null; then
-                    base="$candidate"
-                    break
-                fi
-            done
+        # Commits beyond the base do not guarantee a non-empty diff (an empty
+        # commit, or one later reverted), and an empty diff is indistinguish-
+        # able from no commits at all here — both simply leave this half out.
+        base_manifest="$(git_diff_name_status "${base}...HEAD" | cap_manifest || true)"
+    fi
+
+    if [ -n "$base_manifest" ] && [ -n "$dirty_manifest" ]; then
+        scope="Review the complete current change, which has two parts: (1) the commits on this branch relative to base branch '${base}' — the merge-base diff ${base}...HEAD — and (2) the uncommitted work in the working tree: staged, unstaged, and untracked changes. BOTH parts are in scope and must be reviewed as one change. The uncommitted part is typically a fix to the committed part, so do not treat either part as settled background for the other; a file may legitimately appear in both."
+        # Each half is capped independently: a single 200-entry cap over the
+        # concatenation would let a large committed half swallow the worktree
+        # half whole, which is the exact silent narrowing this path exists to
+        # prevent. The prompt goes over stdin, so the extra entries are cheap.
+        manifest="Committed changes (git diff --name-status ${base}...HEAD):
+${base_manifest}
+
+Uncommitted changes (git status --porcelain):
+${dirty_manifest}"
+        echo "==> Reviewing branch changes against ${base} AND uncommitted work (both halves in scope)"
+    elif [ -n "$dirty_manifest" ]; then
+        scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
+        manifest="$dirty_manifest"
+        if [ -n "$base_problem" ]; then
+            echo "Note: ${base_problem}, so this run covers the working tree only." >&2
+            echo "      Pass --base <ref> to bring this branch's commits into scope." >&2
+            echo "==> Reviewing uncommitted work (no base branch resolved)"
+        else
+            echo "==> Reviewing uncommitted work (HEAD changes no files beyond ${base})"
         fi
-        if [ -z "$base" ] || ! git rev-parse --verify --quiet "$base" >/dev/null; then
-            echo "Could not detect a base branch; pass --base <ref> or --uncommitted." >&2
-            exit 2
-        fi
-        if ! git merge-base "$base" HEAD >/dev/null 2>&1; then
-            echo "Auto-detected base '${base}' shares no merge base with HEAD; pass --base <ref> or --uncommitted." >&2
-            exit 2
-        fi
-        if [ "$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)" -eq 0 ]; then
-            refuse_empty_scope \
-                "the working tree is clean and HEAD has no commits beyond ${base}." \
-                "Pass --base <ref> or --commit <sha> to name a target explicitly."
-        fi
+    elif [ -n "$base_manifest" ]; then
         scope="Review the changes on the current branch relative to base branch '${base}' (the merge-base diff ${base}...HEAD)."
-        manifest="$(git_diff_name_status "${base}...HEAD" | cap_manifest || true)"
-        # Commits beyond the base do not guarantee a non-empty diff: an empty
-        # commit, or one later reverted, leaves nothing for Codex to read.
-        if [ -z "$manifest" ]; then
-            refuse_empty_scope \
-                "the merge-base diff ${base}...HEAD is empty — the commits beyond ${base} change no files." \
-                "Pass --commit <sha> to review a specific commit, or --uncommitted for working-tree changes."
-        fi
-        echo "==> Reviewing branch changes against ${base}"
+        manifest="$base_manifest"
+        echo "==> Reviewing branch changes against ${base} (clean working tree)"
+    elif [ -n "$base_problem" ]; then
+        # Not refuse_empty_scope: nothing was resolved to be empty. This is a
+        # repository/argument problem, and it keeps the usage exit code (2)
+        # the explicit target flags use for the same class of failure.
+        echo "Could not resolve a review target: ${base_problem}." >&2
+        echo "Pass --base <ref> or --commit <sha> to name one explicitly." >&2
+        exit 2
+    elif [ "$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)" -eq 0 ]; then
+        refuse_empty_scope \
+            "the working tree is clean and HEAD has no commits beyond ${base}." \
+            "Pass --base <ref> or --commit <sha> to name a target explicitly."
+    else
+        refuse_empty_scope \
+            "the working tree is clean and the merge-base diff ${base}...HEAD is empty — the commits beyond ${base} change no files." \
+            "Pass --commit <sha> to review a specific commit."
     fi
 fi
 
 # Backstop for every path, so the invariant does not depend on each one
-# remembering it. The auto dirty-tree path in particular decides on one
-# `git status` and builds its manifest from a second: a tree cleaned between
-# the two calls — or a call that failed into `|| true` — would otherwise still
-# reach the model with nothing to review.
+# remembering it. Every manifest above is built through `|| true`, so a git
+# call that failed rather than returning nothing would otherwise reach the
+# model with an empty scope — and a new target path added later inherits the
+# guard for free instead of having to re-derive it.
 if [ -z "$manifest" ]; then
     refuse_empty_scope \
         "the resolved target contains no changed files." \

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -281,11 +281,12 @@ out="$(run review --base "$submod_base")" || fail "submodule-only diff refused a
 echo "$out" | grep -q "vendored" || fail "submodule gitlink missing from manifest: $out"
 git_t config --unset diff.ignoreSubmodules
 
-echo "==> no detectable base: a dirty tree still reviews, a clean one fails fast"
-# Resolving the base is now on the auto path unconditionally, so a repo with
-# no origin/HEAD and no local main/master must not turn a perfectly reviewable
-# dirty tree into a hard failure — it degrades to the worktree half and says
-# so. With nothing else to review it keeps the usage exit code.
+echo "==> an unresolvable base refuses, on a dirty tree as much as a clean one"
+# Degrading to the worktree half would be the original bug in a new place: a
+# fraction of the change reviewed, exit 0, and a stage that reads the status
+# rather than the warning banks it as a clean pass. Which commits are missing
+# is precisely what cannot be determined here, so there is no honest partial
+# scope — the refusal names --uncommitted as the deliberate way to ask for one.
 norem="${test_tmp}/norem"
 mkdir -p "${norem}/scripts"
 cp "${repo}/scripts/codex-review.sh" "${norem}/scripts/"
@@ -297,13 +298,53 @@ git init -q -b feature "$norem"
     if out="$(./scripts/codex-review.sh review 2>&1)"; then
         fail "clean tree with no detectable base was accepted: $out"
     fi
-    echo "$out" | grep -q "Could not resolve a review target" || fail "missing unresolvable-target message: $out"
-    echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked with no resolvable target: $out"
+    echo "$out" | grep -q "Could not resolve a base" || fail "missing unresolvable-base message: $out"
+    echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked with no resolvable base: $out"
     echo loose >loose.txt
-    out="$(./scripts/codex-review.sh review 2>&1)" || fail "dirty tree with no detectable base was refused: $out"
-    echo "$out" | grep -q "no base branch could be detected" || fail "missing base-degradation note: $out"
-    echo "$out" | grep -q "loose.txt" || fail "worktree file missing from degraded manifest: $out"
+    if out="$(./scripts/codex-review.sh review 2>&1)"; then
+        fail "dirty tree with no detectable base reviewed the worktree alone and exited 0: $out"
+    fi
+    echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked on a partial scope: $out"
+    echo "$out" | grep -q -- "--uncommitted" || fail "refusal does not name the deliberate narrow target: $out"
+    # ...and that named escape must actually work, or the refusal is a dead end.
+    out="$(./scripts/codex-review.sh review --uncommitted 2>&1)" || fail "--uncommitted refused with no base: $out"
+    echo "$out" | grep -q "loose.txt" || fail "worktree file missing from --uncommitted manifest: $out"
 )
+
+echo "==> a git failure in either half is refused, not read as an empty half"
+# Neither half may fail into "". A failed `git diff` with a dirty tree would
+# leave the worktree half non-empty, satisfy the non-empty manifest backstop,
+# and ship a one-sided review that exits 0 (a partial clone missing objects is
+# the realistic trigger); a failed `git status` would read as a clean tree and
+# do the same in reverse. The stub fails one subcommand, only when armed, so
+# every other git call in the fixture behaves normally.
+real_git="$(command -v git)"
+cat >"${test_tmp}/bin/git" <<GITSTUB
+#!/usr/bin/env bash
+if [ -n "\${FAIL_GIT_DIFF:-}" ] && [ "\${1:-}" = "diff" ] && [ "\${2:-}" = "--name-status" ]; then
+    echo "fatal: simulated missing object" >&2
+    exit 128
+fi
+if [ -n "\${FAIL_GIT_STATUS:-}" ] && [ "\${1:-}" = "status" ]; then
+    echo "fatal: simulated unreadable index" >&2
+    exit 128
+fi
+exec "${real_git}" "\$@"
+GITSTUB
+chmod +x "${test_tmp}/bin/git"
+git checkout -q feature
+echo halfwork >halfwork.txt
+if out="$(FAIL_GIT_DIFF=1 run review)"; then
+    fail "an unreadable branch diff was reviewed as an empty half and exited 0: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked with a committed half that could not be read: $out"
+echo "$out" | grep -q "refusing rather than reading an unreadable" || fail "missing unreadable-diff refusal message: $out"
+if out="$(FAIL_GIT_STATUS=1 run review)"; then
+    fail "an unreadable worktree was reviewed as clean and exited 0: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked with a worktree half that could not be read: $out"
+echo "$out" | grep -q "refusing rather than reading an unreadable worktree" || fail "missing unreadable-worktree refusal message: $out"
+rm -f halfwork.txt "${test_tmp}/bin/git"
 
 echo "==> gate: another repo's project-scoped plugin install is not accepted"
 fake_claude="${test_tmp}/claude-config"
@@ -402,4 +443,4 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (26 cases)"
+echo "codex-review + codex-gate guards OK (27 cases)"

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -7,7 +7,10 @@
 # strip `origin/` into a nonexistent local ref and silently report nothing
 # to review, and the one a real --base run caught: an empty scope reached
 # Codex, whose "that diff is empty" reply exited 0 and read as the clean pass
-# a capped review loop exits on. Run via `task test:codex-review`.
+# a capped review loop exits on. Also guards the scope union: a branch holding
+# commits AND uncommitted work is the ordinary mid-loop state, and reviewing
+# only one half is how a re-run banks a clean pass for a fraction of the
+# change. Run via `task test:codex-review`.
 set -euo pipefail
 
 repo="$(git rev-parse --show-toplevel)"
@@ -72,6 +75,9 @@ echo "$out" | grep -q "STUB-ARGS:exec review" || fail "codex exec review not inv
 echo "$out" | grep -q "base branch 'origin/develop'" || fail "remote-qualified fallback base missing: $out"
 echo "$out" | grep -q "ADVERSARIAL" || fail "challenge mode instructions missing: $out"
 echo "$out" | grep -q "feature.txt" || fail "changed-file manifest missing from branch-scope prompt: $out"
+# A clean tree has no second half, so the split manifest must not appear —
+# otherwise the union headers would be noise the reviewer has to interpret.
+echo "$out" | grep -q "Uncommitted changes (git status" && fail "clean tree emitted an uncommitted manifest section: $out"
 # The gate is only meaningful if the scale it gates on is defined in the
 # prompt — Codex's own priority labels are an undocumented convention.
 echo "$out" | grep -q "Only P0 and P1 decide" || fail "challenge prompt missing the P0/P1 gating rule: $out"
@@ -102,14 +108,27 @@ echo "$out" | grep -q "watch the hooks" || fail "focus text missing from prompt:
 echo "$out" | grep -q "Only P0 and P1 decide" || fail "review prompt missing the P0/P1 gating rule: $out"
 echo "$out" | grep -q "carried into the pull request description" || fail "review prompt missing the P2 handoff clause: $out"
 
-echo "==> dirty tree auto-selects uncommitted scope and enumerates untracked dirs"
+echo "==> commits plus a dirty tree review BOTH halves, in labelled sections"
+# The reported bug: the two scopes are disjoint and the dirty tree used to win
+# outright, so a re-run after an uncommitted fix reviewed that fix alone and
+# banked a clean pass for a fraction of the change. Both halves must be in one
+# manifest, and each must land in its own section — a file listed under the
+# wrong heading tells the reviewer to collect the wrong diff for it.
 echo x >dirty.txt
 mkdir newdir
 echo y >newdir/inner.txt
-out="$(run review)" || fail "dirty-tree review exited non-zero: $out"
-echo "$out" | grep -q "uncommitted work" || fail "dirty tree did not select uncommitted scope: $out"
-echo "$out" | grep -q "dirty.txt" || fail "untracked file missing from uncommitted manifest: $out"
-echo "$out" | grep -q "newdir/inner.txt" || fail "file inside untracked dir missing from manifest (collapsed to dir entry): $out"
+out="$(run review)" || fail "commits-plus-dirty review exited non-zero: $out"
+echo "$out" | grep -q "BOTH parts are in scope" || fail "commits plus a dirty tree did not select the union scope: $out"
+echo "$out" | grep -q "uncommitted work in the working tree" || fail "union scope does not name the worktree half: $out"
+echo "$out" | grep -q "origin/develop...HEAD" || fail "union scope does not name the committed half: $out"
+committed_half="$(printf '%s\n' "$out" | sed -n '/^Committed changes (git diff/,/^Uncommitted changes (git status/p')"
+uncommitted_half="$(printf '%s\n' "$out" | sed -n '/^Uncommitted changes (git status/,$p')"
+[ -n "$committed_half" ] || fail "union manifest missing its committed section: $out"
+[ -n "$uncommitted_half" ] || fail "union manifest missing its uncommitted section: $out"
+echo "$committed_half" | grep -q "feature.txt" || fail "committed half missing the branch's own commit: $out"
+echo "$committed_half" | grep -q "dirty.txt" && fail "worktree file filed under the committed heading: $out"
+echo "$uncommitted_half" | grep -q "dirty.txt" || fail "untracked file missing from the uncommitted half: $out"
+echo "$uncommitted_half" | grep -q "newdir/inner.txt" || fail "file inside untracked dir missing from manifest (collapsed to dir entry): $out"
 rm -rf dirty.txt newdir
 
 echo "==> a >200-entry dirty tree still reviews (no SIGPIPE abort) and marks truncation"
@@ -134,6 +153,17 @@ if out="$(run review)"; then
 fi
 echo "$out" | grep -q "Nothing to review" || fail "expected nothing-to-review message: $out"
 echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite nothing to review: $out"
+
+echo "==> at the base tip, a dirty tree reviews the worktree alone"
+# The other side of the union: with no commits beyond the base there is no
+# second half, so the split manifest and its headings must not appear.
+echo tipwork >tipwork.txt
+out="$(run review)" || fail "dirty tree at the base tip exited non-zero: $out"
+echo "$out" | grep -q "Review the uncommitted work" || fail "base-tip dirty tree did not select the uncommitted scope: $out"
+echo "$out" | grep -q "BOTH parts are in scope" && fail "union scope selected with no commits beyond the base: $out"
+echo "$out" | grep -q "Committed changes (git diff" && fail "empty committed half still emitted a manifest section: $out"
+echo "$out" | grep -q "tipwork.txt" || fail "worktree file missing from manifest: $out"
+rm -f tipwork.txt
 
 echo "==> --base level with its base refuses, non-zero, without invoking codex"
 # The reported bug: an explicit --base built an empty manifest and shipped a
@@ -251,6 +281,30 @@ out="$(run review --base "$submod_base")" || fail "submodule-only diff refused a
 echo "$out" | grep -q "vendored" || fail "submodule gitlink missing from manifest: $out"
 git_t config --unset diff.ignoreSubmodules
 
+echo "==> no detectable base: a dirty tree still reviews, a clean one fails fast"
+# Resolving the base is now on the auto path unconditionally, so a repo with
+# no origin/HEAD and no local main/master must not turn a perfectly reviewable
+# dirty tree into a hard failure — it degrades to the worktree half and says
+# so. With nothing else to review it keeps the usage exit code.
+norem="${test_tmp}/norem"
+mkdir -p "${norem}/scripts"
+cp "${repo}/scripts/codex-review.sh" "${norem}/scripts/"
+git init -q -b feature "$norem"
+(
+    cd "$norem"
+    git add -A
+    git_t commit -q -m base
+    if out="$(./scripts/codex-review.sh review 2>&1)"; then
+        fail "clean tree with no detectable base was accepted: $out"
+    fi
+    echo "$out" | grep -q "Could not resolve a review target" || fail "missing unresolvable-target message: $out"
+    echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked with no resolvable target: $out"
+    echo loose >loose.txt
+    out="$(./scripts/codex-review.sh review 2>&1)" || fail "dirty tree with no detectable base was refused: $out"
+    echo "$out" | grep -q "no base branch could be detected" || fail "missing base-degradation note: $out"
+    echo "$out" | grep -q "loose.txt" || fail "worktree file missing from degraded manifest: $out"
+)
+
 echo "==> gate: another repo's project-scoped plugin install is not accepted"
 fake_claude="${test_tmp}/claude-config"
 mkdir -p "${fake_claude}/plugins"
@@ -348,4 +402,4 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (24 cases)"
+echo "codex-review + codex-gate guards OK (26 cases)"

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -120,9 +120,11 @@ something to ask permission for.
   A `task challenge` round is long — 5–15 minutes is ordinary, past most
   agents' tool-call timeouts — so **run it in the background and poll**
   instead of blocking one call on it. Growing output means running, not hung;
-  relaunching a live run only doubles the cost. Commit each round's fixes
-  before re-challenging, or the re-run scopes to the fix alone instead of the
-  whole change. Details:
+  relaunching a live run only doubles the cost. Re-challenge with a bare
+  `task challenge` — it covers the branch's commits *and* the working tree,
+  so an uncommitted fix cannot narrow the re-run to itself; an explicit
+  `--base`/`--uncommitted` reviews one half only. Committing each round's
+  fixes first is still tidier, not load-bearing. Details:
   [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
   backgrounding").
 - **`task review`** — verification-checkpoint review; same adjudication, same
@@ -303,9 +305,10 @@ collide `feat/x` with `feat-x` and reintroduce exactly that loss, and adding
 an extension would make `foo` (a file) block `foo.md/bar` (needing a
 directory). Used as-is, the mapping is git's own ref namespace, and git
 already forbids one live branch from being a path prefix of another. A note in the *worktree* would be worse than none:
-`codex-review.sh` reviews the uncommitted diff whenever the tree is dirty, so
-the note would become the next bare `task challenge`'s entire scope — and the
-change it was supposed to review would get a clean pass it never earned.
+`codex-review.sh` puts uncommitted files in scope whenever the tree is dirty,
+so the note would be handed to the next bare `task challenge` as part of the
+change under review — a file of open findings, presented to the reviewer as
+work to adjudicate.
 
 The shepherd stage settles every entry and **edits the PR body to tick it**
 (`- [x] … — fixed in <sha>` / `declined: <reason>` / `filed as #<n>`) in the

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -51,10 +51,12 @@ beyond the auto-detected base (`origin/HEAD`, else a local `main`/`master`)
 *and* the working tree. When both exist the prompt carries one manifest split
 into a `Committed changes` and an `Uncommitted changes` section, so the
 reviewer knows which diff to collect for each path; when only one exists it is
-reviewed on its own. The explicit flags stay narrow deliberately — `--base` is
-committed history only and `--uncommitted` is the worktree only — so they
-remain escapes you opt into rather than a default that quietly drops half the
-change.
+reviewed on its own. If the base cannot be resolved at all, the run refuses
+(exit 2) rather than falling back to the worktree half — a partial review that
+exits 0 is indistinguishable from a clean pass. The explicit flags stay narrow
+deliberately — `--base` is committed history only and `--uncommitted` is the
+worktree only — so they remain escapes you opt into rather than a default that
+quietly drops half the change.
 
 Whichever target you pick, an empty one is refused before Codex is invoked,
 with a non-zero exit. An empty scope has no correct outcome — the model either
@@ -275,8 +277,9 @@ orphan if it belongs to this work, otherwise leave it and mention it. One
 command beats rename-migration logic that would need its own correctness
 argument. The location is deterministic, so a later session finds it the same
 way, and `git status` never sees it — a note left in the *worktree* would be
-worse than none, because a dirty tree makes the next bare `task challenge`
-review the note instead of the branch.
+worse than none, because a dirty tree puts it in the next bare
+`task challenge`'s scope: a file of open findings, handed to the reviewer as
+part of the change to adjudicate.
 
 The shepherd stage settles every entry and ticks it off in the body as it
 goes, so the checkbox — not anyone's memory — is what says whether a finding
@@ -309,9 +312,11 @@ Adjudicate it; never disable the gate to get past a BLOCK.
   means a clean tree with no commits beyond the base. Reaching it from
   `--base <ref>` usually means the work is still uncommitted — drop the flag
   to review both halves, or use `--uncommitted`.
-- **Could not resolve a review target** — no `origin/HEAD` and no local
-  `main`/`master`, or the detected base shares no history with `HEAD`, on a
-  clean tree (exit 2). With a dirty tree the same condition is only a note:
-  the run continues over the working tree alone and says the commits are out
-  of scope. Either name a base with `--base <ref>` or fix the cached ref
-  (`git remote set-head origin --auto`).
+- **Could not resolve a base to review this branch against** — no
+  `origin/HEAD` and no local `main`/`master`, or the detected base shares no
+  history with `HEAD` (exit 2). It refuses on a dirty tree too, rather than
+  quietly reviewing the worktree alone: which commits are missing is exactly
+  what cannot be determined, and a partial review that exits 0 reads as a
+  clean pass. Fix the cached ref (`git remote set-head origin --auto`), name a
+  base with `--base <ref>`, or say the worktree really is the whole target
+  with `--uncommitted`.

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -40,11 +40,21 @@ Review").
 Both accept an explicit target and free-text focus after `--`:
 
 ```bash
-task challenge                                     # auto: dirty tree → uncommitted; clean → origin/HEAD, else local main/master
-task challenge -- --base main                      # branch vs main explicitly
+task challenge                                     # auto: commits beyond the base AND uncommitted work — whatever exists
+task challenge -- --base main                      # committed history only, vs main explicitly
 task review -- --uncommitted                       # staged + unstaged + untracked only
 task challenge -- --base main focus on the update/migration path
 ```
+
+With no target flag, **both halves of the change are in scope**: the commits
+beyond the auto-detected base (`origin/HEAD`, else a local `main`/`master`)
+*and* the working tree. When both exist the prompt carries one manifest split
+into a `Committed changes` and an `Uncommitted changes` section, so the
+reviewer knows which diff to collect for each path; when only one exists it is
+reviewed on its own. The explicit flags stay narrow deliberately — `--base` is
+committed history only and `--uncommitted` is the worktree only — so they
+remain escapes you opt into rather than a default that quietly drops half the
+change.
 
 Whichever target you pick, an empty one is refused before Codex is invoked,
 with a non-zero exit. An empty scope has no correct outcome — the model either
@@ -80,22 +90,25 @@ signal that the reviewed diff can spoof.
 
 Two things not to change when backgrounding:
 
-- **The target.** Bare `task challenge` keeps the auto-selection above — dirty
-  tree → uncommitted, clean tree → `origin/HEAD`. At this point in the loop
-  the tree is normally dirty, so a hardcoded `-- --base main` would review the
-  committed branch and silently skip the very work being challenged (and name
-  the wrong base in a repo that does not use `main`). Add a target flag only
-  when you mean to override. Note `origin/HEAD` is a *cached* ref: if the
-  remote's default branch moved, refresh it with
-  `git remote set-head origin --auto`, or the auto-selected base is silently
-  the old one.
+- **The target.** Bare `task challenge` keeps the auto-selection above — the
+  branch's commits and the working tree, whichever exist. At this point in the
+  loop the tree is normally dirty *and* the branch has commits, so a hardcoded
+  `-- --base main` would review the committed branch and silently skip the
+  very work being challenged (and name the wrong base in a repo that does not
+  use `main`). Add a target flag only when you mean to narrow. Note
+  `origin/HEAD` is a *cached* ref: if the remote's default branch moved,
+  refresh it with `git remote set-head origin --auto`, or the auto-selected
+  base is silently the old one.
 
-  The scopes do not overlap: `--uncommitted` reads the worktree,
-  `--base` diffs commits, and **neither covers both**. A dirty tree always wins
-  the auto-selection, so once the branch has commits, an uncommitted fix
-  narrows the re-run to just that fix — and the clean pass then attests to the
-  fix rather than to the whole change. **Commit each round's fixes before
-  re-running**, so the branch diff is the whole change again.
+  The explicit scopes do not overlap: `--uncommitted` reads the worktree,
+  `--base` diffs commits, and **neither covers both**. That is why passing one
+  mid-loop is risky — an uncommitted fix under `--uncommitted` narrows the
+  re-run to just that fix, and the clean pass then attests to the fix rather
+  than to the whole change. Bare `task challenge` covers both halves, so it is
+  the right thing to re-run. Committing each round's fixes first is still
+  tidier (it keeps the committed half authoritative and shrinks what Codex has
+  to reconcile), but the loop's exit condition no longer depends on your
+  remembering to.
 - **The runner.** Background `task challenge` itself, not
   `/codex:adversarial-review --background`: the slash command calls Codex
   directly, so it never receives the P0/P1/P2 scale that
@@ -105,12 +118,13 @@ Two things not to change when backgrounding:
 **Then leave the tree alone until it finishes.** `codex-review.sh` captures the
 file manifest at launch, but Codex collects the diffs itself as it runs — so
 editing, staging, or committing mid-review has it read a repository that no
-longer matches the manifest, and committing an initially dirty tree empties the
-`--uncommitted` scope outright. Backgrounding buys polling, not parallel edits:
-if there is other work to do, do it after the verdict. Should you capture the
-output to a file, keep it under `git rev-parse --git-path` rather than in the
-worktree — for the same reason the deferred-findings sidecar lives there, a
-stray worktree file becomes the next bare `task challenge`'s entire scope.
+longer matches the manifest, and committing an initially dirty tree empties an
+explicit `--uncommitted` scope outright. Backgrounding buys polling, not
+parallel edits: if there is other work to do, do it after the verdict. Should
+you capture the output to a file, keep it under `git rev-parse --git-path`
+rather than in the worktree — for the same reason the deferred-findings
+sidecar lives there, a stray worktree file lands in the next bare
+`task challenge`'s scope as part of the change under review.
 
 **Still running is not hung.** `codex exec` streams events as it works, so
 growing output is the liveness signal — poll it instead of inferring. Long
@@ -293,5 +307,11 @@ Adjudicate it; never disable the gate to get past a BLOCK.
   (exit 1) instead of asking Codex to review nothing; the message names the
   condition and the way out. Reaching it from `task challenge` with no flags
   means a clean tree with no commits beyond the base. Reaching it from
-  `--base <ref>` usually means the work is still uncommitted — use
-  `--uncommitted`, or commit first.
+  `--base <ref>` usually means the work is still uncommitted — drop the flag
+  to review both halves, or use `--uncommitted`.
+- **Could not resolve a review target** — no `origin/HEAD` and no local
+  `main`/`master`, or the detected base shares no history with `HEAD`, on a
+  clean tree (exit 2). With a dirty tree the same condition is only a note:
+  the run continues over the working tree alone and says the commits are out
+  of scope. Either name a base with `--base <ref>` or fix the cached ref
+  (`git remote set-head origin --auto`).

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -295,10 +295,10 @@ ${dirty_manifest}"
 fi
 
 # Backstop for every path, so the invariant does not depend on each one
-# remembering it. Every manifest above is built through `|| true`, so a git
-# call that failed rather than returning nothing would otherwise reach the
-# model with an empty scope — and a new target path added later inherits the
-# guard for free instead of having to re-derive it.
+# remembering it. The explicit target flags build their manifest through
+# `|| true`, so a git call that failed rather than returning nothing arrives
+# here as an empty one — and a new target path added later inherits the guard
+# for free instead of having to re-derive it.
 if [ -z "$manifest" ]; then
     refuse_empty_scope \
         "the resolved target contains no changed files." \

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -204,7 +204,17 @@ if [ -z "$scope" ]; then
     # One `git status` call feeds both the choice and the manifest, so a tree
     # cleaned between two calls cannot make the run pick a scope it then fails
     # to enumerate.
-    dirty_manifest="$(git_status_porcelain | cap_manifest || true)"
+    #
+    # No `|| true` on either half here, unlike the explicit target flags above:
+    # those refuse when their one manifest comes back empty, so a failed git
+    # call there still fails closed. This path composes two halves, so a failure
+    # swallowed into "" would leave the OTHER half non-empty, satisfy the guard,
+    # and ship a partial review that exits 0 — the precise shape of the bug this
+    # path exists to close.
+    if ! dirty_manifest="$(git_status_porcelain | cap_manifest)"; then
+        echo "git status failed; refusing rather than reading an unreadable worktree as clean." >&2
+        exit 2
+    fi
 
     # origin/HEAD (the remote's actual default branch) outranks local
     # branch-name guesses: a stray local `main` in a develop-default repo must
@@ -220,20 +230,37 @@ if [ -z "$scope" ]; then
             fi
         done
     fi
-    # An unresolvable base is fatal only when there is nothing else to review.
-    # With a dirty tree the worktree half is still a real scope, so degrade to
-    # it with a warning rather than refusing a run that has something to say.
-    base_manifest=""
+    # An unresolvable base is fatal, on a dirty tree as much as a clean one.
+    # Degrading to the worktree half would be the old bug in a new place: the
+    # run would review a fraction of the change and still exit 0, and the
+    # stage's exit condition reads the status, not the stderr warning. Which
+    # commits are missing is exactly what cannot be determined here, so there
+    # is no honest partial scope to fall back to — make the narrowing an
+    # explicit act instead. `--uncommitted` is the one-flag way to say "the
+    # worktree really is all I want reviewed".
     base_problem=""
     if [ -z "$base" ] || ! git rev-parse --verify --quiet "$base" >/dev/null; then
         base_problem="no base branch could be detected (no origin/HEAD, no local main or master)"
     elif ! git merge-base "$base" HEAD >/dev/null 2>&1; then
         base_problem="the auto-detected base '${base}' shares no merge base with HEAD"
-    else
-        # Commits beyond the base do not guarantee a non-empty diff (an empty
-        # commit, or one later reverted), and an empty diff is indistinguish-
-        # able from no commits at all here — both simply leave this half out.
-        base_manifest="$(git_diff_name_status "${base}...HEAD" | cap_manifest || true)"
+    fi
+    if [ -n "$base_problem" ]; then
+        # Not refuse_empty_scope: nothing was resolved to be empty. This is a
+        # repository/argument problem, and it keeps the usage exit code (2)
+        # the explicit target flags use for the same class of failure.
+        echo "Could not resolve a base to review this branch against: ${base_problem}." >&2
+        echo "Refusing rather than reviewing the working tree alone — a partial review that" >&2
+        echo "exits 0 reads as the clean pass a challenge/review stage exits on." >&2
+        echo "Name a target explicitly: --base <ref>, --uncommitted, or --commit <sha>." >&2
+        exit 2
+    fi
+    # Commits beyond the base do not guarantee a non-empty diff (an empty
+    # commit, or one later reverted), and an empty diff is indistinguishable
+    # from no commits at all here — both simply leave this half out.
+    if ! base_manifest="$(git_diff_name_status "${base}...HEAD" | cap_manifest)"; then
+        echo "git diff ${base}...HEAD failed; refusing rather than reading an unreadable" >&2
+        echo "branch diff as an empty half (a partial clone missing objects, for one)." >&2
+        exit 2
     fi
 
     if [ -n "$base_manifest" ] && [ -n "$dirty_manifest" ]; then
@@ -251,24 +278,11 @@ ${dirty_manifest}"
     elif [ -n "$dirty_manifest" ]; then
         scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
         manifest="$dirty_manifest"
-        if [ -n "$base_problem" ]; then
-            echo "Note: ${base_problem}, so this run covers the working tree only." >&2
-            echo "      Pass --base <ref> to bring this branch's commits into scope." >&2
-            echo "==> Reviewing uncommitted work (no base branch resolved)"
-        else
-            echo "==> Reviewing uncommitted work (HEAD changes no files beyond ${base})"
-        fi
+        echo "==> Reviewing uncommitted work (HEAD changes no files beyond ${base})"
     elif [ -n "$base_manifest" ]; then
         scope="Review the changes on the current branch relative to base branch '${base}' (the merge-base diff ${base}...HEAD)."
         manifest="$base_manifest"
         echo "==> Reviewing branch changes against ${base} (clean working tree)"
-    elif [ -n "$base_problem" ]; then
-        # Not refuse_empty_scope: nothing was resolved to be empty. This is a
-        # repository/argument problem, and it keeps the usage exit code (2)
-        # the explicit target flags use for the same class of failure.
-        echo "Could not resolve a review target: ${base_problem}." >&2
-        echo "Pass --base <ref> or --commit <sha> to name one explicitly." >&2
-        exit 2
     elif [ "$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)" -eq 0 ]; then
         refuse_empty_scope \
             "the working tree is clean and HEAD has no commits beyond ${base}." \

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -10,9 +10,11 @@
 #
 # Usage: codex-review.sh <review|challenge> [--base <ref>|--uncommitted|--commit <sha>] [focus text ...]
 #
-# Target selection when no explicit flag is given (mirrors the Codex Claude
-# Code plugin's auto scope): a dirty working tree reviews staged + unstaged +
-# untracked work; a clean tree reviews the branch against the default base.
+# Target selection when no explicit flag is given: whatever exists is in
+# scope. Commits beyond the default base AND a dirty working tree are reviewed
+# together as one change; either alone is reviewed on its own. The explicit
+# flags stay narrow on purpose — --base is committed history only, and
+# --uncommitted is the worktree only — so they remain escapes you opt into.
 # The CLI's --base/--uncommitted/--commit flags are mutually exclusive with
 # custom instructions ("custom review instructions" is its own review mode),
 # so the resolved scope is written INTO the instructions instead.
@@ -89,7 +91,9 @@ refuse_empty_scope() {
 warn_if_dirty() {
     [ -n "$(git_status_porcelain)" ] || return 0
     echo "Note: the working tree is dirty, and --base reviews committed history only." >&2
-    echo "      Uncommitted changes are NOT in scope; use --uncommitted for those." >&2
+    echo "      Uncommitted changes are NOT in scope; drop the flag to review the" >&2
+    echo "      commits and the working tree together, or pass --uncommitted for" >&2
+    echo "      the working tree alone." >&2
 }
 
 scope=""
@@ -131,7 +135,7 @@ while [ $# -gt 0 ]; do
         # --commit belongs here too: a branch whose commits net out to no change
         # (an add and its revert) is already committed and has a clean tree, so
         # both of the other two remedies would be dead ends.
-        empty_hint="Pass --uncommitted for working-tree changes, --commit <sha> for a single commit, or commit your work first."
+        empty_hint="Drop --base to review the commits and the working tree together, pass --uncommitted for working-tree changes only, or --commit <sha> for a single commit."
         shift 2
         ;;
     --commit)
@@ -186,59 +190,101 @@ if [ -n "$target_kind" ] && [ -z "$manifest" ]; then
 fi
 
 if [ -z "$scope" ]; then
-    # Same helper as the manifest built from it two lines down, so the tree
-    # cannot test clean here and then yield a non-empty manifest (or vice
-    # versa) because the two calls disagreed about what counts as a change.
-    if [ -n "$(git_status_porcelain)" ]; then
-        scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
-        manifest="$(git_status_porcelain | cap_manifest || true)"
-        echo "==> Reviewing uncommitted work (dirty tree; pass --base <ref> to review the branch instead)"
+    # BOTH halves are resolved before either is chosen, because a branch
+    # carrying commits AND uncommitted work is the ordinary state mid-loop —
+    # fixes are not committed until the PR stage — and the two scopes are
+    # disjoint: `git status` sees the worktree, `${base}...HEAD` sees the
+    # commits. Choosing one used to silently drop the other, so a re-run after
+    # an uncommitted fix reviewed that fix alone and reported the clean pass
+    # the challenge/review stage exits on: the pass attested to the fix rather
+    # than to the change. Resolving both and reviewing both is what keeps the
+    # exit condition honest without relying on the operator remembering to
+    # commit between rounds.
+    #
+    # One `git status` call feeds both the choice and the manifest, so a tree
+    # cleaned between two calls cannot make the run pick a scope it then fails
+    # to enumerate.
+    dirty_manifest="$(git_status_porcelain | cap_manifest || true)"
+
+    # origin/HEAD (the remote's actual default branch) outranks local
+    # branch-name guesses: a stray local `main` in a develop-default repo must
+    # not silently become the comparison base. The remote-qualified ref is
+    # kept as-is — stripping origin/ could name a branch that does not exist
+    # locally. Name guesses only apply to remoteless repos.
+    base="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+    if [ -z "$base" ]; then
+        for candidate in main master; do
+            if git rev-parse --verify --quiet "$candidate" >/dev/null; then
+                base="$candidate"
+                break
+            fi
+        done
+    fi
+    # An unresolvable base is fatal only when there is nothing else to review.
+    # With a dirty tree the worktree half is still a real scope, so degrade to
+    # it with a warning rather than refusing a run that has something to say.
+    base_manifest=""
+    base_problem=""
+    if [ -z "$base" ] || ! git rev-parse --verify --quiet "$base" >/dev/null; then
+        base_problem="no base branch could be detected (no origin/HEAD, no local main or master)"
+    elif ! git merge-base "$base" HEAD >/dev/null 2>&1; then
+        base_problem="the auto-detected base '${base}' shares no merge base with HEAD"
     else
-        # origin/HEAD (the remote's actual default branch) outranks local
-        # branch-name guesses: a stray local `main` in a develop-default repo
-        # must not silently become the comparison base. The remote-qualified
-        # ref is kept as-is — stripping origin/ could name a branch that does
-        # not exist locally. Name guesses only apply to remoteless repos.
-        base="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"
-        if [ -z "$base" ]; then
-            for candidate in main master; do
-                if git rev-parse --verify --quiet "$candidate" >/dev/null; then
-                    base="$candidate"
-                    break
-                fi
-            done
+        # Commits beyond the base do not guarantee a non-empty diff (an empty
+        # commit, or one later reverted), and an empty diff is indistinguish-
+        # able from no commits at all here — both simply leave this half out.
+        base_manifest="$(git_diff_name_status "${base}...HEAD" | cap_manifest || true)"
+    fi
+
+    if [ -n "$base_manifest" ] && [ -n "$dirty_manifest" ]; then
+        scope="Review the complete current change, which has two parts: (1) the commits on this branch relative to base branch '${base}' — the merge-base diff ${base}...HEAD — and (2) the uncommitted work in the working tree: staged, unstaged, and untracked changes. BOTH parts are in scope and must be reviewed as one change. The uncommitted part is typically a fix to the committed part, so do not treat either part as settled background for the other; a file may legitimately appear in both."
+        # Each half is capped independently: a single 200-entry cap over the
+        # concatenation would let a large committed half swallow the worktree
+        # half whole, which is the exact silent narrowing this path exists to
+        # prevent. The prompt goes over stdin, so the extra entries are cheap.
+        manifest="Committed changes (git diff --name-status ${base}...HEAD):
+${base_manifest}
+
+Uncommitted changes (git status --porcelain):
+${dirty_manifest}"
+        echo "==> Reviewing branch changes against ${base} AND uncommitted work (both halves in scope)"
+    elif [ -n "$dirty_manifest" ]; then
+        scope="Review the uncommitted work in this repository: staged, unstaged, and untracked changes."
+        manifest="$dirty_manifest"
+        if [ -n "$base_problem" ]; then
+            echo "Note: ${base_problem}, so this run covers the working tree only." >&2
+            echo "      Pass --base <ref> to bring this branch's commits into scope." >&2
+            echo "==> Reviewing uncommitted work (no base branch resolved)"
+        else
+            echo "==> Reviewing uncommitted work (HEAD changes no files beyond ${base})"
         fi
-        if [ -z "$base" ] || ! git rev-parse --verify --quiet "$base" >/dev/null; then
-            echo "Could not detect a base branch; pass --base <ref> or --uncommitted." >&2
-            exit 2
-        fi
-        if ! git merge-base "$base" HEAD >/dev/null 2>&1; then
-            echo "Auto-detected base '${base}' shares no merge base with HEAD; pass --base <ref> or --uncommitted." >&2
-            exit 2
-        fi
-        if [ "$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)" -eq 0 ]; then
-            refuse_empty_scope \
-                "the working tree is clean and HEAD has no commits beyond ${base}." \
-                "Pass --base <ref> or --commit <sha> to name a target explicitly."
-        fi
+    elif [ -n "$base_manifest" ]; then
         scope="Review the changes on the current branch relative to base branch '${base}' (the merge-base diff ${base}...HEAD)."
-        manifest="$(git_diff_name_status "${base}...HEAD" | cap_manifest || true)"
-        # Commits beyond the base do not guarantee a non-empty diff: an empty
-        # commit, or one later reverted, leaves nothing for Codex to read.
-        if [ -z "$manifest" ]; then
-            refuse_empty_scope \
-                "the merge-base diff ${base}...HEAD is empty — the commits beyond ${base} change no files." \
-                "Pass --commit <sha> to review a specific commit, or --uncommitted for working-tree changes."
-        fi
-        echo "==> Reviewing branch changes against ${base}"
+        manifest="$base_manifest"
+        echo "==> Reviewing branch changes against ${base} (clean working tree)"
+    elif [ -n "$base_problem" ]; then
+        # Not refuse_empty_scope: nothing was resolved to be empty. This is a
+        # repository/argument problem, and it keeps the usage exit code (2)
+        # the explicit target flags use for the same class of failure.
+        echo "Could not resolve a review target: ${base_problem}." >&2
+        echo "Pass --base <ref> or --commit <sha> to name one explicitly." >&2
+        exit 2
+    elif [ "$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)" -eq 0 ]; then
+        refuse_empty_scope \
+            "the working tree is clean and HEAD has no commits beyond ${base}." \
+            "Pass --base <ref> or --commit <sha> to name a target explicitly."
+    else
+        refuse_empty_scope \
+            "the working tree is clean and the merge-base diff ${base}...HEAD is empty — the commits beyond ${base} change no files." \
+            "Pass --commit <sha> to review a specific commit."
     fi
 fi
 
 # Backstop for every path, so the invariant does not depend on each one
-# remembering it. The auto dirty-tree path in particular decides on one
-# `git status` and builds its manifest from a second: a tree cleaned between
-# the two calls — or a call that failed into `|| true` — would otherwise still
-# reach the model with nothing to review.
+# remembering it. Every manifest above is built through `|| true`, so a git
+# call that failed rather than returning nothing would otherwise reach the
+# model with an empty scope — and a new target path added later inherits the
+# guard for free instead of having to re-derive it.
 if [ -z "$manifest" ]; then
     refuse_empty_scope \
         "the resolved target contains no changed files." \

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -281,11 +281,12 @@ out="$(run review --base "$submod_base")" || fail "submodule-only diff refused a
 echo "$out" | grep -q "vendored" || fail "submodule gitlink missing from manifest: $out"
 git_t config --unset diff.ignoreSubmodules
 
-echo "==> no detectable base: a dirty tree still reviews, a clean one fails fast"
-# Resolving the base is now on the auto path unconditionally, so a repo with
-# no origin/HEAD and no local main/master must not turn a perfectly reviewable
-# dirty tree into a hard failure — it degrades to the worktree half and says
-# so. With nothing else to review it keeps the usage exit code.
+echo "==> an unresolvable base refuses, on a dirty tree as much as a clean one"
+# Degrading to the worktree half would be the original bug in a new place: a
+# fraction of the change reviewed, exit 0, and a stage that reads the status
+# rather than the warning banks it as a clean pass. Which commits are missing
+# is precisely what cannot be determined here, so there is no honest partial
+# scope — the refusal names --uncommitted as the deliberate way to ask for one.
 norem="${test_tmp}/norem"
 mkdir -p "${norem}/scripts"
 cp "${repo}/scripts/codex-review.sh" "${norem}/scripts/"
@@ -297,13 +298,53 @@ git init -q -b feature "$norem"
     if out="$(./scripts/codex-review.sh review 2>&1)"; then
         fail "clean tree with no detectable base was accepted: $out"
     fi
-    echo "$out" | grep -q "Could not resolve a review target" || fail "missing unresolvable-target message: $out"
-    echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked with no resolvable target: $out"
+    echo "$out" | grep -q "Could not resolve a base" || fail "missing unresolvable-base message: $out"
+    echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked with no resolvable base: $out"
     echo loose >loose.txt
-    out="$(./scripts/codex-review.sh review 2>&1)" || fail "dirty tree with no detectable base was refused: $out"
-    echo "$out" | grep -q "no base branch could be detected" || fail "missing base-degradation note: $out"
-    echo "$out" | grep -q "loose.txt" || fail "worktree file missing from degraded manifest: $out"
+    if out="$(./scripts/codex-review.sh review 2>&1)"; then
+        fail "dirty tree with no detectable base reviewed the worktree alone and exited 0: $out"
+    fi
+    echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked on a partial scope: $out"
+    echo "$out" | grep -q -- "--uncommitted" || fail "refusal does not name the deliberate narrow target: $out"
+    # ...and that named escape must actually work, or the refusal is a dead end.
+    out="$(./scripts/codex-review.sh review --uncommitted 2>&1)" || fail "--uncommitted refused with no base: $out"
+    echo "$out" | grep -q "loose.txt" || fail "worktree file missing from --uncommitted manifest: $out"
 )
+
+echo "==> a git failure in either half is refused, not read as an empty half"
+# Neither half may fail into "". A failed `git diff` with a dirty tree would
+# leave the worktree half non-empty, satisfy the non-empty manifest backstop,
+# and ship a one-sided review that exits 0 (a partial clone missing objects is
+# the realistic trigger); a failed `git status` would read as a clean tree and
+# do the same in reverse. The stub fails one subcommand, only when armed, so
+# every other git call in the fixture behaves normally.
+real_git="$(command -v git)"
+cat >"${test_tmp}/bin/git" <<GITSTUB
+#!/usr/bin/env bash
+if [ -n "\${FAIL_GIT_DIFF:-}" ] && [ "\${1:-}" = "diff" ] && [ "\${2:-}" = "--name-status" ]; then
+    echo "fatal: simulated missing object" >&2
+    exit 128
+fi
+if [ -n "\${FAIL_GIT_STATUS:-}" ] && [ "\${1:-}" = "status" ]; then
+    echo "fatal: simulated unreadable index" >&2
+    exit 128
+fi
+exec "${real_git}" "\$@"
+GITSTUB
+chmod +x "${test_tmp}/bin/git"
+git checkout -q feature
+echo halfwork >halfwork.txt
+if out="$(FAIL_GIT_DIFF=1 run review)"; then
+    fail "an unreadable branch diff was reviewed as an empty half and exited 0: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked with a committed half that could not be read: $out"
+echo "$out" | grep -q "refusing rather than reading an unreadable" || fail "missing unreadable-diff refusal message: $out"
+if out="$(FAIL_GIT_STATUS=1 run review)"; then
+    fail "an unreadable worktree was reviewed as clean and exited 0: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked with a worktree half that could not be read: $out"
+echo "$out" | grep -q "refusing rather than reading an unreadable worktree" || fail "missing unreadable-worktree refusal message: $out"
+rm -f halfwork.txt "${test_tmp}/bin/git"
 
 echo "==> gate: another repo's project-scoped plugin install is not accepted"
 fake_claude="${test_tmp}/claude-config"
@@ -402,4 +443,4 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (26 cases)"
+echo "codex-review + codex-gate guards OK (27 cases)"

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -7,7 +7,10 @@
 # strip `origin/` into a nonexistent local ref and silently report nothing
 # to review, and the one a real --base run caught: an empty scope reached
 # Codex, whose "that diff is empty" reply exited 0 and read as the clean pass
-# a capped review loop exits on. Run via `task test:codex-review`.
+# a capped review loop exits on. Also guards the scope union: a branch holding
+# commits AND uncommitted work is the ordinary mid-loop state, and reviewing
+# only one half is how a re-run banks a clean pass for a fraction of the
+# change. Run via `task test:codex-review`.
 set -euo pipefail
 
 repo="$(git rev-parse --show-toplevel)"
@@ -72,6 +75,9 @@ echo "$out" | grep -q "STUB-ARGS:exec review" || fail "codex exec review not inv
 echo "$out" | grep -q "base branch 'origin/develop'" || fail "remote-qualified fallback base missing: $out"
 echo "$out" | grep -q "ADVERSARIAL" || fail "challenge mode instructions missing: $out"
 echo "$out" | grep -q "feature.txt" || fail "changed-file manifest missing from branch-scope prompt: $out"
+# A clean tree has no second half, so the split manifest must not appear —
+# otherwise the union headers would be noise the reviewer has to interpret.
+echo "$out" | grep -q "Uncommitted changes (git status" && fail "clean tree emitted an uncommitted manifest section: $out"
 # The gate is only meaningful if the scale it gates on is defined in the
 # prompt — Codex's own priority labels are an undocumented convention.
 echo "$out" | grep -q "Only P0 and P1 decide" || fail "challenge prompt missing the P0/P1 gating rule: $out"
@@ -102,14 +108,27 @@ echo "$out" | grep -q "watch the hooks" || fail "focus text missing from prompt:
 echo "$out" | grep -q "Only P0 and P1 decide" || fail "review prompt missing the P0/P1 gating rule: $out"
 echo "$out" | grep -q "carried into the pull request description" || fail "review prompt missing the P2 handoff clause: $out"
 
-echo "==> dirty tree auto-selects uncommitted scope and enumerates untracked dirs"
+echo "==> commits plus a dirty tree review BOTH halves, in labelled sections"
+# The reported bug: the two scopes are disjoint and the dirty tree used to win
+# outright, so a re-run after an uncommitted fix reviewed that fix alone and
+# banked a clean pass for a fraction of the change. Both halves must be in one
+# manifest, and each must land in its own section — a file listed under the
+# wrong heading tells the reviewer to collect the wrong diff for it.
 echo x >dirty.txt
 mkdir newdir
 echo y >newdir/inner.txt
-out="$(run review)" || fail "dirty-tree review exited non-zero: $out"
-echo "$out" | grep -q "uncommitted work" || fail "dirty tree did not select uncommitted scope: $out"
-echo "$out" | grep -q "dirty.txt" || fail "untracked file missing from uncommitted manifest: $out"
-echo "$out" | grep -q "newdir/inner.txt" || fail "file inside untracked dir missing from manifest (collapsed to dir entry): $out"
+out="$(run review)" || fail "commits-plus-dirty review exited non-zero: $out"
+echo "$out" | grep -q "BOTH parts are in scope" || fail "commits plus a dirty tree did not select the union scope: $out"
+echo "$out" | grep -q "uncommitted work in the working tree" || fail "union scope does not name the worktree half: $out"
+echo "$out" | grep -q "origin/develop...HEAD" || fail "union scope does not name the committed half: $out"
+committed_half="$(printf '%s\n' "$out" | sed -n '/^Committed changes (git diff/,/^Uncommitted changes (git status/p')"
+uncommitted_half="$(printf '%s\n' "$out" | sed -n '/^Uncommitted changes (git status/,$p')"
+[ -n "$committed_half" ] || fail "union manifest missing its committed section: $out"
+[ -n "$uncommitted_half" ] || fail "union manifest missing its uncommitted section: $out"
+echo "$committed_half" | grep -q "feature.txt" || fail "committed half missing the branch's own commit: $out"
+echo "$committed_half" | grep -q "dirty.txt" && fail "worktree file filed under the committed heading: $out"
+echo "$uncommitted_half" | grep -q "dirty.txt" || fail "untracked file missing from the uncommitted half: $out"
+echo "$uncommitted_half" | grep -q "newdir/inner.txt" || fail "file inside untracked dir missing from manifest (collapsed to dir entry): $out"
 rm -rf dirty.txt newdir
 
 echo "==> a >200-entry dirty tree still reviews (no SIGPIPE abort) and marks truncation"
@@ -134,6 +153,17 @@ if out="$(run review)"; then
 fi
 echo "$out" | grep -q "Nothing to review" || fail "expected nothing-to-review message: $out"
 echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite nothing to review: $out"
+
+echo "==> at the base tip, a dirty tree reviews the worktree alone"
+# The other side of the union: with no commits beyond the base there is no
+# second half, so the split manifest and its headings must not appear.
+echo tipwork >tipwork.txt
+out="$(run review)" || fail "dirty tree at the base tip exited non-zero: $out"
+echo "$out" | grep -q "Review the uncommitted work" || fail "base-tip dirty tree did not select the uncommitted scope: $out"
+echo "$out" | grep -q "BOTH parts are in scope" && fail "union scope selected with no commits beyond the base: $out"
+echo "$out" | grep -q "Committed changes (git diff" && fail "empty committed half still emitted a manifest section: $out"
+echo "$out" | grep -q "tipwork.txt" || fail "worktree file missing from manifest: $out"
+rm -f tipwork.txt
 
 echo "==> --base level with its base refuses, non-zero, without invoking codex"
 # The reported bug: an explicit --base built an empty manifest and shipped a
@@ -251,6 +281,30 @@ out="$(run review --base "$submod_base")" || fail "submodule-only diff refused a
 echo "$out" | grep -q "vendored" || fail "submodule gitlink missing from manifest: $out"
 git_t config --unset diff.ignoreSubmodules
 
+echo "==> no detectable base: a dirty tree still reviews, a clean one fails fast"
+# Resolving the base is now on the auto path unconditionally, so a repo with
+# no origin/HEAD and no local main/master must not turn a perfectly reviewable
+# dirty tree into a hard failure — it degrades to the worktree half and says
+# so. With nothing else to review it keeps the usage exit code.
+norem="${test_tmp}/norem"
+mkdir -p "${norem}/scripts"
+cp "${repo}/scripts/codex-review.sh" "${norem}/scripts/"
+git init -q -b feature "$norem"
+(
+    cd "$norem"
+    git add -A
+    git_t commit -q -m base
+    if out="$(./scripts/codex-review.sh review 2>&1)"; then
+        fail "clean tree with no detectable base was accepted: $out"
+    fi
+    echo "$out" | grep -q "Could not resolve a review target" || fail "missing unresolvable-target message: $out"
+    echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked with no resolvable target: $out"
+    echo loose >loose.txt
+    out="$(./scripts/codex-review.sh review 2>&1)" || fail "dirty tree with no detectable base was refused: $out"
+    echo "$out" | grep -q "no base branch could be detected" || fail "missing base-degradation note: $out"
+    echo "$out" | grep -q "loose.txt" || fail "worktree file missing from degraded manifest: $out"
+)
+
 echo "==> gate: another repo's project-scoped plugin install is not accepted"
 fake_claude="${test_tmp}/claude-config"
 mkdir -p "${fake_claude}/plugins"
@@ -348,4 +402,4 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (24 cases)"
+echo "codex-review + codex-gate guards OK (26 cases)"


### PR DESCRIPTION
## What

`scripts/codex-review.sh`'s auto target selection now resolves **both** halves
of the change before choosing one, and reviews both when both exist.

| tree | commits vs base | scope |
|---|---|---|
| dirty | ahead | **union** — one manifest, `Committed changes` + `Uncommitted changes` sections |
| dirty | not ahead | worktree only |
| clean | ahead | `base...HEAD` only |
| clean | not ahead | refuse (exit 1, unchanged) |

The explicit flags are untouched and stay deliberately narrow — `--base` is
committed history only, `--uncommitted` is the worktree only — so they remain
escapes you opt into rather than a default that drops half the change.

## Why

The two scopes were disjoint (`git status` sees the worktree, `base...HEAD`
sees the commits) and a dirty tree always won auto-selection. A branch carrying
commits *plus* uncommitted changes — the ordinary state mid-loop, since fixes
are not committed until the PR stage — was therefore never fully covered by a
single run.

The concrete failure: round 1 reviews a clean committed branch; the agent fixes
findings without committing; the re-run auto-selects `--uncommitted` and
inspects only that fix. It reports "no P0/P1", the stage exits on that pass, and
every earlier commit went unre-reviewed. The exit condition attested to the fix
rather than to the change. #453 mitigated this in documentation only — a rule
the operator must remember, in a loop whose whole point is not relying on
operator memory.

## Fail-closed, not degrade

Base resolution now runs on the dirty path too, so it had to decide what to do
when it fails (no `origin/HEAD`, no local `main`/`master`, or a base sharing no
history with `HEAD`). It **refuses**, exit 2, on a dirty tree as much as a clean
one. Degrading to the worktree half would be the original bug in a new place: a
fraction of the change reviewed, exit 0, and a stage that reads exit status
rather than a stderr warning banks it as the clean pass. Which commits are
missing is exactly what cannot be determined there, so there is no honest
partial scope — the refusal names `--uncommitted` as the deliberate way to ask
for one, and a test asserts that escape actually works so the refusal is not a
dead end.

For the same reason, neither auto-path manifest swallows a git failure into
`""` any more. Under the union a failed `git diff` would leave the worktree half
non-empty, satisfy the non-empty backstop, and ship a one-sided review that
exits 0 — where before the union it would have hit the empty-manifest refusal.
`git status` gets the mirror guard (an unreadable index otherwise reads as a
clean tree). The explicit flags keep their `|| true`: they refuse on a single
empty manifest, so a git failure there still fails closed.

Each half is capped at 200 entries independently. A single cap over the
concatenation would let a large committed half swallow the worktree half whole
— the exact silent narrowing this PR closes.

## Tests

`scripts/test-codex-review.sh` goes 24 → 27 cases:

- commits + dirty tree land in the **right** sections (a worktree file filed
  under `Committed changes` fails the test) — the case #455 names as
  unrepresented
- at the base tip, no union appears and no empty `Committed changes` heading
- an unresolvable base refuses on both a clean and a dirty tree, and the
  `--uncommitted` escape it names works
- a failed `git diff` **or** `git status` is refused, not read as an empty half
  (a `git` stub fails one subcommand, only when armed)

Mutation-tested: reinstating dirty-wins, dropping the committed entries, making
base failure fatal, removing the degradation, and restoring either `|| true`
each fail a distinct assertion.

## Docs

`docs/guides/codex-review.md` + both `AGENTS.md` layers: "commit each round's
fixes before re-running" stays as guidance but stops being the only thing
between the loop and a hollow clean pass. Also corrects three copies of a claim
this change invalidates — a stray worktree file no longer becomes the next bare
`task challenge`'s *entire* scope, only part of it. The deferred-findings
sidecar argument survives; its mechanism sentence was wrong.

## Verification

- `task verify` — green (lint, guards, parity 106 twins, structure 202
  sections, all 7 render profiles + template-update)
- `task ci` — green (skills drift in sync at v0.12.0, gitleaks clean, Semgrep
  0 findings / 173 rules)
- `task challenge` — round 1 found 1 P1 + 2 P2 (all confirmed, all fixed in
  place); **round 2 clean**
- `task review` — **clean on round 1**
- Root and template twins edited in lockstep; `test:dogfood-parity` green

No deferred findings — both P2s were fixed rather than carried, and the sidecar
sweep found nothing orphaned in this checkout.

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)
