### PR TITLE
feat: cap the Codex review loops at 4 rounds each

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,7 @@ non-draft PR must always mean the automated work is done.
   them to the PR (see "Deferring P2s" below). This loop is
   **self-referential** — the fixes you make in response to a round become the
   next round's input, so it can generate its own work indefinitely — and that
-  is what the cap defends against: max **6** challenge → fix → re-challenge
+  is what the cap defends against: max **4** challenge → fix → re-challenge
   rounds; if P0/P1 findings persist, stop and escalate to Evan.
   "Between rounds, check what the findings are about" below is how you catch
   the loop feeding on itself before the cap does.
@@ -244,7 +244,7 @@ non-draft PR must always mean the automated work is done.
 - **`task review`** — verification-checkpoint review; same adjudication, same
   P0/P1 clean-pass exit condition, the same self-referential shape and so the
   same reason for a cap, and the same background-and-poll handling, with its
-  own max **6** rounds.
+  own max **4** rounds.
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the draft PR** — conventional commit, push the branch,
   **`gh pr create --draft`** with a clear what/why/verification summary (mind
@@ -261,7 +261,7 @@ non-draft PR must always mean the automated work is done.
   `git -c credential.helper= -c credential.helper='!gh auth git-credential' -c url."https://github.com/".insteadOf="git@github.com:" -c url."https://github.com/".insteadOf="ssh://git@github.com/" -c url."https://github.com/".insteadOf="ssh://git@ssh.github.com:443/" -c url."https://github.com/".insteadOf="ssh://git@ssh.github.com/" push`
   (a credential helper only applies to HTTPS, and `insteadOf` is prefix
   matching — every SSH form needs its own mapping, hence all four).
-- **Shepherd the draft to ready for review (`/shepherd`, max 5 rounds).**
+- **Shepherd the draft to ready for review (`/shepherd`, max 4 rounds).**
   `gh pr create --draft` returning is
   the trigger for this stage, not the end of the work — enter it deliberately
   instead of judging for yourself when the PR is finished. The PR stays draft
@@ -328,7 +328,7 @@ non-draft PR must always mean the automated work is done.
   resolve halts the whole change rather than one loop, so it is not a licence
   to move on to the next stage either — a persistent P0/P1 at the challenge or
   review cap means wait for Evan, not open the PR anyway.
-  If checks still fail or findings remain after 5 rounds, stop and
+  If checks still fail or findings remain after 4 rounds, stop and
   summarize what's unresolved on the PR for Evan.
   Where a **vendored** skill (`/shepherd`)
   states a different cap or exit condition, **this file wins** — the skills
@@ -500,7 +500,7 @@ round's fixes, ask where they *live* — in the change you set out to make, or i
 code that exists only because an earlier round asked for it. **A round whose
 findings are all about the previous round's fix is the tell**, and it is
 visible in round 2 — the first round that can show it. Do not wait for the
-pattern to be unmistakable in round 4.
+pattern to be unmistakable in round 3, by which point only one round is left.
 
 **Deleting the added code is a legitimate way to reach a clean pass.** When a
 round's findings are about scaffolding rather than the change, weigh removing
@@ -590,7 +590,7 @@ stated here and in the Dev Loop above, and holds whether or not the optional
 
 **Loop cap and exit:** a stage exits only on a **clean re-run** — no
 confirmed P0 or P1 findings — never on "findings fixed" alone, with at most
-**6** challenge iterations and **6** review iterations (challenge → fix →
+**4** challenge iterations and **4** review iterations (challenge → fix →
 re-challenge, and likewise for review). If P0/P1 disagreement persists at the
 cap, stop and surface it to Evan instead of iterating further.
 

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -224,11 +224,11 @@ release plumbing), disable it for routine development.
 task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
-                # until a CLEAN pass (no P0/P1 findings), ≤6 rounds
-task review     # verification checkpoint — same clean-pass exit, ≤6 rounds
+                # until a CLEAN pass (no P0/P1 findings), ≤4 rounds
+task review     # verification checkpoint — same clean-pass exit, ≤4 rounds
 task ci         # full CI mirror
 # → open a DRAFT PR, then shepherd it: watch CI + reviews, settle the deferred
-#   P2s, adjudicate → fix → push, ≤5 rounds (independent of the loops above)
+#   P2s, adjudicate → fix → push, ≤4 rounds (independent of the loops above)
 # → readiness gate passes → gh pr ready (the handoff to a human)
 # → merging stays a human decision
 ```

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -141,7 +141,7 @@ error silently reverts the lifecycle rather than fixing anything.
   them to the PR (see "Deferring P2s" below). This loop is
   **self-referential** — the fixes you make in response to a round become the
   next round's input, so it can generate its own work indefinitely — and that
-  is what the cap defends against: max **6** challenge → fix → re-challenge
+  is what the cap defends against: max **4** challenge → fix → re-challenge
   rounds; if P0/P1 findings persist, stop and escalate to the maintainer.
   "Between rounds, check what the findings are about" below is how you catch
   the loop feeding on itself before the cap does.
@@ -158,7 +158,7 @@ error silently reverts the lifecycle rather than fixing anything.
 - **`task review`** — verification-checkpoint review; same adjudication, same
   P0/P1 clean-pass exit condition, the same self-referential shape and so the
   same reason for a cap, and the same background-and-poll handling, with its
-  own max **6** rounds.
+  own max **4** rounds.
 [% endif %]
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the draft PR** — conventional commit, push the branch,
@@ -175,7 +175,7 @@ error silently reverts the lifecycle rather than fixing anything.
   `git -c credential.helper= -c credential.helper='!gh auth git-credential' -c url."https://github.com/".insteadOf="git@github.com:" -c url."https://github.com/".insteadOf="ssh://git@github.com/" -c url."https://github.com/".insteadOf="ssh://git@ssh.github.com:443/" -c url."https://github.com/".insteadOf="ssh://git@ssh.github.com/" push`
   (a credential helper only applies to HTTPS, and `insteadOf` is prefix
   matching — every SSH form needs its own mapping, hence all four).
-- **Shepherd the draft to ready for review (`/shepherd`, max 5 rounds).**
+- **Shepherd the draft to ready for review (`/shepherd`, max 4 rounds).**
   `gh pr create --draft` returning is
   the trigger for this stage, not the end of the work — enter it deliberately
   instead of judging for yourself when the PR is finished. The PR stays draft
@@ -245,7 +245,7 @@ error silently reverts the lifecycle rather than fixing anything.
   resolve halts the whole change rather than one loop, so it is not a licence
   to move on to the next stage either — escalate and wait, do not open the PR
   anyway.
-  If checks still fail or findings remain after 5 rounds,
+  If checks still fail or findings remain after 4 rounds,
   stop and summarize what's unresolved on the PR for the maintainer. Where a
   **vendored** skill (`/shepherd`) states a different cap or exit condition,
   **this file wins** — vendored skills are synced on their own release
@@ -412,7 +412,7 @@ round's fixes, ask where they *live* — in the change you set out to make, or i
 code that exists only because an earlier round asked for it. **A round whose
 findings are all about the previous round's fix is the tell**, and it is
 visible in round 2 — the first round that can show it. Do not wait for the
-pattern to be unmistakable in round 4.
+pattern to be unmistakable in round 3, by which point only one round is left.
 
 **Deleting the added code is a legitimate way to reach a clean pass.** When a
 round's findings are about scaffolding rather than the change, weigh removing
@@ -502,7 +502,7 @@ stated here and in the Dev Loop above, and holds whether or not the optional
 
 **Loop cap and exit:** a stage exits only on a **clean re-run** — no
 confirmed P0 or P1 findings — never on "findings fixed" alone, with at most
-**6** challenge iterations and **6** review iterations (challenge → fix →
+**4** challenge iterations and **4** review iterations (challenge → fix →
 re-challenge, and likewise for review). If P0/P1 disagreement persists at the
 cap, stop and surface it to the maintainer instead of iterating further.
 

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -224,11 +224,11 @@ release plumbing), disable it for routine development.
 task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
-                # until a CLEAN pass (no P0/P1 findings), ≤6 rounds
-task review     # verification checkpoint — same clean-pass exit, ≤6 rounds
+                # until a CLEAN pass (no P0/P1 findings), ≤4 rounds
+task review     # verification checkpoint — same clean-pass exit, ≤4 rounds
 task ci         # full CI mirror
 # → open a DRAFT PR, then shepherd it: watch CI + reviews, settle the deferred
-#   P2s, adjudicate → fix → push, ≤5 rounds (independent of the loops above)
+#   P2s, adjudicate → fix → push, ≤4 rounds (independent of the loops above)
 # → readiness gate passes → gh pr ready (the handoff to a human)
 # → merging stays a human decision
 ```


### PR DESCRIPTION
## What

Settle all three second-model review loops at **4 rounds**, in the root layer
and the template it ships. They were bounded inconsistently:

| Stage | Driver | Before | After |
|---|---|---|---|
| Adversarial review | `task challenge` | 6 | **4** |
| Verification checkpoint | `task review` | 6 | **4** |
| PR shepherd (one `@codex review` per round) | `/shepherd` | 5 | **4** |

## Why

The caps exist to bound loops that can generate their own work — each fix adds
surface for the next round to attack. Three different numbers for three loops
with the same failure mode was arbitrary, and 6 is more rounds than a diverging
loop should be allowed to run before a human looks at it.

## Two spots needed rewriting, not renumbering

- **The "between rounds" tell** argued *"the tell is visible in round 2 — don't
  wait for round 4"*. With a cap of 4, round 4 **is** the cap, so the sentence
  lost its point. Now round 3, with the reason stated ("by which point only one
  round is left").
- **`docs/guides/codex-review.md`** has a **verbatim** template twin, gated by
  `task test:dogfood-parity`. It was resynced by copy so byte-equality holds.

## Relationship to the harmon-devkit side

The canonical shepherd and standardize-repo skills carry the same policy, and
were changed in [harmon-devkit#247](https://github.com/evanharmon1/harmon-devkit/pull/247)
and released as `v0.16.0`. Those already landed here through the skills sync in
# 528, so the vendored `.claude/skills/` copies are **already** at 4 rounds on
`main` — this PR is only the policy text that harmon-init owns directly.

`task verify:skills` passes, confirming no drift between the pin and the
vendored copies.

## Explicitly unchanged

- The per-head `@codex review` **retry** limit stays at 2 attempts. That is a
  timeout retry for a Codex result that never arrives — not a review round —
  and it lives in `check-codex-cloud-review.sh`'s state machine.
- `.github/workflows/claude-implement.yml`'s **3 mechanical CI-fix rounds** (and
  its jinja twin). A different loop: no Codex involvement, and it explicitly
  hands off to a shepherd session rather than completing the lifecycle.
- `standardize-repo/references/mode-update.md`'s 10-round copier question
  discovery loop — unrelated machinery.

## Files

- `AGENTS.md` and `template/AGENTS.md.jinja` — the Dev Loop stages, the shepherd
  cap, and the "Loop cap and exit" rule. Six edits each, applied in lockstep.
- `docs/guides/codex-review.md` and its verbatim twin — the "Intended workflow"
  block.

## Verification

- `task verify` — green (includes the full template render matrix)
- `task verify:skills` — green (no vendored drift against the `v0.16.0` pin)
- `task test:dogfood-parity` — 109 verbatim twins identical
- `task test:dogfood-structure` — 206 rendered sections/tasks present
- `task challenge` — clean, no P0/P1 (re-run after rebasing onto the #528 base)
- `task review` — clean, no P0/P1 (same)
- `task ci` — green
- **Rendered end-to-end:** generated a repo with `use_codex_review=true` and
  confirmed all six cap statements read 4, the `codex-review.md` guide reads
  `≤4 rounds`, the `CLAUDE.md`/`GEMINI.md`/`copilot-instructions.md` symlinks
  resolve to the updated `AGENTS.md`, and **no stale 5/6 cap survives anywhere**
  in the output.
- Read-through: grepped every `round`/`iteration` hit in the repo and read it in
  context rather than trusting the find-and-replace. The two rewrites above are
  exactly what that catches and sed would have got wrong.

No deferred P2 findings — neither local stage reported any, in either the
pre-rebase or post-rebase runs.
