### PR TITLE
fix: make skills-sync PR lifecycle draft-first

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -147,7 +147,14 @@ release_content_paths:
 
 use_skills_sync:
   type: bool
-  help: "SKILLS SYNC: Vendor shared agent skills from harmon-devkit (pinned, drift-checked)?"
+  help: >-
+    SKILLS SYNC: Vendor shared agent skills from harmon-devkit (pinned,
+    drift-checked)? Local vendoring and drift checks require no paid service.
+    The generated GitHub sync workflow stays inert until you explicitly
+    configure its CI GitHub App credentials. When enabled, that automation
+    opens draft PRs; GitHub restricts drafts on private repositories to paid
+    plans, so private free-plan repos must leave the automation unconfigured,
+    become public, or upgrade. See docs/CHECKLIST.md.
   default: yes
 
 skill_categories:

--- a/scripts/sync-devkit-release.sh
+++ b/scripts/sync-devkit-release.sh
@@ -474,24 +474,69 @@ open_pr_number() {
     printf '%s\n' "$_pn"
 }
 
-# pr_title N — the current title of PR N. Empty rather than fatal when the PR
-# cannot be read: the caller only uses it to decide whether metadata needs
-# repairing, and "unknown" should mean "repair", not "abort".
+# pr_title N — the current title of PR N. A failed read is indeterminate, not
+# stale metadata: repairing an unchanged ready-for-review PR would demote it,
+# and a later reconciliation has no authority to restore that human handoff.
 pr_title() {
-    gh pr view "$1" --json title --jq '.title // empty' 2>/dev/null || true
+    gh pr view "$1" --json title --jq '.title // empty' 2>/dev/null
+}
+
+# ensure_pr_draft N [HEAD] — fail closed unless PR N is confirmed draft and,
+# when HEAD is supplied, points at that exact verified commit. A rolling
+# sync PR may have been promoted after its previous head passed review; before
+# replacing that head, and again after editing its metadata, return it to the
+# draft workbench so no unverified revision is published to reviewers.
+ensure_pr_draft() {
+    _epd_pr="$1" _epd_expected="${2:-}"
+    _epd_snapshot="$(gh pr view "$_epd_pr" --json headRefOid,isDraft \
+        --jq '[.headRefOid, (.isDraft | tostring)] | join(" ")' 2>/dev/null)" ||
+        die "could not confirm the head and draft state of PR #$_epd_pr"
+    IFS=' ' read -r _epd_head _epd_state <<EOF
+$_epd_snapshot
+EOF
+    if [ -n "$_epd_expected" ] && [ "$_epd_head" != "$_epd_expected" ]; then
+        die "PR #$_epd_pr points at $_epd_head, not the verified head $_epd_expected"
+    fi
+    case "$_epd_state" in
+    true) return 0 ;;
+    false)
+        note "returning sync PR #$_epd_pr to draft"
+        gh pr ready --undo "$_epd_pr" ||
+            die "could not return PR #$_epd_pr to draft"
+        _epd_snapshot="$(gh pr view "$_epd_pr" --json headRefOid,isDraft \
+            --jq '[.headRefOid, (.isDraft | tostring)] | join(" ")' 2>/dev/null)" ||
+            die "could not confirm PR #$_epd_pr became draft"
+        IFS=' ' read -r _epd_head _epd_state <<EOF
+$_epd_snapshot
+EOF
+        if [ -n "$_epd_expected" ] && [ "$_epd_head" != "$_epd_expected" ]; then
+            die "PR #$_epd_pr changed to $_epd_head while returning it to draft (expected $_epd_expected)"
+        fi
+        [ "$_epd_state" = "true" ] ||
+            die "PR #$_epd_pr remained non-draft after conversion"
+        ;;
+    *) die "unexpected draft state '$_epd_state' for PR #$_epd_pr" ;;
+    esac
 }
 
 open_or_update_pr() {
-    _pr_title="$1" _pr_existing="$2"
+    _pr_title="$1" _pr_existing="$2" _pr_expected="${3:-}"
     if [ -n "$_pr_existing" ]; then
         note "updating the open sync PR #$_pr_existing"
         gh pr edit "$_pr_existing" --title "$_pr_title" --body-file "$BODY_FILE" ||
             die "could not update PR #$_pr_existing"
+        ensure_pr_draft "$_pr_existing" "$_pr_expected"
     else
         note "opening a sync PR"
-        gh pr create --base "$BASE_BRANCH" --head "$SYNC_BRANCH" \
+        gh pr create --draft --base "$BASE_BRANCH" --head "$SYNC_BRANCH" \
             --title "$_pr_title" --body-file "$BODY_FILE" ||
             die "could not open the sync PR"
+        _pr_created="$(gh pr view "$SYNC_BRANCH" --json number --jq '.number // empty' 2>/dev/null)" ||
+            die "could not resolve the newly created sync PR"
+        case "$_pr_created" in
+        '' | *[!0-9]*) die "could not resolve the newly created sync PR" ;;
+        esac
+        ensure_pr_draft "$_pr_created" "$_pr_expected"
     fi
 }
 
