### PR TITLE
fix(codex-review): bound over-long CLI stderr lines so the verdict stays readable

### DIFF
--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -365,3 +365,12 @@ Adjudicate it; never disable the gate to get past a BLOCK.
   clean pass. Fix the cached ref (`git remote set-head origin --auto`), name a
   base with `--base <ref>`, or say the worktree really is the whole target
   with `--uncommitted`.
+- **A captured log is enormous, and the verdict is buried** — the CLI logs
+  some errors with the entire API response inlined, so one line can run to
+  hundreds of kilobytes and a retry loop repeats it. `codex-review.sh` bounds
+  each **stderr** line to `CODEX_REVIEW_MAX_STDERR_BYTES` (default 1024) and
+  marks what it cut; stdout, where the verdict is, is never filtered. Set the
+  variable to `0` to capture a payload in full when debugging the CLI itself.
+  A recurring dump usually means the CLI is older than the API it is talking
+  to — compare `codex --version` against the version your devcontainer image
+  ships, and rebuild or pull a newer image if it lags.

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -48,6 +48,17 @@ if ! command -v codex >/dev/null 2>&1; then
     exit 1
 fi
 
+# Per-line ceiling for the CLI's stderr (see bound_stderr_lines at the bottom).
+# Validated here rather than at the point of use so a typo fails before the
+# git work and the review, not after them. 0 disables the bound.
+MAX_STDERR_BYTES="${CODEX_REVIEW_MAX_STDERR_BYTES:-1024}"
+case "$MAX_STDERR_BYTES" in
+'' | *[!0-9]*)
+    echo "CODEX_REVIEW_MAX_STDERR_BYTES must be a non-negative integer (got: '${MAX_STDERR_BYTES}')" >&2
+    exit 2
+    ;;
+esac
+
 # Cap the manifest at 200 entries WITHOUT `head`: head exits early, the git
 # producer takes SIGPIPE, and under `set -o pipefail` a >200-entry tree would
 # abort the review before Codex ever runs. awk reads to EOF (no SIGPIPE) and
@@ -445,7 +456,49 @@ with git):
 
 ${manifest}"
 
+# Codex puts the verdict on stdout and everything else — progress narration
+# and errors alike — on stderr, so a caller capturing both (the documented
+# `task challenge > log 2>&1`) interleaves them. Harmless until the CLI logs
+# an error that inlines an entire API payload: one `codex_models_manager`
+# decode failure emits the whole models JSON as a single ~195 KiB line, and it
+# retries, so eleven lines carried 2.1 MB of a 2.2 MB log and buried the
+# verdict the run exists to produce. Bound the LINE LENGTH rather than
+# matching that message: nothing upstream bounds it, and any future decode
+# error dumps its payload the same way.
+#
+# stderr only. The verdict is on stdout, where a long line is legitimate
+# prose; truncating it would corrupt the very output this protects.
+bound_stderr_lines() {
+    if [ "$MAX_STDERR_BYTES" -eq 0 ]; then
+        cat
+        return
+    fi
+    # LC_ALL=C makes length()/substr() count bytes rather than characters, so
+    # the ceiling holds whatever encoding the payload turns out to be in.
+    # fflush() per line keeps the narration live: a round runs 5-15 minutes and
+    # callers are told to read growing output as "still running, not hung"
+    # (docs/guides/codex-review.md), which a block-buffered filter would break.
+    LC_ALL=C awk -v max="$MAX_STDERR_BYTES" '
+        {
+            if (length($0) > max) {
+                printf "%s... [%d-byte line truncated by codex-review.sh; set CODEX_REVIEW_MAX_STDERR_BYTES=0 for the full text]\n", substr($0, 1, max), length($0)
+            } else {
+                print
+            }
+            fflush()
+        }
+    '
+}
+
 # Feed the prompt through stdin (`review -`): a single argv element is
 # capped (~128 KiB per arg on Linux), and cap_manifest bounds entry count,
 # not bytes — 200 deep paths plus instructions can exceed the argv limit.
