### PR TITLE
feat: rewrite GitHub SSH URLs to HTTPS in devcontainers

### DIFF
--- a/.devcontainer/related-repos.txt
+++ b/.devcontainer/related-repos.txt
@@ -8,7 +8,10 @@
 #   owner/repo                       # default branch, cloned via gh CLI
 #   owner/repo@branch                # specific branch
 #   https://github.com/owner/repo    # full URL (also supports .git suffix)
-#   git@github.com:owner/repo.git    # ssh URL
+#   git@github.com:owner/repo.git    # ssh URL — accepted, but rewritten to
+#                                    # https by the container gitconfig
+#                                    # (post-create-common.sh); bot containers
+#                                    # have no SSH capability at all
 #
 # Lines starting with # are comments; blank lines are ignored. Existing
 # /workspaces/<repo> dirs are never clobbered (no pull, no checkout, no reset).

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -43,7 +43,10 @@ fi
 # forwarded into human ones). HTTPS auth comes from gh (GH_TOKEN, above) in
 # bot/Coder profiles, or VS Code's forwarded host credential helper on attach.
 # Mirrors the host dotfiles policy (harmon-dotfiles ADR 0002).
-git config --global url."https://github.com/".insteadOf "git@github.com:"
+# insteadOf is multi-valued, so reset then re-add: a plain scalar set exits 5
+# ("cannot overwrite multiple values") on re-run and would fail post-create.
+git config --global --unset-all url."https://github.com/".insteadOf || true
+git config --global --add url."https://github.com/".insteadOf "git@github.com:"
 git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
 
 echo "Git user: $(git config --global user.name)"

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -38,6 +38,14 @@ else
     echo "GitHub CLI is not authenticated; skipping gh auth setup."
 fi
 
+# Rewrite GitHub SSH URLs to HTTPS for fetch AND push: in-container git ops
+# never depend on an SSH agent (absent in bot containers; lockout-prone when
+# forwarded into human ones). HTTPS auth comes from gh (GH_TOKEN, above) in
+# bot/Coder profiles, or VS Code's forwarded host credential helper on attach.
+# Mirrors the host dotfiles policy (harmon-dotfiles ADR 0002).
+git config --global url."https://github.com/".insteadOf "git@github.com:"
+git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
+
 echo "Git user: $(git config --global user.name)"
 echo "GitHub auth status:"
 gh auth status || true

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -45,7 +45,10 @@ fi
 # Mirrors the host dotfiles policy (harmon-dotfiles ADR 0002).
 # insteadOf is multi-valued, so reset then re-add: a plain scalar set exits 5
 # ("cannot overwrite multiple values") on re-run and would fail post-create.
-git config --global --unset-all url."https://github.com/".insteadOf || true
+# Unset with --fixed-value so only the two managed values are removed — a
+# whole-key --unset-all would delete user-defined aliases (e.g. github:).
+git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "git@github.com:" || true
+git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "ssh://git@github.com/" || true
 git config --global --add url."https://github.com/".insteadOf "git@github.com:"
 git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,8 +234,10 @@ something to ask permission for.
   `url.insteadOf`; harmon-dotfiles ADR 0002). Never work around an SSH failure
   by pushing to a raw `https://…` URL — a URL push bypasses the named remote
   and leaves stale tracking refs. On an unprovisioned host, force the helper
-  against the *named* remote:
-  `git -c credential.helper= -c credential.helper='!gh auth git-credential' push`.
+  and the rewrite against the *named* remote:
+  `git -c credential.helper= -c credential.helper='!gh auth git-credential' -c url."https://github.com/".insteadOf="git@github.com:" push`
+  (a credential helper only applies to HTTPS, so without the `insteadOf` an
+  SSH-form remote still goes over SSH).
 - **Shepherd the PR (`/shepherd`, max 5 rounds).** `gh pr create` returning is
   the trigger for this stage, not the end of the work — enter it deliberately
   instead of judging for yourself when the PR is finished. `/shepherd` is the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,13 @@ something to ask permission for.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
   a clear what/why/verification summary (mind the `template/` → `fix:`/`feat:`
   title rule below).
