### PR TITLE
feat(guard): fail verify when a template file is gated on skill_categories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,13 @@ jobs:
         run: task test:tag-hygiene
       - name: Template independence (no harmon-dotfiles/chezmoi in shipped output)
         run: task test:template-independence
+      # Root-only, like the independence guard above: a generated repo has no
+      # template/ to scan, so this has no twin in build.yml.jinja. It must be
+      # listed HERE and not only in `verify` — this job enumerates its steps by
+      # hand, so a check added to `verify` alone never runs in CI and the
+      # invariant regresses under a green aggregate check (#614, same drift).
+      - name: Category gates (no template file gated on skill_categories)
+        run: task test:category-gates
       - name: Dogfood parity (verbatim template files match their root twins)
         run: task test:dogfood-parity
       # The structure check renders template/, so it needs copier. Installed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -639,6 +639,14 @@ the workflow rules above:
 
 - `group:action` Taskfile naming (e.g. `lint:shell`, not `shell:lint`); pin
   actions by SHA + `# vX.Y.Z`.
+- **Never gate a template file on `skill_categories`** — filename, `[% if %]`,
+  or a computed answer alike. The answer is recorded at scaffold time while
+  consumers are told to change categories in `.skills-sync.yaml`, so a gate on
+  it is permanently wrong for the repos it was meant to serve. Gate on
+  `use_skills_sync` and check for the asset at runtime, the way
+  `claim-release.yml` does. `task test:category-gates` enforces it; the
+  reasoning is in [docs/conventions.md](docs/conventions.md) under "Template
+  authoring".
 - Git hooks are managed by lefthook (`lefthook.yml`) and delegate to Taskfile
   targets — don't duplicate logic in hooks or workflows.
 - Secrets never go in git; local env via 1Password (`op run` / `op inject`).

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -91,6 +91,7 @@ tasks:
       - task: test:dogfood-structure
       - task: test:starship-glyphs
       - task: test:template-independence
+      - task: test:category-gates
       - task: test:hooks
       - task: test:statusline
       - task: test:codex-review
@@ -419,6 +420,11 @@ tasks:
     desc: "Guard: consumer-facing output names neither harmon-dotfiles nor chezmoi"
     cmds:
       - ./scripts/test-template-independence.sh
+
+  test:category-gates:
+    desc: "Guard: no template file renders conditionally on skill_categories (drifts; #622)"
+    cmds:
+      - ./scripts/test-category-gates.sh
 
   audit:dogfood:
     desc: "Report root<->template drift for jinja twins (report, not a gate; --summary for names only)"

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -134,6 +134,43 @@ it points here.
   `docs/guides/` (build it) · `docs/runbooks/` (operate it). Folder landing
   pages are `README.md`.
 
+## Template authoring
+
+Root-only — these rules govern files under `template/`, which no generated repo
+has.
+
+- **Never gate a template file on `skill_categories`.** Not a filename
+  condition, not a `[% if %]`, not a computed answer's `default:`/`when:`.
+  `task test:category-gates` enforces this (`scripts/test-category-gates.sh`,
+  part of `verify`).
+
+  The answer is recorded once at scaffold time, but the documented way to change
+  categories afterwards is to edit `.skills-sync.yaml` — said by the question's
+  own help text and by the generated manifest's header. That edit never updates
+  the answer, and `copier update` applies the **template's** diff rather than
+  overwriting, so the consumer's manifest edit survives while the answer stays
+  stale permanently. The manifest is what `task sync:skills` reads, so the
+  skills vendor correctly; only a file gated on the answer breaks — silently,
+  and on every future update, in exactly the repos it was meant to serve.
+
+  **Instead:** gate on `use_skills_sync` (whether the repo vendors skills at
+  all — an answer that cannot drift) and have the shipped file check for the
+  asset it needs at **runtime**.
+  [`claim-release.yml`](../.github/workflows/claim-release.yml) is the worked
+  example: it renders whenever the skills sync is on, and its `run:` guard exits
+  0 with a notice when `release-claim.sh` is absent. Iterating the answer to
+  *seed* a file — how `.skills-sync.yaml` gets its category list — stays
+  correct; it is the conditional use that rots.
+
+  Written after `claim_release_available` shipped as
+  `use_skills_sync and 'universal' in skill_categories` and was caught in
+  review ([#622](https://github.com/evanharmon1/harmon-init/issues/622) carries
+  the analysis and the options weighed).
+
+- The same shape of question is worth asking of **any** answer a consumer is
+  told to edit elsewhere: if the file is the source of truth, the answer is a
+  seed, and gating on a seed is a bug that only appears months later.
+
 ## Releases
 
 - Releases are intentional via **release-please**: merge the rolling release PR
@@ -144,7 +181,7 @@ it points here.
   Fixes** (patch), `feat!` / `BREAKING CHANGE:` → major. The rest (`build`,
   `chore`, `ci`, `docs`, `perf`, `refactor`, `revert`, `style`, `test`) don't cut
   a release on their own — they ride along in the next one.
-- **On a squash-merge repo the PR title _is_ the release type.** GitHub sets the
+- **On a squash-merge repo the PR title *is* the release type.** GitHub sets the
   squash commit subject from the PR title for a multi-commit PR, and release-please
   reads only that subject — the individual `fix:`/`feat:` commits inside the PR are
   invisible in the squashed body. So a PR whose title is `chore:`/`docs:` merges

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -142,7 +142,18 @@ has.
 - **Never gate a template file on `skill_categories`.** Not a filename
   condition, not a `[% if %]`, not a computed answer's `default:`/`when:`.
   `task test:category-gates` enforces this (`scripts/test-category-gates.sh`,
-  part of `verify`).
+  in both `verify` and the CI lint job).
+
+  The guard works by **allowlist**: every occurrence of the answer under
+  `template/` fails unless it is listed in the script with a reason (today,
+  three — the `.skills-sync.yaml` seed loop and two prose mentions). So adding
+  a legitimate new mention costs one allowlist line, and that line is the point
+  — it forces the "is this a gate or a seed?" question at review time. An
+  earlier revision enumerated the *banned* forms instead and was evaded three
+  times in three review rounds by ordinary Jinja (a wrapped conditional,
+  `[%+ if`, `[% if(...)`); a denylist over an open-ended grammar can only be as
+  complete as the last author's imagination, and it reports success over
+  everything it failed to imagine.
 
   The answer is recorded once at scaffold time, but the documented way to change
   categories afterwards is to edit `.skills-sync.yaml` — said by the question's

