### PR TITLE
feat(template): ship claim-release workflow so claims stop stranding

### DIFF
--- a/.github/workflows/claim-release.yml
+++ b/.github/workflows/claim-release.yml
@@ -1,0 +1,187 @@
+name: Claim Release
+run-name: releasing claim markers after a close event
+
+# A claim is written by a session (/claim), but its release is owed after
+# the merge — an event no session is guaranteed to witness (/shepherd stops
+# before the merge on policy). This workflow is the release: it undoes the
+# markers the claim record says the claim added and posts the `Claim
+# released —` supersede comment. Contract, design record, and accepted gaps:
+# .claude/skills/track-work/references/claim-lifecycle.md.
+#
+# Merged PRs are deliberately NOT handled here: a merge whose PR carries a
+# closing keyword closes the linked issue, and the issues-closed job releases
+# the claim then (which also covers `gh issue close` and closed-by-hand).
+# Only an unmerged close leaves a stale claim with no issues event coming.
+#
+# The release LOGIC is not here: this file only wires events to
+# `release-claim.sh`, which ships inside the vendored track-work skill so the
+# release always matches the version of the claim convention that wrote the
+# markers. Editing that script here is pointless — `task sync:skills`
+# overwrites it. Change it in harmon-devkit and bump the pin.
+#
+# Two different "no script on disk" cases, handled in two different places.
+# TRANSIENT — scaffolded but `task sync:skills` not run yet: the run: guard
+# below exits 0, because the skill that WRITES claims is the same one that is
+# missing, so there is provably nothing to release. PERMANENT — the repo does
+# not vendor the `universal` category at all: the script is never arriving, so
+# the copier gate (`claim_release_available`) does not render this file, rather
+# than shipping two jobs that fire on every close forever and always no-op.
+#
+# Security: this workflow holds a write-capable token and reads
+# attacker-writable comment bodies, so it always checks out and runs
+# DEFAULT-BRANCH code, never a PR head — a fork PR must not be able to
+# substitute the script this job executes with the token it holds.
+# The script treats every comment value as data (trust gate
+# on the claim author, regex validation before anything becomes an argument),
+# and the blast radius of a fooled parse is availability only. Loop-safety:
+# comments posted with GITHUB_TOKEN never trigger workflow runs, and the
+# generated claude-*.yml issue_comment jobs additionally gate on an
+# allowlisted sender — a future workflow adding a PAT/App token on
+# issue_comment must keep such a gate.
+
+on:
+  issues:
+    types: [closed]
+  pull_request:
+    types: [closed]
+
+# Deliberately NO concurrency group: a group keeps one running and ONE
+# pending run, so a burst of three close events silently cancels the middle
+# one — and a dropped event is a permanently stranded claim, the exact
+# failure this workflow exists to remove. Overlapping runs are safe instead:
+# the script re-reads before writing, recognizes its own bot-authored
+# supersede comments (a duplicate run exits 3), and withholds the comment on
+# partial failure — the worst interleaving is a duplicate release comment,
+# which every reader of the predicate tolerates.
+
+permissions:
+  contents: read
+  issues: write # remove label/assignee, post the supersede comment
+  pull-requests: read # closingIssuesReferences
+
+jobs:
+  on-issue-closed:
+    if: github.event_name == 'issues'
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Release any live claim on the closed issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          STATE_REASON: ${{ github.event.issue.state_reason }}
+          CLOSED_AT: ${{ github.event.issue.closed_at }}
+        run: |
+          # Not-yet-vendored is a genuine no-op, not a swallowed error: this
+          # script and the /claim skill that WRITES these markers ship in the
+          # same vendored skill set, so no script means no claim convention
+          # means nothing was ever claimed. Generated repos vendor skills by
+          # running `task sync:skills` after scaffolding (docs/CHECKLIST.md),
+          # so this window is real and every close event would otherwise fail.
+          #
+          # Test -e, not -x, and cross-check the claim skill. A file that
+          # exists but will not run (exec bit lost in a checkout) must reach
+          # the invocation below and fail the job loudly; and if claims are
+          # being written while the releaser is missing, staying quiet would
+          # strand exactly the claims this workflow exists to release.
+          script=./.claude/skills/track-work/assets/release-claim.sh
+          if [ ! -e "$script" ]; then
+            if [ -e .claude/skills/claim/SKILL.md ]; then
+              echo "::error::the claim skill is vendored but $script is missing — claims written here will strand. Re-run 'task sync:skills'."
+              exit 1
+            fi
+            echo "::notice::$script is not vendored — run 'task sync:skills'. No claim convention is installed, so there is nothing to release."
+            exit 0
+          fi
+          rc=0
+          # --not-after: a claim created after this close belongs to newer
+          # work (a reopen-and-reclaim) and is not this event's to release.
+          # --require-closed: a queued event whose issue was reopened before
+          # this ran is stale — an accidental close/reopen continues the
+          # existing claim, and releasing it would strip active work.
+          "$script" \
+            --repo "$GH_REPO" --issue "$ISSUE_NUMBER" \
+            --reason "issue closed (${STATE_REASON:-closed})" \
+            --not-after "$CLOSED_AT" --require-closed || rc=$?
+          # 3 = no live claim / untrusted claim — benign, the common case.
+          [ "$rc" -eq 0 ] || [ "$rc" -eq 3 ] || exit "$rc"
+
+  on-pr-closed-unmerged:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '"ubuntu-latest"') }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Release claims on the issues this PR would have closed
+        # closingIssuesReferences is GitHub's own closing-keyword resolution
+        # and persists on closed PRs; filtered to same-repo issues (the skill
+        # bans cross-repo closing keywords, and this token could not write
+        # elsewhere anyway).
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CLOSED_AT: ${{ github.event.pull_request.closed_at }}
+          # Untrusted text (a branch name is author-chosen): env only, passed
+          # to the script as data — it compares equality and never evaluates.
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          # Same not-yet-vendored no-op as the issues job above, same reasons.
+          script=./.claude/skills/track-work/assets/release-claim.sh
+          if [ ! -e "$script" ]; then
+            if [ -e .claude/skills/claim/SKILL.md ]; then
+              echo "::error::the claim skill is vendored but $script is missing — claims written here will strand. Re-run 'task sync:skills'."
+              exit 1
+            fi
+            echo "::notice::$script is not vendored — run 'task sync:skills'. No claim convention is installed, so there is nothing to release."
+            exit 0
+          fi
+          job_rc=0
+          # A queued event whose PR was reopened before this ran is stale —
+          # the work is active again and its claim is accurate (the issues
+          # path has the same guard via --require-closed).
+          pr_state="$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" \
+            --json state --jq .state)"
+          if [ "$pr_state" != "CLOSED" ]; then
+            echo "PR #$PR_NUMBER is $pr_state again — the close event is stale, leaving claims alone"
+            exit 0
+          fi
+          issues="$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" \
+            --json closingIssuesReferences \
+            --jq '.closingIssuesReferences[]
+                  | select(.url | startswith("https://github.com/" + env.GH_REPO + "/"))
+                  | .number')"
+          for n in $issues; do
+            rc=0
+            # --branch is the whole ownership test: only the claim whose
+            # Claiming line names this PR's head branch is this close's to
+            # release. A newer or different-branch claim exits 3 untouched.
+            # (No open-PR guards here on purpose: counting open references
+            # let any unrelated fork PR that mentioned the issue suppress
+            # the release forever, and the branch binding already refuses
+            # everything that is not this PR's own claim.)
+            "$script" \
+              --repo "$GH_REPO" --issue "$n" \
+              --reason "PR #${PR_NUMBER} closed without merging" \
+              --not-after "$CLOSED_AT" --branch "$HEAD_REF" || rc=$?
+            # Keep going on failure: one malformed claim must not starve the
+            # releases of the PR's other linked issues; fail the job after.
+            if [ "$rc" -ne 0 ] && [ "$rc" -ne 3 ]; then
+              echo "issue #$n: release failed with exit $rc — continuing to the rest"
+              job_rc="$rc"
+            fi
+          done
+          exit "$job_rc"

