### PR TITLE
fix(devcontainer): own environment git config in the image's XDG layer

### DIFF
--- a/.devcontainer/config/gitconfig
+++ b/.devcontainer/config/gitconfig
@@ -1,11 +1,15 @@
-# Git config baked into the dev container image.
+# Git config baked into the dev container image — the ENVIRONMENT layer.
 # Source of truth: .devcontainer/config/gitconfig
 # Installed to:    /home/vscode/.config/git/config
 #
-# This is git's XDG-compliant second user config location. Git reads it in
-# addition to ~/.gitconfig and merges the two — single-valued keys in
-# ~/.gitconfig (e.g. user.name set by post-create-common.sh) take precedence,
-# but values here apply unmodified unless explicitly overridden.
+# This is git's XDG user config location. Git reads it BEFORE ~/.gitconfig and
+# merges the two: single-valued keys in ~/.gitconfig override same-named keys
+# here, while multi-valued keys (url.insteadOf) accumulate across both files.
+# Everything environment/container-shaped belongs in this file; ~/.gitconfig is
+# reserved for personal config (VS Code's copyGitConfig may copy the host's in
+# on attach — that copy must never be able to break container plumbing).
+# post-create-common.sh appends runtime-only values (git identity) to this
+# file explicitly via `git config --file`.
 
 [alias]
 	ll = log --graph --oneline --decorate
@@ -26,3 +30,17 @@
 
 [push]
 	autoSetupRemote = true
+
+# Rewrite every GitHub SSH URL form to HTTPS for fetch AND push: in-container
+# git ops never depend on an SSH agent (absent in bot containers; lockout-
+# prone when forwarded into human ones). Covers the scp form (git@github.com:)
+# plus all three ssh:// forms, including the explicit port-443 endpoint.
+# HTTPS auth comes from gh (GH_TOKEN in the bot profile, the operator's own
+# `gh auth login` in the dev one), or VS Code's forwarded host credential
+# helper on attach. insteadOf is prefix matching, so every SSH form needs its
+# own mapping.
+[url "https://github.com/"]
+	insteadOf = git@github.com:
+	insteadOf = ssh://git@github.com/
+	insteadOf = ssh://git@ssh.github.com:443/
+	insteadOf = ssh://git@ssh.github.com/

--- a/.devcontainer/related-repos.txt
+++ b/.devcontainer/related-repos.txt
@@ -9,9 +9,10 @@
 #   owner/repo@branch                # specific branch
 #   https://github.com/owner/repo    # full URL (also supports .git suffix)
 #   git@github.com:owner/repo.git    # ssh URL — accepted, but rewritten to
-#                                    # https by the container gitconfig
-#                                    # (post-create-common.sh); bot containers
-#                                    # have no SSH capability at all
+#                                    # https by the image-baked environment
+#                                    # gitconfig (.devcontainer/config/
+#                                    # gitconfig); bot containers have no SSH
+#                                    # capability at all
 #
 # Lines starting with # are comments; blank lines are ignored. Existing
 # /workspaces/<repo> dirs are never clobbered (no pull, no checkout, no reset).

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -111,7 +111,10 @@ fi
 # environment gitconfig (.devcontainer/config/gitconfig) — static config
 # belongs in the image layer, not in runtime writes.
 
-echo "Git user: $(git config --global user.name)"
+# Effective read, not --global: the scoped read surface skips the XDG file
+# once ~/.gitconfig exists, so it would print empty exactly when identity
+# lives in the environment layer.
+echo "Git user: $(git config user.name)"
 echo "GitHub auth status:"
 gh auth status || true
 

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -21,9 +21,23 @@ fi
 # by the Dockerfile. We only wire up the source line in the rc files below.
 PROFILE_SOURCE_LINE='source /usr/local/share/devcontainer-config/shell-aliases.sh'
 
-# Git identity for commits
-git config --global user.name "${DEVCONTAINER_GIT_NAME}"
-git config --global user.email "${DEVCONTAINER_GIT_EMAIL}"
+# All runtime git-config writes target the image's XDG environment config
+# explicitly. `git config --global` picks its file at runtime — ~/.gitconfig
+# when that file exists, the XDG file otherwise — and whether ~/.gitconfig
+# exists here depends on whether VS Code's copyGitConfig has copied the host's
+# in yet, so --global writes land in a different file per attach mode and per
+# lifecycle ordering. Pinning the file makes the environment layer
+# deterministic and keeps ~/.gitconfig personal-only (issue #542).
+ENV_GITCONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/git/config"
+mkdir -p "$(dirname "$ENV_GITCONFIG")"
+
+# Git identity for commits. Written to the environment layer, so in a bot or
+# headless container DEVCONTAINER_GIT_* is the identity. When a human attaches
+# via VS Code and copyGitConfig brings their personal ~/.gitconfig in, its
+# user.* wins over this layer — that copy is personal-only config, and the
+# attaching human's own identity taking precedence is the intended outcome.
+git config --file "$ENV_GITCONFIG" user.name "${DEVCONTAINER_GIT_NAME}"
+git config --file "$ENV_GITCONFIG" user.email "${DEVCONTAINER_GIT_EMAIL}"
 
 # Loud, actionable guidance for an unauthenticated `gh`. The dev profile carries
 # no GH_TOKEN and does not persist its login, so this is that profile's ordinary
