### PR TITLE
feat(devcontainer): add Herdr for persistent remote agent sessions in Coder workspaces

### DIFF
--- a/.devcontainer/dev/devcontainer.json
+++ b/.devcontainer/dev/devcontainer.json
@@ -54,6 +54,7 @@
     "source=codex-config-evanharmon1-harmon-init-dev,target=/home/vscode/.codex,type=volume",
     "source=gemini-config-evanharmon1-harmon-init-dev,target=/home/vscode/.gemini,type=volume",
     "source=agent-deck-config-evanharmon1-harmon-init-dev,target=/home/vscode/.agent-deck,type=volume",
+    "source=herdr-config-evanharmon1-harmon-init-dev,target=/home/vscode/.config/herdr,type=volume",
     "source=shell-history-evanharmon1-harmon-init-dev,target=/home/vscode/.shell-history,type=volume",
     "source=zoxide-data-evanharmon1-harmon-init-dev,target=/home/vscode/.local/share/zoxide,type=volume"
   ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,6 +47,7 @@
     "source=codex-config-evanharmon1-harmon-init,target=/home/vscode/.codex,type=volume",
     "source=gemini-config-evanharmon1-harmon-init,target=/home/vscode/.gemini,type=volume",
     "source=agent-deck-config-evanharmon1-harmon-init,target=/home/vscode/.agent-deck,type=volume",
+    "source=herdr-config-evanharmon1-harmon-init,target=/home/vscode/.config/herdr,type=volume",
     "source=shell-history-evanharmon1-harmon-init,target=/home/vscode/.shell-history,type=volume",
     "source=zoxide-data-evanharmon1-harmon-init,target=/home/vscode/.local/share/zoxide,type=volume"
   ],

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -165,11 +165,18 @@ if [ "${CODER:-}" = "true" ] && [ -d "/home/vscode/.persistent" ]; then
     fi
     ln -sfn "/home/vscode/.persistent/zoxide" "$HOME/.local/share/zoxide"
     mkdir -p "/home/vscode/.persistent/herdr" "$HOME/.config"
+    # Unlike the agent dirs above, ~/.config/herdr can hold the only copy of
+    # session snapshots — never delete the source unless the copy succeeded.
     if [ -d "$HOME/.config/herdr" ] && [ ! -L "$HOME/.config/herdr" ]; then
-        cp -a "$HOME/.config/herdr/." "/home/vscode/.persistent/herdr/" 2>/dev/null || true
-        rm -rf "${HOME:?}/.config/herdr"
+        if cp -a "$HOME/.config/herdr/." "/home/vscode/.persistent/herdr/"; then
+            rm -rf "${HOME:?}/.config/herdr"
+        else
+            echo "WARN: Herdr state migration failed; leaving ~/.config/herdr in place (unpersisted)" >&2
+        fi
     fi
-    ln -sfn "/home/vscode/.persistent/herdr" "$HOME/.config/herdr"
+    if [ ! -e "$HOME/.config/herdr" ] || [ -L "$HOME/.config/herdr" ]; then
+        ln -sfn "/home/vscode/.persistent/herdr" "$HOME/.config/herdr"
+    fi
 fi
 
 # --- Agent-Deck config seeding ---

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -181,6 +181,21 @@ if [ "${CODER:-}" = "true" ] && [ -d "/home/vscode/.persistent" ]; then
     ln -sfn "/home/vscode/.persistent/herdr" "$HOME/.config/herdr"
 fi
 
+# --- Herdr agent integrations ---
+# resume_agents_on_restore only resumes agents whose Herdr integration has
+# recorded a native session reference, and the integration also reports
+# authoritative working/blocked state to the sidebar instead of Herdr
+# screen-scraping. The installer is version-aware and file-writing only (no
+# running server needed), so re-running on every create is safe. Guarded:
+# the pinned shared image may predate the herdr binary, and a failed install
+# only degrades resume back to fresh shells — never block the container on it.
+if command -v herdr >/dev/null 2>&1; then
+    for agent in claude codex; do
+        herdr integration install "$agent" ||
+            echo "WARN: herdr integration install $agent failed (non-fatal)" >&2
+    done
+fi
+
 # --- Agent-Deck config seeding ---
 # When a fresh volume mount shadows ~/.agent-deck, seed it from the image-baked
 # config. Source lives at /usr/local/share/ rather than /tmp/ because /tmp is a

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -166,17 +166,19 @@ if [ "${CODER:-}" = "true" ] && [ -d "/home/vscode/.persistent" ]; then
     ln -sfn "/home/vscode/.persistent/zoxide" "$HOME/.local/share/zoxide"
     mkdir -p "/home/vscode/.persistent/herdr" "$HOME/.config"
     # Unlike the agent dirs above, ~/.config/herdr can hold the only copy of
