### PR TITLE
fix(template): drop private-foreman caveats now that foreman is public

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -183,7 +183,7 @@ use_shared_agents:
 
 use_foreman:
   type: bool
-  help: "FOREMAN: Wire up foreman — deterministic supervisor that dispatches ready issues to headless agents, verifies, opens PRs, shepherds them (task foreman:* wrapping a pinned uvx-run CLI from ponderousdev/foreman; needs uv, read access to that repo, and operator setup: bot identity, arming labels, rulesets)?"
+  help: "FOREMAN: Wire up foreman — deterministic supervisor that dispatches ready issues to headless agents, verifies, opens PRs, shepherds them (task foreman:* wrapping a pinned uvx-run CLI from ponderousdev/foreman; needs uv and operator setup: bot identity, arming labels, rulesets)?"
   default: no
 
 use_codeql:

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -119,13 +119,7 @@ this comment. -->
 - [ ] **Foreman operator setup** — provision the separate READ-ONLY PAT that
       foreman hands to dispatched agents: export/store it as
       `FOREMAN_AGENT_GH_TOKEN` where the bot devcontainer's `init-env.sh` can
-      inject it (1Password → devcontainer.env). Confirm the credential git
-      presents in the bot container can read `ponderousdev/foreman` — uvx
-      cannot fetch the pinned CLI without it, and a fine-grained PAT is bound
-      to ONE resource owner, so a token scoped to this repo's owner cannot
-      also reach it: until foreman is public this needs the bot to hold a
-      grant on that repo per foreman's operator docs
-      (docs/architecture/security.md there). Run `task setup:github-labels`
+      inject it (1Password → devcontainer.env). Run `task setup:github-labels`
       so the `foreman:*` arming labels exist. Import the two tag rulesets
       (`.github/Tag Protection Ruleset - Version Tag Creation.json` /
       `… Immutability.json`, same UI import as the branch ruleset), then add
@@ -138,10 +132,7 @@ this comment. -->
       empirically asserts `v*` tags are immutable and fails until both
       rulesets and the tag exist. Then `task foreman:preflight` (inside the
       bot devcontainer — foreman refuses to start anywhere else) to assert
-      the security controls before any dispatch. Finally, while
-      `ponderousdev/foreman` is private, grant this repo's Renovate
-      installation read access to it (App grant or a `hostRules` token) —
-      without it the `FOREMAN_VERSION` bump PRs silently never appear.
+      the security controls before any dispatch.
 - [ ] **Free SAST coverage** — Harmon Init has no CodeQL workflow (its
       first-party source is shell/config; foreman is a pinned external CLI), so
       Semgrep CE runs in `build.yml` at both visibilities. Generated supported

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -117,13 +117,7 @@ config, toolchain, devcontainer, and dev environment — against the items below
 - [ ] **Foreman operator setup** — provision the separate READ-ONLY PAT that
       foreman hands to dispatched agents: export/store it as
       `FOREMAN_AGENT_GH_TOKEN` where the bot devcontainer's `init-env.sh` can
-      inject it (1Password → devcontainer.env). Confirm the credential git
-      presents in the bot container can read `ponderousdev/foreman` — uvx
-      cannot fetch the pinned CLI without it, and a fine-grained PAT is bound
-      to ONE resource owner, so a token scoped to this repo's owner cannot
-      also reach it: until foreman is public this needs the bot to hold a
-      grant on that repo per foreman's operator docs
-      (docs/architecture/security.md there). Run `task setup:github-labels`
+      inject it (1Password → devcontainer.env). Run `task setup:github-labels`
       so the `foreman:*` arming labels exist. Import the two tag rulesets
       (`.github/Tag Protection Ruleset - Version Tag Creation.json` /
       `… Immutability.json`, same UI import as the branch ruleset), then add
@@ -136,10 +130,7 @@ config, toolchain, devcontainer, and dev environment — against the items below
       empirically asserts `v*` tags are immutable and fails until both
       rulesets and the tag exist. Then `task foreman:preflight` (inside the
       bot devcontainer — foreman refuses to start anywhere else) to assert
-      the security controls before any dispatch. Finally, while
-      `ponderousdev/foreman` is private, grant this repo's Renovate
-      installation read access to it (App grant or a `hostRules` token) —
-      without it the `FOREMAN_VERSION` bump PRs silently never appear.
+      the security controls before any dispatch.
 [% endif %]
 [% if use_codeql %]
 - [ ] **SAST coverage** — public repositories run CodeQL automatically and for


### PR DESCRIPTION
## What

`ponderousdev/foreman` is public now, so the caveats harmon-init ships about
reaching it while it was private are obsolete. This removes them from the
"Foreman operator setup" item in **both** CHECKLIST layers and from the
`use_foreman` question help:

- the bot-container credential check and its fine-grained-PAT resource-owner
  explanation
- the trailing "while `ponderousdev/foreman` is private, grant this repo's
  Renovate installation read access to it" sentence
- `copier.yml`: `needs uv, read access to that repo, and operator setup:` →
  `needs uv and operator setup:`

Prose only — no logic, no behaviour change.

## Why

`uvx --from git+https://github.com/ponderousdev/foreman@vX.Y.Z` now fetches
token-free, and Renovate reads the repo's tags without any App grant or
`hostRules` entry. Verified rather than assumed:

```console
$ gh api repos/ponderousdev/foreman --jq .visibility
public
$ GIT_TERMINAL_PROMPT=0 git -c credential.helper= \
    ls-remote https://github.com/ponderousdev/foreman v2.1.0
c2c486e1409b4e3e7d35b11932175bb8f92e0bab   refs/tags/v2.1.0
```

## Deliberately unchanged