@@ -685,13 +730,15 @@ cmd_run() {
         # here rather than leaving it wrong until someone notices. Either way
         # the push and the verification are skipped — this exact tree already
         # passed them on the open PR.
-        if [ "$(pr_title "$_run_open_pr")" = "$_run_title" ]; then
+        _run_open_title="$(pr_title "$_run_open_pr")" ||
+            die "could not read the title of PR #$_run_open_pr — refusing to change its handoff state"
+        if [ "$_run_open_title" = "$_run_title" ]; then
             note "PR #$_run_open_pr already carries this exact sync at $_run_target — leaving it untouched"
             return 0
         fi
         note "PR #$_run_open_pr has the right branch but stale metadata — repairing it"
         write_pr_body "$_run_current" "$_run_target" "$_run_prov"
-        open_or_update_pr "$_run_title" "$_run_open_pr"
+        open_or_update_pr "$_run_title" "$_run_open_pr" ""
         return 0
     fi
 
@@ -700,11 +747,16 @@ cmd_run() {
     # Force-push: this branch is owned solely by this workflow and is rebuilt
     # from the base every run, so its remote history is disposable by design.
     # Only $SYNC_BRANCH is ever written — never $BASE_BRANCH.
+    # Convert an existing PR before the push: doing this afterward would expose
+    # the replacement head as ready-for-review during the network/write window.
+    if [ -n "$_run_open_pr" ]; then
+        ensure_pr_draft "$_run_open_pr"
+    fi
     note "pushing $SYNC_BRANCH"
     push_sync_branch || die "could not push $SYNC_BRANCH"
 
     write_pr_body "$_run_current" "$_run_target" "$_run_prov"
-    open_or_update_pr "$_run_title" "$_run_open_pr"
+    open_or_update_pr "$_run_title" "$_run_open_pr" "$(git rev-parse HEAD)"
     note "done — merging $SYNC_BRANCH stays a human decision"
 }
 

--- a/scripts/test-sync-devkit-release.sh
+++ b/scripts/test-sync-devkit-release.sh
@@ -172,8 +172,40 @@ pr)
 ${STUB_PR_LIST:-}
 EOF
         ;;
-    view) printf '%s\n' "${STUB_PR_TITLE:-}" ;;
-    create | edit) printf 'https://example.invalid/pr\n' ;;
+    view)
+        case "$*" in
+        *"--json title"*)
+            [ -z "${STUB_FAIL_PR_TITLE_VIEW:-}" ] || exit 1
+            printf '%s\n' "${STUB_PR_TITLE:-}"
+            ;;
+        *"--json number"*)
+            [ -z "${STUB_FAIL_PR_NUMBER_VIEW:-}" ] || exit 1
+            printf '%s\n' "${STUB_PR_NUMBER:-42}"
+            ;;
+        *"--json headRefOid,isDraft"*)
+            [ -z "${STUB_FAIL_PR_DRAFT_VIEW:-}" ] || exit 1
+            _stub_head="${STUB_PR_HEAD:-$(git rev-parse HEAD)}"
+            if [ -f "${STUB_PR_DRAFT_MARKER:-/nonexistent}" ]; then
+                printf '%s %s\n' "$_stub_head" true
+            else
+                printf '%s %s\n' "$_stub_head" "${STUB_PR_IS_DRAFT:-true}"
+            fi
+            ;;
+        *) echo "stub gh: unhandled pr view: $*" >&2; exit 1 ;;
+        esac
+        ;;
+    create) printf 'https://example.invalid/pr/%s\n' "${STUB_PR_NUMBER:-42}" ;;
+    edit)
+        if [ -n "${STUB_EDIT_MAKES_READY:-}" ]; then
+            rm -f "${STUB_PR_DRAFT_MARKER:-/nonexistent}"
+        fi
+        printf 'https://example.invalid/pr/%s\n' "${3:-42}"
+        ;;
+    ready)
+        [ "${3:-}" = "--undo" ] || exit 1
+        [ -z "${STUB_FAIL_READY_UNDO:-}" ] || exit 1
+        : >"$STUB_PR_DRAFT_MARKER"
+        ;;
     *)
         echo "stub gh: unhandled pr subcommand ${2:-}" >&2
         exit 1
