### PR TITLE
fix(template): make a missing project scope visible before a claim depends on it

### DIFF
--- a/.devcontainer/config/claude-hooks/session-start-context.sh
+++ b/.devcontainer/config/claude-hooks/session-start-context.sh
@@ -15,8 +15,14 @@ cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
 # Strip ANSI color codes so the additionalContext payload renders cleanly.
 strip_ansi() { sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'; }
 
+# The outer deadlines must exceed what the sections themselves allow, or the
+# inner bounds are pointless: whatever the section was about to report is lost
+# wholesale, because status.sh buffers each section before printing it. status:gh
+# spends up to NETWORK_TIMEOUT (5s) on the auth probe and then up to another 5s
+# on the PR/run probes it launches in parallel — 10s worst case, so 12 here.
+# status:git makes no network calls at all.
 git_status="$(timeout 5 task status:git 2>/dev/null | strip_ansi || echo '(task status:git unavailable)')"
-gh_status="$(timeout 8 task status:gh 2>/dev/null | strip_ansi || echo '(task status:gh unavailable)')"
+gh_status="$(timeout 12 task status:gh 2>/dev/null | strip_ansi || echo '(task status:gh unavailable)')"
 branch="$(git branch --show-current 2>/dev/null || echo 'unknown')"
 
 reminder=$'Repo conventions:\n- Run `task verify` before committing (lint + build + validate + test).\n- Conventional Commits required (feat/fix/docs/style/refactor/perf/test/chore/ci/build/change/remove/revert).\n- Never bypass git hooks with --no-verify; fix the underlying issue.\n- Use lefthook for git hooks (not pre-commit).\n- See docs/conventions.md (and AGENTS.md) for the authoritative conventions catalog.'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,10 @@ jobs:
       - run: task test:tasks
       - run: task test:codex-review
       - run: task test:ci-results
+      - run: task test:status
       - run: task test:renovate-pins
       - run: task test:release-title
+      - run: task test:setup-github-project
       - run: task test:sync-devkit-release
       - run: task test:skills-pin-parity
       - name: Dogfood parity (verbatim template files match their root twins)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -76,6 +76,7 @@ tasks:
       - task: check
       - task: test:tasks
       - task: test:ci-results
+      - task: test:status
       - task: test:renovate-pins
       - task: test:release-title
       - task: test:setup-github-project
@@ -299,6 +300,11 @@ tasks:
     desc: Unit-test the fail-closed CI aggregate result helper
     cmds:
       - ./scripts/test-ci-results.sh
+
+  test:status:
+    desc: Unit-test the status board-writes scope check (stubbed gh, no network)
+    cmds:
+      - ./scripts/test-status.sh
 
   test:renovate-pins:
     desc: Check every annotated shell version pin is extractable by Renovate

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -12,6 +12,44 @@ Every repo the owner controls feeds that one board; an issue can belong to
 multiple projects, but this default board is its home. Reach for a second,
 focused project only when a body of work needs its own.
 
+## Token scopes
+
+Everything on this page that touches the board — `task setup:github-project`,
+and the `Status` writes the [claim lifecycle](#claiming--making-an-agents-work-visible-while-it-happens)
+makes — goes through the Projects V2 API, and `gh auth login` does **not** grant
+access to it by default. Nothing else notices: the same token still reads
+issues, opens PRs, and drives CI perfectly well, so the gap shows up only as
+board writes that do nothing.
+
+| Scope | Grants | Enough for |
+|---|---|---|
+| *(neither)* | — | nothing here — every board read and write fails |
+| `read:project` | read Projects | reading a card's current `Status`; **no writes** |
+| `project` | read **and write** Projects | everything on this page |
+
+Ask for the full scope. It is a superset, so there is no reason to request
+`read:project` alongside it:
+
+```sh
+gh auth refresh -s project
+```
+
+Check what a token actually carries:
+
+```sh
+gh auth status | grep 'Token scopes'
+```
+
+`task status:gh` reports this as **Project board writes**, so a missing scope
+surfaces at session start — before a claim is made against a board that cannot
+receive it. `task setup:github-project` refuses to run without it rather than
+failing partway through its writes.
+
+Two adjacent scopes, for completeness: an organization's **issue types** need
+`admin:org` (reported by `task status:setup`), and the vendored claim skills
+hint at `gh auth refresh -s read:project,project` — equivalent for this purpose,
+since `project` alone already covers it.
+
 ## Status pipeline
 
 `Status` is a single-select field with exactly one meaning: **where in the flow
@@ -295,6 +333,18 @@ This also removes an owner-type problem: on an organization `Agent` is an org
 **issue field** that the Projects V2 API cannot write anyway, so a claim that
 depended on it would have been impossible there. The label works identically on
 both owner types.
+
+**A board write can fail without anyone learning.** Every `Status` write in the
+lifecycle needs the [`project` scope](#token-scopes). Without it each one exits
+2 — "could not verify" — and the steps handle that correctly *individually*:
+it is an auth condition they cannot fix, so they note it and carry on. In
+aggregate that is the worst outcome available. The agent reports the issue
+claimed, the board says nothing was ever started, and neither is wrong from
+where it stands; the hand-back then cannot restore a prior status it was never
+able to read. Nothing in the loop escalates, so the board silently stops
+tracking agent work in **both** directions until a human happens to notice it
+has gone stale. Check the scope at session start (`task status:gh`), not after
+the claim.
 
 **A claim is a signal, not a lock.** None of these writes is atomic, and two
 sessions running as the same GitHub user are invisible to each other — the

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -61,24 +61,20 @@ one, so `task status:gh` can only report the check as **unknown**, and
 `GH_TOKEN` cannot be refreshed at all. Grant it **Projects: Read and write** at
 the source (organization permissions, for an org-owned board) instead.
 
-That matters here because the bot credential this template documents is exactly
-such a token — and [bot-account.md](guides/bot-account.md) deliberately grants
-it **`Projects: Read-only` — "Grant read; never write."** So an agent running as
-the bot **cannot move a card**, by design, however the scope check reports. Two
-honest ways to live with that, both a decision rather than a default:
+The bot credential this repo documents ([bot-account.md](guides/bot-account.md))
+is exactly such a token. This is a **personal** account, so it is granted no
+Projects permission at all — that row of the PAT table is organization-scoped,
+and a user-owned board has no equivalent setting to hand a second account. So an
+agent running as the bot **cannot move a card**, and there is no permission to
+raise: the board is moved by you, while the claim stays visible through the
+`agent:*` label and the assignee — see
+[Claiming](#claiming--making-an-agents-work-visible-while-it-happens), which is
+exactly why a claim writes all three signals instead of relying on the board
+alone. To have claims move cards here, run the agent under your own `gh` login
+(which the scope table above applies to) rather than the bot's.
 
-- **Leave it read-only** and accept that cards are moved by humans — and, on an
-  organization, by `project-automation.yml` from PR and CI events — not by the
-  claim. The `agent:*` label and the assignee still make the claim visible; see
-  [Claiming](#claiming--making-an-agents-work-visible-while-it-happens), which
-  is exactly why a claim writes all three signals instead of relying on the
-  board alone.
-- **Grant the bot `Projects: Read and write`** if you want claims to move cards,
-  understanding that org permissions are not bounded by the token's repository
-  list — that grant reaches every board the owner has.
-
-Nothing in this repo picks for you, and the status check does not treat a
-read-only bot as broken; it reports what the credential can do.
+The status check does not treat a read-only credential as broken; it reports what
+the credential can do.
 
 ## Status pipeline
 

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -50,6 +50,36 @@ Two adjacent scopes, for completeness: an organization's **issue types** need
 hint at `gh auth refresh -s read:project,project` — equivalent for this purpose,
 since `project` alone already covers it.
 
+### Scopes are only half the story
+
+The table above is about **classic OAuth scopes**, which is what `gh auth login`
+issues and `gh auth refresh` edits. A **fine-grained PAT** or a GitHub App
+installation token has none of them: its Projects access is a *permission*
+granted where the token was issued. `gh auth status` reports no scope list for
+one, so `task status:gh` can only report the check as **unknown**, and
+`gh auth refresh` cannot help — a token supplied through the environment as
+`GH_TOKEN` cannot be refreshed at all. Grant it **Projects: Read and write** at
+the source (organization permissions, for an org-owned board) instead.
+
+That matters here because the bot credential this template documents is exactly
+such a token — and [bot-account.md](guides/bot-account.md) deliberately grants
+it **`Projects: Read-only` — "Grant read; never write."** So an agent running as
+the bot **cannot move a card**, by design, however the scope check reports. Two
+honest ways to live with that, both a decision rather than a default:
+
+- **Leave it read-only** and accept that cards are moved by humans — and, on an
+  organization, by `project-automation.yml` from PR and CI events — not by the
+  claim. The `agent:*` label and the assignee still make the claim visible; see
+  [Claiming](#claiming--making-an-agents-work-visible-while-it-happens), which
+  is exactly why a claim writes all three signals instead of relying on the
+  board alone.
+- **Grant the bot `Projects: Read and write`** if you want claims to move cards,
+  understanding that org permissions are not bounded by the token's repository
+  list — that grant reaches every board the owner has.
+
+Nothing in this repo picks for you, and the status check does not treat a
+read-only bot as broken; it reports what the credential can do.
+
 ## Status pipeline
 
 `Status` is a single-select field with exactly one meaning: **where in the flow

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -85,17 +85,27 @@ case "$scopes_line" in
     ;;
 *"'project'"*) ;;
 *"'"*)
-    cat >&2 <<'SCOPE_ERR'
-This token cannot write GitHub Projects: 'gh auth status' reports no 'project' scope.
-
-Every write below (the board, its Status pipeline, the Size field) would fail on
-the first API call. Fix it, then re-run:
-
-    gh auth refresh -s project
-
-Note that read-only 'read:project' is enough to *see* a board but not to create
-or reconcile one, so this script requires the full 'project' scope.
-SCOPE_ERR
+    # `gh auth refresh` edits the STORED credential, which an env-provided token
+    # overrides — so that remedy is unusable for anyone running on GH_TOKEN or
+    # GITHUB_TOKEN. gh names the source in its report; use it.
+    remedy="    gh auth refresh -s project"
+    case "$auth_report" in
+    *"(GH_TOKEN)"*)
+        remedy="    Reissue the token in GH_TOKEN with the 'project' scope.
+    (gh auth refresh cannot help: the environment token overrides the stored one.)"
+        ;;
+    *"(GITHUB_TOKEN)"*)
+        remedy="    Reissue the token in GITHUB_TOKEN with the 'project' scope.
+    (gh auth refresh cannot help: the environment token overrides the stored one.)"
+        ;;
+    esac
+    printf '%s\n\n%s\n\n%s\n\n%s\n' \
+        "This token cannot write GitHub Projects: 'gh auth status' reports no 'project' scope." \
+        "Every write below (the board, its Status pipeline, the Size field) would fail on
+the first API call. Fix it, then re-run:" \
+        "$remedy" \
+        "Note that read-only 'read:project' is enough to *see* a board but not to create
+or reconcile one, so this script requires the full 'project' scope." >&2
     exit 1
     ;;
 *)

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -73,7 +73,27 @@ done
 # targets GH_HOST or github.com). Older gh (pre-2.40) has no --active — fall back
 # rather than read a usage error as a missing scope; multi-account per host
 # arrived with 2.40, so one host there already means one account.
-gh_host="${GH_HOST:-github.com}"
+# The host this run will target. GH_HOST is gh's override for when a host cannot
+# be determined from repository context, so context comes first when it is unset —
+# forcing github.com would narrow the probe to a host the API calls below do not
+# use, and reject a valid Enterprise login over it.
+gh_host="${GH_HOST:-}"
+if [ -z "$gh_host" ]; then
+    remote_url="$(git config --get remote.origin.url 2>/dev/null || true)"
+    case "$remote_url" in
+    *://*)
+        gh_host="${remote_url#*://}"
+        gh_host="${gh_host#*@}"
+        gh_host="${gh_host%%/*}"
+        gh_host="${gh_host%%:*}"
+        ;;
+    *@*:*)
+        gh_host="${remote_url#*@}"
+        gh_host="${gh_host%%:*}"
+        ;;
+    esac
+fi
+gh_host="${gh_host:-github.com}"
 auth_report="$(gh auth status --active --hostname "$gh_host" 2>&1 || true)"
 case "$auth_report" in
 *"unknown flag"*) auth_report="$(gh auth status --hostname "$gh_host" 2>&1 || true)" ;;

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -66,14 +66,21 @@ done
 # installation token, a future `gh` output change) may still be perfectly able
 # to do the work, and refusing to run would be a worse failure than the one
 # this guard replaces.
-auth_report="$(gh auth status 2>&1 || true)"
+# --active: `gh auth status` reports every known account, and an inactive one
+# holding 'project' must not answer for the credential this run will use. Older
+# gh (pre-2.40) has no such flag — fall back rather than read a usage error as a
+# missing scope.
+auth_report="$(gh auth status --active 2>&1 || true)"
+case "$auth_report" in
+*"unknown flag"*) auth_report="$(gh auth status 2>&1 || true)" ;;
+esac
 scopes_line="$(printf '%s\n' "$auth_report" | grep -i 'token scopes:' || true)"
 case "$scopes_line" in
 "")
     echo "==> Could not read token scopes from 'gh auth status' — continuing; a scope error below means: gh auth refresh -s project" >&2
     ;;
 *"'project'"*) ;;
-*)
+*"'"*)
     cat >&2 <<'SCOPE_ERR'
 This token cannot write GitHub Projects: 'gh auth status' reports no 'project' scope.
 
@@ -86,6 +93,15 @@ Note that read-only 'read:project' is enough to *see* a board but not to create
 or reconcile one, so this script requires the full 'project' scope.
 SCOPE_ERR
     exit 1
+    ;;
+*)
+    # A scopes line with no scopes in it: a fine-grained PAT or an App
+    # installation token, whose Projects access is a permission granted where
+    # the token was issued rather than an OAuth scope. Such a token may be
+    # perfectly able to do this work, and `gh auth refresh` cannot change it
+    # (an env-provided GH_TOKEN cannot be refreshed at all) — so refusing here
+    # would block a capable credential over a naming mismatch.
+    echo "==> Token reports no OAuth scopes (fine-grained or App token) — continuing; if a write below fails, grant it 'Projects: Read and write' where the token was issued" >&2
     ;;
 esac
 

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -55,6 +55,40 @@ for tool in gh jq; do
     fi
 done
 
+# ── Scope preflight ─────────────────────────────────────────────────────────
+# Every mutation below needs the 'project' scope, which `gh auth login` does not
+# grant by default. Without it the run still fails — `gh api graphql` exits
+# non-zero on an INSUFFICIENT_SCOPES error and `set -e` takes the script with it
+# — but it fails at the first projectsV2 query with a raw GraphQL error that
+# says nothing about scopes or how to fix it. Checking here converts that into
+# one actionable line, before any API call. It is deliberately NOT fatal on an
+# unreadable scope list: a token whose scopes cannot be parsed (a GitHub App
+# installation token, a future `gh` output change) may still be perfectly able
+# to do the work, and refusing to run would be a worse failure than the one
+# this guard replaces.
+auth_report="$(gh auth status 2>&1 || true)"
+scopes_line="$(printf '%s\n' "$auth_report" | grep -i 'token scopes:' || true)"
+case "$scopes_line" in
+"")
+    echo "==> Could not read token scopes from 'gh auth status' — continuing; a scope error below means: gh auth refresh -s project" >&2
+    ;;
+*"'project'"*) ;;
+*)
+    cat >&2 <<'SCOPE_ERR'
+This token cannot write GitHub Projects: 'gh auth status' reports no 'project' scope.
+
+Every write below (the board, its Status pipeline, the Size field) would fail on
+the first API call. Fix it, then re-run:
+
+    gh auth refresh -s project
+
+Note that read-only 'read:project' is enough to *see* a board but not to create
+or reconcile one, so this script requires the full 'project' scope.
+SCOPE_ERR
+    exit 1
+    ;;
+esac
+
 # Full Status pipeline (docs/project-management.md), in board order. GitHub's API
 # cannot create the visual groups, so these render as a flat, ordered list.
 status_pipeline='[

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -66,13 +66,17 @@ done
 # installation token, a future `gh` output change) may still be perfectly able
 # to do the work, and refusing to run would be a worse failure than the one
 # this guard replaces.
-# --active: `gh auth status` reports every known account, and an inactive one
-# holding 'project' must not answer for the credential this run will use. Older
-# gh (pre-2.40) has no such flag — fall back rather than read a usage error as a
-# missing scope.
-auth_report="$(gh auth status --active 2>&1 || true)"
+# Narrow the report to the one credential the API calls below will use.
+# `gh auth status` covers every account on every host, and the scope line cannot
+# tell them apart: --active excludes a second account on this host, --hostname
+# excludes an unrelated host whose scopes say nothing about this run (which
+# targets GH_HOST or github.com). Older gh (pre-2.40) has no --active — fall back
+# rather than read a usage error as a missing scope; multi-account per host
+# arrived with 2.40, so one host there already means one account.
+gh_host="${GH_HOST:-github.com}"
+auth_report="$(gh auth status --active --hostname "$gh_host" 2>&1 || true)"
 case "$auth_report" in
-*"unknown flag"*) auth_report="$(gh auth status 2>&1 || true)" ;;
+*"unknown flag"*) auth_report="$(gh auth status --hostname "$gh_host" 2>&1 || true)" ;;
 esac
 scopes_line="$(printf '%s\n' "$auth_report" | grep -i 'token scopes:' || true)"
 case "$scopes_line" in

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -98,6 +98,14 @@ case "$scopes_line" in
         remedy="    Reissue the token in GITHUB_TOKEN with the 'project' scope.
     (gh auth refresh cannot help: the environment token overrides the stored one.)"
         ;;
+    *"(GH_ENTERPRISE_TOKEN)"*)
+        remedy="    Reissue the token in GH_ENTERPRISE_TOKEN with the 'project' scope.
+    (gh auth refresh cannot help: the environment token overrides the stored one.)"
+        ;;
+    *"(GITHUB_ENTERPRISE_TOKEN)"*)
+        remedy="    Reissue the token in GITHUB_ENTERPRISE_TOKEN with the 'project' scope.
+    (gh auth refresh cannot help: the environment token overrides the stored one.)"
+        ;;
     esac
     printf '%s\n\n%s\n\n%s\n\n%s\n' \
         "This token cannot write GitHub Projects: 'gh auth status' reports no 'project' scope." \

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -198,19 +198,24 @@ GH_AUTHED=false
 GH_AUTH_TIMEDOUT=false
 if should_show "gh"; then
     gh_auth_rc=0
-    # --active, because `gh auth status` reports EVERY known account and the
-    # scope line read below cannot tell them apart: a second, inactive account
-    # holding `project` would answer for the credential gh actually uses.
-    # (Residual, accepted: with several hosts each having an active account, all
-    # of them are still reported. Narrowing further needs the repo's host, which
-    # this reporter does not resolve.)
-    run_timeout "${NETWORK_TIMEOUT}" gh auth status --active >"${GH_AUTH_FILE}" 2>&1 ||
+    # `gh auth status` reports every account on every host, and the scope line
+    # read below cannot tell them apart — so narrow it to one credential from
+    # both directions: --active (not a second, inactive account on this host)
+    # and --hostname (not an unrelated host's account, whose scopes say nothing
+    # about the API calls this repo makes). A GitHub Enterprise user who has not
+    # set GH_HOST gets no match and the check reports "unknown", which is the
+    # right answer — better than a green light earned by the wrong token.
+    run_timeout "${NETWORK_TIMEOUT}" gh auth status --active \
+        --hostname "${GH_HOST:-github.com}" >"${GH_AUTH_FILE}" 2>&1 ||
         gh_auth_rc=$?
     if grep -qi 'unknown flag' "${GH_AUTH_FILE}" 2>/dev/null; then
