### PR TITLE
fix(devcontainer): warn when an allow-listed secret is missing everywhere

### DIFF
--- a/.devcontainer/scripts/init-env.sh
+++ b/.devcontainer/scripts/init-env.sh
@@ -130,10 +130,45 @@ done
 # For allowed vars, replace any stale entry with the current host value.
 # Vars not present in the host env are left untouched, so values
 # populated out-of-band (e.g. from 1Password) survive rebuilds.
+#
+# A var missing from BOTH the host env and the env-file is a different case: it
+# is not an out-of-band value being preserved, it is a value nothing will
+# supply. Silence there is how a missing TS_AUTHKEY went unnoticed for hours in
+# a Coder workspace — the container came up fine and only the Tailscale-
+# dependent step failed, far from the cause. So collect those and warn on
+# stderr below.
+#
+# The loop is over ALLOWED_VARS — the post-filter allow-list — NOT over
+# BASE_MANAGED_VARS or EVICT_VARS. That is load-bearing for the profile
+# boundary, not just tidiness: the bot profile deliberately omits TS_AUTHKEY
+# (no tailnet path from a bypassPermissions container), so warning from the
+# managed set would print "TS_AUTHKEY missing" on every bot rebuild —
+# advertising a credential that profile must never hold, and training the
+# reader to expect one. A var this profile is not allowed to populate is not
+# missing; it is correctly absent.
+missing=""
 for var in "${ALLOWED_VARS[@]}"; do
     val="${!var:-}"
     if [ -n "$val" ]; then
         strip_var "$var" "$ENV_FILE"
         echo "${var}=${val}" >>"$ENV_FILE"
+    elif ! grep -q "^${var}=." "$ENV_FILE"; then
+        # `=.` requires at least one character after the `=`: a bare "VAR="
+        # line (or a host var exported empty, which "${!var:-}" already treats
+        # as unset) leaves the container with no usable value, so it warns the
+        # same as a wholly absent one. Var names come from KNOWN_VARS, so they
+        # carry no regex metacharacters.
+        missing="${missing:+$missing }${var}"
     fi
 done
+
+# Names only, never values — this lands in build logs. Non-fatal by design: a
+# rebuild must not be blocked by an optional secret, and this script runs as
+# initializeCommand on the HOST, where a non-zero exit aborts the whole
+# container build.
+if [ -n "$missing" ]; then
+    echo "init-env.sh: warning: allow-listed but unset in the host env and absent from ${ENV_FILE}:" >&2
+    echo "init-env.sh:   ${missing}" >&2
+    echo "init-env.sh: the container will start without them. On Coder/Codespaces set them as" >&2
+    echo "init-env.sh: workspace/repo secrets; locally populate the env-file from 1Password." >&2
+fi

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -305,6 +305,32 @@ captures the same variables from the **host environment**, where they arrive as
 workspace/template parameters. It does **not** call `op` itself — 1Password
 Environments is what supplies the values locally.
 
+A variable already in the env-file but absent from the host env is **left
+alone** — that is how a 1Password-managed value survives a rebuild when you
+haven't also exported it in your shell.
+
+If a variable is missing from **both** places, though, nothing will supply it,
+and `init-env.sh` prints a warning to stderr naming the variables (never their
+values) in the container-build log:
+
+```text
+init-env.sh: warning: allow-listed but unset in the host env and absent from .devcontainer/dev/devcontainer.env:
+init-env.sh:   TS_AUTHKEY
+init-env.sh: the container will start without them. On Coder/Codespaces set them as
+init-env.sh: workspace/repo secrets; locally populate the env-file from 1Password.
+```
+
+The build still succeeds — a missing optional secret must not block a rebuild,
+and `initializeCommand` runs on the host, where a non-zero exit aborts the whole
+build. So this is a signal to read, not a failure. Without it the container comes
+up clean and only the dependent step fails later, far from the cause: a missing
+`TS_AUTHKEY` went unnoticed for hours in a Coder workspace that way.
+
+The warning covers **only** the vars this profile's allow-list permits, so the
+bot profile never reports `TS_AUTHKEY` missing. Its absence there is correct —
+that profile has no tailnet path at all — and naming it would advertise a
+credential the bot container must never hold.
+
 ## Run it in Coder
 
 The devcontainers are Coder-ready: the `CODER` env is passed through, the
@@ -328,6 +354,16 @@ repo** (one template serves every repo). To stand this repo up in Coder:
      `KIMI_API_KEY`/`MOONSHOT_API_KEY`,
      `DEEPSEEK_API_KEY`, `ZAI_API_KEY` for the alt-model wrappers. Coder passes these
      into the workspace's host environment, where `init-env.sh` picks them up.