@@ -271,6 +303,15 @@ run_helper() {
             STUB_RELEASES="${STUB_RELEASES:-}" \
             STUB_PR_LIST="${STUB_PR_LIST:-}" \
             STUB_PR_TITLE="${STUB_PR_TITLE:-}" \
+            STUB_FAIL_PR_TITLE_VIEW="${STUB_FAIL_PR_TITLE_VIEW:-}" \
+            STUB_PR_NUMBER="${STUB_PR_NUMBER:-}" \
+            STUB_PR_HEAD="${STUB_PR_HEAD:-}" \
+            STUB_PR_IS_DRAFT="${STUB_PR_IS_DRAFT:-}" \
+            STUB_PR_DRAFT_MARKER="${STUB_PR_DRAFT_MARKER:-}" \
+            STUB_FAIL_PR_NUMBER_VIEW="${STUB_FAIL_PR_NUMBER_VIEW:-}" \
+            STUB_FAIL_PR_DRAFT_VIEW="${STUB_FAIL_PR_DRAFT_VIEW:-}" \
+            STUB_FAIL_READY_UNDO="${STUB_FAIL_READY_UNDO:-}" \
+            STUB_EDIT_MAKES_READY="${STUB_EDIT_MAKES_READY:-}" \
             STUB_BOT_UID="${STUB_BOT_UID:-12345}" \
             STUB_FAIL_TASKS="${STUB_FAIL_TASKS:-}" \
             STUB_SYNC_TOUCH_UNRELATED="${STUB_SYNC_TOUCH_UNRELATED:-}" \
@@ -300,6 +341,16 @@ v0.9.2-rc.1 false true
 v1.0.0 true false"
     STUB_PR_LIST=""
     STUB_PR_TITLE=""
+    STUB_FAIL_PR_TITLE_VIEW=""
+    STUB_PR_NUMBER="42"
+    STUB_PR_HEAD=""
+    STUB_PR_IS_DRAFT="true"
+    STUB_PR_DRAFT_MARKER="$TMPROOT/pr-draft.$cases"
+    rm -f "$STUB_PR_DRAFT_MARKER"
+    STUB_FAIL_PR_NUMBER_VIEW=""
+    STUB_FAIL_PR_DRAFT_VIEW=""
+    STUB_FAIL_READY_UNDO=""
+    STUB_EDIT_MAKES_READY=""
     STUB_FAIL_TASKS=""
     STUB_SYNC_ADD_AGENT=""
     STUB_SYNC_DELETE_LOCAL_AGENT=""
@@ -324,6 +375,7 @@ start() {
 }
 
 logged() { grep -qF -- "$1" "$STUB_LOG"; }
+log_count() { grep -cF -- "$1" "$STUB_LOG" || true; }
 # A PR was created or updated — as opposed to merely queried, which the
 # no-churn check does before verification runs.
 pr_written() { grep -qE '^gh pr (create|edit)' "$STUB_LOG"; }
@@ -343,6 +395,9 @@ grep -q '^# ref: v0.9.0 ' "$fix/.claude/skills/.SKILLS_PROVENANCE" || fail "prov
 [ -f "$fix/.claude/skills/local-only/SKILL.md" ] || fail "local skill was disturbed"
 pushed "$fix" || fail "sync branch was never pushed"
 logged "gh pr create" || fail "no PR was opened"
+logged "gh pr create --draft" || fail "the sync PR was not created as draft"
+logged "gh pr view 42 --json headRefOid,isDraft" ||
+    fail "the created PR's head and draft state were not confirmed"
 logged "fix(template): sync harmon-devkit skills to v0.9.0" || fail "PR title is not releasing"
 logged "task verify" || fail "verification never ran"
 [ "$(git -C "$fix" rev-parse main)" = "$main_before" ] || fail "main was modified"
@@ -350,6 +405,51 @@ logged "task verify" || fail "verification never ran"
 changed="$(git -C "$fix" diff --no-renames --name-only main "$SYNC_BRANCH" | sort | tr '\n' '|')"
 [ "$changed" = ".claude/skills/.SKILLS_PROVENANCE|.claude/skills/standardize-repo/SKILL.md|.skills-sync.yaml|template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja|" ] ||
     fail "unexpected commit contents: $changed"
+
+start "a created PR that lands ready is returned to draft and re-confirmed"
+fix="$(new_fixture created_ready)"
+STUB_PR_IS_DRAFT="false"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "ready-created remediation exited $rc: $(cat "$LAST_OUT")"
+logged "gh pr ready --undo 42" || fail "the ready-created PR was not returned to draft"
+[ "$(log_count "gh pr view 42 --json headRefOid,isDraft")" -ge 2 ] ||
+    fail "the draft conversion was not re-confirmed"
+
+start "an unresolvable created PR fails closed"
+fix="$(new_fixture created_unknown)"
+STUB_FAIL_PR_NUMBER_VIEW="true"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "an unresolvable created PR was reported as success"
+grep -q "could not resolve the newly created sync PR" "$LAST_OUT" ||
+    fail "the unresolved PR failure was not explicit: $(cat "$LAST_OUT")"
+
+start "a created PR on a different head fails closed"
+fix="$(new_fixture created_wrong_head)"
+STUB_PR_HEAD="0000000000000000000000000000000000000000"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "a created PR on an unverified head was reported as success"
+grep -q "not the verified head" "$LAST_OUT" ||
+    fail "the head mismatch was not explicit: $(cat "$LAST_OUT")"
+
+start "a ready existing PR must become draft before its branch is replaced"
+fix="$(new_fixture existing_ready_refused)"
+STUB_PR_LIST="42 false"
+STUB_PR_IS_DRAFT="false"
+STUB_FAIL_READY_UNDO="true"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "a ready existing PR was overwritten without draft conversion"
+! pushed "$fix" || fail "the branch was pushed before draft conversion succeeded"
+! logged "gh pr edit 42" || fail "the PR was edited after pre-push draft conversion failed"
+
+start "an updated PR is re-converted if metadata editing publishes it ready"
+fix="$(new_fixture existing_edit_ready)"
+STUB_PR_LIST="42 false"
+STUB_PR_IS_DRAFT="false"
+STUB_EDIT_MAKES_READY="true"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "post-edit draft remediation exited $rc: $(cat "$LAST_OUT")"
+[ "$(log_count "gh pr ready --undo 42")" -eq 2 ] ||
+    fail "the PR was not converted both before push and after edit"
 
 start "an event replayed after the sync PR merged is a clean no-op"
 fix="$(new_fixture replay_merged v0.9.0)"
@@ -378,6 +478,24 @@ grep -q "already carries this exact sync" "$LAST_OUT" || fail "reconciliation di
     fail "reconciliation force-pushed an identical tree"
 ! logged "gh pr edit" || fail "reconciliation churned the open PR"
 ! logged "task verify" || fail "reconciliation re-ran the expensive verification"
+
+start "an indeterminate title read leaves an unchanged handed-off PR untouched"
+fix="$(new_fixture title_read_failure)"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "first run exited $rc: $(cat "$LAST_OUT")"
+pushed_before="$(git -C "$fix.origin.git" rev-parse "$SYNC_BRANCH")"
+git -C "$fix" checkout --quiet main
+STUB_PR_LIST="42 false"
+STUB_PR_IS_DRAFT="false"
+STUB_FAIL_PR_TITLE_VIEW="true"
+: >"$STUB_LOG"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" -ne 0 ] || fail "an unreadable title was treated as stale metadata"
+[ "$(git -C "$fix.origin.git" rev-parse "$SYNC_BRANCH")" = "$pushed_before" ] ||
+    fail "an unreadable title churned the remote branch"
+! logged "gh pr edit" || fail "an unreadable title triggered metadata repair"
+! logged "gh pr ready --undo" || fail "an unreadable title revoked the human handoff"
+! logged "task verify" || fail "an unreadable title re-ran verification"
 
 start "a pushed branch whose PR metadata went stale is repaired, not skipped"
 fix="$(new_fixture stale_meta)"

--- a/template/.github/workflows/[% if use_skills_sync %]sync-harmon-devkit.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if use_skills_sync %]sync-harmon-devkit.yml[% endif %].jinja
@@ -14,8 +14,9 @@ run-name: sync-harmon-devkit reconciling the vendored skills pin
 
 on:
   # Weekly reconciliation: a harmon-devkit release must not leave this pin