-        # gh predates --active (added in 2.40). Fall back to the full report
-        # rather than reading a usage error as a failed login.
+        # gh predates --active (added in 2.40). Fall back rather than read a
+        # usage error as a failed login — and keep --hostname, which is far
+        # older. Multi-account per host arrived WITH 2.40, so on a gh this old
+        # one host means one account and the narrowing is complete anyway.
         gh_auth_rc=0
-        run_timeout "${NETWORK_TIMEOUT}" gh auth status >"${GH_AUTH_FILE}" 2>&1 ||
+        run_timeout "${NETWORK_TIMEOUT}" gh auth status \
+            --hostname "${GH_HOST:-github.com}" >"${GH_AUTH_FILE}" 2>&1 ||
             gh_auth_rc=$?
     fi
     # 124 is `timeout`'s own "deadline hit" code. Distinguished from a real

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -178,6 +178,41 @@ has_scope() {
     esac
 }
 
+# gh_target_host — the host gh will actually use for THIS repository.
+#
+# Narrowing `gh auth status --hostname` is only safe against the same host the
+# repo-aware calls use. Forcing github.com disowns a valid Enterprise login
+# (`gh auth login --hostname ghe.example.com`, no GH_HOST exported): the probe
+# exits non-zero, which this script reads as "not authenticated" and skips the
+# whole GitHub section — while `gh pr list` and `gh run list` would have worked
+# fine against that remote. So resolve it the way gh documents: GH_HOST is the
+# override for when a host "cannot be determined from repository context", which
+# means repository context comes first when GH_HOST is unset.
+#
+# Local and network-free — the remote URL is the context. github.com only as a
+# last resort, when there is no remote to read.
+gh_target_host() {
+    local url host=""
+    if [[ -n "${GH_HOST:-}" ]]; then
+        printf '%s' "${GH_HOST}"
+        return 0
+    fi
+    url="$(git config --get remote.origin.url 2>/dev/null || true)"
+    case "${url}" in
+    *://*)                 # scheme://[user@]host[:port]/path
+        host="${url#*://}" # drop the scheme
+        host="${host#*@}"  # drop any userinfo
+        host="${host%%/*}" # drop the path
+        host="${host%%:*}" # drop any port
+        ;;
+    *@*:*) # scp-like: user@host:owner/repo
+        host="${url#*@}"
+        host="${host%%:*}"
+        ;;
+    esac
+    printf '%s' "${host:-github.com}"
+}
+
 # ── Parallel data collection ────────────────────────────────────────────────
 
 PID_PRS=""
@@ -205,11 +240,11 @@ if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
     # read below cannot tell them apart — so narrow it to one credential from
     # both directions: --active (not a second, inactive account on this host)
     # and --hostname (not an unrelated host's account, whose scopes say nothing
-    # about the API calls this repo makes). A GitHub Enterprise user who has not
-    # set GH_HOST gets no match and the check reports "unknown", which is the
-    # right answer — better than a green light earned by the wrong token.
+    # about the API calls this repo makes). The host comes from the repository,
+    # not a github.com assumption — see gh_target_host.
+    gh_host="$(gh_target_host)"
     run_timeout "${NETWORK_TIMEOUT}" gh auth status --active \
-        --hostname "${GH_HOST:-github.com}" >"${GH_AUTH_FILE}" 2>&1 ||
+        --hostname "${gh_host}" >"${GH_AUTH_FILE}" 2>&1 ||
         gh_auth_rc=$?
     if grep -qi 'unknown flag' "${GH_AUTH_FILE}" 2>/dev/null; then
         # gh predates --active (added in 2.40). Fall back rather than read a
@@ -218,7 +253,7 @@ if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
         # one host means one account and the narrowing is complete anyway.
         gh_auth_rc=0
         run_timeout "${NETWORK_TIMEOUT}" gh auth status \
-            --hostname "${GH_HOST:-github.com}" >"${GH_AUTH_FILE}" 2>&1 ||
+            --hostname "${gh_host}" >"${GH_AUTH_FILE}" 2>&1 ||
             gh_auth_rc=$?
     fi
     # 124 is `timeout`'s own "deadline hit" code. Distinguished from a real

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -555,8 +555,13 @@ if [[ "${SECTION}" == "setup" ]]; then
     } | section_box
 
     # Reuses the single bounded probe above rather than making a second,
-    # unbounded `gh auth status` call to learn the same thing.
-    if [[ "${GH_AUTHED}" != true ]]; then
+    # unbounded `gh auth status` call to learn the same thing. Sharing that probe
+    # means sharing its distinctions too: bounding it made a slow network look
+    # exactly like a missing login, and telling an authenticated user to run
+    # `gh auth login` because GitHub was slow sends them to fix the wrong thing.
+    if [[ "${GH_AUTH_TIMEDOUT}" == true ]]; then
+        echo "  (gh auth status timed out after ${NETWORK_TIMEOUT}s -- skipping)" | section_box
+    elif [[ "${GH_AUTHED}" != true ]]; then
         echo "  (gh not authenticated -- run 'gh auth login')" | section_box
     else
         d="${TMPDIR_STATUS}"

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -360,14 +360,38 @@ if should_show "gh"; then
             # included) is vendored into repos that have no board at all.
             # Keying on the skill would demand the `project` scope from every
             # one of them. setup-github-project.sh is generated only for
-            # `project_management: github`, which makes it an exact proxy for
-            # "this repo has a board to write to".
+            # `project_management: github`, which makes it a proxy for "this
+            # repo is configured to have a board".
+            #
+            # The accepted cost, deliberately chosen: a repo on
+            # `project_management: none` whose issues someone adds to a board by
+            # hand gets no session-start warning, and learns from the claim's own
+            # exit 2 instead. Nothing on disk can distinguish that repo from one
+            # that simply opted out — board membership is remote state — so the
+            # gate can only pick which error to make. A red line in every
+            # opted-out repo, every session, is the worse one: it is universal
+            # rather than conditional, and a check that cries wolf everywhere
+            # stops being read where it matters.
             if [[ -f scripts/setup-github-project.sh ]]; then
                 echo ""
                 # Read the file directly — no pipe. A `grep -q` consumer on a
                 # pipeline can take SIGPIPE, which `pipefail` turns into a
                 # failure of the whole pipeline.
                 gh_scopes="$(grep -i 'token scopes:' "${GH_AUTH_FILE}" 2>/dev/null || true)"
+                # `gh auth refresh` edits the STORED credential, and an
+                # env-provided token overrides that — so telling someone running
+                # on GH_TOKEN to refresh is advice that cannot work. gh names the
+                # source in its report, so use it to pick the remedy once rather
+                # than repeating a guess in each branch below.
+                gh_remedy="run: gh auth refresh -s project"
+                case "$(<"${GH_AUTH_FILE}")" in
+                *"(GH_TOKEN)"*)
+                    gh_remedy="reissue GH_TOKEN with the 'project' scope (an env token overrides gh auth refresh)"
+                    ;;
+                *"(GITHUB_TOKEN)"*)
+                    gh_remedy="reissue GITHUB_TOKEN with the 'project' scope (an env token overrides gh auth refresh)"
+                    ;;
+                esac
                 if [[ -z "${gh_scopes}" ]]; then
                     checkline unknown "Project board writes" \
                         "could not read token scopes from gh auth status"
@@ -387,10 +411,10 @@ if should_show "gh"; then
                     # mistaken for working: `--show` reads the card fine, so the
                     # board looks reachable right up to the write that moves it.
                     checkline no "Project board writes" \
-                        "'read:project' is read-only — claims cannot move the board; run: gh auth refresh -s project"
+                        "'read:project' is read-only — claims cannot move the board; ${gh_remedy}"
                 else
                     checkline no "Project board writes" \
-                        "token lacks 'project' — claims cannot move the board; run: gh auth refresh -s project"
+                        "token lacks 'project' — claims cannot move the board; ${gh_remedy}"
                 fi
             fi
         } | section_box

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -196,7 +196,10 @@ GH_AUTH_FILE="${TMPDIR_STATUS}/auth.txt"
 : >"${GH_AUTH_FILE}"
 GH_AUTHED=false
 GH_AUTH_TIMEDOUT=false
-if should_show "gh"; then
+# The setup section needs this too — it reports the same credential's ability to
+# read the board, and used to run its own `gh auth status` to decide whether to
+# render at all. One probe, two consumers.
+if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
     gh_auth_rc=0
     # `gh auth status` reports every account on every host, and the scope line
     # read below cannot tell them apart — so narrow it to one credential from
@@ -228,7 +231,44 @@ if should_show "gh"; then
     esac
 fi
 
-if [[ "${GH_AUTHED}" == true ]]; then
+# The token's scope line, and how to give THIS credential Projects write access.
+# Derived once, because every call site below would otherwise guess — and a
+# remedy that cannot work is worse than none. `gh auth refresh` edits only the
+# STORED classic credential: it cannot touch an env-provided token (which
+# overrides the stored one, on github.com and Enterprise alike) and cannot add a
+# fine-grained or App token's permissions, which are not OAuth scopes at all.
+GH_SCOPES_LINE=""
+GH_REMEDY="run: gh auth refresh -s project"
+if [[ -s "${GH_AUTH_FILE}" ]]; then
+    GH_SCOPES_LINE="$(grep -i 'token scopes:' "${GH_AUTH_FILE}" 2>/dev/null || true)"
+    case "$(<"${GH_AUTH_FILE}")" in
+    *"(GH_TOKEN)"*)
+        GH_REMEDY="reissue GH_TOKEN with Projects write — an env token overrides gh auth refresh"
+        ;;
+    *"(GITHUB_TOKEN)"*)
+        GH_REMEDY="reissue GITHUB_TOKEN with Projects write — an env token overrides gh auth refresh"
+        ;;
+    *"(GH_ENTERPRISE_TOKEN)"*)
+        GH_REMEDY="reissue GH_ENTERPRISE_TOKEN with Projects write — an env token overrides gh auth refresh"
+        ;;
+    *"(GITHUB_ENTERPRISE_TOKEN)"*)
+        GH_REMEDY="reissue GITHUB_ENTERPRISE_TOKEN with Projects write — an env token overrides gh auth refresh"
+        ;;
+    *)
+        # Not an env token. A scope line with no scopes in it is a fine-grained
+        # PAT or an App installation token — a permission, granted at the source.
+        if [[ -n "${GH_SCOPES_LINE}" && "${GH_SCOPES_LINE}" != *"'"* ]]; then
+            GH_REMEDY="set its Projects permission where the token was issued"
+        fi
+        ;;
+    esac
+fi
+
+# `should_show "gh"` as well as the auth flag: the auth probe above now also runs
+# for the setup section, and these two lists are read only by the GitHub section.
+# Without the guard, `task status:setup` would spend two network calls fetching
+# data nothing displays.
+if [[ "${GH_AUTHED}" == true ]] && should_show "gh"; then
     run_timeout "${NETWORK_TIMEOUT}" gh pr list --limit 10 \
         --json number,title,headRefName \
         >"${TMPDIR_STATUS}/prs.json" 2>/dev/null &
@@ -374,47 +414,28 @@ if should_show "gh"; then
             # stops being read where it matters.
             if [[ -f scripts/setup-github-project.sh ]]; then
                 echo ""
-                # Read the file directly — no pipe. A `grep -q` consumer on a
-                # pipeline can take SIGPIPE, which `pipefail` turns into a
-                # failure of the whole pipeline.
-                gh_scopes="$(grep -i 'token scopes:' "${GH_AUTH_FILE}" 2>/dev/null || true)"
-                # `gh auth refresh` edits the STORED credential, and an
-                # env-provided token overrides that — so telling someone running
-                # on GH_TOKEN to refresh is advice that cannot work. gh names the
-                # source in its report, so use it to pick the remedy once rather
-                # than repeating a guess in each branch below.
-                gh_remedy="run: gh auth refresh -s project"
-                case "$(<"${GH_AUTH_FILE}")" in
-                *"(GH_TOKEN)"*)
-                    gh_remedy="reissue GH_TOKEN with the 'project' scope (an env token overrides gh auth refresh)"
-                    ;;
-                *"(GITHUB_TOKEN)"*)
-                    gh_remedy="reissue GITHUB_TOKEN with the 'project' scope (an env token overrides gh auth refresh)"
-                    ;;
-                esac
-                if [[ -z "${gh_scopes}" ]]; then
+                if [[ -z "${GH_SCOPES_LINE}" ]]; then
                     checkline unknown "Project board writes" \
                         "could not read token scopes from gh auth status"
-                elif [[ "${gh_scopes}" != *"'"* ]]; then
+                elif [[ "${GH_SCOPES_LINE}" != *"'"* ]]; then
                     # A fine-grained PAT or App token carries permissions, not
                     # OAuth scopes, and gh reports the line with no scopes in
                     # it. Such a token may well be able to write Projects — so
-                    # this is genuinely unknown, and `gh auth refresh` is the
-                    # wrong advice: an env-provided GH_TOKEN cannot be refreshed
-                    # at all. The generated bot credential is exactly this case.
+                    # this is genuinely unknown rather than a failure. The
+                    # generated bot credential is exactly this case.
                     checkline unknown "Project board writes" \
-                        "no OAuth scopes reported (fine-grained or App token) — set its Projects permission where it was issued"
-                elif has_scope "${gh_scopes}" project; then
+                        "no OAuth scopes reported (fine-grained or App token) — ${GH_REMEDY}"
+                elif has_scope "${GH_SCOPES_LINE}" project; then
                     checkline ok "Project board writes" "token has 'project'"
-                elif has_scope "${gh_scopes}" read:project; then
+                elif has_scope "${GH_SCOPES_LINE}" read:project; then
                     # Called out separately because it is the state most easily
                     # mistaken for working: `--show` reads the card fine, so the
                     # board looks reachable right up to the write that moves it.
                     checkline no "Project board writes" \
-                        "'read:project' is read-only — claims cannot move the board; ${gh_remedy}"
+                        "'read:project' is read-only — claims cannot move the board; ${GH_REMEDY}"
                 else
                     checkline no "Project board writes" \
-                        "token lacks 'project' — claims cannot move the board; ${gh_remedy}"
+                        "token lacks 'project' — claims cannot move the board; ${GH_REMEDY}"
                 fi
             fi
         } | section_box
@@ -533,7 +554,9 @@ if [[ "${SECTION}" == "setup" ]]; then
         fi
     } | section_box
 
-    if ! gh auth status &>/dev/null 2>&1; then
+    # Reuses the single bounded probe above rather than making a second,
+    # unbounded `gh auth status` call to learn the same thing.
+    if [[ "${GH_AUTHED}" != true ]]; then
         echo "  (gh not authenticated -- run 'gh auth login')" | section_box
     else
         d="${TMPDIR_STATUS}"
@@ -811,7 +834,7 @@ if [[ "${SECTION}" == "setup" ]]; then
                     fi
                 else
                     checkline unknown "GitHub Project linked" \
-                        "unreadable — run: gh auth refresh -s project"
+                        "unreadable — ${GH_REMEDY}"
                 fi
                 if [ -f scripts/setup-github-labels.sh ]; then
                     # The expected set is read out of the setup script's own

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -198,8 +198,21 @@ GH_AUTHED=false
 GH_AUTH_TIMEDOUT=false
 if should_show "gh"; then
     gh_auth_rc=0
-    run_timeout "${NETWORK_TIMEOUT}" gh auth status >"${GH_AUTH_FILE}" 2>&1 ||
+    # --active, because `gh auth status` reports EVERY known account and the
+    # scope line read below cannot tell them apart: a second, inactive account
+    # holding `project` would answer for the credential gh actually uses.
+    # (Residual, accepted: with several hosts each having an active account, all
+    # of them are still reported. Narrowing further needs the repo's host, which
+    # this reporter does not resolve.)
+    run_timeout "${NETWORK_TIMEOUT}" gh auth status --active >"${GH_AUTH_FILE}" 2>&1 ||
         gh_auth_rc=$?
+    if grep -qi 'unknown flag' "${GH_AUTH_FILE}" 2>/dev/null; then
+        # gh predates --active (added in 2.40). Fall back to the full report
+        # rather than reading a usage error as a failed login.
+        gh_auth_rc=0
+        run_timeout "${NETWORK_TIMEOUT}" gh auth status >"${GH_AUTH_FILE}" 2>&1 ||
+            gh_auth_rc=$?
+    fi
     # 124 is `timeout`'s own "deadline hit" code. Distinguished from a real
     # failure because bounding this probe made a slow network indistinguishable
     # from a missing login, and reporting "not authenticated" for a timeout
@@ -336,8 +349,15 @@ if should_show "gh"; then
             # Reported in both directions on purpose. A check that prints only
             # on failure is indistinguishable from a check that is not running
             # — which is the very bug this one exists to catch.
-            if [[ -f .claude/skills/track-work/assets/set-issue-status.sh ||
-                -f scripts/setup-github-project.sh ]]; then
+            # Gated on the board tooling itself, NOT on the presence of the
+            # track-work skill: `project_management: none` is the default and
+            # `use_skills_sync` is on, so the universal skill set (track-work
+            # included) is vendored into repos that have no board at all.
+            # Keying on the skill would demand the `project` scope from every
+            # one of them. setup-github-project.sh is generated only for
+            # `project_management: github`, which makes it an exact proxy for
+            # "this repo has a board to write to".
+            if [[ -f scripts/setup-github-project.sh ]]; then
                 echo ""
                 # Read the file directly — no pipe. A `grep -q` consumer on a
                 # pipeline can take SIGPIPE, which `pipefail` turns into a
@@ -346,6 +366,15 @@ if should_show "gh"; then
                 if [[ -z "${gh_scopes}" ]]; then
                     checkline unknown "Project board writes" \
                         "could not read token scopes from gh auth status"
+                elif [[ "${gh_scopes}" != *"'"* ]]; then
+                    # A fine-grained PAT or App token carries permissions, not
+                    # OAuth scopes, and gh reports the line with no scopes in
+                    # it. Such a token may well be able to write Projects — so
+                    # this is genuinely unknown, and `gh auth refresh` is the
+                    # wrong advice: an env-provided GH_TOKEN cannot be refreshed
+                    # at all. The generated bot credential is exactly this case.
+                    checkline unknown "Project board writes" \
+                        "no OAuth scopes reported (fine-grained or App token) — set its Projects permission where it was issued"
                 elif has_scope "${gh_scopes}" project; then
                     checkline ok "Project board writes" "token has 'project'"
                 elif has_scope "${gh_scopes}" read:project; then

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -12,12 +12,17 @@ SECTION="${1:-}"
 TMPDIR_STATUS="$(mktemp -d)"
 trap 'rm -rf "${TMPDIR_STATUS}"' EXIT
 
-NETWORK_TIMEOUT=5
+# Overridable so a test can drive the deadline path without waiting on it.
+NETWORK_TIMEOUT="${NETWORK_TIMEOUT:-5}"
 
 # ── Tool detection ──────────────────────────────────────────────────────────
 
+# NO_COLOR (https://no-color.org/) turns off gum styling as well as ANSI, which
+# makes the board's output plain, stable text — greppable, diffable, and
+# assertable by scripts/test-status.sh without matching around escape sequences
+# or box drawing.
 HAS_GUM=false
