### PR TITLE
build(devcontainer): add shared image producer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
       - run: task test:release-title
       - run: task test:setup-github-project
       - run: task test:sync-devkit-release
+      - run: task test:devcontainer:image:automation
       - run: task test:skills-pin-parity
       - name: Dogfood parity (verbatim template files match their root twins)
         run: task test:dogfood-parity

--- a/.github/workflows/publish-harmon-devcontainer.yml
+++ b/.github/workflows/publish-harmon-devcontainer.yml
@@ -111,6 +111,8 @@ jobs:
         run: |
           source_sha=$(./scripts/publish-devcontainer-image.sh source "$EVENT_NAME" "$EVENT_SHA")
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+      - name: Verify publish and sync automation before registry credentials exist
+        run: ./scripts/test-devcontainer-image-automation.sh
       - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/publish-harmon-devcontainer.yml
+++ b/.github/workflows/publish-harmon-devcontainer.yml
@@ -1,0 +1,247 @@
+name: Publish Harmon devcontainer
+run-name: ${{ github.actor }} is validating the shared Harmon devcontainer image
+
+# ROOT-ONLY. Generated repositories consume this image but never publish it.
+# The first successful publication stops at the documented bootstrap boundary;
+# after thin consumers exist, the final job maintains one rolling pin PR.
+on:
+  pull_request:
+    paths:
+      - "images/devcontainer/**"
+      - "scripts/test-devcontainer-image.sh"
+      - "scripts/publish-devcontainer-image.sh"
+      - ".github/workflows/publish-harmon-devcontainer.yml"
+  push:
+    branches: [main]
+    paths:
+      - "images/devcontainer/**"
+      - "scripts/publish-devcontainer-image.sh"
+      - ".github/workflows/publish-harmon-devcontainer.yml"
+  schedule:
+    # Reconcile a failed publish/sync without a workflow_dispatch that could run
+    # an unreviewed branch's workflow definition with the PR-write App token.
+    - cron: "23 8 * * *"
+
+concurrency:
+  group: >-
+    publish-harmon-devcontainer-${{
+      github.event_name == 'pull_request' && github.event.pull_request.number || 'main'
+    }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  candidate:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - name: Free space on a disposable hosted runner
+        if: runner.environment == 'github-hosted'
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/share/swift
+          sudo docker image prune --all --force || true
+          df -h /
+      - name: Build and smoke-test the native candidate and repository overlay
+        env:
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+        run: ./scripts/test-devcontainer-image.sh "$SOURCE_SHA"
+      - name: Build and smoke-test the arm64 candidate under QEMU
+        env:
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          image="harmon-devcontainer-arm64:${SOURCE_SHA}"
+          docker buildx build --pull --platform linux/arm64 \
+            --build-arg "IMAGE_REVISION=${SOURCE_SHA}" \
+            --load --tag "$image" images/devcontainer
+          docker run --rm --platform linux/arm64 \
+            --env "EXPECTED_REVISION=${SOURCE_SHA}" \
+            --env EXPECTED_ARCHITECTURE=arm64 \
+            "$image" /usr/local/sbin/smoke.sh
+
+  candidate-verify:
+    if: always() && github.event_name == 'pull_request'
+    needs: [candidate]
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    steps:
+      - name: Verify the untrusted-fork boundary
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          CANDIDATE_RESULT: ${{ needs.candidate.result }}
+        run: |
+          test "$CANDIDATE_RESULT" = skipped
+          echo "Untrusted-fork boundary enforced: repository-controlled image build skipped."
+      - name: Verify the candidate passed
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          CANDIDATE_RESULT: ${{ needs.candidate.result }}
+        run: test "$CANDIDATE_RESULT" = success
+
+  publish:
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      source_sha: ${{ steps.source.outputs.source_sha }}
+      digest: ${{ steps.publish.outputs.digest }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event_name == 'push' && github.sha || 'main' }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Resolve the immutable image source revision
+        id: source
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_SHA: ${{ github.sha }}
+        run: |
+          source_sha=$(./scripts/publish-devcontainer-image.sh source "$EVENT_NAME" "$EVENT_SHA")
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Free space on a disposable hosted runner
+        if: runner.environment == 'github-hosted'
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/share/swift
+          sudo docker image prune --all --force || true
+          df -h /
+      - name: Publish once, then validate architectures, provenance, and public pull
+        id: publish
+        env:
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+        run: |
+          digest=$(./scripts/publish-devcontainer-image.sh publish "$SOURCE_SHA")
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+  prepare-pin:
+    if: needs.publish.result == 'success'
+    needs: [publish]
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    timeout-minutes: 60
+    outputs:
+      ready: ${{ steps.bundle.outputs.ready }}
+      base_sha: ${{ steps.bundle.outputs.base_sha }}
+      prepared_sha: ${{ steps.bundle.outputs.prepared_sha }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: ./.github/actions/setup
+        with:
+          lint-tools: "true"
+          gitleaks: "true"
+      - name: Install template-render tooling
+        run: |
+          uv tool install --force copier
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          npm install --global @devcontainers/cli lefthook pnpm
+      - name: Configure git for Copier's rendered repositories
+        run: |
+          git config --global user.name "ci"
+          git config --global user.email "ci@users.noreply.github.com"
+          git config --global init.defaultBranch main
+      - name: Prepare and verify the rolling pin commit without write credentials
+        env:
+          SOURCE_SHA: ${{ needs.publish.outputs.source_sha }}
+          MANIFEST_DIGEST: ${{ needs.publish.outputs.digest }}
+        run: ./scripts/sync-devcontainer-image.sh prepare "$SOURCE_SHA" "$MANIFEST_DIGEST"
+      - name: Bundle the verified commit for the isolated publisher
+        id: bundle
+        run: |
+          base_sha=$(git rev-parse main)
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+          if test "$(git branch --show-current)" != bot/sync-harmon-devcontainer; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "prepared_sha=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          prepared_sha=$(git rev-parse HEAD)
+          git bundle create prepared-pin.bundle main bot/sync-harmon-devcontainer
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+          echo "prepared_sha=$prepared_sha" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: steps.bundle.outputs.ready == 'true'
+        with:
+          name: harmon-devcontainer-prepared-pin
+          path: prepared-pin.bundle
+          if-no-files-found: error
+          retention-days: 1
+
+  sync-pin:
+    if: needs.prepare-pin.outputs.ready == 'true'
+    needs: [publish, prepare-pin]
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    timeout-minutes: 15
+    steps:
+      # This is a fresh runner. It installs no mutable tooling and imports only
+      # a one-commit Git bundle whose parent, tree scope, and pin are checked
+      # before the App private key or token exists in this process namespace.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.prepare-pin.outputs.base_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: harmon-devcontainer-prepared-pin
+      - name: Import and validate the verified commit
+        env:
+          BASE_SHA: ${{ needs.prepare-pin.outputs.base_sha }}
+          PREPARED_SHA: ${{ needs.prepare-pin.outputs.prepared_sha }}
+          SOURCE_SHA: ${{ needs.publish.outputs.source_sha }}
+          MANIFEST_DIGEST: ${{ needs.publish.outputs.digest }}
+        run: |
+          git fetch prepared-pin.bundle \
+            refs/heads/bot/sync-harmon-devcontainer:refs/heads/bot/sync-harmon-devcontainer
+          git checkout bot/sync-harmon-devcontainer
+          test "$(git rev-parse HEAD)" = "$PREPARED_SHA"
+          test "$(git rev-parse HEAD^)" = "$BASE_SHA"
+          changed=$(git diff --no-renames --name-only "$BASE_SHA..HEAD")
+          test "$changed" = ".devcontainer/Dockerfile
+          template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile"
+          expected="FROM ghcr.io/evanharmon1/harmon-devcontainer:sha-${SOURCE_SHA}@${MANIFEST_DIGEST}"
+          for file in ".devcontainer/Dockerfile" \
+            "template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile"; do
+            test "$(sed -n '1p' "$file")" = "$expected"
+            diff -u \
+              <(git show "${BASE_SHA}:${file}" | tail -n +2) \
+              <(tail -n +2 "$file")
+          done
+          test "$(./scripts/sync-devcontainer-image.sh pinned)" = \
+            "$SOURCE_SHA $MANIFEST_DIGEST"
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+      - name: Publish the prepared rolling branch and PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          SOURCE_SHA: ${{ needs.publish.outputs.source_sha }}
+          MANIFEST_DIGEST: ${{ needs.publish.outputs.digest }}
+        run: ./scripts/sync-devcontainer-image.sh publish "$SOURCE_SHA" "$MANIFEST_DIGEST"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -570,6 +570,11 @@ the workflow rules above:
   `template-test`), **not** built per profile — the dogfood build covers every
   profile only because the template `Dockerfile` is kept free of copier
   conditionals (profile-invariant). See `docs/architecture/ci-cd.md`.
+- `.github/workflows/publish-harmon-devcontainer.yml` — root-only producer for
+  the public shared amd64/arm64 toolchain image. Candidate PRs build without
+  registry credentials; trusted `main` publishes immutable source tags and the
+  tested helper maintains one reviewed consumer-pin PR. See
+  `docs/architecture/devcontainer-image.md`.
 - `.github/workflows/claude-{plan,implement,review}.yml` — Claude Code GitHub
   Actions. They (and `release.yml`) authenticate as the CI **GitHub App**
   (`CI_APP_CLIENT_ID` variable + `CI_APP_PRIVATE_KEY` secret) and need the

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -81,6 +81,7 @@ tasks:
       - task: test:release-title
       - task: test:setup-github-project
       - task: test:sync-devkit-release
+      - task: test:devcontainer:image:automation
       - task: test:skills-pin-parity
       - task: test:dogfood-parity
       - task: test:dogfood-structure
@@ -286,6 +287,16 @@ tasks:
     cmds:
       - ./scripts/devcontainer-assert.sh unit
 
+  test:devcontainer:image:
+    desc: Build and smoke-test the canonical shared image and current repository overlay
+    cmds:
+      - ./scripts/test-devcontainer-image.sh {{.CLI_ARGS}}
+
+  test:devcontainer:image:automation:
+    desc: Unit-test shared-image manifest/publish/pin automation (offline, stubbed boundaries)
+    cmds:
+      - ./scripts/test-devcontainer-image-automation.sh
+
   test:hooks:
     desc: Round-trip the Taskfile targets the Claude hooks delegate to
     cmds:
@@ -325,6 +336,20 @@ tasks:
     desc: Unit-test the harmon-devkit release→sync-PR automation (offline, stubbed gh/task)
     cmds:
       - ./scripts/test-sync-devkit-release.sh
+
+  sync:devcontainer-image:prepare:
+    desc: Prepare and verify a rolling shared-image consumer pin without write credentials
+    requires:
+      vars: [SOURCE_SHA, MANIFEST_DIGEST]
+    cmds:
+      - ./scripts/sync-devcontainer-image.sh prepare "{{.SOURCE_SHA}}" "{{.MANIFEST_DIGEST}}"
+
+  sync:devcontainer-image:publish:
+    desc: Publish an already-prepared shared-image consumer pin branch and PR
+    requires:
+      vars: [SOURCE_SHA, MANIFEST_DIGEST]
+    cmds:
+      - ./scripts/sync-devcontainer-image.sh publish "{{.SOURCE_SHA}}" "{{.MANIFEST_DIGEST}}"
 
   # ROOT-ONLY (a generated repo has ONE skills-sync manifest, so it has nothing
   # to compare). Closes a real hole: `verify:skills*` both read only the ROOT

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -33,4 +33,5 @@ onward (diagrams and component deep-dives also live here):
 - [security.md](security.md) — the posture across config, secret state, and GitHub settings; holds the threat-model framing, not the config.
 - [branch-protection.md](branch-protection.md) — in-repo (CODEOWNERS) + out-of-repo (ruleset, Actions toggles, bot model) stitched into one picture (grep can't see GitHub settings).
 - [tests.md](tests.md) — the testing strategy holistically (shape, layers, what's tested where); routes to the testing decision and the guides.
+- [devcontainer-image.md](devcontainer-image.md) — the canonical shared toolchain image, immutable consumer contract, publication, and pin propagation.
 - [foreman.md](foreman.md) — the deterministic supervisor that dispatches armed issues to headless agents and shepherds their PRs to a human merge; state of record is GitHub + git.

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -24,6 +24,8 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
   weekly or daily cadence. It has only schedule/manual triggers, runs Snyk SAST
   and SCA as advisory second-opinion scans, and is never a required PR check.
 - `devcontainer-build.yml` — prebuilds the devcontainer images to GHCR on `.devcontainer/**` changes.
+- `publish-harmon-devcontainer.yml` — **root-only**: validates and publishes the
+  shared amd64/arm64 toolchain image, then maintains its reviewed pin PR.
 - `release.yml` — release-please maintains the rolling release PR.
 - `close-milestone-on-release.yml` — closes the milestone matching the tag on release publish.
 - `sync-harmon-devkit.yml` — **root-only**: turns a published harmon-devkit
@@ -34,8 +36,9 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
 Most root workflows are the rendered form of a `template/` twin and must be
 edited in lockstep (AGENTS.md, "Dogfood parity"). A few are **root-only**: they
 exist because harmon-init sits inside harmon-platform, and a generated repo has
-no such edge. `close-milestone-on-release.yml` and `sync-harmon-devkit.yml` are
-root-only; they have no `template/` counterpart, and the dogfood checks are
+no such edge. `close-milestone-on-release.yml`, `sync-harmon-devkit.yml`, and
+`publish-harmon-devcontainer.yml` are root-only; they have no `template/`
+counterpart, and the dogfood checks are
 twin-driven (they walk `template/`), so root-only files are correctly invisible
 to them. Do not add a twin to make them "consistent".
 
@@ -123,6 +126,16 @@ broken and you are deliberately falling back to the manual route.
 
 The harmon-devkit side of the edge (emitting the dispatch on release) lives in
 that repository's `release.yml`.
+
+## Shared devcontainer publication
+
+The root-only `images/devcontainer/` producer and
+`publish-harmon-devcontainer.yml` own the common Harmon development toolchain.
+Pull requests build candidates without registry credentials; trusted `main`
+runs publish immutable source tags and validate anonymous pulls before the
+least-privilege CI App token is minted for pin propagation. The complete image,
+overlay, bootstrap, monotonic-update, and rollback contract is documented in
+[devcontainer-image.md](devcontainer-image.md).
 
 ## Authentication
 

--- a/docs/architecture/devcontainer-image.md
+++ b/docs/architecture/devcontainer-image.md
@@ -1,0 +1,120 @@
+# Shared devcontainer image
+
+Harmon Init owns the canonical repository-independent development toolchain at
+`images/devcontainer/` and publishes it as:
+
+```text
+ghcr.io/evanharmon1/harmon-devcontainer
+```
+
+Generated repositories remain separate container instances. They keep their
+profiles, Features, mounts, secrets allow-lists, ports, lifecycle commands, and
+checked-in `.devcontainer/config/` policy; only the expensive common toolchain
+is centralized.
+
+## Artifact contract
+
+Every recommended reference has both human-readable provenance and registry
+immutability:
+
+```text
+ghcr.io/evanharmon1/harmon-devcontainer:sha-<40-character-source-commit>@sha256:<manifest-digest>
+```
+
+The image:
+
+- publishes linux/amd64 and linux/arm64 in one manifest list;
+- carries OCI source, revision, version, description, and license labels;
+- contains `/usr/local/share/harmon-devcontainer/manifest.json` with its source
+  revision, architecture, and important tool versions;
+- contains `/usr/local/sbin/install-harmon-repo-config`, the stable contract by
+  which a consumer installs its checked-in policy overlay;
+- contains no repository checkout, project dependencies, credentials, secrets,
+  mounts, ports, or repository-specific config;
+- finishes as `root`, ready for an extension layer. A thin consumer explicitly
+  returns to `USER vscode` after installing its overlay.
+
+The producer build context is `images/devcontainer/`, whose `.dockerignore`
+allows only the Dockerfile and contract helpers. This is the primary control
+that prevents unrelated repository contents from entering a layer.
+
+## Validation and publication
+
+`publish-harmon-devcontainer.yml` has three trusted paths:
+
+1. An in-repository pull request builds and smokes the native image and current
+   repository overlay, then proves the arm64 producer builds. Fork-controlled
+   Dockerfiles are deliberately not executed.
+2. A merge to `main` that changes producer inputs publishes the newest commit
+   touching those inputs at or before the push head. This remains stable when a
+   multi-commit push has an unrelated tail commit. An existing source tag is
+   validated and never overwritten.
+3. A daily reconciliation applies the same producer-path resolution rule, so an
+   interrupted publish or pin sync recovers without selecting a different
+   source revision or needing an unsafe branch-selectable `workflow_dispatch`.
+
+GitHub creates a repository's first container package as private. Before the
+first run can pass anonymous validation, a repository owner must open the
+`harmon-devcontainer` package settings, change its visibility to **Public**, and
+rerun the failed publish job (or let the daily reconciliation retry it). The
+immutable tag already pushed by that first attempt is validated rather than
+overwritten. This is the only visibility bootstrap: the workflow intentionally
+does not receive a long-lived personal token or permission to change package
+settings, and consumer propagation cannot begin while the package is private.
+
+Publication fails closed unless the manifest digest is valid, both required
+architectures exist, the source label and tool manifest match, and an amd64
+image can be pulled with an empty Docker credential directory. A failed check
+cannot advance consumers.
+
+## Pin propagation
+
+After publication, `scripts/sync-devcontainer-image.sh` validates the public
+manifest and maintains one `bot/sync-harmon-devcontainer` PR. It changes only
+the validated `FROM` line in the root and template Dockerfiles, preserving any
+identical repository-specific extension commands. It runs the release-title
+guard and repository verification, never writes `main`, and never merges.
+Commit ancestry prevents a delayed workflow from rolling the open PR back to an
+older source image, and a force-with-lease prevents concurrent writers from
+overwriting a newer rolling branch. Preparation and all repository verification
+finish in a credential-free job. Its one-commit Git bundle crosses to a fresh
+publisher runner, which validates the exact parent, changed paths, and pin before
+minting the short-lived App token. Mutable installers and verification processes
+therefore never share a process namespace with repository-write credentials.
+
+The first image is a deliberate bootstrap exception: consumers keep their
+standalone Dockerfile until a public digest exists. The first adoption is a
+normal reviewed `fix:` PR that runs the helper's `bootstrap` command together
+with the assertion, test, documentation, and Renovate migration. Once that PR
+merges, every later publication takes the rolling automated path.
+
+## Local commands
+
+```bash
+# Offline manifest/reference/sync tests
+task test:devcontainer:image:automation
+
+# Heavy native image + current overlay build (needs a Docker daemon)
+task test:devcontainer:image
+
+# Manual recovery, run as two separate processes so verification never shares
+# a process tree with an exported write token
+task sync:devcontainer-image:prepare \
+  SOURCE_SHA=<40-character-commit> \
+  MANIFEST_DIGEST=sha256:<64-hex-digest>
+task sync:devcontainer-image:publish \
+  SOURCE_SHA=<40-character-commit> \
+  MANIFEST_DIGEST=sha256:<64-hex-digest>
+```
+
+The heavy candidate build is intentionally outside `task ci`, like the existing
+dual-profile prebuild workflow: it requires a Docker daemon, multi-architecture
+emulation, substantial disk, and registry-backed CI infrastructure. Its offline
+contract and automation tests remain inside `task verify`.
+
+## Rollback
+
+A consumer rollback restores the previous reviewed `tag@digest` line. Tags are
+never overwritten, so the old reference cannot silently change. Existing local
+and runner caches remain usable during a registry outage; clean builders fail
+instead of falling back to a floating image.

--- a/images/devcontainer/.dockerignore
+++ b/images/devcontainer/.dockerignore
@@ -1,0 +1,5 @@
+*
+!Dockerfile
+!generate-manifest.sh
+!install-repo-config.sh
+!smoke.sh

--- a/images/devcontainer/Dockerfile
+++ b/images/devcontainer/Dockerfile
@@ -1,0 +1,365 @@
+# hadolint global ignore=DL3002,DL3008,DL3059
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04@sha256:d94c97dd9cacf183d0a6fd12a8e87b526e9e928307674ae9c94139139c0c6eae
+
+ARG TARGETARCH
+ARG IMAGE_REVISION
+
+# ---------- version pins ----------
+# The producer is the one canonical owner of shared devcontainer tool pins.
+# renovate: datasource=github-releases depName=go-task/task extractVersion=^v?(?<version>.+)$
+ARG TASK_VERSION=3.52.0
+# renovate: datasource=github-releases depName=mvdan/sh extractVersion=^v?(?<version>.+)$
+ARG SHFMT_VERSION=3.13.1
+# renovate: datasource=github-releases depName=hadolint/hadolint extractVersion=^v?(?<version>.+)$
+ARG HADOLINT_VERSION=2.14.0
+# renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v?(?<version>.+)$
+ARG ACTIONLINT_VERSION=1.7.12
+# renovate: datasource=github-releases depName=terraform-docs/terraform-docs extractVersion=^v?(?<version>.+)$
+ARG TERRAFORM_DOCS_VERSION=0.24.0
+# renovate: datasource=github-releases depName=mikefarah/yq extractVersion=^v?(?<version>.+)$
+ARG YQ_VERSION=4.53.3
+# renovate: datasource=github-releases depName=zellij-org/zellij extractVersion=^v?(?<version>.+)$
+ARG ZELLIJ_VERSION=0.44.3
+# renovate: datasource=github-releases depName=raine/workmux extractVersion=^v?(?<version>.+)$
+ARG WORKMUX_VERSION=0.1.226
+# renovate: datasource=github-releases depName=njbrake/agent-of-empires extractVersion=^v?(?<version>.+)$
+ARG AOE_VERSION=1.13.1
+# renovate: datasource=npm depName=@anthropic-ai/claude-code
+ARG CLAUDE_CODE_VERSION=2.1.220
+# renovate: datasource=npm depName=@openai/codex
+ARG CODEX_VERSION=0.145.0
+# renovate: datasource=npm depName=@google/gemini-cli
+ARG GEMINI_CLI_VERSION=0.52.0
+# renovate: datasource=github-releases depName=asheshgoplani/agent-deck extractVersion=^v?(?<version>.+)$
+ARG AGENT_DECK_VERSION=1.10.10
+# renovate: datasource=github-releases depName=joshmedeski/sesh extractVersion=^v?(?<version>.+)$
+ARG SESH_VERSION=2.27.0
+# renovate: datasource=npm depName=dmux
+ARG DMUX_VERSION=5.10.0
+# renovate: datasource=pypi depName=semgrep
+ARG SEMGREP_VERSION=1.171.0
+# renovate: datasource=npm depName=@playwright/test
+ARG PLAYWRIGHT_VERSION=1.62.0
+# renovate: datasource=npm depName=@playwright/cli
+ARG PLAYWRIGHT_CLI_VERSION=0.1.17
+# renovate: datasource=github-releases depName=getsops/sops extractVersion=^v?(?<version>.+)$
+ARG SOPS_VERSION=3.13.3
+# renovate: datasource=github-releases depName=nektos/act extractVersion=^v?(?<version>.+)$
+ARG ACT_VERSION=0.2.89
+# renovate: datasource=github-releases depName=wagoodman/dive extractVersion=^v?(?<version>.+)$
+ARG DIVE_VERSION=0.13.1
+# renovate: datasource=github-releases depName=antonmedv/fx extractVersion=^v?(?<version>.+)$
+ARG FX_VERSION=39.2.0
+# renovate: datasource=github-releases depName=charmbracelet/glow extractVersion=^v?(?<version>.+)$
+ARG GLOW_VERSION=2.1.2
+# renovate: datasource=github-releases depName=jesseduffield/lazygit extractVersion=^v?(?<version>.+)$
+ARG LAZYGIT_VERSION=0.63.1
+# renovate: datasource=github-releases depName=XAMPPRocky/tokei extractVersion=^v?(?<version>.+)$
+ARG TOKEI_VERSION=13.0.0-alpha.0
+# renovate: datasource=github-releases depName=dlvhdr/gh-dash extractVersion=^v?(?<version>.+)$
+ARG GH_DASH_VERSION=4.25.2
+# renovate: datasource=github-releases depName=charmbracelet/gum extractVersion=^v?(?<version>.+)$
+ARG GUM_VERSION=0.17.0
+# renovate: datasource=github-releases depName=o2sh/onefetch extractVersion=^v?(?<version>.+)$
+ARG ONEFETCH_VERSION=2.27.1
+# renovate: datasource=github-releases depName=wtfutil/wtf extractVersion=^v?(?<version>.+)$
+ARG WTF_VERSION=0.50.0
+# renovate: datasource=github-releases depName=ducaale/xh extractVersion=^v?(?<version>.+)$
+ARG XH_VERSION=0.26.1
+# renovate: datasource=github-releases depName=evilmartians/lefthook extractVersion=^v?(?<version>.+)$
+ARG LEFTHOOK_VERSION=2.1.10
+# renovate: datasource=github-releases depName=gitleaks/gitleaks extractVersion=^v?(?<version>.+)$
+ARG GITLEAKS_VERSION=8.30.1
+# renovate: datasource=github-releases depName=lycheeverse/lychee extractVersion=^lychee-v(?<version>.+)$
+ARG LYCHEE_VERSION=0.24.2
+# renovate: datasource=github-releases depName=alexpasmantier/television extractVersion=^v?(?<version>.+)$
+ARG TV_VERSION=0.15.9
+# renovate: datasource=github-releases depName=astral-sh/uv extractVersion=^v?(?<version>.+)$
+ARG UV_VERSION=0.11.32
+# renovate: datasource=github-releases depName=starship/starship extractVersion=^v?(?<version>.+)$
+ARG STARSHIP_VERSION=1.26.0
+
+# NODE_MAJOR is intentionally unmanaged: major upgrades are a compatibility
+# decision. UV_INSTALL_DIR is installation configuration, not a version pin.
+ARG NODE_MAJOR=24
+ARG UV_INSTALL_DIR=/usr/local/bin
+
+LABEL org.opencontainers.image.source="https://github.com/evanharmon1/harmon-init" \
+    org.opencontainers.image.revision="${IMAGE_REVISION}" \
+    org.opencontainers.image.version="sha-${IMAGE_REVISION}" \
+    org.opencontainers.image.description="Shared Harmon development and agent toolchain" \
+    org.opencontainers.image.licenses="MIT"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# ---------- apt packages ----------
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bat \
+        btop \
+        direnv \
+        dnsutils \
+        eza \
+        fd-find \
+        ffmpeg \
+        file \
+        fzf \
+        git-crypt \
+        git-delta \
+        git-extras \
+        git-lfs \
+        gron \
+        htop \
+        imagemagick \
+        jo \
+        lynx \
+        mc \
+        micro \
+        mkcert \
+        nmap \
+        ncdu \
+        ncurses-bin \
+        netcat-openbsd \
+        pandoc \
+        pv \
+        ripgrep \
+        sd \
+        shellcheck \
+        socat \
+        strace \
+        tealdeer \
+        tmux \
+        tree \
+        unzip \
+        vim \
+        w3m \
+        yamllint \
+        zip \
+        zoxide \
+        zsh \
+    && git lfs install --system \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/batcat /usr/local/bin/bat \
+    && ln -sf /usr/bin/fdfind /usr/local/bin/fd \
+    && chsh -s /usr/bin/zsh vscode
+
+RUN if [ ! -f /usr/share/doc/fzf/examples/key-bindings.zsh ]; then \
+        mkdir -p /usr/share/doc/fzf/examples \
+        && apt-get update -qq \
+        && apt-get download fzf \
+        && dpkg-deb -x fzf_*.deb / \
+        && rm -f fzf_*.deb \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# ---------- shell environment ----------
+USER vscode
+RUN if [ ! -d "$HOME/.oh-my-zsh" ]; then \
+        sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended; \
+    fi \
+    && git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions \
+        "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions" \
+    && git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting \
+        "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting"
+RUN git clone --single-branch https://github.com/gpakosz/.tmux.git "$HOME/.tmux" \
+    && ln -s -f "$HOME/.tmux/.tmux.conf" "$HOME/.tmux.conf"
+# Build continues with system-wide installs; this is not the runtime-user decision.
+# nosemgrep: dockerfile.security.last-user-is-root.last-user-is-root
+USER root
+
+# ---------- Node.js ----------
+RUN install -d -m 0755 /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+        >/etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
+    && corepack enable pnpm \
+    && rm -rf /var/lib/apt/lists/*
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
+# ---------- task runner ----------
+RUN case "${TARGETARCH}" in \
+        "amd64") export TASK_ARCH="amd64" ;; \
+        "arm64") export TASK_ARCH="arm64" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/go-task/task/releases/download/v${TASK_VERSION}/task_linux_${TASK_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin task
+
+# ---------- code-quality linters ----------
+RUN case "${TARGETARCH}" in \
+        "amd64") export SHFMT_ARCH="amd64" HADOLINT_ARCH="x86_64" ACTIONLINT_ARCH="amd64" ;; \
+        "arm64") export SHFMT_ARCH="arm64" HADOLINT_ARCH="arm64" ACTIONLINT_ARCH="arm64" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${SHFMT_ARCH}" \
+        -o /usr/local/bin/shfmt \
+    && chmod +x /usr/local/bin/shfmt \
+    && curl -fsSL "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-${HADOLINT_ARCH}" \
+        -o /usr/local/bin/hadolint \
+    && chmod +x /usr/local/bin/hadolint \
+    && curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${ACTIONLINT_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin actionlint
+
+# ---------- lefthook + gitleaks ----------
+RUN case "${TARGETARCH}" in \
+        "amd64") export LEFTHOOK_ARCH="x86_64" GITLEAKS_ARCH="x64" ;; \
+        "arm64") export LEFTHOOK_ARCH="arm64" GITLEAKS_ARCH="arm64" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/evilmartians/lefthook/releases/download/v${LEFTHOOK_VERSION}/lefthook_${LEFTHOOK_VERSION}_Linux_${LEFTHOOK_ARCH}" \
+        -o /usr/local/bin/lefthook \
+    && chmod +x /usr/local/bin/lefthook \
+    && curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_${GITLEAKS_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin gitleaks
+
+# ---------- infrastructure and secrets tools ----------
+RUN case "${TARGETARCH}" in \
+        "amd64") export TFDOCS_ARCH="amd64" YQ_ARCH="amd64" SOPS_ARCH="amd64" ACT_ARCH="x86_64" ;; \
+        "arm64") export TFDOCS_ARCH="arm64" YQ_ARCH="arm64" SOPS_ARCH="arm64" ACT_ARCH="arm64" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/terraform-docs/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-${TFDOCS_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin terraform-docs \
+    && curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${YQ_ARCH}" \
+        -o /usr/local/bin/yq \
+    && chmod +x /usr/local/bin/yq \
+    && curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.${SOPS_ARCH}" \
+        -o /usr/local/bin/sops \
+    && chmod +x /usr/local/bin/sops \
+    && curl -fsSL "https://github.com/nektos/act/releases/download/v${ACT_VERSION}/act_Linux_${ACT_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin act
+
+# ---------- CLI utilities ----------
+RUN case "${TARGETARCH}" in \
+        "amd64") export GLOW_ARCH="x86_64" GUM_ARCH="x86_64" XH_ARCH="x86_64" FX_ARCH="amd64" \
+            LAZYGIT_ARCH="x86_64" TOKEI_ARCH="x86_64" DIVE_ARCH="amd64" \
+            GH_DASH_ARCH="amd64" WTF_ARCH="amd64" LYCHEE_ARCH="x86_64" TV_ARCH="x86_64" ;; \
+        "arm64") export GLOW_ARCH="arm64" GUM_ARCH="arm64" XH_ARCH="aarch64" FX_ARCH="arm64" \
+            LAZYGIT_ARCH="arm64" TOKEI_ARCH="aarch64" DIVE_ARCH="arm64" \
+            GH_DASH_ARCH="arm64" WTF_ARCH="arm64" LYCHEE_ARCH="aarch64" TV_ARCH="aarch64" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_${DIVE_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin dive \
+    && curl -fsSL "https://github.com/antonmedv/fx/releases/download/${FX_VERSION}/fx_linux_${FX_ARCH}" -o /usr/local/bin/fx \
+    && chmod +x /usr/local/bin/fx \
+    && curl -fsSL "https://github.com/charmbracelet/glow/releases/download/v${GLOW_VERSION}/glow_${GLOW_VERSION}_Linux_${GLOW_ARCH}.tar.gz" \
+        | tar -xz --strip-components=1 -C /usr/local/bin "glow_${GLOW_VERSION}_Linux_${GLOW_ARCH}/glow" \
+    && curl -fsSL "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_linux_${LAZYGIT_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin lazygit \
+    && curl -fsSL "https://github.com/XAMPPRocky/tokei/releases/download/v${TOKEI_VERSION}/tokei-${TOKEI_ARCH}-unknown-linux-gnu.tar.gz" \
+        | tar -xz -C /usr/local/bin tokei \
+    && curl -fsSL "https://github.com/ducaale/xh/releases/download/v${XH_VERSION}/xh-v${XH_VERSION}-${XH_ARCH}-unknown-linux-musl.tar.gz" \
+        | tar -xz --strip-components=1 -C /usr/local/bin "xh-v${XH_VERSION}-${XH_ARCH}-unknown-linux-musl/xh" \
+    && ln -sf /usr/local/bin/xh /usr/local/bin/xhs \
+    && curl -fsSL "https://github.com/charmbracelet/gum/releases/download/v${GUM_VERSION}/gum_${GUM_VERSION}_Linux_${GUM_ARCH}.tar.gz" \
+        | tar -xz --strip-components=1 -C /usr/local/bin "gum_${GUM_VERSION}_Linux_${GUM_ARCH}/gum" \
+    && curl -fsSL "https://github.com/dlvhdr/gh-dash/releases/download/v${GH_DASH_VERSION}/gh-dash_v${GH_DASH_VERSION}_linux-${GH_DASH_ARCH}" \
+        -o /usr/local/bin/gh-dash \
+    && chmod +x /usr/local/bin/gh-dash \
+    && curl -fsSL "https://github.com/wtfutil/wtf/releases/download/v${WTF_VERSION}/wtf_${WTF_VERSION}_linux_${WTF_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin wtfutil \
+    && if [ "${TARGETARCH}" = "amd64" ]; then \
+        curl -fsSL "https://github.com/o2sh/onefetch/releases/download/${ONEFETCH_VERSION}/onefetch-linux.tar.gz" \
+            | tar -xz -C /usr/local/bin; \
+    fi \
+    && curl -fsSL "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-${LYCHEE_ARCH}-unknown-linux-gnu.tar.gz" \
+        | tar -xz --strip-components=1 -C /usr/local/bin "lychee-${LYCHEE_ARCH}-unknown-linux-gnu/lychee" \
+    && curl -fsSL "https://github.com/alexpasmantier/television/releases/download/${TV_VERSION}/tv-${TV_VERSION}-${TV_ARCH}-unknown-linux-gnu.tar.gz" \
+        | tar -xz --strip-components=1 -C /usr/local/bin "tv-${TV_VERSION}-${TV_ARCH}-unknown-linux-gnu/tv"
+
+# ---------- terminal / workflow tools ----------
+RUN case "${TARGETARCH}" in \
+        "amd64") export ZELLIJ_ARCH="x86_64" WORKMUX_ARCH="amd64" AOE_ARCH="amd64" AGENT_DECK_ARCH="amd64" SESH_ARCH="x86_64" ;; \
+        "arm64") export ZELLIJ_ARCH="aarch64" WORKMUX_ARCH="arm64" AOE_ARCH="arm64" AGENT_DECK_ARCH="arm64" SESH_ARCH="arm64" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/zellij-org/zellij/releases/download/v${ZELLIJ_VERSION}/zellij-${ZELLIJ_ARCH}-unknown-linux-musl.tar.gz" \
+        | tar -xz -C /usr/local/bin zellij \
+    && curl -fsSL "https://github.com/raine/workmux/releases/download/v${WORKMUX_VERSION}/workmux-linux-${WORKMUX_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin workmux \
+    && curl -fsSL "https://github.com/njbrake/agent-of-empires/releases/download/v${AOE_VERSION}/aoe-linux-${AOE_ARCH}.tar.gz" \
+        | tar -xz -C /tmp "aoe-linux-${AOE_ARCH}" \
+    && install -m 0755 "/tmp/aoe-linux-${AOE_ARCH}" /usr/local/bin/aoe \
+    && rm -f "/tmp/aoe-linux-${AOE_ARCH}" \
+    && curl -fsSL "https://github.com/asheshgoplani/agent-deck/releases/download/v${AGENT_DECK_VERSION}/agent-deck_${AGENT_DECK_VERSION}_linux_${AGENT_DECK_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin agent-deck \
+    && curl -fsSL "https://github.com/joshmedeski/sesh/releases/download/v${SESH_VERSION}/sesh_Linux_${SESH_ARCH}.tar.gz" \
+        | tar -xz -C /usr/local/bin sesh
+
+# ---------- Python and prompt tooling ----------
+RUN curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | env UV_INSTALL_DIR="${UV_INSTALL_DIR}" sh
+RUN curl -fsSL https://starship.rs/install.sh | sh -s -- --yes --version "v${STARSHIP_VERSION}"
+
+# ---------- Node.js global packages ----------
+# hadolint ignore=DL3016
+RUN npm install -g \
+        "@commitlint/cli" \
+        "@commitlint/config-conventional" \
+        "markdownlint-cli2" \
+    && npm cache clean --force
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN npm install -g \
+        "@playwright/test@${PLAYWRIGHT_VERSION}" \
+        "@playwright/cli@${PLAYWRIGHT_CLI_VERSION}" \
+    && npx playwright install --with-deps chromium \
+    && (playwright-cli install --with-deps chromium 2>/dev/null || true) \
+    && chmod -R o+rx "${PLAYWRIGHT_BROWSERS_PATH}" \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm cache clean --force
+
+RUN uv pip install --system --break-system-packages --no-cache toml aiogram
+RUN UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/opt/uv-tools \
+    uv tool install "semgrep==${SEMGREP_VERSION}" \
+    && rm -rf /root/.cache/uv
+
+# Keep frequently updated agent CLIs in the final expensive-tool layer.
+# hadolint ignore=DL3016
+RUN npm install -g \
+        "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+        "@google/gemini-cli@${GEMINI_CLI_VERSION}" \
+        "@openai/codex@${CODEX_VERSION}" \
+        "dmux@${DMUX_VERSION}" \
+    && npm cache clean --force
+
+# ---------- image/overlay contract ----------
+COPY generate-manifest.sh smoke.sh /usr/local/sbin/
+COPY install-repo-config.sh /usr/local/sbin/install-harmon-repo-config
+RUN chmod 0755 \
+        /usr/local/sbin/generate-manifest.sh \
+        /usr/local/sbin/install-harmon-repo-config \
+        /usr/local/sbin/smoke.sh \
+    && /usr/local/sbin/generate-manifest.sh "${IMAGE_REVISION}" "${TARGETARCH}" \
+        "task=${TASK_VERSION}" \
+        "shfmt=${SHFMT_VERSION}" \
+        "hadolint=${HADOLINT_VERSION}" \
+        "actionlint=${ACTIONLINT_VERSION}" \
+        "terraform-docs=${TERRAFORM_DOCS_VERSION}" \
+        "yq=${YQ_VERSION}" \
+        "zellij=${ZELLIJ_VERSION}" \
+        "workmux=${WORKMUX_VERSION}" \
+        "aoe=${AOE_VERSION}" \
+        "claude-code=${CLAUDE_CODE_VERSION}" \
+        "codex=${CODEX_VERSION}" \
+        "gemini-cli=${GEMINI_CLI_VERSION}" \
+        "agent-deck=${AGENT_DECK_VERSION}" \
+        "sesh=${SESH_VERSION}" \
+        "dmux=${DMUX_VERSION}" \
+        "semgrep=${SEMGREP_VERSION}" \
+        "playwright=${PLAYWRIGHT_VERSION}" \
+        "playwright-cli=${PLAYWRIGHT_CLI_VERSION}" \
+        "sops=${SOPS_VERSION}" \
+        "act=${ACT_VERSION}" \
+        "lefthook=${LEFTHOOK_VERSION}" \
+        "gitleaks=${GITLEAKS_VERSION}" \
+        "uv=${UV_VERSION}" \
+        "starship=${STARSHIP_VERSION}"
+
+# Extension contract: downstream Dockerfiles run the overlay installer as root
+# and explicitly return to USER vscode after repository policy is installed.
+# nosemgrep: dockerfile.security.last-user-is-root.last-user-is-root
+USER root

--- a/images/devcontainer/generate-manifest.sh
+++ b/images/devcontainer/generate-manifest.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <revision> <architecture> <name=version>..." >&2
+    exit 2
+}
+
+[ "$#" -ge 3 ] || usage
+
+revision="$1"
+architecture="$2"
+shift 2
+
+case "$revision" in
+????????????????????????????????????????)
+    case "$revision" in *[!0-9a-f]*) usage ;; esac
+    ;;
+*) usage ;;
+esac
+
+case "$architecture" in
+amd64 | arm64) ;;
+*) usage ;;
+esac
+
+manifest_dir="${HARMON_MANIFEST_DIR:-/usr/local/share/harmon-devcontainer}"
+manifest_file="${manifest_dir}/manifest.json"
+tmp_file="$(mktemp)"
+trap 'rm -f "$tmp_file"' EXIT
+
+{
+    printf '{\n'
+    printf '  "schemaVersion": 1,\n'
+    printf '  "image": {\n'
+    printf '    "name": "ghcr.io/evanharmon1/harmon-devcontainer",\n'
+    printf '    "revision": "%s",\n' "$revision"
+    printf '    "architecture": "%s"\n' "$architecture"
+    printf '  },\n'
+    printf '  "tools": {\n'
+
+    separator=""
+    for pair in "$@"; do
+        name="${pair%%=*}"
+        version="${pair#*=}"
+        [ "$name" != "$pair" ] || usage
+        case "$name" in "" | *[!a-z0-9_-]*) usage ;; esac
+        case "$version" in "" | *[!A-Za-z0-9._+-]*) usage ;; esac
+        printf '%s    "%s": "%s"' "$separator" "$name" "$version"
+        separator=",
+"
+    done
+    printf '\n  }\n}\n'
+} >"$tmp_file"
+
+jq -e . "$tmp_file" >/dev/null
+install -d -m 0755 "$manifest_dir"
+install -m 0644 "$tmp_file" "$manifest_file"

--- a/images/devcontainer/install-repo-config.sh
+++ b/images/devcontainer/install-repo-config.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+config_dir=/usr/local/share/devcontainer-config
+
+fail() {
+    echo "install-harmon-repo-config: $*" >&2
+    exit 1
+}
+
+[ "$(id -u)" -eq 0 ] || fail "must run as root"
+id vscode >/dev/null 2>&1 || fail "the shared image has no vscode user"
+[ -d "$config_dir" ] || fail "repository config was not copied to $config_dir"
+
+required_files="
+agent-deck.toml
+claude-settings.json
+claude-statusline.sh
+claude-user-defaults.json
+ghostty.terminfo
+gitconfig
+micro-bindings.json
+shell-aliases.sh
+starship.toml
+tmux.conf.local
+zshrc
+zellij.kdl
+television/cable/gh-issues.toml
+claude-hooks/block-no-verify.sh
+claude-hooks/enforce-conventional-commits.sh
+claude-hooks/post-edit-format.sh
+claude-hooks/protect-files.sh
+claude-hooks/session-start-context.sh
+"
+while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    [ -f "${config_dir}/${file}" ] || fail "required repository config is missing: $file"
+done <<EOF
+$required_files
+EOF
+
+tic -x "${config_dir}/ghostty.terminfo"
+
+install -d -m 0755 \
+    /etc/claude-code/hooks \
+    /home/vscode/.agent-deck \
+    /home/vscode/.config/git \
+    /home/vscode/.config/micro \
+    /home/vscode/.config/television/cable \
+    /home/vscode/.config/zellij \
+    /home/vscode/.shell-history
+
+install -m 0644 "${config_dir}/tmux.conf.local" /home/vscode/.tmux.conf.local
+install -m 0644 "${config_dir}/zellij.kdl" /home/vscode/.config/zellij/config.kdl
+install -m 0644 "${config_dir}/micro-bindings.json" /home/vscode/.config/micro/bindings.json
+install -m 0644 "${config_dir}/agent-deck.toml" /home/vscode/.agent-deck/config.toml
+install -m 0644 "${config_dir}/starship.toml" /home/vscode/.config/starship.toml
+install -m 0644 "${config_dir}/gitconfig" /home/vscode/.config/git/config
+install -m 0644 "${config_dir}/television/cable/gh-issues.toml" \
+    /home/vscode/.config/television/cable/gh-issues.toml
+install -m 0644 "${config_dir}/zshrc" /home/vscode/.zshrc
+
+install -m 0644 "${config_dir}/claude-settings.json" /etc/claude-code/managed-settings.json
+install -m 0755 "${config_dir}/claude-statusline.sh" /etc/claude-code/statusline.sh
+for hook in \
+    block-no-verify.sh \
+    enforce-conventional-commits.sh \
+    post-edit-format.sh \
+    protect-files.sh \
+    session-start-context.sh; do
+    install -m 0755 "${config_dir}/claude-hooks/${hook}" "/etc/claude-code/hooks/${hook}"
+done
+
+chown -R vscode:vscode \
+    /home/vscode/.agent-deck \
+    /home/vscode/.config \
+    /home/vscode/.shell-history \
+    /home/vscode/.tmux.conf.local \
+    /home/vscode/.zshrc

--- a/images/devcontainer/smoke.sh
+++ b/images/devcontainer/smoke.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest=/usr/local/share/harmon-devcontainer/manifest.json
+
+fail() {
+    echo "harmon-devcontainer smoke: $*" >&2
+    exit 1
+}
+
+[ "$(id -u)" -eq 0 ] || fail "image default user is not root"
+id vscode >/dev/null 2>&1 || fail "vscode user is missing"
+[ -x /usr/local/sbin/install-harmon-repo-config ] || fail "repository overlay installer is missing"
+[ -f "$manifest" ] || fail "tool manifest is missing"
+jq -e '.schemaVersion == 1' "$manifest" >/dev/null || fail "unexpected manifest schema"
+jq -e '.image.name == "ghcr.io/evanharmon1/harmon-devcontainer"' "$manifest" >/dev/null ||
+    fail "manifest names the wrong image"
+
+if [ -n "${EXPECTED_REVISION:-}" ]; then
+    [ "$(jq -r '.image.revision' "$manifest")" = "$EXPECTED_REVISION" ] ||
+        fail "manifest revision does not match $EXPECTED_REVISION"
+fi
+if [ -n "${EXPECTED_ARCHITECTURE:-}" ]; then
+    [ "$(jq -r '.image.architecture' "$manifest")" = "$EXPECTED_ARCHITECTURE" ] ||
+        fail "manifest architecture does not match $EXPECTED_ARCHITECTURE"
+fi
+
+for tool in task shfmt hadolint actionlint terraform-docs yq lefthook gitleaks sops act uv semgrep \
+    claude codex gemini agent-deck playwright playwright-cli zellij workmux aoe sesh dmux starship \
+    dive fx glow lazygit tokei xh gum gh-dash wtfutil lychee tv; do
+    command -v "$tool" >/dev/null 2>&1 || fail "$tool is not on PATH"
+done
+
+run_version() {
+    _rv_tool="$1"
+    shift
+    "$@" >/dev/null 2>&1 || fail "$_rv_tool cannot execute its version/help command"
+}
+
+# These invocations execute every architecture-specific binary instead of only
+# proving that an appropriately named path exists. workmux and dmux require a
+# live multiplexer session for a zero exit, so their safe help probes only need
+# to reject loader/command-not-found failures (126/127).
+run_version task task --version
+run_version shfmt shfmt --version
+run_version hadolint hadolint --version
+run_version actionlint actionlint -version
+run_version terraform-docs terraform-docs --version
+run_version yq yq --version
+run_version lefthook lefthook version
+run_version gitleaks gitleaks version
+run_version sops sops --version
+run_version act act --version
+run_version uv uv --version
+run_version semgrep semgrep --help
+run_version claude claude --version
+run_version codex codex --version
+run_version gemini gemini --version
+run_version agent-deck agent-deck --version
+run_version playwright playwright --version
+run_version playwright-cli playwright-cli --help
+run_version zellij zellij --version
+run_version aoe aoe --version
+run_version sesh sesh --version
+run_version starship starship --version
+run_version dive dive --version
+run_version fx fx --version
+run_version glow glow --version
+run_version lazygit lazygit --version
+run_version tokei tokei --version
+run_version xh xh --version
+run_version gum gum --version
+run_version gh-dash gh-dash --version
+run_version wtfutil wtfutil --version
+run_version lychee lychee --version
+run_version tv tv --version
+
+for tool in workmux dmux; do
+    _loader_rc=0
+    "$tool" --help >/dev/null 2>&1 || _loader_rc=$?
+    case "$_loader_rc" in
+    126 | 127) fail "$tool is not executable on this architecture" ;;
+    esac
+done
+
+task_version="$(task --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+[ "$task_version" = "$(jq -r '.tools.task' "$manifest")" ] ||
+    fail "task $task_version does not match the manifest"
+
+echo "harmon-devcontainer smoke: passed"

--- a/images/devcontainer/test-overlay.Dockerfile
+++ b/images/devcontainer/test-overlay.Dockerfile
@@ -1,0 +1,7 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+USER root
+COPY .devcontainer/config/ /usr/local/share/devcontainer-config/
+RUN /usr/local/sbin/install-harmon-repo-config
+USER vscode

--- a/renovate.json
+++ b/renovate.json
@@ -93,8 +93,14 @@
       "groupName": "Docker images"
     },
     {
-      "description": "Batch all devcontainer updates (base image + annotated tools) into one PR — must come after the Docker images rule so the base image lands here instead. Root scripts/** and taskfiles/** are included because every regex-managed pin under them (@devcontainers/cli, semgrep, markdownlint-cli2, ruff, black) is a dogfood-parity twin of a template/** copy this rule already claims — a dep whose root and template copies resolve to different groups gets split across two PRs, and each fails test:dogfood-parity. In this repo the group is effectively 'devcontainer + template-shipped tool pins'",
-      "matchFileNames": [".devcontainer/**", "template/**", "scripts/**", "taskfiles/**"],
+      "description": "Batch the canonical shared-image source, current dogfood/template devcontainers, and their coupled script pins into one PR — must come after the Docker images rule so base images land here instead. Root scripts/** and taskfiles/** are included because their regex-managed pins are dogfood-parity twins of template/** copies; splitting a dependency across groups makes each Renovate PR fail parity.",
+      "matchFileNames": [
+        "images/devcontainer/**",
+        ".devcontainer/**",
+        "template/**",
+        "scripts/**",
+        "taskfiles/**"
+      ],
       "groupName": "Devcontainer"
     },
     {

--- a/scripts/publish-devcontainer-image.sh
+++ b/scripts/publish-devcontainer-image.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Build, publish, and validate the canonical public multi-architecture image.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+IMAGE="ghcr.io/evanharmon1/harmon-devcontainer"
+PUBLISH_WORKFLOW=".github/workflows/publish-harmon-devcontainer.yml"
+
+die() {
+    echo "publish-devcontainer-image: $*" >&2
+    exit 1
+}
+
+note() {
+    echo "publish-devcontainer-image: $*" >&2
+}
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || die "$1 is required"
+}
+
+assert_sha() {
+    case "${1:-}" in
+    ????????????????????????????????????????)
+        case "$1" in *[!0-9a-f]*) die "invalid source revision '$1'" ;; esac
+        ;;
+    *) die "invalid source revision '${1:-}'" ;;
+    esac
+}
+
+assert_digest() {
+    case "${1:-}" in
+    sha256:????????????????????????????????????????????????????????????????)
+        case "${1#sha256:}" in *[!0-9a-f]*) die "invalid manifest digest '$1'" ;; esac
+        ;;
+    *) die "invalid manifest digest '${1:-}'" ;;
+    esac
+}
+
+image_ref() {
+    assert_sha "$1"
+    printf '%s:sha-%s\n' "$IMAGE" "$1"
+}
+
+inspect_manifest() {
+    docker buildx imagetools inspect "$1" --format '{{json .Manifest}}'
+}
+
+inspect_existing() {
+    _ie_ref="$1"
+    _ie_error="$(mktemp)"
+    _ie_rc=0
+    _ie_manifest="$(inspect_manifest "$_ie_ref" 2>"$_ie_error")" || _ie_rc=$?
+    if [ "$_ie_rc" -eq 0 ]; then
+        rm -f "$_ie_error"
+        printf '%s\n' "$_ie_manifest"
+        return 0
+    fi
+
+    _ie_message="$(cat "$_ie_error")"
+    rm -f "$_ie_error"
+    case "$_ie_message" in
+    *"manifest unknown"* | *"MANIFEST_UNKNOWN"* | *"not found"*)
+        return 3
+        ;;
+    *)
+        printf '%s\n' "$_ie_message" >&2
+        return 1
+        ;;
+    esac
+}
+
+validate_index() {
+    _vi_source="$1"
+    _vi_expected="$2"
+    assert_sha "$_vi_source"
+    assert_digest "$_vi_expected"
+    _vi_ref="$(image_ref "$_vi_source")"
+    _vi_config="$(mktemp -d)"
+    _vi_manifest="$(DOCKER_CONFIG="$_vi_config" inspect_manifest "$_vi_ref")" || {
+        rm -rf "$_vi_config"
+        die "$_vi_ref is not anonymously inspectable"
+    }
+    rm -rf "$_vi_config"
+
+    _vi_actual="$(printf '%s' "$_vi_manifest" | jq -r '.digest // empty')"
+    [ "$_vi_actual" = "$_vi_expected" ] ||
+        die "source tag resolves to $_vi_actual, expected $_vi_expected"
+    for _vi_arch in amd64 arm64; do
+        printf '%s' "$_vi_manifest" |
+            jq -e --arg arch "$_vi_arch" \
+                'any(.manifests[]?; .platform.os == "linux" and .platform.architecture == $arch)' \
+                >/dev/null || die "manifest $_vi_expected has no linux/$_vi_arch image"
+    done
+    printf '%s\n' "$_vi_expected"
+}
+
+validate_public_image() {
+    _vp_source="$1"
+    _vp_digest="$2"
+    validate_index "$_vp_source" "$_vp_digest" >/dev/null
+    _vp_ref="$(image_ref "$_vp_source")@${_vp_digest}"
+    for _vp_arch in amd64 arm64; do
+        _vp_config="$(mktemp -d)"
+        if ! DOCKER_CONFIG="$_vp_config" docker pull --platform "linux/${_vp_arch}" "$_vp_ref" >/dev/null; then
+            rm -rf "$_vp_config"
+            die "anonymous ${_vp_arch} pull failed for $_vp_ref"
+        fi
+        rm -rf "$_vp_config"
+
+        _vp_revision="$(docker image inspect "$_vp_ref" \
+            --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')"
+        [ "$_vp_revision" = "$_vp_source" ] ||
+            die "published ${_vp_arch} label revision '$_vp_revision' does not match '$_vp_source'"
+        docker run --rm --pull=never --platform "linux/${_vp_arch}" \
+            --env "EXPECTED_REVISION=${_vp_source}" \
+            --env "EXPECTED_ARCHITECTURE=${_vp_arch}" \
+            "$_vp_ref" /usr/local/sbin/smoke.sh >/dev/null ||
+            die "published ${_vp_arch} smoke check failed for $_vp_ref"
+    done
+    note "validated public amd64/arm64 image $_vp_ref"
+}
+
+resolve_source() {
+    _rs_event="${1:-}"
+    _rs_sha="${2:-}"
+    if [ "$_rs_event" = "push" ]; then
+        assert_sha "$_rs_sha"
+        git cat-file -e "${_rs_sha}^{commit}" 2>/dev/null || die "source commit $_rs_sha is unavailable"
+        _rs_head="$_rs_sha"
+    else
+        _rs_head="$(git rev-parse HEAD)"
+        assert_sha "$_rs_head"
+    fi
+    # Push path filters operate over the whole pushed range, so github.sha can
+    # be a later, unrelated commit in a multi-commit push. Resolve from the
+    # event's immutable head using the same producer-path rule as scheduled
+    # reconciliation; both event shapes must name the same image source.
+    _rs_latest="$(git log -1 --format=%H "$_rs_head" -- \
+        images/devcontainer scripts/publish-devcontainer-image.sh "$PUBLISH_WORKFLOW")"
+    assert_sha "$_rs_latest"
+    printf '%s\n' "$_rs_latest"
+}
+
+publish() {
+    _pub_source="$1"
+    assert_sha "$_pub_source"
+    _pub_tag="$(image_ref "$_pub_source")"
+
+    _pub_probe_rc=0
+    _pub_existing="$(inspect_existing "$_pub_tag")" || _pub_probe_rc=$?
+    if [ "$_pub_probe_rc" -eq 0 ]; then
+        _pub_digest="$(printf '%s' "$_pub_existing" | jq -r '.digest // empty')"
+        assert_digest "$_pub_digest"
+        note "immutable tag already exists; validating without overwriting $_pub_tag"
+    elif [ "$_pub_probe_rc" -eq 3 ]; then
+        note "publishing $_pub_tag"
+        docker buildx build \
+            --pull \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg "IMAGE_REVISION=${_pub_source}" \
+            --provenance=true \
+            --sbom=true \
+            --tag "$_pub_tag" \
+            --push \
+            images/devcontainer
+        _pub_manifest="$(inspect_manifest "$_pub_tag")" || die "published tag cannot be inspected"
+        _pub_digest="$(printf '%s' "$_pub_manifest" | jq -r '.digest // empty')"
+        assert_digest "$_pub_digest"
+    else
+        die "cannot determine whether immutable tag exists; refusing to publish $_pub_tag"
+    fi
+
+    validate_public_image "$_pub_source" "$_pub_digest"
+    printf '%s\n' "$_pub_digest"
+}
+
+case "${1:-}" in
+source)
+    need git
+    resolve_source "${2:-}" "${3:-}"
+    ;;
+reference)
+    [ "$#" -eq 3 ] || die "usage: $0 reference <source-sha> <manifest-digest>"
+    assert_digest "$3"
+    printf '%s@%s\n' "$(image_ref "$2")" "$3"
+    ;;
+validate-index)
+    need docker
+    need jq
+    [ "$#" -eq 3 ] || die "usage: $0 validate-index <source-sha> <manifest-digest>"
+    validate_index "$2" "$3"
+    ;;
+validate)
+    need docker
+    need jq
+    [ "$#" -eq 3 ] || die "usage: $0 validate <source-sha> <manifest-digest>"
+    validate_public_image "$2" "$3"
+    ;;
+publish)
+    need docker
+    need jq
+    [ "$#" -eq 2 ] || die "usage: $0 publish <source-sha>"
+    publish "$2"
+    ;;
+*) die "usage: $0 {source|reference|validate-index|validate|publish} ..." ;;
+esac

--- a/scripts/sync-devcontainer-image.sh
+++ b/scripts/sync-devcontainer-image.sh
@@ -1,0 +1,507 @@
+#!/usr/bin/env bash
+# Turn a validated shared-image publication into one reviewed rolling pin PR.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+IMAGE="ghcr.io/evanharmon1/harmon-devcontainer"
+ROOT_DOCKERFILE=".devcontainer/Dockerfile"
+TEMPLATE_DOCKERFILE='template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile'
+BASE_BRANCH="main"
+SYNC_BRANCH="bot/sync-harmon-devcontainer"
+
+BODY_FILE=""
+cleanup() {
+    [ -z "$BODY_FILE" ] || rm -f "$BODY_FILE"
+}
+trap cleanup EXIT
+
+die() {
+    echo "sync-devcontainer-image: $*" >&2
+    exit 1
+}
+
+note() {
+    echo "sync-devcontainer-image: $*"
+}
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || die "$1 is required"
+}
+
+assert_sha() {
+    case "${1:-}" in
+    ????????????????????????????????????????)
+        case "$1" in *[!0-9a-f]*) die "invalid source revision '$1'" ;; esac
+        ;;
+    *) die "invalid source revision '${1:-}'" ;;
+    esac
+}
+
+assert_digest() {
+    case "${1:-}" in
+    sha256:????????????????????????????????????????????????????????????????)
+        case "${1#sha256:}" in *[!0-9a-f]*) die "invalid manifest digest '$1'" ;; esac
+        ;;
+    *) die "invalid manifest digest '${1:-}'" ;;
+    esac
+}
+
+reference() {
+    assert_sha "$1"
+    assert_digest "$2"
+    printf '%s:sha-%s@%s\n' "$IMAGE" "$1" "$2"
+}
+
+read_pin() {
+    _rp_file="$1"
+    [ -f "$_rp_file" ] || die "consumer Dockerfile not found: $_rp_file"
+    _rp_from="$(sed -n 's/^FROM[[:space:]][[:space:]]*//p' "$_rp_file")"
+    _rp_count="$(grep -c '^FROM[[:space:]]' "$_rp_file" || true)"
+    [ "$_rp_count" = 1 ] || die "expected exactly one FROM line in $_rp_file"
+    case "$_rp_from" in
+    "$IMAGE":sha-????????????????????????????????????????@sha256:????????????????????????????????????????????????????????????????)
+        _rp_source="${_rp_from#*:sha-}"
+        _rp_source="${_rp_source%%@*}"
+        _rp_digest="${_rp_from##*@}"
+        assert_sha "$_rp_source"
+        assert_digest "$_rp_digest"
+        printf '%s %s\n' "$_rp_source" "$_rp_digest"
+        ;;
+    *) return 3 ;;
+    esac
+}
+
+cmd_pinned() {
+    cmp -s "$ROOT_DOCKERFILE" "$TEMPLATE_DOCKERFILE" ||
+        die "root/template consumer Dockerfiles differ"
+    _cp_root_rc=0
+    _cp_root="$(read_pin "$ROOT_DOCKERFILE")" || _cp_root_rc=$?
+    _cp_template_rc=0
+    _cp_template="$(read_pin "$TEMPLATE_DOCKERFILE")" || _cp_template_rc=$?
+    if [ "$_cp_root_rc" -eq 3 ] && [ "$_cp_template_rc" -eq 3 ]; then
+        return 3
+    fi
+    [ "$_cp_root_rc" -eq 0 ] || die "$ROOT_DOCKERFILE is not a valid thin consumer"
+    [ "$_cp_template_rc" -eq 0 ] || die "$TEMPLATE_DOCKERFILE is not a valid thin consumer"
+    [ "$_cp_root" = "$_cp_template" ] ||
+        die "root/template consumer pins disagree: $_cp_root vs $_cp_template"
+    printf '%s\n' "$_cp_root"
+}
+
+render_consumer() {
+    _rc_ref="$1"
+    cat <<EOF
+FROM ${_rc_ref}
+
+USER root
+
+# Add genuinely repository-specific native packages here. Shared tools belong
+# in the canonical harmon-init image, not in generated repository Dockerfiles.
+
+COPY .devcontainer/config/ /usr/local/share/devcontainer-config/
+RUN /usr/local/sbin/install-harmon-repo-config
+
+USER vscode
+EOF
+}
+
+write_twins() {
+    _wt_ref="$1"
+    _wt_mode="${2:-update}"
+    _wt_backup="$(mktemp -d)"
+    cp "$ROOT_DOCKERFILE" "$_wt_backup/root"
+    cp "$TEMPLATE_DOCKERFILE" "$_wt_backup/template"
+
+    _wt_rc=0
+    (
+        _wt_done=0
+        # shellcheck disable=SC2317 # Invoked indirectly by the trap below.
+        restore_twins() {
+            if [ "$_wt_done" -eq 0 ]; then
+                cp "$_wt_backup/root" "$ROOT_DOCKERFILE"
+                cp "$_wt_backup/template" "$TEMPLATE_DOCKERFILE"
+            fi
+            rm -f "${ROOT_DOCKERFILE}.tmp.$$" "${TEMPLATE_DOCKERFILE}.tmp.$$"
+        }
+        # Signal traps are resumable unless they terminate explicitly. Disable
+        # all traps first, restore the pair once, and exit nonzero so execution
+        # cannot continue with only the second mv after an interrupted first mv.
+        # shellcheck disable=SC2317 # Invoked indirectly by the trap below.
+        abort_twins() {
+            trap - EXIT HUP INT TERM
+            restore_twins
+            exit 1
+        }
+        trap restore_twins EXIT
+        trap abort_twins HUP INT TERM
+        case "$_wt_mode" in
+        bootstrap)
+            render_consumer "$_wt_ref" >"${ROOT_DOCKERFILE}.tmp.$$"
+            render_consumer "$_wt_ref" >"${TEMPLATE_DOCKERFILE}.tmp.$$"
+            ;;
+        update)
+            sed "s|^FROM[[:space:]][[:space:]]*.*$|FROM ${_wt_ref}|" \
+                "$ROOT_DOCKERFILE" >"${ROOT_DOCKERFILE}.tmp.$$"
+            sed "s|^FROM[[:space:]][[:space:]]*.*$|FROM ${_wt_ref}|" \
+                "$TEMPLATE_DOCKERFILE" >"${TEMPLATE_DOCKERFILE}.tmp.$$"
+            ;;
+        *) die "unknown twin-write mode '$_wt_mode'" ;;
+        esac
+        cmp -s "${ROOT_DOCKERFILE}.tmp.$$" "${TEMPLATE_DOCKERFILE}.tmp.$$" ||
+            die "generated consumer twins differ"
+        mv "${ROOT_DOCKERFILE}.tmp.$$" "$ROOT_DOCKERFILE"
+        if [ "${SYNC_DEVCONTAINER_TEST_FAIL_AFTER_ROOT_WRITE:-}" = "true" ]; then
+            die "injected failure after the first twin write"
+        fi
+        if [ "${SYNC_DEVCONTAINER_TEST_SIGNAL_AFTER_ROOT_WRITE:-}" = "true" ]; then
+            kill -TERM "$BASHPID"
+        fi
+        mv "${TEMPLATE_DOCKERFILE}.tmp.$$" "$TEMPLATE_DOCKERFILE"
+        _wt_done=1
+    ) || _wt_rc=$?
+    rm -rf "$_wt_backup"
+    return "$_wt_rc"
+}
+
+validate_remote() {
+    env -u GH_TOKEN -u GITHUB_TOKEN \
+        ./scripts/publish-devcontainer-image.sh validate-index "$1" "$2" >/dev/null
+}
+
+cmd_bootstrap() {
+    _cb_source="$1"
+    _cb_digest="$2"
+    [ -z "$(git status --porcelain -- "$ROOT_DOCKERFILE" "$TEMPLATE_DOCKERFILE")" ] ||
+        die "bootstrap refuses uncommitted consumer Dockerfile edits"
+    validate_remote "$_cb_source" "$_cb_digest"
+    _cb_rc=0
+    cmd_pinned >/dev/null || _cb_rc=$?
+    [ "$_cb_rc" -eq 3 ] || die "bootstrap is only valid before thin consumers exist"
+    write_twins "$(reference "$_cb_source" "$_cb_digest")" bootstrap
+    note "bootstrapped root/template consumers at $_cb_source $_cb_digest"
+}
+
+cmd_apply() {
+    _ca_source="$1"
+    _ca_digest="$2"
+    validate_remote "$_ca_source" "$_ca_digest"
+    cmd_pinned >/dev/null || die "thin consumers are not bootstrapped; use the reviewed bootstrap migration"
+    write_twins "$(reference "$_ca_source" "$_ca_digest")" update
+    note "updated root/template consumers to $_ca_source $_ca_digest"
+}
+
+run_untrusted() {
+    env -u GH_TOKEN -u GITHUB_TOKEN "$@"
+}
+
+changed_paths() {
+    git diff --name-only HEAD
+    git ls-files --others --exclude-standard
+}
+
+assert_scope() {
+    _as_bad=""
+    while IFS= read -r _as_path; do
+        [ -n "$_as_path" ] || continue
+        case "$_as_path" in
+        "$ROOT_DOCKERFILE" | "$TEMPLATE_DOCKERFILE") ;;
+        *) _as_bad="${_as_bad}  - ${_as_path}\n" ;;
+        esac
+    done <<EOF
+$(changed_paths)
+EOF
+    [ -z "$_as_bad" ] || {
+        printf 'sync-devcontainer-image: unexpected changed paths:\n%b' "$_as_bad" >&2
+        die "the pin sync may only update the two consumer Dockerfiles"
+    }
+}
+
+configure_identity() {
+    _ci_slug="${GH_APP_SLUG:-}"
+    [ -n "$_ci_slug" ] || return 0
+    case "$_ci_slug" in *[!a-zA-Z0-9-]*) die "unexpected GitHub App slug '$_ci_slug'" ;; esac
+    _ci_uid="$(gh api "/users/${_ci_slug}[bot]" --jq '.id')" || die "cannot resolve App bot identity"
+    case "$_ci_uid" in "" | *[!0-9]*) die "unexpected App bot id '$_ci_uid'" ;; esac
+    git config user.name "${_ci_slug}[bot]"
+    git config user.email "${_ci_uid}+${_ci_slug}[bot]@users.noreply.github.com"
+}
+
+git_remote() {
+    if [ -n "${GH_TOKEN:-}" ]; then
+        # shellcheck disable=SC2016
+        git -c credential.helper= \
+            -c credential.helper='!f() { echo username=x-access-token; echo "password=${GH_TOKEN}"; }; f' \
+            "$@"
+    else
+        git "$@"
+    fi
+}
+
+assert_on_base() {
+    [ "$(git branch --show-current)" = "$BASE_BRANCH" ] || die "run must start on $BASE_BRANCH"
+    fetch_base
+    [ "$(git rev-parse HEAD)" = "$(git rev-parse "refs/remotes/origin/$BASE_BRANCH")" ] ||
+        die "local $BASE_BRANCH is not at origin/$BASE_BRANCH"
+}
+
+fetch_base() {
+    git_remote fetch --quiet origin "+refs/heads/$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH" ||
+        die "cannot fetch origin/$BASE_BRANCH"
+}
+
+fetch_sync_branch() {
+    git update-ref -d "refs/remotes/origin/$SYNC_BRANCH" 2>/dev/null || true
+    _fs_rc=0
+    git_remote ls-remote --exit-code --heads origin "$SYNC_BRANCH" >/dev/null 2>&1 || _fs_rc=$?
+    case "$_fs_rc" in
+    0)
+        git_remote fetch --quiet origin "+refs/heads/$SYNC_BRANCH:refs/remotes/origin/$SYNC_BRANCH" ||
+            die "cannot fetch $SYNC_BRANCH"
+        ;;
+    2) ;;
+    *) die "cannot determine whether $SYNC_BRANCH exists" ;;
+    esac
+}
+
+pin_pair_from_ref() {
+    _pfr_ref="$1"
+    _pfr_file="$(git show "${_pfr_ref}:${ROOT_DOCKERFILE}" 2>/dev/null)" || return 0
+    _pfr_from="$(printf '%s\n' "$_pfr_file" | sed -n 's/^FROM[[:space:]][[:space:]]*//p')"
+    case "$_pfr_from" in
+    "$IMAGE":sha-????????????????????????????????????????@sha256:????????????????????????????????????????????????????????????????)
+        _pfr_source="${_pfr_from#*:sha-}"
+        _pfr_source="${_pfr_source%%@*}"
+        _pfr_digest="${_pfr_from##*@}"
+        assert_sha "$_pfr_source"
+        assert_digest "$_pfr_digest"
+        printf '%s %s\n' "$_pfr_source" "$_pfr_digest"
+        ;;
+    esac
+}
+
+pin_from_ref() {
+    _pfr_pair="$(pin_pair_from_ref "$1")"
+    printf '%s\n' "${_pfr_pair%% *}"
+}
+
+newer_floor() {
+    _nf_left="$1"
+    _nf_right="$2"
+    [ -n "$_nf_right" ] || {
+        printf '%s\n' "$_nf_left"
+        return
+    }
+    assert_sha "$_nf_left"
+    assert_sha "$_nf_right"
+    if git merge-base --is-ancestor "$_nf_left" "$_nf_right"; then
+        printf '%s\n' "$_nf_right"
+    elif git merge-base --is-ancestor "$_nf_right" "$_nf_left"; then
+        printf '%s\n' "$_nf_left"
+    else
+        die "consumer pins refer to unrelated source histories"
+    fi
+}
+
+assert_monotonic() {
+    _am_target="$1"
+    _am_floor="$2"
+    git merge-base --is-ancestor "$_am_target" "refs/remotes/origin/$BASE_BRANCH" ||
+        die "target source $_am_target is not on origin/$BASE_BRANCH"
+    [ "${SYNC_DEVCONTAINER_ALLOW_DOWNGRADE:-}" != "true" ] || return 0
+    if [ "$_am_target" = "$_am_floor" ]; then
+        return 0
+    fi
+    if git merge-base --is-ancestor "$_am_floor" "$_am_target"; then
+        return 0
+    fi
+    if git merge-base --is-ancestor "$_am_target" "$_am_floor"; then
+        die "refusing stale image source $_am_target; pin floor is newer at $_am_floor"
+    fi
+    die "target $_am_target and pin floor $_am_floor are unrelated"
+}
+
+open_pr_number() {
+    gh pr list --head "$SYNC_BRANCH" --base "$BASE_BRANCH" --state open \
+        --json number,isCrossRepository \
+        --jq 'map(select(.isCrossRepository == false)) | .[0].number // empty'
+}
+
+write_body() {
+    _wb_old="$1"
+    _wb_source="$2"
+    _wb_digest="$3"
+    BODY_FILE="$(mktemp)"
+    cat >"$BODY_FILE" <<EOF
+Automated update of the immutable Harmon devcontainer toolchain image.
+
+| | |
+| --- | --- |
+| previous source | \`${_wb_old}\` |
+| new source | \`${_wb_source}\` |
+| manifest digest | \`${_wb_digest}\` |
+| image | \`${IMAGE}:sha-${_wb_source}@${_wb_digest}\` |
+
+## What changed
+
+- The root and template thin Dockerfiles now consume the newly published image.
+- The public manifest was validated for linux/amd64 and linux/arm64 before this branch was written.
+
+## Verification
+
+\`task test:devcontainer:permissions\` and \`task verify\` passed before push.
+
+## Merging
+
+Merging stays manual. A newer publication rewrites this one rolling branch and PR.
+EOF
+}
+
+open_or_update_pr() {
+    _op_title="$1"
+    _op_number="$2"
+    if [ -n "$_op_number" ]; then
+        gh pr edit "$_op_number" --title "$_op_title" --body-file "$BODY_FILE"
+    else
+        gh pr create --base "$BASE_BRANCH" --head "$SYNC_BRANCH" \
+            --title "$_op_title" --body-file "$BODY_FILE"
+    fi
+}
+
+cmd_prepare() {
+    _run_source="$1"
+    _run_digest="$2"
+    need task
+    validate_remote "$_run_source" "$_run_digest"
+    [ -z "$(git status --porcelain)" ] || die "working tree is not clean"
+    assert_on_base
+
+    _run_pin_rc=0
+    _run_current="$(cmd_pinned)" || _run_pin_rc=$?
+    if [ "$_run_pin_rc" -eq 3 ]; then
+        note "first image is published and valid; thin consumers are not bootstrapped yet"
+        note "open the reviewed consumer-migration PR with: $0 bootstrap $_run_source $_run_digest"
+        return 0
+    fi
+    [ "$_run_pin_rc" -eq 0 ] || die "cannot read the current consumer pin"
+    _run_current_source="${_run_current%% *}"
+
+    fetch_sync_branch
+    _run_branch_source="$(pin_from_ref "refs/remotes/origin/$SYNC_BRANCH")"
+    _run_floor="$(newer_floor "$_run_current_source" "$_run_branch_source")"
+    assert_monotonic "$_run_source" "$_run_floor"
+
+    if [ "$_run_source $_run_digest" = "$_run_current" ]; then
+        note "consumers already pin $_run_source $_run_digest"
+        return 0
+    fi
+
+    git checkout -B "$SYNC_BRANCH" "$BASE_BRANCH" >/dev/null
+    cmd_apply "$_run_source" "$_run_digest"
+    assert_scope
+
+    _run_title="fix(devcontainer): update shared image to ${_run_source%????????????????????????????????}"
+    PR_TITLE="$_run_title" PR_BODY="" CHANGED_FILES="$(changed_paths)" \
+        run_untrusted task guard:release-title
+
+    git add "$ROOT_DOCKERFILE" "$TEMPLATE_DOCKERFILE"
+    git commit -m "$_run_title" >/dev/null
+    run_untrusted task test:devcontainer:permissions
+    run_untrusted task verify
+
+    note "prepared and verified $SYNC_BRANCH for $_run_source $_run_digest"
+}
+
+cmd_publish_prepared() {
+    _pp_source="$1"
+    _pp_digest="$2"
+    need gh
+    # Registry validation already completed in the unprivileged publish and
+    # prepare jobs. This token-bearing phase deliberately performs only local
+    # Git checks and the narrowly scoped GitHub writes below.
+    [ -z "$(git status --porcelain)" ] || die "prepared working tree is not clean"
+
+    _pp_branch="$(git branch --show-current)"
+    if [ "$_pp_branch" = "$BASE_BRANCH" ]; then
+        _pp_base_rc=0
+        _pp_base="$(cmd_pinned)" || _pp_base_rc=$?
+        if [ "$_pp_base_rc" -eq 3 ]; then
+            note "thin consumers are not bootstrapped; there is no pin PR to publish"
+            return 0
+        fi
+        [ "$_pp_base_rc" -eq 0 ] || die "cannot read the current consumer pin"
+        [ "$_pp_base" = "$_pp_source $_pp_digest" ] ||
+            die "no prepared pin update is present"
+        note "consumers already pin $_pp_source $_pp_digest"
+        return 0
+    fi
+    [ "$_pp_branch" = "$SYNC_BRANCH" ] || die "expected prepared branch $SYNC_BRANCH, found $_pp_branch"
+    [ "$(cmd_pinned)" = "$_pp_source $_pp_digest" ] ||
+        die "prepared branch does not pin the requested image"
+
+    fetch_base
+    fetch_sync_branch
+    _pp_base="$(pin_pair_from_ref "refs/remotes/origin/$BASE_BRANCH")"
+    [ -n "$_pp_base" ] || die "origin/$BASE_BRANCH has no valid thin-consumer pin"
+    if [ "$_pp_base" = "$_pp_source $_pp_digest" ]; then
+        note "origin/$BASE_BRANCH already pins $_pp_source $_pp_digest"
+        return 0
+    fi
+    _pp_base_source="${_pp_base%% *}"
+    _pp_branch_source="$(pin_from_ref "refs/remotes/origin/$SYNC_BRANCH")"
+    _pp_floor="$(newer_floor "$_pp_base_source" "$_pp_branch_source")"
+    assert_monotonic "$_pp_source" "$_pp_floor"
+
+    _pp_title="fix(devcontainer): update shared image to ${_pp_source%????????????????????????????????}"
+    _pp_pr="$(open_pr_number)"
+    _pp_remote_ref="refs/remotes/origin/$SYNC_BRANCH"
+    _pp_remote_oid="$(git rev-parse --verify "$_pp_remote_ref" 2>/dev/null || true)"
+    if [ -n "$_pp_remote_oid" ] &&
+        [ "$(git rev-parse 'HEAD^{tree}')" = "$(git rev-parse "${_pp_remote_ref}^{tree}")" ]; then
+        write_body "$_pp_base_source" "$_pp_source" "$_pp_digest"
+        open_or_update_pr "$_pp_title" "$_pp_pr"
+        note "rolling branch already carries this exact pin; repaired its PR metadata"
+        return 0
+    fi
+
+    if [ -n "${GH_APP_SLUG:-}" ]; then
+        configure_identity
+        git commit --amend --no-edit --reset-author >/dev/null
+    fi
+    if [ -n "$_pp_remote_oid" ]; then
+        _pp_lease="--force-with-lease=refs/heads/${SYNC_BRANCH}:${_pp_remote_oid}"
+    else
+        _pp_lease="--force-with-lease=refs/heads/${SYNC_BRANCH}:"
+    fi
+    git_remote push "$_pp_lease" origin "HEAD:refs/heads/$SYNC_BRANCH"
+    write_body "$_pp_base_source" "$_pp_source" "$_pp_digest"
+    open_or_update_pr "$_pp_title" "$_pp_pr"
+    note "updated $SYNC_BRANCH; merging stays a human decision"
+}
+
+case "${1:-}" in
+reference)
+    [ "$#" -eq 3 ] || die "usage: $0 reference <source-sha> <manifest-digest>"
+    reference "$2" "$3"
+    ;;
+pinned)
+    [ "$#" -eq 1 ] || die "usage: $0 pinned"
+    cmd_pinned
+    ;;
+bootstrap)
+    [ "$#" -eq 3 ] || die "usage: $0 bootstrap <source-sha> <manifest-digest>"
+    cmd_bootstrap "$2" "$3"
+    ;;
+apply)
+    [ "$#" -eq 3 ] || die "usage: $0 apply <source-sha> <manifest-digest>"
+    cmd_apply "$2" "$3"
+    ;;
+prepare)
+    [ "$#" -eq 3 ] || die "usage: $0 prepare <source-sha> <manifest-digest>"
+    cmd_prepare "$2" "$3"
+    ;;
+publish)
+    [ "$#" -eq 3 ] || die "usage: $0 publish <source-sha> <manifest-digest>"
+    cmd_publish_prepared "$2" "$3"
+    ;;
+*) die "usage: $0 {reference|pinned|bootstrap|apply|prepare|publish} ..." ;;
+esac

--- a/scripts/test-devcontainer-image-automation.sh
+++ b/scripts/test-devcontainer-image-automation.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+# Offline tests for the image manifest, publication reference, and rolling pin sync.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+cases=0
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+pass() {
+    cases=$((cases + 1))
+}
+
+sha_a=1111111111111111111111111111111111111111
+digest_a=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+digest_b=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+# Manifest generation is deterministic, valid JSON, and rejects unsafe values.
+manifest_dir="$tmp_root/manifest"
+HARMON_MANIFEST_DIR="$manifest_dir" \
+    images/devcontainer/generate-manifest.sh "$sha_a" amd64 task=3.52.0 codex=0.145.0
+jq -e --arg sha "$sha_a" \
+    '.schemaVersion == 1 and .image.revision == $sha and .tools.task == "3.52.0"' \
+    "$manifest_dir/manifest.json" >/dev/null || fail "generated manifest has the wrong contract"
+if HARMON_MANIFEST_DIR="$manifest_dir" \
+    images/devcontainer/generate-manifest.sh bad amd64 task=3.52.0 >/dev/null 2>&1; then
+    fail "manifest generator accepted a malformed revision"
+fi
+pass
+
+# Pure reference formatting rejects floating/malformed inputs.
+want="ghcr.io/evanharmon1/harmon-devcontainer:sha-${sha_a}@${digest_a}"
+got="$(scripts/publish-devcontainer-image.sh reference "$sha_a" "$digest_a")"
+[ "$got" = "$want" ] || fail "publisher rendered '$got', expected '$want'"
+if scripts/publish-devcontainer-image.sh reference "$sha_a" latest >/dev/null 2>&1; then
+    fail "publisher accepted a floating digest"
+fi
+pass
+
+# Push and scheduled reconciliation resolve the same producer-path commit even
+# when a multi-commit push ends in an unrelated commit.
+source_fixture="$tmp_root/source-fixture"
+mkdir -p "$source_fixture/scripts" "$source_fixture/images/devcontainer" \
+    "$source_fixture/.github/workflows"
+cp scripts/publish-devcontainer-image.sh "$source_fixture/scripts/"
+cp .github/workflows/publish-harmon-devcontainer.yml "$source_fixture/.github/workflows/"
+printf 'FROM scratch\n' >"$source_fixture/images/devcontainer/Dockerfile"
+git -C "$source_fixture" init -b main >/dev/null
+git -C "$source_fixture" config user.name test
+git -C "$source_fixture" config user.email test@example.invalid
+git -C "$source_fixture" add .
+git -C "$source_fixture" commit -m producer >/dev/null
+producer_source="$(git -C "$source_fixture" rev-parse HEAD)"
+printf 'unrelated\n' >"$source_fixture/README.md"
+git -C "$source_fixture" add README.md
+git -C "$source_fixture" commit -m unrelated-tail >/dev/null
+push_head="$(git -C "$source_fixture" rev-parse HEAD)"
+push_source="$(cd "$source_fixture" && ./scripts/publish-devcontainer-image.sh source push "$push_head")"
+scheduled_source="$(cd "$source_fixture" && ./scripts/publish-devcontainer-image.sh source schedule "$push_head")"
+[ "$push_source" = "$producer_source" ] || fail "push resolved unrelated tail as the image source"
+[ "$scheduled_source" = "$producer_source" ] || fail "schedule disagreed with the push image source"
+pass
+
+# Verification completes before the workflow mints its short-lived write token.
+prepare_line="$(grep -n 'sync-devcontainer-image.sh prepare' \
+    .github/workflows/publish-harmon-devcontainer.yml | cut -d: -f1)"
+token_line="$(grep -n 'actions/create-github-app-token@' \
+    .github/workflows/publish-harmon-devcontainer.yml | tail -1 | cut -d: -f1)"
+publish_line="$(grep -n 'sync-devcontainer-image.sh publish' \
+    .github/workflows/publish-harmon-devcontainer.yml | cut -d: -f1)"
+if [ "$prepare_line" -ge "$token_line" ] || [ "$token_line" -ge "$publish_line" ]; then
+    fail "write token is not isolated between prepare and publish steps"
+fi
+pass
+
+# Fixture: real git state and helper, stubbed registry/GitHub/task boundaries.
+fixture="$tmp_root/fixture"
+origin="$tmp_root/origin.git"
+bin_dir="$tmp_root/bin"
+mkdir -p "$fixture/scripts" "$fixture/.devcontainer" \
+    "$fixture/template/[% if devcontainer %].devcontainer[% endif %]" "$bin_dir"
+cp scripts/sync-devcontainer-image.sh scripts/publish-devcontainer-image.sh "$fixture/scripts/"
+
+cat >"$bin_dir/docker" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -n "\${DOCKER_STUB_LOG:-}" ]; then
+    printf '%s\n' "\$*" >>"\$DOCKER_STUB_LOG"
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "buildx imagetools inspect" ]; then
+    if [ "\${DOCKER_STUB_MODE:-}" = transient ]; then
+        echo "ERROR: registry request timed out" >&2
+        exit 1
+    fi
+    if [ "\${DOCKER_STUB_MODE:-}" = missing-once ] && \
+        [ ! -e "\${DOCKER_STUB_STATE:?}" ]; then
+        touch "\$DOCKER_STUB_STATE"
+        echo "ERROR: manifest unknown" >&2
+        exit 1
+    fi
+    if [ "\${DOCKER_STUB_MODE:-}" = missing-arm ]; then
+cat <<'JSON'
+{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","digest":"${digest_a}","manifests":[{"platform":{"os":"linux","architecture":"amd64"}}]}
+JSON
+        exit 0
+    fi
+cat <<'JSON'
+{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","digest":"${digest_a}","manifests":[{"platform":{"os":"linux","architecture":"amd64"}},{"platform":{"os":"linux","architecture":"arm64"}}]}
+JSON
+    exit 0
+fi
+if [ "\${1:-} \${2:-}" = "image inspect" ]; then
+    printf '%s\n' "\${DOCKER_STUB_REVISION:-}"
+fi
+EOF
+cat >"$bin_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-} ${2:-}" in
+"pr list") [ -z "${GH_STUB_PR_NUMBER:-}" ] || printf '%s\n' "$GH_STUB_PR_NUMBER" ;;
+"pr create" | "pr edit") printf '%s\n' "$*" >>"${GH_STUB_LOG:?}" ;;
+*) exit 0 ;;
+esac
+EOF
+cat >"$bin_dir/task" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${TASK_STUB_LOG:?}"
+EOF
+chmod +x "$bin_dir/docker" "$bin_dir/gh" "$bin_dir/task" "$fixture/scripts/"*.sh
+
+cat >"$tmp_root/fixture_dockerfile" <<'EOF'
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+USER vscode
+EOF
+cp "$tmp_root/fixture_dockerfile" "$fixture/.devcontainer/Dockerfile"
+cp "$tmp_root/fixture_dockerfile" "$fixture/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile"
+
+git init --bare "$origin" >/dev/null
+git -C "$fixture" init -b main >/dev/null
+git -C "$fixture" config user.name test
+git -C "$fixture" config user.email test@example.invalid
+git -C "$fixture" remote add origin "$origin"
+git -C "$fixture" add .
+git -C "$fixture" commit -m initial >/dev/null
+old_source="$(git -C "$fixture" rev-parse HEAD)"
+git -C "$fixture" push -u origin main >/dev/null
+
+run_fixture() {
+    (
+        cd "$fixture"
+        env -u GH_TOKEN -u GITHUB_TOKEN \
+            PATH="$bin_dir:$PATH" GH_STUB_LOG="$tmp_root/gh.log" TASK_STUB_LOG="$tmp_root/task.log" \
+            "$@"
+    )
+}
+
+sync_fixture() {
+    run_fixture ./scripts/sync-devcontainer-image.sh prepare "$1" "$2"
+    run_fixture ./scripts/sync-devcontainer-image.sh publish "$1" "$2"
+}
+
+# Bootstrap is destructive by design, so it refuses even parity-preserving
+# uncommitted edits rather than replacing them with the thin-consumer skeleton.
+printf '\nRUN echo unsaved\n' >>"$fixture/.devcontainer/Dockerfile"
+printf '\nRUN echo unsaved\n' \
+    >>"$fixture/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile"
+if run_fixture ./scripts/sync-devcontainer-image.sh bootstrap \
+    "$old_source" "$digest_a" >/dev/null 2>&1; then
+    fail "bootstrap overwrote uncommitted consumer edits"
+fi
+grep -q '^RUN echo unsaved$' "$fixture/.devcontainer/Dockerfile" ||
+    fail "failed bootstrap did not preserve the root edit"
+cp "$tmp_root/fixture_dockerfile" "$fixture/.devcontainer/Dockerfile"
+cp "$tmp_root/fixture_dockerfile" \
+    "$fixture/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile"
+pass
+
+# Bootstrap is explicit, writes byte-identical twins, and then becomes idempotent.
+run_fixture ./scripts/sync-devcontainer-image.sh bootstrap "$old_source" "$digest_a" >/dev/null
+cmp -s "$fixture/.devcontainer/Dockerfile" \
+    "$fixture/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile" ||
+    fail "bootstrap did not write identical consumer twins"
+pinned="$(run_fixture ./scripts/sync-devcontainer-image.sh pinned)"
+[ "$pinned" = "$old_source $digest_a" ] || fail "unexpected bootstrap pin '$pinned'"
+before="$(git -C "$fixture" diff)"
+run_fixture ./scripts/sync-devcontainer-image.sh apply "$old_source" "$digest_a" >/dev/null
+[ "$(git -C "$fixture" diff)" = "$before" ] || fail "idempotent apply changed the consumer"
+
+# Pin changes replace only FROM and preserve identical repository extensions.
+printf '\nRUN echo repository-extension\n' >>"$fixture/.devcontainer/Dockerfile"
+printf '\nRUN echo repository-extension\n' \
+    >>"$fixture/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile"
+run_fixture ./scripts/sync-devcontainer-image.sh apply "$old_source" "$digest_a" >/dev/null
+grep -q '^RUN echo repository-extension$' "$fixture/.devcontainer/Dockerfile" ||
+    fail "pin update erased a repository-specific extension"
+pass
+
+# A malformed/twin-mismatched consumer fails closed.
+printf '# drift\n' >>"$fixture/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile"
+if run_fixture ./scripts/sync-devcontainer-image.sh pinned >/dev/null 2>&1; then
+    fail "pinned accepted divergent consumer twins"
+fi
+cp "$fixture/.devcontainer/Dockerfile" \
+    "$fixture/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile"
+pass
+
+# Registry validation requires exact digest agreement and both architectures.
+if (
+    cd "$fixture"
+    PATH="$bin_dir:$PATH" DOCKER_STUB_MODE=missing-arm \
+        ./scripts/publish-devcontainer-image.sh validate-index "$old_source" "$digest_a"
+) >/dev/null 2>&1; then
+    fail "manifest validation accepted an index without arm64"
+fi
+if run_fixture ./scripts/publish-devcontainer-image.sh validate-index \
+    "$old_source" "$digest_b" >/dev/null 2>&1; then
+    fail "manifest validation accepted a digest mismatch"
+fi
+pass
+
+# A transient inspect failure is not evidence that an immutable tag is absent;
+# publication must fail closed without attempting a build/push.
+docker_log="$tmp_root/docker.log"
+: >"$docker_log"
+if run_fixture env DOCKER_STUB_MODE=transient DOCKER_STUB_LOG="$docker_log" \
+    ./scripts/publish-devcontainer-image.sh publish "$old_source" >/dev/null 2>&1; then
+    fail "publisher treated a transient inspect failure as an absent tag"
+fi
+if grep -q '^buildx build' "$docker_log"; then
+    fail "publisher attempted a build after a transient inspect failure"
+fi
+pass
+
+# An explicit manifest-unknown response is the only probe failure allowed to
+# enter the initial publication path.
+docker_state="$tmp_root/docker-state"
+: >"$docker_log"
+run_fixture env DOCKER_STUB_MODE=missing-once DOCKER_STUB_STATE="$docker_state" \
+    DOCKER_STUB_LOG="$docker_log" DOCKER_STUB_REVISION="$old_source" \
+    ./scripts/publish-devcontainer-image.sh publish "$old_source" >/dev/null
+grep -q '^buildx build' "$docker_log" || fail "absent immutable tag did not trigger publication"
+pass
+
+# The credential-bearing publish phase must not invoke registry validation;
+# that check belongs to the earlier unprivileged jobs.
+publish_body="$(sed -n '/^cmd_publish_prepared()/,/^}/p' scripts/sync-devcontainer-image.sh)"
+if printf '%s\n' "$publish_body" | grep -q 'validate_remote'; then
+    fail "token-bearing publish phase still invokes registry validation"
+fi
+pass
+
+# A failure between the two writes restores both original consumers.
+root_before="$(git hash-object "$fixture/.devcontainer/Dockerfile")"
+template_before="$(git hash-object "$fixture/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile")"
+if run_fixture env SYNC_DEVCONTAINER_TEST_FAIL_AFTER_ROOT_WRITE=true \
+    ./scripts/sync-devcontainer-image.sh apply "$old_source" "$digest_a" >/dev/null 2>&1; then
+    fail "fault-injected twin update unexpectedly succeeded"
+fi
+[ "$(git hash-object "$fixture/.devcontainer/Dockerfile")" = "$root_before" ] ||
+    fail "root consumer was not restored after a partial update"
+[ "$(git hash-object "$fixture/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile")" = "$template_before" ] ||
+    fail "template consumer was not restored after a partial update"
+pass
+
+# A termination signal between twin moves restores both consumers and exits
+# nonzero rather than resuming after the signal handler.
+if run_fixture env SYNC_DEVCONTAINER_TEST_SIGNAL_AFTER_ROOT_WRITE=true \
+    ./scripts/sync-devcontainer-image.sh apply "$old_source" "$digest_a" >/dev/null 2>&1; then
+    fail "signal-injected twin update unexpectedly succeeded"
+fi
+[ "$(git hash-object "$fixture/.devcontainer/Dockerfile")" = "$root_before" ] ||
+    fail "root consumer was not restored after termination"
+[ "$(git hash-object "$fixture/template/[% if devcontainer %].devcontainer[% endif %]/Dockerfile")" = "$template_before" ] ||
+    fail "template consumer was not restored after termination"
+pass
+
+# Commit the bootstrapped floor, advance main, and test one rolling PR update.
+git -C "$fixture" add .
+git -C "$fixture" commit -m bootstrap >/dev/null
+git -C "$fixture" commit --allow-empty -m producer-update >/dev/null
+new_source="$(git -C "$fixture" rev-parse HEAD)"
+git -C "$fixture" push origin main >/dev/null
+
+# The Docker stub returns digest_a; use that digest for registry agreement.
+sync_fixture "$new_source" "$digest_a" >/dev/null
+git --git-dir="$origin" show "refs/heads/bot/sync-harmon-devcontainer:.devcontainer/Dockerfile" |
+    grep -q "sha-${new_source}@${digest_a}" || fail "rolling branch did not advance to the new source"
+[ -s "$tmp_root/gh.log" ] || fail "rolling update did not create/update a PR"
+[ -s "$tmp_root/task.log" ] || fail "rolling update skipped verification"
+pass
+
+# An exact-tree retry repairs stale PR metadata instead of returning early.
+git -C "$fixture" switch main >/dev/null
+: >"$tmp_root/gh.log"
+run_fixture ./scripts/sync-devcontainer-image.sh prepare "$new_source" "$digest_a" >/dev/null
+run_fixture env GH_STUB_PR_NUMBER=7 \
+    ./scripts/sync-devcontainer-image.sh publish "$new_source" "$digest_a" >/dev/null
+grep -q '^pr edit 7 ' "$tmp_root/gh.log" ||
+    fail "exact-tree retry did not repair open PR metadata"
+pass
+
+# A delayed event cannot roll the open branch back to its older source commit.
+git -C "$fixture" switch main >/dev/null
+if run_fixture ./scripts/sync-devcontainer-image.sh prepare "$old_source" "$digest_a" >/dev/null 2>&1; then
+    fail "rolling sync accepted a stale source commit"
+fi
+pass
+
+# A merged pin is a clean no-op even while the old rolling branch still exists.
+git -C "$fixture" merge --ff-only origin/bot/sync-harmon-devcontainer >/dev/null
+git -C "$fixture" push origin main >/dev/null
+sync_fixture "$new_source" "$digest_a" >/dev/null
+pass
+
+# A concurrent writer that advances the remote branch makes the lease reject
+# this stale publisher instead of overwriting the intervening update.
+git -C "$fixture" commit --allow-empty -m newer-producer-update >/dev/null
+newest_source="$(git -C "$fixture" rev-parse HEAD)"
+git -C "$fixture" push origin main >/dev/null
+mkdir -p "$fixture/.git/hooks"
+cat >"$fixture/.git/hooks/pre-push" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+git --git-dir="$origin" update-ref refs/heads/bot/sync-harmon-devcontainer "$newest_source"
+EOF
+chmod +x "$fixture/.git/hooks/pre-push"
+run_fixture ./scripts/sync-devcontainer-image.sh prepare "$newest_source" "$digest_a" >/dev/null
+if run_fixture ./scripts/sync-devcontainer-image.sh publish "$newest_source" "$digest_a" >/dev/null 2>&1; then
+    fail "stale publisher overwrote a concurrent rolling-branch update"
+fi
+pass
+
+echo "devcontainer image automation: ${cases} offline cases passed"

--- a/scripts/test-devcontainer-image-automation.sh
+++ b/scripts/test-devcontainer-image-automation.sh
@@ -66,13 +66,24 @@ scheduled_source="$(cd "$source_fixture" && ./scripts/publish-devcontainer-image
 [ "$scheduled_source" = "$producer_source" ] || fail "schedule disagreed with the push image source"
 pass
 
-# Verification completes before the workflow mints its short-lived write token.
+# The offline automation suite is a required pre-merge check and runs before
+# either registry credentials or the App write token exist in publishing jobs.
+ci_automation_line="$(grep -n 'run: task test:devcontainer:image:automation' \
+    .github/workflows/build.yml | cut -d: -f1)"
+publish_automation_line="$(grep -n 'run: ./scripts/test-devcontainer-image-automation.sh' \
+    .github/workflows/publish-harmon-devcontainer.yml | cut -d: -f1)"
+registry_token_line="$(grep -n 'docker/login-action@' \
+    .github/workflows/publish-harmon-devcontainer.yml | cut -d: -f1)"
 prepare_line="$(grep -n 'sync-devcontainer-image.sh prepare' \
     .github/workflows/publish-harmon-devcontainer.yml | cut -d: -f1)"
 token_line="$(grep -n 'actions/create-github-app-token@' \
     .github/workflows/publish-harmon-devcontainer.yml | tail -1 | cut -d: -f1)"
 publish_line="$(grep -n 'sync-devcontainer-image.sh publish' \
     .github/workflows/publish-harmon-devcontainer.yml | cut -d: -f1)"
+if [ -z "$ci_automation_line" ] || [ -z "$publish_automation_line" ] ||
+    [ "$publish_automation_line" -ge "$registry_token_line" ]; then
+    fail "automation tests are not enforced before image publication"
+fi
 if [ "$prepare_line" -ge "$token_line" ] || [ "$token_line" -ge "$publish_line" ]; then
     fail "write token is not isolated between prepare and publish steps"
 fi

--- a/scripts/test-devcontainer-image.sh
+++ b/scripts/test-devcontainer-image.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Build and smoke-test the canonical Harmon devcontainer image on the host
+# architecture, then prove the current repository overlay installs on top.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "test-devcontainer-image: $1 is required" >&2
+        exit 1
+    }
+}
+
+need docker
+need git
+
+source_revision="${1:-$(git rev-parse HEAD)}"
+case "$source_revision" in
+????????????????????????????????????????)
+    case "$source_revision" in *[!0-9a-f]*) exit 2 ;; esac
+    ;;
+*)
+    echo "usage: $0 [40-character-source-revision]" >&2
+    exit 2
+    ;;
+esac
+
+case "$(docker info --format '{{.Architecture}}')" in
+x86_64 | amd64) architecture=amd64 ;;
+aarch64 | arm64) architecture=arm64 ;;
+*)
+    echo "test-devcontainer-image: unsupported Docker architecture" >&2
+    exit 1
+    ;;
+esac
+
+candidate="harmon-devcontainer-candidate:${source_revision}"
+overlay="harmon-devcontainer-overlay-test:${source_revision}"
+
+cleanup() {
+    docker image rm --force "$overlay" "$candidate" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker build --pull \
+    --build-arg "IMAGE_REVISION=${source_revision}" \
+    --tag "$candidate" \
+    images/devcontainer
+
+docker run --rm \
+    --env "EXPECTED_REVISION=${source_revision}" \
+    --env "EXPECTED_ARCHITECTURE=${architecture}" \
+    "$candidate" \
+    /usr/local/sbin/smoke.sh
+
+docker build \
+    --build-arg "BASE_IMAGE=${candidate}" \
+    --file images/devcontainer/test-overlay.Dockerfile \
+    --tag "$overlay" \
+    .
+
+docker run --rm "$overlay" sh -eu -c '
+    [ "$(id -un)" = vscode ]
+    [ -f /etc/claude-code/managed-settings.json ]
+    [ -x /etc/claude-code/hooks/protect-files.sh ]
+    [ -f /home/vscode/.config/git/config ]
+    [ -f /usr/local/share/devcontainer-config/claude-user-defaults.json ]
+'
+
+echo "test-devcontainer-image: candidate and repository overlay passed"

--- a/scripts/test-renovate-pins.sh
+++ b/scripts/test-renovate-pins.sh
@@ -225,7 +225,16 @@ def twin_name(path):
     name = rendered(path)
     return name[: -len(".jinja")] if name.endswith(".jinja") else name
 
-SWEEP = [".skills-sync.yaml", "Taskfile.yml", ".devcontainer", ".github", "scripts", "taskfiles", "template"]
+SWEEP = [
+    ".skills-sync.yaml",
+    "Taskfile.yml",
+    "images",
+    ".devcontainer",
+    ".github",
+    "scripts",
+    "taskfiles",
+    "template",
+]
 file_pins = {}  # path -> {(dep, datasource), ...}
 for top in SWEEP:
     base = pathlib.Path(top)
@@ -260,6 +269,21 @@ for root_path, root_pins in sorted(file_pins.items()):
                 f"across two PRs, each updating only one twin (verbatim twins "
                 f"then fail test:dogfood-parity)"
             )
+
+# The root-only producer pins must land in the same reviewed Devcontainer batch;
+# generated repositories have no images/devcontainer/ source and therefore no
+# corresponding template rule.
+producer_group = resolve_group(
+    root_cfg,
+    "images/devcontainer/Dockerfile",
+    "semgrep",
+    "pypi",
+)
+if producer_group != "Devcontainer":
+    errors.append(
+        "root config: semgrep in images/devcontainer/Dockerfile resolves to "
+        f"group {producer_group!r}, expected 'Devcontainer'"
+    )
 
 # ── Template config: rendered packageRules route consumer pins correctly ────
 # The generated repo has no parity gate, so the requirement is the opposite


### PR DESCRIPTION
## What changed

- add the canonical amd64/arm64 Harmon devcontainer image with immutable source/digest identity, a machine-readable manifest, installer, and executable smoke coverage
- add a root-only candidate/publish/sync workflow with public-pull validation and a fresh-runner Git-bundle trust boundary before App credentials
- add monotonic rolling-pin automation, offline failure/race coverage, Renovate routing, and architecture documentation

## Why

This is the producer/publishing half of #489. It centralizes the expensive shared toolchain while preserving repository-specific overlays. Consumer Dockerfiles remain on the current image until a separate reviewed bootstrap PR switches both dogfood/template twins together.

## Verification

- `task test:devcontainer:image`
- `task verify`
- `task challenge` (clean after adjudication; live Buildx evidence rejected the repeated `.Manifest.digest` false positive)
- `task review` (no findings)
- `task ci`
- `task audit:dogfood -- --summary`

Part of #489.