### PR TITLE
fix(template): change snyk weekly cron to Sunday and add ponderous-docs to fleet

### DIFF
--- a/managed-repositories.yml
+++ b/managed-repositories.yml
@@ -14,4 +14,5 @@ repositories:
   - ponderousdev/ponderous-site
   - sommerlawn/sommerlawn-infra
   - sommerlawn/sommerlawn-site
+  - ponderousdev/ponderous-docs
   - sommerlawn/sommerlawn-zoho

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -352,7 +352,7 @@ fi
 case "$profile" in
 full)
     [ -f .github/workflows/snyk-scheduled.yml ] || err "weekly Snyk workflow did not render"
-    grep -q '23 6 \* \* 1' .github/workflows/snyk-scheduled.yml || err "weekly Snyk cron is incorrect"
+    grep -q '23 6 \* \* 0' .github/workflows/snyk-scheduled.yml || err "weekly Snyk cron is incorrect"
     ;;
 meta)
     [ -f .github/workflows/snyk-scheduled.yml ] || err "daily Snyk workflow did not render"

--- a/template/.github/workflows/[% if snyk_scan_schedule != 'off' %]snyk-scheduled.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if snyk_scan_schedule != 'off' %]snyk-scheduled.yml[% endif %].jinja
@@ -7,7 +7,7 @@ on:
 [% if snyk_scan_schedule == 'daily' %]
     - cron: "23 6 * * *"
 [% else %]
-    - cron: "23 6 * * 1"
+    - cron: "23 6 * * 0"
 [% endif %]
 
 # Advisory defense in depth only: intentionally no pull_request/push trigger and


### PR DESCRIPTION
## What

Two small fleet-config changes from the `#544` audit:

- **snyk-scheduled.yml**: weekly cron changed from Monday (`23 6 * * 1`) to Sunday (`23 6 * * 0`), matching the fleet decision to run Snyk on Sunday mornings (same day as the skills-sync workflow).
- **managed-repositories.yml**: added `ponderousdev/ponderous-docs` to the fleet inventory.

## Why

See the [fleet-wide decision table](https://github.com/evanharmon1/harmon-init/issues/544#issuecomment-5208033428) in #544.

## Verification

- `task verify` pre-push passed (skills-drift, secrets, template render)

Refs: #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)