--- a/.github/workflows/claim-release.yml
+++ b/.github/workflows/claim-release.yml
@@ -19,13 +19,14 @@ run-name: releasing claim markers after a close event
 # markers. Editing that script here is pointless — `task sync:skills`
 # overwrites it. Change it in harmon-devkit and bump the pin.
 #
-# Two different "no script on disk" cases, handled in two different places.
-# TRANSIENT — scaffolded but `task sync:skills` not run yet: the run: guard
-# below exits 0, because the skill that WRITES claims is the same one that is
-# missing, so there is provably nothing to release. PERMANENT — the repo does
-# not vendor the `universal` category at all: the script is never arriving, so
-# the copier gate (`claim_release_available`) does not render this file, rather
-# than shipping two jobs that fire on every close forever and always no-op.
+# "No script on disk" is handled at RUNTIME, by the run: guard below, not by
+# narrowing the copier gate that renders this file. The gate asks only whether
+# the repo vendors skills at all; which categories it vendors is editable after
+# scaffolding without updating any copier answer, so a gate that tested for the
+# `universal` category would stay false forever in a repo that added it the
+# documented way — leaving the claim skills writing markers with nothing to
+# release them. The guard makes the looser gate safe: no script AND no claim
+# skill means nothing was ever claimed, so it exits 0.
 #
 # Security: this workflow holds a write-capable token and reads
 # attacker-writable comment bodies, so it always checks out and runs