-    # session snapshots — never delete the source unless the copy succeeded.
+    # session snapshots — never delete the source unless the copy succeeded,
+    # and fail the lifecycle rather than continue unpersisted: a
+    # warn-and-continue would let Herdr write snapshots the next rebuild
+    # silently discards.
     if [ -d "$HOME/.config/herdr" ] && [ ! -L "$HOME/.config/herdr" ]; then
-        if cp -a "$HOME/.config/herdr/." "/home/vscode/.persistent/herdr/"; then
-            rm -rf "${HOME:?}/.config/herdr"
-        else
-            echo "WARN: Herdr state migration failed; leaving ~/.config/herdr in place (unpersisted)" >&2
+        if ! cp -a "$HOME/.config/herdr/." "/home/vscode/.persistent/herdr/"; then
+            echo "ERROR: Herdr state migration to ~/.persistent failed;" \
+                "fix the persistent volume and rebuild" >&2
+            exit 1
         fi
+        rm -rf "${HOME:?}/.config/herdr"
     fi
-    if [ ! -e "$HOME/.config/herdr" ] || [ -L "$HOME/.config/herdr" ]; then
-        ln -sfn "/home/vscode/.persistent/herdr" "$HOME/.config/herdr"
-    fi
+    ln -sfn "/home/vscode/.persistent/herdr" "$HOME/.config/herdr"
 fi
 
 # --- Agent-Deck config seeding ---

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -124,6 +124,7 @@ gh auth status || true
 echo "==> Fixing ownership of persistent volume dirs..."
 for dir in /home/vscode/.codex /home/vscode/.claude /home/vscode/.gemini \
     /home/vscode/.agent-deck /home/vscode/.shell-history \
+    /home/vscode/.config /home/vscode/.config/herdr \
     /home/vscode/.local /home/vscode/.local/share /home/vscode/.local/share/zoxide; do
     sudo mkdir -p "$dir"
     sudo chown vscode:vscode "$dir"

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -164,6 +164,12 @@ if [ "${CODER:-}" = "true" ] && [ -d "/home/vscode/.persistent" ]; then
         rm -rf "${HOME:?}/.local/share/zoxide"
     fi
     ln -sfn "/home/vscode/.persistent/zoxide" "$HOME/.local/share/zoxide"
+    mkdir -p "/home/vscode/.persistent/herdr" "$HOME/.config"
+    if [ -d "$HOME/.config/herdr" ] && [ ! -L "$HOME/.config/herdr" ]; then
+        cp -a "$HOME/.config/herdr/." "/home/vscode/.persistent/herdr/" 2>/dev/null || true
+        rm -rf "${HOME:?}/.config/herdr"
+    fi
+    ln -sfn "/home/vscode/.persistent/herdr" "$HOME/.config/herdr"
 fi
 
 # --- Agent-Deck config seeding ---

--- a/.devcontainer/scripts/post-start-common.sh
+++ b/.devcontainer/scripts/post-start-common.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 unset NODE_OPTIONS
 
 for dir in /home/vscode/.codex /home/vscode/.claude /home/vscode/.gemini \
-    /home/vscode/.agent-deck /home/vscode/.shell-history /home/vscode/.local/share/zoxide; do
+    /home/vscode/.agent-deck /home/vscode/.shell-history \
+    /home/vscode/.config/herdr /home/vscode/.local/share/zoxide; do
     sudo mkdir -p "$dir"
     sudo chown vscode:vscode "$dir"
     sudo chmod 700 "$dir"

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -216,11 +216,14 @@ conversations themselves persist regardless, in the `~/.claude`, `~/.codex`,
 and `~/.gemini` volumes, so a pane that restores as a plain shell can still
 resume its agent by hand (e.g. `claude --resume`).
 