+- **Git transport** — pushes authenticate over HTTPS via `gh` (dotfiles-managed
+  hosts and the devcontainers rewrite GitHub SSH URLs to HTTPS via
+  `url.insteadOf`; harmon-dotfiles ADR 0002). Never work around an SSH failure
+  by pushing to a raw `https://…` URL — a URL push bypasses the named remote
+  and leaves stale tracking refs. On an unprovisioned host, force the helper
+  against the *named* remote:
+  `git -c credential.helper= -c credential.helper='!gh auth git-credential' push`.
 - **Shepherd the PR (`/shepherd`, max 5 rounds).** `gh pr create` returning is
   the trigger for this stage, not the end of the work — enter it deliberately
   instead of judging for yourself when the PR is finished. `/shepherd` is the

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -162,7 +162,9 @@ repo** (one template serves every repo). To stand this repo up in Coder:
 
 To work across several repos in one container, list them in
 `.devcontainer/related-repos.txt` (one `owner/repo` per line; `@branch`, full
-URLs, and ssh URLs also work). They are:
+URLs, and ssh URLs also work — ssh URLs are rewritten to https by the
+container gitconfig, which `post-create-common.sh` sets up so in-container
+git operations never depend on an SSH agent). They are:
 
 - **cloned** into `/workspaces/`, beside this repo, on container **create**
   (`scripts/bootstrap-related-repos.sh`) — so a rebuilt or persistence-lost

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -144,8 +144,10 @@ something to ask permission for.
   `url.insteadOf`; harmon-dotfiles ADR 0002). Never work around an SSH failure
   by pushing to a raw `https://…` URL — a URL push bypasses the named remote
   and leaves stale tracking refs. On an unprovisioned host, force the helper
-  against the *named* remote:
-  `git -c credential.helper= -c credential.helper='!gh auth git-credential' push`.
+  and the rewrite against the *named* remote:
+  `git -c credential.helper= -c credential.helper='!gh auth git-credential' -c url."https://github.com/".insteadOf="git@github.com:" push`
+  (a credential helper only applies to HTTPS, so without the `insteadOf` an
+  SSH-form remote still goes over SSH).
 - **Shepherd the PR (`/shepherd`, max 5 rounds).** `gh pr create` returning is
   the trigger for this stage, not the end of the work — enter it deliberately
   instead of judging for yourself when the PR is finished. Where the optional

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -139,6 +139,13 @@ something to ask permission for.
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the PR** — conventional commit, push the branch, `gh pr create` with
   a clear what/why/verification summary.
+- **Git transport** — pushes authenticate over HTTPS via `gh` (dotfiles-managed
+  hosts and the devcontainers rewrite GitHub SSH URLs to HTTPS via
+  `url.insteadOf`; harmon-dotfiles ADR 0002). Never work around an SSH failure
+  by pushing to a raw `https://…` URL — a URL push bypasses the named remote
+  and leaves stale tracking refs. On an unprovisioned host, force the helper
+  against the *named* remote:
+  `git -c credential.helper= -c credential.helper='!gh auth git-credential' push`.
 - **Shepherd the PR (`/shepherd`, max 5 rounds).** `gh pr create` returning is
   the trigger for this stage, not the end of the work — enter it deliberately
   instead of judging for yourself when the PR is finished. Where the optional

--- a/template/[% if devcontainer %].devcontainer[% endif %]/related-repos.txt
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/related-repos.txt
@@ -8,7 +8,10 @@
 #   owner/repo                       # default branch, cloned via gh CLI
 #   owner/repo@branch                # specific branch
 #   https://github.com/owner/repo    # full URL (also supports .git suffix)
-#   git@github.com:owner/repo.git    # ssh URL
+#   git@github.com:owner/repo.git    # ssh URL — accepted, but rewritten to
+#                                    # https by the container gitconfig
+#                                    # (post-create-common.sh); bot containers
+#                                    # have no SSH capability at all
 #
 # Lines starting with # are comments; blank lines are ignored. Existing
 # /workspaces/<repo> dirs are never clobbered (no pull, no checkout, no reset).

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -43,7 +43,10 @@ fi
 # forwarded into human ones). HTTPS auth comes from gh (GH_TOKEN, above) in
 # bot/Coder profiles, or VS Code's forwarded host credential helper on attach.
 # Mirrors the host dotfiles policy (harmon-dotfiles ADR 0002).
