### PR TITLE
fix: conform agent registry validation

### DIFF
--- a/scripts/test-agent-registry.sh
+++ b/scripts/test-agent-registry.sh
@@ -98,6 +98,78 @@ NODE
     echo "PASS: rejects $description"
 }
 
+build_schema_case() {
+    local mutation="$1"
+
+    node --input-type=module - \
+        "$registry" "$schema" "$mutated" "$mutated_schema" "$mutation" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [registryInput, schemaInput, registryOutput, schemaOutput, mutation] =
+  process.argv.slice(2)
+const registry = JSON.parse(await readFile(registryInput, 'utf8'))
+const schema = JSON.parse(await readFile(schemaInput, 'utf8'))
+const instanceObject = { alpha: 1, beta: 2 }
+const reorderedObject = { beta: 2, alpha: 1 }
+
+switch (mutation) {
+  case 'reordered-const':
+    registry.schema_version = instanceObject
+    schema.properties.schema_version = { const: reorderedObject }
+    break
+  case 'reordered-enum':
+    registry.schema_version = instanceObject
+    schema.properties.schema_version = { enum: [reorderedObject] }
+    break
+  case 'reordered-enum-duplicates':
+    schema.properties.schema_version = { enum: [instanceObject, reorderedObject] }
+    break
+  case 'reordered-unique-items':
+    registry.schema_version = [instanceObject, reorderedObject]
+    schema.properties.schema_version = { type: 'array', uniqueItems: true }
+    break
+  case 'unicode-min-length':
+    registry.schema_version = '😀'
+    schema.properties.schema_version = { type: 'string', minLength: 2 }
+    break
+  default:
+    throw new Error(`unknown schema mutation: ${mutation}`)
+}
+
+await writeFile(registryOutput, `${JSON.stringify(registry, null, 2)}\n`)
+await writeFile(schemaOutput, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+}
+
+accepts_schema_case() {
+    local description="$1"
+    local mutation="$2"
+    local output
+
+    build_schema_case "$mutation"
+    if ! output="$(node "$validator" "$mutated" "$mutated_schema" 2>&1)"; then
+        fail "validator rejected $description: $output"
+    fi
+    echo "PASS: accepts $description"
+}
+
+rejects_schema_case() {
+    local description="$1"
+    local mutation="$2"
+    local expected="$3"
+    local output
+
+    build_schema_case "$mutation"
+    if output="$(node "$validator" "$mutated" "$mutated_schema" 2>&1)"; then
+        fail "validator accepted $description"
+    fi
+    case "$output" in
+    *"$expected"*) ;;
+    *) fail "$description failed for the wrong reason: $output" ;;
+    esac
+    echo "PASS: rejects $description"
+}
+
 rejects "duplicate family slugs" \
     'duplicate-family' \
     'duplicate family slug'
@@ -252,6 +324,25 @@ if ! output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
     fail "validator rejected an integer instance under a number schema: $output"
 fi
 echo "PASS: accepts integer instances under number schemas"
+
+accepts_schema_case \
+    "structurally equal const objects with reordered properties" \
+    'reordered-const'
+accepts_schema_case \
+    "structurally equal enum objects with reordered properties" \
+    'reordered-enum'
+rejects_schema_case \
+    "structurally duplicate enum objects with reordered properties" \
+    'reordered-enum-duplicates' \
+    'enum: must contain unique values'
+rejects_schema_case \
+    "structurally duplicate uniqueItems objects with reordered properties" \
+    'reordered-unique-items' \
+    'items must be unique'
+rejects_schema_case \
+    "one Unicode code point under minLength 2" \
+    'unicode-min-length' \
+    'must contain at least 2 character(s)'
 
 node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
 import { readFile, writeFile } from 'node:fs/promises'