-The server socket deliberately does **not** live in that volume. The image sets
-`HERDR_SOCKET_PATH=/tmp/herdr.sock` container-wide, so a socket left behind by a
-dead server cannot ride along in the persisted config directory into the next
-container. (Herdr derives the client socket from the same variable —
-`/tmp/herdr-client.sock`.)
+The default session's server socket deliberately does **not** live in that
+volume. The image sets `HERDR_SOCKET_PATH=/tmp/herdr.sock` container-wide, so a
+socket left behind by a dead server cannot ride along in the persisted config
+directory into the next container. (Herdr derives the client socket from the
+same variable — `/tmp/herdr-client.sock`.) Named sessions (`herdr --session`)
+ignore that override and keep sockets under `~/.config/herdr/sessions/<name>/`,
+so a stale named-session socket can survive a rebuild — harmless, but if a
+named session misbehaves after a rebuild, delete its `herdr.sock` and reattach.
 
 ## Secrets — 1Password Environments (the standard)
 

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -192,7 +192,9 @@ coder ssh <workspace>
 herdr
 ```
 
-or let Herdr do the SSH itself:
+or let Herdr do the SSH itself — this form runs a **local** Herdr thin client,
+so install Herdr on the laptop first (`brew install herdr`, or the installer
+at [herdr.dev](https://herdr.dev/)):
 
 ```bash
 herdr --remote coder.<workspace>

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -199,13 +199,22 @@ herdr --remote coder.<workspace>
 ```
 
 `coder config-ssh` is what writes those `coder.<workspace>` host aliases into
-your SSH config, so run it once before the `--remote` form.
+your SSH config, so run it once before the `--remote` form. Both forms work
+because Coder's agent executes **inside** the workspace container, where Herdr
+and its socket live; an SSH route that terminates on a Docker host instead
+would attach to a host-side Herdr or nothing.
 
-`~/.config/herdr` is a **named volume** (`herdr-config-…`, per profile), so
-Herdr's own state survives a rebuild: with snapshot restore and
-`resume_agents_on_restore` enabled, your agent panes come back after the
-container is rebuilt. The agent *conversations* persist separately, in the
-`~/.claude`, `~/.codex`, and `~/.gemini` volumes.
+`~/.config/herdr` is a **named volume** (`herdr-config-…`, per profile; on
+Coder it is symlinked into the `~/.persistent` volume instead), so Herdr's own
+state survives a rebuild: snapshot restore brings the workspace shape back —
+tabs, panes, cwds, layout — as fresh shells. Whether an agent *conversation*
+resumes inside its restored pane is a separate mechanism:
+`resume_agents_on_restore` only works for agents whose Herdr integration has
+been installed (`herdr integration install <agent>`) and has recorded a native
+session reference — and Gemini has no resume integration in v0.8. The
+conversations themselves persist regardless, in the `~/.claude`, `~/.codex`,
+and `~/.gemini` volumes, so a pane that restores as a plain shell can still
+resume its agent by hand (e.g. `claude --resume`).
 
 The server socket deliberately does **not** live in that volume. The image sets
 `HERDR_SOCKET_PATH=/tmp/herdr.sock` container-wide, so a socket left behind by a

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -171,6 +171,48 @@ a `TERM=… docker exec` prefix changes only the client's environment. Ask for t
 terminal you want with `-e`:
 `docker exec -e TERM=xterm-256color -it <container> bash`.
 
+## Persistent agent sessions (Herdr)
+
+**Herdr** is the agent-session runtime in both profiles: it owns the panes your
+coding agents run in and tracks each one's state (working / blocked / idle) so
+you can see at a glance which agent is waiting on you. `zellij` and `tmux` are
+still installed and still the right tool for general terminal multiplexing —
+Herdr is not a replacement for them, it is the layer that knows what an *agent*
+pane is doing.
+
+The server **auto-starts on the first `herdr` invocation**. There is no `herdr
+server start` subcommand to run first, and looking for one is the usual way to
+waste ten minutes; to check whether a server is already live, run `herdr
+status`.
+
+To attach from a laptop, either SSH in and run it there:
+
+```bash
+coder ssh <workspace>
+herdr
+```
+
+or let Herdr do the SSH itself:
+
+```bash
+herdr --remote coder.<workspace>
+```
+
+`coder config-ssh` is what writes those `coder.<workspace>` host aliases into
+your SSH config, so run it once before the `--remote` form.
+
+`~/.config/herdr` is a **named volume** (`herdr-config-…`, per profile), so
+Herdr's own state survives a rebuild: with snapshot restore and
+`resume_agents_on_restore` enabled, your agent panes come back after the
+container is rebuilt. The agent *conversations* persist separately, in the
+`~/.claude`, `~/.codex`, and `~/.gemini` volumes.
+
+The server socket deliberately does **not** live in that volume. The image sets
+`HERDR_SOCKET_PATH=/tmp/herdr.sock` container-wide, so a socket left behind by a
+dead server cannot ride along in the persisted config directory into the next
+container. (Herdr derives the client socket from the same variable —
+`/tmp/herdr-client.sock`.)
+
 ## Secrets — 1Password Environments (the standard)
 
 Don't hand-write or copy `devcontainer.env`. The standard is **1Password

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -212,8 +212,9 @@ state survives a rebuild: snapshot restore brings the workspace shape back —
 tabs, panes, cwds, layout — as fresh shells. Whether an agent *conversation*
 resumes inside its restored pane is a separate mechanism:
 `resume_agents_on_restore` only works for agents whose Herdr integration has
-been installed (`herdr integration install <agent>`) and has recorded a native
-session reference — and Gemini has no resume integration in v0.8. The
+recorded a native session reference. post-create installs the Claude Code and
+Codex integrations automatically (`herdr integration install`, idempotent) —
+Gemini has no resume integration in v0.8. The
 conversations themselves persist regardless, in the `~/.claude`, `~/.codex`,
 and `~/.gemini` volumes, so a pane that restores as a plain shell can still
 resume its agent by hand (e.g. `claude --resume`).

--- a/images/devcontainer/Dockerfile
+++ b/images/devcontainer/Dockerfile
@@ -298,9 +298,12 @@ RUN case "${TARGETARCH}" in \
         -o /usr/local/bin/herdr \
     && chmod +x /usr/local/bin/herdr
 
-# Keep Herdr's server socket out of ~/.config/herdr — that directory is
-# volume-persisted across rebuilds and a stale socket must not ride along.
-# (Herdr derives the client socket from this too: /tmp/herdr-client.sock.)
+# Keep Herdr's default-session server socket out of ~/.config/herdr — that
+# directory is volume-persisted across rebuilds and a stale socket must not
+# ride along. (Herdr derives the client socket from this too:
+# /tmp/herdr-client.sock. Named sessions ignore this override and keep their
+# sockets under ~/.config/herdr/sessions/<name>/, where a stale one may
+# persist — harmless but not covered.)
 ENV HERDR_SOCKET_PATH=/tmp/herdr.sock
 
 # ---------- Python and prompt tooling ----------

--- a/images/devcontainer/Dockerfile
+++ b/images/devcontainer/Dockerfile
@@ -34,6 +34,9 @@ ARG GEMINI_CLI_VERSION=0.53.0
 ARG AGENT_DECK_VERSION=1.10.11
 # renovate: datasource=github-releases depName=joshmedeski/sesh extractVersion=^v?(?<version>.+)$
 ARG SESH_VERSION=2.28.0
+# renovate: datasource=github-releases depName=herdrdev/herdr extractVersion=^v?(?<version>.+)$
+# Apache-2.0 as of v0.8.0 (AGPL-3.0 before) — never pin below 0.8.0
+ARG HERDR_VERSION=0.8.0
 # renovate: datasource=npm depName=dmux
 ARG DMUX_VERSION=5.10.0
 # renovate: datasource=pypi depName=semgrep
@@ -273,8 +276,10 @@ RUN case "${TARGETARCH}" in \
 
 # ---------- terminal / workflow tools ----------
 RUN case "${TARGETARCH}" in \
-        "amd64") export ZELLIJ_ARCH="x86_64" WORKMUX_ARCH="amd64" AOE_ARCH="amd64" AGENT_DECK_ARCH="amd64" SESH_ARCH="x86_64" ;; \
-        "arm64") export ZELLIJ_ARCH="aarch64" WORKMUX_ARCH="arm64" AOE_ARCH="arm64" AGENT_DECK_ARCH="arm64" SESH_ARCH="arm64" ;; \
+        "amd64") export ZELLIJ_ARCH="x86_64" WORKMUX_ARCH="amd64" AOE_ARCH="amd64" AGENT_DECK_ARCH="amd64" SESH_ARCH="x86_64" \
+            HERDR_ARCH="x86_64" ;; \
+        "arm64") export ZELLIJ_ARCH="aarch64" WORKMUX_ARCH="arm64" AOE_ARCH="arm64" AGENT_DECK_ARCH="arm64" SESH_ARCH="arm64" \
+            HERDR_ARCH="aarch64" ;; \
         *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac \
     && curl -fsSL "https://github.com/zellij-org/zellij/releases/download/v${ZELLIJ_VERSION}/zellij-${ZELLIJ_ARCH}-unknown-linux-musl.tar.gz" \
@@ -288,7 +293,15 @@ RUN case "${TARGETARCH}" in \
     && curl -fsSL "https://github.com/asheshgoplani/agent-deck/releases/download/v${AGENT_DECK_VERSION}/agent-deck_${AGENT_DECK_VERSION}_linux_${AGENT_DECK_ARCH}.tar.gz" \
         | tar -xz -C /usr/local/bin agent-deck \
     && curl -fsSL "https://github.com/joshmedeski/sesh/releases/download/v${SESH_VERSION}/sesh_Linux_${SESH_ARCH}.tar.gz" \
-        | tar -xz -C /usr/local/bin sesh
+        | tar -xz -C /usr/local/bin sesh \
+    && curl -fsSL "https://github.com/herdrdev/herdr/releases/download/v${HERDR_VERSION}/herdr-linux-${HERDR_ARCH}" \
+        -o /usr/local/bin/herdr \
+    && chmod +x /usr/local/bin/herdr
+
+# Keep Herdr's server socket out of ~/.config/herdr — that directory is
+# volume-persisted across rebuilds and a stale socket must not ride along.
+# (Herdr derives the client socket from this too: /tmp/herdr-client.sock.)
+ENV HERDR_SOCKET_PATH=/tmp/herdr.sock
 
 # ---------- Python and prompt tooling ----------
 RUN curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | env UV_INSTALL_DIR="${UV_INSTALL_DIR}" sh
@@ -348,6 +361,7 @@ RUN chmod 0755 \
         "gemini-cli=${GEMINI_CLI_VERSION}" \
         "agent-deck=${AGENT_DECK_VERSION}" \
         "sesh=${SESH_VERSION}" \
+        "herdr=${HERDR_VERSION}" \
         "dmux=${DMUX_VERSION}" \
         "semgrep=${SEMGREP_VERSION}" \
         "playwright=${PLAYWRIGHT_VERSION}" \

--- a/images/devcontainer/smoke.sh
+++ b/images/devcontainer/smoke.sh
@@ -26,7 +26,7 @@ if [ -n "${EXPECTED_ARCHITECTURE:-}" ]; then
 fi
 
 for tool in task shfmt hadolint actionlint terraform-docs yq lefthook gitleaks sops act uv semgrep \
-    claude codex gemini agent-deck playwright playwright-cli zellij workmux aoe sesh dmux starship \
+    claude codex gemini agent-deck playwright playwright-cli zellij workmux aoe sesh herdr dmux starship \
     dive fx glow lazygit tokei xh gum gh-dash wtfutil lychee tv; do
     command -v "$tool" >/dev/null 2>&1 || fail "$tool is not on PATH"
 done
@@ -62,6 +62,7 @@ run_version playwright-cli playwright-cli --help
 run_version zellij zellij --version
 run_version aoe aoe --version
 run_version sesh sesh --version
+run_version herdr herdr --version
 run_version starship starship --version
 run_version dive dive --version
 run_version fx fx --version

--- a/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
@@ -66,6 +66,7 @@
     "source=codex-config-[[ github_org ]]-[[ project_slug ]]-dev,target=/home/vscode/.codex,type=volume",
     "source=gemini-config-[[ github_org ]]-[[ project_slug ]]-dev,target=/home/vscode/.gemini,type=volume",
     "source=agent-deck-config-[[ github_org ]]-[[ project_slug ]]-dev,target=/home/vscode/.agent-deck,type=volume",
+    "source=herdr-config-[[ github_org ]]-[[ project_slug ]]-dev,target=/home/vscode/.config/herdr,type=volume",
     "source=shell-history-[[ github_org ]]-[[ project_slug ]]-dev,target=/home/vscode/.shell-history,type=volume",
     "source=zoxide-data-[[ github_org ]]-[[ project_slug ]]-dev,target=/home/vscode/.local/share/zoxide,type=volume"
   ],

--- a/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
@@ -59,6 +59,7 @@
     "source=codex-config-[[ github_org ]]-[[ project_slug ]],target=/home/vscode/.codex,type=volume",
     "source=gemini-config-[[ github_org ]]-[[ project_slug ]],target=/home/vscode/.gemini,type=volume",
     "source=agent-deck-config-[[ github_org ]]-[[ project_slug ]],target=/home/vscode/.agent-deck,type=volume",
+    "source=herdr-config-[[ github_org ]]-[[ project_slug ]],target=/home/vscode/.config/herdr,type=volume",
     "source=shell-history-[[ github_org ]]-[[ project_slug ]],target=/home/vscode/.shell-history,type=volume",
     "source=zoxide-data-[[ github_org ]]-[[ project_slug ]],target=/home/vscode/.local/share/zoxide,type=volume"
   ],

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -165,11 +165,18 @@ if [ "${CODER:-}" = "true" ] && [ -d "/home/vscode/.persistent" ]; then
     fi
     ln -sfn "/home/vscode/.persistent/zoxide" "$HOME/.local/share/zoxide"
     mkdir -p "/home/vscode/.persistent/herdr" "$HOME/.config"
+    # Unlike the agent dirs above, ~/.config/herdr can hold the only copy of
+    # session snapshots — never delete the source unless the copy succeeded.
     if [ -d "$HOME/.config/herdr" ] && [ ! -L "$HOME/.config/herdr" ]; then
-        cp -a "$HOME/.config/herdr/." "/home/vscode/.persistent/herdr/" 2>/dev/null || true
-        rm -rf "${HOME:?}/.config/herdr"
+        if cp -a "$HOME/.config/herdr/." "/home/vscode/.persistent/herdr/"; then
+            rm -rf "${HOME:?}/.config/herdr"
+        else
+            echo "WARN: Herdr state migration failed; leaving ~/.config/herdr in place (unpersisted)" >&2
+        fi
     fi
-    ln -sfn "/home/vscode/.persistent/herdr" "$HOME/.config/herdr"
+    if [ ! -e "$HOME/.config/herdr" ] || [ -L "$HOME/.config/herdr" ]; then
+        ln -sfn "/home/vscode/.persistent/herdr" "$HOME/.config/herdr"
+    fi
 fi
 
 # --- Agent-Deck config seeding ---

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -181,6 +181,21 @@ if [ "${CODER:-}" = "true" ] && [ -d "/home/vscode/.persistent" ]; then
     ln -sfn "/home/vscode/.persistent/herdr" "$HOME/.config/herdr"
 fi
 
+# --- Herdr agent integrations ---
+# resume_agents_on_restore only resumes agents whose Herdr integration has
+# recorded a native session reference, and the integration also reports
+# authoritative working/blocked state to the sidebar instead of Herdr
+# screen-scraping. The installer is version-aware and file-writing only (no
+# running server needed), so re-running on every create is safe. Guarded:
+# the pinned shared image may predate the herdr binary, and a failed install
+# only degrades resume back to fresh shells — never block the container on it.
+if command -v herdr >/dev/null 2>&1; then
+    for agent in claude codex; do
+        herdr integration install "$agent" ||
+            echo "WARN: herdr integration install $agent failed (non-fatal)" >&2
+    done
+fi
+
 # --- Agent-Deck config seeding ---
 # When a fresh volume mount shadows ~/.agent-deck, seed it from the image-baked
 # config. Source lives at /usr/local/share/ rather than /tmp/ because /tmp is a

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -166,17 +166,19 @@ if [ "${CODER:-}" = "true" ] && [ -d "/home/vscode/.persistent" ]; then
     ln -sfn "/home/vscode/.persistent/zoxide" "$HOME/.local/share/zoxide"
     mkdir -p "/home/vscode/.persistent/herdr" "$HOME/.config"
     # Unlike the agent dirs above, ~/.config/herdr can hold the only copy of
-    # session snapshots — never delete the source unless the copy succeeded.
+    # session snapshots — never delete the source unless the copy succeeded,
+    # and fail the lifecycle rather than continue unpersisted: a
+    # warn-and-continue would let Herdr write snapshots the next rebuild
+    # silently discards.
     if [ -d "$HOME/.config/herdr" ] && [ ! -L "$HOME/.config/herdr" ]; then
-        if cp -a "$HOME/.config/herdr/." "/home/vscode/.persistent/herdr/"; then
-            rm -rf "${HOME:?}/.config/herdr"
-        else
-            echo "WARN: Herdr state migration failed; leaving ~/.config/herdr in place (unpersisted)" >&2
+        if ! cp -a "$HOME/.config/herdr/." "/home/vscode/.persistent/herdr/"; then
+            echo "ERROR: Herdr state migration to ~/.persistent failed;" \
+                "fix the persistent volume and rebuild" >&2
+            exit 1
         fi
+        rm -rf "${HOME:?}/.config/herdr"
     fi
-    if [ ! -e "$HOME/.config/herdr" ] || [ -L "$HOME/.config/herdr" ]; then
-        ln -sfn "/home/vscode/.persistent/herdr" "$HOME/.config/herdr"
-    fi
+    ln -sfn "/home/vscode/.persistent/herdr" "$HOME/.config/herdr"
 fi
 
 # --- Agent-Deck config seeding ---

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -124,6 +124,7 @@ gh auth status || true
 echo "==> Fixing ownership of persistent volume dirs..."
 for dir in /home/vscode/.codex /home/vscode/.claude /home/vscode/.gemini \
     /home/vscode/.agent-deck /home/vscode/.shell-history \
+    /home/vscode/.config /home/vscode/.config/herdr \
     /home/vscode/.local /home/vscode/.local/share /home/vscode/.local/share/zoxide; do
     sudo mkdir -p "$dir"
     sudo chown vscode:vscode "$dir"

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -164,6 +164,12 @@ if [ "${CODER:-}" = "true" ] && [ -d "/home/vscode/.persistent" ]; then
         rm -rf "${HOME:?}/.local/share/zoxide"
     fi
     ln -sfn "/home/vscode/.persistent/zoxide" "$HOME/.local/share/zoxide"
+    mkdir -p "/home/vscode/.persistent/herdr" "$HOME/.config"
+    if [ -d "$HOME/.config/herdr" ] && [ ! -L "$HOME/.config/herdr" ]; then
+        cp -a "$HOME/.config/herdr/." "/home/vscode/.persistent/herdr/" 2>/dev/null || true
+        rm -rf "${HOME:?}/.config/herdr"
+    fi
+    ln -sfn "/home/vscode/.persistent/herdr" "$HOME/.config/herdr"
 fi
 
 # --- Agent-Deck config seeding ---

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-start-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-start-common.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 unset NODE_OPTIONS
 
 for dir in /home/vscode/.codex /home/vscode/.claude /home/vscode/.gemini \
-    /home/vscode/.agent-deck /home/vscode/.shell-history /home/vscode/.local/share/zoxide; do
+    /home/vscode/.agent-deck /home/vscode/.shell-history \
+    /home/vscode/.config/herdr /home/vscode/.local/share/zoxide; do
     sudo mkdir -p "$dir"
     sudo chown vscode:vscode "$dir"
     sudo chmod 700 "$dir"

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -168,6 +168,49 @@ a `TERM=… docker exec` prefix changes only the client's environment. Ask for t
 terminal you want with `-e`:
 `docker exec -e TERM=xterm-256color -it <container> bash`.
 
+## Persistent agent sessions (Herdr)
+
+**Herdr** is the agent-session runtime in both profiles: it owns the panes your
+coding agents run in and tracks each one's state (working / blocked / idle) so
+you can see at a glance which agent is waiting on you. `zellij` and `tmux` are
+still installed and still the right tool for general terminal multiplexing —
+Herdr is not a replacement for them, it is the layer that knows what an *agent*
+pane is doing.
+
+The server **auto-starts on the first `herdr` invocation**. There is no `herdr
+server start` subcommand to run first; to check whether a server is already
+live, run `herdr status`.
+
+To attach from another machine, either SSH into the container's host and run it
+there:
+
+```bash
+ssh <host>
+herdr
+```
+
+or let Herdr do the SSH itself — it wraps `ssh`, so it uses whatever host alias
+your SSH config defines:
+
+```bash
+herdr --remote <ssh-host>
+```
+
+On Coder, `coder ssh <workspace>` is the first form and `coder config-ssh`
+writes the `coder.<workspace>` aliases the second form can target.
+
+`~/.config/herdr` is a **named volume** (`herdr-config-…`, one per profile), so
+Herdr's own state survives a rebuild: with snapshot restore and
+`resume_agents_on_restore` enabled, your agent panes come back after the
+container is rebuilt. The agent *conversations* persist separately, in the
+`~/.claude`, `~/.codex`, and `~/.gemini` volumes.
+
+The server socket deliberately does **not** live in that volume. The image sets
+`HERDR_SOCKET_PATH=/tmp/herdr.sock` container-wide, so a socket left behind by a
+dead server cannot ride along in the persisted config directory into the next
+container. (Herdr derives the client socket from the same variable —
+`/tmp/herdr-client.sock`.)
+
 ## Secrets — 1Password Environments (the standard)
 
 Don't hand-write or copy `devcontainer.env`. The standard is **1Password

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -195,7 +195,9 @@ herdr
 
 or let Herdr do the SSH itself — it wraps `ssh`, so it uses whatever host alias
 your SSH config defines (on Coder, `coder config-ssh` writes the
-`coder.<workspace>` aliases):
+`coder.<workspace>` aliases). This form runs a local Herdr thin client, so
+install Herdr on the machine you attach from first (`brew install herdr` on
+macOS, or the installer at [herdr.dev](https://herdr.dev/)):
 
 ```bash
 herdr --remote <container-ssh-host>

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -213,11 +213,14 @@ conversations themselves persist regardless, in the `~/.claude`, `~/.codex`,
 and `~/.gemini` volumes, so a pane that restores as a plain shell can still
 resume its agent by hand (e.g. `claude --resume`).
 