-  # stale. Sunday morning so the PR is ready for review on Monday. Off the
-  # hour to avoid GitHub's scheduling pile-up.
+  # stale. Sunday morning so its draft workbench is ready for agent/maintainer
+  # shepherding on Monday; AGENTS.md owns the readiness gate and promotion.
+  # Off the hour to avoid GitHub's scheduling pile-up.
   schedule:
     - cron: "17 6 * * 0"
 

--- a/template/scripts/[% if use_skills_sync %]sync-devkit-release.sh[% endif %]
+++ b/template/scripts/[% if use_skills_sync %]sync-devkit-release.sh[% endif %]
@@ -438,24 +438,69 @@ open_pr_number() {
     printf '%s\n' "$_pn"
 }
 
-# pr_title N — the current title of PR N. Empty rather than fatal when the PR
-# cannot be read: the caller only uses it to decide whether metadata needs
-# repairing, and "unknown" should mean "repair", not "abort".
+# pr_title N — the current title of PR N. A failed read is indeterminate, not
+# stale metadata: repairing an unchanged ready-for-review PR would demote it,
+# and a later reconciliation has no authority to restore that human handoff.
 pr_title() {
-    gh pr view "$1" --json title --jq '.title // empty' 2>/dev/null || true
+    gh pr view "$1" --json title --jq '.title // empty' 2>/dev/null
+}
+
+# ensure_pr_draft N [HEAD] — fail closed unless PR N is confirmed draft and,
+# when HEAD is supplied, points at that exact verified commit. A rolling
+# sync PR may have been promoted after its previous head passed review; before
+# replacing that head, and again after editing its metadata, return it to the
+# draft workbench so no unverified revision is published to reviewers.
+ensure_pr_draft() {
+    _epd_pr="$1" _epd_expected="${2:-}"
+    _epd_snapshot="$(gh pr view "$_epd_pr" --json headRefOid,isDraft \
+        --jq '[.headRefOid, (.isDraft | tostring)] | join(" ")' 2>/dev/null)" ||
+        die "could not confirm the head and draft state of PR #$_epd_pr"
+    IFS=' ' read -r _epd_head _epd_state <<EOF
+$_epd_snapshot
+EOF
+    if [ -n "$_epd_expected" ] && [ "$_epd_head" != "$_epd_expected" ]; then
+        die "PR #$_epd_pr points at $_epd_head, not the verified head $_epd_expected"
+    fi
+    case "$_epd_state" in
+    true) return 0 ;;
+    false)
+        note "returning sync PR #$_epd_pr to draft"
+        gh pr ready --undo "$_epd_pr" ||
+            die "could not return PR #$_epd_pr to draft"
+        _epd_snapshot="$(gh pr view "$_epd_pr" --json headRefOid,isDraft \
+            --jq '[.headRefOid, (.isDraft | tostring)] | join(" ")' 2>/dev/null)" ||
+            die "could not confirm PR #$_epd_pr became draft"
+        IFS=' ' read -r _epd_head _epd_state <<EOF
+$_epd_snapshot
+EOF
+        if [ -n "$_epd_expected" ] && [ "$_epd_head" != "$_epd_expected" ]; then
+            die "PR #$_epd_pr changed to $_epd_head while returning it to draft (expected $_epd_expected)"
+        fi
+        [ "$_epd_state" = "true" ] ||
+            die "PR #$_epd_pr remained non-draft after conversion"
+        ;;
+    *) die "unexpected draft state '$_epd_state' for PR #$_epd_pr" ;;
+    esac
 }
 
 open_or_update_pr() {
-    _pr_title="$1" _pr_existing="$2"
+    _pr_title="$1" _pr_existing="$2" _pr_expected="${3:-}"
     if [ -n "$_pr_existing" ]; then
         note "updating the open sync PR #$_pr_existing"
         gh pr edit "$_pr_existing" --title "$_pr_title" --body-file "$BODY_FILE" ||
             die "could not update PR #$_pr_existing"
+        ensure_pr_draft "$_pr_existing" "$_pr_expected"
     else
         note "opening a sync PR"
-        gh pr create --base "$BASE_BRANCH" --head "$SYNC_BRANCH" \
+        gh pr create --draft --base "$BASE_BRANCH" --head "$SYNC_BRANCH" \
             --title "$_pr_title" --body-file "$BODY_FILE" ||
             die "could not open the sync PR"
+        _pr_created="$(gh pr view "$SYNC_BRANCH" --json number --jq '.number // empty' 2>/dev/null)" ||
+            die "could not resolve the newly created sync PR"
+        case "$_pr_created" in
+        '' | *[!0-9]*) die "could not resolve the newly created sync PR" ;;
+        esac
+        ensure_pr_draft "$_pr_created" "$_pr_expected"
     fi
 }
 
