### PR TITLE
fix: cover every GitHub SSH endpoint form in devcontainer rewrite

### DIFF
--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -40,8 +40,8 @@ fi
 
 # Rewrite every GitHub SSH URL form to HTTPS for fetch AND push: in-container
 # git ops never depend on an SSH agent (absent in bot containers; lockout-
-# prone when forwarded into human ones). Covers the scp form, both ssh://
-# forms, and the explicit port-443 endpoint. HTTPS auth comes from gh
+# prone when forwarded into human ones). Covers the scp form (git@github.com:)
+# plus all three ssh:// forms, including the explicit port-443 endpoint. HTTPS auth comes from gh
 # (GH_TOKEN, above) in bot/Coder profiles, or VS Code's forwarded host
 # credential helper on attach. Mirrors the host dotfiles policy
 # (harmon-dotfiles ADR 0002).

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -38,19 +38,21 @@ else
     echo "GitHub CLI is not authenticated; skipping gh auth setup."
 fi
 
-# Rewrite GitHub SSH URLs to HTTPS for fetch AND push: in-container git ops
-# never depend on an SSH agent (absent in bot containers; lockout-prone when
-# forwarded into human ones). HTTPS auth comes from gh (GH_TOKEN, above) in
-# bot/Coder profiles, or VS Code's forwarded host credential helper on attach.
-# Mirrors the host dotfiles policy (harmon-dotfiles ADR 0002).
+# Rewrite every GitHub SSH URL form to HTTPS for fetch AND push: in-container
+# git ops never depend on an SSH agent (absent in bot containers; lockout-
+# prone when forwarded into human ones). Covers the scp form, both ssh://
+# forms, and the explicit port-443 endpoint. HTTPS auth comes from gh
+# (GH_TOKEN, above) in bot/Coder profiles, or VS Code's forwarded host
+# credential helper on attach. Mirrors the host dotfiles policy
+# (harmon-dotfiles ADR 0002).
 # insteadOf is multi-valued, so reset then re-add: a plain scalar set exits 5
 # ("cannot overwrite multiple values") on re-run and would fail post-create.
-# Unset with --fixed-value so only the two managed values are removed — a
+# Unset with --fixed-value so only the four managed values are removed — a
 # whole-key --unset-all would delete user-defined aliases (e.g. github:).
-git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "git@github.com:" || true
-git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "ssh://git@github.com/" || true
-git config --global --add url."https://github.com/".insteadOf "git@github.com:"
-git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
+for ssh_form in "git@github.com:" "ssh://git@github.com/" "ssh://git@ssh.github.com:443/" "ssh://git@ssh.github.com/"; do
+    git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "$ssh_form" || true
+    git config --global --add url."https://github.com/".insteadOf "$ssh_form"
+done
 
 echo "Git user: $(git config --global user.name)"
 echo "GitHub auth status:"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,9 +235,10 @@ something to ask permission for.
   by pushing to a raw `https://…` URL — a URL push bypasses the named remote
   and leaves stale tracking refs. On an unprovisioned host, force the helper
   and the rewrite against the *named* remote:
-  `git -c credential.helper= -c credential.helper='!gh auth git-credential' -c url."https://github.com/".insteadOf="git@github.com:" push`
-  (a credential helper only applies to HTTPS, so without the `insteadOf` an
-  SSH-form remote still goes over SSH).
+  `git -c credential.helper= -c credential.helper='!gh auth git-credential' -c url."https://github.com/".insteadOf="git@github.com:" -c url."https://github.com/".insteadOf="ssh://git@github.com/" push`
+  (a credential helper only applies to HTTPS, and `insteadOf` is prefix
+  matching — both SSH forms need a mapping; add the corresponding one for the
+  port-443 endpoint `ssh://git@ssh.github.com:443/…` if the remote uses it).
 - **Shepherd the PR (`/shepherd`, max 5 rounds).** `gh pr create` returning is
   the trigger for this stage, not the end of the work — enter it deliberately
   instead of judging for yourself when the PR is finished. `/shepherd` is the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,10 +235,9 @@ something to ask permission for.
   by pushing to a raw `https://…` URL — a URL push bypasses the named remote
   and leaves stale tracking refs. On an unprovisioned host, force the helper
   and the rewrite against the *named* remote:
-  `git -c credential.helper= -c credential.helper='!gh auth git-credential' -c url."https://github.com/".insteadOf="git@github.com:" -c url."https://github.com/".insteadOf="ssh://git@github.com/" push`
+  `git -c credential.helper= -c credential.helper='!gh auth git-credential' -c url."https://github.com/".insteadOf="git@github.com:" -c url."https://github.com/".insteadOf="ssh://git@github.com/" -c url."https://github.com/".insteadOf="ssh://git@ssh.github.com:443/" -c url."https://github.com/".insteadOf="ssh://git@ssh.github.com/" push`
   (a credential helper only applies to HTTPS, and `insteadOf` is prefix
-  matching — both SSH forms need a mapping; add the corresponding one for the
-  port-443 endpoint `ssh://git@ssh.github.com:443/…` if the remote uses it).
+  matching — every SSH form needs its own mapping, hence all four).
 - **Shepherd the PR (`/shepherd`, max 5 rounds).** `gh pr create` returning is
   the trigger for this stage, not the end of the work — enter it deliberately
   instead of judging for yourself when the PR is finished. `/shepherd` is the

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -145,9 +145,10 @@ something to ask permission for.
   by pushing to a raw `https://…` URL — a URL push bypasses the named remote
   and leaves stale tracking refs. On an unprovisioned host, force the helper
   and the rewrite against the *named* remote:
-  `git -c credential.helper= -c credential.helper='!gh auth git-credential' -c url."https://github.com/".insteadOf="git@github.com:" push`
-  (a credential helper only applies to HTTPS, so without the `insteadOf` an
-  SSH-form remote still goes over SSH).
+  `git -c credential.helper= -c credential.helper='!gh auth git-credential' -c url."https://github.com/".insteadOf="git@github.com:" -c url."https://github.com/".insteadOf="ssh://git@github.com/" push`
+  (a credential helper only applies to HTTPS, and `insteadOf` is prefix
+  matching — both SSH forms need a mapping; add the corresponding one for the
+  port-443 endpoint `ssh://git@ssh.github.com:443/…` if the remote uses it).
 - **Shepherd the PR (`/shepherd`, max 5 rounds).** `gh pr create` returning is
   the trigger for this stage, not the end of the work — enter it deliberately
   instead of judging for yourself when the PR is finished. Where the optional

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -145,10 +145,9 @@ something to ask permission for.
   by pushing to a raw `https://…` URL — a URL push bypasses the named remote
   and leaves stale tracking refs. On an unprovisioned host, force the helper
   and the rewrite against the *named* remote:
-  `git -c credential.helper= -c credential.helper='!gh auth git-credential' -c url."https://github.com/".insteadOf="git@github.com:" -c url."https://github.com/".insteadOf="ssh://git@github.com/" push`
+  `git -c credential.helper= -c credential.helper='!gh auth git-credential' -c url."https://github.com/".insteadOf="git@github.com:" -c url."https://github.com/".insteadOf="ssh://git@github.com/" -c url."https://github.com/".insteadOf="ssh://git@ssh.github.com:443/" -c url."https://github.com/".insteadOf="ssh://git@ssh.github.com/" push`
   (a credential helper only applies to HTTPS, and `insteadOf` is prefix
-  matching — both SSH forms need a mapping; add the corresponding one for the
-  port-443 endpoint `ssh://git@ssh.github.com:443/…` if the remote uses it).
+  matching — every SSH form needs its own mapping, hence all four).
 - **Shepherd the PR (`/shepherd`, max 5 rounds).** `gh pr create` returning is
   the trigger for this stage, not the end of the work — enter it deliberately
   instead of judging for yourself when the PR is finished. Where the optional

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -40,8 +40,8 @@ fi
 
 # Rewrite every GitHub SSH URL form to HTTPS for fetch AND push: in-container
 # git ops never depend on an SSH agent (absent in bot containers; lockout-