-The server socket deliberately does **not** live in that volume. The image sets
-`HERDR_SOCKET_PATH=/tmp/herdr.sock` container-wide, so a socket left behind by a
-dead server cannot ride along in the persisted config directory into the next
-container. (Herdr derives the client socket from the same variable —
-`/tmp/herdr-client.sock`.)
+The default session's server socket deliberately does **not** live in that
+volume. The image sets `HERDR_SOCKET_PATH=/tmp/herdr.sock` container-wide, so a
+socket left behind by a dead server cannot ride along in the persisted config
+directory into the next container. (Herdr derives the client socket from the
+same variable — `/tmp/herdr-client.sock`.) Named sessions (`herdr --session`)
+ignore that override and keep sockets under `~/.config/herdr/sessions/<name>/`,
+so a stale named-session socket can survive a rebuild — harmless, but if a
+named session misbehaves after a rebuild, delete its `herdr.sock` and reattach.
 
 ## Secrets — 1Password Environments (the standard)
 

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -181,29 +181,37 @@ The server **auto-starts on the first `herdr` invocation**. There is no `herdr
 server start` subcommand to run first; to check whether a server is already
 live, run `herdr status`.
 
-To attach from another machine, either SSH into the container's host and run it
-there:
+To attach from another machine, SSH in and run `herdr` — with the caveat that
+the SSH endpoint must execute **inside the devcontainer**, where this image
+installed Herdr and configured its socket. An SSH server that terminates on the
+Docker host attaches you to a host-side Herdr (or nothing at all). On Coder the
+agent runs inside the workspace container, so `coder ssh <workspace>` lands in
+the right place:
 
 ```bash
-ssh <host>
+ssh <container-ssh-host>
 herdr
 ```
 
 or let Herdr do the SSH itself — it wraps `ssh`, so it uses whatever host alias