-printf '%s\n' "$instructions" | codex exec review -
+#
+# The fd dance routes ONLY stderr through the filter: `3>&1` on the group
+# parks the real stdout on fd3, `2>&1` puts stderr on the pipe, `1>&3` gives
+# codex the real stdout back, and `3>&-` keeps the spare descriptor out of the
+# child. A pipeline rather than `2> >(...)` is deliberate — the shell waits for
+# a pipeline, so the tail of the narration cannot be lost to the script exiting
+# first. Under pipefail the filter exits 0, leaving codex's own status as the
+# rightmost non-zero, so a failed review still fails the task.
+{ printf '%s\n' "$instructions" | codex exec review - 2>&1 1>&3 3>&- | bound_stderr_lines >&2; } 3>&1

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -51,10 +51,20 @@ fi
 # Per-line ceiling for the CLI's stderr (see bound_stderr_lines at the bottom).
 # Validated here rather than at the point of use so a typo fails before the
 # git work and the review, not after them. 0 disables the bound.
+#
+# The 18-digit ceiling is about what `test -eq` can compare, not a view on
+# useful line lengths: a value past INT64_MAX makes it fail with "integer
+# expression expected" on stderr — leaking a confusing line into the stream
+# this whole change exists to keep clean — and then fall through to an
+# effectively unbounded run. 18 digits is the widest that always fits.
 MAX_STDERR_BYTES="${CODEX_REVIEW_MAX_STDERR_BYTES:-1024}"
 case "$MAX_STDERR_BYTES" in
 '' | *[!0-9]*)
     echo "CODEX_REVIEW_MAX_STDERR_BYTES must be a non-negative integer (got: '${MAX_STDERR_BYTES}')" >&2
+    exit 2
+    ;;
+[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]*)
+    echo "CODEX_REVIEW_MAX_STDERR_BYTES is implausibly large (got: '${MAX_STDERR_BYTES}'); use 0 to disable the bound" >&2
     exit 2
     ;;
 esac

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -497,6 +497,21 @@ if out="$(CODEX_REVIEW_MAX_STDERR_BYTES=abc ./scripts/codex-review.sh review --u
 fi
 echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite an invalid bound: $out"
 echo "$out" | grep -q "must be a non-negative integer" || fail "missing validation message: $out"
+
+echo "==> a bound past INT64_MAX is refused rather than leaking a shell error"
+# All-digit but too wide for `test -eq`, which fails with "integer expression
+# expected" ON STDERR and then runs effectively unbounded — a shell error in
+# the very stream this change exists to keep clean.
+if out="$(CODEX_REVIEW_MAX_STDERR_BYTES=999999999999999999999 ./scripts/codex-review.sh review --uncommitted 2>&1)"; then
+    fail "an INT64_MAX-exceeding bound was accepted: $out"
+fi
+echo "$out" | grep -q "integer expression expected" && fail "shell arithmetic error leaked to the caller: $out"
+echo "$out" | grep -q "implausibly large" || fail "missing implausible-bound message: $out"
+# The widest value that still compares cleanly must keep working.
+CODEX_REVIEW_MAX_STDERR_BYTES=999999999999999999 STUB_BIG_STDERR=40000 \
+    ./scripts/codex-review.sh review --uncommitted >/dev/null 2>"$big_err" ||
+    fail "the widest safe bound was rejected: $(cat "$big_err")"
+grep -q "integer expression expected" "$big_err" && fail "shell arithmetic error at the 18-digit boundary: $(cat "$big_err")"
 rm -f bound.txt
 
 echo "==> gate: another repo's project-scoped plugin install is not accepted"