--- a/copier.yml
+++ b/copier.yml
@@ -385,6 +385,22 @@ ci_runs_on_default:
   default: "[% if ci_runner == 'self-hosted' %][\"self-hosted\", \"linux\"][% else %]\"ubuntu-latest\"[% endif %]"
   when: false
 
+# Gates .github/workflows/claim-release.yml, which releases the claim markers
+# an agent session left on an issue once a close event says the work is done.
+# Computed rather than asked, because the answer is a CAPABILITY and not a
+# preference: the workflow only wires events to release-claim.sh, which ships
+# inside the vendored track-work skill. Without the skills sync AND the
+# `universal` category, that script is not on disk and the workflow would be a
+# red job on every close instead of a benign no-op — so there is nothing for a
+# question to offer. A repo that later vendors `universal` picks the workflow
+# up on its next `copier update`. Deliberately NOT tied to project_management:
+# the claim comment is written whether or not a board exists, and needs its
+# release comment either way.
+claim_release_available:
+  type: bool
+  default: "[[ use_skills_sync and 'universal' in skill_categories ]]"
+  when: false
+
 use_node:
   type: bool
   default: "[[ project_type in ['web-astro', 'web-app'] ]]"

--- a/copier.yml
+++ b/copier.yml
@@ -389,16 +389,28 @@ ci_runs_on_default:
 # an agent session left on an issue once a close event says the work is done.
 # Computed rather than asked, because the answer is a CAPABILITY and not a
 # preference: the workflow only wires events to release-claim.sh, which ships
-# inside the vendored track-work skill. Without the skills sync AND the
-# `universal` category, that script is not on disk and the workflow would be a
-# red job on every close instead of a benign no-op — so there is nothing for a
-# question to offer. A repo that later vendors `universal` picks the workflow
-# up on its next `copier update`. Deliberately NOT tied to project_management:
-# the claim comment is written whether or not a board exists, and needs its
-# release comment either way.
+# inside the vendored skills, so a repo with no skills sync has nothing for a
+# question to offer. Deliberately NOT tied to project_management: the claim
+# comment is written whether or not a board exists, and needs its release
+# comment either way.
+#
+# Gates on `use_skills_sync` ALONE, deliberately not on `'universal' in
+# skill_categories`, even though `universal` is the category that carries the
+# script. Categories are editable after scaffolding — `copier.yml:155` and the
+# generated `.skills-sync.yaml` header both say so — and that edit does NOT
+# update the recorded answer. A narrower gate would therefore stay false
+# forever for a repo that adds `universal` the documented way: the claim skills
+# would be vendored and writing `Claiming —` markers while the workflow that
+# releases them was never rendered, stranding claims exactly as this workflow
+# exists to prevent. The runtime guard inside the workflow makes the looser
+# gate safe — with no script AND no claim skill on disk it exits 0 with a
+# notice — so the cost is two no-op jobs per close event in a repo that keeps
+# the skills sync but drops `universal`, and the benefit is that adding the
+# category later just works, with no `copier update` needed at all. See #622
+# for the general form of this coupling.
 claim_release_available:
   type: bool
-  default: "[[ use_skills_sync and 'universal' in skill_categories ]]"
+  default: "[[ use_skills_sync ]]"
   when: false
 
 use_node:

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -35,6 +35,14 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
 - `devcontainer-build.yml` — prebuilds the devcontainer images to GHCR on `.devcontainer/**` changes.
 - `publish-harmon-devcontainer.yml` — **root-only**: validates and publishes the
   shared amd64/arm64 toolchain image, then maintains its reviewed pin PR.
+- `claim-release.yml` — on `issues closed` and on `pull_request closed` **unmerged**,
+  releases the claim markers a session left on an issue. It holds `issues: write`
+  and parses attacker-writable comment bodies, so it always checks out the
+  **default branch** and never a PR head. It only wires events to
+  `release-claim.sh` in the vendored `track-work` skill, which is why the
+  template gates it on `claim_release_available` (skills sync on **and** the
+  `universal` category vendored) — a repo that will never have that script gets
+  no workflow rather than two permanent no-ops.
 - `release.yml` — release-please maintains the rolling release PR.
 - `close-milestone-on-release.yml` — closes the milestone matching the tag on release publish.
 - `sync-harmon-devkit.yml` — **root-only**: turns a published harmon-devkit

