### PR TITLE
feat: define the machine-readable agent registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Lint
         run: task check
       - run: task test:tasks
+      - run: task test:agent-registry
       - run: task test:codex-review
       - run: task test:ci-results
       - run: task test:status

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,6 +75,7 @@ tasks:
     desc: Local verification gate (check → guards → test:template)
     cmds:
       - task: check
+      - task: test:agent-registry
       - task: test:tasks
       - task: test:ci-results
       - task: test:status
@@ -312,6 +313,11 @@ tasks:
     desc: Round-trip the Taskfile targets the Claude hooks delegate to
     cmds:
       - ./scripts/test-hooks.sh
+
+  test:agent-registry:
+    desc: Schema-check the machine-readable agent registry and its cross-record invariants
+    cmds:
+      - ./scripts/test-agent-registry.sh
 
   test:tasks:
     desc: Guard the Taskfile itself (compiles; setup tasks are safe no-ops)

--- a/agent-registry.json
+++ b/agent-registry.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "./agent-registry.schema.json",
+  "schema_version": 1,
+  "labels": {
+    "suggest": {
+      "prefix": "suggest",
+      "axis": "model",
+      "scopes": ["family", "model"],
+      "arming": false
+    },
+    "claim": {
+      "prefix": "claim",
+      "axis": "model",
+      "scopes": ["family", "model"],
+      "arming": false
+    }
+  },
+  "families": [
+    {
+      "slug": "claude",
+      "display_name": "Claude",
+      "models": [
+        { "slug": "opus", "display_name": "Opus" },
+        { "slug": "sonnet", "display_name": "Sonnet" },
+        { "slug": "haiku", "display_name": "Haiku" }
+      ]
+    },
+    {
+      "slug": "codex",
+      "display_name": "OpenAI Codex",
+      "models": [
+        { "slug": "sol", "display_name": "Sol" },
+        { "slug": "terra", "display_name": "Terra" },
+        { "slug": "luna", "display_name": "Luna" }
+      ]
+    },
+    { "slug": "copilot", "display_name": "GitHub Copilot", "models": [] },
+    {
+      "slug": "qwen",
+      "display_name": "Qwen",
+      "models": [{ "slug": "coder", "display_name": "Coder" }]
+    },
+    { "slug": "deepseek", "display_name": "DeepSeek", "models": [] },
+    {
+      "slug": "glm",
+      "display_name": "GLM",
+      "models": [{ "slug": "5-2", "display_name": "5.2" }]
+    },
+    {
+      "slug": "kimi",
+      "display_name": "Kimi",
+      "models": [{ "slug": "k3", "display_name": "K3" }]
+    },
+    { "slug": "minimax", "display_name": "MiniMax", "models": [] },
+    { "slug": "gemini", "display_name": "Gemini", "models": [] }
+  ],
+  "harnesses": [
+    {
+      "slug": "claude-code",
+      "display_name": "Claude Code",
+      "product": "Claude Code CLI",
+      "family_constraint": { "kind": "fixed", "family": "claude" },
+      "model_resolution": {
+        "owner": "runner-config",
+        "details": "The runner or repository configuration selects the Claude model; labels do not."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "claude-code-action",
+      "display_name": "Claude Code Action",
+      "product": "claude-code-action",
+      "family_constraint": { "kind": "fixed", "family": "claude" },
+      "model_resolution": {
+        "owner": "workflow-config",
+        "details": "The GitHub Actions workflow input selects the Claude model."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "claude-code-deepseek",
+      "display_name": "Claude Code with DeepSeek",
+      "product": "Claude Code provider wrapper",
+      "family_constraint": { "kind": "fixed", "family": "deepseek" },
+      "model_resolution": {
+        "owner": "provider-wrapper",
+        "details": "The provider-rewired wrapper fixes the family and its runtime configuration selects the model."
+      },
+      "provider_rewired": true
+    },
+    {
+      "slug": "claude-code-glm",
+      "display_name": "Claude Code with GLM",
+      "product": "Claude Code provider wrapper",
+      "family_constraint": { "kind": "fixed", "family": "glm" },
+      "model_resolution": {
+        "owner": "provider-wrapper",
+        "details": "The provider-rewired wrapper fixes the family and its runtime configuration selects the model."
+      },
+      "provider_rewired": true
+    },
+    {
+      "slug": "claude-code-kimi",
+      "display_name": "Claude Code with Kimi",
+      "product": "Claude Code provider wrapper",
+      "family_constraint": { "kind": "fixed", "family": "kimi" },
+      "model_resolution": {
+        "owner": "provider-wrapper",
+        "details": "The provider-rewired wrapper fixes the family and its runtime configuration selects the model."
+      },
+      "provider_rewired": true
+    },
+    {
+      "slug": "claude-code-minimax",
+      "display_name": "Claude Code with MiniMax",
+      "product": "Claude Code provider wrapper",
+      "family_constraint": { "kind": "fixed", "family": "minimax" },
+      "model_resolution": {
+        "owner": "provider-wrapper",
+        "details": "The provider-rewired wrapper fixes the family and its runtime configuration selects the model."
+      },
+      "provider_rewired": true
+    },
+    {
+      "slug": "codex-cli",
+      "display_name": "OpenAI Codex CLI",
+      "product": "OpenAI Codex CLI",
+      "family_constraint": { "kind": "fixed", "family": "codex" },
+      "model_resolution": {
+        "owner": "runner-config",
+        "details": "The runner or CLI invocation selects the Codex model."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "copilot-cli",
+      "display_name": "GitHub Copilot CLI",
+      "product": "GitHub Copilot CLI",
+      "family_constraint": { "kind": "fixed", "family": "copilot" },
+      "model_resolution": {
+        "owner": "runner-config",
+        "details": "The runner or Copilot configuration selects the model."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "qwen-code",
+      "display_name": "Qwen Code",
+      "product": "Qwen Code CLI",
+      "family_constraint": { "kind": "fixed", "family": "qwen" },
+      "model_resolution": {
+        "owner": "runner-config",
+        "details": "The runner or Qwen Code configuration selects the Qwen model."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "antigravity",
+      "display_name": "Google Antigravity",
+      "product": "Google Antigravity",
+      "family_constraint": { "kind": "fixed", "family": "gemini" },
+      "model_resolution": {
+        "owner": "harness-runtime",
+        "details": "The Antigravity session selects the Gemini model."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "opencode",
+      "display_name": "OpenCode",
+      "product": "OpenCode",
+      "family_constraint": { "kind": "none" },
+      "model_resolution": {
+        "owner": "harness-runtime",
+        "details": "The multi-provider harness selects both provider family and model at runtime."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "pi",
+      "display_name": "Pi",
+      "product": "Pi",
+      "family_constraint": { "kind": "none" },
+      "model_resolution": {
+        "owner": "harness-runtime",
+        "details": "The multi-provider harness selects both provider family and model at runtime."
+      },
+      "provider_rewired": false
+    }
+  ],
+  "foreman_adapters": [
+    {
+      "slug": "claude",
+      "display_name": "Claude",
+      "source_file": "claude.sh",
+      "harness": "claude-code",
+      "classification": "production",
+      "production_dispatchable": true,
+      "provision_label": true
+    },
+    {
+      "slug": "mock",
+      "display_name": "Mock (tests only)",
+      "source_file": "mock.sh",
+      "harness": null,
+      "classification": "test-only",
+      "production_dispatchable": false,
+      "provision_label": false
+    }
+  ]
+}

--- a/agent-registry.schema.json
+++ b/agent-registry.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/evanharmon1/harmon-init/agent-registry.schema.json",
+  "title": "Harmon agent registry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schema_version", "labels", "families", "harnesses", "foreman_adapters"],
+  "properties": {
+    "$schema": { "const": "./agent-registry.schema.json" },
+    "schema_version": { "const": 1 },
+    "labels": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["suggest", "claim"],
+      "properties": {
+        "suggest": { "$ref": "#/$defs/labelNamespace" },
+        "claim": { "$ref": "#/$defs/labelNamespace" }
+      }
+    },
+    "families": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/family" }
+    },
+    "harnesses": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/harness" }
+    },
+    "foreman_adapters": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/foremanAdapter" }
+    }
+  },
+  "$defs": {
+    "slug": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "labelNamespace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prefix", "axis", "scopes", "arming"],
+      "properties": {
+        "prefix": { "enum": ["suggest", "claim"] },
+        "axis": { "const": "model" },
+        "scopes": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": { "enum": ["family", "model"] }
+        },
+        "arming": { "const": false }
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["slug", "display_name"],
+      "properties": {
+        "slug": { "$ref": "#/$defs/slug" },
+        "display_name": { "type": "string", "minLength": 1 }
+      }
+    },
+    "family": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["slug", "display_name", "models"],
+      "properties": {
+        "slug": { "$ref": "#/$defs/slug" },
+        "display_name": { "type": "string", "minLength": 1 },
+        "models": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/model" }
+        }
+      }
+    },
+    "familyConstraint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": { "enum": ["fixed", "none"] },
+        "family": { "$ref": "#/$defs/slug" }
+      }
+    },
+    "modelResolution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owner", "details"],
+      "properties": {
+        "owner": {
+          "enum": ["runner-config", "workflow-config", "provider-wrapper", "harness-runtime"]
+        },
+        "details": { "type": "string", "minLength": 1 }
+      }
+    },
+    "harness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "slug",
+        "display_name",
+        "product",
+        "family_constraint",
+        "model_resolution",
+        "provider_rewired"
+      ],
+      "properties": {
+        "slug": { "$ref": "#/$defs/slug" },
+        "display_name": { "type": "string", "minLength": 1 },
+        "product": { "type": "string", "minLength": 1 },
+        "family_constraint": { "$ref": "#/$defs/familyConstraint" },
+        "model_resolution": { "$ref": "#/$defs/modelResolution" },
+        "provider_rewired": { "type": "boolean" }
+      }
+    },
+    "foremanAdapter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "slug",
+        "display_name",
+        "source_file",
+        "harness",
+        "classification",
+        "production_dispatchable",
+        "provision_label"
+      ],
+      "properties": {
+        "slug": { "$ref": "#/$defs/slug" },
+        "display_name": { "type": "string", "minLength": 1 },
+        "source_file": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*[.]sh$"
+        },
+        "harness": {
+          "type": ["string", "null"],
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "classification": { "enum": ["production", "test-only"] },
+        "production_dispatchable": { "type": "boolean" },
+        "provision_label": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/docs/decisions/0002-foreman-deterministic-supervisor.md
+++ b/docs/decisions/0002-foreman-deterministic-supervisor.md
@@ -4,8 +4,9 @@ Date: 2026-07-12
 
 ## Status
 
-Accepted; distribution superseded. The principles below stand, but foreman no
-longer lives in this repo: the source was extracted to
+Accepted; distribution superseded; arming source amended by ADR 0005. The
+principles below stand, but foreman no longer lives in this repo: the source was
+extracted to
 [ponderousdev/foreman](https://github.com/ponderousdev/foreman) (its spec and
 ADRs govern it now), and harmon-init ships only a thin integration — a
 pinned `uvx` wrapper (`taskfiles/foreman.yml`) plus `.foreman.toml`.

--- a/docs/decisions/0005-unified-agent-vocabulary.md
+++ b/docs/decisions/0005-unified-agent-vocabulary.md
@@ -1,0 +1,120 @@
+# 5. Use one model-centric agent vocabulary and registry
+
+Date: 2026-08-07
+
+## Status
+
+Accepted. Amends ADR 0002's issue-field-versus-label arming decision: Foreman
+arming is label-only on every owner type because the label timeline records the
+actor and project-field changes do not.
+
+## Context
+
+Agent identity had become several incompatible vocabularies. Project planning
+used an `Agent` field, live work used `agent:*` labels, Foreman arming used
+`foreman:*` backend names, and wrappers used product or provider names. The
+copies drifted independently. In particular, harmon-init provisioned Foreman
+selectors for adapters absent from its pinned Foreman release.
+
+The vocabulary also mixed two different questions: which model family should do
+the reasoning, and which executable harness should run it. That made a harness
+slug such as `qwen-code` look interchangeable with a family slug such as `qwen`,
+and left no authoritative answer for where a model is selected.
+
+## Decision
+
+The machine-readable `agent-registry.json`, checked against
+`agent-registry.schema.json`, is the source contract for model families,
+harnesses, model-selection ownership, and Foreman adapter mappings. Executable
+checks and human-facing tables consume or validate against it rather than
+maintaining independent rosters.
+
+The following decisions are adopted together:
+
+1. **D1 — Foreman owns the `foreman:*` namespace.** Every label Foreman reads or
+   writes, including PR lifecycle outputs, uses that prefix.
+2. **D2 — PR delivery is draft-first.** Agents and Foreman keep implementation,
+   CI, automated review, and shepherding on a draft PR. Passing the readiness
+   gate promotes it for human review. The accurate Foreman output is
+   `foreman:ready-for-review`, not `ready-to-merge`; approval remains GitHub's
+   native review decision and merging remains human-only.
+3. **D3 — Claude Actions are mention-triggered and claim-aware.** The
+   `@claude plan|implement|review` commands run behind sender checks. Label-event
+   triggers are retired. A run acquires and always releases the relevant live
+   claim, including on failure.
+4. **D4 — The `Agent` project field is retired.** Advisory routing moves to
+   `suggest:*`; live ownership uses `claim:*`. Existing live fields require a
+   deliberate migration because setup remains additive-only.
+5. **D5 — Completion gets no agent label.** There is no `done:*` or `by:*`
+   family. Claim/release comments, PR authorship, and `ai-generated` preserve
+   history without leaving a second lifecycle marker to drift.
+6. **D6 — Suggestions and claims name model intelligence.** Both accept
+   family-level and optional model-level forms:
+   `suggest:<family>[:<model>]` and `claim:<family>[:<model>]`. Suggestions are
+   human-authored advice; claims are live, agent-authored ownership and are
+   released at wrap or shepherd completion. Neither arms automation.
+7. **D7 — Foreman selectors name harness adapters.** `foreman:<adapter>` selects
+   executable machinery. The registry maps that adapter to a harness and states
+   who selects the model. The family and harness axes are intentionally distinct.
+8. **D8 — Codex's family slug is `codex`.** Model segments, such as `sol` or
+   `luna`, live below that stable family slug.
+9. **D9 — Harness slugs follow product and collision rules.** Product names are
+   lowercase slugs (`antigravity`, `opencode`, `pi`). A product qualifier avoids
+   a family collision (`claude-code`, `codex-cli`, `copilot-cli`, `qwen-code`).
+   Provider-rewired variants use `<harness>-<family>`, including
+   `claude-code-deepseek`, `claude-code-glm`, `claude-code-kimi`, and
+   `claude-code-minimax`. MiniMax's family is `minimax`; `minimax` is never a
+   harness slug. A venue is not a harness, so the GitHub Action is
+   `claude-code-action`, not `gh-action`.
+10. **D10 — Project-management documentation is the human authority.** It must
+    explain the label security boundary, the label-versus-field rule, Claude
+    workflow behavior, the full label taxonomy, and registry-derived family and
+    harness tables. Labels have no per-label permissions; every label-triggered
+    automation consumer must verify who applied it. Labels carry multi-valued,
+    repo-visible, repo-writable, timeline-attributable data; fields carry
+    single-valued planning metadata such as Status, Priority, Size, Product,
+    Domain, and Layer.
+11. **D11 — The registry has executable teeth.** `task verify` schema-checks its
+    structure and semantic relationships. It rejects duplicate family or harness
+    slugs, absent model-resolution ownership, inconsistent family constraints,
+    model labels on the harness axis, and production-dispatchable adapters without
+    a harness mapping. Later drift checks bind provisioning, wrappers, and the
+    pinned upstream adapter roster to the same contract.
+
+Foreman's legacy production adapter `claude.sh` maps to harness `claude-code`.
+Its `mock.sh` adapter is a hermetic test seam only: it has no harness mapping,
+is not production-dispatchable, and must never imply a public `foreman:mock`
+label.
+
+## Rejected alternatives
+
+- **Keep the `Agent` field and `agent:*` labels.** They answer advisory routing
+  and live ownership with the same vocabulary, fail on personal repositories,
+  and provide no actor-attributable arming signal.
+- **Name claims after harnesses.** That makes routing depend on whichever CLI is
+  installed instead of the model capability or cost class and confuses harness
+  aliases with model families.
+- **Treat `suggest:*` as Foreman arming.** Suggestions are deliberately advisory;
+  using them for dispatch would turn ordinary triage edits into execution.
+- **Publish every possible `foreman:*` label.** A selector without a production
+  adapter is a false capability and can strand armed work.
+- **Document `mock` as a public adapter.** Its only role is hermetic upstream
+  testing; exposing it would promise execution machinery that intentionally does
+  no production work.
+- **Maintain the registry only as a Markdown table.** Tables cannot reject drift
+  in CI and would repeat the failure mode this decision resolves.
+
+## Consequences
+
+- Root and generated repositories ship byte-identical registry and schema files,
+  plus the same validator and mutation tests.
+- Consumers can derive family-level labels eagerly and model-level labels on
+  demand without confusing harness slugs for families.
+- Every harness row records where model selection occurs, even when the answer is
+  runner configuration rather than a label or Foreman.
+- Adapter availability is explicit: current production dispatch is the legacy
+  `claude` adapter mapped to `claude-code`; `mock` remains visible to checks but
+  invisible to provisioning.
+- Provisioning, workflow migration, vendored-skill migration, Foreman lifecycle
+  changes, and final documentation remain separate rollout units. The registry
+  establishes their shared contract without prematurely rewriting each consumer.

--- a/scripts/test-agent-registry.sh
+++ b/scripts/test-agent-registry.sh
@@ -149,4 +149,21 @@ case "$output" in
 esac
 echo "PASS: rejects unsupported schema keywords"
 
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.properties.families.items = false
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator accepted a boolean items schema"
+fi
+case "$output" in
+*'boolean and non-object schemas are not supported'*) ;;
+*) fail "boolean items schema failed for the wrong reason: $output" ;;
+esac
+echo "PASS: rejects boolean items schemas"
+
 echo "agent registry mutation tests OK"