-your SSH config defines:
+your SSH config defines (on Coder, `coder config-ssh` writes the
+`coder.<workspace>` aliases):
 
 ```bash
-herdr --remote <ssh-host>
+herdr --remote <container-ssh-host>
 ```
 
-On Coder, `coder ssh <workspace>` is the first form and `coder config-ssh`
-writes the `coder.<workspace>` aliases the second form can target.
-
-`~/.config/herdr` is a **named volume** (`herdr-config-…`, one per profile), so
-Herdr's own state survives a rebuild: with snapshot restore and
-`resume_agents_on_restore` enabled, your agent panes come back after the
-container is rebuilt. The agent *conversations* persist separately, in the
-`~/.claude`, `~/.codex`, and `~/.gemini` volumes.
+`~/.config/herdr` is a **named volume** (`herdr-config-…`, one per profile; on
+Coder it is symlinked into the `~/.persistent` volume instead), so Herdr's own
+state survives a rebuild: snapshot restore brings the workspace shape back —
+tabs, panes, cwds, layout — as fresh shells. Whether an agent *conversation*
+resumes inside its restored pane is a separate mechanism:
+`resume_agents_on_restore` only works for agents whose Herdr integration has
+been installed (`herdr integration install <agent>`) and has recorded a native
+session reference — and Gemini has no resume integration in v0.8. The
+conversations themselves persist regardless, in the `~/.claude`, `~/.codex`,
+and `~/.gemini` volumes, so a pane that restores as a plain shell can still
+resume its agent by hand (e.g. `claude --resume`).
 
 The server socket deliberately does **not** live in that volume. The image sets
 `HERDR_SOCKET_PATH=/tmp/herdr.sock` container-wide, so a socket left behind by a

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -209,8 +209,9 @@ state survives a rebuild: snapshot restore brings the workspace shape back —
 tabs, panes, cwds, layout — as fresh shells. Whether an agent *conversation*
 resumes inside its restored pane is a separate mechanism:
 `resume_agents_on_restore` only works for agents whose Herdr integration has