--- a/docs/architecture/ci-cd.md
+++ b/docs/architecture/ci-cd.md
@@ -39,10 +39,12 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
   releases the claim markers a session left on an issue. It holds `issues: write`
   and parses attacker-writable comment bodies, so it always checks out the
   **default branch** and never a PR head. It only wires events to
-  `release-claim.sh` in the vendored `track-work` skill, which is why the
-  template gates it on `claim_release_available` (skills sync on **and** the
-  `universal` category vendored) — a repo that will never have that script gets
-  no workflow rather than two permanent no-ops.
+  `release-claim.sh` in the vendored `track-work` skill, and no-ops with a
+  notice when that script is absent. The template gates it on
+  `claim_release_available` — `use_skills_sync` alone, deliberately **not** on
+  the `universal` category that carries the script, because categories are
+  edited in `.skills-sync.yaml` without updating any copier answer and a
+  narrower gate would never re-render for a repo that added them (#622).
 - `release.yml` — release-please maintains the rolling release PR.
 - `close-milestone-on-release.yml` — closes the milestone matching the tag on release publish.
 - `sync-harmon-devkit.yml` — **root-only**: turns a published harmon-devkit

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -385,14 +385,28 @@ follows the pipeline honestly — `In Progress` at claim, `Verifying` while CI
 runs, `In Review` awaiting a human, `Ready to Merge` only once actually
 approved, and never `Done`, which belongs to whoever merges.
 
+**A session cannot be relied on to release it.** The release is owed after the
+merge, and no session is guaranteed to witness that: `/shepherd` stops before
+the merge on policy, so the session that claimed the issue is usually over by
+the time a human merges. `.github/workflows/claim-release.yml` is the release —
+on `issues closed` (by any means) and on `pull_request closed` **unmerged**, it
+undoes what the claim record says the claim added and posts the `Claim
+released —` supersede comment. It needs no secret beyond `GITHUB_TOKEN`.
+
+The contract it parses — and the accepted gaps, including the merged-PR and
+fork-PR cases it deliberately does not cover — is
+[`claim-lifecycle.md`](../.claude/skills/track-work/references/claim-lifecycle.md)
+in the vendored `track-work` skill.
+
 > **Whether this is automatic depends on the skills vendored here.** Writing
-> and releasing these markers is implemented by harmon-devkit's `preflight` /
-> `shepherd` / `close` skills; older releases only assign the issue. The pin
-> moves on its own schedule via `sync-harmon-devkit.yml`, so check rather than
-> assume:
+> and releasing these markers is implemented by harmon-devkit's `claim` /
+> `shepherd` / `wrap` skills; older releases only assign the issue, and the
+> three were named `preflight` / `shepherd` / `close` before harmon-devkit
+> v0.21.0. The pin moves on its own schedule via `sync-harmon-devkit.yml`, so
+> check rather than assume:
 >
 > ```sh
-> grep -l 'agent:claude-code' .claude/skills/preflight/SKILL.md
+> grep -rl 'agent:claude-code' .claude/skills/claim/ .claude/skills/wrap/
 > ```
 >
 > A match means claiming is automated end to end. No match means the `agent:`

--- a/template/.github/workflows/[% if claim_release_available %]claim-release.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if claim_release_available %]claim-release.yml[% endif %].jinja
@@ -1,0 +1,187 @@
+name: Claim Release
+run-name: releasing claim markers after a close event
+
+# A claim is written by a session (/claim), but its release is owed after
+# the merge — an event no session is guaranteed to witness (/shepherd stops
+# before the merge on policy). This workflow is the release: it undoes the
+# markers the claim record says the claim added and posts the `Claim
+# released —` supersede comment. Contract, design record, and accepted gaps:
+# .claude/skills/track-work/references/claim-lifecycle.md.
+#
+# Merged PRs are deliberately NOT handled here: a merge whose PR carries a
+# closing keyword closes the linked issue, and the issues-closed job releases
+# the claim then (which also covers `gh issue close` and closed-by-hand).
+# Only an unmerged close leaves a stale claim with no issues event coming.
+#
+# The release LOGIC is not here: this file only wires events to
+# `release-claim.sh`, which ships inside the vendored track-work skill so the
+# release always matches the version of the claim convention that wrote the
+# markers. Editing that script here is pointless — `task sync:skills`
+# overwrites it. Change it in harmon-devkit and bump the pin.
+#
+# Two different "no script on disk" cases, handled in two different places.
+# TRANSIENT — scaffolded but `task sync:skills` not run yet: the run: guard
+# below exits 0, because the skill that WRITES claims is the same one that is
+# missing, so there is provably nothing to release. PERMANENT — the repo does
+# not vendor the `universal` category at all: the script is never arriving, so
+# the copier gate (`claim_release_available`) does not render this file, rather
+# than shipping two jobs that fire on every close forever and always no-op.
+#
+# Security: this workflow holds a write-capable token and reads
+# attacker-writable comment bodies, so it always checks out and runs
+# DEFAULT-BRANCH code, never a PR head — a fork PR must not be able to
+# substitute the script this job executes with the token it holds.
+# The script treats every comment value as data (trust gate
+# on the claim author, regex validation before anything becomes an argument),
+# and the blast radius of a fooled parse is availability only. Loop-safety:
+# comments posted with GITHUB_TOKEN never trigger workflow runs, and the
+# generated claude-*.yml issue_comment jobs additionally gate on an
+# allowlisted sender — a future workflow adding a PAT/App token on
+# issue_comment must keep such a gate.
+
+on:
+  issues:
+    types: [closed]
+  pull_request:
+    types: [closed]
+
+# Deliberately NO concurrency group: a group keeps one running and ONE
+# pending run, so a burst of three close events silently cancels the middle
+# one — and a dropped event is a permanently stranded claim, the exact
+# failure this workflow exists to remove. Overlapping runs are safe instead:
+# the script re-reads before writing, recognizes its own bot-authored
+# supersede comments (a duplicate run exits 3), and withholds the comment on
+# partial failure — the worst interleaving is a duplicate release comment,
+# which every reader of the predicate tolerates.
+
+permissions:
+  contents: read
+  issues: write # remove label/assignee, post the supersede comment
+  pull-requests: read # closingIssuesReferences
+
+jobs:
+  on-issue-closed:
+    if: github.event_name == 'issues'
+    # Runner switch: CI_RUNS_ON repo/org variable unset -> the rendered
+    # default; set it to a JSON runner spec to override without a commit.
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Release any live claim on the closed issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          STATE_REASON: ${{ github.event.issue.state_reason }}
+          CLOSED_AT: ${{ github.event.issue.closed_at }}
+        run: |
+          # Not-yet-vendored is a genuine no-op, not a swallowed error: this
+          # script and the /claim skill that WRITES these markers ship in the
+          # same vendored skill set, so no script means no claim convention
+          # means nothing was ever claimed. Generated repos vendor skills by
+          # running `task sync:skills` after scaffolding (docs/CHECKLIST.md),
+          # so this window is real and every close event would otherwise fail.
+          #
+          # Test -e, not -x, and cross-check the claim skill. A file that
+          # exists but will not run (exec bit lost in a checkout) must reach
+          # the invocation below and fail the job loudly; and if claims are
+          # being written while the releaser is missing, staying quiet would
+          # strand exactly the claims this workflow exists to release.
+          script=./.claude/skills/track-work/assets/release-claim.sh
+          if [ ! -e "$script" ]; then
+            if [ -e .claude/skills/claim/SKILL.md ]; then
+              echo "::error::the claim skill is vendored but $script is missing — claims written here will strand. Re-run 'task sync:skills'."
+              exit 1
+            fi
+            echo "::notice::$script is not vendored — run 'task sync:skills'. No claim convention is installed, so there is nothing to release."
+            exit 0
+          fi
+          rc=0
+          # --not-after: a claim created after this close belongs to newer
+          # work (a reopen-and-reclaim) and is not this event's to release.
+          # --require-closed: a queued event whose issue was reopened before
+          # this ran is stale — an accidental close/reopen continues the
+          # existing claim, and releasing it would strip active work.
+          "$script" \
+            --repo "$GH_REPO" --issue "$ISSUE_NUMBER" \
+            --reason "issue closed (${STATE_REASON:-closed})" \
+            --not-after "$CLOSED_AT" --require-closed || rc=$?
+          # 3 = no live claim / untrusted claim — benign, the common case.
+          [ "$rc" -eq 0 ] || [ "$rc" -eq 3 ] || exit "$rc"
+
+  on-pr-closed-unmerged:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ${{ fromJSON(vars.CI_RUNS_ON || '[[ ci_runs_on_default ]]') }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Release claims on the issues this PR would have closed
+        # closingIssuesReferences is GitHub's own closing-keyword resolution
+        # and persists on closed PRs; filtered to same-repo issues (the skill
+        # bans cross-repo closing keywords, and this token could not write
+        # elsewhere anyway).
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CLOSED_AT: ${{ github.event.pull_request.closed_at }}
+          # Untrusted text (a branch name is author-chosen): env only, passed
+          # to the script as data — it compares equality and never evaluates.
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          # Same not-yet-vendored no-op as the issues job above, same reasons.
+          script=./.claude/skills/track-work/assets/release-claim.sh
+          if [ ! -e "$script" ]; then
+            if [ -e .claude/skills/claim/SKILL.md ]; then
+              echo "::error::the claim skill is vendored but $script is missing — claims written here will strand. Re-run 'task sync:skills'."
+              exit 1
+            fi
+            echo "::notice::$script is not vendored — run 'task sync:skills'. No claim convention is installed, so there is nothing to release."
+            exit 0
+          fi
+          job_rc=0
+          # A queued event whose PR was reopened before this ran is stale —
+          # the work is active again and its claim is accurate (the issues
+          # path has the same guard via --require-closed).
+          pr_state="$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" \
+            --json state --jq .state)"
+          if [ "$pr_state" != "CLOSED" ]; then
+            echo "PR #$PR_NUMBER is $pr_state again — the close event is stale, leaving claims alone"
+            exit 0
+          fi
+          issues="$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" \
+            --json closingIssuesReferences \
+            --jq '.closingIssuesReferences[]
+                  | select(.url | startswith("https://github.com/" + env.GH_REPO + "/"))
+                  | .number')"
+          for n in $issues; do
+            rc=0
+            # --branch is the whole ownership test: only the claim whose
+            # Claiming line names this PR's head branch is this close's to
+            # release. A newer or different-branch claim exits 3 untouched.
+            # (No open-PR guards here on purpose: counting open references
+            # let any unrelated fork PR that mentioned the issue suppress
+            # the release forever, and the branch binding already refuses
+            # everything that is not this PR's own claim.)
+            "$script" \
+              --repo "$GH_REPO" --issue "$n" \
+              --reason "PR #${PR_NUMBER} closed without merging" \
+              --not-after "$CLOSED_AT" --branch "$HEAD_REF" || rc=$?
+            # Keep going on failure: one malformed claim must not starve the
+            # releases of the PR's other linked issues; fail the job after.
+            if [ "$rc" -ne 0 ] && [ "$rc" -ne 3 ]; then
+              echo "issue #$n: release failed with exit $rc — continuing to the rest"
+              job_rc="$rc"
+            fi
+          done
+          exit "$job_rc"