+
+   Coder is the case where this matters most: there is no 1Password app in the
+   workspace, so a **workspace parameter is the only way a secret arrives**. A
+   parameter you forget to set is not backfilled from anywhere — the env-file
+   starts empty on a fresh workspace, so the variable is simply absent. Check
+   the build log for the `init-env.sh: warning:` lines above before assuming a
+   workspace is fully provisioned; they name exactly what did not arrive. On a
+   **rebuild** of an existing workspace the env-file may still hold a value from
+   an earlier build, which is why the warning fires only when both sources are
+   empty.
 3. The build pulls `ghcr.io/evanharmon1/harmon-init-devcontainer` from GHCR as a cache. If that
    package is private, give the Coder builder a read token (or make the package
    public); a cache miss only makes the first build slower.

--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -130,6 +130,11 @@ assert_unit() {
         grep -q "^${1}=" "$2"
     }
 
+    # These allow-list cases run init-env.sh with most vars unset, so its
+    # missing-var warning (asserted in 6 below) fires on every one. They assert
+    # on the ENV-FILE, not stderr, so the warning is discarded: a green run must
+    # not print "warning:" blocks a reader has to triage. `set -e` still catches
+    # a nonzero exit, and 6 is where stderr is captured and checked.
     local bot_allow=(GH_TOKEN FOREMAN_AGENT_GH_TOKEN CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY)
     local dev_allow=(TS_AUTHKEY CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY)
 