@@ -72,8 +86,14 @@ gh_auth_help() {
 # helper. Installing gh's URL-specific helpers here can confuse the remote
 # containers bootstrap when it replaces credential.helper on attach.
 if [ -n "${REMOTE_CONTAINERS_IPC:-}" ] || [ "${REMOTE_CONTAINERS:-}" = "true" ]; then
-    git config --global --unset-all credential.https://github.com.helper || true
-    git config --global --unset-all credential.https://gist.github.com.helper || true
+    # Unset from both global-scope files: a prior `gh auth setup-git` may have
+    # written the helpers to either one (gh uses --global, whose target file
+    # varies — see ENV_GITCONFIG above).
+    for cfg in "$ENV_GITCONFIG" "$HOME/.gitconfig"; do
+        [ -f "$cfg" ] || continue
+        git config --file "$cfg" --unset-all credential.https://github.com.helper || true
+        git config --file "$cfg" --unset-all credential.https://gist.github.com.helper || true
+    done
     echo "VS Code devcontainer detected; skipping gh auth setup-git."
     # VS Code's forwarded host credential covers *git* on this path, but not
     # `gh` — it reads its own config, and the dev profile supplies no GH_TOKEN.
@@ -87,27 +107,16 @@ else
     gh_auth_help "gh auth setup-git"
 fi
 
-# Rewrite every GitHub SSH URL form to HTTPS for fetch AND push: in-container
-# git ops never depend on an SSH agent (absent in bot containers; lockout-
-# prone when forwarded into human ones). Covers the scp form (git@github.com:)
-# plus all three ssh:// forms, including the explicit port-443 endpoint. HTTPS auth comes from gh
-# (GH_TOKEN in the bot profile, the operator's own `gh auth login` in the dev
-# one), or VS Code's forwarded host credential helper on attach.
-# insteadOf is multi-valued, so reset then re-add: a plain scalar set exits 5
-# ("cannot overwrite multiple values") on re-run and would fail post-create.
-# Unset with --fixed-value so only the four managed values are removed — a
-# whole-key --unset-all would delete user-defined aliases (e.g. github:).
-for ssh_form in "git@github.com:" "ssh://git@github.com/" "ssh://git@ssh.github.com:443/" "ssh://git@ssh.github.com/"; do
-    git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "$ssh_form" || true
-    git config --global --add url."https://github.com/".insteadOf "$ssh_form"
-done
+# The GitHub SSH→HTTPS insteadOf rewrites are baked into the image's
+# environment gitconfig (.devcontainer/config/gitconfig) — static config
+# belongs in the image layer, not in runtime writes.
 
 echo "Git user: $(git config --global user.name)"
 echo "GitHub auth status:"
 gh auth status || true
 
-# Automatically set upstream branch without needing --set-upstream when pushing new branches
-git config --global push.autoSetupRemote true
+# push.autoSetupRemote is baked in the environment gitconfig alongside the
+# other static settings.
 
 echo "==> Fixing ownership of persistent volume dirs..."
 for dir in /home/vscode/.codex /home/vscode/.claude /home/vscode/.gemini \

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -342,8 +342,8 @@ repo** (one template serves every repo). To stand this repo up in Coder:
 To work across several repos in one container, list them in
 `.devcontainer/related-repos.txt` (one `owner/repo` per line; `@branch`, full
 URLs, and ssh URLs also work — ssh URLs are rewritten to https by the
-container gitconfig, which `post-create-common.sh` sets up so in-container
-git operations never depend on an SSH agent). They are:
+environment gitconfig baked into the image at `~/.config/git/config`, so
+in-container git operations never depend on an SSH agent). They are:
 
 - **cloned** into `/workspaces/`, beside this repo, on container **create**
   (`scripts/bootstrap-related-repos.sh`) — so a rebuilt or persistence-lost

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/gitconfig
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/gitconfig
@@ -1,11 +1,15 @@
-# Git config baked into the dev container image.
+# Git config baked into the dev container image — the ENVIRONMENT layer.
 # Source of truth: .devcontainer/config/gitconfig
 # Installed to:    /home/vscode/.config/git/config
 #
