### PR TITLE
fix(ci): diff the release guard against the live base branch

### DIFF
--- a/.github/workflows/release-content-guard.yml
+++ b/.github/workflows/release-content-guard.yml
@@ -50,6 +50,12 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          # The base BRANCH, not `pull_request.base.sha`: the payload's base sha
+          # is the base tip as of PR creation and is not refreshed when the base
+          # branch moves, so a rebased/force-pushed head makes the three-dot
+          # merge base fall behind and sweeps the base branch's own commits into
+          # the PR's changed-file list (false positives). `fetch-depth: 0`
+          # fetches every branch, so origin/<base> is present and current.
+          BASE_SHA: origin/${{ github.event.pull_request.base.ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: task guard:release-title

--- a/scripts/require-release-title.sh
+++ b/scripts/require-release-title.sh
@@ -11,13 +11,16 @@
 #
 # Usage:
 #   PR_TITLE="<title>" [PR_BODY="…"] \
-#   [CHANGED_FILES=$'a\nb'  |  BASE_SHA=<sha> [HEAD_SHA=<sha>]] \
+#   [CHANGED_FILES=$'a\nb'  |  BASE_SHA=<commit-ish> [HEAD_SHA=<commit-ish>]] \
 #     require-release-title.sh PREFIX [PREFIX …]
 #
 # PREFIXes are release-worthy path prefixes: a literal directory that matches
 # itself and everything beneath it (so `ai/skills` matches `ai/skills/x`, but
 # NOT the sibling `ai/skills-extra`). Changed files come from $CHANGED_FILES
 # (newline-separated) when set, else from `git diff --name-only BASE...HEAD`.
+# BASE_SHA may be any commit-ish; CI passes the base BRANCH (`origin/main`)
+# rather than a pinned sha, because the webhook's base sha goes stale when the
+# base branch moves and the three-dot merge base then falls behind it.
 # A title is "releasing" iff its type is feat/fix, or it marks a breaking
 # change (`!` before the colon, or a BREAKING CHANGE note in the body).
 #

--- a/template/.github/workflows/[% if use_release_please and release_content_paths %]release-content-guard.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_release_please and release_content_paths %]release-content-guard.yml[% endif %].jinja
@@ -50,6 +50,12 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          # The base BRANCH, not `pull_request.base.sha`: the payload's base sha
+          # is the base tip as of PR creation and is not refreshed when the base
+          # branch moves, so a rebased/force-pushed head makes the three-dot
+          # merge base fall behind and sweeps the base branch's own commits into
+          # the PR's changed-file list (false positives). `fetch-depth: 0`
+          # fetches every branch, so origin/<base> is present and current.
+          BASE_SHA: origin/${{ github.event.pull_request.base.ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: task guard:release-title

--- a/template/scripts/[% if use_release_please %]require-release-title.sh[% endif %]
+++ b/template/scripts/[% if use_release_please %]require-release-title.sh[% endif %]
@@ -11,13 +11,16 @@
 #
 # Usage:
 #   PR_TITLE="<title>" [PR_BODY="…"] \
-#   [CHANGED_FILES=$'a\nb'  |  BASE_SHA=<sha> [HEAD_SHA=<sha>]] \
+#   [CHANGED_FILES=$'a\nb'  |  BASE_SHA=<commit-ish> [HEAD_SHA=<commit-ish>]] \
 #     require-release-title.sh PREFIX [PREFIX …]
 #
 # PREFIXes are release-worthy path prefixes: a literal directory that matches
 # itself and everything beneath it (so `ai/skills` matches `ai/skills/x`, but
 # NOT the sibling `ai/skills-extra`). Changed files come from $CHANGED_FILES
 # (newline-separated) when set, else from `git diff --name-only BASE...HEAD`.
+# BASE_SHA may be any commit-ish; CI passes the base BRANCH (`origin/main`)
+# rather than a pinned sha, because the webhook's base sha goes stale when the
+# base branch moves and the three-dot merge base then falls behind it.
 # A title is "releasing" iff its type is feat/fix, or it marks a breaking
 # change (`!` before the colon, or a BREAKING CHANGE note in the body).
 #


### PR DESCRIPTION
## What

`release-content-guard.yml` (root + `template/` twin) now passes the base
**branch** — `origin/${{ github.event.pull_request.base.ref }}` — as `BASE_SHA`
instead of `github.event.pull_request.base.sha`.

## Why

The webhook's `pull_request.base.sha` is the base tip **as of PR creation** and
is not refreshed when the base branch moves. Once a head is rebased or
force-pushed past newer base commits, the merge base of that stale sha and the
new head falls behind, so `git diff --name-only BASE...HEAD` reports the base
branch's own commits as the PR's changed files.

That fired on the v4.14.2 release PR (#561). Its real diff is two files
(`.release-please-manifest.json`, `CHANGELOG.md`), but the guard reported 13
release-worthy `template/` paths — exactly the files #550 and #568 had landed on
`main` — and failed a PR whose `chore(main): release …` title release-please
mandates and nobody can retitle. A re-run could not clear it: the replayed
payload carries the same stale sha.

`fetch-depth: 0` already fetches every branch, so `origin/<base>` resolves and is
current, and the merge base tracks the head's real fork point.

## Verification

- Against #561's actual shas: `BASE_SHA=origin/main` → pass;
  `BASE_SHA=36ca786` (the stale base) → reproduces the CI failure exactly.
- `task verify`, `task ci` — green.
- `task challenge`, `task review` — clean, no P0/P1 findings.
- Root and `template/` twins edited in lockstep (workflow + the verbatim
  `require-release-title.sh` doc comment).

## Deferred findings

- [x] `.github/workflows/release-content-guard.yml:59` — no regression coverage for the `git diff BASE...HEAD` path: every `task test:release-title` case supplies `CHANGED_FILES`, so a temp-history test (base advances, head rebased) would be needed to prove `origin/<base>...HEAD` excludes base-only commits. Raised by both reviewers. **Filed as #571** — the workflow env line is not script-testable, but the script semantics the fix relies on will be pinned there.