Three things match the deleted text closely enough to look in scope, and are
not:

- **The Bot PAT item's own "scoped to one resource owner" sentence**, in both
  layers. That is about *this* repo's bot PAT and its selected-repositories
  list — unrelated to foreman's visibility. The issue's verify grep
  (`grep -rn 'resource owner\|hostRules'`) is over-broad and claims it should
  return nothing after the fix; after a correct fix it returns exactly these
  two lines.
- **The D4 notes** in `.foreman.toml` and `AGENTS.md`. Those describe the
  *consumer* repo's visibility, not foreman's, and remain true.
- **ADR 0004's 404 reference.** Dated context for a past decision; ADRs are not
  rewritten when the world changes.

## Verification

`task verify` is green for this change — but it had to be run in a clean clone,
because **it cannot pass in place for any change on this repo right now**. That
is a pre-existing defect, not something this PR introduces, and it is filed as
**#598**.

In short: `v0.0.0-probe` and `v4.15.0` both point at `e180d4b`, `git describe
--tags` prefers the probe tag, and anything at distance > 0 makes copier derive
`v0.0.0-probe.post<n>+g<sha>` — invalid PEP 440 — so the render exits 201.

> **Resolved — CI is green.** The probe tag has since been moved to an orphan
> commit unreachable from any branch, and the build was re-run on this same
> head: all 7 `template-test` profiles plus `verify` now pass. **PR #600**
> carries the durable fix (orphan-tag instructions in both CHECKLIST layers,
> `__pycache__`/`*.pyc` ignored, and a `task test:tag-hygiene` guard).
>
> The history is kept below because it is why #598 and #600 exist. Note that an
> earlier revision of this section claimed CI was unaffected by the defect —
> that was wrong; PRs sit at distance ≥ 1 from the tag and all failed.

It turned out to be worse than #598 first recorded, three times over — all
corrected there:

- It is **not** limited to dirty trees. A commit puts HEAD one past the tag, so
  a perfectly clean feature branch (`git status --porcelain` → 0 entries) fails
  identically at `v0.0.0-probe-1-g899f17e`.
- It **blocks pushing**: the lefthook pre-push `template` step runs
  `test:template:minimal` and dies the same way. Pushing this branch required
  removing the local probe tag so the hook could run for real — restored from
  `origin` immediately afterwards, to the same SHA (`e180d4b`). No hook was
  bypassed; `--no-verify` was not used.
- It **breaks CI for every PR**. PRs are by definition at distance ≥ 1. `main`
  passes only because it sits exactly on the tag.

Proof the CI failure here is content-independent — an empty commit off
`e180d4b`, zero diff:

```console
$ git commit --allow-empty -m "test: empty commit, zero content change"
$ git diff e180d4b --stat | wc -l     # 0
$ task test:template:minimal; echo "exit=$?"
packaging.version.InvalidVersion: Invalid version: 'v0.0.0-probe.post1+g59bade8'
exit=201
```

The traceback dies computing `self.template.version`, at the `Copying from
template version …` log line — before any template file is read. Consistently,
`template-test (update)` is the one profile that passes here: it renders from a
released tag rather than from `HEAD`.

### Relationship to #600

PR #600 fixes that defect and touches both CHECKLIST layers, editing the **same
foreman bullet** this PR edits. They do not conflict — verified by test merge
rather than assumed:

```console
$ git merge --no-commit --no-ff origin/fix/probe-tag-verify-598
Auto-merging docs/CHECKLIST.md
Auto-merging template/docs/CHECKLIST.md.jinja
# exit 0, no CONFLICT
```

The merged bullet is also semantically correct: both deletions here survive, and
the orphan-tag instructions from #600 land intact. Either merge order works.

Isolation proof, so the claim is not taken on trust — stash **only** the tracked
edits, leaving the tree dirty:

```console
$ git stash push          # my edits out; untracked .pyc still dirty the tree
$ task test:copier-validators
packaging.version.InvalidVersion: Invalid version: 'v0.0.0-probe.post1+g81ae298'
exit=201                  # fails with the change removed → not the change
```

Control run, same patch, probe tag removed:

```console
$ git clone -q . "$d/r" && cd "$d/r" && git tag -d v0.0.0-probe
$ git describe --tags
v4.15.0
$ git apply my.patch && task verify
=== VERIFY_EXIT=0 ===
```

`test:template:full` and `test:template:iac` both render with
`use_foreman=true` (`scripts/test-template.sh:128`, and line 760 for the
`pm=none + use_foreman=true` case), so the edited `[% if use_foreman %]` block
is genuinely exercised — not skipped.

**Codex cloud review: clean.** `chatgpt-codex-connector[bot]` (actor id
`199175422`, type `Bot`) reported "Didn't find any major issues" against
**`Reviewed commit: 899f17ed26`** — the current head — with no reviews and no
inline comments on any surface. One round; no findings to adjudicate.

Also run, both in the same clone: `task ci` — **exit 0**, covering
`security:sast`, `security:secrets`, `security:audit`, `verify:skills`,
`test:devcontainer:permissions` and all seven template profiles. And
`task challenge` / `task review` — **no P0 or P1 findings** from either, each
clean on its first round.

## Deferred findings

- [x] `scripts/foreman/__pycache__/*.pyc` — [P2, raised by both `task challenge`
      and `task review`, round 1] generated cpython-314 bytecode sits untracked
      in the worktree; not source, goes stale, produces noisy diffs. Never in
      this commit — the three files were staged explicitly, never `git add -A`.
      **Disposition: fixed in #600**, which adds `__pycache__/` and `*.pyc` to
      both `.gitignore` and `template/.gitignore.jinja`. Filed as #598 first;
      #600 is the fix for it.

Closes #586
