### PR TITLE
fix: keep the foreman probe tag out of git describe so dirty-tree verify passes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Full history + tags so `test:tag-hygiene` below is a real assertion.
+          # The default shallow, tagless checkout leaves `git describe` with
+          # nothing to select, which would make that guard vacuous here — and a
+          # poisoned tag on origin is precisely what CI should name outright
+          # rather than surfacing as seven opaque template-test failures.
+          fetch-depth: 0
       - uses: ./.github/actions/setup
         with:
           lint-tools: "true"
@@ -49,6 +55,9 @@ jobs:
       - run: task test:sync-devkit-release
       - run: task test:devcontainer:image:automation
       - run: task test:skills-pin-parity
+      # Meaningful only because this job checks out with fetch-depth: 0 above.
+      - name: Tag hygiene (no non-release tag where git describe would select it)
+        run: task test:tag-hygiene
       - name: Template independence (no harmon-dotfiles/chezmoi in shipped output)
         run: task test:template-independence
       - name: Dogfood parity (verbatim template files match their root twins)

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,14 @@ node_modules/
 # Taskfile fingerprint cache
 .task/
 
+# Python bytecode. Trees that ran foreman v1 (pre-#584) still carry an orphaned
+# scripts/foreman/__pycache__ that was never tracked, so a checkout that predates
+# it is dirty before anyone edits anything. More generally, copier's dirty-tree
+# wip commit stages with `git add -A`, so any unignored bytecode would be swept
+# into every local render.
+__pycache__/
+*.pyc
+
 # Git worktrees
 .worktrees/
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -86,6 +86,7 @@ tasks:
       - task: test:sync-devkit-release
       - task: test:devcontainer:image:automation
       - task: test:skills-pin-parity
+      - task: test:tag-hygiene
       - task: test:dogfood-parity
       - task: test:dogfood-structure
       - task: test:starship-glyphs
@@ -381,6 +382,14 @@ tasks:
     desc: "Guard: the root and template skills-sync manifests pin the same harmon-devkit tag"
     cmds:
       - ./scripts/sync-devkit-release.sh pinned
+
+  # Root-only on purpose: only a repo that copier-renders ITSELF derives a
+  # template version from `git describe`, so only this repo can be broken by a
+  # non-release tag on the commit git describe selects (issue #598).
+  test:tag-hygiene:
+    desc: "Guard: no non-release tag sits where git describe would select it"
+    cmds:
+      - ./scripts/test-tag-hygiene.sh
 
   # ── Dogfood drift (root layer vs template/) ───────────────────
   # Three checks, in increasing looseness. The root layer is template/ rendered

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -133,8 +133,17 @@ this comment. -->
       release-please tags via that App, and bypass-actor App IDs are
       per-installation so the JSON cannot ship them. (Immutability keeps an
       empty bypass list on purpose: a moved `v*` tag is code execution in
-      every consumer, so nobody bypasses it.) Create the standing probe tag
-      (`git tag v0.0.0-probe && git push origin v0.0.0-probe`) — preflight
+      every consumer, so nobody bypasses it.) Create the standing probe tag on
+      an **orphan commit**, so it is reachable from no branch:
+      `git tag v0.0.0-probe "$(git commit-tree "$(git hash-object -t tree /dev/null)" -m 'foreman tag-immutability probe target (orphan; keep unreachable from any branch)')" && git push origin v0.0.0-probe`.
+      Do not tag `HEAD` or any commit on `main`: `git describe` considers only
+      tags reachable from `HEAD` and prefers the nearest, so a probe tag on a
+      release commit outranks the release tag and poisons every `git
+      describe`-derived version — in a repo that renders itself with Copier
+      that fails the template's PEP 440 version check on every commit below the
+      tag, locally and in PR CI alike. The probe only needs the remote tag's
+      sha to differ from `main`'s, so an orphan target satisfies it
+      permanently, and `task test:tag-hygiene` guards the invariant. Preflight
       empirically asserts `v*` tags are immutable and fails until both
       rulesets and the tag exist. Then `task foreman:preflight` (inside the
       bot devcontainer — foreman refuses to start anywhere else) to assert