--- a/scripts/test-agent-registry.sh
+++ b/scripts/test-agent-registry.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# test-agent-registry.sh — schema-check the registry and exercise semantic guards.
+set -euo pipefail
+
+repo="$(git rev-parse --show-toplevel)"
+cd "$repo"
+
+registry="${1:-agent-registry.json}"
+schema="${2:-agent-registry.schema.json}"
+validator="scripts/validate-agent-registry.mjs"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+for required in "$registry" "$schema" "$validator"; do
+    [ -f "$required" ] || fail "missing required registry asset: $required"
+done
+command -v node >/dev/null 2>&1 || fail "node is required to validate the agent registry"
+
+node "$validator" "$registry" "$schema"
+
+test_tmp="$(mktemp -d)"
+trap 'rm -rf "$test_tmp"' EXIT
+mutated="${test_tmp}/agent-registry.json"
+mutated_schema="${test_tmp}/agent-registry.schema.json"
+
+rejects() {
+    local description="$1"
+    local mutation="$2"
+    local expected="$3"
+    local output
+
+    if ! node --input-type=module - "$registry" "$mutated" "$mutation" <<'NODE'; then
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath, mutation] = process.argv.slice(2)
+const registry = JSON.parse(await readFile(inputPath, 'utf8'))
+const adapter = (slug) => registry.foreman_adapters.find((entry) => entry.slug === slug)
+const harness = (slug) => registry.harnesses.find((entry) => entry.slug === slug)
+
+switch (mutation) {
+  case 'duplicate-family':
+    registry.families.push(structuredClone(registry.families[0]))
+    break
+  case 'duplicate-harness':
+    registry.harnesses.push(structuredClone(registry.harnesses[0]))
+    break
+  case 'missing-model-owner':
+    delete registry.harnesses[0].model_resolution.owner
+    break
+  case 'unknown-fixed-family':
+    registry.harnesses[0].family_constraint.family = 'unknown'
+    break
+  case 'family-on-none':
+    for (const entry of registry.harnesses) {
+      if (entry.family_constraint.kind === 'none') entry.family_constraint.family = 'claude'
+    }
+    break
+  case 'production-without-harness':
+    adapter('claude').harness = null
+    break
+  case 'harness-axis':
+    registry.labels.suggest.axis = 'harness'
+    break
+  case 'public-mock':
+    adapter('mock').provision_label = true
+    break
+  case 'bad-minimax-slug':
+    harness('claude-code-minimax').slug = 'claude-code-mini'
+    break
+  case 'bad-claude-harness':
+    adapter('claude').harness = 'qwen-code'
+    break
+  case 'non-production-claude':
+    Object.assign(adapter('claude'), {
+      classification: 'test-only',
+      production_dispatchable: false,
+      provision_label: false
+    })
+    break
+  default:
+    throw new Error(`unknown mutation: ${mutation}`)
+}
+
+await writeFile(outputPath, `${JSON.stringify(registry, null, 2)}\n`)
+NODE
+        fail "could not build mutation: $description"
+    fi
+    if output="$(node "$validator" "$mutated" "$schema" 2>&1)"; then
+        fail "validator accepted mutation: $description"
+    fi
+    case "$output" in
+    *"$expected"*) ;;
+    *) fail "$description failed for the wrong reason: $output" ;;
+    esac
+    echo "PASS: rejects $description"
+}
+
+rejects "duplicate family slugs" \
+    'duplicate-family' \
+    'duplicate family slug'
+rejects "duplicate harness slugs" \
+    'duplicate-harness' \
+    'duplicate harness slug'
+rejects "missing model-resolution ownership" \
+    'missing-model-owner' \
+    'missing required property owner'
+rejects "unknown fixed-family constraints" \
+    'unknown-fixed-family' \
+    'references unknown family unknown'
+rejects "family values on unconstrained harnesses" \
+    'family-on-none' \
+    'with a none constraint'
+rejects "production adapters without a harness mapping" \
+    'production-without-harness' \
+    'needs a production harness mapping'
+rejects "harness-centric suggestion labels" \
+    'harness-axis' \
+    'must equal "model"'
+rejects "public labels for the test-only mock adapter" \
+    'public-mock' \
+    'test-only Foreman adapter mock cannot dispatch or provision a public label'
+rejects "a non-normalized MiniMax harness slug" \
+    'bad-minimax-slug' \
+    'must be named claude-code-<fixed-family>'
+rejects "a legacy claude adapter mapped to the wrong harness" \
+    'bad-claude-harness' \
+    'legacy Foreman adapter claude must map claude.sh to harness claude-code'
+rejects "a non-production legacy claude adapter" \
+    'non-production-claude' \
+    'legacy Foreman adapter claude must be production-dispatchable and provisionable'
+
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.minProperties = 99
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator accepted an unsupported schema keyword"
+fi
+case "$output" in
+*'unsupported schema keyword minProperties'*) ;;
+*) fail "unsupported schema keyword failed for the wrong reason: $output" ;;
+esac
+echo "PASS: rejects unsupported schema keywords"
+
+echo "agent registry mutation tests OK"

--- a/scripts/test-agent-registry.sh
+++ b/scripts/test-agent-registry.sh
@@ -190,6 +190,25 @@ import { readFile, writeFile } from 'node:fs/promises'
 
 const [inputPath, outputPath] = process.argv.slice(2)
 const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.$defs.model.properties.display_name = {
+  $ref: '#/__proto__'
+}
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator accepted an inherited schema reference target"
+fi
+case "$output" in
+*'does not resolve to an object schema'*) ;;
+*) fail "inherited schema reference failed for the wrong reason: $output" ;;
+esac
+echo "PASS: rejects inherited properties while resolving references"
+
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
 schema.properties.families.items = false
 await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
 NODE