@@ -137,7 +142,7 @@ assert_unit() {
     #    including the read-only agent token foreman requires for dispatch.
     env_file="${work_dir}/env-bot-strip"
     : >"$env_file"
-    TS_AUTHKEY=fake GH_TOKEN=fake FOREMAN_AGENT_GH_TOKEN=fake bash "$init_env" "$env_file" "${bot_allow[@]}"
+    TS_AUTHKEY=fake GH_TOKEN=fake FOREMAN_AGENT_GH_TOKEN=fake bash "$init_env" "$env_file" "${bot_allow[@]}" 2>/dev/null
     has_var GH_TOKEN "$env_file" || fail "bot profile dropped allowed GH_TOKEN"
     has_var FOREMAN_AGENT_GH_TOKEN "$env_file" || fail "bot profile dropped allowed FOREMAN_AGENT_GH_TOKEN (foreman dispatch needs it)"
     if has_var TS_AUTHKEY "$env_file"; then
@@ -148,7 +153,7 @@ assert_unit() {
     #    unset in the host env.
     env_file="${work_dir}/env-bot-evict"
     printf 'TS_AUTHKEY=stale\nGH_TOKEN=old\n' >"$env_file"
-    (unset TS_AUTHKEY && GH_TOKEN=new bash "$init_env" "$env_file" "${bot_allow[@]}")
+    (unset TS_AUTHKEY && GH_TOKEN=new bash "$init_env" "$env_file" "${bot_allow[@]}") 2>/dev/null
     if has_var TS_AUTHKEY "$env_file"; then
         fail "bot profile failed to evict a stale TS_AUTHKEY"
     fi
@@ -159,7 +164,7 @@ assert_unit() {
     #    login`) rather than carry the bot's PAT.
     env_file="${work_dir}/env-dev-keep"
     : >"$env_file"
-    TS_AUTHKEY=keep GH_TOKEN=fake FOREMAN_AGENT_GH_TOKEN=fake bash "$init_env" "$env_file" "${dev_allow[@]}"
+    TS_AUTHKEY=keep GH_TOKEN=fake FOREMAN_AGENT_GH_TOKEN=fake bash "$init_env" "$env_file" "${dev_allow[@]}" 2>/dev/null
     has_var TS_AUTHKEY "$env_file" || fail "dev profile dropped allowed TS_AUTHKEY"
     if has_var GH_TOKEN "$env_file"; then
         fail "dev profile injected GH_TOKEN — a human profile must carry no bot credential"
@@ -174,7 +179,7 @@ assert_unit() {
     #     allow-list alone would leave the old token sitting in the env-file.
     env_file="${work_dir}/env-dev-evict"
     printf 'GH_TOKEN=stale\nTS_AUTHKEY=old\n' >"$env_file"
-    (unset GH_TOKEN && TS_AUTHKEY=new bash "$init_env" "$env_file" "${dev_allow[@]}")
+    (unset GH_TOKEN && TS_AUTHKEY=new bash "$init_env" "$env_file" "${dev_allow[@]}") 2>/dev/null
     if has_var GH_TOKEN "$env_file"; then
         fail "dev profile failed to evict a stale GH_TOKEN"
     fi
@@ -183,7 +188,7 @@ assert_unit() {
     #    (it silently overrides CLAUDE_CODE_OAUTH_TOKEN).
     env_file="${work_dir}/env-anthropic"
     : >"$env_file"
-    ANTHROPIC_API_KEY=secret GH_TOKEN=fake bash "$init_env" "$env_file" GH_TOKEN ANTHROPIC_API_KEY
+    ANTHROPIC_API_KEY=secret GH_TOKEN=fake bash "$init_env" "$env_file" GH_TOKEN ANTHROPIC_API_KEY 2>/dev/null
     if has_var ANTHROPIC_API_KEY "$env_file"; then
         fail "ANTHROPIC_API_KEY was allowed into the env-file"
     fi
@@ -191,7 +196,7 @@ assert_unit() {
     # 5. An unknown var passed in the allow-list cannot be smuggled in.
     env_file="${work_dir}/env-smuggle"
     : >"$env_file"
-    HARMON_SMUGGLE=evil bash "$init_env" "$env_file" GH_TOKEN HARMON_SMUGGLE
+    HARMON_SMUGGLE=evil bash "$init_env" "$env_file" GH_TOKEN HARMON_SMUGGLE 2>/dev/null
     if has_var HARMON_SMUGGLE "$env_file"; then
         fail "an unknown var was smuggled into the env-file via the allow-list"
     fi

--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -196,7 +196,89 @@ assert_unit() {
         fail "an unknown var was smuggled into the env-file via the allow-list"
     fi
 
-    # 6. tailscale-connect.sh no-ops (exit 0, prints its "unavailable" message)
+    # 6. A var allow-listed for this profile but absent from BOTH the host env
+    #    and the env-file must WARN on stderr. The silence this replaces is how
+    #    a missing TS_AUTHKEY went unnoticed for hours in a Coder workspace
+    #    (harmon-init#639): the container came up fine and only the Tailscale-
+    #    dependent step failed, far from the cause.
+    local warn_out warn_rc
+    env_file="${work_dir}/env-warn-dev"
+    : >"$env_file"
+    warn_rc=0
+    warn_out="$(unset TS_AUTHKEY CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY &&
+        bash "$init_env" "$env_file" "${dev_allow[@]}" 2>&1 >/dev/null)" || warn_rc=$?
+    [ "$warn_rc" -eq 0 ] ||
+        fail "init-env.sh exited ${warn_rc} on a missing allow-listed var — it runs as initializeCommand on the HOST, so a nonzero exit aborts the container build"
+    case "$warn_out" in
+    *TS_AUTHKEY*) ;;
+    *) fail "dev profile did not warn about a TS_AUTHKEY missing from both the host env and the env-file" ;;
+    esac
+
+    #    The bot profile must stay SILENT about TS_AUTHKEY even when it is
+    #    missing everywhere: it is off that allow-list by design (no tailnet
+    #    path from a bypassPermissions container), so naming it would advertise
+    #    a credential the profile must never hold — and train the reader to
+    #    expect one. Warning from BASE_MANAGED_VARS/EVICT_VARS instead of the
+    #    post-filter allow-list is the accident this pins down.
+    env_file="${work_dir}/env-warn-bot"
+    : >"$env_file"
+    warn_rc=0
+    warn_out="$(unset TS_AUTHKEY GH_TOKEN FOREMAN_AGENT_GH_TOKEN CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY &&
+        bash "$init_env" "$env_file" "${bot_allow[@]}" 2>&1 >/dev/null)" || warn_rc=$?
+    [ "$warn_rc" -eq 0 ] || fail "init-env.sh exited ${warn_rc} warning under the bot profile"
+    case "$warn_out" in
+    *TS_AUTHKEY*) fail "bot profile warned about a missing TS_AUTHKEY — it is off that allow-list by design and must never be advertised there" ;;
+    esac
+    case "$warn_out" in
+    *GH_TOKEN*) ;;
+    *) fail "bot profile did not warn about a GH_TOKEN missing from both the host env and the env-file" ;;
+    esac
+
+    #    A value already in the env-file is the out-of-band case init-env.sh
+    #    exists to preserve (1Password-managed, never exported to the host
+    #    shell): warn about nothing, and leave the value intact.
+    env_file="${work_dir}/env-warn-quiet"
+    printf 'TS_AUTHKEY=fromop\nCLAUDE_CODE_OAUTH_TOKEN=tok\nAGENT_DECK_TELEGRAM_KEY=key\n' >"$env_file"
+    warn_rc=0
+    warn_out="$(unset TS_AUTHKEY CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY &&
+        bash "$init_env" "$env_file" "${dev_allow[@]}" 2>&1 >/dev/null)" || warn_rc=$?
+    [ "$warn_rc" -eq 0 ] || fail "init-env.sh exited ${warn_rc} with every allow-listed var already in the env-file"
+    [ -z "$warn_out" ] || fail "init-env.sh warned about vars already present in the env-file: ${warn_out}"
+    grep -q '^TS_AUTHKEY=fromop$' "$env_file" ||
+        fail "init-env.sh did not preserve the out-of-band TS_AUTHKEY value in the env-file"
+
+    #    A bare "VAR=" env-file line leaves the container with no usable value,
+    #    so the presence test requires at least one character after the `=`.
+    env_file="${work_dir}/env-warn-blank"
+    printf 'TS_AUTHKEY=\nCLAUDE_CODE_OAUTH_TOKEN=tok\nAGENT_DECK_TELEGRAM_KEY=key\n' >"$env_file"
+    warn_rc=0
+    warn_out="$(unset TS_AUTHKEY CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY &&
+        bash "$init_env" "$env_file" "${dev_allow[@]}" 2>&1 >/dev/null)" || warn_rc=$?
+    [ "$warn_rc" -eq 0 ] || fail "init-env.sh exited ${warn_rc} on a blank env-file entry"
+    case "$warn_out" in
+    *TS_AUTHKEY*) ;;
+    *) fail "init-env.sh treated a blank 'TS_AUTHKEY=' env-file line as a usable value" ;;
+    esac
+
+    #    The warning names vars, never VALUES — it lands in build logs. Asserted
+    #    with a var exported EMPTY (which "${!var:-}" treats as unset, so it
+    #    warns) alongside two carrying sentinel secrets that must not appear.
+    env_file="${work_dir}/env-warn-novalue"
+    : >"$env_file"
+    warn_rc=0
+    warn_out="$(TS_AUTHKEY= CLAUDE_CODE_OAUTH_TOKEN=harmon-sentinel-one \
+        AGENT_DECK_TELEGRAM_KEY=harmon-sentinel-two \
+        bash "$init_env" "$env_file" "${dev_allow[@]}" 2>&1 >/dev/null)" || warn_rc=$?
+    [ "$warn_rc" -eq 0 ] || fail "init-env.sh exited ${warn_rc} on an allow-listed var exported empty"
+    case "$warn_out" in
+    *TS_AUTHKEY*) ;;
+    *) fail "init-env.sh did not warn about an allow-listed var exported empty — no usable value reaches the container" ;;
+    esac
+    case "$warn_out" in
+    *harmon-sentinel*) fail "init-env.sh printed a secret VALUE in its warning output" ;;
+    esac
+
+    # 7. tailscale-connect.sh no-ops (exit 0, prints its "unavailable" message)
     #    when `tailscale` is not on PATH. Invoke with an absolute bash path so
     #    the unreachable PATH doesn't also hide the interpreter.
     local ts_out
