### PR TITLE
fix(devcontainer): rewrite the Claude Code status line

### DIFF
--- a/.devcontainer/config/claude-statusline.sh
+++ b/.devcontainer/config/claude-statusline.sh
@@ -1,133 +1,345 @@
 #!/usr/bin/env bash
 # claude-statusline.sh — Claude Code `statusLine` renderer for the dev container.
 #
-# Gives a container session the same two-line status line as a host session:
+# Gives a container session the same four-line status line as a host session:
 #
-#   📁 ~/git/harmon-init  🌿 main  🤖 Opus 5  📟 v2.1.220  🎨 default
-#   🧠 Context Remaining: 60% [======----]
+#   📁 ~/git/my-project  🌿 main  🔀 #512 ✓  ▪ session name  · a1b2c3d4
+#   🧠 ▕████░░░░░░░░░░░░▏ 24%  760k left  🤖 Opus 5 1M · medium · ⚡ · 💭  📟 v2.1.220
+#   💰 $0.43  ✎ +120/-45  ⏱ 11m session
+#   🚦 5h ▕█░░░░░░▏ 🔄 2h13m   ·   7d ▕░░░░░░░▏ 🔄 4d20h
+#
+# Reading down: where you are, how much room and horsepower you have left, what
+# the session has cost, and how close the subscription limits are to biting.
+# Line 4's bars are the same gauge as line 2's at roughly half the width and a
+# muted palette — same reading habit, lower priority.
 #
 # Claude Code pipes the session JSON on stdin and renders whatever we print.
 # Baked into the image at /etc/claude-code/statusline.sh (see the Dockerfile) so
 # it survives the ~/.claude volume mount, and wired up via the `statusLine` key
 # in config/claude-user-defaults.json — a seed default the user can override.
 #
-# `set -e` is deliberately omitted: this runs on every render, so a single
-# failing probe (no git repo, a field a newer payload no longer emits) must
-# degrade to a shorter line rather than blank the status line entirely.
+# This runs on every keystroke-ish refresh, so it is built to stay cheap: two
+# forks total (one `jq`, one `date`) and no others. In particular there is no
+# `git` subprocess — the branch is read straight out of .git/HEAD — no logging,
+# and no network. Everything else is bash builtins, and the helpers below
+# deliberately return through $REPLY rather than $(...) because a command
+# substitution is a subshell fork; at ~20 segments a render that is the
+# difference between a couple of forks and two dozen.
+#
+# `set -e` is deliberately omitted: a single failing probe (no git repo, a
+# field a newer payload no longer emits) must degrade to a shorter line rather
+# than blank the status line entirely.
 set -uo pipefail
 
 input=$(cat)
 
-# ---- colors (256-color palette; honors NO_COLOR) ----
-if [ -n "${NO_COLOR:-}" ]; then
-    color() { :; }
-    reset() { :; }
+# ---- toggles (override in the environment) ----
+: "${STATUSLINE_COLOR:=1}"     # 0 disables color (NO_COLOR is honored too)
+: "${STATUSLINE_HYPERLINK:=1}" # 0 disables the OSC-8 link on the PR number
+: "${STATUSLINE_CTX_WIDTH:=16}"
+: "${STATUSLINE_RL_WIDTH:=7}" # deliberately under half the context bar
+: "${STATUSLINE_RL_PCT:=0}"   # 1 also prints the exact limit percentage
+
+[ -n "${NO_COLOR:-}" ] && STATUSLINE_COLOR=0
+
+# ---- color, precomputed (no forks at render time) ----
+if [ "$STATUSLINE_COLOR" = 1 ]; then
+    e=$'\033'
+    RST="${e}[0m"
+    DIR="${e}[38;5;117m"   # sky blue
+    ROOT="${e}[38;5;103m"  # muted blue
+    GIT="${e}[38;5;150m"   # soft green
+    PR="${e}[38;5;213m"    # pink
+    MODEL="${e}[38;5;147m" # light purple
+    # Both grays sit a step brighter than a "secondary text" palette would
+    # suggest. Anything below ~244 disappears into a dark terminal background —
+    # legible in a screenshot, invisible in use.
+    META="${e}[38;5;250m" # gray
+    DIM="${e}[38;5;245m"  # softer gray
+    COST="${e}[38;5;180m" # soft yellow
+    OK="${e}[38;5;158m"   # mint
+    WARN="${e}[38;5;215m" # peach
+    HOT="${e}[38;5;203m"  # coral
+    # Same three signals a few shades down, for the usage-limit bars. They are
+    # the same gauge as the context window and must read that way, so the hues
+    # match — but they sit further back, and a duller palette says "same idea,
+    # lower priority" without needing a second shape to say it.
+    OK_D="${e}[38;5;71m"    # moss
+    WARN_D="${e}[38;5;173m" # clay
+    HOT_D="${e}[38;5;167m"  # brick
 else
-    color() { printf '\033[38;5;%sm' "$1"; }
-    reset() { printf '\033[0m'; }
+    RST='' DIR='' ROOT='' GIT='' PR='' MODEL='' META='' DIM='' COST=''
+    OK='' WARN='' HOT='' OK_D='' WARN_D='' HOT_D=''
 fi
 
-COLOR_DIR=117     # sky blue
-COLOR_GIT=150     # soft green
-COLOR_MODEL=147   # light purple
-COLOR_VERSION=249 # light gray
-COLOR_STYLE=245   # gray
-
-# Claude Code renders our stdout as ANSI, and a directory name may legally
-# contain ESC or a newline — so every value that reaches the terminal is
-# stripped of control bytes first. Without this, a checkout under a crafted
-# path could inject escape sequences (OSC 52 clipboard writes, extra status
-# lines) on every refresh.
-sanitize() { printf '%s' "$1" | tr -d '[:cntrl:]'; }
-
-# field <emoji> <color> <text> — one "  <emoji> <colored text>" segment.
-field() {
-    printf '  %s %s%s%s' "$1" "$(color "$2")" "$(sanitize "$3")" "$(reset)"
-}
-
-# jq is baked into the image. Without it there is no payload to read, so fall
-# back to the one thing we can still resolve locally.
+# ---- payload ----
+# One jq invocation emits every field in a fixed order. Control bytes are
+# stripped inside jq: Claude Code renders our stdout as ANSI, and a directory,
+# branch, or session name may legally contain ESC or a newline — so without
+# this a checkout under a crafted path could inject escape sequences (OSC 52
+# clipboard writes, extra status lines) on every refresh, or desync the field
+# split below.
 if ! command -v jq >/dev/null 2>&1; then
-    printf '📁 %s\n' "$(sanitize "$PWD")"
+    printf '📁 %s\n' "${PWD//[[:cntrl:]]/}"
     exit 0
 fi
 