--- a/scripts/test-agent-registry.sh
+++ b/scripts/test-agent-registry.sh
@@ -154,6 +154,23 @@ import { readFile, writeFile } from 'node:fs/promises'
 
 const [inputPath, outputPath] = process.argv.slice(2)
 const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.$defs.model.properties.display_name.minLength = 'one'
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator accepted a malformed minLength value"
+fi
+case "$output" in
+*'minLength: must be a non-negative integer'*) ;;
+*) fail "malformed minLength failed for the wrong reason: $output" ;;
+esac
+echo "PASS: rejects malformed supported schema keyword values"
+
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
 schema.properties.families.items = false
 await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
 NODE

--- a/scripts/test-agent-registry.sh
+++ b/scripts/test-agent-registry.sh
@@ -209,6 +209,42 @@ import { readFile, writeFile } from 'node:fs/promises'
 
 const [inputPath, outputPath] = process.argv.slice(2)
 const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.$defs.model.properties.display_name = {
+  $ref: '#/$defs/model/properties'
+}
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator accepted a reference to a schema-container object"
+fi
+case "$output" in
+*'unsupported schema keyword slug'*) ;;
+*) fail "schema-container reference failed for the wrong reason: $output" ;;
+esac
+echo "PASS: audits resolved reference targets as schemas"
+
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.$defs.cycle = { $ref: '#/$defs/cycle' }
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator accepted a cyclic schema reference"
+fi
+case "$output" in
+*'cyclic schema references are not supported'*) ;;
+*) fail "cyclic schema reference failed for the wrong reason: $output" ;;
+esac
+echo "PASS: rejects cyclic schema references without recursing forever"
+
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
 schema.properties.families.items = false
 await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
 NODE

--- a/scripts/test-agent-registry.sh
+++ b/scripts/test-agent-registry.sh
@@ -245,6 +245,19 @@ import { readFile, writeFile } from 'node:fs/promises'
 
 const [inputPath, outputPath] = process.argv.slice(2)
 const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.properties.schema_version = { type: 'number' }
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if ! output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator rejected an integer instance under a number schema: $output"
+fi
+echo "PASS: accepts integer instances under number schemas"
+
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
 schema.properties.families.items = false
 await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
 NODE

--- a/scripts/test-agent-registry.sh
+++ b/scripts/test-agent-registry.sh
@@ -171,6 +171,25 @@ import { readFile, writeFile } from 'node:fs/promises'
 
 const [inputPath, outputPath] = process.argv.slice(2)
 const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.$defs.model.properties.display_name = {
+  $ref: '#/properties/schema_version/const'
+}
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator accepted a reference to a primitive schema node"
+fi
+case "$output" in
+*'does not resolve to an object schema'*) ;;
+*) fail "primitive schema reference failed for the wrong reason: $output" ;;
+esac
+echo "PASS: rejects references to primitive schema nodes"
+
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
 schema.properties.families.items = false
 await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
 NODE

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -232,6 +232,24 @@ else
     err "no Taskfile.yml generated"
 fi
 
+# ── 1a. Machine-readable agent vocabulary survives every render profile ──
+if [ ! -x scripts/test-agent-registry.sh ]; then
+    err "agent registry test is missing or not executable"
+elif ! ./scripts/test-agent-registry.sh; then
+    err "rendered agent registry fails its schema/semantic contract"
+fi
+if have task; then
+    grep -qF './scripts/test-agent-registry.sh' \
+        <<<"$(task --color=false --dry verify 2>&1 || true)" ||
+        err "task verify does not reach test:agent-registry"
+else
+    required task "agent registry verify reachability" || fail=1
+fi
+if [ -f .github/workflows/build.yml ]; then
+    grep -qF 'task test:agent-registry' .github/workflows/build.yml ||
+        err "required CI does not run test:agent-registry"
+fi
+
 # ── 1b. Free security policy renders as a coherent stack ───────────
 [ -x scripts/run-semgrep.sh ] || err "pinned Semgrep CE runner missing or not executable"
 grep -q 'brew "uv"' Brewfile || err "Brewfile must install uv for the Semgrep runner"

--- a/scripts/validate-agent-registry.mjs
+++ b/scripts/validate-agent-registry.mjs
@@ -140,10 +140,20 @@ function assertSchemaKeywordValues(rule, location) {
   }
 }
 
-function assertSupportedSchema(rule, location = '$schema') {
+function assertSupportedSchema(
+  rule,
+  location = '$schema',
+  audit = { active: new Set(), complete: new Set() }
+) {
   if (rule === null || typeof rule !== 'object' || Array.isArray(rule)) {
     throw new Error(`${location}: boolean and non-object schemas are not supported`)
   }
+  if (audit.active.has(rule)) {
+    throw new Error(`${location}: cyclic schema references are not supported`)
+  }
+  if (audit.complete.has(rule)) return
+
+  audit.active.add(rule)
   for (const keyword of Object.keys(rule)) {
     if (!supportedSchemaKeywords.has(keyword)) {
       throw new Error(`${location}: unsupported schema keyword ${keyword}`)
@@ -160,14 +170,17 @@ function assertSupportedSchema(rule, location = '$schema') {
         `${location}: schema reference ${rule.$ref} does not resolve to an object schema`
       )
     }
+    assertSupportedSchema(target, `${location}.$ref(${rule.$ref})`, audit)
   }
   for (const [name, child] of Object.entries(rule.$defs ?? {})) {
-    assertSupportedSchema(child, `${location}.$defs.${name}`)
+    assertSupportedSchema(child, `${location}.$defs.${name}`, audit)
   }
   for (const [name, child] of Object.entries(rule.properties ?? {})) {
-    assertSupportedSchema(child, `${location}.properties.${name}`)
+    assertSupportedSchema(child, `${location}.properties.${name}`, audit)
   }
-  if (Object.hasOwn(rule, 'items')) assertSupportedSchema(rule.items, `${location}.items`)
+  if (Object.hasOwn(rule, 'items')) assertSupportedSchema(rule.items, `${location}.items`, audit)
+  audit.active.delete(rule)
+  audit.complete.add(rule)
 }
 
 try {

--- a/scripts/validate-agent-registry.mjs
+++ b/scripts/validate-agent-registry.mjs
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+const registryPath = path.resolve(process.argv[2] ?? 'agent-registry.json')
+const schemaPath = path.resolve(
+  process.argv[3] ?? path.join(path.dirname(registryPath), 'agent-registry.schema.json')
+)
+
+function loadJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'))
+  } catch (error) {
+    console.error(`agent registry: cannot read valid JSON from ${file}: ${error.message}`)
+    process.exit(1)
+  }
+}
+
+const registry = loadJson(registryPath)
+const schema = loadJson(schemaPath)
+const errors = []
+
+const supportedSchemaKeywords = new Set([
+  '$schema',
+  '$id',
+  '$defs',
+  '$ref',
+  'title',
+  'description',
+  '$comment',
+  'type',
+  'const',
+  'enum',
+  'minLength',
+  'pattern',
+  'minItems',
+  'uniqueItems',
+  'items',
+  'required',
+  'properties',
+  'additionalProperties'
+])
+
+function assertSupportedSchema(rule, location = '$schema') {
+  if (rule === null || typeof rule !== 'object' || Array.isArray(rule)) {
+    throw new Error(`${location}: boolean and non-object schemas are not supported`)
+  }
+  for (const keyword of Object.keys(rule)) {
+    if (!supportedSchemaKeywords.has(keyword)) {
+      throw new Error(`${location}: unsupported schema keyword ${keyword}`)
+    }
+  }
+  if (rule.$ref && Object.keys(rule).some((keyword) => keyword !== '$ref')) {
+    throw new Error(`${location}: schema keywords alongside $ref are not supported`)
+  }
+  if (
+    Object.hasOwn(rule, 'additionalProperties') &&
+    typeof rule.additionalProperties !== 'boolean'
+  ) {
+    throw new Error(`${location}: schema-valued additionalProperties is not supported`)
+  }
+  for (const [name, child] of Object.entries(rule.$defs ?? {})) {
+    assertSupportedSchema(child, `${location}.$defs.${name}`)
+  }
+  for (const [name, child] of Object.entries(rule.properties ?? {})) {
+    assertSupportedSchema(child, `${location}.properties.${name}`)
+  }
+  if (rule.items) assertSupportedSchema(rule.items, `${location}.items`)
+}
+
+try {
+  assertSupportedSchema(schema)
+} catch (error) {
+  console.error(`agent registry: unsupported schema: ${error.message}`)
+  process.exit(1)
+}
+
+function jsonEqual(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right)
+}
+
+function instanceType(value) {
+  if (value === null) return 'null'
+  if (Array.isArray(value)) return 'array'
+  if (Number.isInteger(value)) return 'integer'
+  return typeof value
+}
+
+function resolveRef(ref) {
+  if (!ref.startsWith('#/')) throw new Error(`unsupported schema reference: ${ref}`)
+  return ref
+    .slice(2)
+    .split('/')
+    .map((part) => part.replaceAll('~1', '/').replaceAll('~0', '~'))
+    .reduce((node, part) => node?.[part], schema)
+}
+
+function validateSchema(value, rule, location) {
+  if (rule.$ref) {
+    const target = resolveRef(rule.$ref)
+    if (!target) {
+      errors.push(`${location}: schema reference ${rule.$ref} does not resolve`)
+      return
+    }
+    validateSchema(value, target, location)
+    return
+  }
+
+  if (Object.hasOwn(rule, 'const') && !jsonEqual(value, rule.const)) {
+    errors.push(`${location}: must equal ${JSON.stringify(rule.const)}`)
+  }
+  if (rule.enum && !rule.enum.some((candidate) => jsonEqual(value, candidate))) {
+    errors.push(`${location}: must be one of ${rule.enum.map(JSON.stringify).join(', ')}`)
+  }
+
+  if (rule.type) {
+    const allowed = Array.isArray(rule.type) ? rule.type : [rule.type]
+    const actual = instanceType(value)
+    if (!allowed.includes(actual)) {
+      errors.push(`${location}: expected ${allowed.join(' or ')}, found ${actual}`)
+      return
+    }
+  }
+
+  if (typeof value === 'string') {
+    if (rule.minLength !== undefined && value.length < rule.minLength) {
+      errors.push(`${location}: must contain at least ${rule.minLength} character(s)`)
+    }
+    if (rule.pattern && !new RegExp(rule.pattern, 'u').test(value)) {
+      errors.push(`${location}: does not match ${rule.pattern}`)
+    }
+  }
+
+  if (Array.isArray(value)) {
+    if (rule.minItems !== undefined && value.length < rule.minItems) {
+      errors.push(`${location}: must contain at least ${rule.minItems} item(s)`)
+    }
+    if (rule.uniqueItems) {
+      const serialized = value.map((item) => JSON.stringify(item))
+      if (new Set(serialized).size !== serialized.length) {
+        errors.push(`${location}: items must be unique`)
+      }
+    }
+    if (rule.items) {
+      value.forEach((item, index) => validateSchema(item, rule.items, `${location}[${index}]`))
+    }
+  }
+
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    for (const required of rule.required ?? []) {
+      if (!Object.hasOwn(value, required))
+        errors.push(`${location}: missing required property ${required}`)
+    }
+    if (rule.additionalProperties === false) {
+      for (const key of Object.keys(value)) {
+        if (!Object.hasOwn(rule.properties ?? {}, key)) {
+          errors.push(`${location}: unexpected property ${key}`)
+        }
+      }
+    }
+    for (const [key, childRule] of Object.entries(rule.properties ?? {})) {
+      if (Object.hasOwn(value, key)) validateSchema(value[key], childRule, `${location}.${key}`)
+    }
+  }
+}
+
+function duplicateSlugs(rows) {
+  const seen = new Set()
+  return rows.map((row) => row.slug).filter((slug) => seen.has(slug) || !seen.add(slug))
+}
+
+function semanticError(message) {
+  errors.push(`registry: ${message}`)
+}
+
+validateSchema(registry, schema, '$registry')
+
+// Cross-record constraints cannot be expressed by the structural schema alone.
+if (errors.length === 0) {
+  const familySlugs = new Set(registry.families.map((family) => family.slug))
+  const harnessSlugs = new Set(registry.harnesses.map((harness) => harness.slug))
+
+  for (const slug of duplicateSlugs(registry.families))
+    semanticError(`duplicate family slug: ${slug}`)
+  for (const slug of duplicateSlugs(registry.harnesses))
+    semanticError(`duplicate harness slug: ${slug}`)
+  for (const slug of duplicateSlugs(registry.foreman_adapters)) {
+    semanticError(`duplicate Foreman adapter slug: ${slug}`)
+  }
+
+  for (const family of registry.families) {
+    for (const slug of duplicateSlugs(family.models)) {
+      semanticError(`family ${family.slug} has duplicate model slug: ${slug}`)
+    }
+    if (harnessSlugs.has(family.slug)) {
+      semanticError(`slug ${family.slug} is both a model family and a harness`)
+    }
+  }
+
+  for (const [name, namespace] of Object.entries(registry.labels)) {
+    if (namespace.prefix !== name) semanticError(`${name} label prefix must be ${name}`)
+    if (namespace.axis !== 'model') semanticError(`${name} labels must use the model axis`)
+    if (!namespace.scopes.includes('family') || !namespace.scopes.includes('model')) {
+      semanticError(`${name} labels must support family-level and optional model-level forms`)
+    }
+    if (namespace.arming !== false) semanticError(`${name} labels must never arm dispatch`)
+  }
+
+  for (const harness of registry.harnesses) {
+    const constraint = harness.family_constraint
+    if (constraint.kind === 'fixed') {
+      if (!constraint.family) {
+        semanticError(`harness ${harness.slug} has a fixed family constraint without a family`)
+      } else if (!familySlugs.has(constraint.family)) {
+        semanticError(`harness ${harness.slug} references unknown family ${constraint.family}`)
+      }
+    } else if (Object.hasOwn(constraint, 'family')) {
+      semanticError(
+        `harness ${harness.slug} has family ${constraint.family} with a none constraint`
+      )
+    }
+
+    if (harness.provider_rewired) {
+      if (constraint.kind !== 'fixed' || harness.slug !== `claude-code-${constraint.family}`) {
+        semanticError(
+          `provider-rewired harness ${harness.slug} must be named claude-code-<fixed-family>`
+        )
+      }
+      if (harness.model_resolution.owner !== 'provider-wrapper') {
+        semanticError(
+          `provider-rewired harness ${harness.slug} must delegate model resolution to provider-wrapper`
+        )
+      }
+    } else if (harness.model_resolution.owner === 'provider-wrapper') {
+      semanticError(
+        `non-rewired harness ${harness.slug} cannot delegate model resolution to provider-wrapper`
+      )
+    }
+  }
+
+  for (const adapter of registry.foreman_adapters) {
+    if (adapter.harness !== null && !harnessSlugs.has(adapter.harness)) {
+      semanticError(`Foreman adapter ${adapter.slug} maps unknown harness ${adapter.harness}`)
+    }
+    if (adapter.production_dispatchable) {
+      if (adapter.classification !== 'production' || adapter.harness === null) {
+        semanticError(
+          `production-dispatchable Foreman adapter ${adapter.slug} needs a production harness mapping`
+        )
+      }
+      if (!adapter.provision_label) {
+        semanticError(
+          `production-dispatchable Foreman adapter ${adapter.slug} must provision its selector label`
+        )
+      }
+    }
+    if (adapter.classification === 'test-only') {
+      if (adapter.production_dispatchable || adapter.provision_label) {
+        semanticError(
+          `test-only Foreman adapter ${adapter.slug} cannot dispatch or provision a public label`
+        )
+      }
+    }
+    if (adapter.provision_label && !adapter.production_dispatchable) {
+      semanticError(
+        `Foreman adapter ${adapter.slug} cannot provision a label unless it is production-dispatchable`
+      )
+    }
+  }
+
+  const mock = registry.foreman_adapters.find((adapter) => adapter.slug === 'mock')
+  if (
+    !mock ||
+    mock.source_file !== 'mock.sh' ||
+    mock.classification !== 'test-only' ||
+    mock.harness !== null ||
+    mock.production_dispatchable ||
+    mock.provision_label
+  ) {
+    semanticError('mock must be a mapped file-only, test-only, non-provisionable Foreman adapter')
+  }
+
+  const claude = registry.foreman_adapters.find((adapter) => adapter.slug === 'claude')
+  if (!claude || claude.harness !== 'claude-code' || claude.source_file !== 'claude.sh') {
+    semanticError('legacy Foreman adapter claude must map claude.sh to harness claude-code')
+  }
+  if (
+    !claude ||
+    claude.classification !== 'production' ||
+    !claude.production_dispatchable ||
+    !claude.provision_label
+  ) {
+    semanticError('legacy Foreman adapter claude must be production-dispatchable and provisionable')
+  }
+
+  const minimax = registry.harnesses.find((harness) => harness.slug === 'claude-code-minimax')
+  if (
+    !familySlugs.has('minimax') ||
+    !minimax ||
+    minimax.family_constraint.kind !== 'fixed' ||
+    minimax.family_constraint.family !== 'minimax' ||
+    !minimax.provider_rewired
+  ) {
+    semanticError(
+      'MiniMax must use family minimax and provider-rewired harness claude-code-minimax'
+    )
+  }
+}
+
+if (errors.length > 0) {
+  for (const error of errors) console.error(`FAIL: ${error}`)
+  process.exit(1)
+}
+
+console.log(
+  `agent registry OK: ${registry.families.length} families, ${registry.harnesses.length} harnesses, ${registry.foreman_adapters.length} Foreman adapters`
+)