--- a/scripts/test-tag-hygiene.sh
+++ b/scripts/test-tag-hygiene.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# test-tag-hygiene.sh — the tag `git describe` selects must look like a release.
+#
+# harmon-init renders itself with `copier --vcs-ref=HEAD`, and copier derives the
+# template version from `git describe`. `git describe` considers only tags that
+# are ANCESTORS of HEAD and prefers the NEAREST one — so a non-release tag on a
+# reachable commit close to HEAD outranks the release tag and feeds copier a
+# version string it rejects as non-PEP 440. That kills `test:copier-validators`
+# and `test:template` for every commit descending from that tag, whatever the
+# commit contains (issue #598: `v0.0.0-probe` on the v4.15.0 release commit).
+#
+# The remedy is never to move the release tags but to keep operator tags — the
+# foreman tag-immutability probe target above all — on an ORPHAN commit, which
+# is unreachable from every branch and therefore invisible to `git describe`.
+# docs/CHECKLIST.md carries the recipe.
+#
+# Scope: the SELECTED tag, not every reachable one. This repo's history carries
+# pre-v3 tags that are not release-shaped (`2.0.15`, `list`, from 2024) and are
+# entirely harmless, because `git describe` prefers the nearest tag and never
+# reaches back to them. Failing on those would make `verify` permanently red
+# while saying nothing about the failure this guards. Tags sharing the selected
+# tag's commit ARE checked: that is exactly the #598 shape (two tags on one
+# release commit), and which of them `git describe` reports is not a tie-break
+# worth betting the gate on.
+#
+# Vacuous without tags: GitHub's checkout fetches none by default, leaving
+# `git describe` nothing to select, so this would pass while asserting nothing.
+# The build workflow's lint job therefore checks out with `fetch-depth: 0` — the
+# guard's first job is local `task verify` (this failure class originates on a
+# workstation, where an operator creates the tag), but once such a tag reaches
+# origin, CI naming it directly beats seven opaque template-test failures.
+# A tagless checkout elsewhere still passes by design rather than erroring.
+# Root-only: only a repo that copier-renders ITSELF derives a version this way,
+# so there is no template twin.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Release tags as release-please writes them: v<major>.<minor>.<patch>. Any
+# suffix (pre-release, probe, scratch) is what breaks the derivation, so the
+# pattern is deliberately strict rather than a general semver match.
+RELEASE_TAG_RE='^v[0-9]+\.[0-9]+\.[0-9]+$'
+
+# The nearest tag reachable from HEAD — the one `git describe` derives from.
+# Empty when no tag is reachable (a tagless CI checkout, or a fresh repo).
+nearest=$(git describe --tags --abbrev=0 2>/dev/null || true)
+if [ -z "$nearest" ]; then
+    echo "tag hygiene OK: no tag reachable from HEAD (nothing for git describe to select)"
+    exit 0
+fi
+
+selected_commit=$(git rev-list -n 1 "$nearest")
+
+bad=""
+checked=0
+# Read via a while loop rather than `mapfile`, which macOS bash 3.2 lacks.
+while IFS= read -r tag; do
+    [ -n "$tag" ] || continue
+    checked=$((checked + 1))
+    # `grep -E`, not `grep -P`: BSD grep has no -P.
+    if ! printf '%s\n' "$tag" | grep -qE "$RELEASE_TAG_RE"; then
+        bad="${bad}${bad:+ }${tag}"
+    fi
+done < <(git tag --points-at "$selected_commit")
+
+if [ -n "$bad" ]; then
+    echo "FAIL: non-release tag(s) on the commit git describe selects: ${bad}" >&2
+    cat >&2 <<'EOF'
+`git describe` derives its version from the nearest reachable tag, so this
+outranks the release tag and copier renders a non-PEP 440 template version —
+breaking `task test:copier-validators` and `task test:template` on every commit
+below it, locally and in PR CI alike.
+
+Remediation: the tag must not be reachable from HEAD. Renaming it does NOT
+help — `git describe --tags` considers tags of every name, so any tag on a
+reachable commit still wins. Either delete it, or re-point it at an orphan
+commit using the recipe under "Foreman operator setup" in docs/CHECKLIST.md:
+
+  git tag -d <tag>
+  git push origin :refs/tags/<tag>          # may need a ruleset bypass
+  # keep it (e.g. the foreman probe target)? recreate it unreachable:
+  git tag <tag> "$(git commit-tree "$(git hash-object -t tree /dev/null)" -m 'probe target (orphan; keep unreachable from any branch)')"
+  git push origin <tag>
+EOF
+    exit 1
+fi
+
+echo "tag hygiene OK: git describe selects ${nearest}; ${checked} tag(s) on that commit are release-shaped"