-command -v gum &>/dev/null && HAS_GUM=true
+[[ -z "${NO_COLOR:-}" ]] && command -v gum &>/dev/null && HAS_GUM=true
 
 # Network probes below are bounded so a hung `gh` call cannot wedge the board.
 # Stock macOS ships no `timeout` — it comes from coreutils, which also provides
@@ -89,7 +94,7 @@ should_show() {
 # ANSI only — no extra dependency. Detected here at top level because inside the
 # section's `| section_box` pipe, stdout reads as a non-TTY.
 USE_COLOR=false
-{ [ -t 1 ] || $HAS_GUM; } && USE_COLOR=true
+[[ -z "${NO_COLOR:-}" ]] && { [ -t 1 ] || $HAS_GUM; } && USE_COLOR=true
 
 # c SGR TEXT — wrap TEXT in an ANSI SGR sequence when color is enabled.
 c() {
@@ -161,6 +166,18 @@ has_cred() {
     jq -e --arg n "$2" 'any(.[]; .name == $n)' "$1" >/dev/null 2>&1
 }
 
+# has_scope LINE NAME — true if NAME is present as a quoted scope in a
+# `gh auth status` "Token scopes:" line (`… 'gist', 'project', 'repo'`).
+# Matching on the quotes is what keeps `project` from also matching
+# `read:project` (and vice versa) — the two are different grants and the
+# caller decides which ones satisfy it.
+has_scope() {
+    case "$1" in
+    *"'$2'"*) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
 # ── Parallel data collection ────────────────────────────────────────────────
 
 PID_PRS=""
@@ -169,7 +186,31 @@ PID_TOKEI=""
 
 CURRENT_BRANCH="$(git branch --show-current 2>/dev/null || echo "detached")"
 
-if should_show "gh" && gh auth status &>/dev/null 2>&1; then
+# Resolve auth once and keep the output: it is both the gate for the GitHub
+# section and the only place the token's scopes are reported, and re-running it
+# per use would spend an extra API call to learn the same thing. Captured with
+# `2>&1` because gh has moved this report between stdout and stderr across
+# versions, and bounded by run_timeout — the bare `gh auth status` calls it
+# replaces were the section's only unbounded network probes.
+GH_AUTH_FILE="${TMPDIR_STATUS}/auth.txt"
+: >"${GH_AUTH_FILE}"
+GH_AUTHED=false
+GH_AUTH_TIMEDOUT=false
+if should_show "gh"; then
+    gh_auth_rc=0
+    run_timeout "${NETWORK_TIMEOUT}" gh auth status >"${GH_AUTH_FILE}" 2>&1 ||
+        gh_auth_rc=$?
+    # 124 is `timeout`'s own "deadline hit" code. Distinguished from a real
+    # failure because bounding this probe made a slow network indistinguishable
+    # from a missing login, and reporting "not authenticated" for a timeout
+    # sends the reader to fix the wrong thing.
+    case "${gh_auth_rc}" in
+    0) GH_AUTHED=true ;;
+    124) GH_AUTH_TIMEDOUT=true ;;
+    esac
+fi
+
+if [[ "${GH_AUTHED}" == true ]]; then
     run_timeout "${NETWORK_TIMEOUT}" gh pr list --limit 10 \
         --json number,title,headRefName \
         >"${TMPDIR_STATUS}/prs.json" 2>/dev/null &
@@ -243,7 +284,9 @@ fi
 if should_show "gh"; then
     section_header "GitHub Status"
 
-    if ! gh auth status &>/dev/null 2>&1; then
+    if [[ "${GH_AUTH_TIMEDOUT}" == true ]]; then
+        echo "  (gh auth status timed out after ${NETWORK_TIMEOUT}s -- skipping)" | section_box
+    elif [[ "${GH_AUTHED}" != true ]]; then
         echo "  (gh not authenticated -- skipping)" | section_box
     else
         {
@@ -271,6 +314,50 @@ if should_show "gh"; then
                     "$checks_file"
             else
                 echo "  Recent CI runs: none"
+            fi
+
+            # ── Board writes ────────────────────────────────────────────────
+            # The claim lifecycle moves an issue's project `Status` (a claim
+            # sets In Progress, the PR stages advance it, the hand-back
+            # restores it), and that write needs a token scope `gh auth login`
+            # does not grant by default. Without it every board write exits 2
+            # ("could not verify") and no card moves — and each step handles
+            # that correctly on its own, so nothing escalates: the agent
+            # reports the issue claimed, the board says nothing was started,
+            # and neither is wrong from where it stands.
+            #
+            # `status:setup` has always checked this. It is repeated here
+            # because this section is what session-start orientation runs, and
+            # a tracking surface that has silently stopped tracking has to
+            # surface BEFORE a claim is made, not after a human notices the
+            # board is stale. The cost is nil: the scopes come from the auth
+            # probe above, not a second call.
+            #
+            # Reported in both directions on purpose. A check that prints only
+            # on failure is indistinguishable from a check that is not running
+            # — which is the very bug this one exists to catch.
+            if [[ -f .claude/skills/track-work/assets/set-issue-status.sh ||
+                -f scripts/setup-github-project.sh ]]; then
+                echo ""
+                # Read the file directly — no pipe. A `grep -q` consumer on a
+                # pipeline can take SIGPIPE, which `pipefail` turns into a
+                # failure of the whole pipeline.
+                gh_scopes="$(grep -i 'token scopes:' "${GH_AUTH_FILE}" 2>/dev/null || true)"
+                if [[ -z "${gh_scopes}" ]]; then
+                    checkline unknown "Project board writes" \
+                        "could not read token scopes from gh auth status"
+                elif has_scope "${gh_scopes}" project; then
+                    checkline ok "Project board writes" "token has 'project'"
+                elif has_scope "${gh_scopes}" read:project; then
+                    # Called out separately because it is the state most easily
+                    # mistaken for working: `--show` reads the card fine, so the
+                    # board looks reachable right up to the write that moves it.
+                    checkline no "Project board writes" \
+                        "'read:project' is read-only — claims cannot move the board; run: gh auth refresh -s project"
+                else
+                    checkline no "Project board writes" \
+                        "token lacks 'project' — claims cannot move the board; run: gh auth refresh -s project"
+                fi
             fi
         } | section_box
     fi
@@ -665,7 +752,8 @@ if [[ "${SECTION}" == "setup" ]]; then
                         checkline no "GitHub Project linked" "link a Project v2 to the repo"
                     fi
                 else
-                    checkline unknown "GitHub Project linked" "needs read:project scope"
+                    checkline unknown "GitHub Project linked" \
+                        "unreadable — run: gh auth refresh -s project"
                 fi
                 if [ -f scripts/setup-github-labels.sh ]; then
                     # The expected set is read out of the setup script's own

--- a/scripts/test-setup-github-project.sh
+++ b/scripts/test-setup-github-project.sh
@@ -248,6 +248,21 @@ case "$out" in
 *) fail "read:project must be refused for writes, got: $out" ;;
 esac
 
+echo "==> a fine-grained/App token is NOT refused — its access is a permission"
+# It reports no OAuth scopes at all, which is not the same as lacking one: such a
+# token may well be able to write Projects, and `gh auth refresh` cannot change
+# it either way. Refusing here would block a capable credential.
+printf '%s' "$complete" >"$STUB_FIELDS_FILE"
+: >"$STUB_FIELDS_FILE2"
+rm -f "$tmp_seen"
+: >"$MUTATIONS"
+STUB_SCOPES="none" "$script" --owner someuser --title "Test Project" \
+    >"$tmp/out" 2>&1 || fail "a token reporting no OAuth scopes must not be refused"
+grep -q "no OAuth scopes" "$tmp/out" ||
+    fail "expected the fine-grained-token notice, got: $(cat "$tmp/out")"
+grep -q "gh auth refresh" "$tmp/out" &&
+    fail "gh auth refresh cannot fix a fine-grained token"
+
 echo "==> a token WITH the project scope reconciles normally"
 printf '%s' "$complete" >"$STUB_FIELDS_FILE"
 : >"$STUB_FIELDS_FILE2"

--- a/scripts/test-setup-github-project.sh
+++ b/scripts/test-setup-github-project.sh
@@ -30,6 +30,13 @@ fail() {
 mkdir -p "$tmp/bin"
 cat >"$tmp/bin/gh" <<'STUB'
 #!/usr/bin/env bash
+# The scope preflight's probe. $STUB_SCOPES unset means "authenticated, but the
+# scope list could not be parsed" — the state every reconciliation case below
+# runs in, and one the preflight must not treat as a failure.
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+    [ -n "${STUB_SCOPES:-}" ] && echo "  - Token scopes: ${STUB_SCOPES}"
+    exit 0
+fi
 q=""
 for a in "$@"; do case "$a" in query=*) q="${a#query=}" ;; esac; done
 case "$q" in
@@ -200,5 +207,55 @@ case "$mut" in
 *'name:"raced-in"'*) : ;;
 *) fail "an option added between the snapshot and the write was deleted — the pre-write re-read is missing" ;;
 esac
+
+# ── Scope preflight ─────────────────────────────────────────────────────────
+# Without the 'project' scope the run fails either way — `gh api graphql` exits
+# non-zero on INSUFFICIENT_SCOPES and `set -e` takes the script with it. What is
+# being tested is that it fails BEFORE any API call and says what to do about
+# it, instead of surfacing a raw GraphQL error that names neither.
+
+# run_expecting_scope_failure SCOPES — run with that scope list, require a
+# non-zero exit, and echo the output.
+run_expecting_scope_failure() {
+    printf '%s' "$complete" >"$STUB_FIELDS_FILE"
+    : >"$STUB_FIELDS_FILE2"
+    rm -f "$tmp_seen"
+    : >"$MUTATIONS"
+    if STUB_SCOPES="$1" "$script" --owner someuser --title "Test Project" \
+        >"$tmp/out" 2>&1; then
+        fail "a token with scopes '$1' must not be accepted for board writes"
+    fi
+    cat "$tmp/out"
+}
+
+echo "==> a token without the project scope is refused, naming the remedy"
+out=$(run_expecting_scope_failure "'gist', 'read:org', 'repo'")
+case "$out" in
+*"gh auth refresh -s project"*) ;;
+*) fail "expected the refusal to name the remedy, got: $out" ;;
+esac
+[ "$(updates)" = 0 ] || fail "the preflight must refuse before any mutation"
+case "$out" in
+*"Resolving owner"*) fail "the preflight must refuse before the first API call" ;;
+esac
+
+echo "==> read-only 'read:project' is refused too — writes need the full scope"
+# Easy to mistake for sufficient: it reads a board perfectly well, and every
+# write below still fails.
+out=$(run_expecting_scope_failure "'gist', 'read:project', 'repo'")
+case "$out" in
+*"gh auth refresh -s project"*) ;;
+*) fail "read:project must be refused for writes, got: $out" ;;
+esac
+
+echo "==> a token WITH the project scope reconciles normally"
+printf '%s' "$complete" >"$STUB_FIELDS_FILE"
+: >"$STUB_FIELDS_FILE2"
+rm -f "$tmp_seen"
+: >"$MUTATIONS"
+STUB_SCOPES="'gist', 'project', 'repo'" "$script" --owner someuser \
+    --title "Test Project" >"$tmp/out" 2>&1 ||
+    fail "a token with the project scope must be accepted"
+[ "$(updates)" = 0 ] || fail "an already-synced project should still write nothing"
 
 echo "PASS: setup-github-project.sh field reconciliation"

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -101,6 +101,15 @@ make_stub() {
             echo '    fi'
             echo '    exit 0'
             ;;
+        env-token-no-scope)
+            # A classic PAT supplied through GH_TOKEN: it reports real scopes, so
+            # the scope verdict is correct — but `gh auth refresh` edits the
+            # stored credential, which this one overrides, so that remedy cannot
+            # work here.
+            echo '    echo "  X Failed to log in to github.com using token (GH_TOKEN)"'
+            echo "    echo \"  - Token scopes: 'gist', 'repo'\""
+            echo '    exit 0'
+            ;;
         other-host-has-scope)
             # Two hosts; only the unrelated one holds 'project'. A stub that
             # ignores --hostname proves the cross-host bug; this one honours it,
@@ -230,6 +239,17 @@ case "$out" in
 *"token has 'project'"*) fail "read the ACTIVE account's scopes, not every account's: ${out}" ;;
 *"lacks 'project'"*) ;;
 *) fail "expected the active account's missing scope to be reported, got: ${out}" ;;
+esac
+
+echo "==> an env-provided token gets a remedy that can actually work"
+# The scope verdict is right; only the fix differs. `gh auth refresh` edits the
+# stored credential, which GH_TOKEN overrides — so recommending it here would be
+# advice that silently changes nothing.
+out="$(run_gh_section env-token-no-scope)"
+case "$out" in
+*"gh auth refresh -s project"*) fail "gh auth refresh cannot change an env token: ${out}" ;;
+*"reissue GH_TOKEN"*) ;;
+*) fail "expected an env-token remedy, got: ${out}" ;;
 esac
 
 echo "==> another host's scopes cannot answer for the targeted one"

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -38,9 +38,18 @@ done
 mkdir -p "${TMP}/skills-only/.claude/skills/track-work/assets"
 : >"${TMP}/skills-only/.claude/skills/track-work/assets/set-issue-status.sh"
 
+# A board repo whose remote is a GitHub Enterprise host, and which exports no
+# GH_HOST — the case where forcing github.com disowns a valid login.
+mkdir -p "${TMP}/enterprise/scripts"
+cp "${status}" "${TMP}/enterprise/scripts/status.sh"
+: >"${TMP}/enterprise/scripts/setup-github-project.sh"
+git -C "${TMP}/enterprise" init -q
+git -C "${TMP}/enterprise" remote add origin git@ghe.example.com:owner/repo.git
+
 WITH_BOARD="${TMP}/with-board/scripts/status.sh"
 NO_BOARD="${TMP}/no-board/scripts/status.sh"
 SKILLS_ONLY="${TMP}/skills-only/scripts/status.sh"
+ENTERPRISE="${TMP}/enterprise/scripts/status.sh"
 
 fail() {
     echo "TEST FAIL: $*" >&2
@@ -115,6 +124,20 @@ make_stub() {
             # environment. Same override problem as GH_TOKEN, different name.
             echo '    echo "  X Failed to log in using token (GH_ENTERPRISE_TOKEN)"'
             echo "    echo \"  - Token scopes: 'gist', 'repo'\""
+            echo '    exit 0'
+            ;;
+        records-hostname)
+            # Records the --hostname it was handed, and only authenticates for
+            # the Enterprise host — so forcing github.com fails the probe and
+            # takes the whole section down, exactly as the real gh would.
+            echo '    host=""; prev=""'
+            echo '    for a in "$@"; do case "$prev" in --hostname) host="$a" ;; esac; prev="$a"; done'
+            echo '    echo "$host" >>"$STUB_HOSTS"'
+            echo '    if [ "$host" != "ghe.example.com" ]; then'
+            echo '        echo "You are not logged into any GitHub hosts." >&2'
+            echo '        exit 1'
+            echo '    fi'
+            echo "    echo \"  - Token scopes: 'gist', 'project', 'repo'\""
             echo '    exit 0'
             ;;
         other-host-has-scope)
@@ -267,6 +290,33 @@ case "$out" in
 *"reissue GH_ENTERPRISE_TOKEN"*) ;;
 *) fail "expected the Enterprise env-token remedy, got: ${out}" ;;
 esac
+
+echo "==> the auth host comes from the repository, not a github.com assumption"
+# A GHES repo with no GH_HOST exported. Forcing github.com would fail the probe,
+# which this script reads as "not authenticated" — losing the PR list, the CI
+# list, and the board-writes line all at once, while `gh pr list` would have
+# worked fine against that remote.
+STUB_HOSTS="${TMP}/hosts.txt"
+export STUB_HOSTS
+: >"${STUB_HOSTS}"
+out="$(run_gh_section records-hostname "${ENTERPRISE}")"
+grep -qx 'ghe.example.com' "${STUB_HOSTS}" ||
+    fail "probe used $(tr '\n' ' ' <"${STUB_HOSTS}") — expected the remote's host"
+case "$out" in
+*"not authenticated"*) fail "a valid Enterprise login must not read as unauthenticated: ${out}" ;;
+*"token has 'project'"*) ;;
+*) fail "expected the Enterprise section to render, got: ${out}" ;;
+esac
+
+echo "==> GH_HOST still overrides the repository's remote"
+: >"${STUB_HOSTS}"
+out="$(
+    make_stub records-hostname
+    PATH="${TMP}/bin:${PATH}" NO_COLOR=1 \
+        GH_HOST=ghe.example.com "${WITH_BOARD}" gh 2>&1
+)"
+grep -qx 'ghe.example.com' "${STUB_HOSTS}" ||
+    fail "GH_HOST must win over the remote, got: $(tr '\n' ' ' <"${STUB_HOSTS}")"
 
 echo "==> another host's scopes cannot answer for the targeted one"
 # The scopes of an account on an unrelated host say nothing about the API calls

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -303,6 +303,23 @@ else
     echo "    (skipped: no timeout binary — the probe is unbounded here)"
 fi
 
+echo "==> status:setup distinguishes a timeout from a missing login too"
+# The setup section shares the one auth probe, so it inherits the probe's
+# distinctions or silently loses them: on a deadline it must not tell an
+# authenticated user to run `gh auth login`. Reachable hermetically because this
+# gate precedes every other gh call in that section.
+if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
+    make_stub hangs
+    out="$(PATH="${TMP}/bin:${PATH}" NO_COLOR=1 NETWORK_TIMEOUT=1 "${WITH_BOARD}" setup 2>&1)"
+    case "$out" in
+    *"gh auth login"*) fail "a timeout must not be reported as a missing login: ${out}" ;;
+    *"timed out"*) ;;
+    *) fail "expected a timeout notice from status:setup, got: ${out}" ;;
+    esac
+else
+    echo "    (skipped: no timeout binary — the probe is unbounded here)"
+fi
+
 echo "==> no user-facing message hardcodes the refresh remedy"
 # The remedy is derived from the credential source once, because `gh auth refresh`
 # is wrong for an env-provided or fine-grained token. Every message must use that

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -110,6 +110,13 @@ make_stub() {
             echo "    echo \"  - Token scopes: 'gist', 'repo'\""
             echo '    exit 0'
             ;;
+        enterprise-env-token)
+            # GH_ENTERPRISE_TOKEN is how gh authenticates against GHES from the
+            # environment. Same override problem as GH_TOKEN, different name.
+            echo '    echo "  X Failed to log in using token (GH_ENTERPRISE_TOKEN)"'
+            echo "    echo \"  - Token scopes: 'gist', 'repo'\""
+            echo '    exit 0'
+            ;;
         other-host-has-scope)
             # Two hosts; only the unrelated one holds 'project'. A stub that
             # ignores --hostname proves the cross-host bug; this one honours it,
@@ -252,6 +259,15 @@ case "$out" in
 *) fail "expected an env-token remedy, got: ${out}" ;;
 esac
 
+echo "==> an Enterprise env token gets the same treatment as GH_TOKEN"
+# The override problem is a property of environment tokens, not of github.com.
+out="$(run_gh_section enterprise-env-token)"
+case "$out" in
+*"gh auth refresh -s project"*) fail "gh auth refresh cannot change an env token: ${out}" ;;
+*"reissue GH_ENTERPRISE_TOKEN"*) ;;
+*) fail "expected the Enterprise env-token remedy, got: ${out}" ;;
+esac
+
 echo "==> another host's scopes cannot answer for the targeted one"
 # The scopes of an account on an unrelated host say nothing about the API calls
 # this repo makes.