--- a/scripts/validate-agent-registry.mjs
+++ b/scripts/validate-agent-registry.mjs
@@ -236,7 +236,8 @@ function validateSchema(value, rule, location) {
   if (rule.type) {
     const allowed = Array.isArray(rule.type) ? rule.type : [rule.type]
     const actual = instanceType(value)
-    if (!allowed.includes(actual)) {
+    const integerSatisfiesNumber = actual === 'integer' && allowed.includes('number')
+    if (!allowed.includes(actual) && !integerSatisfiesNumber) {
       errors.push(`${location}: expected ${allowed.join(' or ')}, found ${actual}`)
       return
     }

--- a/scripts/validate-agent-registry.mjs
+++ b/scripts/validate-agent-registry.mjs
@@ -67,7 +67,7 @@ function assertSupportedSchema(rule, location = '$schema') {
   for (const [name, child] of Object.entries(rule.properties ?? {})) {
     assertSupportedSchema(child, `${location}.properties.${name}`)
   }
-  if (rule.items) assertSupportedSchema(rule.items, `${location}.items`)
+  if (Object.hasOwn(rule, 'items')) assertSupportedSchema(rule.items, `${location}.items`)
 }
 
 try {

--- a/scripts/validate-agent-registry.mjs
+++ b/scripts/validate-agent-registry.mjs
@@ -43,6 +43,99 @@ const supportedSchemaKeywords = new Set([
   'additionalProperties'
 ])
 
+const supportedInstanceTypes = new Set([
+  'array',
+  'boolean',
+  'integer',
+  'null',
+  'number',
+  'object',
+  'string'
+])
+
+function schemaError(location, keyword, expectation) {
+  throw new Error(`${location}.${keyword}: ${expectation}`)
+}
+
+function assertSchemaKeywordValues(rule, location) {
+  for (const keyword of ['$schema', '$id', '$ref', 'title', 'description', '$comment']) {
+    if (Object.hasOwn(rule, keyword) && typeof rule[keyword] !== 'string') {
+      schemaError(location, keyword, 'must be a string')
+    }
+  }
+  for (const keyword of ['$schema', '$id', '$ref']) {
+    if (Object.hasOwn(rule, keyword) && rule[keyword].length === 0) {
+      schemaError(location, keyword, 'must not be empty')
+    }
+  }
+
+  if (Object.hasOwn(rule, 'type')) {
+    const types = Array.isArray(rule.type) ? rule.type : [rule.type]
+    if (
+      types.length === 0 ||
+      types.some((type) => typeof type !== 'string' || !supportedInstanceTypes.has(type)) ||
+      new Set(types).size !== types.length
+    ) {
+      schemaError(location, 'type', 'must name one or more unique supported instance types')
+    }
+  }
+
+  if (Object.hasOwn(rule, 'enum')) {
+    if (!Array.isArray(rule.enum) || rule.enum.length === 0) {
+      schemaError(location, 'enum', 'must be a non-empty array')
+    }
+    if (
+      rule.enum.some((candidate, index) =>
+        rule.enum.slice(0, index).some((earlier) => jsonEqual(candidate, earlier))
+      )
+    ) {
+      schemaError(location, 'enum', 'must contain unique values')
+    }
+  }
+
+  for (const keyword of ['minLength', 'minItems']) {
+    if (Object.hasOwn(rule, keyword) && (!Number.isInteger(rule[keyword]) || rule[keyword] < 0)) {
+      schemaError(location, keyword, 'must be a non-negative integer')
+    }
+  }
+
+  if (Object.hasOwn(rule, 'pattern')) {
+    if (typeof rule.pattern !== 'string') schemaError(location, 'pattern', 'must be a string')
+    try {
+      new RegExp(rule.pattern, 'u')
+    } catch {
+      schemaError(location, 'pattern', 'must be a valid regular expression')
+    }
+  }
+
+  if (Object.hasOwn(rule, 'uniqueItems') && typeof rule.uniqueItems !== 'boolean') {
+    schemaError(location, 'uniqueItems', 'must be a boolean')
+  }
+  if (Object.hasOwn(rule, 'required')) {
+    if (
+      !Array.isArray(rule.required) ||
+      rule.required.some((name) => typeof name !== 'string') ||
+      new Set(rule.required).size !== rule.required.length
+    ) {
+      schemaError(location, 'required', 'must be an array of unique strings')
+    }
+  }
+  for (const keyword of ['$defs', 'properties']) {
+    if (
+      Object.hasOwn(rule, keyword) &&
+      (rule[keyword] === null || typeof rule[keyword] !== 'object' || Array.isArray(rule[keyword]))
+    ) {
+      schemaError(location, keyword, 'must be an object')
+    }
+  }
+  if (
+    Object.hasOwn(rule, 'additionalProperties') &&
+    typeof rule.additionalProperties !== 'boolean'
+  ) {
+    schemaError(location, 'additionalProperties', 'must be a boolean')
+  }
+}
+
 function assertSupportedSchema(rule, location = '$schema') {
   if (rule === null || typeof rule !== 'object' || Array.isArray(rule)) {
     throw new Error(`${location}: boolean and non-object schemas are not supported`)
@@ -52,14 +145,9 @@ function assertSupportedSchema(rule, location = '$schema') {
       throw new Error(`${location}: unsupported schema keyword ${keyword}`)
     }
   }
-  if (rule.$ref && Object.keys(rule).some((keyword) => keyword !== '$ref')) {
+  assertSchemaKeywordValues(rule, location)
+  if (Object.hasOwn(rule, '$ref') && Object.keys(rule).some((keyword) => keyword !== '$ref')) {
     throw new Error(`${location}: schema keywords alongside $ref are not supported`)
-  }
-  if (
-    Object.hasOwn(rule, 'additionalProperties') &&
-    typeof rule.additionalProperties !== 'boolean'
-  ) {
-    throw new Error(`${location}: schema-valued additionalProperties is not supported`)
   }
   for (const [name, child] of Object.entries(rule.$defs ?? {})) {
     assertSupportedSchema(child, `${location}.$defs.${name}`)
@@ -73,7 +161,7 @@ function assertSupportedSchema(rule, location = '$schema') {
 try {
   assertSupportedSchema(schema)
 } catch (error) {
-  console.error(`agent registry: unsupported schema: ${error.message}`)
+  console.error(`agent registry: invalid or unsupported schema: ${error.message}`)
   process.exit(1)
 }
 

--- a/scripts/validate-agent-registry.mjs
+++ b/scripts/validate-agent-registry.mjs
@@ -194,7 +194,12 @@ function resolveRef(ref) {
     .slice(2)
     .split('/')
     .map((part) => part.replaceAll('~1', '/').replaceAll('~0', '~'))
-    .reduce((node, part) => node?.[part], schema)
+    .reduce((node, part) => {
+      if (node === null || typeof node !== 'object' || !Object.hasOwn(node, part)) {
+        return undefined
+      }
+      return node[part]
+    }, schema)
 }
 
 function validateSchema(value, rule, location) {

--- a/scripts/validate-agent-registry.mjs
+++ b/scripts/validate-agent-registry.mjs
@@ -57,6 +57,10 @@ function schemaError(location, keyword, expectation) {
   throw new Error(`${location}.${keyword}: ${expectation}`)
 }
 
+function isSchemaObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
 function assertSchemaKeywordValues(rule, location) {
   for (const keyword of ['$schema', '$id', '$ref', 'title', 'description', '$comment']) {
     if (Object.hasOwn(rule, keyword) && typeof rule[keyword] !== 'string') {
@@ -149,6 +153,14 @@ function assertSupportedSchema(rule, location = '$schema') {
   if (Object.hasOwn(rule, '$ref') && Object.keys(rule).some((keyword) => keyword !== '$ref')) {
     throw new Error(`${location}: schema keywords alongside $ref are not supported`)
   }
+  if (Object.hasOwn(rule, '$ref')) {
+    const target = resolveRef(rule.$ref)
+    if (!isSchemaObject(target)) {
+      throw new Error(
+        `${location}: schema reference ${rule.$ref} does not resolve to an object schema`
+      )
+    }
+  }
   for (const [name, child] of Object.entries(rule.$defs ?? {})) {
     assertSupportedSchema(child, `${location}.$defs.${name}`)
   }
@@ -186,10 +198,10 @@ function resolveRef(ref) {
 }
 
 function validateSchema(value, rule, location) {
-  if (rule.$ref) {
+  if (Object.hasOwn(rule, '$ref')) {
     const target = resolveRef(rule.$ref)
-    if (!target) {
-      errors.push(`${location}: schema reference ${rule.$ref} does not resolve`)
+    if (!isSchemaObject(target)) {
+      errors.push(`${location}: schema reference ${rule.$ref} does not resolve to an object schema`)
       return
     }
     validateSchema(value, target, location)

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -49,6 +49,7 @@ jobs:
         run: task guard:codegen
 [% endif %]
       - run: task test:tasks
+      - run: task test:agent-registry
 [% if use_codex_review %]
       - run: task test:codex-review
 [% endif %]

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -103,6 +103,7 @@ tasks:
       - task: build
 [% endif %]
       - task: validate
+      - task: test:agent-registry
       - task: test:tasks
       - task: test:ci-results
       - task: test:status
@@ -630,6 +631,11 @@ tasks:
 [% else %]
       - 'echo "TODO: wire tests for this project (see docs/architecture/tests.md); test files live in tests/"'
 [% endif %]
+
+  test:agent-registry:
+    desc: Schema-check the machine-readable agent registry and its cross-record invariants
+    cmds:
+      - ./scripts/test-agent-registry.sh
 
   test:tasks:
     desc: Guard the Taskfile itself (compiles; setup tasks are safe no-ops)

--- a/template/agent-registry.json
+++ b/template/agent-registry.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "./agent-registry.schema.json",
+  "schema_version": 1,
+  "labels": {
+    "suggest": {
+      "prefix": "suggest",
+      "axis": "model",
+      "scopes": ["family", "model"],
+      "arming": false
+    },
+    "claim": {
+      "prefix": "claim",
+      "axis": "model",
+      "scopes": ["family", "model"],
+      "arming": false
+    }
+  },
+  "families": [
+    {
+      "slug": "claude",
+      "display_name": "Claude",
+      "models": [
+        { "slug": "opus", "display_name": "Opus" },
+        { "slug": "sonnet", "display_name": "Sonnet" },
+        { "slug": "haiku", "display_name": "Haiku" }
+      ]
+    },
+    {
+      "slug": "codex",
+      "display_name": "OpenAI Codex",
+      "models": [
+        { "slug": "sol", "display_name": "Sol" },
+        { "slug": "terra", "display_name": "Terra" },
+        { "slug": "luna", "display_name": "Luna" }
+      ]
+    },
+    { "slug": "copilot", "display_name": "GitHub Copilot", "models": [] },
+    {
+      "slug": "qwen",
+      "display_name": "Qwen",
+      "models": [{ "slug": "coder", "display_name": "Coder" }]
+    },
+    { "slug": "deepseek", "display_name": "DeepSeek", "models": [] },
+    {
+      "slug": "glm",
+      "display_name": "GLM",
+      "models": [{ "slug": "5-2", "display_name": "5.2" }]
+    },
+    {
+      "slug": "kimi",
+      "display_name": "Kimi",
+      "models": [{ "slug": "k3", "display_name": "K3" }]
+    },
+    { "slug": "minimax", "display_name": "MiniMax", "models": [] },
+    { "slug": "gemini", "display_name": "Gemini", "models": [] }
+  ],
+  "harnesses": [
+    {
+      "slug": "claude-code",
+      "display_name": "Claude Code",
+      "product": "Claude Code CLI",
+      "family_constraint": { "kind": "fixed", "family": "claude" },
+      "model_resolution": {
+        "owner": "runner-config",
+        "details": "The runner or repository configuration selects the Claude model; labels do not."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "claude-code-action",
+      "display_name": "Claude Code Action",
+      "product": "claude-code-action",
+      "family_constraint": { "kind": "fixed", "family": "claude" },
+      "model_resolution": {
+        "owner": "workflow-config",
+        "details": "The GitHub Actions workflow input selects the Claude model."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "claude-code-deepseek",
+      "display_name": "Claude Code with DeepSeek",
+      "product": "Claude Code provider wrapper",
+      "family_constraint": { "kind": "fixed", "family": "deepseek" },
+      "model_resolution": {
+        "owner": "provider-wrapper",
+        "details": "The provider-rewired wrapper fixes the family and its runtime configuration selects the model."
+      },
+      "provider_rewired": true
+    },
+    {
+      "slug": "claude-code-glm",
+      "display_name": "Claude Code with GLM",
+      "product": "Claude Code provider wrapper",
+      "family_constraint": { "kind": "fixed", "family": "glm" },
+      "model_resolution": {
+        "owner": "provider-wrapper",
+        "details": "The provider-rewired wrapper fixes the family and its runtime configuration selects the model."
+      },
+      "provider_rewired": true
+    },
+    {
+      "slug": "claude-code-kimi",
+      "display_name": "Claude Code with Kimi",
+      "product": "Claude Code provider wrapper",
+      "family_constraint": { "kind": "fixed", "family": "kimi" },
+      "model_resolution": {
+        "owner": "provider-wrapper",
+        "details": "The provider-rewired wrapper fixes the family and its runtime configuration selects the model."
+      },
+      "provider_rewired": true
+    },
+    {
+      "slug": "claude-code-minimax",
+      "display_name": "Claude Code with MiniMax",
+      "product": "Claude Code provider wrapper",
+      "family_constraint": { "kind": "fixed", "family": "minimax" },
+      "model_resolution": {
+        "owner": "provider-wrapper",
+        "details": "The provider-rewired wrapper fixes the family and its runtime configuration selects the model."
+      },
+      "provider_rewired": true
+    },
+    {
+      "slug": "codex-cli",
+      "display_name": "OpenAI Codex CLI",
+      "product": "OpenAI Codex CLI",
+      "family_constraint": { "kind": "fixed", "family": "codex" },
+      "model_resolution": {
+        "owner": "runner-config",
+        "details": "The runner or CLI invocation selects the Codex model."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "copilot-cli",
+      "display_name": "GitHub Copilot CLI",
+      "product": "GitHub Copilot CLI",
+      "family_constraint": { "kind": "fixed", "family": "copilot" },
+      "model_resolution": {
+        "owner": "runner-config",
+        "details": "The runner or Copilot configuration selects the model."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "qwen-code",
+      "display_name": "Qwen Code",
+      "product": "Qwen Code CLI",
+      "family_constraint": { "kind": "fixed", "family": "qwen" },
+      "model_resolution": {
+        "owner": "runner-config",
+        "details": "The runner or Qwen Code configuration selects the Qwen model."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "antigravity",
+      "display_name": "Google Antigravity",
+      "product": "Google Antigravity",
+      "family_constraint": { "kind": "fixed", "family": "gemini" },
+      "model_resolution": {
+        "owner": "harness-runtime",
+        "details": "The Antigravity session selects the Gemini model."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "opencode",
+      "display_name": "OpenCode",
+      "product": "OpenCode",
+      "family_constraint": { "kind": "none" },
+      "model_resolution": {
+        "owner": "harness-runtime",
+        "details": "The multi-provider harness selects both provider family and model at runtime."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "pi",
+      "display_name": "Pi",
+      "product": "Pi",
+      "family_constraint": { "kind": "none" },
+      "model_resolution": {
+        "owner": "harness-runtime",
+        "details": "The multi-provider harness selects both provider family and model at runtime."
+      },
+      "provider_rewired": false
+    }
+  ],
+  "foreman_adapters": [
+    {
+      "slug": "claude",
+      "display_name": "Claude",
+      "source_file": "claude.sh",
+      "harness": "claude-code",
+      "classification": "production",
+      "production_dispatchable": true,
+      "provision_label": true
+    },
+    {
+      "slug": "mock",
+      "display_name": "Mock (tests only)",
+      "source_file": "mock.sh",
+      "harness": null,
+      "classification": "test-only",
+      "production_dispatchable": false,
+      "provision_label": false
+    }
+  ]
+}

--- a/template/agent-registry.schema.json
+++ b/template/agent-registry.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/evanharmon1/harmon-init/agent-registry.schema.json",
+  "title": "Harmon agent registry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schema_version", "labels", "families", "harnesses", "foreman_adapters"],
+  "properties": {
+    "$schema": { "const": "./agent-registry.schema.json" },
+    "schema_version": { "const": 1 },
+    "labels": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["suggest", "claim"],
+      "properties": {
+        "suggest": { "$ref": "#/$defs/labelNamespace" },
+        "claim": { "$ref": "#/$defs/labelNamespace" }
+      }
+    },
+    "families": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/family" }
+    },
+    "harnesses": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/harness" }
+    },
+    "foreman_adapters": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/foremanAdapter" }
+    }
+  },
+  "$defs": {
+    "slug": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "labelNamespace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prefix", "axis", "scopes", "arming"],
+      "properties": {
+        "prefix": { "enum": ["suggest", "claim"] },
+        "axis": { "const": "model" },
+        "scopes": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": { "enum": ["family", "model"] }
+        },
+        "arming": { "const": false }
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["slug", "display_name"],
+      "properties": {
+        "slug": { "$ref": "#/$defs/slug" },
+        "display_name": { "type": "string", "minLength": 1 }
+      }
+    },
+    "family": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["slug", "display_name", "models"],
+      "properties": {
+        "slug": { "$ref": "#/$defs/slug" },
+        "display_name": { "type": "string", "minLength": 1 },
+        "models": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/model" }
+        }
+      }
+    },
+    "familyConstraint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": { "enum": ["fixed", "none"] },
+        "family": { "$ref": "#/$defs/slug" }
+      }
+    },
+    "modelResolution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owner", "details"],
+      "properties": {
+        "owner": {
+          "enum": ["runner-config", "workflow-config", "provider-wrapper", "harness-runtime"]
+        },
+        "details": { "type": "string", "minLength": 1 }
+      }
+    },
+    "harness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "slug",
+        "display_name",
+        "product",
+        "family_constraint",
+        "model_resolution",
+        "provider_rewired"
+      ],
+      "properties": {
+        "slug": { "$ref": "#/$defs/slug" },
+        "display_name": { "type": "string", "minLength": 1 },
+        "product": { "type": "string", "minLength": 1 },
+        "family_constraint": { "$ref": "#/$defs/familyConstraint" },
+        "model_resolution": { "$ref": "#/$defs/modelResolution" },
+        "provider_rewired": { "type": "boolean" }
+      }
+    },
+    "foremanAdapter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "slug",
+        "display_name",
+        "source_file",
+        "harness",
+        "classification",
+        "production_dispatchable",
+        "provision_label"
+      ],
+      "properties": {
+        "slug": { "$ref": "#/$defs/slug" },
+        "display_name": { "type": "string", "minLength": 1 },
+        "source_file": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*[.]sh$"
+        },
+        "harness": {
+          "type": ["string", "null"],
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "classification": { "enum": ["production", "test-only"] },
+        "production_dispatchable": { "type": "boolean" },
+        "provision_label": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/template/scripts/test-agent-registry.sh
+++ b/template/scripts/test-agent-registry.sh
@@ -149,4 +149,21 @@ case "$output" in
 esac
 echo "PASS: rejects unsupported schema keywords"
 
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.properties.families.items = false
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator accepted a boolean items schema"
+fi
+case "$output" in
+*'boolean and non-object schemas are not supported'*) ;;
+*) fail "boolean items schema failed for the wrong reason: $output" ;;
+esac
+echo "PASS: rejects boolean items schemas"
+
 echo "agent registry mutation tests OK"

--- a/template/scripts/test-agent-registry.sh
+++ b/template/scripts/test-agent-registry.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# test-agent-registry.sh — schema-check the registry and exercise semantic guards.
+set -euo pipefail
+
+repo="$(git rev-parse --show-toplevel)"
+cd "$repo"
+
+registry="${1:-agent-registry.json}"
+schema="${2:-agent-registry.schema.json}"
+validator="scripts/validate-agent-registry.mjs"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+for required in "$registry" "$schema" "$validator"; do
+    [ -f "$required" ] || fail "missing required registry asset: $required"
+done
+command -v node >/dev/null 2>&1 || fail "node is required to validate the agent registry"
+
+node "$validator" "$registry" "$schema"
+
+test_tmp="$(mktemp -d)"
+trap 'rm -rf "$test_tmp"' EXIT
+mutated="${test_tmp}/agent-registry.json"
+mutated_schema="${test_tmp}/agent-registry.schema.json"
+
+rejects() {
+    local description="$1"
+    local mutation="$2"
+    local expected="$3"
+    local output
+
+    if ! node --input-type=module - "$registry" "$mutated" "$mutation" <<'NODE'; then
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath, mutation] = process.argv.slice(2)
+const registry = JSON.parse(await readFile(inputPath, 'utf8'))
+const adapter = (slug) => registry.foreman_adapters.find((entry) => entry.slug === slug)
+const harness = (slug) => registry.harnesses.find((entry) => entry.slug === slug)
+
+switch (mutation) {
+  case 'duplicate-family':
+    registry.families.push(structuredClone(registry.families[0]))
+    break
+  case 'duplicate-harness':
+    registry.harnesses.push(structuredClone(registry.harnesses[0]))
+    break
+  case 'missing-model-owner':
+    delete registry.harnesses[0].model_resolution.owner
+    break
+  case 'unknown-fixed-family':
+    registry.harnesses[0].family_constraint.family = 'unknown'
+    break
+  case 'family-on-none':
+    for (const entry of registry.harnesses) {
+      if (entry.family_constraint.kind === 'none') entry.family_constraint.family = 'claude'
+    }
+    break
+  case 'production-without-harness':
+    adapter('claude').harness = null
+    break
+  case 'harness-axis':
+    registry.labels.suggest.axis = 'harness'
+    break
+  case 'public-mock':
+    adapter('mock').provision_label = true
+    break
+  case 'bad-minimax-slug':
+    harness('claude-code-minimax').slug = 'claude-code-mini'
+    break
+  case 'bad-claude-harness':
+    adapter('claude').harness = 'qwen-code'
+    break
+  case 'non-production-claude':
+    Object.assign(adapter('claude'), {
+      classification: 'test-only',
+      production_dispatchable: false,
+      provision_label: false
+    })
+    break
+  default:
+    throw new Error(`unknown mutation: ${mutation}`)
+}
+
+await writeFile(outputPath, `${JSON.stringify(registry, null, 2)}\n`)
+NODE
+        fail "could not build mutation: $description"
+    fi
+    if output="$(node "$validator" "$mutated" "$schema" 2>&1)"; then
+        fail "validator accepted mutation: $description"
+    fi
+    case "$output" in
+    *"$expected"*) ;;
+    *) fail "$description failed for the wrong reason: $output" ;;
+    esac
+    echo "PASS: rejects $description"
+}
+
+rejects "duplicate family slugs" \
+    'duplicate-family' \
+    'duplicate family slug'
+rejects "duplicate harness slugs" \
+    'duplicate-harness' \
+    'duplicate harness slug'
+rejects "missing model-resolution ownership" \
+    'missing-model-owner' \
+    'missing required property owner'
+rejects "unknown fixed-family constraints" \
+    'unknown-fixed-family' \
+    'references unknown family unknown'
+rejects "family values on unconstrained harnesses" \
+    'family-on-none' \
+    'with a none constraint'
+rejects "production adapters without a harness mapping" \
+    'production-without-harness' \
+    'needs a production harness mapping'
+rejects "harness-centric suggestion labels" \
+    'harness-axis' \
+    'must equal "model"'
+rejects "public labels for the test-only mock adapter" \
+    'public-mock' \
+    'test-only Foreman adapter mock cannot dispatch or provision a public label'
+rejects "a non-normalized MiniMax harness slug" \
+    'bad-minimax-slug' \
+    'must be named claude-code-<fixed-family>'
+rejects "a legacy claude adapter mapped to the wrong harness" \
+    'bad-claude-harness' \
+    'legacy Foreman adapter claude must map claude.sh to harness claude-code'
+rejects "a non-production legacy claude adapter" \
+    'non-production-claude' \
+    'legacy Foreman adapter claude must be production-dispatchable and provisionable'
+
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.minProperties = 99
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator accepted an unsupported schema keyword"
+fi
+case "$output" in
+*'unsupported schema keyword minProperties'*) ;;
+*) fail "unsupported schema keyword failed for the wrong reason: $output" ;;
+esac
+echo "PASS: rejects unsupported schema keywords"
+
+echo "agent registry mutation tests OK"

--- a/template/scripts/test-agent-registry.sh
+++ b/template/scripts/test-agent-registry.sh
@@ -190,6 +190,25 @@ import { readFile, writeFile } from 'node:fs/promises'
 
 const [inputPath, outputPath] = process.argv.slice(2)
 const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.$defs.model.properties.display_name = {
+  $ref: '#/__proto__'
+}
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator accepted an inherited schema reference target"
+fi
+case "$output" in
+*'does not resolve to an object schema'*) ;;
+*) fail "inherited schema reference failed for the wrong reason: $output" ;;
+esac
+echo "PASS: rejects inherited properties while resolving references"
+
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
 schema.properties.families.items = false
 await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
 NODE

