### PR TITLE
fix(template): require current-head Codex shepherd completion

### DIFF
--- a/.dogfood-answers.yml
+++ b/.dogfood-answers.yml
@@ -45,8 +45,9 @@ use_codeql: true
 codeql_languages:
   - python
 
-# This repo dogfoods the Codex second-model review; CodeRabbit stays off.
+# This repo dogfoods local and cloud Codex review; CodeRabbit stays off.
 use_codex_review: true
+use_codex_cloud_review: true
 use_coderabbit: false
 
 devcontainer: true

--- a/.foreman.toml
+++ b/.foreman.toml
@@ -7,6 +7,7 @@
 
 backend = "claude"
 require_approval = true
+require_codex_cloud_review = true
 inputs = "auto"
 verify_command = ["task", "ci"]
 max_parallel = 3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,12 +255,13 @@ something to ask permission for.
   the comment ID returned for that trigger. Poll PR reactions, top-level
   comments, reviews, and inline review comments; fetch trigger reactions by
   that exact comment ID. A Codex result is terminal for that captured head only
-  when it is either: a clean review or top-level comment authored by the
-  expected Codex bot/App whose `Reviewed commit:` identifies that head; a fresh
-  👍 from that bot on that exact trigger comment, created after both the head
-  push and the review request, with no newer contradictory bot result; or
-  review findings authored by that bot which identify that head and must be
-  adjudicated before the cycle can become clean. Earlier comments, reviews,
+  when it is either: a clean review or top-level comment authored by GitHub
+  actor ID `199175422` (`chatgpt-codex-connector[bot]`, type `Bot`) whose
+  `Reviewed commit:` identifies that head; a fresh 👍 from that bot on that
+  exact trigger comment, created after both the head push and the review
+  request, with no newer contradictory bot result; or review findings authored
+  by that bot which identify that head and must be adjudicated before the
+  cycle can become clean. Earlier comments, reviews,
   inline findings, and reactions never count for a newer head. A 👀 is pending,
   not success; if it disappears without a terminal result, the attempt is
   incomplete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,29 @@ something to ask permission for.
   verify` before each push; the local challenge/review loops are not
   re-entered — the post-push cloud/bot review is the second-model check at
   this stage.
+  **Require a current-head Codex result.** On initial shepherd entry and
+  immediately after every fix push, capture the PR's current `headRefOid` and
+  the head's push time, then post `@codex review`. Record the request time and
+  the comment ID returned for that trigger. Poll PR reactions, top-level
+  comments, reviews, and inline review comments; fetch trigger reactions by
+  that exact comment ID. A Codex result is terminal for that captured head only
+  when it is either: a clean review or top-level comment authored by the
+  expected Codex bot/App whose `Reviewed commit:` identifies that head; a fresh
+  👍 from that bot on that exact trigger comment, created after both the head
+  push and the review request, with no newer contradictory bot result; or
+  review findings authored by that bot which identify that head and must be
+  adjudicated before the cycle can become clean. Earlier comments, reviews,
+  inline findings, and reactions never count for a newer head. A 👀 is pending,
+  not success; if it disappears without a terminal result, the attempt is
+  incomplete.
+  Give each attempt a full 10–15 minute window. If the first attempt is
+  incomplete, post `@codex review` once more for the same head and run one more
+  full window, recording and using the new trigger comment ID. If both attempts
+  are incomplete, stop and escalate without reporting green. Waiting and the
+  one allowed re-trigger do not consume a shepherd fix round. Immediately
+  before accepting the result or reporting green, fetch `headRefOid` and all
+  four review surfaces again; a changed head invalidates the result and starts
+  a new current-head cycle.
   Shepherd is **externally driven** — CI results and other people's comments
   are its input, so it cannot manufacture a round on its own. A round is one
   fix push, or one no-change cycle where everything is answered and nothing
@@ -280,12 +303,13 @@ something to ask permission for.
   the middle of the shepherd stage. Bot and human reviews land *after* checks
   settle, so `gh pr checks --watch` returns at exactly the moment the review
   has not run yet: an empty comment list read at that instant means "not
-  reviewed yet", not "nothing to answer". Wait for **both** signals — let
-  every check conclude, then give the reviewer a bounded window (~10–15
-  minutes) on the current head, and proceed on CI alone only if nothing lands
-  in it.
-- **Stop at green.** Once checks pass *and* no review findings are unresolved,
-  report that and stop — merging is always a human decision.
+  reviewed yet", not "nothing to answer". Wait for **both** signals: every
+  check must conclude, and the required current-head Codex cycle above must
+  reach a terminal result. Green CI while that cycle is pending or incomplete
+  is still non-terminal.
+- **Stop at green.** Once checks pass, the current-head Codex cycle is clean,
+  and no review findings are unresolved, report that and stop — merging is
+  always a human decision.
 
 ## Critical Copier Gotchas
 
@@ -368,9 +392,10 @@ on Codex. Setup and mechanics: `docs/guides/codex-review.md`.
 
 These tasks slot into the **Dev Loop** above: after `task verify` goes green,
 before `task ci`. Codex cloud review is also connected to this repo's PRs —
-it posts inline comments only for high-priority findings; a bare 👍 reaction
-from the Codex bot is its clean pass, and a lone 👀 that never resolves means
-the cloud run failed.
+it posts inline comments only for high-priority findings. During shepherding,
+accept its clean comments, reviews, or reactions only under the current-head
+cycle above: stale activity is not evidence for the current commit, and a lone
+👀 that disappears or never resolves is an incomplete attempt.
 
 **Treat Codex findings as hypotheses, not authority.** For every finding:
 

--- a/copier.yml
+++ b/copier.yml
@@ -211,6 +211,21 @@ use_codex_review:
     defaults off.
   default: no
 
+use_codex_cloud_review:
+  type: bool
+  help: >-
+    CODEX CLOUD REVIEW: Require a terminal Codex review attributable to every
+    PR head before shepherding can report green? Defaults off and requires
+    CODEX REVIEW. A maintainer must connect the repository to Codex cloud
+    review through GitHub. Free-tier access is not assumed: availability and
+    quotas depend on the maintainer's ChatGPT plan, and paid access may be
+    required. Private repositories require explicit GitHub connector
+    permission. This is a required shepherd signal, not a GitHub status check;
+    after two unavailable attempts the agent stops and escalates.
+  default: no
+  when: "[[ use_codex_review ]]"
+  validator: "[% if use_codex_cloud_review and not use_codex_review %]Enable CODEX REVIEW before CODEX CLOUD REVIEW.[% endif %]"
+
 use_coderabbit:
   type: bool
   help: >-

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -91,6 +91,10 @@ this comment. -->
       the CodeRabbit GitHub App installation and confirm the App no longer has
       access. Deleting `.coderabbit.yaml` and bot trust does not revoke an
       existing installation.
+- [ ] **[human-only] Connect Codex cloud review** — connect this repository in
+      ChatGPT Codex settings, grant private-repository access if applicable,
+      and confirm review activity is authored by GitHub actor ID `199175422`
+      (`chatgpt-codex-connector[bot]`, type `Bot`).
 - [ ] Actions secret: `CLAUDE_CODE_OAUTH_TOKEN` (claude-* workflows) — generate
       with `claude setup-token`; the value must start **`sk-ant-oat01-`** (an OAuth
       token, billed to your Claude subscription), **not** `sk-ant-api03-` (a raw API

--- a/docs/architecture/foreman.md
+++ b/docs/architecture/foreman.md
@@ -153,6 +153,12 @@ Deterministic triggers → bounded agent actions on open foreman PRs:
 - **Green + adjudicated + `mergeStateStatus=CLEAN`** → `ready-to-merge` label
   plus a dependency-aware suggested merge order. Foreman performs no merge
   action of any kind.
+- **`require_codex_cloud_review = true`** → Foreman fails closed before that
+  label, removes a stale readiness label from fresh PR status before any
+  state-specific return, and escalates to the manual shepherd procedure, which
+  owns the current-head Codex trigger, bounded retries, and terminal-result
+  validation. Watch mode writes this handoff and its detail to the heartbeat
+  log instead of silently idling.
 
 ## Watch mode and unattended runs
 

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -224,7 +224,9 @@ task ci         # full CI mirror
 The full staged loop — including the PR-shepherding rounds — is defined in
 AGENTS.md ("Dev Loop"). If Codex cloud review is connected to the repo, PRs
 get a cloud pass too: inline comments only for high-priority findings, a
-bare 👍 reaction as the clean pass.
+👍 from the pinned Codex bot actor ID `199175422` on the exact
+`@codex review` trigger comment as the clean pass. That reaction must post
+after both the current head was pushed and its review request was created.
 
 ## Finding priorities
 

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -2,11 +2,12 @@
 
 A second AI model — the [OpenAI Codex CLI](https://developers.openai.com/codex/cli)
 — reviews changes in this repo: manual review/challenge tasks, plus an optional
-automatic Claude Code → Codex stop-gate. Everything is local and advisory:
-nothing runs in CI, no PR check depends on Codex, and `verify`/`ci` never
-invoke it. Findings are hypotheses for the primary agent to adjudicate — the
-protocol and the loop caps live in AGENTS.md ("Second-Model
-Review").
+automatic Claude Code → Codex stop-gate. Those tasks are local and advisory:
+nothing runs in CI, no PR check depends on Codex, and `verify`/`ci` never invoke
+it. Repositories can separately opt into a required current-head result from
+Codex cloud review during PR shepherding. Findings are hypotheses for the
+primary agent to adjudicate — the protocol and the loop caps live in AGENTS.md
+("Second-Model Review").
 
 ## Setup
 
@@ -29,6 +30,15 @@ Review").
    /plugin install codex@openai-codex
    /codex:setup
    ```
