### PR TITLE
fix(test): sanitize GH_APP_SLUG in devcontainer image automation fixture

### DIFF
--- a/scripts/test-devcontainer-image-automation.sh
+++ b/scripts/test-devcontainer-image-automation.sh
@@ -165,7 +165,11 @@ git -C "$fixture" push -u origin main >/dev/null
 run_fixture() {
     (
         cd "$fixture"
-        env -u GH_TOKEN -u GITHUB_TOKEN \
+        # Sanitize inherited env: the sync-harmon-devkit workflow exports
+        # GH_APP_SLUG job-wide, which would leak into the fixture and drive
+        # sync-devcontainer-image.sh's App-identity path against the gh stub
+        # (die "unexpected App bot id ''") — exactly as it failed in CI.
+        env -u GH_TOKEN -u GITHUB_TOKEN -u GH_APP_SLUG \
             PATH="$bin_dir:$PATH" GH_STUB_LOG="$tmp_root/gh.log" TASK_STUB_LOG="$tmp_root/task.log" \
             "$@"
     )


### PR DESCRIPTION
## What

The v0.15.0 skills-sync run failed at its `task verify` step and (correctly) pushed nothing. Root cause: `.github/workflows/sync-harmon-devkit.yml` exports `GH_APP_SLUG` job-wide, and `test-devcontainer-image-automation.sh`'s `run_fixture` — which deliberately sanitizes inherited env (`GH_TOKEN`, `GITHUB_TOKEN`) — missed it. The inherited slug drove `sync-devcontainer-image.sh`'s App-identity path (`gh api /users/<slug>[bot]`) against the test's `gh` stub, whose empty `.id` dies as `unexpected App bot id ''`.

One-line fix: add `-u GH_APP_SLUG` to the fixture's env sanitizer, with a comment recording why.

## Reproduction (A/B verified)

- Pre-fix script with `GH_APP_SLUG=ci-app GH_TOKEN=fake` (simulating the workflow env): fails with the exact CI error — `sync-devcontainer-image: unexpected App bot id ''`
- Fixed script, same env: **18 offline cases passed**
- `task verify` green locally

## Notes

- Introduced by #501 (test landed after the last successful sync, so this is its first run inside the sync workflow's env).
- Follow-up consideration (not in scope): dedicated fixture coverage for the App-identity path with a stubbed numeric id — currently covered only for the sibling script in `test-sync-devkit-release.sh`.
- After merge, the v0.15.0 sync needs a re-fire: `gh api repos/evanharmon1/harmon-init/dispatches -f event_type=harmon-devkit-released -f 'client_payload[tag]=v0.15.0'` (or the next devkit release re-triggers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)