--- a/template/.github/workflows/[% if claim_release_available %]claim-release.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if claim_release_available %]claim-release.yml[% endif %].jinja
@@ -19,13 +19,14 @@ run-name: releasing claim markers after a close event
 # markers. Editing that script here is pointless — `task sync:skills`
 # overwrites it. Change it in harmon-devkit and bump the pin.
 #
-# Two different "no script on disk" cases, handled in two different places.
-# TRANSIENT — scaffolded but `task sync:skills` not run yet: the run: guard
-# below exits 0, because the skill that WRITES claims is the same one that is
-# missing, so there is provably nothing to release. PERMANENT — the repo does
-# not vendor the `universal` category at all: the script is never arriving, so
-# the copier gate (`claim_release_available`) does not render this file, rather
-# than shipping two jobs that fire on every close forever and always no-op.
+# "No script on disk" is handled at RUNTIME, by the run: guard below, not by
+# narrowing the copier gate that renders this file. The gate asks only whether
+# the repo vendors skills at all; which categories it vendors is editable after
+# scaffolding without updating any copier answer, so a gate that tested for the
+# `universal` category would stay false forever in a repo that added it the
+# documented way — leaving the claim skills writing markers with nothing to
+# release them. The guard makes the looser gate safe: no script AND no claim
+# skill means nothing was ever claimed, so it exits 0.
 #
 # Security: this workflow holds a write-capable token and reads
 # attacker-writable comment bodies, so it always checks out and runs

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -450,14 +450,32 @@ approved, and never `Done`, which belongs to whoever merges. On org repos
 `project-automation.yml` already syncs `Status` from PR and CI events; anything
 writing the card should defer to it there rather than racing it.
 