-# This is git's XDG-compliant second user config location. Git reads it in
-# addition to ~/.gitconfig and merges the two — single-valued keys in
-# ~/.gitconfig (e.g. user.name set by post-create-common.sh) take precedence,
-# but values here apply unmodified unless explicitly overridden.
+# This is git's XDG user config location. Git reads it BEFORE ~/.gitconfig and
+# merges the two: single-valued keys in ~/.gitconfig override same-named keys
+# here, while multi-valued keys (url.insteadOf) accumulate across both files.
+# Everything environment/container-shaped belongs in this file; ~/.gitconfig is
+# reserved for personal config (VS Code's copyGitConfig may copy the host's in
+# on attach — that copy must never be able to break container plumbing).
+# post-create-common.sh appends runtime-only values (git identity) to this
+# file explicitly via `git config --file`.
 
 [alias]
 	ll = log --graph --oneline --decorate
@@ -26,3 +30,17 @@
 
 [push]
 	autoSetupRemote = true
+
+# Rewrite every GitHub SSH URL form to HTTPS for fetch AND push: in-container
+# git ops never depend on an SSH agent (absent in bot containers; lockout-
+# prone when forwarded into human ones). Covers the scp form (git@github.com:)
+# plus all three ssh:// forms, including the explicit port-443 endpoint.
+# HTTPS auth comes from gh (GH_TOKEN in the bot profile, the operator's own
+# `gh auth login` in the dev one), or VS Code's forwarded host credential
+# helper on attach. insteadOf is prefix matching, so every SSH form needs its
+# own mapping.
+[url "https://github.com/"]
+	insteadOf = git@github.com:
+	insteadOf = ssh://git@github.com/
+	insteadOf = ssh://git@ssh.github.com:443/
+	insteadOf = ssh://git@ssh.github.com/

--- a/template/[% if devcontainer %].devcontainer[% endif %]/related-repos.txt
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/related-repos.txt
@@ -22,9 +22,6 @@
 # tools) AND sandbox.filesystem.allowRead (the Bash sandbox). See
 # docs/guides/devcontainers.md.
 #
-# Harmon platform sibling repositories. These are cloned into /workspaces/
-# alongside harmon-init when the devcontainer is created.
-https://github.com/evanharmon1/harmon-devkit
-https://github.com/evanharmon1/harmon-dotfiles
-https://github.com/evanharmon1/harmon-ops
-https://github.com/evanharmon1/evanharmon-site
+# Examples — uncomment and edit:
+#   your-org/shared-libs
+#   your-org/api@main

--- a/template/[% if devcontainer %].devcontainer[% endif %]/related-repos.txt
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/related-repos.txt
@@ -9,9 +9,10 @@
 #   owner/repo@branch                # specific branch
 #   https://github.com/owner/repo    # full URL (also supports .git suffix)
 #   git@github.com:owner/repo.git    # ssh URL — accepted, but rewritten to
-#                                    # https by the container gitconfig
-#                                    # (post-create-common.sh); bot containers
-#                                    # have no SSH capability at all
+#                                    # https by the image-baked environment
+#                                    # gitconfig (.devcontainer/config/
+#                                    # gitconfig); bot containers have no SSH
+#                                    # capability at all
 #
 # Lines starting with # are comments; blank lines are ignored. Existing
 # /workspaces/<repo> dirs are never clobbered (no pull, no checkout, no reset).
@@ -21,6 +22,9 @@
 # tools) AND sandbox.filesystem.allowRead (the Bash sandbox). See
 # docs/guides/devcontainers.md.
 #
-# Examples — uncomment and edit:
-#   your-org/shared-libs
-#   your-org/api@main
+# Harmon platform sibling repositories. These are cloned into /workspaces/
+# alongside harmon-init when the devcontainer is created.
+https://github.com/evanharmon1/harmon-devkit
+https://github.com/evanharmon1/harmon-dotfiles
+https://github.com/evanharmon1/harmon-ops
+https://github.com/evanharmon1/evanharmon-site

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -111,7 +111,10 @@ fi
 # environment gitconfig (.devcontainer/config/gitconfig) — static config
 # belongs in the image layer, not in runtime writes.
 