@@ -286,6 +302,24 @@ if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; th
 else
     echo "    (skipped: no timeout binary — the probe is unbounded here)"
 fi
+
+echo "==> no user-facing message hardcodes the refresh remedy"
+# The remedy is derived from the credential source once, because `gh auth refresh`
+# is wrong for an env-provided or fine-grained token. Every message must use that
+# derivation — a hardcoded copy is how one call site silently drifts back to
+# advice that cannot work, and the setup section (which needs live GitHub data to
+# render) cannot be driven by the stub above. So assert it statically instead:
+# the literal may appear only in a comment or in the derivation itself.
+while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in
+    *"#"*"gh auth refresh"*) continue ;; # a comment explaining the rule
+    *GH_REMEDY=*) continue ;;            # the derivation itself
+    *) fail "hardcoded refresh remedy — use \${GH_REMEDY}: ${line}" ;;
+    esac
+done <<EOF
+$(grep -n 'gh auth refresh' "${status}" || true)
+EOF
 
 echo "==> the session-start hook allows more time than this section can spend"
 # A coupling that rots silently, and whose failure is total rather than partial:

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# test-status.sh — unit-test status.sh's "Project board writes" check: the token
+# scope the claim lifecycle needs is reported from the section that session-start
+# orientation actually runs (`task status:gh`), in every scope state. Run via
+# `task test:status`.
+#
+# Hermetic in two directions:
+#
+#   * every `gh` call is answered by a stub on PATH, so this makes no network
+#     requests and cannot depend on the scopes of the developer's own token —
+#     which is the whole point. The bug it guards (a claim that silently no-ops
+#     on a token without the scope) is INVISIBLE when tested with a token that
+#     has it.
+#   * the checks run against fixture roots this script builds, never against the
+#     repo it lives in. status.sh resolves its own root from BASH_SOURCE and
+#     feature-detects the board tooling from it, so a test that used the host
+#     repo would assert one profile's layout and fail in every other — a repo
+#     generated with `project_management: none` correctly omits the check.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+status="./scripts/status.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+# Two fixture roots, each holding a copy of the script under test:
+#   with-board — has the board tooling, so the check applies
+#   no-board   — has none of it, so the check must not render at all
+for fixture in with-board no-board; do
+    mkdir -p "${TMP}/${fixture}/scripts"
+    cp "${status}" "${TMP}/${fixture}/scripts/status.sh"
+done
+# The marker status.sh feature-detects on. Contents are never read.
+: >"${TMP}/with-board/scripts/setup-github-project.sh"
+
+WITH_BOARD="${TMP}/with-board/scripts/status.sh"
+NO_BOARD="${TMP}/no-board/scripts/status.sh"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+# make_stub SCENARIO — write $TMP/bin/gh answering `auth status` per SCENARIO.
+# Every other gh call returns an empty JSON array: status.sh reads pr/run lists
+# through jq, and a stub that failed them would exercise the wrong code path.
+# An unrecognized call exits non-zero rather than defaulting to success, so a
+# future probe added to this section shows up here instead of passing silently.
+make_stub() {
+    local scenario="$1"
+    mkdir -p "${TMP}/bin"
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then'
+        case "$scenario" in
+        project)
+            echo "    echo \"  - Token scopes: 'gist', 'project', 'repo'\""
+            echo '    exit 0'
+            ;;
+        read-only)
+            echo "    echo \"  - Token scopes: 'gist', 'read:project', 'repo'\""
+            echo '    exit 0'
+            ;;
+        none)
+            echo "    echo \"  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'\""
+            echo '    exit 0'
+            ;;
+        unparseable)
+            # Authenticated, but the scopes are not reported in the form we
+            # parse — a GitHub App installation token, or a future gh that
+            # renames the line. Must read as "unknown", never as satisfied.
+            echo '    echo "  x Logged in to github.com"'
+            echo '    exit 0'
+            ;;
+        unauthenticated)
+            echo '    echo "You are not logged into any GitHub hosts." >&2'
+            echo '    exit 1'
+            ;;
+        hangs)
+            # Outlives the probe's deadline. Driven with NETWORK_TIMEOUT=1 so
+            # the case costs a second rather than the default five.
+            echo '    sleep 30'
+            echo '    exit 0'
+            ;;
+        *) fail "unknown stub scenario: ${scenario}" ;;
+        esac
+        echo 'fi'
+        echo 'case "$*" in'
+        echo '*"pr list"* | *"run list"*) echo "[]" ;;'
+        echo '*) echo "stub: unexpected gh call: $*" >&2; exit 1 ;;'
+        echo 'esac'
+    } >"${TMP}/bin/gh"
+    chmod +x "${TMP}/bin/gh"
+}
+
+# run_gh_section SCENARIO [SCRIPT] — status.sh's gh section, with the stub on
+# PATH. SCRIPT defaults to the with-board fixture. NO_COLOR keeps the assertions
+# free of ANSI escapes.
+run_gh_section() {
+    make_stub "$1"
+    local script="${2:-${WITH_BOARD}}"
+    PATH="${TMP}/bin:${PATH}" NO_COLOR=1 "${script}" gh 2>&1
+}
+
+echo "==> a token with 'project' reports the board as writable"
+out="$(run_gh_section project)"
+case "$out" in
+*"Project board writes"*"token has 'project'"*) ;;
+*) fail "expected a satisfied board-writes line, got: ${out}" ;;
+esac
+
+echo "==> read-only 'read:project' is NOT reported as satisfied"
+# The state most easily mistaken for working: --show reads the card fine, so the
+# board looks reachable right up to the write that moves it.
+out="$(run_gh_section read-only)"
+case "$out" in
+*"token has 'project'"*) fail "read:project must not satisfy a WRITE check: ${out}" ;;
+*"read-only"*"gh auth refresh -s project"*) ;;
+*) fail "expected a read-only warning naming the remedy, got: ${out}" ;;
+esac
+
+echo "==> a token with neither scope warns and names the remedy"
+out="$(run_gh_section none)"
+case "$out" in
+*"lacks 'project'"*"gh auth refresh -s project"*) ;;
+*) fail "expected a missing-scope warning naming the remedy, got: ${out}" ;;
+esac
+
+echo "==> unreadable scopes read as unknown, not as satisfied"
+out="$(run_gh_section unparseable)"
+case "$out" in
+*"token has 'project'"*) fail "an unparseable scope list must not pass: ${out}" ;;
+*"could not read token scopes"*) ;;
+*) fail "expected an unknown-scopes line, got: ${out}" ;;
+esac
+
+echo "==> an unauthenticated gh skips the section without erroring"
+out="$(run_gh_section unauthenticated)"
+case "$out" in
+*"not authenticated"*) ;;
+*) fail "expected the unauthenticated skip, got: ${out}" ;;
+esac
+case "$out" in
+*"Project board writes"*) fail "board-writes line rendered without auth: ${out}" ;;
+esac
+
+echo "==> a repo with no project tooling omits the check entirely"
+# Not-applicable is not the same as fine: a repo generated with
+# `project_management: none` has no board to write to, and a warning there would
+# be noise the reader cannot act on.
+out="$(run_gh_section project "${NO_BOARD}")"
+case "$out" in
+*"Project board writes"*) fail "board-writes line rendered in a repo with no board tooling: ${out}" ;;
+esac
+
+echo "==> a probe that outlives its deadline says so, not 'not authenticated'"
+# Bounding the auth probe made a slow network look exactly like a missing login.
+# Reporting the latter for the former sends the reader to fix the wrong thing.
+# Skipped where no `timeout` binary exists (stock macOS): run_timeout then runs
+# the probe unbounded by design, and there is no deadline to hit.
+if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
+    make_stub hangs
+    out="$(PATH="${TMP}/bin:${PATH}" NO_COLOR=1 NETWORK_TIMEOUT=1 "${WITH_BOARD}" gh 2>&1)"
+    case "$out" in
+    *"timed out"*) ;;
+    *"not authenticated"*) fail "a timeout must not be reported as missing auth: ${out}" ;;
+    *) fail "expected a timeout notice, got: ${out}" ;;
+    esac
+else
+    echo "    (skipped: no timeout binary — the probe is unbounded here)"
+fi
+
+echo "==> the check never runs the setup section's Projects query"
+# The line is fed by the auth probe the section already makes. If it ever grows a
+# GraphQL call, the network cost lands in every session start — the reason the
+# setup section is excluded from the default dashboard in the first place.
+out="$(run_gh_section project)"
+case "$out" in
+*"stub: unexpected gh call"*) fail "the gh section made an unstubbed call: ${out}" ;;
+esac
+
+echo "status.sh tests passed"

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -101,6 +101,19 @@ make_stub() {
             echo '    fi'
             echo '    exit 0'
             ;;
+        other-host-has-scope)
+            # Two hosts; only the unrelated one holds 'project'. A stub that
+            # ignores --hostname proves the cross-host bug; this one honours it,
+            # so the check must read the targeted host's line only.
+            echo "    host=\"\"; prev=\"\""
+            echo '    for a in "$@"; do case "$prev" in --hostname) host="$a" ;; esac; prev="$a"; done'
+            echo '    if [ "$host" = "github.com" ]; then'
+            echo "        echo \"  - Token scopes: 'gist', 'repo'\""
+            echo '    else'
+            echo "        echo \"  - Token scopes: 'gist', 'project', 'repo'\""
+            echo '    fi'
+            echo '    exit 0'
+            ;;
         no-active-flag)
             # gh predates --active (pre-2.40): the flag is a usage error, which
             # must not read as a failed login.
@@ -219,6 +232,16 @@ case "$out" in
 *) fail "expected the active account's missing scope to be reported, got: ${out}" ;;
 esac
 
+echo "==> another host's scopes cannot answer for the targeted one"
+# The scopes of an account on an unrelated host say nothing about the API calls
+# this repo makes.
+out="$(run_gh_section other-host-has-scope)"
+case "$out" in
+*"token has 'project'"*) fail "read the targeted host's scopes, not every host's: ${out}" ;;
+*"lacks 'project'"*) ;;
+*) fail "expected the targeted host's missing scope to be reported, got: ${out}" ;;
+esac
+
 echo "==> gh without --active falls back instead of reading as unauthenticated"
 out="$(run_gh_section no-active-flag)"
 case "$out" in
@@ -242,6 +265,26 @@ if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; th
     esac
 else
     echo "    (skipped: no timeout binary — the probe is unbounded here)"
+fi
+
+echo "==> the session-start hook allows more time than this section can spend"
+# A coupling that rots silently, and whose failure is total rather than partial:
+# status.sh buffers each section before printing it (section_box reads all of its
+# input first), so an outer deadline that fires mid-section discards everything
+# the section was about to report — including the board-writes line. The section
+# spends up to NETWORK_TIMEOUT on the auth probe and then up to NETWORK_TIMEOUT
+# again on the PR/run probes, so the hook must allow more than twice the probe
+# budget. Skipped where the hook is not generated (no devcontainer).
+hook=".devcontainer/config/claude-hooks/session-start-context.sh"
+if [ -f "$hook" ]; then
+    budget="$(sed -n -E 's/.*timeout ([0-9]+) task status:gh.*/\1/p' "$hook")"
+    probe="$(sed -n -E 's/^NETWORK_TIMEOUT="\$\{NETWORK_TIMEOUT:-([0-9]+)\}"$/\1/p' "${status}")"
+    [ -n "$budget" ] || fail "could not read the status:gh timeout out of ${hook}"
+    [ -n "$probe" ] || fail "could not read NETWORK_TIMEOUT out of ${status}"
+    [ "$budget" -gt "$((probe * 2))" ] ||
+        fail "hook allows ${budget}s but the section can spend $((probe * 2))s on probes alone — the board-writes line is lost first"
+else
+    echo "    (skipped: no devcontainer hook in this profile)"
 fi
 
 echo "==> the check never runs the setup section's Projects query"

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -23,18 +23,24 @@ status="./scripts/status.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "${TMP}"' EXIT
 
-# Two fixture roots, each holding a copy of the script under test:
-#   with-board — has the board tooling, so the check applies
-#   no-board   — has none of it, so the check must not render at all
-for fixture in with-board no-board; do
+# Three fixture roots, each holding a copy of the script under test:
+#   with-board  — has the board tooling, so the check applies
+#   no-board    — has none of it, so the check must not render at all
+#   skills-only — the DEFAULT generated profile: `project_management: none` with
+#                 `use_skills_sync: true`, so the vendored universal skill set
+#                 (track-work included) is present but there is no board
+for fixture in with-board no-board skills-only; do
     mkdir -p "${TMP}/${fixture}/scripts"
     cp "${status}" "${TMP}/${fixture}/scripts/status.sh"
 done
-# The marker status.sh feature-detects on. Contents are never read.
+# The markers status.sh feature-detects on. Contents are never read.
 : >"${TMP}/with-board/scripts/setup-github-project.sh"
+mkdir -p "${TMP}/skills-only/.claude/skills/track-work/assets"
+: >"${TMP}/skills-only/.claude/skills/track-work/assets/set-issue-status.sh"
 
 WITH_BOARD="${TMP}/with-board/scripts/status.sh"
 NO_BOARD="${TMP}/no-board/scripts/status.sh"
+SKILLS_ONLY="${TMP}/skills-only/scripts/status.sh"
 
 fail() {
     echo "TEST FAIL: $*" >&2
@@ -75,6 +81,35 @@ make_stub() {
         unauthenticated)
             echo '    echo "You are not logged into any GitHub hosts." >&2'
             echo '    exit 1'
+            ;;
+        fine-grained)
+            # A fine-grained PAT or App token: permissions, not OAuth scopes, so
+            # gh reports the line with nothing in it.
+            echo '    echo "  - Token scopes: none"'
+            echo '    exit 0'
+            ;;
+        inactive-has-scope)
+            # Two accounts on one host; only the INACTIVE one holds 'project'.
+            # A stub that ignores --active proves the aggregate-read bug; this
+            # one honours it, so the check must read the active account's line.
+            echo '    if [ "$3" = "--active" ]; then'
+            echo "        echo \"  - Active account: true\""
+            echo "        echo \"  - Token scopes: 'gist', 'repo'\""
+            echo '    else'
+            echo "        echo \"  - Token scopes: 'gist', 'repo'\""
+            echo "        echo \"  - Token scopes: 'gist', 'project', 'repo'\""
+            echo '    fi'
+            echo '    exit 0'
+            ;;
+        no-active-flag)
+            # gh predates --active (pre-2.40): the flag is a usage error, which
+            # must not read as a failed login.
+            echo '    if [ "$3" = "--active" ]; then'
+            echo '        echo "unknown flag: --active" >&2'
+            echo '        exit 1'
+            echo '    fi'
+            echo "    echo \"  - Token scopes: 'gist', 'project', 'repo'\""
+            echo '    exit 0'
             ;;
         hangs)
             # Outlives the probe's deadline. Driven with NETWORK_TIMEOUT=1 so
@@ -151,6 +186,45 @@ echo "==> a repo with no project tooling omits the check entirely"
 out="$(run_gh_section project "${NO_BOARD}")"
 case "$out" in
 *"Project board writes"*) fail "board-writes line rendered in a repo with no board tooling: ${out}" ;;
+esac
+
+echo "==> the vendored track-work skill alone does NOT trigger the check"
+# The default generated profile: `project_management: none` (the default) with
+# `use_skills_sync: true` vendors the universal skill set, so keying the check on
+# track-work's presence would demand the `project` scope from every repo that
+# merely completed the documented skills-sync step.
+out="$(run_gh_section none "${SKILLS_ONLY}")"
+case "$out" in
+*"Project board writes"*) fail "the skill's presence must not imply a board: ${out}" ;;
+esac
+
+echo "==> a fine-grained/App token reads as unknown, with the right remedy"
+# Its Projects access is a permission, not a scope, so it may well be able to
+# write — and `gh auth refresh` cannot change it either way.
+out="$(run_gh_section fine-grained)"
+case "$out" in
+*"lacks 'project'"*) fail "a scope-less token must not be reported as lacking a scope: ${out}" ;;
+*"no OAuth scopes reported"*) ;;
+*) fail "expected the fine-grained-token notice, got: ${out}" ;;
+esac
+case "$out" in
+*"gh auth refresh"*) fail "gh auth refresh cannot fix a fine-grained token: ${out}" ;;
+esac
+
+echo "==> an inactive account's scopes cannot answer for the active one"
+out="$(run_gh_section inactive-has-scope)"
+case "$out" in
+*"token has 'project'"*) fail "read the ACTIVE account's scopes, not every account's: ${out}" ;;
+*"lacks 'project'"*) ;;
+*) fail "expected the active account's missing scope to be reported, got: ${out}" ;;
+esac
+
+echo "==> gh without --active falls back instead of reading as unauthenticated"
+out="$(run_gh_section no-active-flag)"
+case "$out" in
+*"not authenticated"*) fail "a usage error must not read as a failed login: ${out}" ;;
+*"token has 'project'"*) ;;
+*) fail "expected the fallback to read the full report, got: ${out}" ;;
 esac
 
 echo "==> a probe that outlives its deadline says so, not 'not authenticated'"

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -53,8 +53,15 @@ jobs:
       - run: task test:codex-review
 [% endif %]
       - run: task test:ci-results
+      - run: task test:status
 [% if use_release_please %]
       - run: task test:release-title
+[% endif %]
+[% if project_management == 'github' %]
+      - run: task test:setup-github-project
+[% endif %]
+[% if project_management == 'github' and github_org != author_git_provider_username %]
+      - run: task test:setup-github-issue-fields
 [% endif %]
 [% if use_foreman %]
       - run: task foreman:test

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -104,6 +104,7 @@ tasks:
       - task: validate
       - task: test:tasks
       - task: test:ci-results
+      - task: test:status
 [% if use_codex_review %]
       - task: test:codex-review
 [% endif %]
@@ -629,6 +630,11 @@ tasks:
     desc: Unit-test the fail-closed CI aggregate result helper
     cmds:
       - ./scripts/test-ci-results.sh