@@ -208,7 +290,7 @@ assert_unit() {
     *) fail "tailscale-connect.sh did not report tailscale unavailable: ${ts_out}" ;;
     esac
 
-    # 7. The shared post-create guidance must never steer a BOT container to an
+    # 8. The shared post-create guidance must never steer a BOT container to an
     #    operator `gh auth login`. Following that advice would put a human
     #    credential — `workflow` scope included — inside a bypassPermissions
     #    agent container, which is the escalation the bot PAT's denials exist to
@@ -240,7 +322,7 @@ assert_unit() {
         fail "post-create gh guidance omits the operator login where the profile declares one"
     fi
 
-    # 8. Static devcontainer.json invariants via the devcontainers CLI.
+    # 9. Static devcontainer.json invariants via the devcontainers CLI.
     assert_config_invariants "$repo_root" "$bot_config" bot
     assert_config_invariants "$repo_root" "$dev_config" dev
 

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/init-env.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/init-env.sh
@@ -130,10 +130,45 @@ done
 # For allowed vars, replace any stale entry with the current host value.
 # Vars not present in the host env are left untouched, so values
 # populated out-of-band (e.g. from 1Password) survive rebuilds.
+#
+# A var missing from BOTH the host env and the env-file is a different case: it
+# is not an out-of-band value being preserved, it is a value nothing will
+# supply. Silence there is how a missing TS_AUTHKEY went unnoticed for hours in
+# a Coder workspace — the container came up fine and only the Tailscale-
+# dependent step failed, far from the cause. So collect those and warn on
+# stderr below.
+#
+# The loop is over ALLOWED_VARS — the post-filter allow-list — NOT over
+# BASE_MANAGED_VARS or EVICT_VARS. That is load-bearing for the profile
+# boundary, not just tidiness: the bot profile deliberately omits TS_AUTHKEY
+# (no tailnet path from a bypassPermissions container), so warning from the
+# managed set would print "TS_AUTHKEY missing" on every bot rebuild —
+# advertising a credential that profile must never hold, and training the
+# reader to expect one. A var this profile is not allowed to populate is not
+# missing; it is correctly absent.
+missing=""
 for var in "${ALLOWED_VARS[@]}"; do
     val="${!var:-}"
     if [ -n "$val" ]; then
         strip_var "$var" "$ENV_FILE"
         echo "${var}=${val}" >>"$ENV_FILE"
+    elif ! grep -q "^${var}=." "$ENV_FILE"; then
+        # `=.` requires at least one character after the `=`: a bare "VAR="
+        # line (or a host var exported empty, which "${!var:-}" already treats
+        # as unset) leaves the container with no usable value, so it warns the
+        # same as a wholly absent one. Var names come from KNOWN_VARS, so they
+        # carry no regex metacharacters.
+        missing="${missing:+$missing }${var}"
     fi
 done
+
+# Names only, never values — this lands in build logs. Non-fatal by design: a
+# rebuild must not be blocked by an optional secret, and this script runs as
+# initializeCommand on the HOST, where a non-zero exit aborts the whole
+# container build.
+if [ -n "$missing" ]; then
+    echo "init-env.sh: warning: allow-listed but unset in the host env and absent from ${ENV_FILE}:" >&2
+    echo "init-env.sh:   ${missing}" >&2
+    echo "init-env.sh: the container will start without them. On Coder/Codespaces set them as" >&2
+    echo "init-env.sh: workspace/repo secrets; locally populate the env-file from 1Password." >&2
+fi

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -306,6 +306,32 @@ captures the same variables from the **host environment**, where they arrive as
 workspace/template parameters. It does **not** call `op` itself — 1Password
 Environments is what supplies the values locally.
 
+A variable already in the env-file but absent from the host env is **left
+alone** — that is how a 1Password-managed value survives a rebuild when you
+haven't also exported it in your shell.
+
+If a variable is missing from **both** places, though, nothing will supply it,
+and `init-env.sh` prints a warning to stderr naming the variables (never their
+values) in the container-build log:
+
+```text
+init-env.sh: warning: allow-listed but unset in the host env and absent from .devcontainer/dev/devcontainer.env:
+init-env.sh:   TS_AUTHKEY
+init-env.sh: the container will start without them. On Coder/Codespaces set them as
+init-env.sh: workspace/repo secrets; locally populate the env-file from 1Password.
+```
+
+The build still succeeds — a missing optional secret must not block a rebuild,
+and `initializeCommand` runs on the host, where a non-zero exit aborts the whole
+build. So this is a signal to read, not a failure. Without it the container comes
+up clean and only the dependent step fails later, far from the cause: a missing
+`TS_AUTHKEY` went unnoticed for hours in a Coder workspace that way.
+
+The warning covers **only** the vars this profile's allow-list permits, so the
+bot profile never reports `TS_AUTHKEY` missing. Its absence there is correct —
+that profile has no tailnet path at all — and naming it would advertise a
+credential the bot container must never hold.
+
 ## Run it in Coder
 
 The devcontainers are Coder-ready: the `CODER` env is passed through, the
@@ -329,6 +355,16 @@ repo** (one template serves every repo). To stand this repo up in Coder:
      (+ `TS_AUTHKEY` if you want Tailscale)[% if use_alternative_claude_providers %]; `KIMI_API_KEY`/`MOONSHOT_API_KEY`,
      `DEEPSEEK_API_KEY`, `ZAI_API_KEY` for the alt-model wrappers[% endif %]. Coder passes these
      into the workspace's host environment, where `init-env.sh` picks them up.
+
+   Coder is the case where this matters most: there is no 1Password app in the
+   workspace, so a **workspace parameter is the only way a secret arrives**. A
+   parameter you forget to set is not backfilled from anywhere — the env-file
+   starts empty on a fresh workspace, so the variable is simply absent. Check
+   the build log for the `init-env.sh: warning:` lines above before assuming a
+   workspace is fully provisioned; they name exactly what did not arrive. On a
+   **rebuild** of an existing workspace the env-file may still hold a value from
+   an earlier build, which is why the warning fires only when both sources are
+   empty.
 3. The build pulls `[[ devcontainer_image ]]` from GHCR as a cache. If that
    package is private, give the Coder builder a read token (or make the package
    public); a cache miss only makes the first build slower.

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -130,6 +130,11 @@ assert_unit() {
         grep -q "^${1}=" "$2"
     }
 
+    # These allow-list cases run init-env.sh with most vars unset, so its
+    # missing-var warning (asserted in 6 below) fires on every one. They assert
+    # on the ENV-FILE, not stderr, so the warning is discarded: a green run must
+    # not print "warning:" blocks a reader has to triage. `set -e` still catches
+    # a nonzero exit, and 6 is where stderr is captured and checked.
     local bot_allow=(GH_TOKEN FOREMAN_AGENT_GH_TOKEN CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY)
     local dev_allow=(TS_AUTHKEY CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY)
 
@@ -137,7 +142,7 @@ assert_unit() {
     #    including the read-only agent token foreman requires for dispatch.
     env_file="${work_dir}/env-bot-strip"
     : >"$env_file"
-    TS_AUTHKEY=fake GH_TOKEN=fake FOREMAN_AGENT_GH_TOKEN=fake bash "$init_env" "$env_file" "${bot_allow[@]}"
+    TS_AUTHKEY=fake GH_TOKEN=fake FOREMAN_AGENT_GH_TOKEN=fake bash "$init_env" "$env_file" "${bot_allow[@]}" 2>/dev/null
     has_var GH_TOKEN "$env_file" || fail "bot profile dropped allowed GH_TOKEN"
     has_var FOREMAN_AGENT_GH_TOKEN "$env_file" || fail "bot profile dropped allowed FOREMAN_AGENT_GH_TOKEN (foreman dispatch needs it)"
     if has_var TS_AUTHKEY "$env_file"; then
@@ -148,7 +153,7 @@ assert_unit() {
     #    unset in the host env.
     env_file="${work_dir}/env-bot-evict"
     printf 'TS_AUTHKEY=stale\nGH_TOKEN=old\n' >"$env_file"
-    (unset TS_AUTHKEY && GH_TOKEN=new bash "$init_env" "$env_file" "${bot_allow[@]}")
+    (unset TS_AUTHKEY && GH_TOKEN=new bash "$init_env" "$env_file" "${bot_allow[@]}") 2>/dev/null
     if has_var TS_AUTHKEY "$env_file"; then
         fail "bot profile failed to evict a stale TS_AUTHKEY"
     fi
@@ -159,7 +164,7 @@ assert_unit() {
     #    login`) rather than carry the bot's PAT.
     env_file="${work_dir}/env-dev-keep"
     : >"$env_file"
-    TS_AUTHKEY=keep GH_TOKEN=fake FOREMAN_AGENT_GH_TOKEN=fake bash "$init_env" "$env_file" "${dev_allow[@]}"
+    TS_AUTHKEY=keep GH_TOKEN=fake FOREMAN_AGENT_GH_TOKEN=fake bash "$init_env" "$env_file" "${dev_allow[@]}" 2>/dev/null
     has_var TS_AUTHKEY "$env_file" || fail "dev profile dropped allowed TS_AUTHKEY"
     if has_var GH_TOKEN "$env_file"; then
         fail "dev profile injected GH_TOKEN — a human profile must carry no bot credential"
@@ -174,7 +179,7 @@ assert_unit() {
     #     allow-list alone would leave the old token sitting in the env-file.
     env_file="${work_dir}/env-dev-evict"
     printf 'GH_TOKEN=stale\nTS_AUTHKEY=old\n' >"$env_file"
-    (unset GH_TOKEN && TS_AUTHKEY=new bash "$init_env" "$env_file" "${dev_allow[@]}")
+    (unset GH_TOKEN && TS_AUTHKEY=new bash "$init_env" "$env_file" "${dev_allow[@]}") 2>/dev/null
     if has_var GH_TOKEN "$env_file"; then
         fail "dev profile failed to evict a stale GH_TOKEN"
     fi
@@ -183,7 +188,7 @@ assert_unit() {
     #    (it silently overrides CLAUDE_CODE_OAUTH_TOKEN).
     env_file="${work_dir}/env-anthropic"
     : >"$env_file"
-    ANTHROPIC_API_KEY=secret GH_TOKEN=fake bash "$init_env" "$env_file" GH_TOKEN ANTHROPIC_API_KEY
+    ANTHROPIC_API_KEY=secret GH_TOKEN=fake bash "$init_env" "$env_file" GH_TOKEN ANTHROPIC_API_KEY 2>/dev/null
     if has_var ANTHROPIC_API_KEY "$env_file"; then
         fail "ANTHROPIC_API_KEY was allowed into the env-file"
     fi
@@ -191,7 +196,7 @@ assert_unit() {
     # 5. An unknown var passed in the allow-list cannot be smuggled in.
     env_file="${work_dir}/env-smuggle"
     : >"$env_file"
-    HARMON_SMUGGLE=evil bash "$init_env" "$env_file" GH_TOKEN HARMON_SMUGGLE
+    HARMON_SMUGGLE=evil bash "$init_env" "$env_file" GH_TOKEN HARMON_SMUGGLE 2>/dev/null
     if has_var HARMON_SMUGGLE "$env_file"; then
         fail "an unknown var was smuggled into the env-file via the allow-list"
     fi

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -196,7 +196,89 @@ assert_unit() {
         fail "an unknown var was smuggled into the env-file via the allow-list"
     fi
 
-    # 6. tailscale-connect.sh no-ops (exit 0, prints its "unavailable" message)
+    # 6. A var allow-listed for this profile but absent from BOTH the host env
+    #    and the env-file must WARN on stderr. The silence this replaces is how
+    #    a missing TS_AUTHKEY went unnoticed for hours in a Coder workspace
+    #    (harmon-init#639): the container came up fine and only the Tailscale-
+    #    dependent step failed, far from the cause.
+    local warn_out warn_rc
+    env_file="${work_dir}/env-warn-dev"
+    : >"$env_file"
+    warn_rc=0
+    warn_out="$(unset TS_AUTHKEY CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY &&
+        bash "$init_env" "$env_file" "${dev_allow[@]}" 2>&1 >/dev/null)" || warn_rc=$?
+    [ "$warn_rc" -eq 0 ] ||
+        fail "init-env.sh exited ${warn_rc} on a missing allow-listed var — it runs as initializeCommand on the HOST, so a nonzero exit aborts the container build"
+    case "$warn_out" in
+    *TS_AUTHKEY*) ;;
+    *) fail "dev profile did not warn about a TS_AUTHKEY missing from both the host env and the env-file" ;;
+    esac
+
+    #    The bot profile must stay SILENT about TS_AUTHKEY even when it is
+    #    missing everywhere: it is off that allow-list by design (no tailnet
+    #    path from a bypassPermissions container), so naming it would advertise
+    #    a credential the profile must never hold — and train the reader to
+    #    expect one. Warning from BASE_MANAGED_VARS/EVICT_VARS instead of the
+    #    post-filter allow-list is the accident this pins down.
+    env_file="${work_dir}/env-warn-bot"
+    : >"$env_file"
+    warn_rc=0
+    warn_out="$(unset TS_AUTHKEY GH_TOKEN FOREMAN_AGENT_GH_TOKEN CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY &&
+        bash "$init_env" "$env_file" "${bot_allow[@]}" 2>&1 >/dev/null)" || warn_rc=$?
+    [ "$warn_rc" -eq 0 ] || fail "init-env.sh exited ${warn_rc} warning under the bot profile"
+    case "$warn_out" in
+    *TS_AUTHKEY*) fail "bot profile warned about a missing TS_AUTHKEY — it is off that allow-list by design and must never be advertised there" ;;
+    esac
+    case "$warn_out" in
+    *GH_TOKEN*) ;;
+    *) fail "bot profile did not warn about a GH_TOKEN missing from both the host env and the env-file" ;;
+    esac
+
+    #    A value already in the env-file is the out-of-band case init-env.sh
+    #    exists to preserve (1Password-managed, never exported to the host
+    #    shell): warn about nothing, and leave the value intact.
+    env_file="${work_dir}/env-warn-quiet"
+    printf 'TS_AUTHKEY=fromop\nCLAUDE_CODE_OAUTH_TOKEN=tok\nAGENT_DECK_TELEGRAM_KEY=key\n' >"$env_file"
+    warn_rc=0
+    warn_out="$(unset TS_AUTHKEY CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY &&
+        bash "$init_env" "$env_file" "${dev_allow[@]}" 2>&1 >/dev/null)" || warn_rc=$?
+    [ "$warn_rc" -eq 0 ] || fail "init-env.sh exited ${warn_rc} with every allow-listed var already in the env-file"
+    [ -z "$warn_out" ] || fail "init-env.sh warned about vars already present in the env-file: ${warn_out}"
+    grep -q '^TS_AUTHKEY=fromop$' "$env_file" ||
+        fail "init-env.sh did not preserve the out-of-band TS_AUTHKEY value in the env-file"
+
+    #    A bare "VAR=" env-file line leaves the container with no usable value,
+    #    so the presence test requires at least one character after the `=`.
+    env_file="${work_dir}/env-warn-blank"
+    printf 'TS_AUTHKEY=\nCLAUDE_CODE_OAUTH_TOKEN=tok\nAGENT_DECK_TELEGRAM_KEY=key\n' >"$env_file"
+    warn_rc=0
+    warn_out="$(unset TS_AUTHKEY CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY &&
+        bash "$init_env" "$env_file" "${dev_allow[@]}" 2>&1 >/dev/null)" || warn_rc=$?
+    [ "$warn_rc" -eq 0 ] || fail "init-env.sh exited ${warn_rc} on a blank env-file entry"
+    case "$warn_out" in
+    *TS_AUTHKEY*) ;;
+    *) fail "init-env.sh treated a blank 'TS_AUTHKEY=' env-file line as a usable value" ;;
+    esac
+
+    #    The warning names vars, never VALUES — it lands in build logs. Asserted
+    #    with a var exported EMPTY (which "${!var:-}" treats as unset, so it
+    #    warns) alongside two carrying sentinel secrets that must not appear.
+    env_file="${work_dir}/env-warn-novalue"
+    : >"$env_file"
+    warn_rc=0
+    warn_out="$(TS_AUTHKEY= CLAUDE_CODE_OAUTH_TOKEN=harmon-sentinel-one \
+        AGENT_DECK_TELEGRAM_KEY=harmon-sentinel-two \
+        bash "$init_env" "$env_file" "${dev_allow[@]}" 2>&1 >/dev/null)" || warn_rc=$?
+    [ "$warn_rc" -eq 0 ] || fail "init-env.sh exited ${warn_rc} on an allow-listed var exported empty"
+    case "$warn_out" in
+    *TS_AUTHKEY*) ;;
+    *) fail "init-env.sh did not warn about an allow-listed var exported empty — no usable value reaches the container" ;;
+    esac
+    case "$warn_out" in
+    *harmon-sentinel*) fail "init-env.sh printed a secret VALUE in its warning output" ;;
+    esac
+
+    # 7. tailscale-connect.sh no-ops (exit 0, prints its "unavailable" message)
     #    when `tailscale` is not on PATH. Invoke with an absolute bash path so
     #    the unreachable PATH doesn't also hide the interpreter.
     local ts_out
