### PR TITLE
fix(devcontainer): avoid multi-arch public-pull digest collision

### DIFF
--- a/docs/architecture/devcontainer-image.md
+++ b/docs/architecture/devcontainer-image.md
@@ -63,9 +63,12 @@ does not receive a long-lived personal token or permission to change package
 settings, and consumer propagation cannot begin while the package is private.
 
 Publication fails closed unless the manifest digest is valid, both required
-architectures exist, the source label and tool manifest match, and an amd64
-image can be pulled with an empty Docker credential directory. A failed check
-cannot advance consumers.
+architectures exist, the source label and tool manifest match, and each
+platform's image can be pulled with an empty Docker credential directory.
+Validation pulls each platform by its own child-manifest digest resolved from
+the validated index — two platforms pulled through the shared top-level
+reference would collide locally on the second pull ("cannot overwrite
+digest"). A failed check cannot advance consumers.
 
 ## Pin propagation
 

--- a/scripts/publish-devcontainer-image.sh
+++ b/scripts/publish-devcontainer-image.sh
@@ -95,28 +95,59 @@ validate_index() {
     printf '%s\n' "$_vi_expected"
 }
 
+platform_child_digest() {
+    _pc_index="$1"
+    _pc_arch="$2"
+    _pc_child="$(printf '%s' "$_pc_index" | jq -r --arg arch "$_pc_arch" \
+        'first(.manifests[]? | select(.platform.os == "linux" and .platform.architecture == $arch) | .digest) // empty')"
+    assert_digest "$_pc_child"
+    printf '%s\n' "$_pc_child"
+}
+
 validate_public_image() {
     _vp_source="$1"
     _vp_digest="$2"
     validate_index "$_vp_source" "$_vp_digest" >/dev/null
     _vp_ref="$(image_ref "$_vp_source")@${_vp_digest}"
+    _vp_config="$(mktemp -d)"
+    _vp_index="$(DOCKER_CONFIG="$_vp_config" inspect_manifest "$_vp_ref")" || {
+        rm -rf "$_vp_config"
+        die "$_vp_ref is not anonymously inspectable"
+    }
+    rm -rf "$_vp_config"
+
+    # Pull each platform by its unique child-manifest digest. Pulling both
+    # platforms through the shared top-level reference makes the second pull
+    # fail locally with "cannot overwrite digest" after Docker binds the first
+    # platform's child to that reference — a client-side collision that is
+    # indistinguishable from a registry denial in the exit status alone.
+    _vp_amd64_child="$(platform_child_digest "$_vp_index" amd64)"
+    _vp_arm64_child="$(platform_child_digest "$_vp_index" arm64)"
+    [ "$_vp_amd64_child" != "$_vp_arm64_child" ] ||
+        die "index $_vp_digest resolves amd64 and arm64 to one child digest $_vp_amd64_child"
     for _vp_arch in amd64 arm64; do
+        if [ "$_vp_arch" = amd64 ]; then
+            _vp_child_ref="${IMAGE}@${_vp_amd64_child}"
+        else
+            _vp_child_ref="${IMAGE}@${_vp_arm64_child}"
+        fi
         _vp_config="$(mktemp -d)"
-        if ! DOCKER_CONFIG="$_vp_config" docker pull --platform "linux/${_vp_arch}" "$_vp_ref" >/dev/null; then
+        if ! DOCKER_CONFIG="$_vp_config" docker pull --platform "linux/${_vp_arch}" "$_vp_child_ref" >/dev/null; then
             rm -rf "$_vp_config"
-            die "anonymous ${_vp_arch} pull failed for $_vp_ref"
+            die "anonymous linux/${_vp_arch} pull of $_vp_child_ref was refused by the registry or network (child-digest pulls cannot collide with a local reference)"
         fi
         rm -rf "$_vp_config"
 
-        _vp_revision="$(docker image inspect "$_vp_ref" \
+        _vp_revision="$(docker image inspect "$_vp_child_ref" \
             --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')"
         [ "$_vp_revision" = "$_vp_source" ] ||
             die "published ${_vp_arch} label revision '$_vp_revision' does not match '$_vp_source'"
         docker run --rm --pull=never --platform "linux/${_vp_arch}" \
             --env "EXPECTED_REVISION=${_vp_source}" \
             --env "EXPECTED_ARCHITECTURE=${_vp_arch}" \
-            "$_vp_ref" /usr/local/sbin/smoke.sh >/dev/null ||
-            die "published ${_vp_arch} smoke check failed for $_vp_ref"
+            "$_vp_child_ref" /usr/local/sbin/smoke.sh >/dev/null ||
+            die "published ${_vp_arch} smoke check failed for $_vp_child_ref"
+        docker image rm "$_vp_child_ref" >/dev/null 2>&1 || true
     done
     note "validated public amd64/arm64 image $_vp_ref"
 }

--- a/scripts/test-devcontainer-image-automation.sh
+++ b/scripts/test-devcontainer-image-automation.sh
@@ -19,6 +19,8 @@ pass() {
 sha_a=1111111111111111111111111111111111111111
 digest_a=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 digest_b=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+child_amd64=sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+child_arm64=sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
 
 # Manifest generation is deterministic, valid JSON, and rejects unsafe values.
 manifest_dir="$tmp_root/manifest"
@@ -116,14 +118,26 @@ if [ "\${1:-} \${2:-} \${3:-}" = "buildx imagetools inspect" ]; then
     fi
     if [ "\${DOCKER_STUB_MODE:-}" = missing-arm ]; then
 cat <<'JSON'
-{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","digest":"${digest_a}","manifests":[{"platform":{"os":"linux","architecture":"amd64"}}]}
+{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","digest":"${digest_a}","manifests":[{"digest":"${child_amd64}","platform":{"os":"linux","architecture":"amd64"}}]}
+JSON
+        exit 0
+    fi
+    if [ "\${DOCKER_STUB_MODE:-}" = duplicate-child ]; then
+cat <<'JSON'
+{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","digest":"${digest_a}","manifests":[{"digest":"${child_amd64}","platform":{"os":"linux","architecture":"amd64"}},{"digest":"${child_amd64}","platform":{"os":"linux","architecture":"arm64"}}]}
 JSON
         exit 0
     fi
 cat <<'JSON'
-{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","digest":"${digest_a}","manifests":[{"platform":{"os":"linux","architecture":"amd64"}},{"platform":{"os":"linux","architecture":"arm64"}}]}
+{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","digest":"${digest_a}","manifests":[{"digest":"${child_amd64}","platform":{"os":"linux","architecture":"amd64"}},{"digest":"${child_arm64}","platform":{"os":"linux","architecture":"arm64"}}]}
 JSON
     exit 0
+fi
+if [ "\${1:-}" = "pull" ]; then
+    if [ -z "\${DOCKER_CONFIG:-}" ] || [ -s "\${DOCKER_CONFIG}/config.json" ]; then
+        echo "ERROR: stub pull ran with ambient registry credentials" >&2
+        exit 1
+    fi
 fi
 if [ "\${1:-} \${2:-}" = "image inspect" ]; then
     printf '%s\n' "\${DOCKER_STUB_REVISION:-}"
@@ -260,6 +274,32 @@ run_fixture env DOCKER_STUB_MODE=missing-once DOCKER_STUB_STATE="$docker_state" 
     DOCKER_STUB_LOG="$docker_log" DOCKER_STUB_REVISION="$old_source" \
     ./scripts/publish-devcontainer-image.sh publish "$old_source" >/dev/null
 grep -q '^buildx build' "$docker_log" || fail "absent immutable tag did not trigger publication"
+pass
+
+# An existing-tag reconciliation rerun validates without any push and pulls
+# each platform anonymously by its distinct child-manifest digest — never
+# through the shared top-level index reference, whose second platform pull
+# fails locally with "cannot overwrite digest".
+: >"$docker_log"
+run_fixture env DOCKER_STUB_LOG="$docker_log" DOCKER_STUB_REVISION="$old_source" \
+    ./scripts/publish-devcontainer-image.sh publish "$old_source" >/dev/null
+if grep -q '^buildx build' "$docker_log"; then
+    fail "existing-tag rerun attempted a build/push"
+fi
+grep -q "^pull --platform linux/amd64 ghcr.io/evanharmon1/harmon-devcontainer@${child_amd64}\$" \
+    "$docker_log" || fail "amd64 validation did not pull its own child digest"
+grep -q "^pull --platform linux/arm64 ghcr.io/evanharmon1/harmon-devcontainer@${child_arm64}\$" \
+    "$docker_log" || fail "arm64 validation did not pull its own child digest"
+if grep '^pull ' "$docker_log" | grep -q "@${digest_a}"; then
+    fail "validation pulled through the top-level index digest"
+fi
+pass
+
+# An index that resolves both platforms to one child digest fails closed.
+if run_fixture env DOCKER_STUB_MODE=duplicate-child DOCKER_STUB_REVISION="$old_source" \
+    ./scripts/publish-devcontainer-image.sh validate "$old_source" "$digest_a" >/dev/null 2>&1; then
+    fail "validation accepted duplicate per-platform child digests"
+fi
 pass
 
 # The credential-bearing publish phase must not invoke registry validation;


### PR DESCRIPTION
## What

Repairs the deterministic publication-validation failure from run 30670207455: `validate_public_image` pulled `linux/amd64` and `linux/arm64` through the same local top-level `tag@digest` reference, so after Docker bound the first platform's child manifest to that reference the second pull always failed with `cannot overwrite digest`, blocking `publish` → `prepare-pin` → `sync-pin` reconciliation.

Closes #505.

## How

- `scripts/publish-devcontainer-image.sh`
  - Keeps the anonymous source-tag → top-level-digest check in `validate_index` unchanged.
  - Anonymously inspects the digest-pinned index and resolves each required platform's **child-manifest digest** (`platform_child_digest`).
  - Pulls, label-checks, and smoke-tests each platform by its unique `ghcr.io/evanharmon1/harmon-devcontainer@sha256:<child>` reference — child digests are distinct per platform, so no local reference collision is possible.
  - Fails closed if an index resolves both platforms to one child digest.
  - Retains an empty `DOCKER_CONFIG` for every anonymous registry operation.
  - Removes pulled validation images after use.
  - Failure message now states the error is registry/network-side, distinguishable from a local Docker reference collision.
- `scripts/test-devcontainer-image-automation.sh`
  - Stub index now carries per-platform child digests; the stub `pull` fails if ambient registry credentials are present (self-enforcing empty-credential validation).
  - New cases: an existing-tag rerun validates without any build/push, pulls amd64 and arm64 by their distinct child digests, and never pulls through the top-level index digest; an index with duplicate per-platform child digests is rejected. Existing cases preserve exact source-tag/top-level-digest validation and the missing-platform rejection.
- `docs/architecture/devcontainer-image.md` — validation description updated to match (per-platform child-digest pulls, both architectures).

Root-only producer tooling; no `template/` changes, no template twin (per #489's source-layout contract).

## Verification

- `task test:devcontainer:image:automation` — 20 offline cases pass (was 17)
- `task verify` — green
- `task challenge` — clean pass, no findings
- `task review` — clean pass, no findings
- `task ci` — green

## After merge

Rerun/reconcile the publisher for source `ad4e2d25dd641ceab29fbe1dca9ff6ec6a6a07e5` (or let the daily reconciliation retry); a passing run should advance the rolling `bot/sync-harmon-devcontainer` pin PR and unblock Phase B (#504).

🤖 Generated with [Claude Code](https://claude.com/claude-code)