+
+  test:status:
+    desc: Unit-test the status board-writes scope check (stubbed gh, no network)
+    cmds:
+      - ./scripts/test-status.sh
 [% if use_codex_review %]
 
   test:codex-review:

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-hooks/session-start-context.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-hooks/session-start-context.sh
@@ -15,8 +15,14 @@ cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
 # Strip ANSI color codes so the additionalContext payload renders cleanly.
 strip_ansi() { sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'; }
 
+# The outer deadlines must exceed what the sections themselves allow, or the
+# inner bounds are pointless: whatever the section was about to report is lost
+# wholesale, because status.sh buffers each section before printing it. status:gh
+# spends up to NETWORK_TIMEOUT (5s) on the auth probe and then up to another 5s
+# on the PR/run probes it launches in parallel — 10s worst case, so 12 here.
+# status:git makes no network calls at all.
 git_status="$(timeout 5 task status:git 2>/dev/null | strip_ansi || echo '(task status:git unavailable)')"
-gh_status="$(timeout 8 task status:gh 2>/dev/null | strip_ansi || echo '(task status:gh unavailable)')"
+gh_status="$(timeout 12 task status:gh 2>/dev/null | strip_ansi || echo '(task status:gh unavailable)')"
 branch="$(git branch --show-current 2>/dev/null || echo 'unknown')"
 
 reminder=$'Repo conventions:\n- Run `task verify` before committing (lint + build + validate + test).\n- Conventional Commits required (feat/fix/docs/style/refactor/perf/test/chore/ci/build/change/remove/revert).\n- Never bypass git hooks with --no-verify; fix the underlying issue.\n- Use lefthook for git hooks (not pre-commit).\n- See docs/conventions.md (and AGENTS.md) for the authoritative conventions catalog.'

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -12,6 +12,44 @@ Every repo the owner controls feeds that one board; an issue can belong to
 multiple projects, but this default board is its home. Reach for a second,
 focused project only when a body of work needs its own.
 
+## Token scopes
+
+Everything on this page that touches the board — `task setup:github-project`,
+and the `Status` writes the [claim lifecycle](#claiming--making-an-agents-work-visible-while-it-happens)
+makes — goes through the Projects V2 API, and `gh auth login` does **not** grant
+access to it by default. Nothing else notices: the same token still reads
+issues, opens PRs, and drives CI perfectly well, so the gap shows up only as
+board writes that do nothing.
+
+| Scope | Grants | Enough for |
+|---|---|---|
+| *(neither)* | — | nothing here — every board read and write fails |
+| `read:project` | read Projects | reading a card's current `Status`; **no writes** |
+| `project` | read **and write** Projects | everything on this page |
+
+Ask for the full scope. It is a superset, so there is no reason to request
+`read:project` alongside it:
+
+```sh
+gh auth refresh -s project
+```
+
+Check what a token actually carries:
+
+```sh
+gh auth status | grep 'Token scopes'
+```
+
+`task status:gh` reports this as **Project board writes**, so a missing scope
+surfaces at session start — before a claim is made against a board that cannot
+receive it. `task setup:github-project` refuses to run without it rather than
+failing partway through its writes.
+
+Two adjacent scopes, for completeness: an organization's **issue types** need
+`admin:org` (reported by `task status:setup`), and the vendored claim skills
+hint at `gh auth refresh -s read:project,project` — equivalent for this purpose,
+since `project` alone already covers it.
+
 ## Status pipeline
 
 `Status` is a single-select field with exactly one meaning: **where in the flow
@@ -349,6 +387,18 @@ both owner types.
 These labels ship with `task setup:github-labels`, which is generated only for
 `project_management: github`. A repo on `none` or `linear` gets no label
 families at all, so a claim there rests on the assignee and the claim comment.
+
+**A board write can fail without anyone learning.** Every `Status` write in the
+lifecycle needs the [`project` scope](#token-scopes). Without it each one exits
+2 — "could not verify" — and the steps handle that correctly *individually*:
+it is an auth condition they cannot fix, so they note it and carry on. In
+aggregate that is the worst outcome available. The agent reports the issue
+claimed, the board says nothing was ever started, and neither is wrong from
+where it stands; the hand-back then cannot restore a prior status it was never
+able to read. Nothing in the loop escalates, so the board silently stops
+tracking agent work in **both** directions until a human happens to notice it
+has gone stale. Check the scope at session start (`task status:gh`), not after
+the claim.
 
 **A claim is a signal, not a lock.** None of these writes is atomic, and two
 sessions running as the same GitHub user are invisible to each other — the

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -60,25 +60,37 @@ one, so `task status:gh` can only report the check as **unknown**, and
 `gh auth refresh` cannot help — a token supplied through the environment as
 `GH_TOKEN` cannot be refreshed at all. Grant it **Projects: Read and write** at
 the source (organization permissions, for an org-owned board) instead.
-[% if devcontainer %]
+[% if devcontainer and github_org != author_git_provider_username %]
 That matters here because the bot credential this template documents is exactly
 such a token — and [bot-account.md](guides/bot-account.md) deliberately grants
 it **`Projects: Read-only`**. So an agent running as the bot **cannot move a
 card**, by design, however the scope check reports. Two honest ways to live with
 that, both a decision rather than a default:
 
-- **Leave it read-only** and accept that cards are moved by humans — and, on an
-  organization, by `project-automation.yml` from PR and CI events — not by the
-  claim. The `agent:*` label and the assignee still make the claim visible; see
+- **Leave it read-only** and accept that cards are moved by humans and by
+  `project-automation.yml` from PR and CI events, not by the claim. The
+  `agent:*` label and the assignee still make the claim visible; see
   [Claiming](#claiming--making-an-agents-work-visible-while-it-happens), which
   is exactly why a claim writes all three signals instead of relying on the
   board alone.
 - **Grant the bot `Projects: Read and write`** if you want claims to move cards,
-  understanding that org permissions are not bounded by the token's repository
-  list — that grant reaches every board the owner has.
+  understanding that organization permissions are not bounded by the token's
+  repository list — that grant reaches every board the owner has.
 
 Nothing here picks for you, and the status check does not treat a read-only bot
 as broken; it reports what the credential can do.
+[% elif devcontainer %]
+The bot credential this template documents ([bot-account.md](guides/bot-account.md))
+is exactly such a token. On a personal account it is granted no Projects
+permission at all — that row of the PAT table is organization-scoped, and a
+user-owned board has no equivalent setting to hand a second account. So an agent
+running as the bot **cannot move a card**, and there is no permission to raise:
+the board is moved by you, while the claim stays visible through the `agent:*`
+label and the assignee — see
+[Claiming](#claiming--making-an-agents-work-visible-while-it-happens), which is
+exactly why a claim writes all three signals instead of relying on the board
+alone. To have claims move cards on a personal board, run the agent under your
+own `gh` login (which the scope table above applies to) rather than the bot's.
 [% endif %]
 
 ## Status pipeline

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -50,6 +50,37 @@ Two adjacent scopes, for completeness: an organization's **issue types** need
 hint at `gh auth refresh -s read:project,project` — equivalent for this purpose,
 since `project` alone already covers it.
 
+### Scopes are only half the story
+
+The table above is about **classic OAuth scopes**, which is what `gh auth login`
+issues and `gh auth refresh` edits. A **fine-grained PAT** or a GitHub App
+installation token has none of them: its Projects access is a *permission*
+granted where the token was issued. `gh auth status` reports no scope list for
+one, so `task status:gh` can only report the check as **unknown**, and
+`gh auth refresh` cannot help — a token supplied through the environment as
+`GH_TOKEN` cannot be refreshed at all. Grant it **Projects: Read and write** at
+the source (organization permissions, for an org-owned board) instead.
+[% if devcontainer %]
+That matters here because the bot credential this template documents is exactly
+such a token — and [bot-account.md](guides/bot-account.md) deliberately grants
+it **`Projects: Read-only`**. So an agent running as the bot **cannot move a
+card**, by design, however the scope check reports. Two honest ways to live with
+that, both a decision rather than a default:
+
+- **Leave it read-only** and accept that cards are moved by humans — and, on an
+  organization, by `project-automation.yml` from PR and CI events — not by the
+  claim. The `agent:*` label and the assignee still make the claim visible; see
+  [Claiming](#claiming--making-an-agents-work-visible-while-it-happens), which
+  is exactly why a claim writes all three signals instead of relying on the
+  board alone.
+- **Grant the bot `Projects: Read and write`** if you want claims to move cards,
+  understanding that org permissions are not bounded by the token's repository
+  list — that grant reaches every board the owner has.
+
+Nothing here picks for you, and the status check does not treat a read-only bot
+as broken; it reports what the credential can do.
+[% endif %]
+
 ## Status pipeline
 
 `Status` is a single-select field with exactly one meaning: **where in the flow

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -85,17 +85,27 @@ case "$scopes_line" in
     ;;
 *"'project'"*) ;;
 *"'"*)
-    cat >&2 <<'SCOPE_ERR'
-This token cannot write GitHub Projects: 'gh auth status' reports no 'project' scope.
-
-Every write below (the board, its Status pipeline, the Size field) would fail on
-the first API call. Fix it, then re-run:
-
-    gh auth refresh -s project
-
-Note that read-only 'read:project' is enough to *see* a board but not to create
-or reconcile one, so this script requires the full 'project' scope.
-SCOPE_ERR
+    # `gh auth refresh` edits the STORED credential, which an env-provided token
+    # overrides — so that remedy is unusable for anyone running on GH_TOKEN or
+    # GITHUB_TOKEN. gh names the source in its report; use it.
+    remedy="    gh auth refresh -s project"
+    case "$auth_report" in
+    *"(GH_TOKEN)"*)
+        remedy="    Reissue the token in GH_TOKEN with the 'project' scope.
+    (gh auth refresh cannot help: the environment token overrides the stored one.)"
+        ;;
+    *"(GITHUB_TOKEN)"*)
+        remedy="    Reissue the token in GITHUB_TOKEN with the 'project' scope.
+    (gh auth refresh cannot help: the environment token overrides the stored one.)"
+        ;;
+    esac
+    printf '%s\n\n%s\n\n%s\n\n%s\n' \
+        "This token cannot write GitHub Projects: 'gh auth status' reports no 'project' scope." \
+        "Every write below (the board, its Status pipeline, the Size field) would fail on
+the first API call. Fix it, then re-run:" \
+        "$remedy" \
+        "Note that read-only 'read:project' is enough to *see* a board but not to create
+or reconcile one, so this script requires the full 'project' scope." >&2
     exit 1
     ;;
 *)

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -73,7 +73,27 @@ done
 # targets GH_HOST or github.com). Older gh (pre-2.40) has no --active — fall back
 # rather than read a usage error as a missing scope; multi-account per host
 # arrived with 2.40, so one host there already means one account.
-gh_host="${GH_HOST:-github.com}"
+# The host this run will target. GH_HOST is gh's override for when a host cannot
+# be determined from repository context, so context comes first when it is unset —
+# forcing github.com would narrow the probe to a host the API calls below do not
+# use, and reject a valid Enterprise login over it.
+gh_host="${GH_HOST:-}"
+if [ -z "$gh_host" ]; then
+    remote_url="$(git config --get remote.origin.url 2>/dev/null || true)"
+    case "$remote_url" in
+    *://*)
+        gh_host="${remote_url#*://}"
+        gh_host="${gh_host#*@}"
+        gh_host="${gh_host%%/*}"
+        gh_host="${gh_host%%:*}"
+        ;;
+    *@*:*)
+        gh_host="${remote_url#*@}"
+        gh_host="${gh_host%%:*}"
+        ;;
+    esac
+fi
+gh_host="${gh_host:-github.com}"
 auth_report="$(gh auth status --active --hostname "$gh_host" 2>&1 || true)"
 case "$auth_report" in
 *"unknown flag"*) auth_report="$(gh auth status --hostname "$gh_host" 2>&1 || true)" ;;

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -66,14 +66,21 @@ done
 # installation token, a future `gh` output change) may still be perfectly able
 # to do the work, and refusing to run would be a worse failure than the one
 # this guard replaces.
-auth_report="$(gh auth status 2>&1 || true)"
+# --active: `gh auth status` reports every known account, and an inactive one
+# holding 'project' must not answer for the credential this run will use. Older
+# gh (pre-2.40) has no such flag — fall back rather than read a usage error as a
+# missing scope.
+auth_report="$(gh auth status --active 2>&1 || true)"
+case "$auth_report" in
+*"unknown flag"*) auth_report="$(gh auth status 2>&1 || true)" ;;
+esac
 scopes_line="$(printf '%s\n' "$auth_report" | grep -i 'token scopes:' || true)"
 case "$scopes_line" in
 "")
     echo "==> Could not read token scopes from 'gh auth status' — continuing; a scope error below means: gh auth refresh -s project" >&2
     ;;
 *"'project'"*) ;;
-*)
+*"'"*)
     cat >&2 <<'SCOPE_ERR'
 This token cannot write GitHub Projects: 'gh auth status' reports no 'project' scope.
 
@@ -86,6 +93,15 @@ Note that read-only 'read:project' is enough to *see* a board but not to create
 or reconcile one, so this script requires the full 'project' scope.
 SCOPE_ERR
     exit 1
+    ;;
+*)
+    # A scopes line with no scopes in it: a fine-grained PAT or an App
+    # installation token, whose Projects access is a permission granted where
+    # the token was issued rather than an OAuth scope. Such a token may be
+    # perfectly able to do this work, and `gh auth refresh` cannot change it
+    # (an env-provided GH_TOKEN cannot be refreshed at all) — so refusing here
+    # would block a capable credential over a naming mismatch.
+    echo "==> Token reports no OAuth scopes (fine-grained or App token) — continuing; if a write below fails, grant it 'Projects: Read and write' where the token was issued" >&2
     ;;
 esac
 

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -55,6 +55,40 @@ for tool in gh jq; do
     fi
 done
 
+# ── Scope preflight ─────────────────────────────────────────────────────────
+# Every mutation below needs the 'project' scope, which `gh auth login` does not
+# grant by default. Without it the run still fails — `gh api graphql` exits
+# non-zero on an INSUFFICIENT_SCOPES error and `set -e` takes the script with it
+# — but it fails at the first projectsV2 query with a raw GraphQL error that
+# says nothing about scopes or how to fix it. Checking here converts that into
+# one actionable line, before any API call. It is deliberately NOT fatal on an
+# unreadable scope list: a token whose scopes cannot be parsed (a GitHub App
+# installation token, a future `gh` output change) may still be perfectly able
+# to do the work, and refusing to run would be a worse failure than the one
+# this guard replaces.
+auth_report="$(gh auth status 2>&1 || true)"
+scopes_line="$(printf '%s\n' "$auth_report" | grep -i 'token scopes:' || true)"
+case "$scopes_line" in
+"")
+    echo "==> Could not read token scopes from 'gh auth status' — continuing; a scope error below means: gh auth refresh -s project" >&2
+    ;;
+*"'project'"*) ;;
+*)
+    cat >&2 <<'SCOPE_ERR'
+This token cannot write GitHub Projects: 'gh auth status' reports no 'project' scope.
+
+Every write below (the board, its Status pipeline, the Size field) would fail on
+the first API call. Fix it, then re-run:
+
+    gh auth refresh -s project
+
+Note that read-only 'read:project' is enough to *see* a board but not to create
+or reconcile one, so this script requires the full 'project' scope.
+SCOPE_ERR
+    exit 1
+    ;;
+esac
+
 # Full Status pipeline (docs/project-management.md), in board order. GitHub's API
 # cannot create the visual groups, so these render as a flat, ordered list.
 status_pipeline='[

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -66,13 +66,17 @@ done
 # installation token, a future `gh` output change) may still be perfectly able
 # to do the work, and refusing to run would be a worse failure than the one
 # this guard replaces.
-# --active: `gh auth status` reports every known account, and an inactive one
-# holding 'project' must not answer for the credential this run will use. Older
-# gh (pre-2.40) has no such flag — fall back rather than read a usage error as a
-# missing scope.
-auth_report="$(gh auth status --active 2>&1 || true)"
+# Narrow the report to the one credential the API calls below will use.
+# `gh auth status` covers every account on every host, and the scope line cannot
+# tell them apart: --active excludes a second account on this host, --hostname
+# excludes an unrelated host whose scopes say nothing about this run (which
+# targets GH_HOST or github.com). Older gh (pre-2.40) has no --active — fall back
+# rather than read a usage error as a missing scope; multi-account per host
+# arrived with 2.40, so one host there already means one account.
+gh_host="${GH_HOST:-github.com}"
+auth_report="$(gh auth status --active --hostname "$gh_host" 2>&1 || true)"
 case "$auth_report" in
-*"unknown flag"*) auth_report="$(gh auth status 2>&1 || true)" ;;
+*"unknown flag"*) auth_report="$(gh auth status --hostname "$gh_host" 2>&1 || true)" ;;
 esac
 scopes_line="$(printf '%s\n' "$auth_report" | grep -i 'token scopes:' || true)"
 case "$scopes_line" in

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -98,6 +98,14 @@ case "$scopes_line" in
         remedy="    Reissue the token in GITHUB_TOKEN with the 'project' scope.
     (gh auth refresh cannot help: the environment token overrides the stored one.)"
         ;;
+    *"(GH_ENTERPRISE_TOKEN)"*)
+        remedy="    Reissue the token in GH_ENTERPRISE_TOKEN with the 'project' scope.
+    (gh auth refresh cannot help: the environment token overrides the stored one.)"
+        ;;
+    *"(GITHUB_ENTERPRISE_TOKEN)"*)
+        remedy="    Reissue the token in GITHUB_ENTERPRISE_TOKEN with the 'project' scope.
+    (gh auth refresh cannot help: the environment token overrides the stored one.)"
+        ;;
     esac
     printf '%s\n\n%s\n\n%s\n\n%s\n' \
         "This token cannot write GitHub Projects: 'gh auth status' reports no 'project' scope." \

--- a/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
@@ -248,6 +248,21 @@ case "$out" in
 *) fail "read:project must be refused for writes, got: $out" ;;
 esac
 
+echo "==> a fine-grained/App token is NOT refused — its access is a permission"
+# It reports no OAuth scopes at all, which is not the same as lacking one: such a
+# token may well be able to write Projects, and `gh auth refresh` cannot change
+# it either way. Refusing here would block a capable credential.
+printf '%s' "$complete" >"$STUB_FIELDS_FILE"
+: >"$STUB_FIELDS_FILE2"
+rm -f "$tmp_seen"
+: >"$MUTATIONS"
+STUB_SCOPES="none" "$script" --owner someuser --title "Test Project" \
+    >"$tmp/out" 2>&1 || fail "a token reporting no OAuth scopes must not be refused"
+grep -q "no OAuth scopes" "$tmp/out" ||
+    fail "expected the fine-grained-token notice, got: $(cat "$tmp/out")"
+grep -q "gh auth refresh" "$tmp/out" &&
+    fail "gh auth refresh cannot fix a fine-grained token"
+
 echo "==> a token WITH the project scope reconciles normally"
 printf '%s' "$complete" >"$STUB_FIELDS_FILE"
 : >"$STUB_FIELDS_FILE2"

--- a/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
@@ -30,6 +30,13 @@ fail() {
 mkdir -p "$tmp/bin"
 cat >"$tmp/bin/gh" <<'STUB'
 #!/usr/bin/env bash
+# The scope preflight's probe. $STUB_SCOPES unset means "authenticated, but the
+# scope list could not be parsed" — the state every reconciliation case below
+# runs in, and one the preflight must not treat as a failure.
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+    [ -n "${STUB_SCOPES:-}" ] && echo "  - Token scopes: ${STUB_SCOPES}"
+    exit 0
+fi
 q=""
 for a in "$@"; do case "$a" in query=*) q="${a#query=}" ;; esac; done
 case "$q" in
@@ -200,5 +207,55 @@ case "$mut" in
 *'name:"raced-in"'*) : ;;
 *) fail "an option added between the snapshot and the write was deleted — the pre-write re-read is missing" ;;
 esac