-git config --global url."https://github.com/".insteadOf "git@github.com:"
+# insteadOf is multi-valued, so reset then re-add: a plain scalar set exits 5
+# ("cannot overwrite multiple values") on re-run and would fail post-create.
+git config --global --unset-all url."https://github.com/".insteadOf || true
+git config --global --add url."https://github.com/".insteadOf "git@github.com:"
 git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
 
 echo "Git user: $(git config --global user.name)"

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -38,6 +38,14 @@ else
     echo "GitHub CLI is not authenticated; skipping gh auth setup."
 fi
 
+# Rewrite GitHub SSH URLs to HTTPS for fetch AND push: in-container git ops
+# never depend on an SSH agent (absent in bot containers; lockout-prone when
+# forwarded into human ones). HTTPS auth comes from gh (GH_TOKEN, above) in
+# bot/Coder profiles, or VS Code's forwarded host credential helper on attach.
+# Mirrors the host dotfiles policy (harmon-dotfiles ADR 0002).
+git config --global url."https://github.com/".insteadOf "git@github.com:"
+git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
+
 echo "Git user: $(git config --global user.name)"
 echo "GitHub auth status:"
 gh auth status || true

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -45,7 +45,10 @@ fi
 # Mirrors the host dotfiles policy (harmon-dotfiles ADR 0002).
 # insteadOf is multi-valued, so reset then re-add: a plain scalar set exits 5
 # ("cannot overwrite multiple values") on re-run and would fail post-create.
-git config --global --unset-all url."https://github.com/".insteadOf || true
+# Unset with --fixed-value so only the two managed values are removed — a
+# whole-key --unset-all would delete user-defined aliases (e.g. github:).
+git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "git@github.com:" || true
+git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "ssh://git@github.com/" || true
 git config --global --add url."https://github.com/".insteadOf "git@github.com:"
 git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
 

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -166,7 +166,9 @@ repo** (one template serves every repo). To stand this repo up in Coder:
 
 To work across several repos in one container, list them in
 `.devcontainer/related-repos.txt` (one `owner/repo` per line; `@branch`, full
-URLs, and ssh URLs also work). They are:
+URLs, and ssh URLs also work — ssh URLs are rewritten to https by the
+container gitconfig, which `post-create-common.sh` sets up so in-container
+git operations never depend on an SSH agent). They are:
 
 - **cloned** into `/workspaces/`, beside this repo, on container **create**
   (`scripts/bootstrap-related-repos.sh`) — so a rebuilt or persistence-lost


### PR DESCRIPTION
## What

Carries the platform git-transport policy (harmon-dotfiles ADR 0002, evanharmon1/harmon-dotfiles#40; devcontainer twin change in evanharmon1/harmon-devkit#225) into the template and this repo's own devcontainer:

- **`post-create-common.sh`** (template twin + this repo's) sets `url.insteadOf` for both SSH forms (`git@github.com:`, `ssh://git@github.com/`), fetch and push — in-container git operations never depend on an SSH agent. HTTPS auth comes from gh (`GH_TOKEN`) in bot/Coder profiles or VS Code's forwarded host credential helper on attach.
- **`related-repos.txt`** twins and both devcontainers guides document the rewrite (SSH-form entries were previously un-cloneable in bot containers despite being "supported").
- **`AGENTS.md` + `template/AGENTS.md.jinja`** gain a Git transport bullet in the Dev Loop so agents in this repo and every generated repo know: HTTPS via `gh`; never work around SSH failures with raw-URL pushes (stale tracking refs); on unprovisioned hosts force the helper against the *named* remote.

Refs evanharmon1/harmon-dotfiles#37

## Why

Repo creation was already HTTPS (`gh repo create` follows gh's `git_protocol: https`), so the remaining gaps were the devcontainer scripts and agent guidance. This repo's own remote was SSH until today — it hit the exact issue-#37 lockout during this work (`sign_and_send_pubkey: ... communication with agent failed` on `git fetch`).

## Verification

- `task verify` green locally, including the template render tests (`test-template` web-astro pass, devcontainer CLI validation, gitleaks)
- Same two-line script change as evanharmon1/harmon-devkit#225, whose CI built both devcontainer images green

## Note

The devkit shepherd/preflight skill updates reach this repo's vendored `.claude/skills/` via the normal devkit-release sync (`sync-devkit-release.sh`) after the next devkit release — not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)