--- a/template/scripts/test-agent-registry.sh
+++ b/template/scripts/test-agent-registry.sh
@@ -154,6 +154,23 @@ import { readFile, writeFile } from 'node:fs/promises'
 
 const [inputPath, outputPath] = process.argv.slice(2)
 const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.$defs.model.properties.display_name.minLength = 'one'
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator accepted a malformed minLength value"
+fi
+case "$output" in
+*'minLength: must be a non-negative integer'*) ;;
+*) fail "malformed minLength failed for the wrong reason: $output" ;;
+esac
+echo "PASS: rejects malformed supported schema keyword values"
+
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
 schema.properties.families.items = false
 await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
 NODE

--- a/template/scripts/test-agent-registry.sh
+++ b/template/scripts/test-agent-registry.sh
@@ -209,6 +209,42 @@ import { readFile, writeFile } from 'node:fs/promises'
 
 const [inputPath, outputPath] = process.argv.slice(2)
 const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.$defs.model.properties.display_name = {
+  $ref: '#/$defs/model/properties'
+}
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator accepted a reference to a schema-container object"
+fi
+case "$output" in
+*'unsupported schema keyword slug'*) ;;
+*) fail "schema-container reference failed for the wrong reason: $output" ;;
+esac
+echo "PASS: audits resolved reference targets as schemas"
+
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.$defs.cycle = { $ref: '#/$defs/cycle' }
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator accepted a cyclic schema reference"
+fi
+case "$output" in
+*'cyclic schema references are not supported'*) ;;
+*) fail "cyclic schema reference failed for the wrong reason: $output" ;;
+esac
+echo "PASS: rejects cyclic schema references without recursing forever"
+
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
 schema.properties.families.items = false
 await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
 NODE