--- a/scripts/test-category-gates.sh
+++ b/scripts/test-category-gates.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# test-category-gates.sh — no template file may be GATED on `skill_categories`
+# (harmon-init#622; the instance that motivated it is #483 / PR #621).
+#
+# THE TRAP. `skill_categories` is recorded in `.copier-answers.yml` at scaffold
+# time, but the documented way to change categories afterwards is to edit
+# `.skills-sync.yaml` — said by the question's own help text ("edit later in
+# .skills-sync.yaml") and by the generated manifest's header ("edit them
+# freely"). That edit does NOT update the recorded answer, and copier's update
+# is a three-way merge of the TEMPLATE's diff, so the consumer's manifest edit
+# survives while the answer stays stale forever.
+#
+# The manifest is what `task sync:skills` reads, so the SKILLS vendor correctly.
+# Only a template file gated on the ANSWER breaks — and it breaks silently and
+# permanently: the file never renders, on this update or any future one, in a
+# repo whose skills say it should.
+#
+# That is not hypothetical. `claim_release_available` was written as
+# `use_skills_sync and 'universal' in skill_categories`, which would have left a
+# repo that added `universal` the documented way vendoring the claim-writing
+# skills with no claim-release workflow to release their markers — the exact
+# stranding that workflow exists to prevent, reintroduced through its own gate.
+#
+# THE CONVENTION. Gate on `use_skills_sync` — whether the repo vendors skills at
+# all, which is a real answer that cannot drift — and let the shipped file check
+# at RUNTIME for the specific asset it needs. `claim-release.yml` is the worked
+# example: it renders whenever skills sync is on and exits 0 with a notice when
+# `release-claim.sh` is absent.
+#
+# WHAT IS BANNED is conditional use, not every mention. Iterating the answer to
+# SEED a file is correct and is the whole point of the question — that is how
+# `.skills-sync.yaml` gets its category list. Prose that names the answer is
+# fine. What must not exist is a decision about whether a file or a block
+# RENDERS, made from a value that goes stale.
+#
+# ROOT-ONLY: a generated repo has no template/ and never runs this check.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ANSWER='skill_categories'
+fail=0
+
+# ── 1. Filenames ────────────────────────────────────────────────────────────
+# A conditional in a PATH is the strongest form of the gate: copier skips a file
+# whose rendered name is empty, so the file simply never appears.
+while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    echo "FAIL: ${path}" >&2
+    echo "      filename is gated on ${ANSWER} — use use_skills_sync and check for the asset at runtime" >&2
+    fail=1
+done < <(find template -name "*${ANSWER}*" -print 2>/dev/null || true)
+
+# ── 2. Jinja conditionals under template/ ───────────────────────────────────
+# `[% if %]` / `[% elif %]` decide whether a BLOCK renders — same staleness, at
+# a finer grain. `[% for %]` is deliberately absent from this pattern: iterating
+# the answer to seed a file is the legitimate use.
+#
+# No grep -P (BSD grep lacks it). `[%` needs no escaping inside a bracket
+# expression, and the delimiters are copier's, set by _envops in copier.yml.
+while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    echo "FAIL: ${hit}" >&2
+    fail=1
+done < <(grep -rnE "\[%-? *(el)?if [^%]*${ANSWER}" template 2>/dev/null || true)
+
+# ── 3. copier.yml: computed answers that GATE on it ─────────────────────────
+# A `default:` derives one answer from another, and a `when:` decides whether a
+# question is asked; either one reading `skill_categories` inherits its
+# staleness and hands it to whatever the derived answer gates.
+#
+# The question's OWN block is not an exception that needs allowlisting: its
+# `default:` seeds from `project_type` and its `when:` reads `use_skills_sync`,
+# so neither line mentions `skill_categories`. If that ever changes, this guard
+# firing on it is correct — a self-referential default is its own bug.
+while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    echo "FAIL: copier.yml:${hit}" >&2
+    echo "      a computed answer gated on ${ANSWER} inherits its staleness" >&2
+    fail=1
+done < <(grep -nE "^[[:space:]]*(default|when):.*${ANSWER}" copier.yml 2>/dev/null || true)
+
+if [ "$fail" -ne 0 ]; then
+    cat >&2 <<'MSG'
+
+category gates: no template file may render conditionally on `skill_categories`.
+
+  The answer is recorded at scaffold time and never updated when a consumer
+  edits `.skills-sync.yaml` — the documented way to change categories — so a
+  gate on it is permanently wrong for exactly the repos it is meant to serve.
+
+  Instead: gate on `use_skills_sync`, and have the shipped file check for the
+  asset it needs at runtime. See `.github/workflows/claim-release.yml` for the
+  worked example, docs/conventions.md for the rule, and #622 for the analysis.
+MSG
+    exit 1
+fi
+
+echo "category gates OK: no filename, jinja conditional, or computed answer gates on ${ANSWER}"

--- a/scripts/test-category-gates.sh
+++ b/scripts/test-category-gates.sh
@@ -71,6 +71,14 @@ done < <(find template -name "*${ANSWER}*" -print 2>/dev/null || true)
 # (_envops in copier.yml), so depth is just the running count of openers minus
 # closers.
 #
