### PR TITLE
fix(template): distinguish self-referential review loops from shepherd

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,9 +204,13 @@ something to ask permission for.
   then **re-run `task challenge`**. The stage passes only when a re-run comes
   back with **no confirmed P0 or P1 findings** — fixing the findings is not
   the exit condition, a clean pass is. **P2s do not gate this stage**: carry
-  them to the PR (see "Deferring P2s" below). Max **6** challenge → fix →
-  re-challenge
+  them to the PR (see "Deferring P2s" below). This loop is
+  **self-referential** — the fixes you make in response to a round become the
+  next round's input, so it can generate its own work indefinitely — and that
+  is what the cap defends against: max **6** challenge → fix → re-challenge
   rounds; if P0/P1 findings persist, stop and escalate to Evan.
+  "Between rounds, check what the findings are about" below is how you catch
+  the loop feeding on itself before the cap does.
   A `task challenge` round is long — 5–15 minutes is ordinary, past most
   agents' tool-call timeouts — so **run it in the background and poll**
   instead of blocking one call on it. Growing output means running, not hung;
@@ -218,8 +222,9 @@ something to ask permission for.
   [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
   backgrounding").
 - **`task review`** — verification-checkpoint review; same adjudication, same
-  P0/P1 clean-pass exit condition, and the same background-and-poll handling,
-  with its own max **6** rounds.
+  P0/P1 clean-pass exit condition, the same self-referential shape and so the
+  same reason for a cap, and the same background-and-poll handling, with its
+  own max **6** rounds.
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
   a clear what/why/verification summary (mind the `template/` → `fix:`/`feat:`
@@ -243,9 +248,18 @@ something to ask permission for.
   but do not leave them unaddressed. Shepherd-round fixes must pass `task
   verify` before each push; the local challenge/review loops are not
   re-entered — the post-push cloud/bot review is the second-model check at
-  this stage. This cap is independent of the other loop caps. If checks still
-  fail or findings remain after 5 rounds, stop and summarize what's
-  unresolved on the PR for Evan. Where a **vendored** skill (`/shepherd`)
+  this stage.
+  Shepherd is **externally driven** — CI results and other people's comments
+  are its input, so it cannot manufacture its own rounds; its cap is
+  independent of the other loop caps and bounds how long you wait on others,
+  not self-generated work. Caps do not carry across stages and neither do
+  decisions: **a decision to stop one loop does not transfer to another**,
+  because each is bounded for its own reason. "We have looped enough" is a
+  judgement about one loop's self-generated work, and carrying it here skips
+  this stage instead of bounding it, leaving the PR with reviews unanswered.
+  If checks still fail or findings remain after 5 rounds, stop and
+  summarize what's unresolved on the PR for Evan.
+  Where a **vendored** skill (`/shepherd`)
   states a different cap or exit condition, **this file wins** — the skills
   are synced from harmon-devkit on its own release cadence and can lag a
   policy change made here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,16 +250,18 @@ something to ask permission for.
   re-entered — the post-push cloud/bot review is the second-model check at
   this stage.
   Shepherd is **externally driven** — CI results and other people's comments
-  are its input, so it cannot manufacture a round on its own; its cap is
-  independent of the other loop caps and bounds how long you wait on others,
+  are its input, so it cannot manufacture a round on its own. A round is one
+  fix push, or one no-change cycle where everything is answered and nothing
+  needs fixing; waiting on CI or a reviewer is never a round, and this cap is
+  independent of any other stage's. What it bounds is other people's findings,
   not self-generated work. It is not wholly immune, though — a reviewer can
   flag the fix your *last* round pushed, so if the rounds start circling your
   own patches, step back and ask whether the findings are about the change you
-  set out to make or about a previous round's fix. Deciding that nothing more
-  has landed is governed by "Checks green is a non-terminal state" below, not
-  by the absence of an immediate reply. Caps do not carry across stages and
-  neither do
-  decisions: **a decision to stop one loop does not transfer to another**,
+  set out to make or about a previous round's fix. Whether anything more has
+  landed is settled by "Checks green is a non-terminal state" below, not by
+  the absence of an immediate reply. Stopping one stage's loop is never a
+  decision about another's:
+  **a decision to stop one loop does not transfer to another**,
   because each is bounded for its own reason. "We have looped enough" is a
   judgement about one loop's self-generated work, and carrying it here skips
   this stage instead of bounding it, leaving the PR with reviews unanswered.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,13 +250,23 @@ something to ask permission for.
   re-entered — the post-push cloud/bot review is the second-model check at
   this stage.
   Shepherd is **externally driven** — CI results and other people's comments
-  are its input, so it cannot manufacture its own rounds; its cap is
+  are its input, so it cannot manufacture a round on its own; its cap is
   independent of the other loop caps and bounds how long you wait on others,
-  not self-generated work. Caps do not carry across stages and neither do
+  not self-generated work. It is not wholly immune, though — a reviewer can
+  flag the fix your *last* round pushed, so if the rounds start circling your
+  own patches, step back and ask whether the findings are about the change you
+  set out to make or about a previous round's fix. Deciding that nothing more
+  has landed is governed by "Checks green is a non-terminal state" below, not
+  by the absence of an immediate reply. Caps do not carry across stages and
+  neither do
   decisions: **a decision to stop one loop does not transfer to another**,
   because each is bounded for its own reason. "We have looped enough" is a
   judgement about one loop's self-generated work, and carrying it here skips
   this stage instead of bounding it, leaving the PR with reviews unanswered.
+  The converse also holds: stopping to **escalate** something you cannot
+  resolve halts the whole change rather than one loop, so it is not a licence
+  to move on to the next stage either — a persistent P0/P1 at the challenge or
+  review cap means wait for Evan, not open the PR anyway.
   If checks still fail or findings remain after 5 rounds, stop and
   summarize what's unresolved on the PR for Evan.
   Where a **vendored** skill (`/shepherd`)

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -114,9 +114,13 @@ something to ask permission for.
   then **re-run `task challenge`**. The stage passes only when a re-run comes
   back with **no confirmed P0 or P1 findings** — fixing the findings is not
   the exit condition, a clean pass is. **P2s do not gate this stage**: carry
-  them to the PR (see "Deferring P2s" below). Max **6** challenge → fix →
-  re-challenge
+  them to the PR (see "Deferring P2s" below). This loop is
+  **self-referential** — the fixes you make in response to a round become the
+  next round's input, so it can generate its own work indefinitely — and that
+  is what the cap defends against: max **6** challenge → fix → re-challenge
   rounds; if P0/P1 findings persist, stop and escalate to the maintainer.
+  "Between rounds, check what the findings are about" below is how you catch
+  the loop feeding on itself before the cap does.
   A `task challenge` round is long — 5–15 minutes is ordinary, past most
   agents' tool-call timeouts — so **run it in the background and poll**
   instead of blocking one call on it. Growing output means running, not hung;
@@ -128,8 +132,9 @@ something to ask permission for.
   [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
   backgrounding").
 - **`task review`** — verification-checkpoint review; same adjudication, same
-  P0/P1 clean-pass exit condition, and the same background-and-poll handling,
-  with its own max **6** rounds.
+  P0/P1 clean-pass exit condition, the same self-referential shape and so the
+  same reason for a cap, and the same background-and-poll handling, with its
+  own max **6** rounds.
 [% endif %]
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
@@ -154,8 +159,16 @@ something to ask permission for.
   file as a follow-up issue, but do not leave them unaddressed.
   Shepherd-round fixes must pass `task verify` before each push; the local
   challenge/review loops are not re-entered — the post-push cloud/bot review
-  is the second-model check at this stage. This cap is independent of the
-  other loop caps. If checks still fail or findings remain after 5 rounds,
+  is the second-model check at this stage.
+  Shepherd is **externally driven** — CI results and other people's comments
+  are its input, so it cannot manufacture its own rounds; its cap is
+  independent of the other loop caps and bounds how long you wait on others,
+  not self-generated work. Caps do not carry across stages and neither do
+  decisions: **a decision to stop one loop does not transfer to another**,
+  because each is bounded for its own reason. "We have looped enough" is a
+  judgement about one loop's self-generated work, and carrying it here skips
+  this stage instead of bounding it, leaving the PR with reviews unanswered.
+  If checks still fail or findings remain after 5 rounds,
   stop and summarize what's unresolved on the PR for the maintainer. Where a
   **vendored** skill (`/shepherd`) states a different cap or exit condition,
   **this file wins** — vendored skills are synced on their own release

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -161,13 +161,23 @@ something to ask permission for.
   challenge/review loops are not re-entered — the post-push cloud/bot review
   is the second-model check at this stage.
   Shepherd is **externally driven** — CI results and other people's comments
-  are its input, so it cannot manufacture its own rounds; its cap is
+  are its input, so it cannot manufacture a round on its own; its cap is
   independent of the other loop caps and bounds how long you wait on others,
-  not self-generated work. Caps do not carry across stages and neither do
+  not self-generated work. It is not wholly immune, though — a reviewer can
+  flag the fix your *last* round pushed, so if the rounds start circling your
+  own patches, step back and ask whether the findings are about the change you
+  set out to make or about a previous round's fix. Deciding that nothing more
+  has landed is governed by "Checks green is a non-terminal state" below, not
+  by the absence of an immediate reply. Caps do not carry across stages and
+  neither do
   decisions: **a decision to stop one loop does not transfer to another**,
   because each is bounded for its own reason. "We have looped enough" is a
   judgement about one loop's self-generated work, and carrying it here skips
   this stage instead of bounding it, leaving the PR with reviews unanswered.
+  The converse also holds: stopping to **escalate** something you cannot
+  resolve halts the whole change rather than one loop, so it is not a licence
+  to move on to the next stage either — escalate and wait, do not open the PR
+  anyway.
   If checks still fail or findings remain after 5 rounds,
   stop and summarize what's unresolved on the PR for the maintainer. Where a
   **vendored** skill (`/shepherd`) states a different cap or exit condition,

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -161,16 +161,18 @@ something to ask permission for.
   challenge/review loops are not re-entered — the post-push cloud/bot review
   is the second-model check at this stage.
   Shepherd is **externally driven** — CI results and other people's comments
-  are its input, so it cannot manufacture a round on its own; its cap is
-  independent of the other loop caps and bounds how long you wait on others,
+  are its input, so it cannot manufacture a round on its own. A round is one
+  fix push, or one no-change cycle where everything is answered and nothing
+  needs fixing; waiting on CI or a reviewer is never a round, and this cap is
+  independent of any other stage's. What it bounds is other people's findings,
   not self-generated work. It is not wholly immune, though — a reviewer can
   flag the fix your *last* round pushed, so if the rounds start circling your
   own patches, step back and ask whether the findings are about the change you
-  set out to make or about a previous round's fix. Deciding that nothing more
-  has landed is governed by "Checks green is a non-terminal state" below, not
-  by the absence of an immediate reply. Caps do not carry across stages and
-  neither do
-  decisions: **a decision to stop one loop does not transfer to another**,
+  set out to make or about a previous round's fix. Whether anything more has
+  landed is settled by "Checks green is a non-terminal state" below, not by
+  the absence of an immediate reply. Stopping one stage's loop is never a
+  decision about another's:
+  **a decision to stop one loop does not transfer to another**,
   because each is bounded for its own reason. "We have looped enough" is a
   judgement about one loop's self-generated work, and carrying it here skips
   this stage instead of bounding it, leaving the PR with reviews unanswered.


### PR DESCRIPTION
## What

`AGENTS.md`'s Dev Loop presented `task challenge`, `task review` and
`/shepherd` as three members of one list — each with a round cap and the same
"exits only on a clean pass" shape. Nothing said *why* they can run long, so
the stages read as interchangeable. This names the property on each stage, in
both the root file and `template/AGENTS.md.jinja`.

- **`challenge`/`review` are self-referential** — the fixes made in response to
  a round become the next round's input, so the loop can generate its own work
  indefinitely. That is what their caps defend against, and the existing
  "Between rounds, check what the findings are about" paragraph is the
  early-warning check, now cross-referenced from the bullet.
- **shepherd is externally driven** — CI results and other people's comments
  are its input, so it cannot manufacture a round on its own. A round is one
  fix push or one no-change adjudication cycle; waiting on CI or a reviewer is
  never a round. It is *not* wholly immune — a reviewer can flag the fix your
  last round pushed — but it cannot run away without someone else's assent.
- **A decision to stop one loop does not transfer to another**, because each is
  bounded for its own reason. With the converse stated too: escalating halts
  the whole change rather than one loop, so it is not a licence to move on to
  the next stage either.

## Why

Because the three read as interchangeable, an agent told to stop the challenge
loop on evanharmon1/harmon-devkit#190 carried "stop looping" across to shepherd
and skipped it entirely on the resulting PR (#202), which then sat with three
unanswered Codex findings. The stop instruction was correct for the loop it was
about; the generalisation was not, and the text offered nothing to block it.
The two errors were mirror images — over-running a self-referential loop, then
under-running an externally-driven one — and both trace to this missing
distinction.

## Notes for review

Two deliberate judgment calls, both worth a second opinion:

1. **Diverges from the issue's literal AC wording.** AC 2 says the shepherd cap
   "bounds waiting on others". Taken literally that invites counting poll
   windows as rounds, which contradicts `shepherd/SKILL.md`'s round accounting
   (one round = one fix push **or** one no-change adjudication cycle, with
   waits bounded separately) — and in a generated repo without that skill
   vendored, this bullet *is* the procedure, so the miscount would be
   load-bearing and could end shepherding early. The text keeps the contrast
   the AC is after (other people's findings vs. self-generated work) but states
   the unit explicitly.
2. **The non-transfer rule is unconditional, not gated on `use_codex_review`.**
   Codex proposed gating the whole comparison behind the conditional, since a
   default render has no other capped loop. Declined: the rule is independently
   true without a second-model loop, and gating it would remove from every
   default-configured repo exactly the guidance whose absence caused the
   incident above. The dangling *phrase* it flagged ("the other loop caps",
   which predates this change) is fixed — now "independent of any other
   stage's" — and the rule stands on stages rather than named loops.

## Verification

- `task verify` green; `task ci` green (full mirror).
- `task challenge` — **clean pass at round 3**. Round 1 raised two confirmed
  P1s (the non-transfer rule was silent on escalation; "cannot manufacture its
  own rounds" overclaimed against `shepherd/SKILL.md`). Round 2's P1 was
  **mooted by deletion** rather than answered: the clause "a clean push draws
  no reply and the stage ends" was round 1's own explanatory support and
  contradicted the adjacent "Checks green is a non-terminal state" bullet, so it
  was removed and the sentence now defers to that bullet. Both round-2 findings
  were about round 1's fix — the tell `AGENTS.md` describes — which is why
  deletion was weighed against a third hardening pass.
- `task review` — **clean pass at round 2** ("no P0, P1, or material P2
  findings"). Round 1's two P1s are the judgment calls above.
- Codex-off render checked directly (`use_codex_review` defaults to `no`): the
  shepherd text stands alone, with no references to the challenge/review
  bullets or the Second-Model Review section that a default render removes.
- Dogfood: parity 106/106, structure 202/202. `audit:dogfood` shows AGENTS.md
  at 340 differing lines vs. a 339-line pre-existing baseline — wrapping was
  matched between layers so the change adds ~1 line of drift, not 20.

One unexplained result, stated rather than smoothed over: the first `task ci`
run failed on `test:template:update`. I had piped that run through `tail -40`
and truncated the diagnostic output away, so the cause was not captured. The
profile passes in isolation and a full `task ci` re-run of the same tree passes
(`CI_EXIT=0`). Unrelated to a prose-only change, but flagging it since it is a
required gate and CI here will be another sample.

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)