--- a/template/scripts/test-agent-registry.sh
+++ b/template/scripts/test-agent-registry.sh
@@ -245,6 +245,19 @@ import { readFile, writeFile } from 'node:fs/promises'
 
 const [inputPath, outputPath] = process.argv.slice(2)
 const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.properties.schema_version = { type: 'number' }
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if ! output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator rejected an integer instance under a number schema: $output"
+fi
+echo "PASS: accepts integer instances under number schemas"
+
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
 schema.properties.families.items = false
 await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
 NODE

--- a/template/scripts/test-agent-registry.sh
+++ b/template/scripts/test-agent-registry.sh
@@ -171,6 +171,25 @@ import { readFile, writeFile } from 'node:fs/promises'
 
 const [inputPath, outputPath] = process.argv.slice(2)
 const schema = JSON.parse(await readFile(inputPath, 'utf8'))
+schema.$defs.model.properties.display_name = {
+  $ref: '#/properties/schema_version/const'
+}
+await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+if output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
+    fail "validator accepted a reference to a primitive schema node"
+fi
+case "$output" in
+*'does not resolve to an object schema'*) ;;
+*) fail "primitive schema reference failed for the wrong reason: $output" ;;
+esac
+echo "PASS: rejects references to primitive schema nodes"
+
+node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [inputPath, outputPath] = process.argv.slice(2)
+const schema = JSON.parse(await readFile(inputPath, 'utf8'))
 schema.properties.families.items = false
 await writeFile(outputPath, `${JSON.stringify(schema, null, 2)}\n`)
 NODE

--- a/template/scripts/validate-agent-registry.mjs
+++ b/template/scripts/validate-agent-registry.mjs
@@ -140,10 +140,20 @@ function assertSchemaKeywordValues(rule, location) {
   }
 }
 