@@ -596,4 +611,4 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (33 cases)"
+echo "codex-review + codex-gate guards OK (38 cases)"

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -23,9 +23,23 @@ fail() {
 test_tmp="$(mktemp -d)"
 trap 'rm -rf "$test_tmp"' EXIT
 
-# Stub codex: print the invocation so assertions can grep it.
+# Stub codex: print the invocation so assertions can grep it. STUB_BIG_STDERR
+# and STUB_EXIT arm the payload-dump reproduction and a failing CLI; both are
+# off unless set, so every other test sees the plain stub.
 mkdir -p "${test_tmp}/bin"
-printf '%s\n' '#!/usr/bin/env bash' 'printf "STUB-ARGS:%s %s %s\n" "$1" "$2" "${3:-}"' 'if [ "${3:-}" = "-" ]; then printf "STUB-PROMPT:%s\n" "$(cat)"; fi' >"${test_tmp}/bin/codex"
+cat >"${test_tmp}/bin/codex" <<'CODEXSTUB'
+#!/usr/bin/env bash
+printf "STUB-ARGS:%s %s %s\n" "$1" "$2" "${3:-}"
+if [ -n "${STUB_BIG_STDERR:-}" ]; then
+    # One over-long stderr line (the models-JSON dump), ordinary narration
+    # around it, and a long prose line on stdout standing in for a verdict.
+    awk -v n="${STUB_BIG_STDERR}" 'BEGIN { l = ""; while (length(l) < n) l = l "PAYLOAD"; printf "ERROR codex_models_manager: simulated payload dump; body: %s\n", l }' >&2
+    echo "short stderr narration" >&2
+    awk 'BEGIN { p = ""; while (length(p) < 4000) p = p "verdict prose "; printf "P0 finding: %s\n", p }'
+fi
+if [ "${3:-}" = "-" ]; then printf "STUB-PROMPT:%s\n" "$(cat)"; fi
+exit "${STUB_EXIT:-0}"
+CODEXSTUB
 chmod +x "${test_tmp}/bin/codex"
 PATH="${test_tmp}/bin:${PATH}"
 export PATH
@@ -435,6 +449,55 @@ fi
 echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked with a worktree half that could not be read: $out"
 echo "$out" | grep -q "refusing rather than reading an unreadable worktree" || fail "missing unreadable-worktree refusal message: $out"
 rm -f halfwork.txt "${test_tmp}/bin/git"
+
+# The reported bug: one codex_models_manager decode error inlines the entire
+# models JSON as a single ~195 KiB stderr line, and the CLI retries, so eleven
+# lines carried 2.1 MB of a 2.2 MB captured log — the verdict a plain `tail`
+# should have shown was buried, and `cat`-ing the log to read the findings
+# overran an agent's tool-output limit. The bound is on line LENGTH rather than
+# on that message, so these guard the class: any future payload dump is covered.
+echo bound >bound.txt
+big_out="${test_tmp}/bound.out"
+big_err="${test_tmp}/bound.err"
+longest() { awk '{ if (length($0) > m) m = length($0) } END { print m + 0 }' "$1"; }
+
+echo "==> an over-long CLI stderr line is bounded, and stdout is left alone"
+STUB_BIG_STDERR=40000 ./scripts/codex-review.sh review --uncommitted >"$big_out" 2>"$big_err" ||
+    fail "review with a payload-dumping stub exited non-zero: $(cat "$big_err")"
+[ "$(longest "$big_err")" -lt 2000 ] ||
+    fail "over-long stderr line was not bounded (longest $(longest "$big_err") bytes)"
+grep -q "truncated by codex-review.sh" "$big_err" ||
+    fail "no truncation marker, so a reader cannot tell output was dropped"
+grep -q "short stderr narration" "$big_err" ||
+    fail "bounding the long line also dropped the ordinary narration around it"
+# stdout carries the verdict, where a long prose line is legitimate; filtering
+# it would corrupt the very output the bound exists to keep readable.
+[ "$(longest "$big_out")" -gt 4000 ] ||
+    fail "a long stdout line was truncated; only stderr may be bounded"
+grep -q "truncated by codex-review.sh" "$big_out" &&
+    fail "truncation marker reached stdout; only stderr may be bounded"
+
+echo "==> the stderr filter preserves the CLI's exit status"
+# pipefail must surface codex's own status, not the filter's — otherwise a
+# failed review reads as the clean pass a capped loop exits on.
+status=0
+STUB_EXIT=7 STUB_BIG_STDERR=40000 ./scripts/codex-review.sh review --uncommitted >/dev/null 2>&1 || status=$?
+[ "$status" -eq 7 ] || fail "codex exit status lost through the filter (got ${status}, want 7)"
+
+echo "==> CODEX_REVIEW_MAX_STDERR_BYTES=0 restores the unbounded output"
+CODEX_REVIEW_MAX_STDERR_BYTES=0 STUB_BIG_STDERR=40000 \
+    ./scripts/codex-review.sh review --uncommitted >/dev/null 2>"$big_err" ||
+    fail "review with the bound disabled exited non-zero: $(cat "$big_err")"
+[ "$(longest "$big_err")" -gt 40000 ] ||
+    fail "escape hatch did not restore the full line (longest $(longest "$big_err") bytes)"
+
+echo "==> a non-numeric bound is refused before the CLI is invoked"
+if out="$(CODEX_REVIEW_MAX_STDERR_BYTES=abc ./scripts/codex-review.sh review --uncommitted 2>&1)"; then
+    fail "non-numeric bound accepted: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite an invalid bound: $out"
+echo "$out" | grep -q "must be a non-negative integer" || fail "missing validation message: $out"
+rm -f bound.txt
 
 echo "==> gate: another repo's project-scoped plugin install is not accepted"
 fake_claude="${test_tmp}/claude-config"

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -365,3 +365,12 @@ Adjudicate it; never disable the gate to get past a BLOCK.
   clean pass. Fix the cached ref (`git remote set-head origin --auto`), name a
   base with `--base <ref>`, or say the worktree really is the whole target
   with `--uncommitted`.
+- **A captured log is enormous, and the verdict is buried** — the CLI logs
+  some errors with the entire API response inlined, so one line can run to
+  hundreds of kilobytes and a retry loop repeats it. `codex-review.sh` bounds
+  each **stderr** line to `CODEX_REVIEW_MAX_STDERR_BYTES` (default 1024) and
+  marks what it cut; stdout, where the verdict is, is never filtered. Set the
+  variable to `0` to capture a payload in full when debugging the CLI itself.
+  A recurring dump usually means the CLI is older than the API it is talking
+  to — compare `codex --version` against the version your devcontainer image
+  ships, and rebuild or pull a newer image if it lags.

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -48,6 +48,17 @@ if ! command -v codex >/dev/null 2>&1; then
     exit 1
 fi
 
+# Per-line ceiling for the CLI's stderr (see bound_stderr_lines at the bottom).
+# Validated here rather than at the point of use so a typo fails before the
+# git work and the review, not after them. 0 disables the bound.
+MAX_STDERR_BYTES="${CODEX_REVIEW_MAX_STDERR_BYTES:-1024}"
+case "$MAX_STDERR_BYTES" in
+'' | *[!0-9]*)
+    echo "CODEX_REVIEW_MAX_STDERR_BYTES must be a non-negative integer (got: '${MAX_STDERR_BYTES}')" >&2
+    exit 2
+    ;;
+esac
+
 # Cap the manifest at 200 entries WITHOUT `head`: head exits early, the git
 # producer takes SIGPIPE, and under `set -o pipefail` a >200-entry tree would
 # abort the review before Codex ever runs. awk reads to EOF (no SIGPIPE) and