-been installed (`herdr integration install <agent>`) and has recorded a native
-session reference — and Gemini has no resume integration in v0.8. The
+recorded a native session reference. post-create installs the Claude Code and
+Codex integrations automatically (`herdr integration install`, idempotent) —
+Gemini has no resume integration in v0.8. The
 conversations themselves persist regardless, in the `~/.claude`, `~/.codex`,
 and `~/.gemini` volumes, so a pane that restores as a plain shell can still
 resume its agent by hand (e.g. `claude --resume`).


### PR DESCRIPTION
## What

Adds the [Herdr](https://herdr.dev) terminal runtime (v0.8.0, Apache-2.0) to the devcontainer stack so coding-agent sessions persist across disconnects and rebuilds — the always-on Coder workspace workflow from #636:

- **Shared image** (`images/devcontainer/Dockerfile`): Renovate-pinned `HERDR_VERSION=0.8.0` (license comment forbids pinning below the AGPL→Apache boundary), multi-arch binary install, `herdr` in the smoke test, and container-wide `HERDR_SOCKET_PATH=/tmp/herdr.sock` so the default-session socket stays out of persisted state.
- **Persistence**: `herdr-config-*` named volume for `~/.config/herdr` in all four devcontainer profiles (root + dev, both layers); on Coder (where envbuilder ignores named mounts) the directory is migrated and symlinked into `~/.persistent` with a copy-before-delete guard; both lifecycle ownership loops chown it.
- **Docs** (root guide + template twin): tool split (Herdr for agent sessions, zellij/tmux for general multiplexing), attach flows (`coder ssh` / `herdr --remote`, with the inside-the-container SSH-endpoint caveat), accurate resume semantics (`resume_agents_on_restore` needs `herdr integration install <agent>`; Gemini has none in v0.8; manual resume from the persisted conversation volumes is the fallback), and the named-session socket caveat.

## Why

Refs #636 (persistent remote agent sessions in Coder workspaces). Not `Closes`: the operator SSH-attach acceptance criterion is only verifiable after the image publishes and the consumer pin bumps, and the headless-server-start question remains an open follow-up in the issue.

## Release sequencing

The shared-image sha cannot exist before this merges (two-phase publish flow by design), so between this merge and the consumer-pin PR the pinned image lacks `herdr` — everything degrades gracefully (empty volume dir, docs ahead of the binary), but **merge the follow-up pin PR before cutting the next release** so consumers don't render docs for a missing tool.

## Verification

- `task verify` green after every round; final `task ci` (verify + skills drift + devcontainer assert + security) green on the committed tree.
- `task challenge`: 4 rounds — 4 P1s confirmed+fixed (volume ownership, Coder persistence routing, resume overpromise, migration data-loss guard), 1 P1 rejected by-design (pin sequencing, above), round 4 clean.
- `task review`: clean on round 1.
- `hadolint` clean; dogfood parity (82 verbatim twins) + structure (191 sections) green.
- Upstream facts (asset names, `--version`, `herdr status`, no `server start`, `HERDR_SOCKET_PATH` + derived client socket) verified against herdrdev/herdr v0.8.0.

## Deferred findings

- [x] `.devcontainer/scripts/post-create-common.sh:171-175` (and template twin) — a failed Coder Herdr migration warns and continues, so Herdr keeps writing unpersisted snapshots the next rebuild discards; consider failing closed (or blocking use) until migration succeeds. — fixed in 1860ed1 (migration failure now fails post-create; source retained)
- [x] `template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja:196-202` (and root twin) — `herdr --remote` needs Herdr installed on the laptop (thin client); docs advertise the form without the host-install prerequisite (e.g. `brew install herdr`). — fixed in 1860ed1 (both twins document the local thin-client install)
- [x] `.devcontainer/scripts/post-create-common.sh:171-172` (and template twin) — no regression test covers the Coder Herdr migration (fresh state / successful migration / failed copy retains source); consider a shell fixture. — filed as #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)