+[% if claim_release_available %]
+**A session cannot be relied on to release it.** The release is owed after the
+merge, and no session is guaranteed to witness that: `/shepherd` stops before
+the merge on policy, so the session that claimed the issue is usually over by
+the time a human merges. `.github/workflows/claim-release.yml` is the release —
+on `issues closed` (by any means) and on `pull_request closed` **unmerged**, it
+undoes what the claim record says the claim added and posts the `Claim
+released —` supersede comment. It needs no secret beyond `GITHUB_TOKEN`.
+
+That workflow runs `release-claim.sh` out of the vendored `track-work` skill,
+so it does nothing until you have run `task sync:skills` — which is also when
+the skills that *write* claims arrive, so the two are never out of step. The
+contract it parses, and the gaps it deliberately does not cover (a merged PR
+with no closing keyword, an unmerged fork PR), are in
+`.claude/skills/track-work/references/claim-lifecycle.md`.
+
+[% endif %]
 > **Whether this is automatic depends on the skills you have vendored.**
 > Writing and releasing these markers is implemented by harmon-devkit's
-> `preflight` / `shepherd` / `close` skills; older releases only assign the
-> issue. Check yours rather than assuming — the pin moves on its own schedule,
-> via the automated devkit-release sync:
+> `claim` / `shepherd` / `wrap` skills; older releases only assign the issue,
+> and the three were named `preflight` / `shepherd` / `close` before
+> harmon-devkit v0.21.0. Check yours rather than assuming — the pin moves on
+> its own schedule, via the automated devkit-release sync:
 >
 > ```sh
-> grep -l 'agent:claude-code' .claude/skills/preflight/SKILL.md
+> grep -rl 'agent:claude-code' .claude/skills/claim/ .claude/skills/wrap/
 > ```
 >
 > A match means claiming is automated end to end. No match means the `agent:`