+
+# ── Scope preflight ─────────────────────────────────────────────────────────
+# Without the 'project' scope the run fails either way — `gh api graphql` exits
+# non-zero on INSUFFICIENT_SCOPES and `set -e` takes the script with it. What is
+# being tested is that it fails BEFORE any API call and says what to do about
+# it, instead of surfacing a raw GraphQL error that names neither.
+
+# run_expecting_scope_failure SCOPES — run with that scope list, require a
+# non-zero exit, and echo the output.
+run_expecting_scope_failure() {
+    printf '%s' "$complete" >"$STUB_FIELDS_FILE"
+    : >"$STUB_FIELDS_FILE2"
+    rm -f "$tmp_seen"
+    : >"$MUTATIONS"
+    if STUB_SCOPES="$1" "$script" --owner someuser --title "Test Project" \
+        >"$tmp/out" 2>&1; then
+        fail "a token with scopes '$1' must not be accepted for board writes"
+    fi
+    cat "$tmp/out"
+}
+
+echo "==> a token without the project scope is refused, naming the remedy"
+out=$(run_expecting_scope_failure "'gist', 'read:org', 'repo'")
+case "$out" in
+*"gh auth refresh -s project"*) ;;
+*) fail "expected the refusal to name the remedy, got: $out" ;;
+esac
+[ "$(updates)" = 0 ] || fail "the preflight must refuse before any mutation"
+case "$out" in
+*"Resolving owner"*) fail "the preflight must refuse before the first API call" ;;
+esac
+
+echo "==> read-only 'read:project' is refused too — writes need the full scope"
+# Easy to mistake for sufficient: it reads a board perfectly well, and every
+# write below still fails.
+out=$(run_expecting_scope_failure "'gist', 'read:project', 'repo'")
+case "$out" in
+*"gh auth refresh -s project"*) ;;
+*) fail "read:project must be refused for writes, got: $out" ;;
+esac
+
+echo "==> a token WITH the project scope reconciles normally"
+printf '%s' "$complete" >"$STUB_FIELDS_FILE"
+: >"$STUB_FIELDS_FILE2"
+rm -f "$tmp_seen"
+: >"$MUTATIONS"
+STUB_SCOPES="'gist', 'project', 'repo'" "$script" --owner someuser \
+    --title "Test Project" >"$tmp/out" 2>&1 ||
+    fail "a token with the project scope must be accepted"
+[ "$(updates)" = 0 ] || fail "an already-synced project should still write nothing"
 
 echo "PASS: setup-github-project.sh field reconciliation"

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -198,19 +198,24 @@ GH_AUTHED=false
 GH_AUTH_TIMEDOUT=false
 if should_show "gh"; then
     gh_auth_rc=0
-    # --active, because `gh auth status` reports EVERY known account and the
-    # scope line read below cannot tell them apart: a second, inactive account
-    # holding `project` would answer for the credential gh actually uses.
-    # (Residual, accepted: with several hosts each having an active account, all
-    # of them are still reported. Narrowing further needs the repo's host, which
-    # this reporter does not resolve.)
-    run_timeout "${NETWORK_TIMEOUT}" gh auth status --active >"${GH_AUTH_FILE}" 2>&1 ||
+    # `gh auth status` reports every account on every host, and the scope line
+    # read below cannot tell them apart — so narrow it to one credential from
+    # both directions: --active (not a second, inactive account on this host)
+    # and --hostname (not an unrelated host's account, whose scopes say nothing
+    # about the API calls this repo makes). A GitHub Enterprise user who has not
+    # set GH_HOST gets no match and the check reports "unknown", which is the
+    # right answer — better than a green light earned by the wrong token.
+    run_timeout "${NETWORK_TIMEOUT}" gh auth status --active \
+        --hostname "${GH_HOST:-github.com}" >"${GH_AUTH_FILE}" 2>&1 ||
         gh_auth_rc=$?
     if grep -qi 'unknown flag' "${GH_AUTH_FILE}" 2>/dev/null; then
-        # gh predates --active (added in 2.40). Fall back to the full report
-        # rather than reading a usage error as a failed login.
+        # gh predates --active (added in 2.40). Fall back rather than read a
+        # usage error as a failed login — and keep --hostname, which is far
+        # older. Multi-account per host arrived WITH 2.40, so on a gh this old
+        # one host means one account and the narrowing is complete anyway.
         gh_auth_rc=0
-        run_timeout "${NETWORK_TIMEOUT}" gh auth status >"${GH_AUTH_FILE}" 2>&1 ||
+        run_timeout "${NETWORK_TIMEOUT}" gh auth status \
+            --hostname "${GH_HOST:-github.com}" >"${GH_AUTH_FILE}" 2>&1 ||
             gh_auth_rc=$?
     fi
     # 124 is `timeout`'s own "deadline hit" code. Distinguished from a real

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -178,6 +178,41 @@ has_scope() {
     esac
 }
 
+# gh_target_host — the host gh will actually use for THIS repository.
+#
+# Narrowing `gh auth status --hostname` is only safe against the same host the
+# repo-aware calls use. Forcing github.com disowns a valid Enterprise login
+# (`gh auth login --hostname ghe.example.com`, no GH_HOST exported): the probe
+# exits non-zero, which this script reads as "not authenticated" and skips the
+# whole GitHub section — while `gh pr list` and `gh run list` would have worked
+# fine against that remote. So resolve it the way gh documents: GH_HOST is the
+# override for when a host "cannot be determined from repository context", which
+# means repository context comes first when GH_HOST is unset.
+#
+# Local and network-free — the remote URL is the context. github.com only as a
+# last resort, when there is no remote to read.
+gh_target_host() {
+    local url host=""
+    if [[ -n "${GH_HOST:-}" ]]; then
+        printf '%s' "${GH_HOST}"
+        return 0
+    fi
+    url="$(git config --get remote.origin.url 2>/dev/null || true)"
+    case "${url}" in
+    *://*)                 # scheme://[user@]host[:port]/path
+        host="${url#*://}" # drop the scheme
+        host="${host#*@}"  # drop any userinfo
+        host="${host%%/*}" # drop the path
+        host="${host%%:*}" # drop any port
+        ;;
+    *@*:*) # scp-like: user@host:owner/repo
+        host="${url#*@}"
+        host="${host%%:*}"
+        ;;
+    esac
+    printf '%s' "${host:-github.com}"
+}
+
 # ── Parallel data collection ────────────────────────────────────────────────
 
 PID_PRS=""
@@ -205,11 +240,11 @@ if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
     # read below cannot tell them apart — so narrow it to one credential from
     # both directions: --active (not a second, inactive account on this host)
     # and --hostname (not an unrelated host's account, whose scopes say nothing
-    # about the API calls this repo makes). A GitHub Enterprise user who has not
-    # set GH_HOST gets no match and the check reports "unknown", which is the
-    # right answer — better than a green light earned by the wrong token.
+    # about the API calls this repo makes). The host comes from the repository,
+    # not a github.com assumption — see gh_target_host.
+    gh_host="$(gh_target_host)"
     run_timeout "${NETWORK_TIMEOUT}" gh auth status --active \
-        --hostname "${GH_HOST:-github.com}" >"${GH_AUTH_FILE}" 2>&1 ||
+        --hostname "${gh_host}" >"${GH_AUTH_FILE}" 2>&1 ||
         gh_auth_rc=$?
     if grep -qi 'unknown flag' "${GH_AUTH_FILE}" 2>/dev/null; then
         # gh predates --active (added in 2.40). Fall back rather than read a
@@ -218,7 +253,7 @@ if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
         # one host means one account and the narrowing is complete anyway.
         gh_auth_rc=0
         run_timeout "${NETWORK_TIMEOUT}" gh auth status \
-            --hostname "${GH_HOST:-github.com}" >"${GH_AUTH_FILE}" 2>&1 ||
+            --hostname "${gh_host}" >"${GH_AUTH_FILE}" 2>&1 ||
             gh_auth_rc=$?
     fi
     # 124 is `timeout`'s own "deadline hit" code. Distinguished from a real

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -555,8 +555,13 @@ if [[ "${SECTION}" == "setup" ]]; then
     } | section_box
 
     # Reuses the single bounded probe above rather than making a second,
-    # unbounded `gh auth status` call to learn the same thing.
-    if [[ "${GH_AUTHED}" != true ]]; then
+    # unbounded `gh auth status` call to learn the same thing. Sharing that probe
+    # means sharing its distinctions too: bounding it made a slow network look
+    # exactly like a missing login, and telling an authenticated user to run
+    # `gh auth login` because GitHub was slow sends them to fix the wrong thing.
+    if [[ "${GH_AUTH_TIMEDOUT}" == true ]]; then
+        echo "  (gh auth status timed out after ${NETWORK_TIMEOUT}s -- skipping)" | section_box
+    elif [[ "${GH_AUTHED}" != true ]]; then
         echo "  (gh not authenticated -- run 'gh auth login')" | section_box
     else
         d="${TMPDIR_STATUS}"

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -360,14 +360,38 @@ if should_show "gh"; then
             # included) is vendored into repos that have no board at all.
             # Keying on the skill would demand the `project` scope from every
             # one of them. setup-github-project.sh is generated only for
-            # `project_management: github`, which makes it an exact proxy for
-            # "this repo has a board to write to".
+            # `project_management: github`, which makes it a proxy for "this
+            # repo is configured to have a board".
+            #
+            # The accepted cost, deliberately chosen: a repo on
+            # `project_management: none` whose issues someone adds to a board by
+            # hand gets no session-start warning, and learns from the claim's own
+            # exit 2 instead. Nothing on disk can distinguish that repo from one
+            # that simply opted out — board membership is remote state — so the
+            # gate can only pick which error to make. A red line in every
+            # opted-out repo, every session, is the worse one: it is universal
+            # rather than conditional, and a check that cries wolf everywhere
+            # stops being read where it matters.
             if [[ -f scripts/setup-github-project.sh ]]; then
                 echo ""
                 # Read the file directly — no pipe. A `grep -q` consumer on a
                 # pipeline can take SIGPIPE, which `pipefail` turns into a
                 # failure of the whole pipeline.
                 gh_scopes="$(grep -i 'token scopes:' "${GH_AUTH_FILE}" 2>/dev/null || true)"
+                # `gh auth refresh` edits the STORED credential, and an
+                # env-provided token overrides that — so telling someone running
+                # on GH_TOKEN to refresh is advice that cannot work. gh names the
+                # source in its report, so use it to pick the remedy once rather
+                # than repeating a guess in each branch below.
+                gh_remedy="run: gh auth refresh -s project"
+                case "$(<"${GH_AUTH_FILE}")" in
+                *"(GH_TOKEN)"*)
+                    gh_remedy="reissue GH_TOKEN with the 'project' scope (an env token overrides gh auth refresh)"
+                    ;;
+                *"(GITHUB_TOKEN)"*)
+                    gh_remedy="reissue GITHUB_TOKEN with the 'project' scope (an env token overrides gh auth refresh)"
+                    ;;
+                esac
                 if [[ -z "${gh_scopes}" ]]; then
                     checkline unknown "Project board writes" \
                         "could not read token scopes from gh auth status"
@@ -387,10 +411,10 @@ if should_show "gh"; then
                     # mistaken for working: `--show` reads the card fine, so the
                     # board looks reachable right up to the write that moves it.
                     checkline no "Project board writes" \
-                        "'read:project' is read-only — claims cannot move the board; run: gh auth refresh -s project"
+                        "'read:project' is read-only — claims cannot move the board; ${gh_remedy}"
                 else
                     checkline no "Project board writes" \
-                        "token lacks 'project' — claims cannot move the board; run: gh auth refresh -s project"
+                        "token lacks 'project' — claims cannot move the board; ${gh_remedy}"
                 fi
             fi
         } | section_box

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -196,7 +196,10 @@ GH_AUTH_FILE="${TMPDIR_STATUS}/auth.txt"
 : >"${GH_AUTH_FILE}"
 GH_AUTHED=false
 GH_AUTH_TIMEDOUT=false
-if should_show "gh"; then
+# The setup section needs this too — it reports the same credential's ability to
+# read the board, and used to run its own `gh auth status` to decide whether to
+# render at all. One probe, two consumers.
+if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
     gh_auth_rc=0
     # `gh auth status` reports every account on every host, and the scope line
     # read below cannot tell them apart — so narrow it to one credential from
@@ -228,7 +231,44 @@ if should_show "gh"; then
     esac
 fi
 
-if [[ "${GH_AUTHED}" == true ]]; then
+# The token's scope line, and how to give THIS credential Projects write access.
+# Derived once, because every call site below would otherwise guess — and a
+# remedy that cannot work is worse than none. `gh auth refresh` edits only the
+# STORED classic credential: it cannot touch an env-provided token (which
+# overrides the stored one, on github.com and Enterprise alike) and cannot add a
+# fine-grained or App token's permissions, which are not OAuth scopes at all.
+GH_SCOPES_LINE=""
+GH_REMEDY="run: gh auth refresh -s project"
+if [[ -s "${GH_AUTH_FILE}" ]]; then
+    GH_SCOPES_LINE="$(grep -i 'token scopes:' "${GH_AUTH_FILE}" 2>/dev/null || true)"
+    case "$(<"${GH_AUTH_FILE}")" in
+    *"(GH_TOKEN)"*)
+        GH_REMEDY="reissue GH_TOKEN with Projects write — an env token overrides gh auth refresh"
+        ;;
+    *"(GITHUB_TOKEN)"*)
+        GH_REMEDY="reissue GITHUB_TOKEN with Projects write — an env token overrides gh auth refresh"
+        ;;
+    *"(GH_ENTERPRISE_TOKEN)"*)
+        GH_REMEDY="reissue GH_ENTERPRISE_TOKEN with Projects write — an env token overrides gh auth refresh"
+        ;;
+    *"(GITHUB_ENTERPRISE_TOKEN)"*)
+        GH_REMEDY="reissue GITHUB_ENTERPRISE_TOKEN with Projects write — an env token overrides gh auth refresh"
+        ;;
+    *)
+        # Not an env token. A scope line with no scopes in it is a fine-grained
+        # PAT or an App installation token — a permission, granted at the source.
+        if [[ -n "${GH_SCOPES_LINE}" && "${GH_SCOPES_LINE}" != *"'"* ]]; then
+            GH_REMEDY="set its Projects permission where the token was issued"
+        fi
+        ;;
+    esac
+fi
+
+# `should_show "gh"` as well as the auth flag: the auth probe above now also runs
+# for the setup section, and these two lists are read only by the GitHub section.
+# Without the guard, `task status:setup` would spend two network calls fetching
+# data nothing displays.
+if [[ "${GH_AUTHED}" == true ]] && should_show "gh"; then
     run_timeout "${NETWORK_TIMEOUT}" gh pr list --limit 10 \
         --json number,title,headRefName \
         >"${TMPDIR_STATUS}/prs.json" 2>/dev/null &
@@ -374,47 +414,28 @@ if should_show "gh"; then
             # stops being read where it matters.
             if [[ -f scripts/setup-github-project.sh ]]; then
                 echo ""
-                # Read the file directly — no pipe. A `grep -q` consumer on a
-                # pipeline can take SIGPIPE, which `pipefail` turns into a
-                # failure of the whole pipeline.
-                gh_scopes="$(grep -i 'token scopes:' "${GH_AUTH_FILE}" 2>/dev/null || true)"
-                # `gh auth refresh` edits the STORED credential, and an
-                # env-provided token overrides that — so telling someone running
-                # on GH_TOKEN to refresh is advice that cannot work. gh names the
-                # source in its report, so use it to pick the remedy once rather
-                # than repeating a guess in each branch below.
-                gh_remedy="run: gh auth refresh -s project"
-                case "$(<"${GH_AUTH_FILE}")" in
-                *"(GH_TOKEN)"*)
-                    gh_remedy="reissue GH_TOKEN with the 'project' scope (an env token overrides gh auth refresh)"
-                    ;;
-                *"(GITHUB_TOKEN)"*)
-                    gh_remedy="reissue GITHUB_TOKEN with the 'project' scope (an env token overrides gh auth refresh)"
-                    ;;
-                esac
-                if [[ -z "${gh_scopes}" ]]; then
+                if [[ -z "${GH_SCOPES_LINE}" ]]; then
                     checkline unknown "Project board writes" \
                         "could not read token scopes from gh auth status"
-                elif [[ "${gh_scopes}" != *"'"* ]]; then
+                elif [[ "${GH_SCOPES_LINE}" != *"'"* ]]; then
                     # A fine-grained PAT or App token carries permissions, not
                     # OAuth scopes, and gh reports the line with no scopes in
                     # it. Such a token may well be able to write Projects — so
-                    # this is genuinely unknown, and `gh auth refresh` is the
-                    # wrong advice: an env-provided GH_TOKEN cannot be refreshed
-                    # at all. The generated bot credential is exactly this case.
+                    # this is genuinely unknown rather than a failure. The
+                    # generated bot credential is exactly this case.
                     checkline unknown "Project board writes" \
-                        "no OAuth scopes reported (fine-grained or App token) — set its Projects permission where it was issued"
-                elif has_scope "${gh_scopes}" project; then
+                        "no OAuth scopes reported (fine-grained or App token) — ${GH_REMEDY}"
+                elif has_scope "${GH_SCOPES_LINE}" project; then
                     checkline ok "Project board writes" "token has 'project'"
-                elif has_scope "${gh_scopes}" read:project; then
+                elif has_scope "${GH_SCOPES_LINE}" read:project; then
                     # Called out separately because it is the state most easily
                     # mistaken for working: `--show` reads the card fine, so the
                     # board looks reachable right up to the write that moves it.
                     checkline no "Project board writes" \
-                        "'read:project' is read-only — claims cannot move the board; ${gh_remedy}"
+                        "'read:project' is read-only — claims cannot move the board; ${GH_REMEDY}"
                 else
                     checkline no "Project board writes" \
-                        "token lacks 'project' — claims cannot move the board; ${gh_remedy}"
+                        "token lacks 'project' — claims cannot move the board; ${GH_REMEDY}"
                 fi
             fi
         } | section_box
@@ -533,7 +554,9 @@ if [[ "${SECTION}" == "setup" ]]; then
         fi
     } | section_box
 
-    if ! gh auth status &>/dev/null 2>&1; then
+    # Reuses the single bounded probe above rather than making a second,
+    # unbounded `gh auth status` call to learn the same thing.
+    if [[ "${GH_AUTHED}" != true ]]; then
         echo "  (gh not authenticated -- run 'gh auth login')" | section_box
     else
         d="${TMPDIR_STATUS}"
@@ -811,7 +834,7 @@ if [[ "${SECTION}" == "setup" ]]; then
                     fi
                 else
                     checkline unknown "GitHub Project linked" \
-                        "unreadable — run: gh auth refresh -s project"
+                        "unreadable — ${GH_REMEDY}"
                 fi
                 if [ -f scripts/setup-github-labels.sh ]; then
                     # The expected set is read out of the setup script's own

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -198,8 +198,21 @@ GH_AUTHED=false
 GH_AUTH_TIMEDOUT=false
 if should_show "gh"; then
     gh_auth_rc=0
-    run_timeout "${NETWORK_TIMEOUT}" gh auth status >"${GH_AUTH_FILE}" 2>&1 ||
+    # --active, because `gh auth status` reports EVERY known account and the
+    # scope line read below cannot tell them apart: a second, inactive account
+    # holding `project` would answer for the credential gh actually uses.
+    # (Residual, accepted: with several hosts each having an active account, all
+    # of them are still reported. Narrowing further needs the repo's host, which
+    # this reporter does not resolve.)
+    run_timeout "${NETWORK_TIMEOUT}" gh auth status --active >"${GH_AUTH_FILE}" 2>&1 ||
         gh_auth_rc=$?
+    if grep -qi 'unknown flag' "${GH_AUTH_FILE}" 2>/dev/null; then
+        # gh predates --active (added in 2.40). Fall back to the full report
+        # rather than reading a usage error as a failed login.
+        gh_auth_rc=0
+        run_timeout "${NETWORK_TIMEOUT}" gh auth status >"${GH_AUTH_FILE}" 2>&1 ||
+            gh_auth_rc=$?
+    fi
     # 124 is `timeout`'s own "deadline hit" code. Distinguished from a real
     # failure because bounding this probe made a slow network indistinguishable
     # from a missing login, and reporting "not authenticated" for a timeout
@@ -336,8 +349,15 @@ if should_show "gh"; then
             # Reported in both directions on purpose. A check that prints only
             # on failure is indistinguishable from a check that is not running
             # — which is the very bug this one exists to catch.
