### PR TITLE
fix(codex-review): warn when --base lags an upstream carried into the branch

### DIFF
--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -54,6 +54,20 @@ happened. `--base` on a dirty tree also says so on stderr: it reviews
 committed history only, and the uncommitted work it excludes is often the very
 change you meant to review.
 
+`--base` also warns when the ref you named lags its own upstream and your
+branch already carries some of the difference — `--base main` on a checkout
+whose local `main` trails `origin/main` puts those already-merged commits
+inside `main...HEAD`, so the review spends a round on findings against files
+your branch never touched. The warning counts the already-merged commits caught
+in the scope and names the remote-qualified alternative (`--base origin/main`),
+and it is advisory: an intentionally older base still runs. Partly-updated
+branches count too — rebasing onto a mid-point of the gap still leaves those
+commits in scope. It stays quiet when the base has no upstream (a tag, a sha,
+`origin/main` itself), when your branch carries none of the upstream commits,
+when the base has run *ahead* of its upstream rather than behind, and when the
+gap changes no files at all (a change and its revert) — the two scopes are
+byte-identical there, so there is nothing to warn about.
+
 Inside Claude Code the plugin's slash commands are the interactive
 equivalents: `/codex:review` and
 `/codex:adversarial-review --base main --background` (with extra focus text

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -92,6 +92,72 @@ warn_if_dirty() {
     echo "      Uncommitted changes are NOT in scope; use --uncommitted for those." >&2
 }
 
+# An explicit --base gets the same guarantee the auto-detect path already has:
+# the comparison base must be the branch the PR will actually merge into. A
+# local branch lagging its upstream is precisely the case that path resolves
+# refs/remotes/origin/HEAD to avoid — with a stale base, commits that already
+# merged upstream sit inside base...HEAD and get reviewed as if this branch
+# introduced them. Observed cost: findings against a file the branch never
+# touched, and a whole review round spent triaging them.
+#
+# Advisory, never fatal (exit stays 0): reviewing against a deliberately older
+# base is a legitimate thing to ask for, and the run is advisory anyway.
+#
+# The trigger compares the two MERGE BASES, not "is the upstream tip an
+# ancestor of HEAD". Contamination is a property of where each diff starts:
+# base...HEAD begins at merge-base(base, HEAD), upstream...HEAD begins at
+# merge-base(upstream, HEAD), and the commits the stale base drags in are
+# exactly those the second reaches and the first does not. Counting them IS the
+# test — a count of zero covers both innocent shapes without a special case:
+# a branch carrying nothing of the upstream (the merge bases coincide, so
+# base...HEAD is already correct and a warning would be crying wolf), and a
+# base that has diverged ahead of its upstream rather than fallen behind.
+#
+# Testing the upstream tip instead would miss the ordinary half-updated branch
+# — base at A, upstream since advanced A→B→C, HEAD carrying B but not yet C —
+# where C is not an ancestor of HEAD and yet B's already-merged changes sit
+# inside base...HEAD.
+#
+# Only a local branch has an upstream, and only its SHORT name answers to
+# @{upstream} — `refs/heads/main@{upstream}` is not an upstream query and just
+# fails, so the full-ref spelling that --base otherwise accepts would skip this
+# check silently. Normalize through symbolic-full-name, which maps every local
+# spelling (main, heads/main, refs/heads/main) onto one name and resolves tags,
+# raw shas, and remote-qualified refs like origin/main to something outside
+# refs/heads/ — none of which has an upstream to compare against, and
+# origin/main is already the ref this warning would have recommended.
+warn_if_base_stale() {
+    local full ref upstream mb_base mb_up t_base t_up carried plural
+    full="$(git rev-parse --symbolic-full-name "$1" 2>/dev/null || true)"
+    case "$full" in
+    refs/heads/*) ref="${full#refs/heads/}" ;;
+    *) return 0 ;;
+    esac
+    upstream="$(git rev-parse --abbrev-ref "${ref}@{upstream}" 2>/dev/null || true)"
+    [ -n "$upstream" ] || return 0
+    mb_base="$(git merge-base "$ref" HEAD 2>/dev/null || true)"
+    mb_up="$(git merge-base "$upstream" HEAD 2>/dev/null || true)"
+    { [ -n "$mb_base" ] && [ -n "$mb_up" ]; } || return 0
+    carried="$(git rev-list --count "${mb_base}..${mb_up}" 2>/dev/null || echo 0)"
+    [ "$carried" -gt 0 ] || return 0
+    # Commits are the unit of the count but trees are the unit of the review:
+    # an upstream gap that nets out to nothing — a change and its revert — puts
+    # commits between the two merge bases while leaving base...HEAD and
+    # upstream...HEAD byte-identical. Codex would read the same diff either way,
+    # so warning there is the same crying-wolf this check exists to avoid.
+    t_base="$(git rev-parse "${mb_base}^{tree}" 2>/dev/null || true)"
+    t_up="$(git rev-parse "${mb_up}^{tree}" 2>/dev/null || true)"
+    [ "$t_base" != "$t_up" ] || return 0
+    if [ "$carried" -eq 1 ]; then
+        plural=""
+    else
+        plural="s"
+    fi
+    echo "Warning: base '$1' lags its upstream '${upstream}', so the review scope $1...HEAD" >&2
+    echo "         contains ${carried} commit${plural} that already merged upstream." >&2
+    echo "         Pass --base ${upstream} to review only this branch's changes." >&2
+}
+
 scope=""
 manifest=""
 focus=""
@@ -100,6 +166,9 @@ focus=""
 target_kind=""
 empty_desc=""
 empty_hint=""
+# The --base ref itself, kept because the post-parse warnings need it: it is
+# otherwise only reachable interpolated into the scope sentence.
+base_ref=""
 require_single_target() {
     if [ -n "$scope" ]; then
         echo "conflicting target flags: --base, --uncommitted, and --commit are mutually exclusive." >&2
@@ -127,6 +196,7 @@ while [ $# -gt 0 ]; do
         scope="Review the changes on the current branch relative to base branch '$2' (the merge-base diff $2...HEAD)."
         manifest="$(git_diff_name_status "$2...HEAD" 2>/dev/null | cap_manifest || true)"
         target_kind="base"
+        base_ref="$2"
         empty_desc="the merge-base diff $2...HEAD is empty — HEAD changes no files beyond '$2'."
         # --commit belongs here too: a branch whose commits net out to no change
         # (an add and its revert) is already committed and has a clean tree, so
@@ -180,6 +250,7 @@ done
 # conflicting flags, whatever that base's diff contains).
 if [ "$target_kind" = "base" ]; then
     warn_if_dirty
+    warn_if_base_stale "$base_ref"
 fi
 if [ -n "$target_kind" ] && [ -z "$manifest" ]; then
     refuse_empty_scope "$empty_desc" "$empty_hint"

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -102,6 +102,96 @@ echo "$out" | grep -q "watch the hooks" || fail "focus text missing from prompt:
 echo "$out" | grep -q "Only P0 and P1 decide" || fail "review prompt missing the P0/P1 gating rule: $out"
 echo "$out" | grep -q "carried into the pull request description" || fail "review prompt missing the P2 handoff clause: $out"
 
+echo "==> --base warns when the ref lags an upstream HEAD already contains"
+# The reported bug: `--base main` on a checkout whose local main trails
+# origin/main reviews the already-merged commits as if this branch introduced
+# them, drawing findings against files the branch never touched.
+# basestale is pinned at the CURRENT origin/develop and tracks it, so advancing
+# the upstream afterwards leaves it behind by exactly the new commits.
+git branch -q --track basestale origin/develop
+(
+    cd "${test_tmp}/upstream"
+    echo one >merged-one.txt
+    echo two >merged-two.txt
+    git add merged-one.txt merged-two.txt
+    git_t commit -q -m "upstream work 1" -- merged-one.txt
+    git_t commit -q -m "upstream work 2" -- merged-two.txt
+)
+git fetch -q origin
+pre_merge="$(git rev-parse HEAD)"
+git_t merge -q --no-edit origin/develop
+out="$(run review --base basestale)" || fail "stale-base run exited non-zero (must stay advisory): $out"
+# Advisory, not fatal: the review still has to happen, or the warning has
+# turned a nudge into a refusal.
+echo "$out" | grep -q "STUB-ARGS:exec review" || fail "stale-base warning suppressed the review: $out"
+echo "$out" | grep -q "lags its upstream 'origin/develop'" || fail "stale-base warning missing: $out"
+echo "$out" | grep -q "contains 2 commits that already merged upstream" || fail "stale-base warning miscounted the carried commits: $out"
+echo "$out" | grep -q -- "--base origin/develop" || fail "stale-base warning does not name the remote-qualified ref: $out"
+
+echo "==> --base warns on a HALF-updated branch, where the upstream tip is not in HEAD"
+# Base at A, upstream since advanced A->B->C, HEAD carrying B but not C. The
+# upstream tip is NOT an ancestor of HEAD, yet B's already-merged changes sit
+# inside basestale...HEAD — so an is-ancestor(upstream, HEAD) trigger goes
+# silent on exactly the contamination it exists to catch. The merge bases are
+# what differ (A vs B), which is why the check compares those.
+git checkout -q -b halfway "$pre_merge"
+git_t merge -q --no-edit origin/develop~1
+out="$(run review --base basestale)" || fail "half-updated stale-base run exited non-zero: $out"
+echo "$out" | grep -q "lags its upstream 'origin/develop'" || fail "no warning on a half-updated branch: $out"
+echo "$out" | grep -q "contains 1 commit that already merged upstream" || fail "half-updated warning miscounted (or mis-pluralized) the carried commits: $out"
+git checkout -q feature
+
+echo "==> a stale base whose upstream commits are NOT in HEAD stays silent"
+# The other side of the merge-base comparison: with nothing of the upstream in
+# HEAD both diffs start at the same commit, base...HEAD is already correct, and
+# a warning here would be a false positive on a healthy run.
+git checkout -q -b prestale "$pre_merge"
+out="$(run review --base basestale)" || fail "pre-merge stale-base run exited non-zero: $out"
+echo "$out" | grep -q "lags its upstream" && fail "warned on a base whose upstream commits HEAD does not contain: $out"
+git checkout -q feature
+
+echo "==> --base refs with no upstream never warn"
+# A tag, a raw sha, and a remote-qualified ref have no @{upstream}; each must
+# reach the review silently instead of erroring out of the resolution attempt.
+git tag basetag basestale
+for ref in basetag "$(git rev-parse basestale)" origin/develop; do
+    out="$(run review --base "$ref")" || fail "--base '$ref' exited non-zero: $out"
+    echo "$out" | grep -q "STUB-ARGS:exec review" || fail "--base '$ref' did not reach codex: $out"
+    echo "$out" | grep -q "lags its upstream" && fail "--base '$ref' has no upstream but warned: $out"
+done
+
+echo "==> a tree-neutral upstream gap does not warn"
+# The gap is real in commits and empty in content — a file added upstream and
+# reverted upstream. base...HEAD and origin/develop...HEAD are then identical,
+# so Codex reads the same diff either way and there is nothing to warn about.
+# neutralbase is pinned BEFORE the pair lands, so it is genuinely behind.
+git branch -q --track neutralbase origin/develop
+(
+    cd "${test_tmp}/upstream"
+    echo scratch >revertme.txt
+    git add revertme.txt
+    git_t commit -q -m "add revertme"
+    git rm -q revertme.txt
+    git_t commit -q -m "revert revertme"
+)
+git fetch -q origin
+git checkout -q -b neutral origin/develop
+echo n >neutral.txt
+git add neutral.txt
+git_t commit -q -m "work on top of the tree-neutral gap"
+out="$(run review --base neutralbase)" || fail "tree-neutral run exited non-zero: $out"
+echo "$out" | grep -q "lags its upstream" && fail "warned on an upstream gap that changes no files: $out"
+git checkout -q feature
+
+echo "==> the full-ref spelling of a local branch still warns"
+# --base accepts refs/heads/<branch> (rev-parse resolves it), but
+# `refs/heads/main@{upstream}` is not an upstream query and simply fails, so
+# without normalization this spelling would skip the check silently.
+for ref in refs/heads/basestale heads/basestale; do
+    out="$(run review --base "$ref")" || fail "--base '$ref' exited non-zero: $out"
+    echo "$out" | grep -q "lags its upstream 'origin/develop'" || fail "--base '$ref' skipped the stale-base check: $out"
+done
+
 echo "==> dirty tree auto-selects uncommitted scope and enumerates untracked dirs"
 echo x >dirty.txt
 mkdir newdir
@@ -348,4 +438,4 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (24 cases)"
+echo "codex-review + codex-gate guards OK (30 cases)"

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -54,6 +54,20 @@ happened. `--base` on a dirty tree also says so on stderr: it reviews
 committed history only, and the uncommitted work it excludes is often the very
 change you meant to review.
 
+`--base` also warns when the ref you named lags its own upstream and your
+branch already carries some of the difference — `--base main` on a checkout
+whose local `main` trails `origin/main` puts those already-merged commits
+inside `main...HEAD`, so the review spends a round on findings against files
+your branch never touched. The warning counts the already-merged commits caught
+in the scope and names the remote-qualified alternative (`--base origin/main`),
+and it is advisory: an intentionally older base still runs. Partly-updated
+branches count too — rebasing onto a mid-point of the gap still leaves those
+commits in scope. It stays quiet when the base has no upstream (a tag, a sha,
+`origin/main` itself), when your branch carries none of the upstream commits,
+when the base has run *ahead* of its upstream rather than behind, and when the
+gap changes no files at all (a change and its revert) — the two scopes are
+byte-identical there, so there is nothing to warn about.
+
 Inside Claude Code the plugin's slash commands are the interactive
 equivalents: `/codex:review` and
 `/codex:adversarial-review --base main --background` (with extra focus text

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -92,6 +92,72 @@ warn_if_dirty() {
     echo "      Uncommitted changes are NOT in scope; use --uncommitted for those." >&2
 }
 
+# An explicit --base gets the same guarantee the auto-detect path already has:
+# the comparison base must be the branch the PR will actually merge into. A
+# local branch lagging its upstream is precisely the case that path resolves
+# refs/remotes/origin/HEAD to avoid — with a stale base, commits that already
+# merged upstream sit inside base...HEAD and get reviewed as if this branch
+# introduced them. Observed cost: findings against a file the branch never
+# touched, and a whole review round spent triaging them.
+#
+# Advisory, never fatal (exit stays 0): reviewing against a deliberately older
+# base is a legitimate thing to ask for, and the run is advisory anyway.
+#
+# The trigger compares the two MERGE BASES, not "is the upstream tip an
+# ancestor of HEAD". Contamination is a property of where each diff starts:
+# base...HEAD begins at merge-base(base, HEAD), upstream...HEAD begins at
+# merge-base(upstream, HEAD), and the commits the stale base drags in are
+# exactly those the second reaches and the first does not. Counting them IS the
+# test — a count of zero covers both innocent shapes without a special case:
+# a branch carrying nothing of the upstream (the merge bases coincide, so
+# base...HEAD is already correct and a warning would be crying wolf), and a
+# base that has diverged ahead of its upstream rather than fallen behind.
+#
+# Testing the upstream tip instead would miss the ordinary half-updated branch
+# — base at A, upstream since advanced A→B→C, HEAD carrying B but not yet C —
+# where C is not an ancestor of HEAD and yet B's already-merged changes sit
+# inside base...HEAD.
+#
+# Only a local branch has an upstream, and only its SHORT name answers to
+# @{upstream} — `refs/heads/main@{upstream}` is not an upstream query and just
+# fails, so the full-ref spelling that --base otherwise accepts would skip this
+# check silently. Normalize through symbolic-full-name, which maps every local
+# spelling (main, heads/main, refs/heads/main) onto one name and resolves tags,
+# raw shas, and remote-qualified refs like origin/main to something outside
+# refs/heads/ — none of which has an upstream to compare against, and
+# origin/main is already the ref this warning would have recommended.
+warn_if_base_stale() {
+    local full ref upstream mb_base mb_up t_base t_up carried plural
+    full="$(git rev-parse --symbolic-full-name "$1" 2>/dev/null || true)"
+    case "$full" in
+    refs/heads/*) ref="${full#refs/heads/}" ;;
+    *) return 0 ;;
+    esac
+    upstream="$(git rev-parse --abbrev-ref "${ref}@{upstream}" 2>/dev/null || true)"
+    [ -n "$upstream" ] || return 0
+    mb_base="$(git merge-base "$ref" HEAD 2>/dev/null || true)"
+    mb_up="$(git merge-base "$upstream" HEAD 2>/dev/null || true)"
+    { [ -n "$mb_base" ] && [ -n "$mb_up" ]; } || return 0
+    carried="$(git rev-list --count "${mb_base}..${mb_up}" 2>/dev/null || echo 0)"
+    [ "$carried" -gt 0 ] || return 0
+    # Commits are the unit of the count but trees are the unit of the review:
+    # an upstream gap that nets out to nothing — a change and its revert — puts
+    # commits between the two merge bases while leaving base...HEAD and
+    # upstream...HEAD byte-identical. Codex would read the same diff either way,
+    # so warning there is the same crying-wolf this check exists to avoid.
+    t_base="$(git rev-parse "${mb_base}^{tree}" 2>/dev/null || true)"
+    t_up="$(git rev-parse "${mb_up}^{tree}" 2>/dev/null || true)"
+    [ "$t_base" != "$t_up" ] || return 0
+    if [ "$carried" -eq 1 ]; then
+        plural=""
+    else
+        plural="s"
+    fi
+    echo "Warning: base '$1' lags its upstream '${upstream}', so the review scope $1...HEAD" >&2
+    echo "         contains ${carried} commit${plural} that already merged upstream." >&2
+    echo "         Pass --base ${upstream} to review only this branch's changes." >&2
+}
+
 scope=""
 manifest=""
 focus=""
@@ -100,6 +166,9 @@ focus=""
 target_kind=""
 empty_desc=""
 empty_hint=""
+# The --base ref itself, kept because the post-parse warnings need it: it is
+# otherwise only reachable interpolated into the scope sentence.
+base_ref=""
 require_single_target() {
     if [ -n "$scope" ]; then
         echo "conflicting target flags: --base, --uncommitted, and --commit are mutually exclusive." >&2
@@ -127,6 +196,7 @@ while [ $# -gt 0 ]; do
         scope="Review the changes on the current branch relative to base branch '$2' (the merge-base diff $2...HEAD)."
         manifest="$(git_diff_name_status "$2...HEAD" 2>/dev/null | cap_manifest || true)"
         target_kind="base"
+        base_ref="$2"
         empty_desc="the merge-base diff $2...HEAD is empty — HEAD changes no files beyond '$2'."
         # --commit belongs here too: a branch whose commits net out to no change
         # (an add and its revert) is already committed and has a clean tree, so
@@ -180,6 +250,7 @@ done
 # conflicting flags, whatever that base's diff contains).
 if [ "$target_kind" = "base" ]; then
     warn_if_dirty
+    warn_if_base_stale "$base_ref"
 fi
 if [ -n "$target_kind" ] && [ -z "$manifest" ]; then
     refuse_empty_scope "$empty_desc" "$empty_hint"

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -102,6 +102,96 @@ echo "$out" | grep -q "watch the hooks" || fail "focus text missing from prompt:
 echo "$out" | grep -q "Only P0 and P1 decide" || fail "review prompt missing the P0/P1 gating rule: $out"
 echo "$out" | grep -q "carried into the pull request description" || fail "review prompt missing the P2 handoff clause: $out"
 
+echo "==> --base warns when the ref lags an upstream HEAD already contains"
+# The reported bug: `--base main` on a checkout whose local main trails
+# origin/main reviews the already-merged commits as if this branch introduced
+# them, drawing findings against files the branch never touched.
+# basestale is pinned at the CURRENT origin/develop and tracks it, so advancing
+# the upstream afterwards leaves it behind by exactly the new commits.
+git branch -q --track basestale origin/develop
+(
+    cd "${test_tmp}/upstream"
+    echo one >merged-one.txt
+    echo two >merged-two.txt
+    git add merged-one.txt merged-two.txt
+    git_t commit -q -m "upstream work 1" -- merged-one.txt
+    git_t commit -q -m "upstream work 2" -- merged-two.txt
+)
+git fetch -q origin
+pre_merge="$(git rev-parse HEAD)"
+git_t merge -q --no-edit origin/develop
+out="$(run review --base basestale)" || fail "stale-base run exited non-zero (must stay advisory): $out"
+# Advisory, not fatal: the review still has to happen, or the warning has
+# turned a nudge into a refusal.
+echo "$out" | grep -q "STUB-ARGS:exec review" || fail "stale-base warning suppressed the review: $out"
+echo "$out" | grep -q "lags its upstream 'origin/develop'" || fail "stale-base warning missing: $out"
+echo "$out" | grep -q "contains 2 commits that already merged upstream" || fail "stale-base warning miscounted the carried commits: $out"
+echo "$out" | grep -q -- "--base origin/develop" || fail "stale-base warning does not name the remote-qualified ref: $out"
+
+echo "==> --base warns on a HALF-updated branch, where the upstream tip is not in HEAD"
+# Base at A, upstream since advanced A->B->C, HEAD carrying B but not C. The
+# upstream tip is NOT an ancestor of HEAD, yet B's already-merged changes sit
+# inside basestale...HEAD — so an is-ancestor(upstream, HEAD) trigger goes
+# silent on exactly the contamination it exists to catch. The merge bases are
+# what differ (A vs B), which is why the check compares those.
+git checkout -q -b halfway "$pre_merge"
+git_t merge -q --no-edit origin/develop~1
+out="$(run review --base basestale)" || fail "half-updated stale-base run exited non-zero: $out"
+echo "$out" | grep -q "lags its upstream 'origin/develop'" || fail "no warning on a half-updated branch: $out"
+echo "$out" | grep -q "contains 1 commit that already merged upstream" || fail "half-updated warning miscounted (or mis-pluralized) the carried commits: $out"
+git checkout -q feature
+
+echo "==> a stale base whose upstream commits are NOT in HEAD stays silent"
+# The other side of the merge-base comparison: with nothing of the upstream in
+# HEAD both diffs start at the same commit, base...HEAD is already correct, and
+# a warning here would be a false positive on a healthy run.
+git checkout -q -b prestale "$pre_merge"
+out="$(run review --base basestale)" || fail "pre-merge stale-base run exited non-zero: $out"
+echo "$out" | grep -q "lags its upstream" && fail "warned on a base whose upstream commits HEAD does not contain: $out"
+git checkout -q feature
+
+echo "==> --base refs with no upstream never warn"
+# A tag, a raw sha, and a remote-qualified ref have no @{upstream}; each must
+# reach the review silently instead of erroring out of the resolution attempt.
+git tag basetag basestale
+for ref in basetag "$(git rev-parse basestale)" origin/develop; do
+    out="$(run review --base "$ref")" || fail "--base '$ref' exited non-zero: $out"
+    echo "$out" | grep -q "STUB-ARGS:exec review" || fail "--base '$ref' did not reach codex: $out"
+    echo "$out" | grep -q "lags its upstream" && fail "--base '$ref' has no upstream but warned: $out"
+done
+
+echo "==> a tree-neutral upstream gap does not warn"
+# The gap is real in commits and empty in content — a file added upstream and
+# reverted upstream. base...HEAD and origin/develop...HEAD are then identical,
+# so Codex reads the same diff either way and there is nothing to warn about.
+# neutralbase is pinned BEFORE the pair lands, so it is genuinely behind.
+git branch -q --track neutralbase origin/develop
+(
+    cd "${test_tmp}/upstream"
+    echo scratch >revertme.txt
+    git add revertme.txt
+    git_t commit -q -m "add revertme"
+    git rm -q revertme.txt
+    git_t commit -q -m "revert revertme"
+)
+git fetch -q origin
+git checkout -q -b neutral origin/develop
+echo n >neutral.txt
+git add neutral.txt
+git_t commit -q -m "work on top of the tree-neutral gap"
+out="$(run review --base neutralbase)" || fail "tree-neutral run exited non-zero: $out"
+echo "$out" | grep -q "lags its upstream" && fail "warned on an upstream gap that changes no files: $out"
+git checkout -q feature
+
+echo "==> the full-ref spelling of a local branch still warns"
+# --base accepts refs/heads/<branch> (rev-parse resolves it), but
+# `refs/heads/main@{upstream}` is not an upstream query and simply fails, so
+# without normalization this spelling would skip the check silently.
+for ref in refs/heads/basestale heads/basestale; do
+    out="$(run review --base "$ref")" || fail "--base '$ref' exited non-zero: $out"
+    echo "$out" | grep -q "lags its upstream 'origin/develop'" || fail "--base '$ref' skipped the stale-base check: $out"
+done
+
 echo "==> dirty tree auto-selects uncommitted scope and enumerates untracked dirs"
 echo x >dirty.txt
 mkdir newdir
@@ -348,4 +438,4 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (24 cases)"
+echo "codex-review + codex-gate guards OK (30 cases)"


### PR DESCRIPTION
## What

`--base <ref>` validated only that the ref resolved to a commit and shared a merge base
with `HEAD`, then built the review scope from `$ref...HEAD`. Nothing checked whether the
ref had fallen behind its upstream, so `--base main` on a checkout whose local `main`
trails `origin/main` put those already-merged commits inside the diff and reviewed them
as if the branch had introduced them.

Adds `warn_if_base_stale` next to the existing dirty-tree note. It is **advisory** — exit
stays 0 and the review still runs, since deliberately reviewing against an older base is a
legitimate thing to ask of an advisory tool.

Closes #454

## Why this trigger

The naive condition ("the base is behind its upstream") warns on branches that are already
being reviewed correctly, and a warning that fires on healthy runs stops being read. The
condition here is instead a property of the two **merge bases**: `base...HEAD` starts at
`merge-base(base, HEAD)`, `upstream...HEAD` starts at `merge-base(upstream, HEAD)`, and the
commits at fault are exactly those the second reaches and the first does not — qualified by
a tree comparison, so a gap that changes no files does not warn either.

Three narrowing passes landed on that, each catching a case the previous one got wrong:

| Trigger | Fails on |
| --- | --- |
| base is behind its upstream | warns when `HEAD` carries none of the gap — the diff is already correct |
| upstream tip is an ancestor of `HEAD` | silent on a half-updated branch (base at A, upstream A→B→C, `HEAD` carrying B not C) — real contamination, no warning |
| **merge bases differ by ≥1 commit that changes files** | — |

The middle row was found by `task challenge` (P1) and the tree qualification by `task review`
(P2); both are reproduced in the tests. A `refs/heads/main` spelling silently skipped the
check entirely, since only a short branch name answers to `@{upstream}` — normalized via
`--symbolic-full-name`, which also drops tags, raw shas, and remote-qualified refs, none of
which have an upstream to compare against.

## Verification

- `task verify` and `task ci` green (render matrix, gitleaks, Semgrep).
- `scripts/test-codex-review.sh`: 24 → 30 cases, covering fully-behind, half-updated,
  no-carry, tree-neutral, no-upstream (tag / raw sha / `origin/*`), and the
  `refs/heads/…` + `heads/…` spellings.
- Every condition in the new function is **mutation-tested** — each was individually
  reverted and confirmed to fail a specific case. One condition survived deletion with all
  tests passing (a strict-ancestor guard subsumed by the commit count) and was removed as
  dead logic rather than back-filled with a test.
- `task challenge` and `task review` each exited on a **clean re-run**, not on "findings
  fixed".
- All three files are verbatim twins; root and `template/` are byte-identical
  (`task test:dogfood-parity`, 106 twins).
- Title pre-flighted against `guard:release-title` — releasing type, required here because
  the diff touches `template/`.

## Deferred findings

None. Every finding from both stages was confirmed and fixed in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