--- a/template/docs/architecture/ci-cd.md.jinja
+++ b/template/docs/architecture/ci-cd.md.jinja
@@ -38,6 +38,15 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
 [% if devcontainer %]
 - `devcontainer-build.yml` — prebuilds the devcontainer images to GHCR on `.devcontainer/**` changes.
 [% endif %]
+[% if claim_release_available %]
+- `claim-release.yml` — on `issues closed` and on `pull_request closed`
+  **unmerged**, releases the claim markers an agent session left on an issue
+  (assignee, `agent:*` label, and the `Claiming —` comment's supersede). It
+  holds `issues: write` and parses attacker-writable comment bodies, so it
+  always checks out the **default branch** and never a PR head. It only wires
+  events to `release-claim.sh` in the vendored `track-work` skill, so it
+  no-ops until you have run `task sync:skills`.
+[% endif %]
 [% if use_release_please %]
 - `release.yml` — release-please maintains the rolling release PR.
 [% endif %]


### PR DESCRIPTION
## What

Ships `claim-release.yml` in **both layers** — the template and the root
dogfood copy — so a claim written by an agent session is released by the close
event, not left for whoever notices.

Also fixes a live wrong answer in the shipped project-management doc (both
layers) and lists the new workflow in the CI/CD inventory (both layers).

## Why

A claim is written by a session, but its release is owed **after the merge** —
an event no session is guaranteed to witness, since `/shepherd` stops before
the merge on policy. harmon-devkit has shipped this workflow since v0.13.1;
neither harmon-init nor the template ever did, so both strand every claim whose
session ends before a human merges.

Measured on `main` before this branch: **#542**, claimed and merge-closed
2026-08-05, never released — two days after nine older stranded claims were
backfilled by hand. The backfill cleared the symptom; the leak resumed on the
very next claim. harmon-devkit, which has the workflow, has zero.

## How

**Ported from harmon-devkit v0.21.0** (`3983bd6`, the tag both layers already
pin), adapted in exactly three ways and otherwise byte-for-byte unchanged:

| Adaptation | Why |
| --- | --- |
| Script path → `.claude/skills/track-work/assets/release-claim.sh` | devkit calls its own tree; the vendored path is where consumers get it |
| `runs-on` → `ci_runs_on_default` | matches every other template workflow |
| "repo-local on purpose" rationale restated | it inverts once the template owns the name |

No logic changed. The rename is already upstream — v0.21.0 contains
`cfc2085 feat(skills)!: rename the session suite`, so the workflow's prose
already says `/claim` and `/wrap`.

**Gated on a computed `claim_release_available`** = `use_skills_sync`,
`when: false`, following the `ci_runs_on_default` precedent. Computed rather
than asked because availability is a **capability, not a preference**: a repo
with no skills sync has no `release-claim.sh` and nothing for a question to
offer. Deliberately *not* tied to `project_management` — the `Claiming —`
comment is written whether or not a board exists, which is exactly why this
repo stranded claims while running no board.

It is also deliberately **not** narrowed to `'universal' in skill_categories`,
even though `universal` is the category carrying the script. Categories are
edited after scaffolding (`copier.yml:155` and the generated
`.skills-sync.yaml` header both say so) and that edit never updates the
recorded answer — so the narrower gate stayed false *forever* for a repo that
added `universal` the documented way, vendoring the claim-writing skills with
nothing rendered to release their markers. Codex caught this (see the thread on
`copier.yml`); fixed in f6c119e. The runtime guard below is what makes the
looser gate safe.

**One guard the devkit original does not need.** The template ships no vendored
skills (only `.claude/skills/.gitkeep`), so between `copier copy` and
`task sync:skills` a generated repo has the workflow but not the script. The
copier gate covers the permanent case; this covers the transient one. It tests
`-e` rather than `-x` and cross-checks the claim skill, so only *provable*
absence is silent:

| State | Behavior |
| --- | --- |
| Nothing vendored (fresh scaffold) | notice, exit 0 — the skill that *writes* claims is equally absent |
| Claim skill present, releaser missing | **error, exit 1** — claims would strand |
| Present but exec bit lost | falls through, fails loudly at invocation |
| Fully vendored | normal operation |

A naive `-x` guard would silently swallow rows 2 and 3 — the exact stranding
this workflow exists to prevent.

## Verification

- `task verify` — **exit 0** on the clean committed tree (includes the full
  `test:template` render matrix, `test:dogfood-parity`, `test:dogfood-structure`)
- `task ci` — full CI mirror
- `task challenge` — round 1, **no P0/P1**
- `task review` — round 1, **no P0/P1**
- `guard:release-title` pre-flighted with this PR's title
- **Branch coverage**, re-verified after the gate fix with valid multiselect
  syntax. (An earlier run in this PR passed `--data skill_categories=repo`,
  which copier rejects as `Not a YAML list`; that render *errored out*, and its
  empty output was misread as a working gate. Corrected below.)

  | answers | workflow |
  | --- | --- |
  | defaults | present |
  | `skill_categories=["universal","repo"]` | present |
  | `skill_categories=["repo"]` | present — guard no-ops with a notice |
  | `use_skills_sync=false` | absent |

  `minimal` covers the OFF branch, the other five profiles the ON branch; no
  unrendered jinja markers in any render.
- **End-to-end against a real stranded claim**, not a synthetic one:
  `release-claim.sh` run with the exact arguments the issues-closed job passes
  (`--reason --not-after --require-closed`) against #542 returned **exit 0**,
  correctly identifying the assignee to remove and composing the supersede
  comment. Dry run — #542's actual release is a separate write.
- Guard tested across all four vendoring states above.

## Notes for reviewers

**Feeds #592** (workflow/fork/Actions hardening audit, open, explicitly covers
both layers). This adds a write-scoped workflow that parses attacker-writable
comment bodies, and it arrives pre-hardened: default-branch checkout and never
a PR head, `persist-credentials: false`, same-repo gate on the PR path,
env-indirection for the untrusted `HEAD_REF`, and the trust gate inside the
script. Worth recording there as a positive confirmation rather than a new gap.