-function assertSupportedSchema(rule, location = '$schema') {
+function assertSupportedSchema(
+  rule,
+  location = '$schema',
+  audit = { active: new Set(), complete: new Set() }
+) {
   if (rule === null || typeof rule !== 'object' || Array.isArray(rule)) {
     throw new Error(`${location}: boolean and non-object schemas are not supported`)
   }
+  if (audit.active.has(rule)) {
+    throw new Error(`${location}: cyclic schema references are not supported`)
+  }
+  if (audit.complete.has(rule)) return
+
+  audit.active.add(rule)
   for (const keyword of Object.keys(rule)) {
     if (!supportedSchemaKeywords.has(keyword)) {
       throw new Error(`${location}: unsupported schema keyword ${keyword}`)
@@ -160,14 +170,17 @@ function assertSupportedSchema(rule, location = '$schema') {
         `${location}: schema reference ${rule.$ref} does not resolve to an object schema`
       )
     }
+    assertSupportedSchema(target, `${location}.$ref(${rule.$ref})`, audit)
   }
   for (const [name, child] of Object.entries(rule.$defs ?? {})) {
-    assertSupportedSchema(child, `${location}.$defs.${name}`)
+    assertSupportedSchema(child, `${location}.$defs.${name}`, audit)
   }
   for (const [name, child] of Object.entries(rule.properties ?? {})) {
-    assertSupportedSchema(child, `${location}.properties.${name}`)
+    assertSupportedSchema(child, `${location}.properties.${name}`, audit)
   }
-  if (Object.hasOwn(rule, 'items')) assertSupportedSchema(rule.items, `${location}.items`)
+  if (Object.hasOwn(rule, 'items')) assertSupportedSchema(rule.items, `${location}.items`, audit)
+  audit.active.delete(rule)
+  audit.complete.add(rule)
 }
 
 try {

--- a/template/scripts/validate-agent-registry.mjs
+++ b/template/scripts/validate-agent-registry.mjs
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+const registryPath = path.resolve(process.argv[2] ?? 'agent-registry.json')
+const schemaPath = path.resolve(
+  process.argv[3] ?? path.join(path.dirname(registryPath), 'agent-registry.schema.json')
+)
+
+function loadJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'))
+  } catch (error) {
+    console.error(`agent registry: cannot read valid JSON from ${file}: ${error.message}`)
+    process.exit(1)
+  }
+}
+
+const registry = loadJson(registryPath)
+const schema = loadJson(schemaPath)
+const errors = []
+
+const supportedSchemaKeywords = new Set([
+  '$schema',
+  '$id',
+  '$defs',
+  '$ref',
+  'title',
+  'description',
+  '$comment',
+  'type',
+  'const',
+  'enum',
+  'minLength',
+  'pattern',
+  'minItems',
+  'uniqueItems',
+  'items',
+  'required',
+  'properties',
+  'additionalProperties'
+])
+
+function assertSupportedSchema(rule, location = '$schema') {
+  if (rule === null || typeof rule !== 'object' || Array.isArray(rule)) {
+    throw new Error(`${location}: boolean and non-object schemas are not supported`)
+  }
+  for (const keyword of Object.keys(rule)) {
+    if (!supportedSchemaKeywords.has(keyword)) {
+      throw new Error(`${location}: unsupported schema keyword ${keyword}`)
+    }
+  }
+  if (rule.$ref && Object.keys(rule).some((keyword) => keyword !== '$ref')) {
+    throw new Error(`${location}: schema keywords alongside $ref are not supported`)
+  }
+  if (
+    Object.hasOwn(rule, 'additionalProperties') &&
+    typeof rule.additionalProperties !== 'boolean'
+  ) {
+    throw new Error(`${location}: schema-valued additionalProperties is not supported`)
+  }
+  for (const [name, child] of Object.entries(rule.$defs ?? {})) {
+    assertSupportedSchema(child, `${location}.$defs.${name}`)
+  }
+  for (const [name, child] of Object.entries(rule.properties ?? {})) {
+    assertSupportedSchema(child, `${location}.properties.${name}`)
+  }
+  if (rule.items) assertSupportedSchema(rule.items, `${location}.items`)
+}
+
+try {
+  assertSupportedSchema(schema)
+} catch (error) {
+  console.error(`agent registry: unsupported schema: ${error.message}`)
+  process.exit(1)
+}
+
+function jsonEqual(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right)
+}
+
+function instanceType(value) {
+  if (value === null) return 'null'
+  if (Array.isArray(value)) return 'array'
+  if (Number.isInteger(value)) return 'integer'
+  return typeof value
+}
+
+function resolveRef(ref) {
+  if (!ref.startsWith('#/')) throw new Error(`unsupported schema reference: ${ref}`)
+  return ref
+    .slice(2)
+    .split('/')
+    .map((part) => part.replaceAll('~1', '/').replaceAll('~0', '~'))
+    .reduce((node, part) => node?.[part], schema)
+}
+
+function validateSchema(value, rule, location) {
+  if (rule.$ref) {
+    const target = resolveRef(rule.$ref)
+    if (!target) {
+      errors.push(`${location}: schema reference ${rule.$ref} does not resolve`)
+      return
+    }
+    validateSchema(value, target, location)
+    return
+  }
+
+  if (Object.hasOwn(rule, 'const') && !jsonEqual(value, rule.const)) {
+    errors.push(`${location}: must equal ${JSON.stringify(rule.const)}`)
+  }
+  if (rule.enum && !rule.enum.some((candidate) => jsonEqual(value, candidate))) {
+    errors.push(`${location}: must be one of ${rule.enum.map(JSON.stringify).join(', ')}`)
+  }
+
+  if (rule.type) {
+    const allowed = Array.isArray(rule.type) ? rule.type : [rule.type]
+    const actual = instanceType(value)
+    if (!allowed.includes(actual)) {
+      errors.push(`${location}: expected ${allowed.join(' or ')}, found ${actual}`)
+      return
+    }
+  }
+
+  if (typeof value === 'string') {
+    if (rule.minLength !== undefined && value.length < rule.minLength) {
+      errors.push(`${location}: must contain at least ${rule.minLength} character(s)`)
+    }
+    if (rule.pattern && !new RegExp(rule.pattern, 'u').test(value)) {
+      errors.push(`${location}: does not match ${rule.pattern}`)
+    }
+  }
+
+  if (Array.isArray(value)) {
+    if (rule.minItems !== undefined && value.length < rule.minItems) {
+      errors.push(`${location}: must contain at least ${rule.minItems} item(s)`)
+    }
+    if (rule.uniqueItems) {
+      const serialized = value.map((item) => JSON.stringify(item))
+      if (new Set(serialized).size !== serialized.length) {
+        errors.push(`${location}: items must be unique`)
+      }
+    }
+    if (rule.items) {
+      value.forEach((item, index) => validateSchema(item, rule.items, `${location}[${index}]`))
+    }
+  }
+
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    for (const required of rule.required ?? []) {
+      if (!Object.hasOwn(value, required))
+        errors.push(`${location}: missing required property ${required}`)
+    }
+    if (rule.additionalProperties === false) {
+      for (const key of Object.keys(value)) {
+        if (!Object.hasOwn(rule.properties ?? {}, key)) {
+          errors.push(`${location}: unexpected property ${key}`)
+        }
+      }
+    }
+    for (const [key, childRule] of Object.entries(rule.properties ?? {})) {
+      if (Object.hasOwn(value, key)) validateSchema(value[key], childRule, `${location}.${key}`)
+    }
+  }
+}
+
+function duplicateSlugs(rows) {
+  const seen = new Set()
+  return rows.map((row) => row.slug).filter((slug) => seen.has(slug) || !seen.add(slug))
+}
+
+function semanticError(message) {
+  errors.push(`registry: ${message}`)
+}
+
+validateSchema(registry, schema, '$registry')
+
+// Cross-record constraints cannot be expressed by the structural schema alone.
+if (errors.length === 0) {
+  const familySlugs = new Set(registry.families.map((family) => family.slug))
+  const harnessSlugs = new Set(registry.harnesses.map((harness) => harness.slug))
+
+  for (const slug of duplicateSlugs(registry.families))
+    semanticError(`duplicate family slug: ${slug}`)
+  for (const slug of duplicateSlugs(registry.harnesses))
+    semanticError(`duplicate harness slug: ${slug}`)
+  for (const slug of duplicateSlugs(registry.foreman_adapters)) {
+    semanticError(`duplicate Foreman adapter slug: ${slug}`)
+  }
+
+  for (const family of registry.families) {
+    for (const slug of duplicateSlugs(family.models)) {
+      semanticError(`family ${family.slug} has duplicate model slug: ${slug}`)
+    }
+    if (harnessSlugs.has(family.slug)) {
+      semanticError(`slug ${family.slug} is both a model family and a harness`)
+    }
+  }
+
+  for (const [name, namespace] of Object.entries(registry.labels)) {
+    if (namespace.prefix !== name) semanticError(`${name} label prefix must be ${name}`)
+    if (namespace.axis !== 'model') semanticError(`${name} labels must use the model axis`)
+    if (!namespace.scopes.includes('family') || !namespace.scopes.includes('model')) {
+      semanticError(`${name} labels must support family-level and optional model-level forms`)
+    }
+    if (namespace.arming !== false) semanticError(`${name} labels must never arm dispatch`)
+  }
+
+  for (const harness of registry.harnesses) {
+    const constraint = harness.family_constraint
+    if (constraint.kind === 'fixed') {
+      if (!constraint.family) {
+        semanticError(`harness ${harness.slug} has a fixed family constraint without a family`)
+      } else if (!familySlugs.has(constraint.family)) {
+        semanticError(`harness ${harness.slug} references unknown family ${constraint.family}`)
+      }
+    } else if (Object.hasOwn(constraint, 'family')) {
+      semanticError(
+        `harness ${harness.slug} has family ${constraint.family} with a none constraint`
+      )
+    }
+
+    if (harness.provider_rewired) {
+      if (constraint.kind !== 'fixed' || harness.slug !== `claude-code-${constraint.family}`) {
+        semanticError(
+          `provider-rewired harness ${harness.slug} must be named claude-code-<fixed-family>`
+        )
+      }
+      if (harness.model_resolution.owner !== 'provider-wrapper') {
+        semanticError(
+          `provider-rewired harness ${harness.slug} must delegate model resolution to provider-wrapper`
+        )
+      }
+    } else if (harness.model_resolution.owner === 'provider-wrapper') {
+      semanticError(
+        `non-rewired harness ${harness.slug} cannot delegate model resolution to provider-wrapper`
+      )
+    }
+  }
+
+  for (const adapter of registry.foreman_adapters) {
+    if (adapter.harness !== null && !harnessSlugs.has(adapter.harness)) {
+      semanticError(`Foreman adapter ${adapter.slug} maps unknown harness ${adapter.harness}`)
+    }
+    if (adapter.production_dispatchable) {
+      if (adapter.classification !== 'production' || adapter.harness === null) {
+        semanticError(
+          `production-dispatchable Foreman adapter ${adapter.slug} needs a production harness mapping`
+        )
+      }
+      if (!adapter.provision_label) {
+        semanticError(
+          `production-dispatchable Foreman adapter ${adapter.slug} must provision its selector label`
+        )
+      }
+    }
+    if (adapter.classification === 'test-only') {
+      if (adapter.production_dispatchable || adapter.provision_label) {
+        semanticError(
+          `test-only Foreman adapter ${adapter.slug} cannot dispatch or provision a public label`
+        )
+      }
+    }
+    if (adapter.provision_label && !adapter.production_dispatchable) {
+      semanticError(
+        `Foreman adapter ${adapter.slug} cannot provision a label unless it is production-dispatchable`
+      )
+    }
+  }
+
+  const mock = registry.foreman_adapters.find((adapter) => adapter.slug === 'mock')
+  if (
+    !mock ||
+    mock.source_file !== 'mock.sh' ||
+    mock.classification !== 'test-only' ||
+    mock.harness !== null ||
+    mock.production_dispatchable ||
+    mock.provision_label
+  ) {
+    semanticError('mock must be a mapped file-only, test-only, non-provisionable Foreman adapter')
+  }
+
+  const claude = registry.foreman_adapters.find((adapter) => adapter.slug === 'claude')
+  if (!claude || claude.harness !== 'claude-code' || claude.source_file !== 'claude.sh') {
+    semanticError('legacy Foreman adapter claude must map claude.sh to harness claude-code')
+  }
+  if (
+    !claude ||
+    claude.classification !== 'production' ||
+    !claude.production_dispatchable ||
+    !claude.provision_label
+  ) {
+    semanticError('legacy Foreman adapter claude must be production-dispatchable and provisionable')
+  }
+
+  const minimax = registry.harnesses.find((harness) => harness.slug === 'claude-code-minimax')
+  if (
+    !familySlugs.has('minimax') ||
+    !minimax ||
+    minimax.family_constraint.kind !== 'fixed' ||
+    minimax.family_constraint.family !== 'minimax' ||
+    !minimax.provider_rewired
+  ) {
+    semanticError(
+      'MiniMax must use family minimax and provider-rewired harness claude-code-minimax'
+    )
+  }
+}
+
+if (errors.length > 0) {
+  for (const error of errors) console.error(`FAIL: ${error}`)
+  process.exit(1)
+}
+
+console.log(
+  `agent registry OK: ${registry.families.length} families, ${registry.harnesses.length} harnesses, ${registry.foreman_adapters.length} Foreman adapters`
+)