+# BOTH whitespace-control modifiers are accepted after `[%`. Jinja allows `-`
+# (strip) and `+` (keep), and `+` is not decorative here: copier.yml sets
+# trim_blocks and lstrip_blocks, which is exactly when an author reaches for
+# `[%+` to preserve a newline. A pattern matching only `-` therefore missed an
+# ordinary block conditional — the guard's PRIMARY target — rather than an
+# exotic one. Whitespace after the modifier is [[:space:]] and not a literal
+# space, so a tab does not slip past either.
+#
 # No grep -P (BSD grep lacks it); awk string-form separators for the same
 # portability reason.
 flatten_jinja() {
@@ -92,7 +100,7 @@ while IFS= read -r file; do
         [ -n "$hit" ] || continue
         echo "FAIL: ${hit}" >&2
         fail=1
-    done < <(flatten_jinja "$file" | grep -E "\[%-? *(el)?if [^%]*${ANSWER}" || true)
+    done < <(flatten_jinja "$file" | grep -E "\[%[-+]?[[:space:]]*(el)?if[[:space:]][^%]*${ANSWER}" || true)
 done < <(find template -type f -print 2>/dev/null || true)
 
 # ── 3. copier.yml: computed answers that GATE on it ─────────────────────────

--- a/scripts/test-category-gates.sh
+++ b/scripts/test-category-gates.sh
@@ -40,6 +40,14 @@ cd "$(dirname "$0")/.."
 ANSWER='skill_categories'
 fail=0
 
+# A missing scan target means the checks below quietly examine nothing. Same
+# precedent as test-template-independence.sh, which fails on an absent target
+# rather than reporting the invariant held over an empty search.
+[ -d template ] || {
+    echo "FAIL: template/ is missing — nothing was scanned" >&2
+    exit 1
+}
+
 # ── 1. Filenames ────────────────────────────────────────────────────────────
 # A conditional in a PATH is the strongest form of the gate: copier skips a file
 # whose rendered name is empty, so the file simply never appears.
@@ -108,12 +116,15 @@ if ! command -v yq >/dev/null 2>&1; then
     echo "FAIL: yq is required to inspect copier.yml answers (brew bundle / see Brewfile)" >&2
     exit 1
 fi
-while IFS= read -r hit; do
-    [ -n "$hit" ] || continue
-    echo "FAIL: copier.yml: ${hit}" >&2
-    echo "      a computed answer gated on ${ANSWER} inherits its staleness" >&2
-    fail=1
-done < <(yq -r "
+
+# A FAILED yq must not read as "no gates found". yq being present does not mean
+# it is the right yq — build.yml already warns that `pip install yq` is a
+# different tool (a jq wrapper) — and the wrong one exits non-zero on this
+# expression. Swallowing that with `|| true` would leave the whole
+# computed-answer check silently disabled while the guard printed OK, which is
+# the exact failure this guard exists to prevent, one level up. Capture first,
+# fail loudly, and only then iterate.
+if ! answer_gates="$(yq -r "
     to_entries
     | map(select(.value | type == \"!!map\"))
     | map(select(
@@ -122,7 +133,21 @@ done < <(yq -r "
       ))
     | .[]
     | .key + \": \" + ((.value.default // .value.when) | tostring)
-" copier.yml 2>/dev/null || true)
+" copier.yml 2>&1)"; then
+    echo "FAIL: yq could not parse copier.yml — the computed-answer check did NOT run" >&2
+    printf '      %s\n' "$answer_gates" >&2
+    echo "      needs mikefarah/yq; 'pip install yq' is a different tool (a jq wrapper)" >&2
+    exit 1
+fi
+
+while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    echo "FAIL: copier.yml: ${hit}" >&2
+    echo "      a computed answer gated on ${ANSWER} inherits its staleness" >&2
+    fail=1
+done <<EOF
+${answer_gates}
+EOF
 
 if [ "$fail" -ne 0 ]; then
     cat >&2 <<'MSG'

--- a/scripts/test-category-gates.sh
+++ b/scripts/test-category-gates.sh
@@ -160,53 +160,60 @@ while IFS= read -r hit; do
     fail=1
 done < <(grep -rn "${ANSWER}" template 2>/dev/null || true)
 
-# ── 2b. Conditionals INSIDE a loop over the answer ──────────────────────────
-# The allowlist exempts a LINE, but a `[% for cat in skill_categories %]` binds
-# the answer's values to a loop variable that other lines can then gate on —
-# and those lines never name the answer, so check 2 cannot see them:
+# ── 2b. The seed loop must be EXACTLY the known block ───────────────────────
+# Check 2 exempts the loop's opening LINE, and that is where every remaining
+# hole lived. `[% for cat in skill_categories %]` binds the answer to a loop
+# variable, so lines gating on THAT never name the answer and check 2 cannot
+# see them — and an earlier scanner that walked the loop body still missed
+# conditionals sharing the `for` or `endfor` line itself.
 #
-#   [% for cat in skill_categories %]      <- allowlisted, subtracted
-#   [% if cat == 'universal' %]            <- no `skill_categories` anywhere
-#     - [[ cat ]]
-#   [% endif %]
-#   [% endfor %]
+# Both were symptoms of the same thing: hand-parsing Jinja. Every round of
+# review found another syntax the scanner did not model — a whitespace-control
+# modifier, a parenthesised expression, an inline ternary, a boundary line.
+# Jinja's grammar is not something a regex should be trying to follow.
 #
-# That renders content conditionally on the stale answer while the guard exits
-# 0, which is the invariant failing inside the one file the exemption protects.
-# Nothing else could reach it: the exemption is exactly where the hole is.
+# So this does not parse the loop; it PINS it. The block below is the entire
+# legitimate use of the answer in template content, all three lines of it. If
+# the file does not contain those bytes exactly, the guard fails — whether the
+# change is a nested conditional, a same-line one, a boundary-line one, an
+# inline ternary, or a form nobody has thought of yet. There is no grammar left
+# to outsmart.
 #
-# ANY conditional inside such a loop fails, not only one naming the loop
-# variable. A conditional there decides which categories reach the output, so
-# whatever it tests, the emitted list is no longer simply the answer — and the
-# exemption exists on the premise that this loop is a faithful seed. Being
-# strict costs nothing today (the loop is three lines and holds no conditional)
-# and removes a judgement call from the next reader.
-while IFS= read -r hit; do
-    [ -n "$hit" ] || continue
-    echo "FAIL: ${hit%%:*}:${hit#*:}" >&2
-    echo "      conditional inside a loop over ${ANSWER} — the loop variable" >&2
-    echo "      carries the stale answer, so this gates on it indirectly" >&2
-    fail=1
-done < <(
-    find template -type f -print 2>/dev/null | while IFS= read -r f; do
-        [ -n "$f" ] || continue
-        awk -v F="$f" -v A="${ANSWER}" '
-            # depth counts nested [% for %] once we are inside a loop over the
-            # answer; the opening line itself is never scanned for a conditional.
-            index($0, "for ") && index($0, " in " A) && depth == 0 { depth = 1; next }
-            depth > 0 {
-                if (index($0, "[% for ") || index($0, "[%- for ") || index($0, "[%+ for ")) depth++
-                if (index($0, "endfor")) { depth--; if (depth <= 0) { depth = 0; next } }
-                # Statement form `[% if %]` AND expression form
-                # `[[ x if cond else y ]]` — inside a loop over the answer both
-                # decide what the emitted list contains, and the second slipped
-                # a statement-only pattern in testing.
-                if ($0 ~ /\[%[-+]?[[:space:]]*(el)?if[[:space:](]/ ||
-                    $0 ~ /\[\[[^]]*[[:space:]]if[[:space:]]/) print F ":" NR ":" $0
-            }
-        ' "$f"
-    done
-)
+# Reformatting the loop is a deliberate act that costs one edit here, and that
+# is the point: the loop's exact shape is what the exemption in check 2 is
+# vouching for, so the two must be changed together.
+SEED_FILE='template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja'
+SEED_BLOCK='[% for cat in skill_categories %]
+  - [[ cat ]]
+[% endfor %]'
+
+if [ -f "$SEED_FILE" ]; then
+    # Compared as ONE flattened string, with newlines mapped to \001 on both
+    # sides, then matched with a quoted shell `case` — a literal substring test.
+    #
+    # NOT `grep -F`: it treats newlines in the PATTERN as pattern separators,
+    # so a multi-line -F pattern means "any one of these lines", which matches
+    # a tampered block just as happily as the real one. That version of this
+    # check was silently inert — it reported OK on every attack below — which
+    # is precisely the failure this guard exists to catch, met for the third
+    # time inside the guard itself. `grep -z` only changes the INPUT record
+    # separator and does not fix it.
+    _seed_actual=$(tr '\n' '\001' <"$SEED_FILE")
+    _seed_want=$(printf '%s' "$SEED_BLOCK" | tr '\n' '\001')
+    case "$_seed_actual" in
+    *"$_seed_want"*) _seed_ok=1 ;;
+    *) _seed_ok=0 ;;
+    esac
+    if [ "$_seed_ok" -ne 1 ]; then
+        echo "FAIL: ${SEED_FILE}" >&2
+        echo "      the ${ANSWER} seed loop is not the exact expected block:" >&2
+        printf '        %s\n' "$SEED_BLOCK" | sed 's/^/      /' >&2
+        echo "      anything else there can gate output on the stale answer." >&2
+        echo "      If the loop was reformatted deliberately, update SEED_BLOCK" >&2
+        echo "      in scripts/test-category-gates.sh to match." >&2
+        fail=1
+    fi
+fi
 
 # ── 3. copier.yml: computed answers that GATE on it ─────────────────────────
 # A `default:` derives one answer from another, and a `when:` decides whether a

--- a/scripts/test-category-gates.sh
+++ b/scripts/test-category-gates.sh
@@ -52,32 +52,77 @@ done < <(find template -name "*${ANSWER}*" -print 2>/dev/null || true)
 
 # ── 2. Jinja conditionals under template/ ───────────────────────────────────
 # `[% if %]` / `[% elif %]` decide whether a BLOCK renders — same staleness, at
-# a finer grain. `[% for %]` is deliberately absent from this pattern: iterating
-# the answer to seed a file is the legitimate use.
+# a finer grain. `[% for %]` is deliberately NOT matched: iterating the answer
+# to seed a file is the legitimate use.
 #
-# No grep -P (BSD grep lacks it). `[%` needs no escaping inside a bracket
-# expression, and the delimiters are copier's, set by _envops in copier.yml.
-while IFS= read -r hit; do
-    [ -n "$hit" ] || continue
-    echo "FAIL: ${hit}" >&2
-    fail=1
-done < <(grep -rnE "\[%-? *(el)?if [^%]*${ANSWER}" template 2>/dev/null || true)
+# Jinja statements may WRAP, and a line-based grep reads a wrapped one as two
+# lines that each look harmless — verified: a conditional split after
+# `[% if use_skills_sync` passed a line-based version of this check. So join
+# each statement into one logical line first, carrying its starting line number,
+# and match against that. Statements are delimited by copier's `[%`/`%]`
+# (_envops in copier.yml), so depth is just the running count of openers minus
+# closers.
+#
+# No grep -P (BSD grep lacks it); awk string-form separators for the same
+# portability reason.
+flatten_jinja() {
+    awk '
+        function cnt(s, pat,   a) { return split(s, a, pat) - 1 }
+        {
+            if (buf == "") { buf = $0; start = NR } else { buf = buf " " $0 }
+            if (cnt(buf, "\\[%") > cnt(buf, "%\\]")) next
+            print FILENAME ":" start ":" buf
+            buf = ""
+        }
+        END { if (buf != "") print FILENAME ":" start ":" buf }
+    ' "$1"
+}
+
+while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    while IFS= read -r hit; do
+        [ -n "$hit" ] || continue
+        echo "FAIL: ${hit}" >&2
+        fail=1
+    done < <(flatten_jinja "$file" | grep -E "\[%-? *(el)?if [^%]*${ANSWER}" || true)
+done < <(find template -type f -print 2>/dev/null || true)
 
 # ── 3. copier.yml: computed answers that GATE on it ─────────────────────────
 # A `default:` derives one answer from another, and a `when:` decides whether a
 # question is asked; either one reading `skill_categories` inherits its
 # staleness and hands it to whatever the derived answer gates.
 #
-# The question's OWN block is not an exception that needs allowlisting: its
-# `default:` seeds from `project_type` and its `when:` reads `use_skills_sync`,
-# so neither line mentions `skill_categories`. If that ever changes, this guard
-# firing on it is correct — a self-referential default is its own bug.
+# Parsed with yq rather than grepped, because a folded scalar hides the answer
+# from any line-based match — also verified: a `default: >-` wrapping before
+# `and 'universal' in skill_categories` passed a grepped version of this check,
+# while yq reports the joined value exactly. yq is already a hard dependency
+# (Brewfile, and build.yml installs it), so requiring it here adds nothing; a
+# MISSING yq is a hard failure rather than a skip, since a guard that silently
+# stops guarding is worse than no guard.
+#
+# The question's OWN block needs no allowlist entry: its `default:` seeds from
+# `project_type` and its `when:` reads `use_skills_sync`, so neither value
+# mentions `skill_categories`. If that ever changes, firing on it is correct —
+# a self-referential default is its own bug.
+if ! command -v yq >/dev/null 2>&1; then
+    echo "FAIL: yq is required to inspect copier.yml answers (brew bundle / see Brewfile)" >&2
+    exit 1
+fi
 while IFS= read -r hit; do
     [ -n "$hit" ] || continue
-    echo "FAIL: copier.yml:${hit}" >&2
+    echo "FAIL: copier.yml: ${hit}" >&2
     echo "      a computed answer gated on ${ANSWER} inherits its staleness" >&2
     fail=1
-done < <(grep -nE "^[[:space:]]*(default|when):.*${ANSWER}" copier.yml 2>/dev/null || true)
+done < <(yq -r "
+    to_entries
+    | map(select(.value | type == \"!!map\"))
+    | map(select(
+        ((.value.default // \"\") | tostring | contains(\"${ANSWER}\"))
+        or ((.value.when // \"\") | tostring | contains(\"${ANSWER}\"))
+      ))
+    | .[]
+    | .key + \": \" + ((.value.default // .value.when) | tostring)
+" copier.yml 2>/dev/null || true)
 
 if [ "$fail" -ne 0 ]; then
     cat >&2 <<'MSG'

--- a/scripts/test-category-gates.sh
+++ b/scripts/test-category-gates.sh
@@ -58,50 +58,85 @@ while IFS= read -r path; do
     fail=1
 done < <(find template -name "*${ANSWER}*" -print 2>/dev/null || true)
 
-# ── 2. Jinja conditionals under template/ ───────────────────────────────────
-# `[% if %]` / `[% elif %]` decide whether a BLOCK renders — same staleness, at
-# a finer grain. `[% for %]` is deliberately NOT matched: iterating the answer
-# to seed a file is the legitimate use.
+# ── 2. Every mention under template/, minus an allowlist ────────────────────
+# ALLOWLIST, NOT A PATTERN LIST — and that choice was made the expensive way.
+# An earlier revision enumerated the banned FORMS and was evaded three times in
+# three review rounds, each by ordinary Jinja an author would plausibly write:
 #
-# Jinja statements may WRAP, and a line-based grep reads a wrapped one as two
-# lines that each look harmless — verified: a conditional split after
-# `[% if use_skills_sync` passed a line-based version of this check. So join
-# each statement into one logical line first, carrying its starting line number,
-# and match against that. Statements are delimited by copier's `[%`/`%]`
-# (_envops in copier.yml), so depth is just the running count of openers minus
-# closers.
+#   [% if use_skills_sync
+#      and 'universal' in skill_categories %]      wrapped across lines
+#   [%+ if 'universal' in skill_categories %]      whitespace-control modifier
+#   [% if('universal' in skill_categories) %]      parenthesised expression
 #
-# BOTH whitespace-control modifiers are accepted after `[%`. Jinja allows `-`
-# (strip) and `+` (keep), and `+` is not decorative here: copier.yml sets
-# trim_blocks and lstrip_blocks, which is exactly when an author reaches for
-# `[%+` to preserve a newline. A pattern matching only `-` therefore missed an
-# ordinary block conditional — the guard's PRIMARY target — rather than an
-# exotic one. Whitespace after the modifier is [[:space:]] and not a literal
-# space, so a tab does not slip past either.
+# Each was fixed, and the next round found another. That is the shape of the
+# problem, not bad luck: Jinja's grammar is open-ended, so an enumeration of
+# what is forbidden can only ever be as complete as the last person's
+# imagination — and it reports success over everything it failed to imagine,
+# which is worse than not checking at all.
 #
-# No grep -P (BSD grep lacks it); awk string-form separators for the same
-# portability reason.
-flatten_jinja() {
-    awk '
-        function cnt(s, pat,   a) { return split(s, a, pat) - 1 }
-        {
-            if (buf == "") { buf = $0; start = NR } else { buf = buf " " $0 }
-            if (cnt(buf, "\\[%") > cnt(buf, "%\\]")) next
-            print FILENAME ":" start ":" buf
-            buf = ""
-        }
-        END { if (buf != "") print FILENAME ":" start ":" buf }
-    ' "$1"
+# So the polarity is inverted. EVERY occurrence of the answer under template/
+# fails unless it is listed below with a reason. New legitimate uses cost one
+# allowlist line; new evasions cost nothing, because there is nothing left to
+# evade. Same "intentional divergences are allowlisted, WITH REASONS" pattern
+# as scripts/audit-dogfood.sh and scripts/test-dogfood-structure.sh.
+#
+# Entries are `path|substring`, matched literally (grep -F) against the whole
+# line — never a regex, so a metacharacter in an entry cannot silently widen
+# it. Keep them narrow enough to be about the specific legitimate use: a
+# too-broad entry re-opens the hole this design closes.
+#
+#   .skills-sync.yaml…jinja|[% for cat in skill_categories %]
+#       Seeds the manifest's category list from the answer. This is the whole
+#       purpose of the question, and it is ITERATION, not a gate: it decides
+#       the file's CONTENTS, never whether the file renders. A consumer then
+#       owns that list — which is precisely the drift the guard exists for.
+#   .skills-sync.yaml…jinja|Categories came from the skill_categories
+#       Header prose telling the consumer where the list came from.
+#   CHECKLIST.md.jinja|from your `skill_categories` answer
+#       Consumer-facing prose explaining the answer.
+ALLOWLIST="
+.skills-sync.yaml[% endif %].jinja|[% for cat in skill_categories %]
+.skills-sync.yaml[% endif %].jinja|Categories came from the skill_categories
+docs/CHECKLIST.md.jinja|from your \`skill_categories\` answer
+"
+
+allowed() {
+    # $1 = path, $2 = the matched line. Literal comparisons throughout.
+    while IFS= read -r entry; do
+        [ -n "$entry" ] || continue
+        _a_path=${entry%%|*}
+        _a_text=${entry#*|}
+        case "$1" in
+        *"$_a_path"*) ;;
+        *) continue ;;
+        esac
+        case "$2" in
+        *"$_a_text"*) return 0 ;;
+        esac
+    done <<EOF
+${ALLOWLIST}
+EOF
+    return 1
 }
 
-while IFS= read -r file; do
-    [ -n "$file" ] || continue
-    while IFS= read -r hit; do
-        [ -n "$hit" ] || continue
-        echo "FAIL: ${hit}" >&2
-        fail=1
-    done < <(flatten_jinja "$file" | grep -E "\[%[-+]?[[:space:]]*(el)?if[[:space:]][^%]*${ANSWER}" || true)
-done < <(find template -type f -print 2>/dev/null || true)
+while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    # grep -n output: path:line:text — path may contain ':'? No: copier's
+    # jinja names use [% %] and spaces, never a colon, so the first two
+    # fields split cleanly.
+    hit_path=${hit%%:*}
+    hit_rest=${hit#*:}
+    hit_line=${hit_rest%%:*}
+    hit_text=${hit_rest#*:}
+    if allowed "$hit_path" "$hit_text"; then
+        continue
+    fi
+    echo "FAIL: ${hit_path}:${hit_line}" >&2
+    echo "      ${hit_text}" >&2
+    echo "      mentions ${ANSWER}; if this is a legitimate seed/prose use, add it" >&2
+    echo "      to ALLOWLIST in scripts/test-category-gates.sh WITH a reason" >&2
+    fail=1
+done < <(grep -rn "${ANSWER}" template 2>/dev/null || true)
 
 # ── 3. copier.yml: computed answers that GATE on it ─────────────────────────
 # A `default:` derives one answer from another, and a `when:` decides whether a

--- a/scripts/test-category-gates.sh
+++ b/scripts/test-category-gates.sh
@@ -80,10 +80,15 @@ done < <(find template -name "*${ANSWER}*" -print 2>/dev/null || true)
 # evade. Same "intentional divergences are allowlisted, WITH REASONS" pattern
 # as scripts/audit-dogfood.sh and scripts/test-dogfood-structure.sh.
 #
-# Entries are `path|substring`, matched literally (grep -F) against the whole
-# line — never a regex, so a metacharacter in an entry cannot silently widen
-# it. Keep them narrow enough to be about the specific legitimate use: a
-# too-broad entry re-opens the hole this design closes.
+# Entries are `path|text`. The PATH is the COMPLETE repo-relative path and is
+# compared for equality — never a substring, because a substring exemption
+# leaks to any lookalike path: with suffix matching, a stray
+# `template/foo.skills-sync.yaml[% endif %].jinja` (or a `.bak` copy) inherited
+# the real file's exemption and could carry a gate. The TEXT is matched
+# literally and subtracted from the line (see `allowed` below), never treated
+# as a regex, so a metacharacter in an entry cannot silently widen it. Keep the
+# text narrow enough to be about the specific legitimate use: a too-broad entry
+# re-opens the hole this design closes.
 #
 #   .skills-sync.yaml…jinja|[% for cat in skill_categories %]
 #       Seeds the manifest's category list from the answer. This is the whole
@@ -95,9 +100,9 @@ done < <(find template -name "*${ANSWER}*" -print 2>/dev/null || true)
 #   CHECKLIST.md.jinja|from your `skill_categories` answer
 #       Consumer-facing prose explaining the answer.
 ALLOWLIST="
-.skills-sync.yaml[% endif %].jinja|[% for cat in skill_categories %]
-.skills-sync.yaml[% endif %].jinja|Categories came from the skill_categories
-docs/CHECKLIST.md.jinja|from your \`skill_categories\` answer
+template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja|[% for cat in skill_categories %]
+template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja|Categories came from the skill_categories
+template/docs/CHECKLIST.md.jinja|from your \`skill_categories\` answer
 "
 
 # allowed PATH LINE — true only when NOTHING on the line is unaccounted for.
@@ -116,10 +121,9 @@ allowed() {
         [ -n "$entry" ] || continue
         _a_path=${entry%%|*}
         _a_text=${entry#*|}
-        case "$1" in
-        *"$_a_path"*) ;;
-        *) continue ;;
-        esac
+        # EXACT path, not a substring: a suffix match let any lookalike path
+        # inherit this exemption.
+        [ "$1" = "$_a_path" ] || continue
         # Strip ONE occurrence. Quoting inside the expansion keeps the text
         # literal, so a glob character in an entry cannot widen the match.
         case "$_a_residue" in

--- a/scripts/test-category-gates.sh
+++ b/scripts/test-category-gates.sh
@@ -160,6 +160,54 @@ while IFS= read -r hit; do
     fail=1
 done < <(grep -rn "${ANSWER}" template 2>/dev/null || true)
 
+# ── 2b. Conditionals INSIDE a loop over the answer ──────────────────────────
+# The allowlist exempts a LINE, but a `[% for cat in skill_categories %]` binds
+# the answer's values to a loop variable that other lines can then gate on —
+# and those lines never name the answer, so check 2 cannot see them:
+#
+#   [% for cat in skill_categories %]      <- allowlisted, subtracted
+#   [% if cat == 'universal' %]            <- no `skill_categories` anywhere
+#     - [[ cat ]]
+#   [% endif %]
+#   [% endfor %]
+#
+# That renders content conditionally on the stale answer while the guard exits
+# 0, which is the invariant failing inside the one file the exemption protects.
+# Nothing else could reach it: the exemption is exactly where the hole is.
+#
+# ANY conditional inside such a loop fails, not only one naming the loop
+# variable. A conditional there decides which categories reach the output, so
+# whatever it tests, the emitted list is no longer simply the answer — and the
+# exemption exists on the premise that this loop is a faithful seed. Being
+# strict costs nothing today (the loop is three lines and holds no conditional)
+# and removes a judgement call from the next reader.
+while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    echo "FAIL: ${hit%%:*}:${hit#*:}" >&2
+    echo "      conditional inside a loop over ${ANSWER} — the loop variable" >&2
+    echo "      carries the stale answer, so this gates on it indirectly" >&2
+    fail=1
+done < <(
+    find template -type f -print 2>/dev/null | while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        awk -v F="$f" -v A="${ANSWER}" '
+            # depth counts nested [% for %] once we are inside a loop over the
+            # answer; the opening line itself is never scanned for a conditional.
+            index($0, "for ") && index($0, " in " A) && depth == 0 { depth = 1; next }
+            depth > 0 {
+                if (index($0, "[% for ") || index($0, "[%- for ") || index($0, "[%+ for ")) depth++
+                if (index($0, "endfor")) { depth--; if (depth <= 0) { depth = 0; next } }
+                # Statement form `[% if %]` AND expression form
+                # `[[ x if cond else y ]]` — inside a loop over the answer both
+                # decide what the emitted list contains, and the second slipped
+                # a statement-only pattern in testing.
+                if ($0 ~ /\[%[-+]?[[:space:]]*(el)?if[[:space:](]/ ||
+                    $0 ~ /\[\[[^]]*[[:space:]]if[[:space:]]/) print F ":" NR ":" $0
+            }
+        ' "$f"
+    done
+)
+
 # ── 3. copier.yml: computed answers that GATE on it ─────────────────────────
 # A `default:` derives one answer from another, and a `when:` decides whether a
 # question is asked; either one reading `skill_categories` inherits its

--- a/scripts/test-category-gates.sh
+++ b/scripts/test-category-gates.sh
@@ -100,8 +100,18 @@ ALLOWLIST="
 docs/CHECKLIST.md.jinja|from your \`skill_categories\` answer
 "
 
+# allowed PATH LINE — true only when NOTHING on the line is unaccounted for.
+#
+# It works by SUBTRACTION, not by matching. Each applicable entry removes one
+# occurrence of its approved text from a working copy of the line; the line is
+# allowed only if no `skill_categories` survives that. An earlier version
+# returned true on the first entry that matched anywhere in the line, which
+# accepted the whole line on the strength of its approved part — appending
+# `[[ 'bad' if 'universal' in skill_categories else 'ok' ]]` to the allowlisted
+# header passed the guard. Approving the prose on a line must not approve
+# whatever else shares that line.
 allowed() {
-    # $1 = path, $2 = the matched line. Literal comparisons throughout.
+    _a_residue=$2
     while IFS= read -r entry; do
         [ -n "$entry" ] || continue
         _a_path=${entry%%|*}
@@ -110,13 +120,21 @@ allowed() {
         *"$_a_path"*) ;;
         *) continue ;;
         esac
-        case "$2" in
-        *"$_a_text"*) return 0 ;;
+        # Strip ONE occurrence. Quoting inside the expansion keeps the text
+        # literal, so a glob character in an entry cannot widen the match.
+        case "$_a_residue" in
+        *"$_a_text"*)
+            _a_residue="${_a_residue%%"$_a_text"*}${_a_residue#*"$_a_text"}"
+            ;;
         esac
     done <<EOF
 ${ALLOWLIST}
 EOF
-    return 1
+    # Anything left is unapproved.
+    case "$_a_residue" in
+    *"$ANSWER"*) return 1 ;;
+    esac
+    return 0
 }
 
 while IFS= read -r hit; do

--- a/scripts/test-category-gates.sh
+++ b/scripts/test-category-gates.sh
@@ -215,6 +215,33 @@ if [ -f "$SEED_FILE" ]; then
     fi
 fi
 
+# ── 2c. An allowlisted file may hold no MORE mentions than it is allowed ────
+# The block pin above proves a canonical seed loop EXISTS; it says nothing
+# about a second one. And check 2 exempts by line TEXT, so a duplicate of an
+# approved line is exempted just as readily as the original — append a whole
+# second `[% for cat in skill_categories %]` loop with a conditional inside it
+# and every check so far is satisfied while the file gates on the stale answer.
+#
+# So count. Each allowlisted file gets exactly as many mentions as it has
+# allowlist entries, no more. That closes duplicate loops and duplicate prose
+# alike, without either check having to reason about what the duplicate does.
+while IFS= read -r apath; do
+    [ -n "$apath" ] || continue
+    [ -f "$apath" ] || continue
+    _want=$(printf '%s\n' "$ALLOWLIST" | grep -c "^$(printf '%s' "$apath" | sed 's/[][\.*^$/]/\\&/g')|") || _want=0
+    _have=$(grep -c "${ANSWER}" "$apath") || _have=0
+    if [ "$_have" -gt "$_want" ]; then
+        echo "FAIL: ${apath}" >&2
+        echo "      ${_have} lines mention ${ANSWER} but only ${_want} are allowlisted" >&2
+        echo "      — a duplicate of an approved line is exempted just like the" >&2
+        echo "      original, so extras must be added to ALLOWLIST or removed:" >&2
+        grep -n "${ANSWER}" "$apath" | sed 's/^/        /' >&2
+        fail=1
+    fi
+done < <(printf '%s\n' "$ALLOWLIST" | while IFS= read -r e; do
+    [ -n "$e" ] && printf '%s\n' "${e%%|*}"
+done | sort -u)
+
 # ── 3. copier.yml: computed answers that GATE on it ─────────────────────────
 # A `default:` derives one answer from another, and a `when:` decides whether a
 # question is asked; either one reading `skill_categories` inherits its

--- a/scripts/test-category-gates.sh
+++ b/scripts/test-category-gates.sh
@@ -58,189 +58,124 @@ while IFS= read -r path; do
     fail=1
 done < <(find template -name "*${ANSWER}*" -print 2>/dev/null || true)
 
-# ── 2. Every mention under template/, minus an allowlist ────────────────────
-# ALLOWLIST, NOT A PATTERN LIST — and that choice was made the expensive way.
-# An earlier revision enumerated the banned FORMS and was evaded three times in
-# three review rounds, each by ordinary Jinja an author would plausibly write:
+# ── 2. Mention-lines under template/ must match EXPECTED exactly ────────────
+# PIN THE LINES, DO NOT JUDGE THEM — and that choice was made the expensive
+# way. Five earlier revisions each tried to decide whether a given occurrence
+# was acceptable, and review defeated every one with something it had not
+# modelled: a denylist of Jinja forms (beaten by a wrapped conditional, then
+# `[%+ if`, then `[% if(...)`), a per-line allowlist (beaten by a lookalike
+# path, then by a gate appended to an approved line), and a mention count
+# (beaten by trading one approved mention for another).
 #
-#   [% if use_skills_sync
-#      and 'universal' in skill_categories %]      wrapped across lines
-#   [%+ if 'universal' in skill_categories %]      whitespace-control modifier
-#   [% if('universal' in skill_categories) %]      parenthesised expression
+# The common thread is the question itself. "Is this occurrence close enough to
+# an approved one?" has an endless supply of edge cases, and every answer that
+# is not exhaustive reports success over the cases it missed — worse than not
+# checking, because `verify` going green then means less than it did.
 #
-# Each was fixed, and the next round found another. That is the shape of the
-# problem, not bad luck: Jinja's grammar is open-ended, so an enumeration of
-# what is forbidden can only ever be as complete as the last person's
-# imagination — and it reports success over everything it failed to imagine,
-# which is worse than not checking at all.
+# EXPECTED is the complete, byte-for-byte list of lines that may mention the
+# answer, grouped by the file they live in. Not patterns, not counts — the
+# literal lines. A file's mention-lines must equal its block exactly, in order.
 #
-# So the polarity is inverted. EVERY occurrence of the answer under template/
-# fails unless it is listed below with a reason. New legitimate uses cost one
-# allowlist line; new evasions cost nothing, because there is nothing left to
-# evade. Same "intentional divergences are allowlisted, WITH REASONS" pattern
-# as scripts/audit-dogfood.sh and scripts/test-dogfood-structure.sh.
+# This replaces four earlier mechanisms (a per-line allowlist, literal
+# subtraction of approved text, a per-file mention cap, and a separate
+# exact-block pin for the seed loop), each of which was defeated in review by
+# something the previous one did not model: a lookalike path, a gate appended
+# to an approved line, a duplicated approved line, and finally trading one
+# approved mention for another so the totals still matched. Every one of those
+# is a way of asking "is this occurrence close enough to an approved one?" —
+# a question with an endless supply of edge cases.
 #
-# Entries are `path|text`. The PATH is the COMPLETE repo-relative path and is
-# compared for equality — never a substring, because a substring exemption
-# leaks to any lookalike path: with suffix matching, a stray
-# `template/foo.skills-sync.yaml[% endif %].jinja` (or a `.bak` copy) inherited
-# the real file's exemption and could carry a gate. The TEXT is matched
-# literally and subtracted from the line (see `allowed` below), never treated
-# as a regex, so a metacharacter in an entry cannot silently widen it. Keep the
-# text narrow enough to be about the specific legitimate use: a too-broad entry
-# re-opens the hole this design closes.
+# Comparing the whole set removes the question. Adding a mention, removing one,
+# editing one, reordering them, or swapping one for another all change the set,
+# so all of them fail without anything here having to anticipate them.
 #
-#   .skills-sync.yaml…jinja|[% for cat in skill_categories %]
-#       Seeds the manifest's category list from the answer. This is the whole
-#       purpose of the question, and it is ITERATION, not a gate: it decides
-#       the file's CONTENTS, never whether the file renders. A consumer then
-#       owns that list — which is precisely the drift the guard exists for.
-#   .skills-sync.yaml…jinja|Categories came from the skill_categories
-#       Header prose telling the consumer where the list came from.
-#   CHECKLIST.md.jinja|from your `skill_categories` answer
-#       Consumer-facing prose explaining the answer.
-ALLOWLIST="
-template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja|[% for cat in skill_categories %]
-template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja|Categories came from the skill_categories
-template/docs/CHECKLIST.md.jinja|from your \`skill_categories\` answer
-"
+# Editing these files deliberately costs one edit to EXPECTED, which is the
+# point: these lines are the entire licensed use of the answer in template
+# content, and a change to them deserves the review that updating this forces.
+#
+# Two consequences worth stating, because they are features and not oversights:
+#   - Reformatting an approved line fails until EXPECTED is updated. Whitespace
+#     included; the comparison is byte-exact.
+#   - A file with NO mentions and no EXPECTED block is fine — it is check 2's
+#     job to reject unapproved mentions, and it does that by finding any file
+#     whose mention-lines are not empty and not in EXPECTED.
+EXPECTED_SEED_FILE='template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja'
+EXPECTED_SEED='# harmon-devkit, pinned to a tag. Categories came from the skill_categories
+[% for cat in skill_categories %]'
 
-# allowed PATH LINE — true only when NOTHING on the line is unaccounted for.
-#
-# It works by SUBTRACTION, not by matching. Each applicable entry removes one
-# occurrence of its approved text from a working copy of the line; the line is
-# allowed only if no `skill_categories` survives that. An earlier version
-# returned true on the first entry that matched anywhere in the line, which
-# accepted the whole line on the strength of its approved part — appending
-# `[[ 'bad' if 'universal' in skill_categories else 'ok' ]]` to the allowlisted
-# header passed the guard. Approving the prose on a line must not approve
-# whatever else shares that line.
-allowed() {
-    _a_residue=$2
-    while IFS= read -r entry; do
-        [ -n "$entry" ] || continue
-        _a_path=${entry%%|*}
-        _a_text=${entry#*|}
-        # EXACT path, not a substring: a suffix match let any lookalike path
-        # inherit this exemption.
-        [ "$1" = "$_a_path" ] || continue
-        # Strip ONE occurrence. Quoting inside the expansion keeps the text
-        # literal, so a glob character in an entry cannot widen the match.
-        case "$_a_residue" in
-        *"$_a_text"*)
-            _a_residue="${_a_residue%%"$_a_text"*}${_a_residue#*"$_a_text"}"
-            ;;
-        esac
-    done <<EOF
-${ALLOWLIST}
-EOF
-    # Anything left is unapproved.
-    case "$_a_residue" in
-    *"$ANSWER"*) return 1 ;;
+EXPECTED_CHECKLIST_FILE='template/docs/CHECKLIST.md.jinja'
+EXPECTED_CHECKLIST='      skill categories this repo gets (from your `skill_categories` answer). Set'
+
+# expected_for PATH — echo the approved mention-lines for PATH, or nothing.
+expected_for() {
+    case "$1" in
+    "$EXPECTED_SEED_FILE") printf '%s\n' "$EXPECTED_SEED" ;;
+    "$EXPECTED_CHECKLIST_FILE") printf '%s\n' "$EXPECTED_CHECKLIST" ;;
+    *) : ;;
     esac
-    return 0
 }
 
-while IFS= read -r hit; do
-    [ -n "$hit" ] || continue
-    # grep -n output: path:line:text — path may contain ':'? No: copier's
-    # jinja names use [% %] and spaces, never a colon, so the first two
-    # fields split cleanly.
-    hit_path=${hit%%:*}
-    hit_rest=${hit#*:}
-    hit_line=${hit_rest%%:*}
-    hit_text=${hit_rest#*:}
-    if allowed "$hit_path" "$hit_text"; then
-        continue
+# Every file under template/ that mentions the answer at all must match its
+# expected block exactly. Files with no expected block must have no mentions.
+while IFS= read -r tf; do
+    [ -n "$tf" ] || continue
+    _actual=$(grep "${ANSWER}" "$tf" 2>/dev/null) || continue
+    _want=$(expected_for "$tf")
+    [ "$_actual" = "$_want" ] && continue
+    echo "FAIL: ${tf}" >&2
+    if [ -z "$_want" ]; then
+        echo "      mentions ${ANSWER}, which no template file may do unless its" >&2
+        echo "      exact lines are listed in EXPECTED (scripts/test-category-gates.sh):" >&2
+    else
+        echo "      its ${ANSWER} lines do not match EXPECTED exactly." >&2
+        echo "      expected:" >&2
+        printf '%s\n' "$_want" | sed 's/^/        /' >&2
+        echo "      found:" >&2
     fi
-    echo "FAIL: ${hit_path}:${hit_line}" >&2
-    echo "      ${hit_text}" >&2
-    echo "      mentions ${ANSWER}; if this is a legitimate seed/prose use, add it" >&2
-    echo "      to ALLOWLIST in scripts/test-category-gates.sh WITH a reason" >&2
+    printf '%s\n' "$_actual" | sed 's/^/        /' >&2
     fail=1
-done < <(grep -rn "${ANSWER}" template 2>/dev/null || true)
+done < <(find template -type f -print 2>/dev/null || true)
 
-# ── 2b. The seed loop must be EXACTLY the known block ───────────────────────
-# Check 2 exempts the loop's opening LINE, and that is where every remaining
-# hole lived. `[% for cat in skill_categories %]` binds the answer to a loop
-# variable, so lines gating on THAT never name the answer and check 2 cannot
-# see them — and an earlier scanner that walked the loop body still missed
-# conditionals sharing the `for` or `endfor` line itself.
+# ── 2b. The seed loop's BODY must be exactly the known block ────────────────
+# Check 2 pins the lines that MENTION the answer, which cannot see the lines
+# that do not. `[% for cat in skill_categories %]` binds the answer to a loop
+# variable, so a conditional in the body gates on it while naming only `cat`:
 #
-# Both were symptoms of the same thing: hand-parsing Jinja. Every round of
-# review found another syntax the scanner did not model — a whitespace-control
-# modifier, a parenthesised expression, an inline ternary, a boundary line.
-# Jinja's grammar is not something a regex should be trying to follow.
+#   [% for cat in skill_categories %]   <- pinned by check 2
+#   [% if cat == 'universal' %]         <- no `skill_categories`, invisible there
+#     - [[ cat ]]
+#   [% endif %]
+#   [% endfor %]
 #
-# So this does not parse the loop; it PINS it. The block below is the entire
-# legitimate use of the answer in template content, all three lines of it. If
-# the file does not contain those bytes exactly, the guard fails — whether the
-# change is a nested conditional, a same-line one, a boundary-line one, an
-# inline ternary, or a form nobody has thought of yet. There is no grammar left
-# to outsmart.
-#
-# Reformatting the loop is a deliberate act that costs one edit here, and that
-# is the point: the loop's exact shape is what the exemption in check 2 is
-# vouching for, so the two must be changed together.
-SEED_FILE='template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja'
+# So the whole three-line block is pinned too. Both checks are load-bearing and
+# neither subsumes the other: check 2 catches changes to the mention-lines
+# themselves (edits, duplicates, removals, trades), this catches changes around
+# them. Dropping this one while rewriting check 2 silently reintroduced the
+# body-conditional hole, which the attack matrix caught before it shipped.
 SEED_BLOCK='[% for cat in skill_categories %]
   - [[ cat ]]
 [% endfor %]'
 
-if [ -f "$SEED_FILE" ]; then
-    # Compared as ONE flattened string, with newlines mapped to \001 on both
-    # sides, then matched with a quoted shell `case` — a literal substring test.
-    #
-    # NOT `grep -F`: it treats newlines in the PATTERN as pattern separators,
-    # so a multi-line -F pattern means "any one of these lines", which matches
-    # a tampered block just as happily as the real one. That version of this
-    # check was silently inert — it reported OK on every attack below — which
-    # is precisely the failure this guard exists to catch, met for the third
-    # time inside the guard itself. `grep -z` only changes the INPUT record
-    # separator and does not fix it.
-    _seed_actual=$(tr '\n' '\001' <"$SEED_FILE")
+if [ -f "$EXPECTED_SEED_FILE" ]; then
+    # Flattened and compared with a quoted `case` — a literal substring test.
+    # NOT `grep -F`: it reads newlines in the PATTERN as pattern separators, so
+    # a multi-line -F pattern means "any ONE of these lines" and matches a
+    # tampered block as happily as the real one. That version of this check was
+    # silently inert against every attack below.
+    _seed_actual=$(tr '\n' '\001' <"$EXPECTED_SEED_FILE")
     _seed_want=$(printf '%s' "$SEED_BLOCK" | tr '\n' '\001')
     case "$_seed_actual" in
-    *"$_seed_want"*) _seed_ok=1 ;;
-    *) _seed_ok=0 ;;
-    esac
-    if [ "$_seed_ok" -ne 1 ]; then
-        echo "FAIL: ${SEED_FILE}" >&2
+    *"$_seed_want"*) : ;;
+    *)
+        echo "FAIL: ${EXPECTED_SEED_FILE}" >&2
         echo "      the ${ANSWER} seed loop is not the exact expected block:" >&2
-        printf '        %s\n' "$SEED_BLOCK" | sed 's/^/      /' >&2
-        echo "      anything else there can gate output on the stale answer." >&2
-        echo "      If the loop was reformatted deliberately, update SEED_BLOCK" >&2
-        echo "      in scripts/test-category-gates.sh to match." >&2
+        printf '%s\n' "$SEED_BLOCK" | sed 's/^/        /' >&2
+        echo "      anything else inside it can gate output on the stale answer." >&2
+        echo "      If reformatted deliberately, update SEED_BLOCK to match." >&2
         fail=1
-    fi
+        ;;
+    esac
 fi
-
-# ── 2c. An allowlisted file may hold no MORE mentions than it is allowed ────
-# The block pin above proves a canonical seed loop EXISTS; it says nothing
-# about a second one. And check 2 exempts by line TEXT, so a duplicate of an
-# approved line is exempted just as readily as the original — append a whole
-# second `[% for cat in skill_categories %]` loop with a conditional inside it
-# and every check so far is satisfied while the file gates on the stale answer.
-#
-# So count. Each allowlisted file gets exactly as many mentions as it has
-# allowlist entries, no more. That closes duplicate loops and duplicate prose
-# alike, without either check having to reason about what the duplicate does.
-while IFS= read -r apath; do
-    [ -n "$apath" ] || continue
-    [ -f "$apath" ] || continue
-    _want=$(printf '%s\n' "$ALLOWLIST" | grep -c "^$(printf '%s' "$apath" | sed 's/[][\.*^$/]/\\&/g')|") || _want=0
-    _have=$(grep -c "${ANSWER}" "$apath") || _have=0
-    if [ "$_have" -gt "$_want" ]; then
-        echo "FAIL: ${apath}" >&2
-        echo "      ${_have} lines mention ${ANSWER} but only ${_want} are allowlisted" >&2
-        echo "      — a duplicate of an approved line is exempted just like the" >&2
-        echo "      original, so extras must be added to ALLOWLIST or removed:" >&2
-        grep -n "${ANSWER}" "$apath" | sed 's/^/        /' >&2
-        fail=1
-    fi
-done < <(printf '%s\n' "$ALLOWLIST" | while IFS= read -r e; do
-    [ -n "$e" ] && printf '%s\n' "${e%%|*}"
-done | sort -u)
 
 # ── 3. copier.yml: computed answers that GATE on it ─────────────────────────
 # A `default:` derives one answer from another, and a `when:` decides whether a


### PR DESCRIPTION
## What

Makes a convention enforceable: **no template file may render conditionally on
`skill_categories`**. Adds `scripts/test-category-gates.sh` (wired into
`verify`), plus the rule and its reasoning in `docs/conventions.md` and
`AGENTS.md`.

Root-only, like `test:template-independence` — a generated repo has no
`template/`.

## Why

`skill_categories` is recorded in `.copier-answers.yml` at scaffold time, but
the documented way to change categories afterwards is to edit
`.skills-sync.yaml` — said by the question's own help text (`copier.yml:155`)
and by the generated manifest's header. That edit never updates the answer.

**Measured, not assumed.** Scaffold with `skill_categories=["repo"]`, add
`universal` to `.skills-sync.yaml` the documented way, then `copier update`:

```
categories after update:  universal, repo          <- consumer edit INTACT
recorded answer:          skill_categories: [repo] <- STALE
```

`copier update` applies the *template's* diff rather than overwriting, so the
manifest keeps the edit — and the manifest is what `task sync:skills` reads, so
skills vendor correctly. The damage is confined to template files gated on the
**answer**, which then never render, on that update or any future one, in
exactly the repos whose skills say they should.

That is not theoretical: `claim_release_available` shipped as
`use_skills_sync and 'universal' in skill_categories`, which would have left a
repo that added `universal` the documented way vendoring the claim-writing
skills with no `claim-release.yml` to release their markers — the stranding
that workflow exists to prevent, reintroduced through its own gate. #621 fixed
that instance; this makes the class unrepeatable.

## The convention

Gate on **`use_skills_sync`** — whether the repo vendors skills at all, an
answer that cannot drift — and have the shipped file check for the asset it
needs at **runtime**. `claim-release.yml` is the worked example: it renders
whenever skills sync is on, and exits 0 with a notice when `release-claim.sh`
is absent.

Banned is *conditional* use, not every mention. Iterating the answer to **seed**
a file is the legitimate use the question exists for.

| Form | Guard |
| --- | --- |
| filename containing `skill_categories` | **fails** |
| `[% if %]` / `[% elif %]` testing it | **fails** |
| same, wrapped across lines | **fails** |
| computed answer's `default:` / `when:` | **fails** |
| same, as a folded scalar | **fails** |
| `[% for %]` iteration (seeding) | passes — legitimate |
| prose naming the answer | passes — legitimate |

## How it is checked

Both scans read **structure**, not lines, because two ordinary formatting
choices walk through a line-based grep — each verified by injecting it and
watching an earlier version of the guard exit 0:

- **Jinja statements are joined into one logical line** first (counting `[%`
  against `%]`, carrying the start line for the message), so a conditional
  wrapped after `[% if use_skills_sync` is still seen.
- **`copier.yml` is parsed with `yq`**, so a folded, literal, or quoted scalar
  all arrive as the same joined string. `copier.yml` already uses folded
  scalars for long expressions, making that the *likely* recurrence rather than
  an exotic one.

**Failures are loud, never silent.** A missing `yq`, a `yq` that cannot parse
`copier.yml` (e.g. `pip install yq`, a different tool — `build.yml` already
warns about it), or a missing `template/` all exit 1. An earlier revision used
`|| true` there and printed "category gates OK" having checked nothing, which
is the same failure the guard exists to prevent, one level up.

## Verification

- `task verify` — exit 0, clean committed tree, guard running inside it
- `task ci` — exit 0, guard running inside it
- `task challenge` — round 2 clean re-run, no P0/P1
- `task review` — round 1, no P0/P1
- `shellcheck --severity=error` + `shfmt -d` clean
- **Every behavior injected and observed**, not reasoned about: 6 gate forms
  each fail the guard; a stub `yq` exiting 2 now fails instead of passing; the
  clean tree passes; both legitimate uses still pass. `copier.yml` restored and
  diff-verified after each probe.

## Deferred findings

- [x] **Fixed here; #629 closed as completed.** `scripts/test-category-gates.sh:95` — the jinja check matches only
  `[% if %]` / `[% elif %]` **statements**, so Jinja's inline conditional
  inside a variable expression evades it:
  `[[ 'a' if 'universal' in skill_categories else 'b' ]]` passes the guard
  (confirmed by injection, exit 0). Weaker failure than the covered forms — an
  inline ternary changes *content inside a file that still renders*, so it
  cannot reproduce the motivating bug of a whole workflow never rendering.
  Deliberately not patched in the round that found it: adding one more form to
  an enumeration invites the next, and the durable fix is likely a **redesign**
  — flag every `skill_categories` occurrence under `template/` except an
  allowlist of legitimate ones (today: the `[% for %]` seed loop, and prose in
  `.skills-sync.yaml.jinja` and `CHECKLIST.md.jinja`), the same
  "divergences allowlisted with reasons" pattern the dogfood scripts use. That
  turns an open-ended enumeration into a closed set. Worth deciding
  deliberately rather than at the tail of a review loop.

  **Disposition: fixed in `1bc426e`, and #629 closed as completed.** It was
  filed as a follow-up, then pulled forward when review found a *third*
  evasion of the enumerated patterns (`[% if(...)`). Three ordinary Jinja forms
  in three rounds — each patched, each followed by another — made the
  enumeration the diagnosis rather than the fix, so the guard was inverted to
  the allowlist #629 itself recommended. That closes the inline-expression gap
  and six forms nobody had raised.

## On #622

`Refs`, deliberately, not a closing keyword — one of its four acceptance
criteria is **not** satisfied as written, and that is worth a maintainer's
judgement rather than my reinterpretation:

| # | Criterion | State |
| --- | --- | --- |
| 1 | a decision is recorded, with reasoning | met — [comment](https://github.com/evanharmon1/harmon-init/issues/622#issuecomment-5198689052) |
| 2 | adding `universal` renders `universal`-gated files, **or** the documented path cannot diverge | **neither branch is true** — see below |
| 3 | `copier.yml:155` and the manifest header agree with the mechanism | met — both already describe the answer as a *seed* and `.skills-sync.yaml` as the thing to edit, which is exactly the chosen mechanism; no edit needed |
| 4 | `task test:template:all` and `task verify` pass | met |

Criterion 2 was written before the analysis. This PR takes a third route it
does not describe: it does not make category-gated files render, and it does
not change the documented editing path — it makes such files **impossible**, so
the divergence has nothing left to break. That satisfies the issue's
*invariant* while matching neither branch of its criterion, so ticking it would
mean rewording it to fit what I built, which is the one thing a tick must never
do.

If you agree the invariant is met, that issue can be shut by hand after this
merges; otherwise criterion 2 names work still outstanding. (Phrased apart from
the issue number on purpose — a keyword written next to it would auto-close on
merge whatever the surrounding sentence meant.)

Refs #622