@@ -635,13 +680,15 @@ cmd_run() {
         # here rather than leaving it wrong until someone notices. Either way
         # the push and the verification are skipped — this exact tree already
         # passed them on the open PR.
-        if [ "$(pr_title "$_run_open_pr")" = "$_run_title" ]; then
+        _run_open_title="$(pr_title "$_run_open_pr")" ||
+            die "could not read the title of PR #$_run_open_pr — refusing to change its handoff state"
+        if [ "$_run_open_title" = "$_run_title" ]; then
             note "PR #$_run_open_pr already carries this exact sync at $_run_target — leaving it untouched"
             return 0
         fi
         note "PR #$_run_open_pr has the right branch but stale metadata — repairing it"
         write_pr_body "$_run_current" "$_run_target" "$_run_prov"
-        open_or_update_pr "$_run_title" "$_run_open_pr"
+        open_or_update_pr "$_run_title" "$_run_open_pr" ""
         return 0
     fi
 
@@ -650,11 +697,16 @@ cmd_run() {
     # Force-push: this branch is owned solely by this workflow and is rebuilt
     # from the base every run, so its remote history is disposable by design.
     # Only $SYNC_BRANCH is ever written — never $BASE_BRANCH.
+    # Convert an existing PR before the push: doing this afterward would expose
+    # the replacement head as ready-for-review during the network/write window.
+    if [ -n "$_run_open_pr" ]; then
+        ensure_pr_draft "$_run_open_pr"
+    fi
     note "pushing $SYNC_BRANCH"
     push_sync_branch || die "could not push $SYNC_BRANCH"
 
     write_pr_body "$_run_current" "$_run_target" "$_run_prov"
-    open_or_update_pr "$_run_title" "$_run_open_pr"
+    open_or_update_pr "$_run_title" "$_run_open_pr" "$(git rev-parse HEAD)"
     note "done — merging $SYNC_BRANCH stays a human decision"
 }
 

--- a/template/scripts/[% if use_skills_sync %]test-sync-devkit-release.sh[% endif %]
+++ b/template/scripts/[% if use_skills_sync %]test-sync-devkit-release.sh[% endif %]
@@ -130,10 +130,41 @@ api--repos/*/releases/tags/*)
     *) echo "$_tag false false" ;;
     esac
     ;;
-pr--list) echo '';;
+pr--list) echo "${STUB_PR_LIST:-}";;
 pr--create) echo "created";;
-pr--edit) echo "edited";;
-pr--view) echo '{"title":""}';;
+pr--edit)
+    if [ -n "${STUB_EDIT_MAKES_READY:-}" ]; then
+        rm -f "${STUB_PR_DRAFT_MARKER:-/nonexistent}"
+    fi
+    echo "edited"
+    ;;
+pr--view)
+    case "$*" in
+    *"--json title"*)
+        [ -z "${STUB_FAIL_PR_TITLE_VIEW:-}" ] || exit 1
+        echo "${STUB_PR_TITLE:-}"
+        ;;
+    *"--json number"*)
+        [ -z "${STUB_FAIL_PR_NUMBER_VIEW:-}" ] || exit 1
+        echo "${STUB_PR_NUMBER:-42}"
+        ;;
+    *"--json headRefOid,isDraft"*)
+        [ -z "${STUB_FAIL_PR_DRAFT_VIEW:-}" ] || exit 1
+        _stub_head="${STUB_PR_HEAD:-$(git rev-parse HEAD)}"
+        if [ -f "${STUB_PR_DRAFT_MARKER:-/nonexistent}" ]; then
+            echo "$_stub_head true"
+        else
+            echo "$_stub_head ${STUB_PR_IS_DRAFT:-true}"
+        fi
+        ;;
+    *) exit 1;;
+    esac
+    ;;
+pr--ready)
+    [ "${3:-}" = "--undo" ] || exit 1
+    [ -z "${STUB_FAIL_READY_UNDO:-}" ] || exit 1
+    : >"$STUB_PR_DRAFT_MARKER"
+    ;;
 api--/users/*) echo '12345' ;;
 *) exit 0;;
 esac
@@ -143,11 +174,33 @@ SCRIPT
 
 export TASK_LOG="$TEST_ROOT/task.log"
 export GH_LOG="$TEST_ROOT/gh.log"
+export STUB_PR_LIST=""
+export STUB_PR_TITLE=""
+export STUB_FAIL_PR_TITLE_VIEW=""
+export STUB_PR_NUMBER="42"
+export STUB_PR_HEAD=""
+export STUB_PR_IS_DRAFT="true"
+export STUB_PR_DRAFT_MARKER="$TEST_ROOT/pr-draft"
+export STUB_FAIL_PR_NUMBER_VIEW=""
+export STUB_FAIL_PR_DRAFT_VIEW=""
+export STUB_FAIL_READY_UNDO=""
+export STUB_EDIT_MAKES_READY=""
 
 clear_logs() {
     rm -f "$TASK_LOG" "$GH_LOG"
     : >"$TASK_LOG"
     : >"$GH_LOG"
+    STUB_PR_LIST=""
+    STUB_PR_TITLE=""
+    STUB_FAIL_PR_TITLE_VIEW=""
+    STUB_PR_NUMBER="42"
+    STUB_PR_HEAD=""
+    STUB_PR_IS_DRAFT="true"
+    rm -f "$STUB_PR_DRAFT_MARKER"
+    STUB_FAIL_PR_NUMBER_VIEW=""
+    STUB_FAIL_PR_DRAFT_VIEW=""
+    STUB_FAIL_READY_UNDO=""
+    STUB_EDIT_MAKES_READY=""
 }
 
 # ── Assertions ────────────────────────────────────────────────────────
@@ -290,7 +343,117 @@ test_happy_path() {
     assert_task_not_logged "task verify:skills" || return 1
     assert_task_not_logged "task verify" || return 1
     assert_gh_logged "gh pr create" || return 1
+    assert_gh_logged "gh pr create --draft" || return 1
+    assert_gh_logged "gh pr view 42 --json headRefOid,isDraft" || return 1
     assert_commit_title "$FIXTURE" "fix: sync harmon-devkit skills to v0.9.0" || return 1
+}
+
+test_ready_created_pr_is_reverted() {
+    note "a created PR that lands ready is returned to draft"
+    FIXTURE="$(build_fixture v0.1.0)"
+    clear_logs
+    STUB_PR_IS_DRAFT="false"
+    write_gh_stub
+    write_task_stub pass
+    run_helper_with_tag v0.9.0 || return 1
+    assert_gh_logged "gh pr ready --undo 42" || return 1
+    [ "$(grep -cF 'gh pr view 42 --json headRefOid,isDraft' "$GH_LOG")" -ge 2 ] || {
+        echo "draft conversion was not re-confirmed" >&2
+        return 1
+    }
+}
+
+test_created_pr_head_mismatch_fails() {
+    note "a created PR on a different head fails closed"
+    FIXTURE="$(build_fixture v0.1.0)"
+    clear_logs
+    STUB_PR_HEAD="0000000000000000000000000000000000000000"
+    write_gh_stub
+    write_task_stub pass
+    ! run_helper_with_tag v0.9.0 || {
+        echo "a PR on an unverified head was reported as success" >&2
+        return 1
+    }
+}
+
+test_unresolvable_created_pr_fails() {
+    note "an unresolvable created PR fails closed"
+    FIXTURE="$(build_fixture v0.1.0)"
+    clear_logs
+    STUB_FAIL_PR_NUMBER_VIEW="true"
+    write_gh_stub
+    write_task_stub pass
+    ! run_helper_with_tag v0.9.0 || {
+        echo "an unresolvable PR was reported as success" >&2
+        return 1
+    }
+}
+
+test_ready_existing_pr_is_drafted_before_push() {
+    note "a ready existing PR must become draft before force-push"
+    FIXTURE="$(build_fixture v0.1.0)"
+    clear_logs
+    STUB_PR_LIST="42"
+    STUB_PR_IS_DRAFT="false"
+    STUB_FAIL_READY_UNDO="true"
+    write_gh_stub
+    write_task_stub pass
+    ! run_helper_with_tag v0.9.0 || {
+        echo "a ready PR was overwritten without draft conversion" >&2
+        return 1
+    }
+    ! git --git-dir="$TEST_ROOT/origin.git" show-ref --verify --quiet "refs/heads/bot/sync-harmon-devkit" || {
+        echo "sync branch was pushed before draft conversion" >&2
+        return 1
+    }
+}
+
+test_updated_pr_is_rechecked_after_edit() {
+    note "an updated PR is re-converted if editing publishes it ready"
+    FIXTURE="$(build_fixture v0.1.0)"
+    clear_logs
+    STUB_PR_LIST="42"
+    STUB_PR_IS_DRAFT="false"
+    STUB_EDIT_MAKES_READY="true"
+    write_gh_stub
+    write_task_stub pass
+    run_helper_with_tag v0.9.0 || return 1
+    [ "$(grep -cF 'gh pr ready --undo 42' "$GH_LOG")" -eq 2 ] || {
+        echo "PR was not converted before push and after edit" >&2
+        return 1
+    }
+}
+
+test_indeterminate_title_preserves_handoff() {
+    note "an indeterminate title read preserves an unchanged handed-off PR"
+    FIXTURE="$(build_fixture v0.1.0)"
+    clear_logs
+    write_gh_stub
+    write_task_stub pass
+    run_helper_with_tag v0.9.0 || return 1
+    _pushed_before="$(git --git-dir="$TEST_ROOT/origin.git" rev-parse bot/sync-harmon-devkit)"
+    git -C "$FIXTURE" checkout --quiet main
+    clear_logs
+    STUB_PR_LIST="42"
+    STUB_PR_IS_DRAFT="false"
+    STUB_FAIL_PR_TITLE_VIEW="true"
+    write_gh_stub
+    ! run_helper_with_tag v0.9.0 || {
+        echo "an unreadable title was treated as stale metadata" >&2
+        return 1
+    }
+    [ "$(git --git-dir="$TEST_ROOT/origin.git" rev-parse bot/sync-harmon-devkit)" = "$_pushed_before" ] || {
+        echo "an unreadable title churned the remote branch" >&2
+        return 1
+    }
+    ! grep -qF "gh pr edit" "$GH_LOG" || {
+        echo "an unreadable title triggered metadata repair" >&2
+        return 1
+    }
+    ! grep -qF "gh pr ready --undo" "$GH_LOG" || {
+        echo "an unreadable title revoked the human handoff" >&2
+        return 1
+    }
 }
 
 test_happy_path_with_agents() {
@@ -484,6 +647,12 @@ TESTS=(
     test_reject_unknown_release
     test_pinned
     test_happy_path
+    test_ready_created_pr_is_reverted
+    test_unresolvable_created_pr_fails
+    test_created_pr_head_mismatch_fails
+    test_ready_existing_pr_is_drafted_before_push
+    test_updated_pr_is_rechecked_after_edit
+    test_indeterminate_title_preserves_handoff
     test_happy_path_with_agents
     test_noop_when_current
     test_dirty_tree_refused


### PR DESCRIPTION
## Summary

- create harmon-devkit skills-sync pull requests as drafts and confirm GitHub preserved the requested state
- return an existing rolling PR to draft before replacing its head, then re-check its exact head and draft state after metadata updates
- fail closed on indeterminate PR number, title, head, or draft-state reads
- add regression coverage in both the dogfood script and rendered template script

## Why

The rolling skills-sync workflow could publish an unverified head as ready for review. A newly created PR was non-draft, and an existing PR that had previously passed review remained ready while a later release force-pushed a replacement head. This implements all four lifecycle defects described in #670 while retaining manual merge ownership.

Closes #670

## Verification

- `./scripts/test-sync-devkit-release.sh` — 45 cases passed
- rendered template sync test — 24 cases passed
- `task verify`
- `task challenge` — three adjudicated rounds; no confirmed P0/P1 remained
- `task review` — no confirmed P0/P1
- `task ci`
- `task audit:dogfood -- --summary`
- `PR_TITLE='fix: make skills-sync PR lifecycle draft-first' BASE_SHA=main task guard:release-title`
- commit and push hooks, including offline skills drift, gitleaks, and minimal template render

## Second-model adjudication

| Finding | Priority | Classification | Evidence | Action |
| --- | --- | --- | --- | --- |
| Private GitHub Free repositories cannot create draft PRs | P1 | False positive for this change | `use_skills_sync` provides free local vendoring; the generated PR workflow is inert until the maintainer explicitly configures `CI_APP_CLIENT_ID` and its App secret, and the generated checklist documents the private-plan limitation immediately before that setup | Rejected default-off request; commit `907e01f` clarifies the free local path, explicit automation opt-in, private-plan limitation, and shepherd handoff |
| The sync helper itself does not shepherd and promote the draft | P1 | False positive / outside issue contract | #670 explicitly requires draft creation and confirmation; promotion requires the full AGENTS readiness gate and cannot safely be performed by this token-limited producer | Rejected; promotion ownership documentation retained below as P2 |
| Created/updated PR state was not bound to the verified commit | P1 | Confirmed | Draft state alone could describe a different head | Added exact `headRefOid` verification before reporting success, with mismatch tests |
| Returning a rolling ready PR to draft revokes an earlier handoff | P1 | Required lifecycle transition | #670 explicitly requires demotion before replacing the previously reviewed head and again after edit | Kept the required behavior; minimized exposure with pre-push conversion and post-edit exact-head checks |
| An indeterminate title read could demote an unchanged ready PR | P1 | Confirmed | The old `|| true` converted a read failure into apparent stale metadata | Made title reads fail closed and added no-edit/no-push/no-demotion regression tests |

## Deferred findings

- [x] `scripts/sync-devkit-release.sh:750` — A maintainer or automation can promote the rolling PR in the non-atomic interval between the pre-push draft-state check and the force-push, briefly exposing the replacement head as ready; GitHub provides no atomic compare-and-swap across PR draft state and branch updates. — filed as #673
- [x] `scripts/sync-devkit-release.sh:752` — The open-PR lookup can become stale during verification; if a PR appears after the initial lookup, the script may skip draft conversion, force-push its head, then fail while trying to create a duplicate PR. — filed as #673
- [x] `template/.github/workflows/sync-harmon-devkit.yml.jinja:17` — Generated workflow/docs should name the owner and procedure for shepherding and promoting the draft sync PR; the current Sunday comment says the PR will be ready for Monday without explaining the manual/agent handoff. — fixed in `907e01f`; #673 remains open for the two race-hardening items above