--- a/template/scripts/validate-agent-registry.mjs
+++ b/template/scripts/validate-agent-registry.mjs
@@ -236,7 +236,8 @@ function validateSchema(value, rule, location) {
   if (rule.type) {
     const allowed = Array.isArray(rule.type) ? rule.type : [rule.type]
     const actual = instanceType(value)
-    if (!allowed.includes(actual)) {
+    const integerSatisfiesNumber = actual === 'integer' && allowed.includes('number')
+    if (!allowed.includes(actual) && !integerSatisfiesNumber) {
       errors.push(`${location}: expected ${allowed.join(' or ')}, found ${actual}`)
       return
     }

--- a/template/scripts/validate-agent-registry.mjs
+++ b/template/scripts/validate-agent-registry.mjs
@@ -67,7 +67,7 @@ function assertSupportedSchema(rule, location = '$schema') {
   for (const [name, child] of Object.entries(rule.properties ?? {})) {
     assertSupportedSchema(child, `${location}.properties.${name}`)
   }
-  if (rule.items) assertSupportedSchema(rule.items, `${location}.items`)
+  if (Object.hasOwn(rule, 'items')) assertSupportedSchema(rule.items, `${location}.items`)
 }
 
 try {

--- a/template/scripts/validate-agent-registry.mjs
+++ b/template/scripts/validate-agent-registry.mjs
@@ -43,6 +43,99 @@ const supportedSchemaKeywords = new Set([
   'additionalProperties'
 ])
 
+const supportedInstanceTypes = new Set([
+  'array',
+  'boolean',
+  'integer',
+  'null',
+  'number',
+  'object',
+  'string'
+])
+
+function schemaError(location, keyword, expectation) {
+  throw new Error(`${location}.${keyword}: ${expectation}`)
+}
+
+function assertSchemaKeywordValues(rule, location) {
+  for (const keyword of ['$schema', '$id', '$ref', 'title', 'description', '$comment']) {
+    if (Object.hasOwn(rule, keyword) && typeof rule[keyword] !== 'string') {
+      schemaError(location, keyword, 'must be a string')
+    }
+  }
+  for (const keyword of ['$schema', '$id', '$ref']) {
+    if (Object.hasOwn(rule, keyword) && rule[keyword].length === 0) {
+      schemaError(location, keyword, 'must not be empty')
+    }
+  }
+
+  if (Object.hasOwn(rule, 'type')) {
+    const types = Array.isArray(rule.type) ? rule.type : [rule.type]
+    if (
+      types.length === 0 ||
+      types.some((type) => typeof type !== 'string' || !supportedInstanceTypes.has(type)) ||
+      new Set(types).size !== types.length
+    ) {
+      schemaError(location, 'type', 'must name one or more unique supported instance types')
+    }
+  }
+
+  if (Object.hasOwn(rule, 'enum')) {
+    if (!Array.isArray(rule.enum) || rule.enum.length === 0) {
+      schemaError(location, 'enum', 'must be a non-empty array')
+    }
+    if (
+      rule.enum.some((candidate, index) =>
+        rule.enum.slice(0, index).some((earlier) => jsonEqual(candidate, earlier))
+      )
+    ) {
+      schemaError(location, 'enum', 'must contain unique values')
+    }
+  }
+
+  for (const keyword of ['minLength', 'minItems']) {
+    if (Object.hasOwn(rule, keyword) && (!Number.isInteger(rule[keyword]) || rule[keyword] < 0)) {
+      schemaError(location, keyword, 'must be a non-negative integer')
+    }
+  }
+
+  if (Object.hasOwn(rule, 'pattern')) {
+    if (typeof rule.pattern !== 'string') schemaError(location, 'pattern', 'must be a string')
+    try {
+      new RegExp(rule.pattern, 'u')
+    } catch {
+      schemaError(location, 'pattern', 'must be a valid regular expression')
+    }
+  }
+
+  if (Object.hasOwn(rule, 'uniqueItems') && typeof rule.uniqueItems !== 'boolean') {
+    schemaError(location, 'uniqueItems', 'must be a boolean')
+  }
+  if (Object.hasOwn(rule, 'required')) {
+    if (
+      !Array.isArray(rule.required) ||
+      rule.required.some((name) => typeof name !== 'string') ||
+      new Set(rule.required).size !== rule.required.length
+    ) {
+      schemaError(location, 'required', 'must be an array of unique strings')
+    }
+  }
+  for (const keyword of ['$defs', 'properties']) {
+    if (
+      Object.hasOwn(rule, keyword) &&
+      (rule[keyword] === null || typeof rule[keyword] !== 'object' || Array.isArray(rule[keyword]))
+    ) {
+      schemaError(location, keyword, 'must be an object')
+    }
+  }
+  if (
+    Object.hasOwn(rule, 'additionalProperties') &&
+    typeof rule.additionalProperties !== 'boolean'
+  ) {
+    schemaError(location, 'additionalProperties', 'must be a boolean')
+  }
+}
+
 function assertSupportedSchema(rule, location = '$schema') {
   if (rule === null || typeof rule !== 'object' || Array.isArray(rule)) {
     throw new Error(`${location}: boolean and non-object schemas are not supported`)
@@ -52,14 +145,9 @@ function assertSupportedSchema(rule, location = '$schema') {
       throw new Error(`${location}: unsupported schema keyword ${keyword}`)
     }
   }
-  if (rule.$ref && Object.keys(rule).some((keyword) => keyword !== '$ref')) {
+  assertSchemaKeywordValues(rule, location)
+  if (Object.hasOwn(rule, '$ref') && Object.keys(rule).some((keyword) => keyword !== '$ref')) {
     throw new Error(`${location}: schema keywords alongside $ref are not supported`)
-  }
-  if (
-    Object.hasOwn(rule, 'additionalProperties') &&
-    typeof rule.additionalProperties !== 'boolean'
-  ) {
-    throw new Error(`${location}: schema-valued additionalProperties is not supported`)
   }
   for (const [name, child] of Object.entries(rule.$defs ?? {})) {
     assertSupportedSchema(child, `${location}.$defs.${name}`)
@@ -73,7 +161,7 @@ function assertSupportedSchema(rule, location = '$schema') {
 try {
   assertSupportedSchema(schema)
 } catch (error) {
-  console.error(`agent registry: unsupported schema: ${error.message}`)
+  console.error(`agent registry: invalid or unsupported schema: ${error.message}`)
   process.exit(1)
 }
 

--- a/template/scripts/validate-agent-registry.mjs
+++ b/template/scripts/validate-agent-registry.mjs
@@ -194,7 +194,12 @@ function resolveRef(ref) {
     .slice(2)
     .split('/')
     .map((part) => part.replaceAll('~1', '/').replaceAll('~0', '~'))
-    .reduce((node, part) => node?.[part], schema)
+    .reduce((node, part) => {
+      if (node === null || typeof node !== 'object' || !Object.hasOwn(node, part)) {
+        return undefined
+      }
+      return node[part]
+    }, schema)
 }
 
 function validateSchema(value, rule, location) {

--- a/template/scripts/validate-agent-registry.mjs
+++ b/template/scripts/validate-agent-registry.mjs
@@ -57,6 +57,10 @@ function schemaError(location, keyword, expectation) {
   throw new Error(`${location}.${keyword}: ${expectation}`)
 }
 
+function isSchemaObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
 function assertSchemaKeywordValues(rule, location) {
   for (const keyword of ['$schema', '$id', '$ref', 'title', 'description', '$comment']) {
     if (Object.hasOwn(rule, keyword) && typeof rule[keyword] !== 'string') {
@@ -149,6 +153,14 @@ function assertSupportedSchema(rule, location = '$schema') {
   if (Object.hasOwn(rule, '$ref') && Object.keys(rule).some((keyword) => keyword !== '$ref')) {
     throw new Error(`${location}: schema keywords alongside $ref are not supported`)
   }
+  if (Object.hasOwn(rule, '$ref')) {
+    const target = resolveRef(rule.$ref)
+    if (!isSchemaObject(target)) {
+      throw new Error(
+        `${location}: schema reference ${rule.$ref} does not resolve to an object schema`
+      )
+    }
+  }
   for (const [name, child] of Object.entries(rule.$defs ?? {})) {
     assertSupportedSchema(child, `${location}.$defs.${name}`)
   }
@@ -186,10 +198,10 @@ function resolveRef(ref) {
 }
 
 function validateSchema(value, rule, location) {
-  if (rule.$ref) {
+  if (Object.hasOwn(rule, '$ref')) {
     const target = resolveRef(rule.$ref)
-    if (!target) {
-      errors.push(`${location}: schema reference ${rule.$ref} does not resolve`)
+    if (!isSchemaObject(target)) {
+      errors.push(`${location}: schema reference ${rule.$ref} does not resolve to an object schema`)
       return
     }
     validateSchema(value, target, location)


### PR DESCRIPTION
Closes #660

## Summary

- add a canonical machine-readable registry for model families, harnesses, and Foreman adapters
- ship the registry, schema, dependency-free validator, and mutation tests in both root and Copier template layers
- wire registry validation into local verify, required CI, and every rendered template profile
- record the vocabulary, compatibility mappings, label semantics, and ownership decisions in ADR 0005

## Why

Agent vocabulary had grown across model families, harness products, provider-rewired Claude Code variants, and legacy Foreman adapter names without one enforceable contract. This change makes those distinctions explicit and prevents incompatible labels, mappings, or model-resolution ownership from drifting silently.

## Impact

Generated repositories receive the same versioned registry and validation gate. Existing legacy Foreman adapter slug claude remains compatible while mapping explicitly to the claude-code harness; mock remains test-only and non-provisionable.

## Validation

- task verify
- task challenge: clean capped round with no P0, P1, or P2 findings
- task review: no P0/P1 findings; one P2 deferred below
- task ci
- pre-commit, commit-msg, and pre-push hooks

## Review adjudication

| Finding | Priority | Classification | Evidence | Action |
|---|---:|---|---|---|
| Required CI omitted registry validation | P1 | Confirmed | Generated build workflow called explicit tests rather than verify | Added the task to root/template required CI and a render assertion |
| Mutation selected the final harness by array order | P2 | Confirmed | Appending a harness changed the mutation target | Replaced order-dependent jq mutation with named Node mutations |
| Generated runner lacked jq | P1 | Confirmed | Registry mutation test required an undeclared binary | Removed jq; the shipped suite now depends only on Node |
| Claude production flags were not pinned | P2 | Confirmed | A test-only Claude adapter could satisfy the old checks | Added semantic checks and a mutation regression |
| Accepted ADR body was rewritten | P2 | Confirmed | ADR policy is append-only | Restored the body and retained only the supersession status marker |
| Schema files were formatted with the wrong Prettier config | P1 | Confirmed | Generated Node profiles use different settings from the root | Formatted with the generated-project config and verified web/meta renders |
| Unsupported validation keywords failed open | P2 | Confirmed | minProperties was silently ignored | Added a recursive supported-keyword audit and mutation regression |
| Supported schema keyword values were trusted | P2 | Confirmed | A string minLength bypassed checks through JavaScript coercion | Added fail-closed value validation for every supported keyword and the exact mutation regression in d026f93 |
| `$ref` targets could be primitive nodes | P2 | Confirmed | A reference to `schema_version.const` resolved to `1` and behaved like an empty schema | Added object-schema checks at audit/runtime boundaries and the exact mutation regression in 0ede828 |
| `$ref` resolution traversed inherited properties | P2 | Confirmed | `#/__proto__` reached `Object.prototype` despite not existing in the JSON document | Required every JSON Pointer segment to be an own property and added the exact mutation regression in 7b08b55 |
| Resolved references can target schema-container objects | P2 | Confirmed | `#/$defs/model/properties` resolves to an object whose member names are not schema keywords, but runtime validation treats it as an empty rule | With Evan's two-round extension, recursively audited resolved targets, rejected reference cycles, and added exact regressions in d7d10e7 |
| Integer instances failed number schemas | P2 | Confirmed | JSON Schema `number` includes `integer`, but exact instance-type membership rejected `1` | Accepted integer as a subtype of number and added the exact `schema_version` mutation regression in 5d2f825 |
| JSON value equality depended on object key order | P2 | Confirmed | `JSON.stringify` treats `{a: 1, b: 2}` and `{b: 2, a: 1}` as different for `const`, `enum`, and `uniqueItems` | Escalated after the final authorized round; no seventh fix round started |
| `minLength` counted UTF-16 code units | P2 | Confirmed | JavaScript `.length` counts `😀` as two units although JSON Schema counts one Unicode code point | Escalated after the final authorized round; no seventh fix round started |

## Deferred findings

- [x] Verification review P2: reject boolean items schemas such as items: false explicitly — fixed in 5fd0e20 with property-presence validation and a mutation regression.