@@ -208,7 +290,7 @@ assert_unit() {
     *) fail "tailscale-connect.sh did not report tailscale unavailable: ${ts_out}" ;;
     esac
 
-    # 7. The shared post-create guidance must never steer a BOT container to an
+    # 8. The shared post-create guidance must never steer a BOT container to an
     #    operator `gh auth login`. Following that advice would put a human
     #    credential — `workflow` scope included — inside a bypassPermissions
     #    agent container, which is the escalation the bot PAT's denials exist to
@@ -240,7 +322,7 @@ assert_unit() {
         fail "post-create gh guidance omits the operator login where the profile declares one"
     fi
 
-    # 8. Static devcontainer.json invariants via the devcontainers CLI.
+    # 9. Static devcontainer.json invariants via the devcontainers CLI.
     assert_config_invariants "$repo_root" "$bot_config" bot
     assert_config_invariants "$repo_root" "$dev_config" dev
 


### PR DESCRIPTION
Closes #639

## What

`init-env.sh` injected an allow-listed variable only when it was set in the
host env, and did nothing otherwise — no `else`, no diagnostic, exit 0. It now
warns on stderr when a variable is absent from **both** the host env and the
env-file.

## Why

The silence was correct for the case it was written for: a 1Password-managed
value that lives in the env-file with no host export must survive a rebuild. But
the same branch also covered the case where *nothing* will supply the value. A
missing `TS_AUTHKEY` went unnoticed for hours in a Coder workspace that way —
the container came up clean and only the Tailscale-dependent step failed, far
from the cause.

Coder is where this bites hardest: there is no 1Password app in the workspace, so
a workspace parameter is the only way a secret arrives, and a parameter you forget
to set is not backfilled from anywhere.

## Design notes

**The warning iterates `ALLOWED_VARS`, not `BASE_MANAGED_VARS`/`EVICT_VARS`.**
This is load-bearing for the profile boundary rather than a detail: the bot
profile deliberately omits `TS_AUTHKEY` because a `bypassPermissions` container
gets no tailnet path at all, so warning from the managed set would print
`TS_AUTHKEY missing` on every bot rebuild — advertising a credential that
profile must never hold, and training the reader to expect one. A variable a
profile is not allowed to populate is not missing; it is correctly absent.

**Non-fatal.** `initializeCommand` runs on the *host*, where a non-zero exit
aborts the whole container build, and a missing optional secret must not do that.

**Names only, never values** — this output lands in build logs.

**A bare `VAR=` line counts as absent** (`grep "^VAR=."`), matching how
`"${!var:-}"` already treats an empty host export as unset. Neither leaves the
container a usable value.

## Verification

- `task verify` — green (EXIT=0)
- `task ci` — green (EXIT=0), against this exact head
- `task test:dogfood-parity` — 82 verbatim twins identical
- `task test:dogfood-structure` — 190 rendered sections present in the root layer
- `task challenge` — clean, no findings at any severity (1 round)
- `task review` — clean, no P0/P1/P2 (1 round)
- `guard:release-title` — `fix(devcontainer): …` is a releasing type

Five new assertions in `devcontainer-assert.sh`: dev warns for a missing
`TS_AUTHKEY`; **bot stays silent about it** while still warning for `GH_TOKEN`; a
value already in the env-file warns about nothing and is preserved; a blank entry
warns; and no secret value appears in the output.

**Mutation-tested.** Switching only the warning source to `BASE_MANAGED_VARS`
(leaving injection untouched) trips the bot-silence assertion:
`ASSERT FAIL: bot profile warned about a missing TS_AUTHKEY`. A coarser mutation
was caught by a pre-existing assertion instead, so the precise one was needed to
prove the new check bites.

Also verified against a real `copier`-rendered consumer project: the shipped
`devcontainer-assert.sh` passes there, and the rendered docs carry no unrendered
Jinja delimiters.

## Two-layer scope

Six files — both layers, per dogfood parity. `init-env.sh` and
`devcontainer-assert.sh` are **verbatim** twins (byte-equality, gated by
`test:dogfood-parity`); `devcontainers.md` is a Jinja twin (gated on structure).
The issue named the counterpart for `init-env.sh` only; the other two have twins
too.

## Second commit

The new warning fired during the pre-existing allow-list assertions, so a *green*
`task ci` began printing five `init-env.sh: warning:` blocks a reader has to
triage before concluding nothing is wrong. Those assertions check the env-file,
not stderr, so their stderr is discarded; assertion 6 is where stderr is captured
and asserted, so nothing about the warning goes unchecked.

## Deferred findings

None — both Codex stages returned clean at every severity.

## Not in scope

[#612](https://github.com/evanharmon1/harmon-init/issues/612) is a live defect in
`devcontainer-assert.sh` (its static `test("GH_TOKEN")` matches on the
`FOREMAN_AGENT_GH_TOKEN` substring). This PR edits that file but leaves it alone —
separately tracked, and fixing it here would widen the change beyond #639.

Note for review: `docs/guides/devcontainers.md` is also edited by #637, so one of
the two will need a rebase.