-echo "Git user: $(git config --global user.name)"
+# Effective read, not --global: the scoped read surface skips the XDG file
+# once ~/.gitconfig exists, so it would print empty exactly when identity
+# lives in the environment layer.
+echo "Git user: $(git config user.name)"
 echo "GitHub auth status:"
 gh auth status || true
 

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -21,9 +21,23 @@ fi
 # by the Dockerfile. We only wire up the source line in the rc files below.
 PROFILE_SOURCE_LINE='source /usr/local/share/devcontainer-config/shell-aliases.sh'
 
-# Git identity for commits
-git config --global user.name "${DEVCONTAINER_GIT_NAME}"
-git config --global user.email "${DEVCONTAINER_GIT_EMAIL}"
+# All runtime git-config writes target the image's XDG environment config
+# explicitly. `git config --global` picks its file at runtime — ~/.gitconfig
+# when that file exists, the XDG file otherwise — and whether ~/.gitconfig
+# exists here depends on whether VS Code's copyGitConfig has copied the host's
+# in yet, so --global writes land in a different file per attach mode and per
+# lifecycle ordering. Pinning the file makes the environment layer
+# deterministic and keeps ~/.gitconfig personal-only (issue #542).
+ENV_GITCONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/git/config"
+mkdir -p "$(dirname "$ENV_GITCONFIG")"
+
+# Git identity for commits. Written to the environment layer, so in a bot or
+# headless container DEVCONTAINER_GIT_* is the identity. When a human attaches
+# via VS Code and copyGitConfig brings their personal ~/.gitconfig in, its
+# user.* wins over this layer — that copy is personal-only config, and the
+# attaching human's own identity taking precedence is the intended outcome.
+git config --file "$ENV_GITCONFIG" user.name "${DEVCONTAINER_GIT_NAME}"
+git config --file "$ENV_GITCONFIG" user.email "${DEVCONTAINER_GIT_EMAIL}"
 
 # Loud, actionable guidance for an unauthenticated `gh`. The dev profile carries
 # no GH_TOKEN and does not persist its login, so this is that profile's ordinary
@@ -72,8 +86,14 @@ gh_auth_help() {
 # helper. Installing gh's URL-specific helpers here can confuse the remote
 # containers bootstrap when it replaces credential.helper on attach.
 if [ -n "${REMOTE_CONTAINERS_IPC:-}" ] || [ "${REMOTE_CONTAINERS:-}" = "true" ]; then
-    git config --global --unset-all credential.https://github.com.helper || true
-    git config --global --unset-all credential.https://gist.github.com.helper || true
+    # Unset from both global-scope files: a prior `gh auth setup-git` may have
+    # written the helpers to either one (gh uses --global, whose target file
+    # varies — see ENV_GITCONFIG above).
+    for cfg in "$ENV_GITCONFIG" "$HOME/.gitconfig"; do
+        [ -f "$cfg" ] || continue
+        git config --file "$cfg" --unset-all credential.https://github.com.helper || true
+        git config --file "$cfg" --unset-all credential.https://gist.github.com.helper || true
+    done
     echo "VS Code devcontainer detected; skipping gh auth setup-git."
     # VS Code's forwarded host credential covers *git* on this path, but not
     # `gh` — it reads its own config, and the dev profile supplies no GH_TOKEN.
@@ -87,27 +107,16 @@ else
     gh_auth_help "gh auth setup-git"
 fi
 
-# Rewrite every GitHub SSH URL form to HTTPS for fetch AND push: in-container
-# git ops never depend on an SSH agent (absent in bot containers; lockout-
-# prone when forwarded into human ones). Covers the scp form (git@github.com:)
-# plus all three ssh:// forms, including the explicit port-443 endpoint. HTTPS auth comes from gh
-# (GH_TOKEN in the bot profile, the operator's own `gh auth login` in the dev
-# one), or VS Code's forwarded host credential helper on attach.
-# insteadOf is multi-valued, so reset then re-add: a plain scalar set exits 5
-# ("cannot overwrite multiple values") on re-run and would fail post-create.
-# Unset with --fixed-value so only the four managed values are removed — a
-# whole-key --unset-all would delete user-defined aliases (e.g. github:).
-for ssh_form in "git@github.com:" "ssh://git@github.com/" "ssh://git@ssh.github.com:443/" "ssh://git@ssh.github.com/"; do
-    git config --global --fixed-value --unset-all url."https://github.com/".insteadOf "$ssh_form" || true
-    git config --global --add url."https://github.com/".insteadOf "$ssh_form"
-done
+# The GitHub SSH→HTTPS insteadOf rewrites are baked into the image's
+# environment gitconfig (.devcontainer/config/gitconfig) — static config
+# belongs in the image layer, not in runtime writes.
 
 echo "Git user: $(git config --global user.name)"
 echo "GitHub auth status:"
 gh auth status || true
 
-# Automatically set upstream branch without needing --set-upstream when pushing new branches
-git config --global push.autoSetupRemote true
+# push.autoSetupRemote is baked in the environment gitconfig alongside the
+# other static settings.
 
 echo "==> Fixing ownership of persistent volume dirs..."
 for dir in /home/vscode/.codex /home/vscode/.claude /home/vscode/.gemini \

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -343,8 +343,8 @@ repo** (one template serves every repo). To stand this repo up in Coder:
 To work across several repos in one container, list them in
 `.devcontainer/related-repos.txt` (one `owner/repo` per line; `@branch`, full
 URLs, and ssh URLs also work — ssh URLs are rewritten to https by the
-container gitconfig, which `post-create-common.sh` sets up so in-container
-git operations never depend on an SSH agent). They are:
+environment gitconfig baked into the image at `~/.config/git/config`, so
+in-container git operations never depend on an SSH agent). They are:
 
 - **cloned** into `/workspaces/`, beside this repo, on container **create**
   (`scripts/bootstrap-related-repos.sh`) — so a rebuilt or persistence-lost