--- a/scripts/test-agent-registry.sh
+++ b/scripts/test-agent-registry.sh
@@ -128,8 +128,16 @@ switch (mutation) {
     registry.schema_version = [instanceObject, reorderedObject]
     schema.properties.schema_version = { type: 'array', uniqueItems: true }
     break
+  case 'distinct-unique-items':
+    registry.schema_version = [{ value: 1 }, { value: '1' }]
+    schema.properties.schema_version = { type: 'array', uniqueItems: true }
+    break
   case 'unicode-min-length':
     registry.schema_version = '😀'
+    schema.properties.schema_version = { type: 'string', minLength: 2 }
+    break
+  case 'unicode-min-length-exact':
+    registry.schema_version = '😀x'
     schema.properties.schema_version = { type: 'string', minLength: 2 }
     break
   default:
@@ -339,10 +347,16 @@ rejects_schema_case \
     "structurally duplicate uniqueItems objects with reordered properties" \
     'reordered-unique-items' \
     'items must be unique'
+accepts_schema_case \
+    "structurally distinct uniqueItems values" \
+    'distinct-unique-items'
 rejects_schema_case \
     "one Unicode code point under minLength 2" \
     'unicode-min-length' \
     'must contain at least 2 character(s)'
+accepts_schema_case \
+    "two Unicode code points at minLength 2" \
+    'unicode-min-length-exact'
 
 node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
 import { readFile, writeFile } from 'node:fs/promises'

--- a/scripts/validate-agent-registry.mjs
+++ b/scripts/validate-agent-registry.mjs
@@ -191,7 +191,25 @@ try {
 }
 
 function jsonEqual(left, right) {
-  return JSON.stringify(left) === JSON.stringify(right)
+  if (left === right) return true
+  if (left === null || right === null || typeof left !== 'object' || typeof right !== 'object') {
+    return false
+  }
+
+  const leftIsArray = Array.isArray(left)
+  if (leftIsArray !== Array.isArray(right)) return false
+  if (leftIsArray) {
+    return (
+      left.length === right.length && left.every((item, index) => jsonEqual(item, right[index]))
+    )
+  }
+
+  const leftKeys = Object.keys(left)
+  const rightKeys = Object.keys(right)
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every((key) => Object.hasOwn(right, key) && jsonEqual(left[key], right[key]))
+  )
 }
 
 function instanceType(value) {
@@ -244,7 +262,7 @@ function validateSchema(value, rule, location) {
   }
 
   if (typeof value === 'string') {
-    if (rule.minLength !== undefined && value.length < rule.minLength) {
+    if (rule.minLength !== undefined && [...value].length < rule.minLength) {
       errors.push(`${location}: must contain at least ${rule.minLength} character(s)`)
     }
     if (rule.pattern && !new RegExp(rule.pattern, 'u').test(value)) {
@@ -257,8 +275,10 @@ function validateSchema(value, rule, location) {
       errors.push(`${location}: must contain at least ${rule.minItems} item(s)`)
     }
     if (rule.uniqueItems) {
-      const serialized = value.map((item) => JSON.stringify(item))
-      if (new Set(serialized).size !== serialized.length) {
+      const hasDuplicate = value.some((candidate, index) =>
+        value.slice(0, index).some((earlier) => jsonEqual(candidate, earlier))
+      )
+      if (hasDuplicate) {
         errors.push(`${location}: items must be unique`)
       }
     }

--- a/scripts/validate-agent-registry.mjs
+++ b/scripts/validate-agent-registry.mjs
@@ -190,26 +190,27 @@ try {
   process.exit(1)
 }
 
+function canonicalJson(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+    .join(',')}}`
+}
+
 function jsonEqual(left, right) {
-  if (left === right) return true
-  if (left === null || right === null || typeof left !== 'object' || typeof right !== 'object') {
-    return false
-  }
+  return canonicalJson(left) === canonicalJson(right)
+}
 
-  const leftIsArray = Array.isArray(left)
-  if (leftIsArray !== Array.isArray(right)) return false
-  if (leftIsArray) {
-    return (
-      left.length === right.length && left.every((item, index) => jsonEqual(item, right[index]))
-    )
+function satisfiesMinLength(value, minimum) {
+  let length = 0
+  const codePoints = value[Symbol.iterator]()
+  while (length < minimum && !codePoints.next().done) {
+    length += 1
   }
-
-  const leftKeys = Object.keys(left)
-  const rightKeys = Object.keys(right)
-  return (
-    leftKeys.length === rightKeys.length &&
-    leftKeys.every((key) => Object.hasOwn(right, key) && jsonEqual(left[key], right[key]))
-  )
+  return length >= minimum
 }
 
 function instanceType(value) {
@@ -262,7 +263,7 @@ function validateSchema(value, rule, location) {
   }
 
   if (typeof value === 'string') {
-    if (rule.minLength !== undefined && [...value].length < rule.minLength) {
+    if (rule.minLength !== undefined && !satisfiesMinLength(value, rule.minLength)) {
       errors.push(`${location}: must contain at least ${rule.minLength} character(s)`)
     }
     if (rule.pattern && !new RegExp(rule.pattern, 'u').test(value)) {
@@ -275,10 +276,8 @@ function validateSchema(value, rule, location) {
       errors.push(`${location}: must contain at least ${rule.minItems} item(s)`)
     }
     if (rule.uniqueItems) {
-      const hasDuplicate = value.some((candidate, index) =>
-        value.slice(0, index).some((earlier) => jsonEqual(candidate, earlier))
-      )
-      if (hasDuplicate) {
+      const canonicalItems = value.map(canonicalJson)
+      if (new Set(canonicalItems).size !== canonicalItems.length) {
         errors.push(`${location}: items must be unique`)
       }
     }

--- a/template/scripts/test-agent-registry.sh
+++ b/template/scripts/test-agent-registry.sh
@@ -98,6 +98,78 @@ NODE
     echo "PASS: rejects $description"
 }
 
+build_schema_case() {
+    local mutation="$1"
+
+    node --input-type=module - \
+        "$registry" "$schema" "$mutated" "$mutated_schema" "$mutation" <<'NODE'
+import { readFile, writeFile } from 'node:fs/promises'
+
+const [registryInput, schemaInput, registryOutput, schemaOutput, mutation] =
+  process.argv.slice(2)
+const registry = JSON.parse(await readFile(registryInput, 'utf8'))
+const schema = JSON.parse(await readFile(schemaInput, 'utf8'))
+const instanceObject = { alpha: 1, beta: 2 }
+const reorderedObject = { beta: 2, alpha: 1 }
+
+switch (mutation) {
+  case 'reordered-const':
+    registry.schema_version = instanceObject
+    schema.properties.schema_version = { const: reorderedObject }
+    break
+  case 'reordered-enum':
+    registry.schema_version = instanceObject
+    schema.properties.schema_version = { enum: [reorderedObject] }
+    break
+  case 'reordered-enum-duplicates':
+    schema.properties.schema_version = { enum: [instanceObject, reorderedObject] }
+    break
+  case 'reordered-unique-items':
+    registry.schema_version = [instanceObject, reorderedObject]
+    schema.properties.schema_version = { type: 'array', uniqueItems: true }
+    break
+  case 'unicode-min-length':
+    registry.schema_version = '😀'
+    schema.properties.schema_version = { type: 'string', minLength: 2 }
+    break
+  default:
+    throw new Error(`unknown schema mutation: ${mutation}`)
+}
+
+await writeFile(registryOutput, `${JSON.stringify(registry, null, 2)}\n`)
+await writeFile(schemaOutput, `${JSON.stringify(schema, null, 2)}\n`)
+NODE
+}
+
+accepts_schema_case() {
+    local description="$1"
+    local mutation="$2"
+    local output
+
+    build_schema_case "$mutation"
+    if ! output="$(node "$validator" "$mutated" "$mutated_schema" 2>&1)"; then
+        fail "validator rejected $description: $output"
+    fi
+    echo "PASS: accepts $description"
+}
+
+rejects_schema_case() {
+    local description="$1"
+    local mutation="$2"
+    local expected="$3"
+    local output
+
+    build_schema_case "$mutation"
+    if output="$(node "$validator" "$mutated" "$mutated_schema" 2>&1)"; then
+        fail "validator accepted $description"
+    fi
+    case "$output" in
+    *"$expected"*) ;;
+    *) fail "$description failed for the wrong reason: $output" ;;
+    esac
+    echo "PASS: rejects $description"
+}
+
 rejects "duplicate family slugs" \
     'duplicate-family' \
     'duplicate family slug'
@@ -252,6 +324,25 @@ if ! output="$(node "$validator" "$registry" "$mutated_schema" 2>&1)"; then
     fail "validator rejected an integer instance under a number schema: $output"
 fi
 echo "PASS: accepts integer instances under number schemas"
+
+accepts_schema_case \
+    "structurally equal const objects with reordered properties" \
+    'reordered-const'
+accepts_schema_case \
+    "structurally equal enum objects with reordered properties" \
+    'reordered-enum'
+rejects_schema_case \
+    "structurally duplicate enum objects with reordered properties" \
+    'reordered-enum-duplicates' \
+    'enum: must contain unique values'
+rejects_schema_case \
+    "structurally duplicate uniqueItems objects with reordered properties" \
+    'reordered-unique-items' \
+    'items must be unique'
+rejects_schema_case \
+    "one Unicode code point under minLength 2" \
+    'unicode-min-length' \
+    'must contain at least 2 character(s)'
 
 node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
 import { readFile, writeFile } from 'node:fs/promises'

--- a/template/scripts/test-agent-registry.sh
+++ b/template/scripts/test-agent-registry.sh
@@ -128,8 +128,16 @@ switch (mutation) {
     registry.schema_version = [instanceObject, reorderedObject]
     schema.properties.schema_version = { type: 'array', uniqueItems: true }
     break
+  case 'distinct-unique-items':
+    registry.schema_version = [{ value: 1 }, { value: '1' }]
+    schema.properties.schema_version = { type: 'array', uniqueItems: true }
+    break
   case 'unicode-min-length':
     registry.schema_version = '😀'
+    schema.properties.schema_version = { type: 'string', minLength: 2 }
+    break
+  case 'unicode-min-length-exact':
+    registry.schema_version = '😀x'
     schema.properties.schema_version = { type: 'string', minLength: 2 }
     break
   default:
@@ -339,10 +347,16 @@ rejects_schema_case \
     "structurally duplicate uniqueItems objects with reordered properties" \
     'reordered-unique-items' \
     'items must be unique'
+accepts_schema_case \
+    "structurally distinct uniqueItems values" \
+    'distinct-unique-items'
 rejects_schema_case \
     "one Unicode code point under minLength 2" \
     'unicode-min-length' \
     'must contain at least 2 character(s)'
+accepts_schema_case \
+    "two Unicode code points at minLength 2" \
+    'unicode-min-length-exact'
 
 node --input-type=module - "$schema" "$mutated_schema" <<'NODE'
 import { readFile, writeFile } from 'node:fs/promises'

--- a/template/scripts/validate-agent-registry.mjs
+++ b/template/scripts/validate-agent-registry.mjs
@@ -191,7 +191,25 @@ try {
 }
 
 function jsonEqual(left, right) {
-  return JSON.stringify(left) === JSON.stringify(right)
+  if (left === right) return true
+  if (left === null || right === null || typeof left !== 'object' || typeof right !== 'object') {
+    return false
+  }
+
+  const leftIsArray = Array.isArray(left)
+  if (leftIsArray !== Array.isArray(right)) return false
+  if (leftIsArray) {
+    return (
+      left.length === right.length && left.every((item, index) => jsonEqual(item, right[index]))
+    )
+  }
+
+  const leftKeys = Object.keys(left)
+  const rightKeys = Object.keys(right)
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every((key) => Object.hasOwn(right, key) && jsonEqual(left[key], right[key]))
+  )
 }
 
 function instanceType(value) {
@@ -244,7 +262,7 @@ function validateSchema(value, rule, location) {
   }
 
   if (typeof value === 'string') {
-    if (rule.minLength !== undefined && value.length < rule.minLength) {
+    if (rule.minLength !== undefined && [...value].length < rule.minLength) {
       errors.push(`${location}: must contain at least ${rule.minLength} character(s)`)
     }
     if (rule.pattern && !new RegExp(rule.pattern, 'u').test(value)) {
@@ -257,8 +275,10 @@ function validateSchema(value, rule, location) {
       errors.push(`${location}: must contain at least ${rule.minItems} item(s)`)
     }
     if (rule.uniqueItems) {
-      const serialized = value.map((item) => JSON.stringify(item))
-      if (new Set(serialized).size !== serialized.length) {
+      const hasDuplicate = value.some((candidate, index) =>
+        value.slice(0, index).some((earlier) => jsonEqual(candidate, earlier))
+      )
+      if (hasDuplicate) {
         errors.push(`${location}: items must be unique`)
       }
     }

--- a/template/scripts/validate-agent-registry.mjs
+++ b/template/scripts/validate-agent-registry.mjs
@@ -190,26 +190,27 @@ try {
   process.exit(1)
 }
 
+function canonicalJson(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+    .join(',')}}`
+}
+
 function jsonEqual(left, right) {
-  if (left === right) return true
-  if (left === null || right === null || typeof left !== 'object' || typeof right !== 'object') {
-    return false
-  }
+  return canonicalJson(left) === canonicalJson(right)
+}
 
-  const leftIsArray = Array.isArray(left)
-  if (leftIsArray !== Array.isArray(right)) return false
-  if (leftIsArray) {
-    return (
-      left.length === right.length && left.every((item, index) => jsonEqual(item, right[index]))
-    )
+function satisfiesMinLength(value, minimum) {
+  let length = 0
+  const codePoints = value[Symbol.iterator]()
+  while (length < minimum && !codePoints.next().done) {
+    length += 1
   }
-
-  const leftKeys = Object.keys(left)
-  const rightKeys = Object.keys(right)
-  return (
-    leftKeys.length === rightKeys.length &&
-    leftKeys.every((key) => Object.hasOwn(right, key) && jsonEqual(left[key], right[key]))
-  )
+  return length >= minimum
 }
 
 function instanceType(value) {
@@ -262,7 +263,7 @@ function validateSchema(value, rule, location) {
   }
 
   if (typeof value === 'string') {
-    if (rule.minLength !== undefined && [...value].length < rule.minLength) {
+    if (rule.minLength !== undefined && !satisfiesMinLength(value, rule.minLength)) {
       errors.push(`${location}: must contain at least ${rule.minLength} character(s)`)
     }
     if (rule.pattern && !new RegExp(rule.pattern, 'u').test(value)) {
@@ -275,10 +276,8 @@ function validateSchema(value, rule, location) {
       errors.push(`${location}: must contain at least ${rule.minItems} item(s)`)
     }
     if (rule.uniqueItems) {
-      const hasDuplicate = value.some((candidate, index) =>
-        value.slice(0, index).some((earlier) => jsonEqual(candidate, earlier))
-      )
-      if (hasDuplicate) {
+      const canonicalItems = value.map(canonicalJson)
+      if (new Set(canonicalItems).size !== canonicalItems.length) {
         errors.push(`${location}: items must be unique`)
       }
     }


### PR DESCRIPTION
Closes #669

## Summary

- compare JSON values structurally for `const`, `enum`, enum uniqueness, and `uniqueItems`
- count Unicode code points rather than UTF-16 code units for `minLength`
- add exact conformance regressions to both root and Copier template test suites

## Root cause

The dependency-free validator used `JSON.stringify` as an equality predicate, so object member insertion order affected JSON Schema equality. It also used JavaScript string `.length`, which measures UTF-16 code units rather than Unicode code points.

## Impact

Generated repositories receive the same corrected validator and mutation suite. Structurally equal objects now compare consistently regardless of property order, and astral Unicode characters count as one character for `minLength`.

## Validation

- focused `./scripts/test-agent-registry.sh`
- `task check`
- `task verify`
- `task challenge` — no P0/P1 findings; two P2s deferred below
- `task review -- --base origin/main` — no P0/P1 or material P2 findings
- `task ci`
- pre-commit, commit-msg, and pre-push hooks
- `PR_TITLE='fix: conform agent registry validation' BASE_SHA=origin/main task guard:release-title`

## Review adjudication

| Finding | Priority | Classification | Evidence | Action |
|---|---:|---|---|---|
| `uniqueItems` is quadratic for large distinct arrays | P2 | Confirmed | Pairwise structural comparison checks every predecessor and allocates slices | Fixed in `fed4a1c` with deterministic canonical keys and Set-based uniqueness |
| `minLength` materializes all code points | P2 | Confirmed | `[...value]` scans the full string and allocates an array even for small thresholds | Fixed in `fed4a1c` with threshold-bounded Unicode iteration |
| Untracked settings updater creates a personal-checkout dependency | P1 | False positive for this PR | `update_claude_settings.py` appeared concurrently, is untracked, and is absent from `origin/main...3cf1127` | Preserved untouched and explicitly excluded from the commit |
| Untracked settings updater is non-idempotent | P1 | False positive for this PR | Same unrelated untracked file; exact-commit re-review excluded it | Preserved untouched and explicitly excluded from the commit |

## Deferred findings

- [x] Challenge P2: quadratic `uniqueItems` validation — fixed in `fed4a1c` with deterministic canonical keys and Set-based uniqueness.
- [x] Challenge P2: full-string allocation when checking `minLength` — fixed in `fed4a1c` with threshold-bounded Unicode iteration.