+
+5. **If `use_codex_cloud_review` is enabled, connect this repository to Codex
+   cloud review for PR shepherding.** The Copier opt-in adds the policy but
+   cannot grant GitHub access: a maintainer must connect Codex through ChatGPT
+   and allow the repository in the GitHub connector. Availability and quotas
+   depend on the maintainer's ChatGPT plan, and private repositories require
+   explicit connector access. Cloud review is a required shepherd signal, not
+   a required GitHub status check; if it stays unavailable for both bounded
+   attempts, the agent stops and escalates.
 
 ## Manual reviews
 

--- a/scripts/foreman/cli.py
+++ b/scripts/foreman/cli.py
@@ -285,7 +285,14 @@ def cmd_status(args: argparse.Namespace) -> int:
                 status.get("statusCheckRollup")
             )
             labels = [label["name"] for label in status.get("labels") or []]
-            state = "ready-to-merge" if "ready-to-merge" in labels else "pr-open"
+            state = (
+                "ready-to-merge"
+                if shepherd_mod.ready_label_is_authoritative(
+                    labels,
+                    require_codex_cloud_review=cfg.require_codex_cloud_review,
+                )
+                else "pr-open"
+            )
             if state == "ready-to-merge":
                 ready.append(
                     shepherd_mod.PrWork(

--- a/scripts/foreman/config.py
+++ b/scripts/foreman/config.py
@@ -22,6 +22,7 @@ class Config:
     backend: str = "claude"
     backend_version: str = ""  # expected CLI version prefix; "" = don't assert
     require_approval: bool = True  # strict arming: only foreman-approved units dispatch
+    require_codex_cloud_review: bool = False
     inputs: str = "auto"  # auto | fields | labels
     verify_command: list[str] = field(default_factory=lambda: ["task", "ci"])
     max_parallel: int = 3

--- a/scripts/foreman/shepherd.py
+++ b/scripts/foreman/shepherd.py
@@ -219,6 +219,9 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
         title=status["title"],
     )
     remote_name = worktree.remote(cfg)
+    status_labels = {entry["name"] for entry in status.get("labels") or []}
+    if cfg.require_codex_cloud_review and "ready-to-merge" in status_labels:
+        gh.label_own_pr(work.number, remove=["ready-to-merge"])
     checks_state, failed = classify_checks(status.get("statusCheckRollup"))
 
     if checks_state == "pending":
@@ -388,6 +391,12 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
         return work
 
     if merge_state == "CLEAN":
+        if cfg.require_codex_cloud_review:
+            work.state, work.detail = (
+                "escalated",
+                "current-head Codex cloud review requires manual shepherd completion",
+            )
+            return work
         gh.label_own_pr(work.number, add=["ready-to-merge"])
         work.state, work.detail = (
             "ready",

--- a/scripts/foreman/shepherd.py
+++ b/scripts/foreman/shepherd.py
@@ -93,6 +93,13 @@ def classify_checks(rollup: list[dict] | None) -> tuple[str, list[dict]]:
     return "green", []
 
 
+def ready_label_is_authoritative(
+    labels: list[str], *, require_codex_cloud_review: bool
+) -> bool:
+    """Whether read-only reporting may trust Foreman's readiness label."""
+    return "ready-to-merge" in labels and not require_codex_cloud_review
+
+
 def trusted_review_threads(
     gh: GitHub, cfg: Config, threads: list[dict]
 ) -> tuple[list[dict], int]:

--- a/scripts/foreman/tests/test_shepherd.py
+++ b/scripts/foreman/tests/test_shepherd.py
@@ -9,7 +9,12 @@ from unittest.mock import MagicMock, patch
 from foreman import signatures as signatures_mod
 from foreman.config import Config
 from foreman.github import GitHub
-from foreman.shepherd import classify_checks, shepherd_pr, trusted_review_threads
+from foreman.shepherd import (
+    classify_checks,
+    ready_label_is_authoritative,
+    shepherd_pr,
+    trusted_review_threads,
+)
 from foreman.tests.fakes import make_github
 from foreman.util import ForemanError
 
@@ -46,6 +51,24 @@ class ClassifyChecks(unittest.TestCase):
         state, failed = classify_checks([{"state": "FAILURE", "context": "ci/legacy"}])
         self.assertEqual(state, "red")
         self.assertEqual(failed[0]["context"], "ci/legacy")
+
+
+class ReadinessLabelAuthority(unittest.TestCase):
+    def test_default_policy_accepts_readiness_label(self):
+        self.assertTrue(
+            ready_label_is_authoritative(
+                ["foreman-dispatched", "ready-to-merge"],
+                require_codex_cloud_review=False,
+            )
+        )
+
+    def test_cloud_review_policy_ignores_stale_readiness_label(self):
+        self.assertFalse(
+            ready_label_is_authoritative(
+                ["foreman-dispatched", "ready-to-merge"],
+                require_codex_cloud_review=True,
+            )
+        )
 
 
 class TrustedReviewThreads(unittest.TestCase):

--- a/scripts/foreman/tests/test_shepherd.py
+++ b/scripts/foreman/tests/test_shepherd.py
@@ -140,6 +140,7 @@ class MergeReadiness(unittest.TestCase):
             "mergeStateStatus": merge_state,
             "mergeable": mergeable,
             "statusCheckRollup": [],
+            "labels": [],
         }
         gh.review_threads.return_value = []
         gh.viewer.return_value = "bot"
@@ -158,6 +159,35 @@ class MergeReadiness(unittest.TestCase):
         work = shepherd_pr(gh, Config(), Path("."), {"number": 23, "_unit": 17}, [])
         self.assertEqual(work.state, "ready")
         gh.label_own_pr.assert_called_once_with(23, add=["ready-to-merge"])
+
+    @patch("foreman.shepherd.worktree.remote", return_value="origin")
+    def test_cloud_review_requirement_fails_closed_to_manual_shepherd(self, _remote):
+        gh = self.github("CLEAN", "MERGEABLE")
+        cfg = Config(require_codex_cloud_review=True)
+        gh.pr_status.return_value["labels"] = [{"name": "ready-to-merge"}]
+        work = shepherd_pr(gh, cfg, Path("."), {"number": 23, "_unit": 17}, [])
+        self.assertEqual(work.state, "escalated")
+        self.assertIn("manual shepherd", work.detail)
+        gh.label_own_pr.assert_called_once_with(23, remove=["ready-to-merge"])
+
+    @patch("foreman.shepherd.worktree.remote", return_value="origin")
+    def test_cloud_review_requirement_removes_readiness_while_checks_run(self, _remote):
+        gh = self.github("CLEAN", "MERGEABLE")
+        gh.pr_status.return_value["statusCheckRollup"] = [
+            {"status": "IN_PROGRESS", "conclusion": ""}
+        ]
+        gh.pr_status.return_value["labels"] = [{"name": "ready-to-merge"}]
+
+        work = shepherd_pr(
+            gh,
+            Config(require_codex_cloud_review=True),
+            Path("."),
+            {"number": 23, "_unit": 17},
+            [],
+        )
+
+        self.assertEqual(work.state, "settling")
+        gh.label_own_pr.assert_called_once_with(23, remove=["ready-to-merge"])
 
 
 class SignatureCatalog(unittest.TestCase):

--- a/scripts/foreman/tests/test_watch.py
+++ b/scripts/foreman/tests/test_watch.py
@@ -33,14 +33,14 @@ class HumanHandoffMessages(unittest.TestCase):
         report = ShepherdReport(
             environmental={
                 23: "current-head Codex cloud review requires manual shepherd completion",
-                7: "environmental CI failure persisted",
+                7: "environmental CI failure\n  persisted after retry",
             }
         )
 
         self.assertEqual(
             human_handoff_messages(report),
             [
-                "NEEDS HUMAN #7: environmental CI failure persisted",
+                "NEEDS HUMAN #7: environmental CI failure persisted after retry",
                 (
                     "NEEDS HUMAN #23: current-head Codex cloud review requires "
                     "manual shepherd completion"

--- a/scripts/foreman/tests/test_watch.py
+++ b/scripts/foreman/tests/test_watch.py
@@ -1,11 +1,12 @@
-"""Watch-mode plumbing that must not regress: interval parsing."""
+"""Watch-mode plumbing and durable human-handoff reporting."""
 
 from __future__ import annotations
 
 import unittest
 
+from foreman.shepherd import ShepherdReport
 from foreman.util import ForemanError
-from foreman.watch import parse_interval
+from foreman.watch import human_handoff_messages, parse_interval
 
 
 class ParseInterval(unittest.TestCase):
@@ -25,6 +26,27 @@ class ParseInterval(unittest.TestCase):
         for bad in ("0", "0s", "0m", "0h"):
             with self.assertRaises(ForemanError):
                 parse_interval(bad)
+
+
+class HumanHandoffMessages(unittest.TestCase):
+    def test_environmental_handoffs_are_sorted_and_include_detail(self):
+        report = ShepherdReport(
+            environmental={
+                23: "current-head Codex cloud review requires manual shepherd completion",
+                7: "environmental CI failure persisted",
+            }
+        )
+
+        self.assertEqual(
+            human_handoff_messages(report),
+            [
+                "NEEDS HUMAN #7: environmental CI failure persisted",
+                (
+                    "NEEDS HUMAN #23: current-head Codex cloud review requires "
+                    "manual shepherd completion"
+                ),
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/foreman/watch.py
+++ b/scripts/foreman/watch.py
@@ -26,6 +26,14 @@ DEFAULT_INTERVAL_S = 300
 MAX_CONSECUTIVE_FAILURES = 3
 
 
+def human_handoff_messages(report: shepherd_mod.ShepherdReport) -> list[str]:
+    """Durable heartbeat lines for shepherd work that needs a person."""
+    return [
+        f"NEEDS HUMAN #{unit_number}: {detail}"
+        for unit_number, detail in sorted(report.environmental.items())
+    ]
+
+
 def parse_interval(text: str) -> int:
     match = re.fullmatch(r"(\d+)\s*([smh]?)", text.strip())
     if not match:
@@ -90,8 +98,11 @@ def run_watch(
             ready = len(shep.ready_order)
             heartbeat(
                 f"open={len(open_units)} dispatched={dispatched} waiting={waiting} "
-                f"failed={failed} prs-ready={ready} cost=${total_cost:.2f}"
+                f"failed={failed} prs-ready={ready} "
+                f"needs-human={len(shep.environmental)} cost=${total_cost:.2f}"
             )
+            for message in human_handoff_messages(shep):
+                heartbeat(message)
             if shep.ready_order and dispatched == 0 and not failed:
                 if not idle_notified:
                     info(

--- a/scripts/foreman/watch.py
+++ b/scripts/foreman/watch.py
@@ -29,7 +29,7 @@ MAX_CONSECUTIVE_FAILURES = 3
 def human_handoff_messages(report: shepherd_mod.ShepherdReport) -> list[str]:
     """Durable heartbeat lines for shepherd work that needs a person."""
     return [
-        f"NEEDS HUMAN #{unit_number}: {detail}"
+        f"NEEDS HUMAN #{unit_number}: {' '.join(detail.split())}"
         for unit_number, detail in sorted(report.environmental.items())
     ]
 

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -870,7 +870,7 @@ if [ "$profile" = "full" ]; then
     grep -Fq 'headRefOid' AGENTS.md || err "AGENTS missing current-head Codex shepherd contract (use_codex_cloud_review=true)"
     grep -Fq 'exact trigger comment' AGENTS.md || err "AGENTS permits unbound Codex reactions (use_codex_cloud_review=true)"
     grep -Fq 'comment ID returned for that trigger' AGENTS.md || err "AGENTS does not retain the Codex trigger comment ID"
-    grep -Fq 'expected Codex bot/App' AGENTS.md || err "AGENTS missing Codex result actor authentication (use_codex_cloud_review=true)"
+    grep -Fq 'actor ID `199175422`' AGENTS.md || err "AGENTS missing pinned Codex result actor identity (use_codex_cloud_review=true)"
     grep -Fq 'Reviewed commit:' AGENTS.md || err "AGENTS missing commit-bound Codex result contract (use_codex_cloud_review=true)"
     grep -Fq 'If both attempts' AGENTS.md &&
         grep -Fq 'are incomplete, stop and escalate without reporting green' AGENTS.md ||
@@ -878,8 +878,12 @@ if [ "$profile" = "full" ]; then
     ! grep -Fq 'proceed on CI alone' AGENTS.md || err "AGENTS permits CI-only completion despite use_codex_cloud_review=true"
     grep -Fq 'require_codex_cloud_review = true' .foreman.toml ||
         err "Foreman does not fail closed for required Codex cloud review"
+    grep -Fq 'Connect Codex cloud review' docs/CHECKLIST.md ||
+        err "CHECKLIST missing required Codex cloud connector setup"
 else
     ! grep -Fq '@codex review' AGENTS.md || err "AGENTS rendered Codex shepherd trigger but use_codex_cloud_review is off"
+    ! grep -Fq 'Connect Codex cloud review' docs/CHECKLIST.md ||
+        err "CHECKLIST rendered Codex cloud connector setup without explicit opt-in"
 fi
 if [ "$profile" = "meta" ]; then
     grep -Fq 'proceed on CI alone' AGENTS.md || err "AGENTS lost local-only Codex shepherd fallback"

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -145,6 +145,7 @@ full)
         --data snyk_scan_schedule=weekly
         --data release_content_paths="src docs"
         --data use_codex_review=true
+        --data use_codex_cloud_review=true
         --data use_coderabbit=true
     )
     ;;
@@ -162,6 +163,7 @@ meta)
         --data project_management=linear
         --data snyk_scan_schedule=daily
         --data use_codeql=false
+        --data use_codex_review=true
     )
     copier_flags+=(--skip-tasks)
     ;;
@@ -839,19 +841,19 @@ else
     grep -q 'expected_login' .foreman.toml || err ".foreman.toml missing expected_login"
 fi
 
-# ── 9d3. codex review renders per use_codex_review (default off) ────
-# Only `full` opts in; every other profile uses the default (off). The
-# tasks, helper scripts, project Codex config, Claude plugin enablement,
-# and guide are all conditional — assert they appear/disappear together so
-# a broken gate can't ship dead weight into opted-out repos or drop the
-# wiring from opted-in ones.
-if [ "$profile" = "full" ]; then
+# ── 9d3. local/cloud Codex review render independently (both default off) ────
+# `meta` opts into local review only; `full` opts into local + cloud review.
+# Every other profile leaves both off. This covers the legacy local-only
+# behavior as well as the stricter explicit cloud-review contract.
+if [ "$profile" = "full" ] || [ "$profile" = "meta" ]; then
     [ -x scripts/codex-review.sh ] || err "scripts/codex-review.sh missing or not executable (use_codex_review=true)"
     [ -x scripts/codex-gate.sh ] || err "scripts/codex-gate.sh missing or not executable (use_codex_review=true)"
     [ -x scripts/test-codex-review.sh ] || err "scripts/test-codex-review.sh missing or not executable (use_codex_review=true)"
     grep -q 'test:codex-review:' Taskfile.yml || err "test:codex-review task missing (use_codex_review=true)"
     [ -f .codex/config.toml ] || err ".codex/config.toml missing (use_codex_review=true)"
     [ -f docs/guides/codex-review.md ] || err "docs/guides/codex-review.md missing (use_codex_review=true)"
+    grep -Fq 'use_codex_cloud_review' docs/guides/codex-review.md ||
+        err "Codex guide missing optional cloud review setup (use_codex_review=true)"
     grep -q 'challenge:codex:' Taskfile.yml || err "challenge:codex task missing (use_codex_review=true)"
     grep -q 'codex:gate:enable:' Taskfile.yml || err "codex:gate:enable task missing (use_codex_review=true)"
     grep -q '"codex@openai-codex": true' .claude/settings.json || err ".claude/settings.json missing codex plugin enablement (use_codex_review=true)"
@@ -862,6 +864,27 @@ else
     [ ! -f docs/guides/codex-review.md ] || err "docs/guides/codex-review.md rendered but use_codex_review is off"
     ! grep -q 'challenge:codex' Taskfile.yml || err "challenge:codex task rendered but use_codex_review is off"
     ! grep -q 'codex@openai-codex' .claude/settings.json || err "codex plugin enablement rendered but use_codex_review is off"
+fi
+if [ "$profile" = "full" ]; then
+    grep -Fq '@codex review' AGENTS.md || err "AGENTS missing explicit Codex shepherd trigger (use_codex_cloud_review=true)"
+    grep -Fq 'headRefOid' AGENTS.md || err "AGENTS missing current-head Codex shepherd contract (use_codex_cloud_review=true)"
+    grep -Fq 'exact trigger comment' AGENTS.md || err "AGENTS permits unbound Codex reactions (use_codex_cloud_review=true)"
+    grep -Fq 'comment ID returned for that trigger' AGENTS.md || err "AGENTS does not retain the Codex trigger comment ID"
+    grep -Fq 'expected Codex bot/App' AGENTS.md || err "AGENTS missing Codex result actor authentication (use_codex_cloud_review=true)"
+    grep -Fq 'Reviewed commit:' AGENTS.md || err "AGENTS missing commit-bound Codex result contract (use_codex_cloud_review=true)"
+    grep -Fq 'If both attempts' AGENTS.md &&
+        grep -Fq 'are incomplete, stop and escalate without reporting green' AGENTS.md ||
+        err "AGENTS missing bounded Codex retry contract (use_codex_cloud_review=true)"
+    ! grep -Fq 'proceed on CI alone' AGENTS.md || err "AGENTS permits CI-only completion despite use_codex_cloud_review=true"
+    grep -Fq 'require_codex_cloud_review = true' .foreman.toml ||
+        err "Foreman does not fail closed for required Codex cloud review"
+else
+    ! grep -Fq '@codex review' AGENTS.md || err "AGENTS rendered Codex shepherd trigger but use_codex_cloud_review is off"
+fi
+if [ "$profile" = "meta" ]; then
+    grep -Fq 'proceed on CI alone' AGENTS.md || err "AGENTS lost local-only Codex shepherd fallback"
+    grep -Fq 'require_codex_cloud_review = false' .foreman.toml ||
+        err "Foreman cloud review gate enabled without explicit opt-in"
 fi
 
 # ── 9d4. CodeRabbit renders only when explicitly enabled ───────────

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -167,12 +167,13 @@ something to ask permission for.
   the comment ID returned for that trigger. Poll PR reactions, top-level
   comments, reviews, and inline review comments; fetch trigger reactions by
   that exact comment ID. A Codex result is terminal for that captured head only
-  when it is either: a clean review or top-level comment authored by the
-  expected Codex bot/App whose `Reviewed commit:` identifies that head; a fresh
-  👍 from that bot on that exact trigger comment, created after both the head
-  push and the review request, with no newer contradictory bot result; or
-  review findings authored by that bot which identify that head and must be
-  adjudicated before the cycle can become clean. Earlier comments, reviews,
+  when it is either: a clean review or top-level comment authored by GitHub
+  actor ID `199175422` (`chatgpt-codex-connector[bot]`, type `Bot`) whose
+  `Reviewed commit:` identifies that head; a fresh 👍 from that bot on that
+  exact trigger comment, created after both the head push and the review
+  request, with no newer contradictory bot result; or review findings authored
+  by that bot which identify that head and must be adjudicated before the
+  cycle can become clean. Earlier comments, reviews,
   inline findings, and reactions never count for a newer head. A 👀 is pending,
   not success; if it disappears without a terminal result, the attempt is
   incomplete.

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -160,6 +160,31 @@ something to ask permission for.
   Shepherd-round fixes must pass `task verify` before each push; the local
   challenge/review loops are not re-entered — the post-push cloud/bot review
   is the second-model check at this stage.
+[% if use_codex_cloud_review %]
+  **Require a current-head Codex result.** On initial shepherd entry and
+  immediately after every fix push, capture the PR's current `headRefOid` and
+  the head's push time, then post `@codex review`. Record the request time and
+  the comment ID returned for that trigger. Poll PR reactions, top-level
+  comments, reviews, and inline review comments; fetch trigger reactions by
+  that exact comment ID. A Codex result is terminal for that captured head only
+  when it is either: a clean review or top-level comment authored by the
+  expected Codex bot/App whose `Reviewed commit:` identifies that head; a fresh
+  👍 from that bot on that exact trigger comment, created after both the head
+  push and the review request, with no newer contradictory bot result; or
+  review findings authored by that bot which identify that head and must be
+  adjudicated before the cycle can become clean. Earlier comments, reviews,
+  inline findings, and reactions never count for a newer head. A 👀 is pending,
+  not success; if it disappears without a terminal result, the attempt is
+  incomplete.
+  Give each attempt a full 10–15 minute window. If the first attempt is
+  incomplete, post `@codex review` once more for the same head and run one more
+  full window, recording and using the new trigger comment ID. If both attempts
+  are incomplete, stop and escalate without reporting green. Waiting and the
+  one allowed re-trigger do not consume a shepherd fix round. Immediately
+  before accepting the result or reporting green, fetch `headRefOid` and all
+  four review surfaces again; a changed head invalidates the result and starts
+  a new current-head cycle.
+[% endif %]
   Shepherd is **externally driven** — CI results and other people's comments
   are its input, so it cannot manufacture a round on its own. A round is one
   fix push, or one no-change cycle where everything is answered and nothing
@@ -190,12 +215,22 @@ something to ask permission for.
   the middle of the shepherd stage. Bot and human reviews land *after* checks
   settle, so `gh pr checks --watch` returns at exactly the moment the review
   has not run yet: an empty comment list read at that instant means "not
-  reviewed yet", not "nothing to answer". Wait for **both** signals — let
+  reviewed yet", not "nothing to answer".
+[% if use_codex_cloud_review %]
+  Wait for **both** signals: every check must conclude, and the required
+  current-head Codex cycle above must reach a terminal result. Green CI while
+  that cycle is pending or incomplete is still non-terminal.
+- **Stop at green.** Once checks pass, the current-head Codex cycle is clean,
+  and no review findings are unresolved, report that and stop — merging is
+  always a human decision.
+[% else %]
+  Wait for **both** signals — let
   every check conclude, then give the reviewer a bounded window (~10–15
   minutes) on the current head, and proceed on CI alone only if nothing lands
   in it.
 - **Stop at green.** Once checks pass *and* no review findings are unresolved,
   report that and stop — merging is always a human decision.
+[% endif %]
 
 ## Definition of Done
 
@@ -259,10 +294,17 @@ Setup and mechanics: [docs/guides/codex-review.md](docs/guides/codex-review.md).
   past a BLOCK** — adjudicate the finding or escalate to the maintainer instead.
 
 These tasks slot into the **Dev Loop** above: after `task verify` goes green,
-before `task ci`. If Codex cloud review is also connected to the repo, it
-reviews PRs too — it posts inline comments only for high-priority findings;
-a bare 👍 reaction from the Codex bot is its clean pass, and a lone 👀 that
-never resolves means the cloud run failed.
+before `task ci`.
+[% if use_codex_cloud_review %]
+Codex cloud review is also connected to the repo; it reviews PRs too and posts
+inline comments only for high-priority findings.
+During shepherding, accept its clean comments, reviews, or reactions only under
+the current-head cycle above: stale activity is not evidence for the current
+commit, and a lone 👀 that disappears or never resolves is an incomplete
+attempt.
+[% else %]
+These local tasks do not imply that Codex cloud review is installed or required.
+[% endif %]
 
 **Treat Codex findings as hypotheses, not authority.** For every finding:
 

--- a/template/[% if use_foreman %].foreman.toml[% endif %].jinja
+++ b/template/[% if use_foreman %].foreman.toml[% endif %].jinja
@@ -8,6 +8,7 @@
 
 backend = "claude"
 require_approval = true
+require_codex_cloud_review = [[ 'true' if use_codex_cloud_review else 'false' ]]
 inputs = "auto"
 [% if use_node %]
 # `task ci` includes the port-binding `test:e2e` tier, while `task verify` is

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -75,6 +75,12 @@ config, toolchain, devcontainer, and dev environment — against the items below
       installation. Deleting `.coderabbit.yaml` and bot trust does not revoke
       existing App access.
 [% endif %]
+[% if use_codex_cloud_review %]
+- [ ] **[human-only] Connect Codex cloud review** — connect this repository in
+      ChatGPT Codex settings, grant private-repository access if applicable,
+      and confirm review activity is authored by GitHub actor ID `199175422`
+      (`chatgpt-codex-connector[bot]`, type `Bot`).
+[% endif %]
 - [ ] Actions secret: `CLAUDE_CODE_OAUTH_TOKEN` (claude-* workflows) — generate
       with `claude setup-token`; the value must start **`sk-ant-oat01-`** (an OAuth
       token, billed to your Claude subscription), **not** `sk-ant-api03-` (a raw API

--- a/template/docs/architecture/[% if use_foreman %]foreman.md[% endif %]
+++ b/template/docs/architecture/[% if use_foreman %]foreman.md[% endif %]
@@ -153,6 +153,12 @@ Deterministic triggers → bounded agent actions on open foreman PRs:
 - **Green + adjudicated + `mergeStateStatus=CLEAN`** → `ready-to-merge` label
   plus a dependency-aware suggested merge order. Foreman performs no merge
   action of any kind.
+- **`require_codex_cloud_review = true`** → Foreman fails closed before that
+  label, removes a stale readiness label from fresh PR status before any
+  state-specific return, and escalates to the manual shepherd procedure, which
+  owns the current-head Codex trigger, bounded retries, and terminal-result
+  validation. Watch mode writes this handoff and its detail to the heartbeat
+  log instead of silently idling.
 
 ## Watch mode and unattended runs
 

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -224,7 +224,9 @@ task ci         # full CI mirror
 The full staged loop — including the PR-shepherding rounds — is defined in
 AGENTS.md ("Dev Loop"). If Codex cloud review is connected to the repo, PRs
 get a cloud pass too: inline comments only for high-priority findings, a
-bare 👍 reaction as the clean pass.
+👍 from the pinned Codex bot actor ID `199175422` on the exact
+`@codex review` trigger comment as the clean pass. That reaction must post
+after both the current head was pushed and its review request was created.
 
 ## Finding priorities
 

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -2,11 +2,12 @@
 
 A second AI model — the [OpenAI Codex CLI](https://developers.openai.com/codex/cli)
 — reviews changes in this repo: manual review/challenge tasks, plus an optional
-automatic Claude Code → Codex stop-gate. Everything is local and advisory:
-nothing runs in CI, no PR check depends on Codex, and `verify`/`ci` never
-invoke it. Findings are hypotheses for the primary agent to adjudicate — the
-protocol and the loop caps live in AGENTS.md ("Second-Model
-Review").
+automatic Claude Code → Codex stop-gate. Those tasks are local and advisory:
+nothing runs in CI, no PR check depends on Codex, and `verify`/`ci` never invoke
+it. Repositories can separately opt into a required current-head result from
+Codex cloud review during PR shepherding. Findings are hypotheses for the
+primary agent to adjudicate — the protocol and the loop caps live in AGENTS.md
+("Second-Model Review").
 
 ## Setup
 
@@ -29,6 +30,15 @@ Review").
    /plugin install codex@openai-codex
    /codex:setup
    ```
+
+5. **If `use_codex_cloud_review` is enabled, connect this repository to Codex
+   cloud review for PR shepherding.** The Copier opt-in adds the policy but
+   cannot grant GitHub access: a maintainer must connect Codex through ChatGPT
+   and allow the repository in the GitHub connector. Availability and quotas
+   depend on the maintainer's ChatGPT plan, and private repositories require
+   explicit connector access. Cloud review is a required shepherd signal, not
+   a required GitHub status check; if it stays unavailable for both bounded
+   attempts, the agent stops and escalates.
 
 ## Manual reviews
 

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/cli.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/cli.py
@@ -285,7 +285,14 @@ def cmd_status(args: argparse.Namespace) -> int:
                 status.get("statusCheckRollup")
             )
             labels = [label["name"] for label in status.get("labels") or []]
-            state = "ready-to-merge" if "ready-to-merge" in labels else "pr-open"
+            state = (
+                "ready-to-merge"
+                if shepherd_mod.ready_label_is_authoritative(
+                    labels,
+                    require_codex_cloud_review=cfg.require_codex_cloud_review,
+                )
+                else "pr-open"
+            )
             if state == "ready-to-merge":
                 ready.append(
                     shepherd_mod.PrWork(

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/config.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/config.py
@@ -22,6 +22,7 @@ class Config:
     backend: str = "claude"
     backend_version: str = ""  # expected CLI version prefix; "" = don't assert
     require_approval: bool = True  # strict arming: only foreman-approved units dispatch
+    require_codex_cloud_review: bool = False
     inputs: str = "auto"  # auto | fields | labels
     verify_command: list[str] = field(default_factory=lambda: ["task", "ci"])
     max_parallel: int = 3

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/shepherd.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/shepherd.py
@@ -219,6 +219,9 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
         title=status["title"],
     )
     remote_name = worktree.remote(cfg)
+    status_labels = {entry["name"] for entry in status.get("labels") or []}
+    if cfg.require_codex_cloud_review and "ready-to-merge" in status_labels:
+        gh.label_own_pr(work.number, remove=["ready-to-merge"])
     checks_state, failed = classify_checks(status.get("statusCheckRollup"))
 
     if checks_state == "pending":
@@ -388,6 +391,12 @@ def shepherd_pr(gh: GitHub, cfg: Config, root: Path, pr: dict, catalog) -> PrWor
         return work
 
     if merge_state == "CLEAN":
+        if cfg.require_codex_cloud_review:
+            work.state, work.detail = (
+                "escalated",
+                "current-head Codex cloud review requires manual shepherd completion",
+            )
+            return work
         gh.label_own_pr(work.number, add=["ready-to-merge"])
         work.state, work.detail = (
             "ready",

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/shepherd.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/shepherd.py
@@ -93,6 +93,13 @@ def classify_checks(rollup: list[dict] | None) -> tuple[str, list[dict]]:
     return "green", []
 
 
+def ready_label_is_authoritative(
+    labels: list[str], *, require_codex_cloud_review: bool
+) -> bool:
+    """Whether read-only reporting may trust Foreman's readiness label."""
+    return "ready-to-merge" in labels and not require_codex_cloud_review
+
+
 def trusted_review_threads(
     gh: GitHub, cfg: Config, threads: list[dict]
 ) -> tuple[list[dict], int]:

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/watch.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/watch.py
@@ -26,6 +26,14 @@ DEFAULT_INTERVAL_S = 300
 MAX_CONSECUTIVE_FAILURES = 3
 
 
+def human_handoff_messages(report: shepherd_mod.ShepherdReport) -> list[str]:
+    """Durable heartbeat lines for shepherd work that needs a person."""
+    return [
+        f"NEEDS HUMAN #{unit_number}: {detail}"
+        for unit_number, detail in sorted(report.environmental.items())
+    ]
+
+
 def parse_interval(text: str) -> int:
     match = re.fullmatch(r"(\d+)\s*([smh]?)", text.strip())
     if not match:
@@ -90,8 +98,11 @@ def run_watch(
             ready = len(shep.ready_order)
             heartbeat(
                 f"open={len(open_units)} dispatched={dispatched} waiting={waiting} "
-                f"failed={failed} prs-ready={ready} cost=${total_cost:.2f}"
+                f"failed={failed} prs-ready={ready} "
+                f"needs-human={len(shep.environmental)} cost=${total_cost:.2f}"
             )
+            for message in human_handoff_messages(shep):
+                heartbeat(message)
             if shep.ready_order and dispatched == 0 and not failed:
                 if not idle_notified:
                     info(

--- a/template/scripts/[% if use_foreman %]foreman[% endif %]/watch.py
+++ b/template/scripts/[% if use_foreman %]foreman[% endif %]/watch.py
@@ -29,7 +29,7 @@ MAX_CONSECUTIVE_FAILURES = 3
 def human_handoff_messages(report: shepherd_mod.ShepherdReport) -> list[str]:
     """Durable heartbeat lines for shepherd work that needs a person."""
     return [
-        f"NEEDS HUMAN #{unit_number}: {detail}"
+        f"NEEDS HUMAN #{unit_number}: {' '.join(detail.split())}"
         for unit_number, detail in sorted(report.environmental.items())
     ]
 


### PR DESCRIPTION
## Summary

- add an explicit, default-off `use_codex_cloud_review` Copier option, separate from local advisory Codex review
- require every initial PR head and post-fix head to receive an exact-trigger, bot-authenticated, current-commit Codex result before shepherding can report green
- bound unavailable cloud review to two 10–15 minute attempts, then stop and escalate
- make Foreman fail closed: remove stale `ready-to-merge` state from fresh PR status, hand off to manual shepherding, and surface the handoff in watch heartbeats
- update root/template docs, dogfood answers, render assertions, and Foreman regression coverage in lockstep

## Why

The previous policy could accept stale Codex activity after a fix push or proceed on CI alone before a current-head review completed. That allowed the last change on a PR to escape the intended second-model check. Cloud review is also an account/App dependency, so it must be an explicit opt-in rather than silently changing the existing local-review option.

This PR establishes the harmon-init policy and fail-closed integration. Canonical executable shepherd/standardization support is tracked in evanharmon1/harmon-devkit#219; issue #490 should remain open until that implementation is released and synced back.

## Validation

- `task verify`
- `task challenge` — six-round capped loop; final round clean for P0/P1
- `task review` — clean for P0/P1
- `task ci`
- 105 Foreman unit tests
- all six Copier render profiles
- dogfood parity and structure checks
- gitleaks and Semgrep: zero findings
- release-title guard for this PR title
- pre-commit and pre-push hooks
- current-head Codex cloud review clean for `571d783`

## Review adjudication

| Finding | Priority | Classification | Action |
|---|---:|---|---|
| Local/cloud option coupling | P1 | Confirmed | Added separate default-off cloud option |
| Unauthenticated clean result | P1 | Confirmed | Required expected bot/App identity |
| Existing users implicitly gain SaaS dependency | P1 | Confirmed | Kept cloud dependency behind explicit opt-in |
| Fresh thumbs-up not bound to request | P1 | Confirmed | Bound reactions to exact trigger comment ID |
| Foreman could bypass required cloud review | P1 | Confirmed | Added fail-closed manual handoff |
| Stale readiness label survives handoff/early returns | P1 | Confirmed | Remove from fresh PR status before state-specific returns |
| Watch mode hides manual handoff | P1 | Confirmed | Added durable `needs-human` heartbeat output |
| Trigger-ID wording and free-tier disclosure | P2 | Confirmed | Clarified policy and Copier help |
| Guide still described a bare 👍 clean pass | P2 | Confirmed | Bound guide text to actor, exact trigger, and current request in `040a166` |
| Read-only Foreman status trusted stale readiness | P2 | Confirmed | Ignore the label while cloud review is outstanding in `571d783` |

## Deferred findings

- [x] `template/AGENTS.md.jinja:171` — Pin the connected Codex App's immutable identity during setup and require it on every accepted result surface instead of leaving `expected Codex bot/App` to agent interpretation. — fixed in `608151e`
- [x] `template/scripts/foreman/watch.py:31` — Normalize or escape multiline environmental details so every human-handoff heartbeat remains a single timestamped log record. — fixed in `608151e`
- [x] `template/AGENTS.md.jinja:163` — Refresh the pinned harmon-devkit shepherd/standardization skills for the exact-trigger, two-attempt fail-closed contract. — filed as `evanharmon1/harmon-devkit#219`; acceptance contract updated with actor authentication, exact-trigger correlation, and standardization support
- [x] `template/docs/CHECKLIST.md.jinja` — Add a `use_codex_cloud_review`-gated human setup item for connecting Codex cloud review so generated-repo setup cannot appear complete while every PR will escalate. — fixed in `608151e`

Refs #490