### PR TITLE
feat(devcontainer): default to claude-opus-4-8 instead of claude-opus-5

### DIFF
--- a/.devcontainer/config/claude-user-defaults.json
+++ b/.devcontainer/config/claude-user-defaults.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-5",
+  "model": "claude-opus-4-8",
   "statusLine": {
     "type": "command",
     "command": "/etc/claude-code/statusline.sh",

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-user-defaults.json
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-user-defaults.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-5",
+  "model": "claude-opus-4-8",
   "statusLine": {
     "type": "command",
     "command": "/etc/claude-code/statusline.sh",


### PR DESCRIPTION
## What

Change the seeded Claude model in the devcontainer from `claude-opus-5` to `claude-opus-4-8`.

## Why

Opus 4.8 is a more stable, well-understood default. The workflow files that use `--model opus` (symbolic name for latest Opus) are unchanged.

## Verification

- `task check` — green
- `task test:dogfood-parity` — green (82 verbatim twins identical)
- `task test:template:minimal` — green (pre-push gate)

## Files changed

| File | Change |
|---|---|
| `template/…/config/claude-user-defaults.json` | `"model": "claude-opus-4-8"` |
| `.devcontainer/config/claude-user-defaults.json` | Same (root dogfood copy) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)