@@ -445,7 +456,49 @@ with git):
 
 ${manifest}"
 
+# Codex puts the verdict on stdout and everything else — progress narration
+# and errors alike — on stderr, so a caller capturing both (the documented
+# `task challenge > log 2>&1`) interleaves them. Harmless until the CLI logs
+# an error that inlines an entire API payload: one `codex_models_manager`
+# decode failure emits the whole models JSON as a single ~195 KiB line, and it
+# retries, so eleven lines carried 2.1 MB of a 2.2 MB log and buried the
+# verdict the run exists to produce. Bound the LINE LENGTH rather than
+# matching that message: nothing upstream bounds it, and any future decode
+# error dumps its payload the same way.
+#
+# stderr only. The verdict is on stdout, where a long line is legitimate
+# prose; truncating it would corrupt the very output this protects.
+bound_stderr_lines() {
+    if [ "$MAX_STDERR_BYTES" -eq 0 ]; then
+        cat
+        return
+    fi
+    # LC_ALL=C makes length()/substr() count bytes rather than characters, so
+    # the ceiling holds whatever encoding the payload turns out to be in.
+    # fflush() per line keeps the narration live: a round runs 5-15 minutes and
+    # callers are told to read growing output as "still running, not hung"
+    # (docs/guides/codex-review.md), which a block-buffered filter would break.
+    LC_ALL=C awk -v max="$MAX_STDERR_BYTES" '
+        {
+            if (length($0) > max) {
+                printf "%s... [%d-byte line truncated by codex-review.sh; set CODEX_REVIEW_MAX_STDERR_BYTES=0 for the full text]\n", substr($0, 1, max), length($0)
+            } else {
+                print
+            }
+            fflush()
+        }
+    '
+}
+
 # Feed the prompt through stdin (`review -`): a single argv element is
 # capped (~128 KiB per arg on Linux), and cap_manifest bounds entry count,
 # not bytes — 200 deep paths plus instructions can exceed the argv limit.