--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -124,6 +124,15 @@ htmlcov/
 # Foreman runtime artifacts (logs, prompts, resume states — never state-of-record)
 .foreman/
 .foreman-stop
+[% if not use_python %]
+
+# Python bytecode. Foreman used to ship in-repo Python; a checkout that ran that
+# version keeps an orphaned scripts/foreman/__pycache__ which was never tracked,
+# so `git status` is dirty before anyone edits anything. (Python projects ignore
+# these in the block above.)
+__pycache__/
+*.pyc
+[% endif %]
 [% endif %]
 [% if include_terraform %]
 

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -131,8 +131,16 @@ config, toolchain, devcontainer, and dev environment — against the items below
       release-please tags via that App, and bypass-actor App IDs are
       per-installation so the JSON cannot ship them. (Immutability keeps an
       empty bypass list on purpose: a moved `v*` tag is code execution in
-      every consumer, so nobody bypasses it.) Create the standing probe tag
-      (`git tag v0.0.0-probe && git push origin v0.0.0-probe`) — preflight
+      every consumer, so nobody bypasses it.) Create the standing probe tag on
+      an **orphan commit**, so it is reachable from no branch:
+      `git tag v0.0.0-probe "$(git commit-tree "$(git hash-object -t tree /dev/null)" -m 'foreman tag-immutability probe target (orphan; keep unreachable from any branch)')" && git push origin v0.0.0-probe`.
+      Do not tag `HEAD` or any commit on `main`: `git describe` considers only
+      tags reachable from `HEAD` and prefers the nearest, so a probe tag on a
+      release commit outranks the release tag, and everything deriving a
+      version from `git describe` — release tooling, image tags, package
+      builds — then reports `0.0.0-probe` instead of the release. The probe
+      only needs the remote tag's sha to differ from `main`'s, so an orphan
+      target satisfies it permanently. Preflight
       empirically asserts `v*` tags are immutable and fails until both
       rulesets and the tag exist. Then `task foreman:preflight` (inside the
       bot devcontainer — foreman refuses to start anywhere else) to assert


### PR DESCRIPTION
## What

`v0.0.0-probe` — foreman's tag-immutability probe target — sits on the
`v4.15.0` release commit, and `git describe --tags` prefers it over the
release tag. Copier derives the template version from `git describe`, so it
produces `0.0.0probe0.post1.dev0+<sha>`, which `packaging` rejects as
non-PEP 440. That kills `test:copier-validators` and `test:template` for
**every commit descending from that tag** — every dirty local tree and every
pull request alike (a PR is at distance >= 1 by definition).

This PR makes the two requirements coexist: the probe tag lives on an
**orphan commit**, unreachable from any branch and therefore invisible to
`git describe`, while still satisfying foreman's probe — which only needs the
remote tag's sha to differ from `main`'s and never cares where it points.

## Why this shape

Retagging rather than special-casing copier, because `git describe` picking a
non-release tag is the actual defect and it would keep biting anything else
that derives a version this way.