-            if [[ -f .claude/skills/track-work/assets/set-issue-status.sh ||
-                -f scripts/setup-github-project.sh ]]; then
+            # Gated on the board tooling itself, NOT on the presence of the
+            # track-work skill: `project_management: none` is the default and
+            # `use_skills_sync` is on, so the universal skill set (track-work
+            # included) is vendored into repos that have no board at all.
+            # Keying on the skill would demand the `project` scope from every
+            # one of them. setup-github-project.sh is generated only for
+            # `project_management: github`, which makes it an exact proxy for
+            # "this repo has a board to write to".
+            if [[ -f scripts/setup-github-project.sh ]]; then
                 echo ""
                 # Read the file directly — no pipe. A `grep -q` consumer on a
                 # pipeline can take SIGPIPE, which `pipefail` turns into a
@@ -346,6 +366,15 @@ if should_show "gh"; then
                 if [[ -z "${gh_scopes}" ]]; then
                     checkline unknown "Project board writes" \
                         "could not read token scopes from gh auth status"
+                elif [[ "${gh_scopes}" != *"'"* ]]; then
+                    # A fine-grained PAT or App token carries permissions, not
+                    # OAuth scopes, and gh reports the line with no scopes in
+                    # it. Such a token may well be able to write Projects — so
+                    # this is genuinely unknown, and `gh auth refresh` is the
+                    # wrong advice: an env-provided GH_TOKEN cannot be refreshed
+                    # at all. The generated bot credential is exactly this case.
+                    checkline unknown "Project board writes" \
+                        "no OAuth scopes reported (fine-grained or App token) — set its Projects permission where it was issued"
                 elif has_scope "${gh_scopes}" project; then
                     checkline ok "Project board writes" "token has 'project'"
                 elif has_scope "${gh_scopes}" read:project; then

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -12,12 +12,17 @@ SECTION="${1:-}"
 TMPDIR_STATUS="$(mktemp -d)"
 trap 'rm -rf "${TMPDIR_STATUS}"' EXIT
 
-NETWORK_TIMEOUT=5
+# Overridable so a test can drive the deadline path without waiting on it.
+NETWORK_TIMEOUT="${NETWORK_TIMEOUT:-5}"
 
 # ── Tool detection ──────────────────────────────────────────────────────────
 
+# NO_COLOR (https://no-color.org/) turns off gum styling as well as ANSI, which
+# makes the board's output plain, stable text — greppable, diffable, and
+# assertable by scripts/test-status.sh without matching around escape sequences
+# or box drawing.
 HAS_GUM=false
-command -v gum &>/dev/null && HAS_GUM=true
+[[ -z "${NO_COLOR:-}" ]] && command -v gum &>/dev/null && HAS_GUM=true
 
 # Network probes below are bounded so a hung `gh` call cannot wedge the board.
 # Stock macOS ships no `timeout` — it comes from coreutils, which also provides
@@ -89,7 +94,7 @@ should_show() {
 # ANSI only — no extra dependency. Detected here at top level because inside the
 # section's `| section_box` pipe, stdout reads as a non-TTY.
 USE_COLOR=false
-{ [ -t 1 ] || $HAS_GUM; } && USE_COLOR=true
+[[ -z "${NO_COLOR:-}" ]] && { [ -t 1 ] || $HAS_GUM; } && USE_COLOR=true
 
 # c SGR TEXT — wrap TEXT in an ANSI SGR sequence when color is enabled.
 c() {
@@ -161,6 +166,18 @@ has_cred() {
     jq -e --arg n "$2" 'any(.[]; .name == $n)' "$1" >/dev/null 2>&1
 }
 
+# has_scope LINE NAME — true if NAME is present as a quoted scope in a
+# `gh auth status` "Token scopes:" line (`… 'gist', 'project', 'repo'`).
+# Matching on the quotes is what keeps `project` from also matching
+# `read:project` (and vice versa) — the two are different grants and the
+# caller decides which ones satisfy it.
+has_scope() {
+    case "$1" in
+    *"'$2'"*) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
 # ── Parallel data collection ────────────────────────────────────────────────
 
 PID_PRS=""
@@ -169,7 +186,31 @@ PID_TOKEI=""
 
 CURRENT_BRANCH="$(git branch --show-current 2>/dev/null || echo "detached")"
 
-if should_show "gh" && gh auth status &>/dev/null 2>&1; then
+# Resolve auth once and keep the output: it is both the gate for the GitHub
+# section and the only place the token's scopes are reported, and re-running it
+# per use would spend an extra API call to learn the same thing. Captured with
+# `2>&1` because gh has moved this report between stdout and stderr across
+# versions, and bounded by run_timeout — the bare `gh auth status` calls it
+# replaces were the section's only unbounded network probes.
+GH_AUTH_FILE="${TMPDIR_STATUS}/auth.txt"
+: >"${GH_AUTH_FILE}"
+GH_AUTHED=false
+GH_AUTH_TIMEDOUT=false
+if should_show "gh"; then
+    gh_auth_rc=0
+    run_timeout "${NETWORK_TIMEOUT}" gh auth status >"${GH_AUTH_FILE}" 2>&1 ||
+        gh_auth_rc=$?
+    # 124 is `timeout`'s own "deadline hit" code. Distinguished from a real
+    # failure because bounding this probe made a slow network indistinguishable
+    # from a missing login, and reporting "not authenticated" for a timeout
+    # sends the reader to fix the wrong thing.
+    case "${gh_auth_rc}" in
+    0) GH_AUTHED=true ;;
+    124) GH_AUTH_TIMEDOUT=true ;;
+    esac
+fi
+
+if [[ "${GH_AUTHED}" == true ]]; then
     run_timeout "${NETWORK_TIMEOUT}" gh pr list --limit 10 \
         --json number,title,headRefName \
         >"${TMPDIR_STATUS}/prs.json" 2>/dev/null &
@@ -243,7 +284,9 @@ fi
 if should_show "gh"; then
     section_header "GitHub Status"
 
-    if ! gh auth status &>/dev/null 2>&1; then
+    if [[ "${GH_AUTH_TIMEDOUT}" == true ]]; then
+        echo "  (gh auth status timed out after ${NETWORK_TIMEOUT}s -- skipping)" | section_box
+    elif [[ "${GH_AUTHED}" != true ]]; then
         echo "  (gh not authenticated -- skipping)" | section_box
     else
         {
@@ -271,6 +314,50 @@ if should_show "gh"; then
                     "$checks_file"
             else
                 echo "  Recent CI runs: none"
+            fi
+
+            # ── Board writes ────────────────────────────────────────────────
+            # The claim lifecycle moves an issue's project `Status` (a claim
+            # sets In Progress, the PR stages advance it, the hand-back
+            # restores it), and that write needs a token scope `gh auth login`
+            # does not grant by default. Without it every board write exits 2
+            # ("could not verify") and no card moves — and each step handles
+            # that correctly on its own, so nothing escalates: the agent
+            # reports the issue claimed, the board says nothing was started,
+            # and neither is wrong from where it stands.
+            #
+            # `status:setup` has always checked this. It is repeated here
+            # because this section is what session-start orientation runs, and
+            # a tracking surface that has silently stopped tracking has to
+            # surface BEFORE a claim is made, not after a human notices the
+            # board is stale. The cost is nil: the scopes come from the auth
+            # probe above, not a second call.
+            #
+            # Reported in both directions on purpose. A check that prints only
+            # on failure is indistinguishable from a check that is not running
+            # — which is the very bug this one exists to catch.
+            if [[ -f .claude/skills/track-work/assets/set-issue-status.sh ||
+                -f scripts/setup-github-project.sh ]]; then
+                echo ""
+                # Read the file directly — no pipe. A `grep -q` consumer on a
+                # pipeline can take SIGPIPE, which `pipefail` turns into a
+                # failure of the whole pipeline.
+                gh_scopes="$(grep -i 'token scopes:' "${GH_AUTH_FILE}" 2>/dev/null || true)"
+                if [[ -z "${gh_scopes}" ]]; then
+                    checkline unknown "Project board writes" \
+                        "could not read token scopes from gh auth status"
+                elif has_scope "${gh_scopes}" project; then
+                    checkline ok "Project board writes" "token has 'project'"
+                elif has_scope "${gh_scopes}" read:project; then
+                    # Called out separately because it is the state most easily
+                    # mistaken for working: `--show` reads the card fine, so the
+                    # board looks reachable right up to the write that moves it.
+                    checkline no "Project board writes" \
+                        "'read:project' is read-only — claims cannot move the board; run: gh auth refresh -s project"
+                else
+                    checkline no "Project board writes" \
+                        "token lacks 'project' — claims cannot move the board; run: gh auth refresh -s project"
+                fi
             fi
         } | section_box
     fi
@@ -665,7 +752,8 @@ if [[ "${SECTION}" == "setup" ]]; then
                         checkline no "GitHub Project linked" "link a Project v2 to the repo"
                     fi
                 else
-                    checkline unknown "GitHub Project linked" "needs read:project scope"
+                    checkline unknown "GitHub Project linked" \
+                        "unreadable — run: gh auth refresh -s project"
                 fi
                 if [ -f scripts/setup-github-labels.sh ]; then
                     # The expected set is read out of the setup script's own

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -101,6 +101,15 @@ make_stub() {
             echo '    fi'
             echo '    exit 0'
             ;;
+        env-token-no-scope)
+            # A classic PAT supplied through GH_TOKEN: it reports real scopes, so
+            # the scope verdict is correct — but `gh auth refresh` edits the
+            # stored credential, which this one overrides, so that remedy cannot
+            # work here.
+            echo '    echo "  X Failed to log in to github.com using token (GH_TOKEN)"'
+            echo "    echo \"  - Token scopes: 'gist', 'repo'\""
+            echo '    exit 0'
+            ;;
         other-host-has-scope)
             # Two hosts; only the unrelated one holds 'project'. A stub that
             # ignores --hostname proves the cross-host bug; this one honours it,
@@ -230,6 +239,17 @@ case "$out" in
 *"token has 'project'"*) fail "read the ACTIVE account's scopes, not every account's: ${out}" ;;
 *"lacks 'project'"*) ;;
 *) fail "expected the active account's missing scope to be reported, got: ${out}" ;;
+esac
+
+echo "==> an env-provided token gets a remedy that can actually work"
+# The scope verdict is right; only the fix differs. `gh auth refresh` edits the
+# stored credential, which GH_TOKEN overrides — so recommending it here would be
+# advice that silently changes nothing.
+out="$(run_gh_section env-token-no-scope)"
+case "$out" in
+*"gh auth refresh -s project"*) fail "gh auth refresh cannot change an env token: ${out}" ;;
+*"reissue GH_TOKEN"*) ;;
+*) fail "expected an env-token remedy, got: ${out}" ;;
 esac
 
 echo "==> another host's scopes cannot answer for the targeted one"

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -38,9 +38,18 @@ done
 mkdir -p "${TMP}/skills-only/.claude/skills/track-work/assets"
 : >"${TMP}/skills-only/.claude/skills/track-work/assets/set-issue-status.sh"
 
+# A board repo whose remote is a GitHub Enterprise host, and which exports no
+# GH_HOST — the case where forcing github.com disowns a valid login.
+mkdir -p "${TMP}/enterprise/scripts"
+cp "${status}" "${TMP}/enterprise/scripts/status.sh"
+: >"${TMP}/enterprise/scripts/setup-github-project.sh"
+git -C "${TMP}/enterprise" init -q
+git -C "${TMP}/enterprise" remote add origin git@ghe.example.com:owner/repo.git
+
 WITH_BOARD="${TMP}/with-board/scripts/status.sh"
 NO_BOARD="${TMP}/no-board/scripts/status.sh"
 SKILLS_ONLY="${TMP}/skills-only/scripts/status.sh"
+ENTERPRISE="${TMP}/enterprise/scripts/status.sh"
 
 fail() {
     echo "TEST FAIL: $*" >&2
@@ -115,6 +124,20 @@ make_stub() {
             # environment. Same override problem as GH_TOKEN, different name.
             echo '    echo "  X Failed to log in using token (GH_ENTERPRISE_TOKEN)"'
             echo "    echo \"  - Token scopes: 'gist', 'repo'\""
+            echo '    exit 0'
+            ;;
+        records-hostname)
+            # Records the --hostname it was handed, and only authenticates for
+            # the Enterprise host — so forcing github.com fails the probe and
+            # takes the whole section down, exactly as the real gh would.
+            echo '    host=""; prev=""'
+            echo '    for a in "$@"; do case "$prev" in --hostname) host="$a" ;; esac; prev="$a"; done'
+            echo '    echo "$host" >>"$STUB_HOSTS"'
+            echo '    if [ "$host" != "ghe.example.com" ]; then'
+            echo '        echo "You are not logged into any GitHub hosts." >&2'
+            echo '        exit 1'
+            echo '    fi'
+            echo "    echo \"  - Token scopes: 'gist', 'project', 'repo'\""
             echo '    exit 0'
             ;;
         other-host-has-scope)
@@ -267,6 +290,33 @@ case "$out" in
 *"reissue GH_ENTERPRISE_TOKEN"*) ;;
 *) fail "expected the Enterprise env-token remedy, got: ${out}" ;;
 esac
+
+echo "==> the auth host comes from the repository, not a github.com assumption"
+# A GHES repo with no GH_HOST exported. Forcing github.com would fail the probe,
+# which this script reads as "not authenticated" — losing the PR list, the CI
+# list, and the board-writes line all at once, while `gh pr list` would have
+# worked fine against that remote.
+STUB_HOSTS="${TMP}/hosts.txt"
+export STUB_HOSTS
+: >"${STUB_HOSTS}"
+out="$(run_gh_section records-hostname "${ENTERPRISE}")"
+grep -qx 'ghe.example.com' "${STUB_HOSTS}" ||
+    fail "probe used $(tr '\n' ' ' <"${STUB_HOSTS}") — expected the remote's host"
+case "$out" in
+*"not authenticated"*) fail "a valid Enterprise login must not read as unauthenticated: ${out}" ;;
+*"token has 'project'"*) ;;
+*) fail "expected the Enterprise section to render, got: ${out}" ;;
+esac
+
+echo "==> GH_HOST still overrides the repository's remote"
+: >"${STUB_HOSTS}"
+out="$(
+    make_stub records-hostname
+    PATH="${TMP}/bin:${PATH}" NO_COLOR=1 \
+        GH_HOST=ghe.example.com "${WITH_BOARD}" gh 2>&1
+)"
+grep -qx 'ghe.example.com' "${STUB_HOSTS}" ||
+    fail "GH_HOST must win over the remote, got: $(tr '\n' ' ' <"${STUB_HOSTS}")"
 
 echo "==> another host's scopes cannot answer for the targeted one"
 # The scopes of an account on an unrelated host say nothing about the API calls

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -303,6 +303,23 @@ else
     echo "    (skipped: no timeout binary — the probe is unbounded here)"
 fi
 
+echo "==> status:setup distinguishes a timeout from a missing login too"
+# The setup section shares the one auth probe, so it inherits the probe's
+# distinctions or silently loses them: on a deadline it must not tell an
+# authenticated user to run `gh auth login`. Reachable hermetically because this
+# gate precedes every other gh call in that section.
+if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
+    make_stub hangs
+    out="$(PATH="${TMP}/bin:${PATH}" NO_COLOR=1 NETWORK_TIMEOUT=1 "${WITH_BOARD}" setup 2>&1)"
+    case "$out" in
+    *"gh auth login"*) fail "a timeout must not be reported as a missing login: ${out}" ;;
+    *"timed out"*) ;;
+    *) fail "expected a timeout notice from status:setup, got: ${out}" ;;
+    esac
+else
+    echo "    (skipped: no timeout binary — the probe is unbounded here)"
+fi
+
 echo "==> no user-facing message hardcodes the refresh remedy"
 # The remedy is derived from the credential source once, because `gh auth refresh`
 # is wrong for an env-provided or fine-grained token. Every message must use that

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -110,6 +110,13 @@ make_stub() {
             echo "    echo \"  - Token scopes: 'gist', 'repo'\""
             echo '    exit 0'
             ;;
+        enterprise-env-token)
+            # GH_ENTERPRISE_TOKEN is how gh authenticates against GHES from the
+            # environment. Same override problem as GH_TOKEN, different name.
+            echo '    echo "  X Failed to log in using token (GH_ENTERPRISE_TOKEN)"'
+            echo "    echo \"  - Token scopes: 'gist', 'repo'\""
+            echo '    exit 0'
+            ;;
         other-host-has-scope)
             # Two hosts; only the unrelated one holds 'project'. A stub that
             # ignores --hostname proves the cross-host bug; this one honours it,
@@ -252,6 +259,15 @@ case "$out" in
 *) fail "expected an env-token remedy, got: ${out}" ;;
 esac
 
+echo "==> an Enterprise env token gets the same treatment as GH_TOKEN"
+# The override problem is a property of environment tokens, not of github.com.
+out="$(run_gh_section enterprise-env-token)"
+case "$out" in
+*"gh auth refresh -s project"*) fail "gh auth refresh cannot change an env token: ${out}" ;;
+*"reissue GH_ENTERPRISE_TOKEN"*) ;;
+*) fail "expected the Enterprise env-token remedy, got: ${out}" ;;
+esac
+
 echo "==> another host's scopes cannot answer for the targeted one"
 # The scopes of an account on an unrelated host say nothing about the API calls
 # this repo makes.
@@ -286,6 +302,24 @@ if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; th
 else
     echo "    (skipped: no timeout binary — the probe is unbounded here)"
 fi