-printf '%s\n' "$instructions" | codex exec review -
+#
+# The fd dance routes ONLY stderr through the filter: `3>&1` on the group
+# parks the real stdout on fd3, `2>&1` puts stderr on the pipe, `1>&3` gives
+# codex the real stdout back, and `3>&-` keeps the spare descriptor out of the
+# child. A pipeline rather than `2> >(...)` is deliberate — the shell waits for
+# a pipeline, so the tail of the narration cannot be lost to the script exiting
+# first. Under pipefail the filter exits 0, leaving codex's own status as the
+# rightmost non-zero, so a failed review still fails the task.
+{ printf '%s\n' "$instructions" | codex exec review - 2>&1 1>&3 3>&- | bound_stderr_lines >&2; } 3>&1

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -51,10 +51,20 @@ fi
 # Per-line ceiling for the CLI's stderr (see bound_stderr_lines at the bottom).
 # Validated here rather than at the point of use so a typo fails before the
 # git work and the review, not after them. 0 disables the bound.
+#
+# The 18-digit ceiling is about what `test -eq` can compare, not a view on
+# useful line lengths: a value past INT64_MAX makes it fail with "integer
+# expression expected" on stderr — leaking a confusing line into the stream
+# this whole change exists to keep clean — and then fall through to an
+# effectively unbounded run. 18 digits is the widest that always fits.
 MAX_STDERR_BYTES="${CODEX_REVIEW_MAX_STDERR_BYTES:-1024}"
 case "$MAX_STDERR_BYTES" in
 '' | *[!0-9]*)
     echo "CODEX_REVIEW_MAX_STDERR_BYTES must be a non-negative integer (got: '${MAX_STDERR_BYTES}')" >&2
+    exit 2
+    ;;
+[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]*)
+    echo "CODEX_REVIEW_MAX_STDERR_BYTES is implausibly large (got: '${MAX_STDERR_BYTES}'); use 0 to disable the bound" >&2
     exit 2
     ;;
 esac

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -497,6 +497,21 @@ if out="$(CODEX_REVIEW_MAX_STDERR_BYTES=abc ./scripts/codex-review.sh review --u
 fi
 echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite an invalid bound: $out"
 echo "$out" | grep -q "must be a non-negative integer" || fail "missing validation message: $out"