The guard checks the tag `git describe` **selects** (the nearest reachable
tag, plus any tag sharing its commit — the exact #598 shape), not every
reachable tag. Checking all reachable tags was my first cut and it was wrong:
this repo carries harmless 2024-era tags (`2.0.15`, `list`) that `git
describe` never reaches, so that version would have made `verify` permanently
red while saying nothing about the real failure.

## Changes

- **`docs/CHECKLIST.md` + `template/docs/CHECKLIST.md.jinja`** — the "Foreman
  operator setup" item now creates the probe tag on an orphan commit via
  `git commit-tree`, with the rationale for why tagging `HEAD` poisons
  describe-derived versions. Hand-diffed against each other (these twins have
  no automated gate); the only divergence is the rationale clause — the root
  cites copier's PEP 440 check and the root-only guard task, the template
  stays consumer-neutral.
- **`scripts/test-tag-hygiene.sh` + `task test:tag-hygiene`** (new, root-only)
  — asserts the selected tag is release-shaped. Wired into `verify` and the CI
  `lint` job. That job now checks out with `fetch-depth: 0` so the guard is a
  real assertion in CI rather than a vacuous one: a poisoned tag on origin now
  gets named directly instead of surfacing as seven opaque `template-test`
  failures.
- **`.gitignore`** — ignore `__pycache__/` and `*.pyc` so a checkout that ran
  foreman v1 is not dirty before anyone edits anything. Mirrored into
  `template/.gitignore.jinja` under `use_foreman and not use_python`, since
  foreman-using non-Python consumers have the same residue and their rendered
  ignore only emitted these rules inside the `use_python` block.

## Verification

- `task verify` — **exit 0 on a deliberately dirty tree**, all 7 template
  profiles green. Copier derived `4.15.0.post1.dev0+d5be214` where it
  previously raised `InvalidVersion` on `0.0.0probe0.post1.dev0+…`. This is
  the AC 1 evidence, and it required deleting the probe tag **locally** (see
  the operator step below).
- `task ci` — exit 0 (full mirror: verify, skills drift, devcontainer
  permissions, security).
- Guard self-test, by hand: clean tree passes; a `v0.0.0-bad` tag on the
  selected commit fails with the remediation; a nearer non-release tag on a
  child commit fails; deleting it passes again.
- `task challenge` — round 1 raised 3 P2s (all confirmed and fixed in place,
  including a real error in my own remediation text, which advised renaming
  the tag; renaming does not help because `git describe --tags` considers
  tags of every name). Round 2: **no P0/P1 and no P2s**.
- `task review` — **no P0/P1**; two P2 coverage gaps deferred below.
- PR title pre-flighted with `PR_TITLE=… BASE_SHA=main task guard:release-title`
  (releasing `fix:` type required — `template/` is touched).

## Requires an operator step (Evan) — CI here is expected to be red until then

This PR cannot fix the tag on `origin`. Deleting/moving it is blocked by the
Tag Immutability ruleset, whose bypass list is empty **on purpose**, so the
surgery is a security-settings action that belongs to you, not to an agent:

```sh
# temporarily add a bypass to / disable the "Version Tag Immutability" ruleset, then:
git tag -d v0.0.0-probe
git push origin :refs/tags/v0.0.0-probe
git tag v0.0.0-probe "$(git commit-tree "$(git hash-object -t tree /dev/null)" -m 'foreman tag-immutability probe target (orphan; keep unreachable from any branch)')"
git push origin v0.0.0-probe
# restore the ruleset, then re-run: task foreman:preflight   (5b/5c should still pass)
```

Until that lands, **this branch's CI fails for exactly the reason the PR
documents** — as does every other PR on the repo. After it lands, both the
template jobs and the new tag-hygiene step go green with no further code
change.

Acceptance criteria 2, 3 and 4 on the issue are ticked. **AC 1 is left
unticked deliberately**: `task verify` on a fresh clone still fails until the
origin tag moves, so the criterion is not yet true from the repository's own
state, even though the code side of it is complete and proven locally.

## Deferred findings

- [x] filed as #601 — `scripts/test-tag-hygiene.sh` — no automated regression test for the
  tag-selection logic. Self-tested by hand only; nothing reproduces #598's
  poisoned layout in CI. Add a temp git-repo fixture covering: release tag
  alone (pass), release + `v0.0.0-probe` on the selected commit (fail), probe
  on an orphan commit (pass), no tags at all (vacuous pass).
- [x] filed as #602 — `template/.gitignore.jinja` — the new `use_foreman and not use_python`
  branch is exercised by no template-test profile (`iac`/`full` enable both
  foreman and python, `minimal` has foreman off, and `test:dogfood-structure`
  does not inspect `.gitignore` bodies). Add a non-python `use_foreman` render
  assertion for `__pycache__/` and `*.pyc`, ideally also asserting they are
  not duplicated for python profiles.

Closes #598