**No vendored file is edited.** `release-claim.sh` and `claim-lifecycle.md`
live in harmon-devkit and arrive via the pin; this PR consumes them and changes
neither.

## Deferred findings

- [x] **Fixed in f6c119e; general form filed as #622.** `copier.yml:401` (`claim_release_available`) — the gate reads the
  recorded `skill_categories` copier answer, but `copier.yml:155` ("edit later
  in `.skills-sync.yaml`") and the template's `.skills-sync.yaml` header ("edit
  them freely") both point consumers at that file instead. A repo scaffolded
  *without* `universal` that later adds it there vendors the claim-writing
  skills while `copier update` still evaluates the gate false — so claims are
  written and the workflow is never rendered to release them. Confirmed real
  (both challenge and review flagged it independently); P2 because it needs a
  specific post-scaffold action and most repos take `universal` by default. Not
  fixable by reading live config — copier answers cannot read
  `.skills-sync.yaml` at render time. Affects **any** `skill_categories`-gated
  file, not just this one, so it likely wants its own issue rather than a patch
  here. **Disposition:** Codex cloud review raised the same finding on the PR
  with a concrete remedy — gate on `use_skills_sync` alone — which is option 1
  of the four #622 weighs, and is right for *this* file because the runtime
  guard already covers the case the narrow gate was protecting against. Applied
  in f6c119e, so the instance that shipped a correctness bug is fixed here;
  #622 keeps the general policy question (any `skill_categories`-gated file has
  this coupling) open.

Closes #483