+
+echo "==> a bound past INT64_MAX is refused rather than leaking a shell error"
+# All-digit but too wide for `test -eq`, which fails with "integer expression
+# expected" ON STDERR and then runs effectively unbounded — a shell error in
+# the very stream this change exists to keep clean.
+if out="$(CODEX_REVIEW_MAX_STDERR_BYTES=999999999999999999999 ./scripts/codex-review.sh review --uncommitted 2>&1)"; then
+    fail "an INT64_MAX-exceeding bound was accepted: $out"
+fi
+echo "$out" | grep -q "integer expression expected" && fail "shell arithmetic error leaked to the caller: $out"
+echo "$out" | grep -q "implausibly large" || fail "missing implausible-bound message: $out"
+# The widest value that still compares cleanly must keep working.
+CODEX_REVIEW_MAX_STDERR_BYTES=999999999999999999 STUB_BIG_STDERR=40000 \
+    ./scripts/codex-review.sh review --uncommitted >/dev/null 2>"$big_err" ||
+    fail "the widest safe bound was rejected: $(cat "$big_err")"
+grep -q "integer expression expected" "$big_err" && fail "shell arithmetic error at the 18-digit boundary: $(cat "$big_err")"
 rm -f bound.txt
 
 echo "==> gate: another repo's project-scoped plugin install is not accepted"
@@ -596,4 +611,4 @@ if out="$(CLAUDE_CONFIG_DIR="${fake_claude}2" CLAUDE_PLUGIN_DATA="${test_tmp}/pl
 fi
 echo "$out" | grep -q "non-interactive" || fail "missing non-interactive disable refusal message: $out"
 