### PR DESCRIPTION
## What

Moves the devcontainer's environment git config out of runtime `git config --global` writes and into the image-baked XDG layer (`.devcontainer/config/gitconfig` → `~/.config/git/config`), per the corrected diagnosis on #542:

- The four GitHub SSH→HTTPS `insteadOf` rewrites and `push.autoSetupRemote` are now baked statically; the post-create loop and duplicate write are gone.
- The remaining runtime writes — git identity, the VS Code-path credential-helper unsets — pin their target file explicitly with `git config --file`. `--global` picks its file at runtime (`~/.gitconfig` when present, the XDG file otherwise), so the old writes landed in a different file depending on whether VS Code's `copyGitConfig` had copied the host file in yet.
- The post-create status echo reads effective identity (unscoped): the `--global`-scoped read skips the XDG file once `~/.gitconfig` exists, so it would print empty exactly when identity lives in the environment layer.
- Docs and `related-repos.txt` now attribute the rewrites to the image-baked gitconfig rather than post-create.

## Why

`~/.gitconfig` becomes personal-only: VS Code's `copyGitConfig` copy of the host file can no longer carry host-shaped config (the macOS `/opt/homebrew/bin/gh` credential-helper path) into Linux containers, and the environment layer is deterministic instead of depending on copy ordering. Identity ownership: bot/headless containers have no copied `~/.gitconfig`, so `DEVCONTAINER_GIT_*` wins there; a human attach whose personal config arrives via copy keeps their own `user.*` by file precedence — the copy-ordering race the issue asked to confirm empirically is designed out (post-create never touches `~/.gitconfig`). Companion dotfiles change already shipped (harmon-dotfiles#45).

Both touched devcontainer files are verbatim dogfood twins; root and `template/` copies changed together.

## Verification

- `task verify` green; `task ci` (full mirror incl. render matrix + security) green.
- `task challenge`: round 1's P1 ("XDG file ignored when `~/.gitconfig` exists") empirically refuted — git merges both files for effective reads (git 2.55.0: rewrites and `push.autoSetupRemote` apply with `~/.gitconfig` present); its one real corollary (the scoped status echo) fixed. Round 2 clean (no P0/P1).
- `task review`: clean on round 1 (no P0/P1); its doc-accuracy P2 fixed in-branch, the rest deferred below.

## Deferred findings

- [x] `.devcontainer/scripts/post-create-common.sh:31` — with a nondefault `XDG_CONFIG_HOME` or `GIT_CONFIG_GLOBAL` set, `ENV_GITCONFIG` diverges from the fixed `/home/vscode/.config/git/config` the image installs (`install-repo-config.sh:58`); under `GIT_CONFIG_GLOBAL` git ignores the identity written there. Prior `--global` writes followed git's effective global path. Neither devcontainer profile sets either variable. — declined: no current trigger — both devcontainer profiles use git's default paths, the image installs to the default XDG location, and honoring a nondefault `XDG_CONFIG_HOME` would require the image installer and post-create to change together; noted on #608 for pinning in its test if cheap.
- [x] `.devcontainer/config/gitconfig:42-46` — no regression coverage for the git config layering: a later edit dropping a rewrite or moving writes back to `--global` stays green. Add a temporary-`HOME`/`XDG_CONFIG_HOME` test exercising identity precedence, URL rewriting, and credential-helper cleanup (issue #542 scenarios). — filed as #608

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)