-json() { printf '%s' "$input" | jq -r "$1" 2>/dev/null; }
+fields=$(printf '%s' "$input" | jq -r '
+  def s: (. // "") | tostring | explode
+         | map(select(. > 31 and . != 127)) | implode;
+  def n: (. // 0) | if type == "number" then floor else 0 end;
+  [ ((.workspace.current_dir // .cwd)   | s)
+  , (.workspace.project_dir             | s)
+  , (.model.display_name                | s)
+  , (.effort.level                      | s)
+  , ((.fast_mode        == true)        | s)
+  , ((.thinking.enabled == true)        | s)
+  , (.version                           | s)
+  , (.output_style.name                 | s)
+  , (.session_id                        | s | .[0:8])
+  , (.session_name                      | s)
+  , ((.context_window.used_percentage
+       // (100 - (.context_window.remaining_percentage // 100))) | n)
+  , (.context_window.context_window_size    | n)
+  , (.cost.total_cost_usd                   | (. // 0) | tostring)
+  , (.cost.total_lines_added                | n)
+  , (.cost.total_lines_removed              | n)
+  , (.cost.total_duration_ms                | n)
+  , (.pr.number                             | s)
+  , (.pr.url                                | s)
+  , (.pr.review_state                       | s)
+  , (.rate_limits.five_hour.used_percentage | n)
+  , (.rate_limits.five_hour.resets_at       | n)
+  , (.rate_limits.seven_day.used_percentage | n)
+  , (.rate_limits.seven_day.resets_at       | n)
+  ] | map(tostring) | join("\u001f")' 2>/dev/null)
 
-current_dir=$(json '.workspace.current_dir // .cwd // ""')
-model_name=$(json '.model.display_name // ""')
-cc_version=$(json '.version // ""')
-output_style=$(json '.output_style.name // ""')
+# Split on U+001F (unit separator), not a tab: TAB is IFS *whitespace*, so
+# `read` would collapse runs of it and silently shift every field after the
+# first empty one. The filter above strips control bytes from every value, so
+# a US can never occur inside one.
+IFS=$'\037' read -r cur_dir proj_dir model effort fast thinking cc_ver style \
+    sid sname ctx_pct ctx_size cost lines_add lines_del dur_ms \
+    pr_num pr_url pr_state rl5_pct rl5_at rl7_pct rl7_at <<<"$fields"
 
-# jq exits nonzero (and prints nothing) on an unparseable payload, so the
-# fallbacks belong here rather than in the filters above.
-[ -n "$model_name" ] || model_name="Claude"
+[ -n "${model:-}" ] || model="Claude"
+[ -n "${cur_dir:-}" ] || cur_dir="$PWD"
 
-# ---- git branch (resolved in the session's directory, not ours) ----
-git_branch=""
-if [ -n "$current_dir" ] && cd "$current_dir" 2>/dev/null; then
-    if git rev-parse --git-dir >/dev/null 2>&1; then
-        git_branch=$(git branch --show-current 2>/dev/null)
-        [ -n "$git_branch" ] || git_branch=$(git rev-parse --short HEAD 2>/dev/null)
+# One clock read serves every relative figure below. The wall-clock time itself
+# is deliberately not shown: the terminal, the OS, and the wall already have it,
+# and it is the one number here that says nothing about the session.
+now=$(date +%s)
+
+# ---- helpers (results land in $REPLY) ----
+num() { case "${1:-}" in '' | *[!0-9]*) return 1 ;; esac }
+
+# bar <used-pct> <width> — the filled portion represents consumption.
+bar() {
+    local pct=$1 width=$2 i=0
+    ((pct < 0)) && pct=0
+    ((pct > 100)) && pct=100
+    local filled=$((pct * width / 100))
+    REPLY='▕'
+    while ((i < width)); do
+        if ((i < filled)); then REPLY+='█'; else REPLY+='░'; fi
+        ((i++))
+    done
+    REPLY+='▏'
+}
+
+# heat <used-pct> [ok] [warn] [hot] — go/caution/stop by consumption, at the
+# same 60/80 thresholds everywhere. The palette is an argument so the limit
+# bars can run the muted set without forking the thresholds along with it.
+heat() {
+    if (($1 >= 80)); then
+        REPLY=${4:-$HOT}
+    elif (($1 >= 60)); then
+        REPLY=${3:-$WARN}
+    else
+        REPLY=${2:-$OK}
     fi
+}
+
+# compact <tokens> — 940k / 1.2M, so the figure never jitters in width.
+compact() {
+    local v=$1
+    if ((v >= 1000000)); then
+        printf -v REPLY '%d.%dM' $((v / 1000000)) $((v % 1000000 / 100000))
+    elif ((v >= 1000)); then
+        printf -v REPLY '%dk' $((v / 1000))
+    else
+        REPLY=$v
+    fi
+}
+
+# dur <seconds> — 1d6h / 2h13m / 14m / 45s, dropping units that read as noise.
+dur() {
+    local s=$1
+    if ((s >= 86400)); then
+        printf -v REPLY '%dd%dh' $((s / 86400)) $((s % 86400 / 3600))
+    elif ((s >= 3600)); then
+        printf -v REPLY '%dh%02dm' $((s / 3600)) $((s % 3600 / 60))
+    elif ((s >= 60)); then
+        printf -v REPLY '%dm' $((s / 60))
+    else
+        printf -v REPLY '%ds' "$s"
+    fi
+}
+
+tilde() {
+    case "$1" in
+    "$HOME") REPLY='~' ;;
+    "$HOME"/*) REPLY="~${1#"$HOME"}" ;;
+    *) REPLY=$1 ;;
+    esac
+}
+
+# seg <emoji> <color> <text>
+seg() { printf '  %s %s%s%s' "$1" "$2" "$3" "$RST"; }
+
+# ---- git branch, without forking git ----
+# Walk up from the session directory to the first .git. In a linked worktree
+# .git is a FILE holding `gitdir: <path>`, and that path's HEAD is the one that
+# describes the checkout you are actually sitting in.
+branch='' gitdir='' d=$cur_dir
+while [ -n "$d" ] && [ "$d" != / ]; do
+    if [ -d "$d/.git" ]; then
+        gitdir="$d/.git"
+        break
+    elif [ -f "$d/.git" ]; then
+        read -r _ gitdir <"$d/.git" 2>/dev/null
+        case "$gitdir" in /*) ;; *) gitdir="$d/$gitdir" ;; esac
+        break
+    fi
+    # A relative or otherwise slashless value leaves `${d%/*}` equal to `d`,
+    # which would spin here forever. Stop instead of ascending nowhere.
+    parent=${d%/*}
+    [ "$parent" = "$d" ] && break
+    d=$parent
+done
+if [ -n "$gitdir" ] && [ -r "$gitdir/HEAD" ]; then
+    read -r head <"$gitdir/HEAD" 2>/dev/null
+    case "$head" in
+    "ref: refs/heads/"*) branch="${head#ref: refs/heads/}" ;;
+    *) branch="${head:0:7}" ;;
+    esac
+    branch="${branch//[[:cntrl:]]/}"
 fi
 
-# ---- display path (~ for $HOME, matching the host status line) ----
-display_dir="${current_dir:-unknown}"
-case "$display_dir" in
-"$HOME") display_dir="~" ;;
-"$HOME"/*) display_dir="~${display_dir#"$HOME"}" ;;
-esac
+# =====================================================================
+# line 1 — where you are
+# =====================================================================
+tilde "$cur_dir"
+printf '📁 %s%s%s' "$DIR" "$REPLY" "$RST"
 
-# ---- context window ----
-# Claude Code already reports `remaining_percentage`; prefer it so the bar never
-# disagrees with the figure the CLI itself shows (its rounding is not ours, and
-# it accounts for reserved output tokens). The token sum is a fallback for
-# payloads that predate the field.
-context_pct=""
-context_bar=""
-context_color=158 # mint green
-remaining=$(json '.context_window.remaining_percentage // empty')
-if ! [[ "$remaining" =~ ^[0-9]+$ ]]; then
-    remaining=""
-    context_size=$(json '.context_window.context_window_size // 0')
-    context_used=$(json '(.context_window.current_usage // {})
-        | (.input_tokens // 0)
-        + (.cache_creation_input_tokens // 0)
-        + (.cache_read_input_tokens // 0)')
-    if [[ "$context_size" =~ ^[0-9]+$ ]] && [[ "$context_used" =~ ^[0-9]+$ ]] &&
-        [ "$context_size" -gt 0 ] && [ "$context_used" -gt 0 ]; then
-        remaining=$((100 - context_used * 100 / context_size))
-    fi
+# The launch directory only earns space when it is not the one you are in.
+if [ -n "${proj_dir:-}" ] && [ "$proj_dir" != "$cur_dir" ]; then
+    tilde "$proj_dir"
+    seg '⌂' "$ROOT" "$REPLY"
 fi
 
-if [ -n "$remaining" ]; then
-    ((remaining < 0)) && remaining=0
-    ((remaining > 100)) && remaining=100
+[ -n "$branch" ] && seg '🌿' "$GIT" "$branch"
 
-    if [ "$remaining" -le 20 ]; then
-        context_color=203 # coral red
-    elif [ "$remaining" -le 40 ]; then
-        context_color=215 # peach
+if num "${pr_num:-}"; then
+    label="#$pr_num"
+    # OSC-8 hides pr.url behind the number: clickable, zero extra columns.
+    # Terminals that do not implement it ignore the sequence.
+    if [ "$STATUSLINE_HYPERLINK" = 1 ] && [ -n "${pr_url:-}" ] && [ "$STATUSLINE_COLOR" = 1 ]; then
+        label="${e}]8;;${pr_url}${e}\\${label}${e}]8;;${e}\\"
     fi
-
-    filled=$((remaining / 10))
-    context_bar=$(printf '%*s' "$filled" '' | tr ' ' '=')
-    context_bar+=$(printf '%*s' "$((10 - filled))" '' | tr ' ' '-')
-    context_pct="${remaining}%"
+    case "${pr_state:-}" in
+    approved) label+=' ✓' ;;
+    changes_requested) label+=' ✗' ;;
+    pending | commented) label+=' ⋯' ;;
+    esac
+    seg '🔀' "$PR" "$label"
 fi
 
-# ---- render ----
-printf '📁 %s%s%s' "$(color "$COLOR_DIR")" "$(sanitize "$display_dir")" "$(reset)"
-[ -n "$git_branch" ] && field '🌿' "$COLOR_GIT" "$git_branch"
-field '🤖' "$COLOR_MODEL" "$model_name"
-[ -n "$cc_version" ] && field '📟' "$COLOR_VERSION" "v${cc_version}"
-[ -n "$output_style" ] && field '🎨' "$COLOR_STYLE" "$output_style"
+[ -n "${sname:-}" ] && seg '▪' "$META" "$sname"
+[ -n "${sid:-}" ] && seg '·' "$DIM" "$sid"
 
-if [ -n "$context_pct" ]; then
-    printf '\n🧠 %sContext Remaining: %s [%s]%s' \
-        "$(color "$context_color")" "$context_pct" "$context_bar" "$(reset)"
+# =====================================================================
+# line 2 — context window, and what is answering
+# =====================================================================
+printf '\n'
+if num "${ctx_pct:-}"; then
+    heat "$ctx_pct"
+    ctx_color=$REPLY
+    bar "$ctx_pct" "$STATUSLINE_CTX_WIDTH"
+    printf '🧠 %s%s %s%%%s' "$ctx_color" "$REPLY" "$ctx_pct" "$RST"
+    # Derive the headroom from the same percentage the bar uses. The raw token
+    # sum is more precise but disagrees with used_percentage (which also counts
+    # reserved output tokens), and a bar that contradicts the number beside it
+    # is worse than a slightly rounded figure.
+    if num "${ctx_size:-}" && ((ctx_size > 0)); then
+        compact $((ctx_size * (100 - ctx_pct) / 100))
+        printf ' %s%s left%s' "$DIM" "$REPLY" "$RST"
+    fi
 else
-    printf '\n🧠 %sContext Remaining: TBD%s' "$(color "$context_color")" "$(reset)"
+    printf '🧠 %scontext n/a%s' "$DIM" "$RST"
 fi
+
+# "Opus 5 (1M context)" is accurate and too wide; the parenthetical is the only
+# part that varies between the two, so keep it and drop the filler word.
+mode="${model/ (1M context)/ 1M}"
+[ -n "${effort:-}" ] && mode+=" · $effort"
+[ "${fast:-}" = true ] && mode+=' · ⚡'
+[ "${thinking:-}" = true ] && mode+=' · 💭'
+seg '🤖' "$MODEL" "$mode"
+
+[ -n "${cc_ver:-}" ] && seg '📟' "$DIM" "v$cc_ver"
+[ -n "${style:-}" ] && [ "$style" != default ] && seg '🎨' "$META" "$style"
+
+# =====================================================================
+# line 3 — what the session has spent
+# =====================================================================
+printf '\n'
+case "${cost:-}" in
+'' | *[!0-9.]*) cost=0 ;;
+esac
+printf '💰 %s$%.2f%s' "$COST" "$cost" "$RST"
+
+if num "${lines_add:-}" && num "${lines_del:-}" && ((lines_add + lines_del > 0)); then
+    printf '  ✎ %s+%s%s/%s-%s%s' "$OK" "$lines_add" "$RST" "$HOT" "$lines_del" "$RST"
+fi
+
+if num "${dur_ms:-}" && ((dur_ms > 0)); then
+    dur $((dur_ms / 1000))
+    seg '⏱' "$META" "$REPLY session"
+fi
+
+# =====================================================================
+# line 4 — subscription usage limits
+# =====================================================================
+# Two independent rolling windows, each with its own allowance and its own
+# reset, on a line of their own. Each reads as: window, how full it is, how long
+# until it empties. Same bar and same heat colors as the context window, so one
+# reading habit covers both — but at well under half the width, because these
+# are a background concern and should not compete with the context gauge for
+# attention at a glance.
+rl() {
+    local label=$1 pct=$2 at=$3 gauge
+    num "$pct" || return 0
+    heat "$pct" "$OK_D" "$WARN_D" "$HOT_D"
+    gauge=$REPLY
+    bar "$pct" "$STATUSLINE_RL_WIDTH"
+    gauge+="$REPLY$RST"
+    ((STATUSLINE_RL_PCT)) && gauge+="$DIM ${pct}%$RST"
+    printf '%s%s%s %s' "$META" "$label" "$RST" "$gauge"
+    # A reset already in the past means a stale payload, not "due now" — drop
+    # it rather than render a countdown that has stopped meaning anything.
+    if num "$at" && ((at > now)); then
+        dur $((at - now))
+        printf ' %s🔄 %s%s' "$DIM" "$REPLY" "$RST"
+    fi
+}
+if num "${rl5_pct:-}" || num "${rl7_pct:-}"; then
+    printf '\n🚦 '
+    rl 5h "${rl5_pct:-}" "${rl5_at:-}"
+    if num "${rl5_pct:-}" && num "${rl7_pct:-}"; then
+        printf '%s   ·   %s' "$DIM" "$RST"
+    fi
+    rl 7d "${rl7_pct:-}" "${rl7_at:-}"
+fi
+
 printf '\n'

--- a/.devcontainer/config/claude-statusline.sh
+++ b/.devcontainer/config/claude-statusline.sh
@@ -90,8 +90,11 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 fields=$(jq -r '
+  # C0 (0-31), DEL, and C1 (128-159) all go. C1 matters because a terminal in
+  # 8-bit mode reads U+009B as CSI outright — the same escape this strips in
+  # its ESC-[ form, arriving by a route a C0-only filter would wave through.
   def s: (. // "") | tostring | explode
-         | map(select(. > 31 and . != 127)) | implode;
+         | map(select(. > 31 and . != 127 and (. < 128 or . > 159))) | implode;
   def n: (. // 0) | if type == "number" then floor else 0 end;
   # Like n, but absence stays absent. A session without a subscription — API
   # key, Bedrock, Vertex, an alternative provider — has no .rate_limits at all,
@@ -133,7 +136,11 @@ IFS=$'\037' read -r cur_dir proj_dir model effort fast thinking cc_ver style \
     pr_num pr_url pr_state rl5_pct rl5_at rl7_pct rl7_at <<<"$fields"
 
 [ -n "${model:-}" ] || model="Claude"
-[ -n "${cur_dir:-}" ] || cur_dir="$PWD"
+# $PWD never passed through the jq filter, so it is stripped here instead.
+# Without this, running from a directory whose name contains ESC or BEL would
+# reopen the injection path on exactly the paths that reach this fallback — an
+# unparseable payload, or one carrying no workspace at all.
+[ -n "${cur_dir:-}" ] || cur_dir="${PWD//[[:cntrl:]]/}"
 
 # One clock read serves every relative figure below. The wall-clock time itself
 # is deliberately not shown: the terminal, the OS, and the wall already have it,
@@ -153,6 +160,10 @@ num() { case "${1:-}" in '' | *[!0-9]*) return 1 ;; esac }
 sane() {
     local v=$1
     case "$v" in '' | *[!0-9]*) v=$2 ;; esac
+    # 10# because bash reads a leading zero as octal: STATUSLINE_CTX_WIDTH=08
+    # passes the digits-only test above and then dies on "value too great for
+    # base", which is a stranger failure than the typo it came from.
+    v=$((10#$v))
     ((v < $3)) && v=$3
     ((v > $4)) && v=$4
     REPLY=$v

--- a/.devcontainer/config/claude-statusline.sh
+++ b/.devcontainer/config/claude-statusline.sh
@@ -18,10 +18,12 @@
 # it survives the ~/.claude volume mount, and wired up via the `statusLine` key
 # in config/claude-user-defaults.json — a seed default the user can override.
 #
-# This runs on every keystroke-ish refresh, so it is built to stay cheap: two
-# forks total (one `jq`, one `date`) and no others. In particular there is no
-# `git` subprocess — the branch is read straight out of .git/HEAD — no logging,
-# and no network. Everything else is bash builtins, and the helpers below
+# This runs on every keystroke-ish refresh, so it is built to stay cheap: it
+# executes exactly two external commands, `jq` and `date`. In particular there
+# is no `git` subprocess — the branch is read straight out of .git/HEAD — stdin
+# is drained by `read` rather than `cat`, and jq is fed by here-string rather
+# than a pipeline, so neither costs an extra process. No logging, and no
+# network. Everything else is bash builtins, and the helpers below
 # deliberately return through $REPLY rather than $(...) because a command
 # substitution is a subshell fork; at ~20 segments a render that is the
 # difference between a couple of forks and two dozen.
@@ -31,7 +33,10 @@
 # than blank the status line entirely.
 set -uo pipefail
 
-input=$(cat)
+# Drain stdin with the builtin rather than `cat`. -d '' reads to EOF in one go
+# and returns nonzero there, which is the normal path — the payload is in
+# $input either way, so the status is deliberately ignored.
+IFS= read -r -d '' input || true
 
 # ---- toggles (override in the environment) ----
 : "${STATUSLINE_COLOR:=1}"     # 0 disables color (NO_COLOR is honored too)
@@ -84,10 +89,15 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 0
 fi
 
-fields=$(printf '%s' "$input" | jq -r '
+fields=$(jq -r '
   def s: (. // "") | tostring | explode
          | map(select(. > 31 and . != 127)) | implode;
   def n: (. // 0) | if type == "number" then floor else 0 end;
+  # Like n, but absence stays absent. A session without a subscription — API
+  # key, Bedrock, Vertex, an alternative provider — has no .rate_limits at all,
+  # and folding that to 0 would draw two empty quota bars claiming a fresh
+  # allowance the session does not have. Only a real 0 may render as 0.
+  def o: if . == null then "" else (. | n) end;
   [ ((.workspace.current_dir // .cwd)   | s)
   , (.workspace.project_dir             | s)
   , (.model.display_name                | s)
@@ -108,11 +118,11 @@ fields=$(printf '%s' "$input" | jq -r '
   , (.pr.number                             | s)
   , (.pr.url                                | s)
   , (.pr.review_state                       | s)
-  , (.rate_limits.five_hour.used_percentage | n)
-  , (.rate_limits.five_hour.resets_at       | n)
-  , (.rate_limits.seven_day.used_percentage | n)
-  , (.rate_limits.seven_day.resets_at       | n)
-  ] | map(tostring) | join("\u001f")' 2>/dev/null)
+  , (.rate_limits.five_hour.used_percentage | o)
+  , (.rate_limits.five_hour.resets_at       | o)
+  , (.rate_limits.seven_day.used_percentage | o)
+  , (.rate_limits.seven_day.resets_at       | o)
+  ] | map(tostring) | join("\u001f")' <<<"$input" 2>/dev/null)
 
 # Split on U+001F (unit separator), not a tab: TAB is IFS *whitespace*, so
 # `read` would collapse runs of it and silently shift every field after the
@@ -132,6 +142,24 @@ now=$(date +%s)
 
 # ---- helpers (results land in $REPLY) ----
 num() { case "${1:-}" in '' | *[!0-9]*) return 1 ;; esac }
+
+# sane <value> <default> <min> <max> — a bounded integer, whatever was passed.
+#
+# The numeric overrides are user-supplied and end up inside (( )), where bash
+# resolves a bare word as a *variable name*: STATUSLINE_CTX_WIDTH=abc is an
+# unbound variable under `set -u`, which aborts the render mid-line. A typo in
+# an optional knob must not be able to blank the status line, and an absurd
+# width must not make every refresh build an unbounded string.
+sane() {
+    local v=$1
+    case "$v" in '' | *[!0-9]*) v=$2 ;; esac
+    ((v < $3)) && v=$3
+    ((v > $4)) && v=$4
+    REPLY=$v
+}
+sane "$STATUSLINE_CTX_WIDTH" 16 1 60 && STATUSLINE_CTX_WIDTH=$REPLY
+sane "$STATUSLINE_RL_WIDTH" 7 0 60 && STATUSLINE_RL_WIDTH=$REPLY
+sane "$STATUSLINE_RL_PCT" 0 0 1 && STATUSLINE_RL_PCT=$REPLY
 
 # bar <used-pct> <width> — the filled portion represents consumption.
 bar() {

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -49,13 +49,33 @@ is volume-backed because Claude Code writes your in-app changes there. Every
 `/model` and friends stick, and a wiped volume gets the defaults back. What the
 volume never holds is the code those settings point at.
 
-`config/claude-statusline.sh` renders the same two-line status line as a host
+`config/claude-statusline.sh` renders the same four-line status line as a host
 session, so a container session reads identically:
 
 ```text
-📁 ~/git/harmon-init  🌿 main  🤖 Opus 5  📟 v2.1.220  🎨 default
-🧠 Context Remaining: 60% [======----]
+📁 ~/git/harmon-init  🌿 main  🔀 #512 ✓  ▪ session name  · a1b2c3d4
+🧠 ▕████░░░░░░░░░░░░▏ 24%  760k left  🤖 Opus 5 1M · medium · ⚡ · 💭  📟 v2.1.220
+💰 $0.43  ✎ +120/-45  ⏱ 11m session
+🚦 5h ▕█░░░░░░▏ 🔄 2h13m   ·   7d ▕░░░░░░░▏ 🔄 4d20h
 ```
+
+Reading down: where you are, how much room and horsepower are left, what the
+session has cost, and how close the 5-hour and 7-day subscription limits are to
+biting (`🔄` is time until that window resets). Segments that would say nothing
+are omitted rather than shown empty — the PR only appears on a branch that has
+one, `⚡` and `💭` only when fast mode and extended thinking are on, and the
+launch directory only when it differs from the one you are in.
+
+Both gauges fill as they are consumed and shift mint → peach → coral past 60%
+and 80%; the limit bars run the same scale at under half the width in a muted
+palette, so they read as the same thing at lower priority. `NO_COLOR` is
+honored, and `STATUSLINE_CTX_WIDTH`, `STATUSLINE_RL_WIDTH`, `STATUSLINE_RL_PCT`
+(exact limit percentages) and `STATUSLINE_HYPERLINK` (the OSC-8 link behind the
+PR number) tune the rest.
+
+It is built to be cheap, because it re-renders constantly: two forks per render
+(`jq` and `date`), no `git` subprocess — the branch is read from `.git/HEAD`
+directly, worktrees included — and nothing written to disk.
 
 To use your own instead, point `statusLine.command` in `~/.claude/settings.json`
 at it — the seed merge will not overwrite it.

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-statusline.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-statusline.sh
@@ -1,133 +1,345 @@
 #!/usr/bin/env bash
 # claude-statusline.sh — Claude Code `statusLine` renderer for the dev container.
 #
-# Gives a container session the same two-line status line as a host session:
+# Gives a container session the same four-line status line as a host session:
 #
-#   📁 ~/git/harmon-init  🌿 main  🤖 Opus 5  📟 v2.1.220  🎨 default
-#   🧠 Context Remaining: 60% [======----]
+#   📁 ~/git/my-project  🌿 main  🔀 #512 ✓  ▪ session name  · a1b2c3d4
+#   🧠 ▕████░░░░░░░░░░░░▏ 24%  760k left  🤖 Opus 5 1M · medium · ⚡ · 💭  📟 v2.1.220
+#   💰 $0.43  ✎ +120/-45  ⏱ 11m session
+#   🚦 5h ▕█░░░░░░▏ 🔄 2h13m   ·   7d ▕░░░░░░░▏ 🔄 4d20h
+#
+# Reading down: where you are, how much room and horsepower you have left, what
+# the session has cost, and how close the subscription limits are to biting.
+# Line 4's bars are the same gauge as line 2's at roughly half the width and a
+# muted palette — same reading habit, lower priority.
 #
 # Claude Code pipes the session JSON on stdin and renders whatever we print.
 # Baked into the image at /etc/claude-code/statusline.sh (see the Dockerfile) so
 # it survives the ~/.claude volume mount, and wired up via the `statusLine` key
 # in config/claude-user-defaults.json — a seed default the user can override.
 #
-# `set -e` is deliberately omitted: this runs on every render, so a single
-# failing probe (no git repo, a field a newer payload no longer emits) must
-# degrade to a shorter line rather than blank the status line entirely.
+# This runs on every keystroke-ish refresh, so it is built to stay cheap: two
+# forks total (one `jq`, one `date`) and no others. In particular there is no
+# `git` subprocess — the branch is read straight out of .git/HEAD — no logging,
+# and no network. Everything else is bash builtins, and the helpers below
+# deliberately return through $REPLY rather than $(...) because a command
+# substitution is a subshell fork; at ~20 segments a render that is the
+# difference between a couple of forks and two dozen.
+#
+# `set -e` is deliberately omitted: a single failing probe (no git repo, a
+# field a newer payload no longer emits) must degrade to a shorter line rather
+# than blank the status line entirely.
 set -uo pipefail
 
 input=$(cat)
 
-# ---- colors (256-color palette; honors NO_COLOR) ----
-if [ -n "${NO_COLOR:-}" ]; then
-    color() { :; }
-    reset() { :; }
+# ---- toggles (override in the environment) ----
+: "${STATUSLINE_COLOR:=1}"     # 0 disables color (NO_COLOR is honored too)
+: "${STATUSLINE_HYPERLINK:=1}" # 0 disables the OSC-8 link on the PR number
+: "${STATUSLINE_CTX_WIDTH:=16}"
+: "${STATUSLINE_RL_WIDTH:=7}" # deliberately under half the context bar
+: "${STATUSLINE_RL_PCT:=0}"   # 1 also prints the exact limit percentage
+
+[ -n "${NO_COLOR:-}" ] && STATUSLINE_COLOR=0
+
+# ---- color, precomputed (no forks at render time) ----
+if [ "$STATUSLINE_COLOR" = 1 ]; then
+    e=$'\033'
+    RST="${e}[0m"
+    DIR="${e}[38;5;117m"   # sky blue
+    ROOT="${e}[38;5;103m"  # muted blue
+    GIT="${e}[38;5;150m"   # soft green
+    PR="${e}[38;5;213m"    # pink
+    MODEL="${e}[38;5;147m" # light purple
+    # Both grays sit a step brighter than a "secondary text" palette would
+    # suggest. Anything below ~244 disappears into a dark terminal background —
+    # legible in a screenshot, invisible in use.
+    META="${e}[38;5;250m" # gray
+    DIM="${e}[38;5;245m"  # softer gray
+    COST="${e}[38;5;180m" # soft yellow
+    OK="${e}[38;5;158m"   # mint
+    WARN="${e}[38;5;215m" # peach
+    HOT="${e}[38;5;203m"  # coral
+    # Same three signals a few shades down, for the usage-limit bars. They are
+    # the same gauge as the context window and must read that way, so the hues
+    # match — but they sit further back, and a duller palette says "same idea,
+    # lower priority" without needing a second shape to say it.
+    OK_D="${e}[38;5;71m"    # moss
+    WARN_D="${e}[38;5;173m" # clay
+    HOT_D="${e}[38;5;167m"  # brick
 else
-    color() { printf '\033[38;5;%sm' "$1"; }
-    reset() { printf '\033[0m'; }
+    RST='' DIR='' ROOT='' GIT='' PR='' MODEL='' META='' DIM='' COST=''
+    OK='' WARN='' HOT='' OK_D='' WARN_D='' HOT_D=''
 fi
 
-COLOR_DIR=117     # sky blue
-COLOR_GIT=150     # soft green
-COLOR_MODEL=147   # light purple
-COLOR_VERSION=249 # light gray
-COLOR_STYLE=245   # gray
-
-# Claude Code renders our stdout as ANSI, and a directory name may legally
-# contain ESC or a newline — so every value that reaches the terminal is
-# stripped of control bytes first. Without this, a checkout under a crafted
-# path could inject escape sequences (OSC 52 clipboard writes, extra status
-# lines) on every refresh.
-sanitize() { printf '%s' "$1" | tr -d '[:cntrl:]'; }
-
-# field <emoji> <color> <text> — one "  <emoji> <colored text>" segment.
-field() {
-    printf '  %s %s%s%s' "$1" "$(color "$2")" "$(sanitize "$3")" "$(reset)"
-}
-
-# jq is baked into the image. Without it there is no payload to read, so fall
-# back to the one thing we can still resolve locally.
+# ---- payload ----
+# One jq invocation emits every field in a fixed order. Control bytes are
+# stripped inside jq: Claude Code renders our stdout as ANSI, and a directory,
+# branch, or session name may legally contain ESC or a newline — so without
+# this a checkout under a crafted path could inject escape sequences (OSC 52
+# clipboard writes, extra status lines) on every refresh, or desync the field
+# split below.
 if ! command -v jq >/dev/null 2>&1; then
-    printf '📁 %s\n' "$(sanitize "$PWD")"
+    printf '📁 %s\n' "${PWD//[[:cntrl:]]/}"
     exit 0
 fi
 
-json() { printf '%s' "$input" | jq -r "$1" 2>/dev/null; }
+fields=$(printf '%s' "$input" | jq -r '
+  def s: (. // "") | tostring | explode
+         | map(select(. > 31 and . != 127)) | implode;
+  def n: (. // 0) | if type == "number" then floor else 0 end;
+  [ ((.workspace.current_dir // .cwd)   | s)
+  , (.workspace.project_dir             | s)
+  , (.model.display_name                | s)
+  , (.effort.level                      | s)
+  , ((.fast_mode        == true)        | s)
+  , ((.thinking.enabled == true)        | s)
+  , (.version                           | s)
+  , (.output_style.name                 | s)
+  , (.session_id                        | s | .[0:8])
+  , (.session_name                      | s)
+  , ((.context_window.used_percentage
+       // (100 - (.context_window.remaining_percentage // 100))) | n)
+  , (.context_window.context_window_size    | n)
+  , (.cost.total_cost_usd                   | (. // 0) | tostring)
+  , (.cost.total_lines_added                | n)
+  , (.cost.total_lines_removed              | n)
+  , (.cost.total_duration_ms                | n)
+  , (.pr.number                             | s)
+  , (.pr.url                                | s)
+  , (.pr.review_state                       | s)
+  , (.rate_limits.five_hour.used_percentage | n)
+  , (.rate_limits.five_hour.resets_at       | n)
+  , (.rate_limits.seven_day.used_percentage | n)
+  , (.rate_limits.seven_day.resets_at       | n)
+  ] | map(tostring) | join("\u001f")' 2>/dev/null)
 
-current_dir=$(json '.workspace.current_dir // .cwd // ""')
-model_name=$(json '.model.display_name // ""')
-cc_version=$(json '.version // ""')
-output_style=$(json '.output_style.name // ""')
+# Split on U+001F (unit separator), not a tab: TAB is IFS *whitespace*, so
+# `read` would collapse runs of it and silently shift every field after the
+# first empty one. The filter above strips control bytes from every value, so
+# a US can never occur inside one.
+IFS=$'\037' read -r cur_dir proj_dir model effort fast thinking cc_ver style \
+    sid sname ctx_pct ctx_size cost lines_add lines_del dur_ms \
+    pr_num pr_url pr_state rl5_pct rl5_at rl7_pct rl7_at <<<"$fields"
 
-# jq exits nonzero (and prints nothing) on an unparseable payload, so the
-# fallbacks belong here rather than in the filters above.
-[ -n "$model_name" ] || model_name="Claude"
+[ -n "${model:-}" ] || model="Claude"
+[ -n "${cur_dir:-}" ] || cur_dir="$PWD"
 
-# ---- git branch (resolved in the session's directory, not ours) ----
-git_branch=""
-if [ -n "$current_dir" ] && cd "$current_dir" 2>/dev/null; then
-    if git rev-parse --git-dir >/dev/null 2>&1; then
-        git_branch=$(git branch --show-current 2>/dev/null)
-        [ -n "$git_branch" ] || git_branch=$(git rev-parse --short HEAD 2>/dev/null)
+# One clock read serves every relative figure below. The wall-clock time itself
+# is deliberately not shown: the terminal, the OS, and the wall already have it,
+# and it is the one number here that says nothing about the session.
+now=$(date +%s)
+
+# ---- helpers (results land in $REPLY) ----
+num() { case "${1:-}" in '' | *[!0-9]*) return 1 ;; esac }
+
+# bar <used-pct> <width> — the filled portion represents consumption.
+bar() {
+    local pct=$1 width=$2 i=0
+    ((pct < 0)) && pct=0
+    ((pct > 100)) && pct=100
+    local filled=$((pct * width / 100))
+    REPLY='▕'
+    while ((i < width)); do
+        if ((i < filled)); then REPLY+='█'; else REPLY+='░'; fi
+        ((i++))
+    done
+    REPLY+='▏'
+}
+
+# heat <used-pct> [ok] [warn] [hot] — go/caution/stop by consumption, at the
+# same 60/80 thresholds everywhere. The palette is an argument so the limit
+# bars can run the muted set without forking the thresholds along with it.
+heat() {
+    if (($1 >= 80)); then
+        REPLY=${4:-$HOT}
+    elif (($1 >= 60)); then
+        REPLY=${3:-$WARN}
+    else
+        REPLY=${2:-$OK}
     fi
+}
+
+# compact <tokens> — 940k / 1.2M, so the figure never jitters in width.
+compact() {
+    local v=$1
+    if ((v >= 1000000)); then
+        printf -v REPLY '%d.%dM' $((v / 1000000)) $((v % 1000000 / 100000))
+    elif ((v >= 1000)); then
+        printf -v REPLY '%dk' $((v / 1000))
+    else
+        REPLY=$v
+    fi
+}
+
+# dur <seconds> — 1d6h / 2h13m / 14m / 45s, dropping units that read as noise.
+dur() {
+    local s=$1
+    if ((s >= 86400)); then
+        printf -v REPLY '%dd%dh' $((s / 86400)) $((s % 86400 / 3600))
+    elif ((s >= 3600)); then
+        printf -v REPLY '%dh%02dm' $((s / 3600)) $((s % 3600 / 60))
+    elif ((s >= 60)); then
+        printf -v REPLY '%dm' $((s / 60))
+    else
+        printf -v REPLY '%ds' "$s"
+    fi
+}
+
+tilde() {
+    case "$1" in
+    "$HOME") REPLY='~' ;;
+    "$HOME"/*) REPLY="~${1#"$HOME"}" ;;
+    *) REPLY=$1 ;;
+    esac
+}
+
+# seg <emoji> <color> <text>
+seg() { printf '  %s %s%s%s' "$1" "$2" "$3" "$RST"; }
+
+# ---- git branch, without forking git ----
+# Walk up from the session directory to the first .git. In a linked worktree
+# .git is a FILE holding `gitdir: <path>`, and that path's HEAD is the one that
+# describes the checkout you are actually sitting in.
+branch='' gitdir='' d=$cur_dir
+while [ -n "$d" ] && [ "$d" != / ]; do
+    if [ -d "$d/.git" ]; then
+        gitdir="$d/.git"
+        break
+    elif [ -f "$d/.git" ]; then
+        read -r _ gitdir <"$d/.git" 2>/dev/null
+        case "$gitdir" in /*) ;; *) gitdir="$d/$gitdir" ;; esac
+        break
+    fi
+    # A relative or otherwise slashless value leaves `${d%/*}` equal to `d`,
+    # which would spin here forever. Stop instead of ascending nowhere.
+    parent=${d%/*}
+    [ "$parent" = "$d" ] && break
+    d=$parent
+done
+if [ -n "$gitdir" ] && [ -r "$gitdir/HEAD" ]; then
+    read -r head <"$gitdir/HEAD" 2>/dev/null
+    case "$head" in
+    "ref: refs/heads/"*) branch="${head#ref: refs/heads/}" ;;
+    *) branch="${head:0:7}" ;;
+    esac
+    branch="${branch//[[:cntrl:]]/}"
 fi
 
-# ---- display path (~ for $HOME, matching the host status line) ----
-display_dir="${current_dir:-unknown}"
-case "$display_dir" in
-"$HOME") display_dir="~" ;;
-"$HOME"/*) display_dir="~${display_dir#"$HOME"}" ;;
-esac
+# =====================================================================
+# line 1 — where you are
+# =====================================================================
+tilde "$cur_dir"
+printf '📁 %s%s%s' "$DIR" "$REPLY" "$RST"
 
-# ---- context window ----
-# Claude Code already reports `remaining_percentage`; prefer it so the bar never
-# disagrees with the figure the CLI itself shows (its rounding is not ours, and
-# it accounts for reserved output tokens). The token sum is a fallback for
-# payloads that predate the field.
-context_pct=""
-context_bar=""
-context_color=158 # mint green
-remaining=$(json '.context_window.remaining_percentage // empty')
-if ! [[ "$remaining" =~ ^[0-9]+$ ]]; then
-    remaining=""
-    context_size=$(json '.context_window.context_window_size // 0')
-    context_used=$(json '(.context_window.current_usage // {})
-        | (.input_tokens // 0)
-        + (.cache_creation_input_tokens // 0)
-        + (.cache_read_input_tokens // 0)')
-    if [[ "$context_size" =~ ^[0-9]+$ ]] && [[ "$context_used" =~ ^[0-9]+$ ]] &&
-        [ "$context_size" -gt 0 ] && [ "$context_used" -gt 0 ]; then
-        remaining=$((100 - context_used * 100 / context_size))
-    fi
+# The launch directory only earns space when it is not the one you are in.
+if [ -n "${proj_dir:-}" ] && [ "$proj_dir" != "$cur_dir" ]; then
+    tilde "$proj_dir"
+    seg '⌂' "$ROOT" "$REPLY"
 fi
 
-if [ -n "$remaining" ]; then
-    ((remaining < 0)) && remaining=0
-    ((remaining > 100)) && remaining=100
+[ -n "$branch" ] && seg '🌿' "$GIT" "$branch"
 
-    if [ "$remaining" -le 20 ]; then
-        context_color=203 # coral red
-    elif [ "$remaining" -le 40 ]; then
-        context_color=215 # peach
+if num "${pr_num:-}"; then
+    label="#$pr_num"
+    # OSC-8 hides pr.url behind the number: clickable, zero extra columns.
+    # Terminals that do not implement it ignore the sequence.
+    if [ "$STATUSLINE_HYPERLINK" = 1 ] && [ -n "${pr_url:-}" ] && [ "$STATUSLINE_COLOR" = 1 ]; then
+        label="${e}]8;;${pr_url}${e}\\${label}${e}]8;;${e}\\"
     fi
-
-    filled=$((remaining / 10))
-    context_bar=$(printf '%*s' "$filled" '' | tr ' ' '=')
-    context_bar+=$(printf '%*s' "$((10 - filled))" '' | tr ' ' '-')
-    context_pct="${remaining}%"
+    case "${pr_state:-}" in
+    approved) label+=' ✓' ;;
+    changes_requested) label+=' ✗' ;;
+    pending | commented) label+=' ⋯' ;;
+    esac
+    seg '🔀' "$PR" "$label"
 fi
 
-# ---- render ----
-printf '📁 %s%s%s' "$(color "$COLOR_DIR")" "$(sanitize "$display_dir")" "$(reset)"
-[ -n "$git_branch" ] && field '🌿' "$COLOR_GIT" "$git_branch"
-field '🤖' "$COLOR_MODEL" "$model_name"
-[ -n "$cc_version" ] && field '📟' "$COLOR_VERSION" "v${cc_version}"
-[ -n "$output_style" ] && field '🎨' "$COLOR_STYLE" "$output_style"
+[ -n "${sname:-}" ] && seg '▪' "$META" "$sname"
+[ -n "${sid:-}" ] && seg '·' "$DIM" "$sid"
 
-if [ -n "$context_pct" ]; then
-    printf '\n🧠 %sContext Remaining: %s [%s]%s' \
-        "$(color "$context_color")" "$context_pct" "$context_bar" "$(reset)"
+# =====================================================================
+# line 2 — context window, and what is answering
+# =====================================================================
+printf '\n'
+if num "${ctx_pct:-}"; then
+    heat "$ctx_pct"
+    ctx_color=$REPLY
+    bar "$ctx_pct" "$STATUSLINE_CTX_WIDTH"
+    printf '🧠 %s%s %s%%%s' "$ctx_color" "$REPLY" "$ctx_pct" "$RST"
+    # Derive the headroom from the same percentage the bar uses. The raw token
+    # sum is more precise but disagrees with used_percentage (which also counts
+    # reserved output tokens), and a bar that contradicts the number beside it
+    # is worse than a slightly rounded figure.
+    if num "${ctx_size:-}" && ((ctx_size > 0)); then
+        compact $((ctx_size * (100 - ctx_pct) / 100))
+        printf ' %s%s left%s' "$DIM" "$REPLY" "$RST"
+    fi
 else
-    printf '\n🧠 %sContext Remaining: TBD%s' "$(color "$context_color")" "$(reset)"
+    printf '🧠 %scontext n/a%s' "$DIM" "$RST"
 fi
+
+# "Opus 5 (1M context)" is accurate and too wide; the parenthetical is the only
+# part that varies between the two, so keep it and drop the filler word.
+mode="${model/ (1M context)/ 1M}"
+[ -n "${effort:-}" ] && mode+=" · $effort"
+[ "${fast:-}" = true ] && mode+=' · ⚡'
+[ "${thinking:-}" = true ] && mode+=' · 💭'
+seg '🤖' "$MODEL" "$mode"
+
+[ -n "${cc_ver:-}" ] && seg '📟' "$DIM" "v$cc_ver"
+[ -n "${style:-}" ] && [ "$style" != default ] && seg '🎨' "$META" "$style"
+
+# =====================================================================
+# line 3 — what the session has spent
+# =====================================================================
+printf '\n'
+case "${cost:-}" in
+'' | *[!0-9.]*) cost=0 ;;
+esac
+printf '💰 %s$%.2f%s' "$COST" "$cost" "$RST"
+
+if num "${lines_add:-}" && num "${lines_del:-}" && ((lines_add + lines_del > 0)); then
+    printf '  ✎ %s+%s%s/%s-%s%s' "$OK" "$lines_add" "$RST" "$HOT" "$lines_del" "$RST"
+fi
+
+if num "${dur_ms:-}" && ((dur_ms > 0)); then
+    dur $((dur_ms / 1000))
+    seg '⏱' "$META" "$REPLY session"
+fi
+
+# =====================================================================
+# line 4 — subscription usage limits
+# =====================================================================
+# Two independent rolling windows, each with its own allowance and its own
+# reset, on a line of their own. Each reads as: window, how full it is, how long
+# until it empties. Same bar and same heat colors as the context window, so one
+# reading habit covers both — but at well under half the width, because these
+# are a background concern and should not compete with the context gauge for
+# attention at a glance.
+rl() {
+    local label=$1 pct=$2 at=$3 gauge
+    num "$pct" || return 0
+    heat "$pct" "$OK_D" "$WARN_D" "$HOT_D"
+    gauge=$REPLY
+    bar "$pct" "$STATUSLINE_RL_WIDTH"
+    gauge+="$REPLY$RST"
+    ((STATUSLINE_RL_PCT)) && gauge+="$DIM ${pct}%$RST"
+    printf '%s%s%s %s' "$META" "$label" "$RST" "$gauge"
+    # A reset already in the past means a stale payload, not "due now" — drop
+    # it rather than render a countdown that has stopped meaning anything.
+    if num "$at" && ((at > now)); then
+        dur $((at - now))
+        printf ' %s🔄 %s%s' "$DIM" "$REPLY" "$RST"
+    fi
+}
+if num "${rl5_pct:-}" || num "${rl7_pct:-}"; then
+    printf '\n🚦 '
+    rl 5h "${rl5_pct:-}" "${rl5_at:-}"
+    if num "${rl5_pct:-}" && num "${rl7_pct:-}"; then
+        printf '%s   ·   %s' "$DIM" "$RST"
+    fi
+    rl 7d "${rl7_pct:-}" "${rl7_at:-}"
+fi
+
 printf '\n'

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-statusline.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-statusline.sh
@@ -90,8 +90,11 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 fields=$(jq -r '
+  # C0 (0-31), DEL, and C1 (128-159) all go. C1 matters because a terminal in
+  # 8-bit mode reads U+009B as CSI outright — the same escape this strips in
+  # its ESC-[ form, arriving by a route a C0-only filter would wave through.
   def s: (. // "") | tostring | explode
-         | map(select(. > 31 and . != 127)) | implode;
+         | map(select(. > 31 and . != 127 and (. < 128 or . > 159))) | implode;
   def n: (. // 0) | if type == "number" then floor else 0 end;
   # Like n, but absence stays absent. A session without a subscription — API
   # key, Bedrock, Vertex, an alternative provider — has no .rate_limits at all,
@@ -133,7 +136,11 @@ IFS=$'\037' read -r cur_dir proj_dir model effort fast thinking cc_ver style \
     pr_num pr_url pr_state rl5_pct rl5_at rl7_pct rl7_at <<<"$fields"
 
 [ -n "${model:-}" ] || model="Claude"
-[ -n "${cur_dir:-}" ] || cur_dir="$PWD"
+# $PWD never passed through the jq filter, so it is stripped here instead.
+# Without this, running from a directory whose name contains ESC or BEL would
+# reopen the injection path on exactly the paths that reach this fallback — an
+# unparseable payload, or one carrying no workspace at all.
+[ -n "${cur_dir:-}" ] || cur_dir="${PWD//[[:cntrl:]]/}"
 
 # One clock read serves every relative figure below. The wall-clock time itself
 # is deliberately not shown: the terminal, the OS, and the wall already have it,
@@ -153,6 +160,10 @@ num() { case "${1:-}" in '' | *[!0-9]*) return 1 ;; esac }
 sane() {
     local v=$1
     case "$v" in '' | *[!0-9]*) v=$2 ;; esac
+    # 10# because bash reads a leading zero as octal: STATUSLINE_CTX_WIDTH=08
+    # passes the digits-only test above and then dies on "value too great for
+    # base", which is a stranger failure than the typo it came from.
+    v=$((10#$v))
     ((v < $3)) && v=$3
     ((v > $4)) && v=$4
     REPLY=$v

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-statusline.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-statusline.sh
@@ -18,10 +18,12 @@
 # it survives the ~/.claude volume mount, and wired up via the `statusLine` key
 # in config/claude-user-defaults.json — a seed default the user can override.
 #
-# This runs on every keystroke-ish refresh, so it is built to stay cheap: two
-# forks total (one `jq`, one `date`) and no others. In particular there is no
-# `git` subprocess — the branch is read straight out of .git/HEAD — no logging,
-# and no network. Everything else is bash builtins, and the helpers below
+# This runs on every keystroke-ish refresh, so it is built to stay cheap: it
+# executes exactly two external commands, `jq` and `date`. In particular there
+# is no `git` subprocess — the branch is read straight out of .git/HEAD — stdin
+# is drained by `read` rather than `cat`, and jq is fed by here-string rather
+# than a pipeline, so neither costs an extra process. No logging, and no
+# network. Everything else is bash builtins, and the helpers below
 # deliberately return through $REPLY rather than $(...) because a command
 # substitution is a subshell fork; at ~20 segments a render that is the
 # difference between a couple of forks and two dozen.
@@ -31,7 +33,10 @@
 # than blank the status line entirely.
 set -uo pipefail
 
-input=$(cat)
+# Drain stdin with the builtin rather than `cat`. -d '' reads to EOF in one go
+# and returns nonzero there, which is the normal path — the payload is in
+# $input either way, so the status is deliberately ignored.
+IFS= read -r -d '' input || true
 
 # ---- toggles (override in the environment) ----
 : "${STATUSLINE_COLOR:=1}"     # 0 disables color (NO_COLOR is honored too)
@@ -84,10 +89,15 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 0
 fi
 
-fields=$(printf '%s' "$input" | jq -r '
+fields=$(jq -r '
   def s: (. // "") | tostring | explode
          | map(select(. > 31 and . != 127)) | implode;
   def n: (. // 0) | if type == "number" then floor else 0 end;
+  # Like n, but absence stays absent. A session without a subscription — API
+  # key, Bedrock, Vertex, an alternative provider — has no .rate_limits at all,
+  # and folding that to 0 would draw two empty quota bars claiming a fresh
+  # allowance the session does not have. Only a real 0 may render as 0.
+  def o: if . == null then "" else (. | n) end;
   [ ((.workspace.current_dir // .cwd)   | s)
   , (.workspace.project_dir             | s)
   , (.model.display_name                | s)
@@ -108,11 +118,11 @@ fields=$(printf '%s' "$input" | jq -r '
   , (.pr.number                             | s)
   , (.pr.url                                | s)
   , (.pr.review_state                       | s)
-  , (.rate_limits.five_hour.used_percentage | n)
-  , (.rate_limits.five_hour.resets_at       | n)
-  , (.rate_limits.seven_day.used_percentage | n)
-  , (.rate_limits.seven_day.resets_at       | n)
-  ] | map(tostring) | join("\u001f")' 2>/dev/null)
+  , (.rate_limits.five_hour.used_percentage | o)
+  , (.rate_limits.five_hour.resets_at       | o)
+  , (.rate_limits.seven_day.used_percentage | o)
+  , (.rate_limits.seven_day.resets_at       | o)
+  ] | map(tostring) | join("\u001f")' <<<"$input" 2>/dev/null)
 
 # Split on U+001F (unit separator), not a tab: TAB is IFS *whitespace*, so
 # `read` would collapse runs of it and silently shift every field after the
@@ -132,6 +142,24 @@ now=$(date +%s)
 
 # ---- helpers (results land in $REPLY) ----
 num() { case "${1:-}" in '' | *[!0-9]*) return 1 ;; esac }
+
+# sane <value> <default> <min> <max> — a bounded integer, whatever was passed.
+#
+# The numeric overrides are user-supplied and end up inside (( )), where bash
+# resolves a bare word as a *variable name*: STATUSLINE_CTX_WIDTH=abc is an
+# unbound variable under `set -u`, which aborts the render mid-line. A typo in
+# an optional knob must not be able to blank the status line, and an absurd
+# width must not make every refresh build an unbounded string.
+sane() {
+    local v=$1
+    case "$v" in '' | *[!0-9]*) v=$2 ;; esac
+    ((v < $3)) && v=$3
+    ((v > $4)) && v=$4
+    REPLY=$v
+}
+sane "$STATUSLINE_CTX_WIDTH" 16 1 60 && STATUSLINE_CTX_WIDTH=$REPLY
+sane "$STATUSLINE_RL_WIDTH" 7 0 60 && STATUSLINE_RL_WIDTH=$REPLY
+sane "$STATUSLINE_RL_PCT" 0 0 1 && STATUSLINE_RL_PCT=$REPLY
 
 # bar <used-pct> <width> — the filled portion represents consumption.
 bar() {

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -49,13 +49,33 @@ is volume-backed because Claude Code writes your in-app changes there. Every
 `/model` and friends stick, and a wiped volume gets the defaults back. What the
 volume never holds is the code those settings point at.
 
-`config/claude-statusline.sh` renders a two-line status line matching the one a
+`config/claude-statusline.sh` renders a four-line status line matching the one a
 host session shows:
 
 ```text
-📁 ~/git/[[ project_slug ]]  🌿 main  🤖 Opus 5  📟 v2.1.220  🎨 default
-🧠 Context Remaining: 60% [======----]
+📁 ~/git/[[ project_slug ]]  🌿 main  🔀 #512 ✓  ▪ session name  · a1b2c3d4
+🧠 ▕████░░░░░░░░░░░░▏ 24%  760k left  🤖 Opus 5 1M · medium · ⚡ · 💭  📟 v2.1.220
+💰 $0.43  ✎ +120/-45  ⏱ 11m session
+🚦 5h ▕█░░░░░░▏ 🔄 2h13m   ·   7d ▕░░░░░░░▏ 🔄 4d20h
 ```
+
+Reading down: where you are, how much room and horsepower are left, what the
+session has cost, and how close the 5-hour and 7-day subscription limits are to
+biting (`🔄` is time until that window resets). Segments that would say nothing
+are omitted rather than shown empty — the PR only appears on a branch that has
+one, `⚡` and `💭` only when fast mode and extended thinking are on, and the
+launch directory only when it differs from the one you are in.
+
+Both gauges fill as they are consumed and shift mint → peach → coral past 60%
+and 80%; the limit bars run the same scale at under half the width in a muted
+palette, so they read as the same thing at lower priority. `NO_COLOR` is
+honored, and `STATUSLINE_CTX_WIDTH`, `STATUSLINE_RL_WIDTH`, `STATUSLINE_RL_PCT`
+(exact limit percentages) and `STATUSLINE_HYPERLINK` (the OSC-8 link behind the
+PR number) tune the rest.
+
+It is built to be cheap, because it re-renders constantly: two forks per render
+(`jq` and `date`), no `git` subprocess — the branch is read from `.git/HEAD`
+directly, worktrees included — and nothing written to disk.
 
 To use your own instead, point `statusLine.command` in `~/.claude/settings.json`
 at it — the seed merge will not overwrite it.


### PR DESCRIPTION
## What

Replaces the generated `cc-statusline` renderer with a purpose-built one, in both
layers (root `.devcontainer` twin + `template/`) and both guides.

```text
📁 ~/git/harmon-init  🌿 main  🔀 #512 ✓  ▪ session name  · a1b2c3d4
🧠 ▕████░░░░░░░░░░░░▏ 24%  760k left  🤖 Opus 5 1M · medium · ⚡ · 💭  📟 v2.1.220
💰 $0.43  ✎ +120/-45  ⏱ 11m session
🚦 5h ▕█░░░░░░▏ 🔄 2h13m   ·   7d ▕░░░░░░░▏ 🔄 4d20h
```

Reading down: where you are, how much room and horsepower are left, what the
session has cost, and how close the 5-hour and 7-day subscription limits are to
biting. Segments that would say nothing are omitted rather than rendered empty —
the PR only on a branch that has one, `⚡`/`💭` only when fast mode and extended
thinking are on, the launch directory only when it differs from the cwd, and the
whole limits line only when the session actually has limits.

Both gauges fill as consumed and shift mint → peach → coral past 60%/80%. The
limit bars run the same scale at under half the width in a muted palette, so
they read as the same thing at lower priority.

## Why

The old renderer was not merely missing fields — it was expensive in two ways
that a status line cannot afford, because it re-renders constantly:

- **It logged its full stdin payload on every render.** On the host that had
  reached **173 MB across 85,006 renders**, still growing. This one writes
  nothing.
- **It forked `jq` ~15 times per render**, plus a subshell per color segment.
  This one executes **two external commands** — `jq` and `date`. The payload is
  destructured in a single `jq` pass, colors are precomputed, helpers return
  through `$REPLY` instead of `$(...)`, stdin is drained by `read` rather than
  `cat`, `jq` is fed by here-string rather than a pipeline, and the git branch is
  read straight from `.git/HEAD` (linked worktrees included) instead of shelling
  out to `git`. **19ms vs 81ms** per render.

Control bytes — C0, DEL, and C1 — are stripped from every payload-derived value
inside `jq`, so a crafted directory, branch, or session name cannot inject escape
sequences (OSC 52 clipboard writes, extra status lines) into a line the terminal
renders as ANSI on every refresh. C1 matters because a terminal in 8-bit mode
reads U+009B as CSI outright.

## Bugs found and fixed while building this

- Splitting the `jq` output on TAB silently shifted every field after the first
  empty one — TAB is IFS whitespace, so `read` collapses runs of it. Separator is
  now U+001F.
- A path containing no slash made the `.git`-walk loop spin forever.
- Absent `.rate_limits` (API key, Bedrock, Vertex, alternative providers) drew
  two full empty quota bars claiming an allowance the session does not have; when
  only one window existed the other was fabricated beside it.
- The `$PWD` fallback bypassed the control-byte filter, reopening the injection
  path on exactly the paths that reach it.
- `STATUSLINE_CTX_WIDTH=08` passed digits-only validation and then died in bash
  arithmetic as octal (`value too great for base`).

## Verification

`task ci` green (verify + skills drift + devcontainer assert + security).
`shellcheck`/`shfmt` clean. Dogfood parity holds — 109 verbatim twins identical.
Image bake path unchanged (same filename, same `0755`), so no Dockerfile change.

Second-model review: `task challenge` passed clean on two consecutive rounds and
`task review` passed, all with **no P0 or P1 findings**.

An edge-case harness covers PR states, fast mode, near-full context, multi-day
sessions, worktrees (`.git`-as-file), non-git directories, empty/malformed/null
payloads, stale rate-limit resets, absent and single-window rate limits, every
numeric override given non-numeric/zero/negative/absurd/leading-zero values, and
ANSI + C1 injection.

## Deferred findings

P2s from the review rounds, carried here rather than fixed in place:

- [ ] `.devcontainer/config/claude-statusline.sh` (jq field block) — a payload
      carrying neither `used_percentage` nor `remaining_percentage` renders `0%`
      and `$0.00` rather than "unavailable", and the rewrite dropped the old
      `current_usage` token-sum fallback for pre-`used_percentage` payloads. Real
      sessions always send these, so this is empty-state polish, not a live
      defect. Decide: preserve absence like the rate limits now do, or restore
      the token-sum fallback.
- [ ] `.devcontainer/config/claude-statusline.sh` — no committed behavioral test.
      `task verify` gates only lint and root/template parity for this file, so
      regressions in the 23-position `jq`→`read` protocol, absent telemetry,
      worktree discovery, control-byte stripping or the documented overrides
      would all pass. The development harness covers exactly these; converting it
      to a checked-in `task test:*` tier means a new two-layer twin, so it is
      flagged rather than assumed.
- [ ] `.devcontainer/config/claude-statusline.sh` (git branch walk) — a repo
      selected via `GIT_DIR`/`GIT_WORK_TREE` has no ancestor `.git`, so the walk
      finds no branch where the previous `git rev-parse` implementation resolved
      one. A behavioural regression vs what shipped before, though Claude Code
      does not normally set those. Fix: consult `$GIT_DIR` before walking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
