### PR TITLE
build(devcontainer): stage the sync-pin bundle outside the checkout

### DIFF
--- a/.github/workflows/publish-harmon-devcontainer.yml
+++ b/.github/workflows/publish-harmon-devcontainer.yml
@@ -205,9 +205,14 @@ jobs:
           ref: ${{ needs.prepare-pin.outputs.base_sha }}
           fetch-depth: 0
           persist-credentials: false
+      # The bundle must land OUTSIDE the checkout: an artifact downloaded into
+      # the worktree stays behind as an untracked file, and the token-bearing
+      # publish phase fails closed on any dirty tree (first observed on run
+      # 30722269327, the first ready=true sync-pin).
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: harmon-devcontainer-prepared-pin
+          path: ${{ runner.temp }}/prepared-pin
       - name: Import and validate the verified commit
         env:
           BASE_SHA: ${{ needs.prepare-pin.outputs.base_sha }}
@@ -215,7 +220,7 @@ jobs:
           SOURCE_SHA: ${{ needs.publish.outputs.source_sha }}
           MANIFEST_DIGEST: ${{ needs.publish.outputs.digest }}
         run: |
-          git fetch prepared-pin.bundle \
+          git fetch "${RUNNER_TEMP}/prepared-pin/prepared-pin.bundle" \
             refs/heads/bot/sync-harmon-devcontainer:refs/heads/bot/sync-harmon-devcontainer
           git checkout bot/sync-harmon-devcontainer
           test "$(git rev-parse HEAD)" = "$PREPARED_SHA"

--- a/scripts/test-devcontainer-image-automation.sh
+++ b/scripts/test-devcontainer-image-automation.sh
@@ -91,6 +91,18 @@ if [ "$prepare_line" -ge "$token_line" ] || [ "$token_line" -ge "$publish_line" 
 fi
 pass
 
+# The sync-pin bundle must be staged OUTSIDE the checkout: an artifact
+# downloaded into the worktree survives as an untracked file, and the
+# token-bearing publish phase fails closed on any dirty tree — which killed
+# the first ready=true sync-pin (run 30722269327).
+grep -q 'path: ${{ runner.temp }}/prepared-pin' \
+    .github/workflows/publish-harmon-devcontainer.yml ||
+    fail "sync-pin downloads the prepared bundle into the repository checkout"
+grep -qF 'git fetch "${RUNNER_TEMP}/prepared-pin/prepared-pin.bundle"' \
+    .github/workflows/publish-harmon-devcontainer.yml ||
+    fail "bundle import does not read from the runner temp staging path"
+pass
+
 # Fixture: real git state and helper, stubbed registry/GitHub/task boundaries.
 fixture="$tmp_root/fixture"
 origin="$tmp_root/origin.git"


### PR DESCRIPTION
## What

Repairs the first `ready=true` `sync-pin` failure ([run 30722269327](https://github.com/evanharmon1/harmon-init/actions/runs/30722269327)): the job downloaded the `harmon-devcontainer-prepared-pin` artifact **into the repository checkout**, so after the bundle import the `prepared-pin.bundle` file remained untracked and `cmd_publish_prepared`'s clean-tree guard failed closed with `prepared working tree is not clean`. Latent since #501 — every earlier run skipped `sync-pin` (`ready=false`, consumers not yet thin), so this only became reachable after #516 merged.

The image itself published and validated fine (source `80e5c1b`, digest `sha256:788d4711…`); only pin propagation was blocked.

## How

- `sync-pin` now downloads the artifact to `${{ runner.temp }}/prepared-pin` and imports the bundle from that path — the checkout stays clean, and the fail-closed guard keeps its meaning.
- `scripts/test-devcontainer-image-automation.sh` asserts both the staged download path and the temp-path `git fetch`, so the bundle can never silently return to the checkout.

Root-only producer/publisher change — no `template/` content, hence the non-releasing `build:` title (consumers receive nothing until a rolling pin PR merges; this unblocks exactly that).

## Verification

- `task test:devcontainer:image:automation` — 21 offline cases pass
- `task verify` — green
- `task challenge` / `task review` — both clean first pass (no findings)
- `task ci` — green

## After merge

The merge touches a producer path, so the publisher runs again: new image from the merge commit → fixed `sync-pin` → the first rolling `bot/sync-harmon-devcontainer` pin PR should finally appear.

Refs #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)