+
+echo "==> no user-facing message hardcodes the refresh remedy"
+# The remedy is derived from the credential source once, because `gh auth refresh`
+# is wrong for an env-provided or fine-grained token. Every message must use that
+# derivation — a hardcoded copy is how one call site silently drifts back to
+# advice that cannot work, and the setup section (which needs live GitHub data to
+# render) cannot be driven by the stub above. So assert it statically instead:
+# the literal may appear only in a comment or in the derivation itself.
+while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in
+    *"#"*"gh auth refresh"*) continue ;; # a comment explaining the rule
+    *GH_REMEDY=*) continue ;;            # the derivation itself
+    *) fail "hardcoded refresh remedy — use \${GH_REMEDY}: ${line}" ;;
+    esac
+done <<EOF
+$(grep -n 'gh auth refresh' "${status}" || true)
+EOF
 
 echo "==> the session-start hook allows more time than this section can spend"
 # A coupling that rots silently, and whose failure is total rather than partial:

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# test-status.sh — unit-test status.sh's "Project board writes" check: the token
+# scope the claim lifecycle needs is reported from the section that session-start
+# orientation actually runs (`task status:gh`), in every scope state. Run via
+# `task test:status`.
+#
+# Hermetic in two directions:
+#
+#   * every `gh` call is answered by a stub on PATH, so this makes no network
+#     requests and cannot depend on the scopes of the developer's own token —
+#     which is the whole point. The bug it guards (a claim that silently no-ops
+#     on a token without the scope) is INVISIBLE when tested with a token that
+#     has it.
+#   * the checks run against fixture roots this script builds, never against the
+#     repo it lives in. status.sh resolves its own root from BASH_SOURCE and
+#     feature-detects the board tooling from it, so a test that used the host
+#     repo would assert one profile's layout and fail in every other — a repo
+#     generated with `project_management: none` correctly omits the check.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+status="./scripts/status.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+# Two fixture roots, each holding a copy of the script under test:
+#   with-board — has the board tooling, so the check applies
+#   no-board   — has none of it, so the check must not render at all
+for fixture in with-board no-board; do
+    mkdir -p "${TMP}/${fixture}/scripts"
+    cp "${status}" "${TMP}/${fixture}/scripts/status.sh"
+done
+# The marker status.sh feature-detects on. Contents are never read.
+: >"${TMP}/with-board/scripts/setup-github-project.sh"
+
+WITH_BOARD="${TMP}/with-board/scripts/status.sh"
+NO_BOARD="${TMP}/no-board/scripts/status.sh"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+# make_stub SCENARIO — write $TMP/bin/gh answering `auth status` per SCENARIO.
+# Every other gh call returns an empty JSON array: status.sh reads pr/run lists
+# through jq, and a stub that failed them would exercise the wrong code path.
+# An unrecognized call exits non-zero rather than defaulting to success, so a
+# future probe added to this section shows up here instead of passing silently.
+make_stub() {
+    local scenario="$1"
+    mkdir -p "${TMP}/bin"
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then'
+        case "$scenario" in
+        project)
+            echo "    echo \"  - Token scopes: 'gist', 'project', 'repo'\""
+            echo '    exit 0'
+            ;;
+        read-only)
+            echo "    echo \"  - Token scopes: 'gist', 'read:project', 'repo'\""
+            echo '    exit 0'
+            ;;
+        none)
+            echo "    echo \"  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'\""
+            echo '    exit 0'
+            ;;
+        unparseable)
+            # Authenticated, but the scopes are not reported in the form we
+            # parse — a GitHub App installation token, or a future gh that
+            # renames the line. Must read as "unknown", never as satisfied.
+            echo '    echo "  x Logged in to github.com"'
+            echo '    exit 0'
+            ;;
+        unauthenticated)
+            echo '    echo "You are not logged into any GitHub hosts." >&2'
+            echo '    exit 1'
+            ;;
+        hangs)
+            # Outlives the probe's deadline. Driven with NETWORK_TIMEOUT=1 so
+            # the case costs a second rather than the default five.
+            echo '    sleep 30'
+            echo '    exit 0'
+            ;;
+        *) fail "unknown stub scenario: ${scenario}" ;;
+        esac
+        echo 'fi'
+        echo 'case "$*" in'
+        echo '*"pr list"* | *"run list"*) echo "[]" ;;'
+        echo '*) echo "stub: unexpected gh call: $*" >&2; exit 1 ;;'
+        echo 'esac'
+    } >"${TMP}/bin/gh"
+    chmod +x "${TMP}/bin/gh"
+}
+
+# run_gh_section SCENARIO [SCRIPT] — status.sh's gh section, with the stub on
+# PATH. SCRIPT defaults to the with-board fixture. NO_COLOR keeps the assertions
+# free of ANSI escapes.
+run_gh_section() {
+    make_stub "$1"
+    local script="${2:-${WITH_BOARD}}"
+    PATH="${TMP}/bin:${PATH}" NO_COLOR=1 "${script}" gh 2>&1
+}
+
+echo "==> a token with 'project' reports the board as writable"
+out="$(run_gh_section project)"
+case "$out" in
+*"Project board writes"*"token has 'project'"*) ;;
+*) fail "expected a satisfied board-writes line, got: ${out}" ;;
+esac
+
+echo "==> read-only 'read:project' is NOT reported as satisfied"
+# The state most easily mistaken for working: --show reads the card fine, so the
+# board looks reachable right up to the write that moves it.
+out="$(run_gh_section read-only)"
+case "$out" in
+*"token has 'project'"*) fail "read:project must not satisfy a WRITE check: ${out}" ;;
+*"read-only"*"gh auth refresh -s project"*) ;;
+*) fail "expected a read-only warning naming the remedy, got: ${out}" ;;
+esac
+
+echo "==> a token with neither scope warns and names the remedy"
+out="$(run_gh_section none)"
+case "$out" in
+*"lacks 'project'"*"gh auth refresh -s project"*) ;;
+*) fail "expected a missing-scope warning naming the remedy, got: ${out}" ;;
+esac
+
+echo "==> unreadable scopes read as unknown, not as satisfied"
+out="$(run_gh_section unparseable)"
+case "$out" in
+*"token has 'project'"*) fail "an unparseable scope list must not pass: ${out}" ;;
+*"could not read token scopes"*) ;;
+*) fail "expected an unknown-scopes line, got: ${out}" ;;
+esac
+
+echo "==> an unauthenticated gh skips the section without erroring"
+out="$(run_gh_section unauthenticated)"
+case "$out" in
+*"not authenticated"*) ;;
+*) fail "expected the unauthenticated skip, got: ${out}" ;;
+esac
+case "$out" in
+*"Project board writes"*) fail "board-writes line rendered without auth: ${out}" ;;
+esac
+
+echo "==> a repo with no project tooling omits the check entirely"
+# Not-applicable is not the same as fine: a repo generated with
+# `project_management: none` has no board to write to, and a warning there would
+# be noise the reader cannot act on.
+out="$(run_gh_section project "${NO_BOARD}")"
+case "$out" in
+*"Project board writes"*) fail "board-writes line rendered in a repo with no board tooling: ${out}" ;;
+esac
+
+echo "==> a probe that outlives its deadline says so, not 'not authenticated'"
+# Bounding the auth probe made a slow network look exactly like a missing login.
+# Reporting the latter for the former sends the reader to fix the wrong thing.
+# Skipped where no `timeout` binary exists (stock macOS): run_timeout then runs
+# the probe unbounded by design, and there is no deadline to hit.
+if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
+    make_stub hangs
+    out="$(PATH="${TMP}/bin:${PATH}" NO_COLOR=1 NETWORK_TIMEOUT=1 "${WITH_BOARD}" gh 2>&1)"
+    case "$out" in
+    *"timed out"*) ;;
+    *"not authenticated"*) fail "a timeout must not be reported as missing auth: ${out}" ;;
+    *) fail "expected a timeout notice, got: ${out}" ;;
+    esac
+else
+    echo "    (skipped: no timeout binary — the probe is unbounded here)"
+fi
+
+echo "==> the check never runs the setup section's Projects query"
+# The line is fed by the auth probe the section already makes. If it ever grows a
+# GraphQL call, the network cost lands in every session start — the reason the
+# setup section is excluded from the default dashboard in the first place.
+out="$(run_gh_section project)"
+case "$out" in
+*"stub: unexpected gh call"*) fail "the gh section made an unstubbed call: ${out}" ;;
+esac
+
+echo "status.sh tests passed"

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -101,6 +101,19 @@ make_stub() {
             echo '    fi'
             echo '    exit 0'
             ;;
+        other-host-has-scope)
+            # Two hosts; only the unrelated one holds 'project'. A stub that
+            # ignores --hostname proves the cross-host bug; this one honours it,
+            # so the check must read the targeted host's line only.
+            echo "    host=\"\"; prev=\"\""
+            echo '    for a in "$@"; do case "$prev" in --hostname) host="$a" ;; esac; prev="$a"; done'
+            echo '    if [ "$host" = "github.com" ]; then'
+            echo "        echo \"  - Token scopes: 'gist', 'repo'\""
+            echo '    else'
+            echo "        echo \"  - Token scopes: 'gist', 'project', 'repo'\""
+            echo '    fi'
+            echo '    exit 0'
+            ;;
         no-active-flag)
             # gh predates --active (pre-2.40): the flag is a usage error, which
             # must not read as a failed login.
@@ -219,6 +232,16 @@ case "$out" in
 *) fail "expected the active account's missing scope to be reported, got: ${out}" ;;
 esac
 
+echo "==> another host's scopes cannot answer for the targeted one"
+# The scopes of an account on an unrelated host say nothing about the API calls
+# this repo makes.
+out="$(run_gh_section other-host-has-scope)"
+case "$out" in
+*"token has 'project'"*) fail "read the targeted host's scopes, not every host's: ${out}" ;;
+*"lacks 'project'"*) ;;
+*) fail "expected the targeted host's missing scope to be reported, got: ${out}" ;;
+esac
+
 echo "==> gh without --active falls back instead of reading as unauthenticated"
 out="$(run_gh_section no-active-flag)"
 case "$out" in
@@ -242,6 +265,26 @@ if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; th
     esac
 else
     echo "    (skipped: no timeout binary — the probe is unbounded here)"
+fi
+
+echo "==> the session-start hook allows more time than this section can spend"
+# A coupling that rots silently, and whose failure is total rather than partial:
+# status.sh buffers each section before printing it (section_box reads all of its
+# input first), so an outer deadline that fires mid-section discards everything
+# the section was about to report — including the board-writes line. The section
+# spends up to NETWORK_TIMEOUT on the auth probe and then up to NETWORK_TIMEOUT
+# again on the PR/run probes, so the hook must allow more than twice the probe
+# budget. Skipped where the hook is not generated (no devcontainer).
+hook=".devcontainer/config/claude-hooks/session-start-context.sh"
+if [ -f "$hook" ]; then
+    budget="$(sed -n -E 's/.*timeout ([0-9]+) task status:gh.*/\1/p' "$hook")"
+    probe="$(sed -n -E 's/^NETWORK_TIMEOUT="\$\{NETWORK_TIMEOUT:-([0-9]+)\}"$/\1/p' "${status}")"
+    [ -n "$budget" ] || fail "could not read the status:gh timeout out of ${hook}"
+    [ -n "$probe" ] || fail "could not read NETWORK_TIMEOUT out of ${status}"
+    [ "$budget" -gt "$((probe * 2))" ] ||
+        fail "hook allows ${budget}s but the section can spend $((probe * 2))s on probes alone — the board-writes line is lost first"
+else
+    echo "    (skipped: no devcontainer hook in this profile)"
 fi
 
 echo "==> the check never runs the setup section's Projects query"

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -23,18 +23,24 @@ status="./scripts/status.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "${TMP}"' EXIT
 
-# Two fixture roots, each holding a copy of the script under test:
-#   with-board — has the board tooling, so the check applies
-#   no-board   — has none of it, so the check must not render at all
-for fixture in with-board no-board; do
+# Three fixture roots, each holding a copy of the script under test:
+#   with-board  — has the board tooling, so the check applies
+#   no-board    — has none of it, so the check must not render at all
+#   skills-only — the DEFAULT generated profile: `project_management: none` with
+#                 `use_skills_sync: true`, so the vendored universal skill set
+#                 (track-work included) is present but there is no board
+for fixture in with-board no-board skills-only; do
     mkdir -p "${TMP}/${fixture}/scripts"
     cp "${status}" "${TMP}/${fixture}/scripts/status.sh"
 done
-# The marker status.sh feature-detects on. Contents are never read.
+# The markers status.sh feature-detects on. Contents are never read.
 : >"${TMP}/with-board/scripts/setup-github-project.sh"
+mkdir -p "${TMP}/skills-only/.claude/skills/track-work/assets"
+: >"${TMP}/skills-only/.claude/skills/track-work/assets/set-issue-status.sh"
 
 WITH_BOARD="${TMP}/with-board/scripts/status.sh"
 NO_BOARD="${TMP}/no-board/scripts/status.sh"
+SKILLS_ONLY="${TMP}/skills-only/scripts/status.sh"
 
 fail() {
     echo "TEST FAIL: $*" >&2
@@ -75,6 +81,35 @@ make_stub() {
         unauthenticated)
             echo '    echo "You are not logged into any GitHub hosts." >&2'
             echo '    exit 1'
+            ;;
+        fine-grained)
+            # A fine-grained PAT or App token: permissions, not OAuth scopes, so
+            # gh reports the line with nothing in it.
+            echo '    echo "  - Token scopes: none"'
+            echo '    exit 0'
+            ;;
+        inactive-has-scope)
+            # Two accounts on one host; only the INACTIVE one holds 'project'.
+            # A stub that ignores --active proves the aggregate-read bug; this
+            # one honours it, so the check must read the active account's line.
+            echo '    if [ "$3" = "--active" ]; then'
+            echo "        echo \"  - Active account: true\""
+            echo "        echo \"  - Token scopes: 'gist', 'repo'\""
+            echo '    else'
+            echo "        echo \"  - Token scopes: 'gist', 'repo'\""
+            echo "        echo \"  - Token scopes: 'gist', 'project', 'repo'\""
+            echo '    fi'
+            echo '    exit 0'
+            ;;
+        no-active-flag)
+            # gh predates --active (pre-2.40): the flag is a usage error, which
+            # must not read as a failed login.
+            echo '    if [ "$3" = "--active" ]; then'
+            echo '        echo "unknown flag: --active" >&2'
+            echo '        exit 1'
+            echo '    fi'
+            echo "    echo \"  - Token scopes: 'gist', 'project', 'repo'\""
+            echo '    exit 0'
             ;;
         hangs)
             # Outlives the probe's deadline. Driven with NETWORK_TIMEOUT=1 so
@@ -151,6 +186,45 @@ echo "==> a repo with no project tooling omits the check entirely"
 out="$(run_gh_section project "${NO_BOARD}")"
 case "$out" in
 *"Project board writes"*) fail "board-writes line rendered in a repo with no board tooling: ${out}" ;;
+esac
+
+echo "==> the vendored track-work skill alone does NOT trigger the check"
+# The default generated profile: `project_management: none` (the default) with
+# `use_skills_sync: true` vendors the universal skill set, so keying the check on
+# track-work's presence would demand the `project` scope from every repo that
+# merely completed the documented skills-sync step.
+out="$(run_gh_section none "${SKILLS_ONLY}")"
+case "$out" in
+*"Project board writes"*) fail "the skill's presence must not imply a board: ${out}" ;;
+esac
+
+echo "==> a fine-grained/App token reads as unknown, with the right remedy"
+# Its Projects access is a permission, not a scope, so it may well be able to
+# write — and `gh auth refresh` cannot change it either way.
+out="$(run_gh_section fine-grained)"
+case "$out" in
+*"lacks 'project'"*) fail "a scope-less token must not be reported as lacking a scope: ${out}" ;;
+*"no OAuth scopes reported"*) ;;
+*) fail "expected the fine-grained-token notice, got: ${out}" ;;
+esac
+case "$out" in
+*"gh auth refresh"*) fail "gh auth refresh cannot fix a fine-grained token: ${out}" ;;
+esac
+
+echo "==> an inactive account's scopes cannot answer for the active one"
+out="$(run_gh_section inactive-has-scope)"
+case "$out" in
+*"token has 'project'"*) fail "read the ACTIVE account's scopes, not every account's: ${out}" ;;
+*"lacks 'project'"*) ;;
+*) fail "expected the active account's missing scope to be reported, got: ${out}" ;;
+esac
+
+echo "==> gh without --active falls back instead of reading as unauthenticated"
+out="$(run_gh_section no-active-flag)"
+case "$out" in
+*"not authenticated"*) fail "a usage error must not read as a failed login: ${out}" ;;
+*"token has 'project'"*) ;;
+*) fail "expected the fallback to read the full report, got: ${out}" ;;
 esac
 
 echo "==> a probe that outlives its deadline says so, not 'not authenticated'"


### PR DESCRIPTION
Closes #465

## What

The claim lifecycle writes an issue's project `Status` — `In Progress` at claim,
advanced through the PR stages, restored at hand-back — and that write needs the
`project` token scope, which `gh auth login` does not grant. Without it every
board write exits 2 ("could not verify") and no card moves.

Each step handles that correctly *on its own*: it is an auth condition they
cannot fix, so they note it and carry on. In aggregate that is the worst outcome
available — the agent reports the issue claimed, the board says nothing was ever
started, neither is wrong from where it stands, and nothing escalates until a
human notices the board has gone stale.

The condition was already detectable, and shown in the wrong place: the
`read:project` checkline lived only in `status:setup`, which session-start
orientation does not run. The one moment designed to catch a broken tracking
surface was the moment that could not see this one.

## Changes

**`scripts/status.sh`** — a `Project board writes` line in the `gh` section, fed
by the auth probe that section already makes (no extra API call, so
`status:setup` stays deliberately excluded from the default dashboard). Reported
in both directions on purpose: a check that prints only on failure is
indistinguishable from a check that is not running, which is the bug it exists
to catch.

It resolves one credential rather than "a token": `--active` excludes a second
account on the host, `--hostname` excludes an unrelated host, and the remedy is
derived from the credential *source* — `gh auth refresh` cannot change an
env-provided token (`GH_TOKEN`, `GITHUB_TOKEN`, and the two `*_ENTERPRISE_TOKEN`
variants) and cannot add a fine-grained or App token's permissions, which are
not OAuth scopes. `read:project` is called out separately from "no scope at all",
because it reads a card fine right up to the write that moves it.

**`scripts/setup-github-project.sh`** — a scope preflight before the first API
call. The run already failed without the scope (`gh api graphql` exits non-zero
on `INSUFFICIENT_SCOPES` under `set -e`); what it lacked was a cause. It is
deliberately *non-fatal* when the scope list cannot be parsed — a fine-grained or
App token may be perfectly capable, and refusing would be worse than the failure
it replaces.

**`docs/project-management.md`** — names the scopes, the remedy, and why the
failure is invisible from both ends. Standardised on `gh auth refresh -s project`
to match `docs/CHECKLIST.md` rather than the redundant `read:project,project`.

**`scripts/test-status.sh`** (new) — 18 hermetic cases over a stubbed `gh`,
asserting against fixture roots the test builds, so it holds in every copier
profile. `status.sh` had no test tier at all before this.

**`.github/workflows/build.yml`** — CI enumerates test targets instead of running
`verify`, so `test:setup-github-project` was **never running in CI**. Added it
alongside `test:status`, or this change's own coverage would have been
CI-invisible too.

**`.devcontainer/config/claude-hooks/session-start-context.sh`** — `timeout 8
task status:gh` was below the section's own worst case (5s auth + 5s list probes),
and `status.sh` buffers each section before printing, so an outer kill discards
everything it was about to report. Raised to 12s, with a test asserting the
budget exceeds twice `NETWORK_TIMEOUT`.

## Verification

- `task verify` green (8 runs; 6/6 copier profiles each) · `task ci` green
- 18 test cases, 15 mutations exercised, all caught
- `task challenge` — clean pass after 4 rounds · `task review` — clean pass, re-run
  against the final artifact
- Root/template twins: `status.sh` and `setup-github-project.sh` byte-equal
  (parity gate, 107 twins); `docs/project-management.md` is allowlisted in **both**
  dogfood gates, so it was hand-ported deliberately — no gate would have caught a
  one-sided edit

## Notes for the reviewer

**One P1 was rejected, not fixed.** Challenge round 3 asked to gate the check on
the vendored `track-work` skill instead of `setup-github-project.sh` — the exact
gate removed in round 1, on the same reviewer's P1 that keying on the skill
demands a broad scope from every default-profile repo. Both findings are one
tradeoff seen from opposite sides and neither is satisfiable: board membership is
*remote* state, so nothing on disk separates "opted out" from "opted out but
boarded anyway". A red line in every opted-out repo every session is the worse
error — universal where the miss is conditional. The reasoning is in a comment in
`status.sh`, not in `docs/project-management.md`, which ships only to
`project_management: github` repos and so would be invisible to the affected
audience.

**A design question this surfaced but does not settle.** `bot-account.md`
deliberately grants the bot `Projects: Read-only` — "Grant read; never write." So
on an org repo an agent running as the bot **cannot move a card**, by design,
however the scope check reports. The docs now state that and lay out both honest
responses; changing the bot's permissions is a policy decision (org-wide, not
bounded by the token's repository list) and is not made here.

**A pre-existing harness flake, unrelated to this PR.** The first `task ci` run
failed in `test:template:update` with `git clone … failed to copy file to
…/.git/objects/…: No such file or directory` — a parallel-temp-dir race in
`test:template:all`. The same task passed in every `verify` run on identical
content and 3/3 in isolation; the re-run of `task ci` was clean. Filing separately.

No deferred findings — every P2 raised across both stages was fixed in place, and
the `deferred-findings` tree is empty (verified, not assumed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