-# prone when forwarded into human ones). Covers the scp form, both ssh://
-# forms, and the explicit port-443 endpoint. HTTPS auth comes from gh
+# prone when forwarded into human ones). Covers the scp form (git@github.com:)
+# plus all three ssh:// forms, including the explicit port-443 endpoint. HTTPS auth comes from gh
 # (GH_TOKEN, above) in bot/Coder profiles, or VS Code's forwarded host
 # credential helper on attach. Mirrors the host dotfiles policy
 # (harmon-dotfiles ADR 0002).

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -38,19 +38,21 @@ else
     echo "GitHub CLI is not authenticated; skipping gh auth setup."
 fi
 
-# Rewrite GitHub SSH URLs to HTTPS for fetch AND push: in-container git ops
-# never depend on an SSH agent (absent in bot containers; lockout-prone when
-# forwarded into human ones). HTTPS auth comes from gh (GH_TOKEN, above) in
-# bot/Coder profiles, or VS Code's forwarded host credential helper on attach.
-# Mirrors the host dotfiles policy (harmon-dotfiles ADR 0002).
+# Rewrite every GitHub SSH URL form to HTTPS for fetch AND push: in-container
+# git ops never depend on an SSH agent (absent in bot containers; lockout-
+# prone when forwarded into human ones). Covers the scp form, both ssh://
+# forms, and the explicit port-443 endpoint. HTTPS auth comes from gh
+# (GH_TOKEN, above) in bot/Coder profiles, or VS Code's forwarded host
+# credential helper on attach. Mirrors the host dotfiles policy
+# (harmon-dotfiles ADR 0002).
 # insteadOf is multi-valued, so reset then re-add: a plain scalar set exits 5
 # ("cannot overwrite multiple values") on re-run and would fail post-create.
-# Unset with --fixed-value so only the two managed values are removed — a
+# Unset with --fixed-value so only the four managed values are removed — a
 # whole-key --unset-all would delete user-defined aliases (e.g. github:).
-git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "git@github.com:" || true
-git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "ssh://git@github.com/" || true
-git config --global --add url."https://github.com/".insteadOf "git@github.com:"
-git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
+for ssh_form in "git@github.com:" "ssh://git@github.com/" "ssh://git@ssh.github.com:443/" "ssh://git@ssh.github.com/"; do
+    git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "$ssh_form" || true
+    git config --global --add url."https://github.com/".insteadOf "$ssh_form"
+done
 
 echo "Git user: $(git config --global user.name)"
 echo "GitHub auth status:"


### PR DESCRIPTION
## What

Propagates the endpoint-coverage findings from harmon-devkit#225 (Codex P1 + P2 there) into the template and this repo's own devcontainer:

- **Both `post-create-common.sh` copies** now rewrite all four GitHub SSH URL forms — adding `ssh://git@ssh.github.com:443/` and `ssh://git@ssh.github.com/` — restructured as a fixed-value unset+add loop (idempotent across re-runs, preserves user-defined aliases; both re-verified in a scratch HOME with a pre-seeded `github:` alias).
- **`AGENTS.md` + `template/AGENTS.md.jinja`** fallback command now carries both standard SSH-form mappings (`insteadOf` is prefix matching, so `git@github.com:` alone misses `ssh://`-form remotes) and documents the port-443 case.

Refs evanharmon1/harmon-dotfiles#37 · mirrors harmon-devkit#225 (`e755cec`) and harmon-dotfiles#40 (`bfde849`)

## Verification

- `task verify` green locally, including template render tests
- All four forms confirmed rewriting to `https://github.com/…` via `ls-remote --get-url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)