-echo "codex-review + codex-gate guards OK (33 cases)"
+echo "codex-review + codex-gate guards OK (38 cases)"

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -23,9 +23,23 @@ fail() {
 test_tmp="$(mktemp -d)"
 trap 'rm -rf "$test_tmp"' EXIT
 
-# Stub codex: print the invocation so assertions can grep it.
+# Stub codex: print the invocation so assertions can grep it. STUB_BIG_STDERR
+# and STUB_EXIT arm the payload-dump reproduction and a failing CLI; both are
+# off unless set, so every other test sees the plain stub.
 mkdir -p "${test_tmp}/bin"
-printf '%s\n' '#!/usr/bin/env bash' 'printf "STUB-ARGS:%s %s %s\n" "$1" "$2" "${3:-}"' 'if [ "${3:-}" = "-" ]; then printf "STUB-PROMPT:%s\n" "$(cat)"; fi' >"${test_tmp}/bin/codex"
+cat >"${test_tmp}/bin/codex" <<'CODEXSTUB'
+#!/usr/bin/env bash
+printf "STUB-ARGS:%s %s %s\n" "$1" "$2" "${3:-}"
+if [ -n "${STUB_BIG_STDERR:-}" ]; then
+    # One over-long stderr line (the models-JSON dump), ordinary narration
+    # around it, and a long prose line on stdout standing in for a verdict.
+    awk -v n="${STUB_BIG_STDERR}" 'BEGIN { l = ""; while (length(l) < n) l = l "PAYLOAD"; printf "ERROR codex_models_manager: simulated payload dump; body: %s\n", l }' >&2
+    echo "short stderr narration" >&2
+    awk 'BEGIN { p = ""; while (length(p) < 4000) p = p "verdict prose "; printf "P0 finding: %s\n", p }'
+fi
+if [ "${3:-}" = "-" ]; then printf "STUB-PROMPT:%s\n" "$(cat)"; fi
+exit "${STUB_EXIT:-0}"
+CODEXSTUB
 chmod +x "${test_tmp}/bin/codex"
 PATH="${test_tmp}/bin:${PATH}"
 export PATH
@@ -435,6 +449,55 @@ fi
 echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked with a worktree half that could not be read: $out"
 echo "$out" | grep -q "refusing rather than reading an unreadable worktree" || fail "missing unreadable-worktree refusal message: $out"
 rm -f halfwork.txt "${test_tmp}/bin/git"
+
+# The reported bug: one codex_models_manager decode error inlines the entire
+# models JSON as a single ~195 KiB stderr line, and the CLI retries, so eleven
+# lines carried 2.1 MB of a 2.2 MB captured log — the verdict a plain `tail`
+# should have shown was buried, and `cat`-ing the log to read the findings
+# overran an agent's tool-output limit. The bound is on line LENGTH rather than
+# on that message, so these guard the class: any future payload dump is covered.
+echo bound >bound.txt
+big_out="${test_tmp}/bound.out"
+big_err="${test_tmp}/bound.err"
+longest() { awk '{ if (length($0) > m) m = length($0) } END { print m + 0 }' "$1"; }
+
+echo "==> an over-long CLI stderr line is bounded, and stdout is left alone"
+STUB_BIG_STDERR=40000 ./scripts/codex-review.sh review --uncommitted >"$big_out" 2>"$big_err" ||
+    fail "review with a payload-dumping stub exited non-zero: $(cat "$big_err")"
+[ "$(longest "$big_err")" -lt 2000 ] ||
+    fail "over-long stderr line was not bounded (longest $(longest "$big_err") bytes)"
+grep -q "truncated by codex-review.sh" "$big_err" ||
+    fail "no truncation marker, so a reader cannot tell output was dropped"
+grep -q "short stderr narration" "$big_err" ||
+    fail "bounding the long line also dropped the ordinary narration around it"
+# stdout carries the verdict, where a long prose line is legitimate; filtering
+# it would corrupt the very output the bound exists to keep readable.
+[ "$(longest "$big_out")" -gt 4000 ] ||
+    fail "a long stdout line was truncated; only stderr may be bounded"
+grep -q "truncated by codex-review.sh" "$big_out" &&
+    fail "truncation marker reached stdout; only stderr may be bounded"
+
+echo "==> the stderr filter preserves the CLI's exit status"
+# pipefail must surface codex's own status, not the filter's — otherwise a
+# failed review reads as the clean pass a capped loop exits on.
+status=0
+STUB_EXIT=7 STUB_BIG_STDERR=40000 ./scripts/codex-review.sh review --uncommitted >/dev/null 2>&1 || status=$?
+[ "$status" -eq 7 ] || fail "codex exit status lost through the filter (got ${status}, want 7)"
+
+echo "==> CODEX_REVIEW_MAX_STDERR_BYTES=0 restores the unbounded output"
+CODEX_REVIEW_MAX_STDERR_BYTES=0 STUB_BIG_STDERR=40000 \
+    ./scripts/codex-review.sh review --uncommitted >/dev/null 2>"$big_err" ||
+    fail "review with the bound disabled exited non-zero: $(cat "$big_err")"
+[ "$(longest "$big_err")" -gt 40000 ] ||
+    fail "escape hatch did not restore the full line (longest $(longest "$big_err") bytes)"
+
+echo "==> a non-numeric bound is refused before the CLI is invoked"
+if out="$(CODEX_REVIEW_MAX_STDERR_BYTES=abc ./scripts/codex-review.sh review --uncommitted 2>&1)"; then
+    fail "non-numeric bound accepted: $out"
+fi
+echo "$out" | grep -q "STUB-ARGS" && fail "codex invoked despite an invalid bound: $out"
+echo "$out" | grep -q "must be a non-negative integer" || fail "missing validation message: $out"
+rm -f bound.txt
 
 echo "==> gate: another repo's project-scoped plugin install is not accepted"
 fake_claude="${test_tmp}/claude-config"


### PR DESCRIPTION
## What

Bound each **stderr** line from the Codex CLI to `CODEX_REVIEW_MAX_STDERR_BYTES`
(default 1024 bytes) in `scripts/codex-review.sh`, and mark what was cut.

## Why

Codex puts the review verdict on stdout and everything else on stderr, so the
documented `task challenge > log 2>&1` capture interleaves them. Harmless until
the CLI hits an error that inlines an entire API payload: a
`codex_models_manager` decode failure emits the whole models JSON as one
~195 KiB line, and it retries. Per #605, eleven such lines carried 2.1 MB of a
2.2 MB log — the verdict a plain `tail` should have shown was buried, and
`cat`-ing the log to read the findings overran an agent's tool-output limit.

The bound is on line **length**, not on that message. Nothing upstream bounds
it, so any future payload dump is covered by the same guard — which is what
AC #3 asks for ("regardless of which error produces it").

Two deliberate non-choices:

- **stdout is never filtered.** A long line there is legitimate verdict prose;
  truncating it would corrupt the output this change exists to protect.
- **A pipeline, not `2> >(...)`.** The shell waits for a pipeline, so the tail
  of the narration cannot be lost to the script exiting first. `awk` `fflush()`es
  per line, so a 5–15 minute round still shows live progress — the guide tells
  readers to treat growing output as "running, not hung", which a block-buffered
  filter would break.

## Verification

Measured with the issue's own Verify block, against a **real** `task challenge`
run on this branch (the failure mode is live on this container):

| | Before (#605, PR 599) | After (this branch) |
|---|---|---|
| Total bytes | 2,192,787 | **66,674** |
| Longest line | ~195,000 | **1,130** |
| Noise share | **97.6%** | **20.4%** |

That run truncated 12 lines and suppressed 2.2 MB. AC #2 holds too — the verdict
is readable from a plain `tail -12`, no grepping. A second round on the final
commit measured 16.2%; across both round-2 runs the bound suppressed 3.9 MB over
21 lines.

Worth noting the failure mode is **live on this container**, so the fix was
validated under real conditions, not only against the test stub.

Gates run, all green: `task check`, `task verify`, `task challenge`, `task
review`, `task ci`. Both review stages were re-run against the final commit
after the second fix below, and both exited clean with no P0/P1 and no P2s.
`PR_TITLE=… BASE_SHA=main task guard:release-title` pre-flighted (this touches
`template/`, so the title must be a releasing type).

New regression coverage in `scripts/test-codex-review.sh` (38 cases), all
mutation-checked — reverting the fix fails them:

- an over-long stderr line is bounded, ordinary narration survives, and a long
  **stdout** line is left alone
- the filter preserves the CLI's exit status under `pipefail` (a failed review
  must not read as the clean pass a capped loop exits on)
- `CODEX_REVIEW_MAX_STDERR_BYTES=0` restores the full output
- a non-numeric bound, and one past `INT64_MAX`, are both refused before the CLI
  is invoked

The second commit is a defect found in the first while testing edge cases: an
all-digit bound wider than `INT64_MAX` passed validation, then made
`[ "$MAX_STDERR_BYTES" -eq 0 ]` fail with "integer expression expected" **on
stderr** — a shell error in the stream this change exists to keep clean — before
falling through to an effectively unbounded run. Accepted width is now capped at
18 digits, the widest that always compares cleanly.

## Deferred findings

None. Both local stages returned no findings at any priority — no P0/P1, and no
P2s to carry into shepherding.

## AC #4 — the version-tracking decision

**Already tracked; no annotation needed.** The issue says codex "carries no
`# renovate:` annotation in this repo". It does:

```
images/devcontainer/Dockerfile:29  # renovate: datasource=npm depName=@openai/codex
images/devcontainer/Dockerfile:30  ARG CODEX_VERSION=0.146.0
```

`0.146.0` is npm's current latest, and the pinned consumer image
(`sha-4fd95f15`) was built from a commit that contains that bump.

The observed `0.137.0` is this **container** being stale, not a tracking gap —
its codex package was installed 2026-07-17, three weeks before the 2026-08-03
bump, and Claude Code here is `2.1.219` against the pinned `2.1.220`.

That is the argument for fixing the output rather than the version: tracking was
already correct and still did not prevent the noise. `docs/guides/codex-review.md`
gains a troubleshooting entry naming that diagnostic.

## Two-layer parity

`codex-review.sh`, `test-codex-review.sh`, and `docs/guides/codex-review.md` are
verbatim (non-jinja) template twins, so all three were edited in lockstep;
`task test:dogfood-parity` gates it, and the challenge round independently
`cmp`'d them.

Closes #605
