### PR TITLE
feat: drive label provisioning from the agent registry with a drift gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
         run: task check
       - run: task test:tasks
       - run: task test:agent-registry
+      - run: task test:registry-drift
       - run: task test:codex-review
       - run: task test:ci-results
       - run: task test:status

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -76,6 +76,7 @@ tasks:
     cmds:
       - task: check
       - task: test:agent-registry
+      - task: test:registry-drift
       - task: test:tasks
       - task: test:ci-results
       - task: test:status
@@ -318,6 +319,11 @@ tasks:
     desc: Schema-check the machine-readable agent registry and its cross-record invariants
     cmds:
       - ./scripts/test-agent-registry.sh
+
+  test:registry-drift:
+    desc: Bind label provisioning, provider wrappers, and Foreman adapters to the agent registry (offline drift gate)
+    cmds:
+      - ./scripts/test-registry-drift.sh
 
   test:tasks:
     desc: Guard the Taskfile itself (compiles; setup tasks are safe no-ops)

--- a/scripts/agent-registry-labels.mjs
+++ b/scripts/agent-registry-labels.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// agent-registry-labels.mjs — render the agent-vocabulary GitHub labels from the
+// machine-readable agent registry (agent-registry.json). This is the SINGLE
+// source of the `suggest:*`, `claim:*`, and `foreman:<adapter>` label lines:
+// setup-github-labels.sh provisions them and test-registry-drift.sh checks them,
+// both by calling this file, so the two can never disagree.
+//
+// Output: one `name|hex-color|description` line per label (the format
+// setup-github-labels.sh consumes). Only FAMILY-LEVEL suggest/claim labels are
+// emitted — model-level `suggest:<family>:<model>` / `claim:<family>:<model>`
+// are created on demand, never seeded (an unbounded roster otherwise). Foreman
+// adapter selectors are emitted only for adapters the registry marks
+// `provision_label` (a selector without a production adapter can strand armed
+// work — ADR 0005 D11), so `mock` never yields a `foreman:mock` label.
+//
+// Usage: node agent-registry-labels.mjs <mode> [registry-path]
+//   mode = suggest-claim | foreman-adapters | all
+// Registry defaults to ../agent-registry.json relative to this file.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+// Colors mirror setup-github-labels.sh's family grouping: claim inherits the
+// retired agent:* teal (it answers the same "who is working this" question);
+// suggest is a softer advisory blue; foreman selectors share the arming blue.
+const COLOR_SUGGEST = 'BFD4F2'
+const COLOR_CLAIM = '006B75'
+const COLOR_FOREMAN = '1D76DB'
+
+const MODES = new Set(['suggest-claim', 'foreman-adapters', 'all'])
+
+const mode = process.argv[2]
+if (!MODES.has(mode)) {
+  console.error(
+    `agent-registry-labels: mode must be one of ${[...MODES].join(', ')} (got ${mode ?? '<none>'})`
+  )
+  process.exit(2)
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const registryPath = path.resolve(process.argv[3] ?? path.join(here, '..', 'agent-registry.json'))
+
+let registry
+try {
+  registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'))
+} catch (error) {
+  console.error(
+    `agent-registry-labels: cannot read valid JSON from ${registryPath}: ${error.message}`
+  )
+  process.exit(1)
+}
+
+// Output is one `name|color|desc` label RECORD per line, consumed by a
+// line-and-pipe-splitting shell loop. A slug or display_name carrying a newline
+// or a `|` would split into extra/garbled records — a schema-valid display_name
+// like "Claude\nrogue|FFFFFF|x" would inject a whole label. The slug pattern
+// already forbids both, but display_name is a free string, so fail closed on any
+// field that could break the transport rather than emitting a smuggled record.
+const field = (value, where) => {
+  if (/[\n\r|]/.test(value)) {
+    console.error(
+      `agent-registry-labels: ${where} contains a newline or '|' (${JSON.stringify(value)}); ` +
+        `it would corrupt the label record stream — fix agent-registry.json`
+    )
+    process.exit(1)
+  }
+  return value
+}
+
+// GitHub caps label names at 50 characters. A schema-valid slug can render a
+// longer `<prefix>:<slug>` label, and `gh label create` fails ONLY on that
+// label — after earlier ones were already provisioned (a partial run). Fail
+// closed here so the whole set is rejected before any of it reaches GitHub.
+const GH_LABEL_NAME_MAX = 50
+const labelName = (prefix, slug) => {
+  const name = `${prefix}:${slug}`
+  if (name.length > GH_LABEL_NAME_MAX) {
+    console.error(
+      `agent-registry-labels: label '${name}' is ${name.length} chars, over GitHub's ` +
+        `${GH_LABEL_NAME_MAX}-char limit — shorten the slug in agent-registry.json`
+    )
+    process.exit(1)
+  }
+  return name
+}
+
+const lines = []
+
+if (mode === 'suggest-claim' || mode === 'all') {
+  for (const family of registry.families ?? []) {
+    const slug = field(family.slug, `family slug`)
+    const name = field(family.display_name, `family '${slug}' display_name`)
+    lines.push(
+      `${labelName('suggest', slug)}|${COLOR_SUGGEST}|Suggested for the ${name} family (advisory)`
+    )
+    lines.push(`${labelName('claim', slug)}|${COLOR_CLAIM}|Claimed by ${name}`)
+  }
+}
+
+if (mode === 'foreman-adapters' || mode === 'all') {
+  for (const adapter of registry.foreman_adapters ?? []) {
+    if (adapter.provision_label !== true) continue
+    const slug = field(adapter.slug, `foreman adapter slug`)
+    const name = field(adapter.display_name, `foreman adapter '${slug}' display_name`)
+    lines.push(
+      `${labelName('foreman', slug)}|${COLOR_FOREMAN}|Arm this issue for foreman dispatch with the ${name} backend`
+    )
+  }
+}
+
+process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''))

--- a/scripts/agent-registry-labels.mjs
+++ b/scripts/agent-registry-labels.mjs
@@ -69,11 +69,13 @@ const field = (value, where) => {
   return value
 }
 
-// GitHub caps label names at 50 characters. A schema-valid slug can render a
-// longer `<prefix>:<slug>` label, and `gh label create` fails ONLY on that
-// label — after earlier ones were already provisioned (a partial run). Fail
-// closed here so the whole set is rejected before any of it reaches GitHub.
+// GitHub caps label NAMES at 50 and DESCRIPTIONS at 100 characters. A schema-
+// valid slug/display_name can render a longer name or description, and
+// `gh label create` then fails ONLY on that label — after earlier ones were
+// already provisioned (a partial run). Fail closed on BOTH limits here so the
+// whole set is rejected before any of it reaches GitHub.
 const GH_LABEL_NAME_MAX = 50
+const GH_LABEL_DESC_MAX = 100
 const labelName = (prefix, slug) => {
   const name = `${prefix}:${slug}`
   if (name.length > GH_LABEL_NAME_MAX) {
@@ -85,6 +87,16 @@ const labelName = (prefix, slug) => {
   }
   return name
 }
+const record = (name, color, description) => {
+  if (description.length > GH_LABEL_DESC_MAX) {
+    console.error(
+      `agent-registry-labels: label '${name}' description is ${description.length} chars, over ` +
+        `GitHub's ${GH_LABEL_DESC_MAX}-char limit — shorten the display_name in agent-registry.json`
+    )
+    process.exit(1)
+  }
+  return `${name}|${color}|${description}`
+}
 
 const lines = []
 
@@ -93,9 +105,13 @@ if (mode === 'suggest-claim' || mode === 'all') {
     const slug = field(family.slug, `family slug`)
     const name = field(family.display_name, `family '${slug}' display_name`)
     lines.push(
-      `${labelName('suggest', slug)}|${COLOR_SUGGEST}|Suggested for the ${name} family (advisory)`
+      record(
+        labelName('suggest', slug),
+        COLOR_SUGGEST,
+        `Suggested for the ${name} family (advisory)`
+      )
     )
-    lines.push(`${labelName('claim', slug)}|${COLOR_CLAIM}|Claimed by ${name}`)
+    lines.push(record(labelName('claim', slug), COLOR_CLAIM, `Claimed by ${name}`))
   }
 }
 
@@ -105,7 +121,11 @@ if (mode === 'foreman-adapters' || mode === 'all') {
     const slug = field(adapter.slug, `foreman adapter slug`)
     const name = field(adapter.display_name, `foreman adapter '${slug}' display_name`)
     lines.push(
-      `${labelName('foreman', slug)}|${COLOR_FOREMAN}|Arm this issue for foreman dispatch with the ${name} backend`
+      record(
+        labelName('foreman', slug),
+        COLOR_FOREMAN,
+        `Arm this issue for foreman dispatch with the ${name} backend`
+      )
     )
   }
 }

--- a/scripts/audit-foreman-adapters.sh
+++ b/scripts/audit-foreman-adapters.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# audit-foreman-adapters.sh — compare the registry's declared Foreman adapter
+# roster (agent-registry.json → foreman_adapters[].source_file) against the
+# backend scripts the PINNED Foreman release actually ships.
+#
+# This is the LIVE half of the drift contract and it needs the network (it reads
+# ponderousdev/foreman over the GitHub API), so it is deliberately NOT part of
+# `task verify` / `task ci` — those stay offline and reproducible. The offline
+# gate (test-registry-drift.sh) checks everything derivable from the registry
+# alone; this task is what catches the registry lagging a new Foreman release.
+# Run it after bumping FOREMAN_VERSION, or on demand:  task foreman:audit-adapters
+#
+# Exit: 0 agree · 1 the rosters differ (remediation printed) · 2 could not read
+# the pinned release (indeterminate — not a pass).
+set -euo pipefail
+
+registry="agent-registry.json"
+foreman_version=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --foreman-version)
+        [ "$#" -ge 2 ] || {
+            echo "Missing value for $1" >&2
+            exit 2
+        }
+        foreman_version="$2"
+        shift 2
+        ;;
+    --registry)
+        [ "$#" -ge 2 ] || {
+            echo "Missing value for $1" >&2
+            exit 2
+        }
+        registry="$2"
+        shift 2
+        ;;
+    *)
+        echo "Unknown argument: $1" >&2
+        exit 2
+        ;;
+    esac
+done
+
+if [ -z "$foreman_version" ]; then
+    echo "Usage: $0 --foreman-version <x.y.z> [--registry <path>]" >&2
+    exit 2
+fi
+for tool in gh jq; do
+    command -v "$tool" >/dev/null 2>&1 || {
+        echo "Required tool not found: $tool" >&2
+        exit 2
+    }
+done
+[ -f "$registry" ] || {
+    echo "registry not found: $registry" >&2
+    exit 2
+}
+
+ref="v${foreman_version}"
+# The backend adapters are hermetic *.sh scripts under this path in the Foreman
+# source tree; a recursive tree read avoids paging the contents API.
+tree_json="$(gh api "repos/ponderousdev/foreman/git/trees/${ref}?recursive=1" 2>/dev/null)" || {
+    echo "could not read Foreman tree at ${ref} — check the tag exists and gh is authenticated (indeterminate, not a pass)" >&2
+    exit 2
+}
+
+# A truncated tree is a PARTIAL listing: GitHub caps recursive Trees responses,
+# so an adapter could be silently absent and we would wrongly flag a live
+# registry entry as stale. Refuse to compare against an incomplete list.
+if [ "$(printf '%s' "$tree_json" | jq -r '.truncated')" = "true" ]; then
+    echo "Foreman tree at ${ref} was truncated by the GitHub API — cannot enumerate adapters completely (indeterminate, not a pass)" >&2
+    exit 2
+fi
+
+shipped="$(printf '%s' "$tree_json" |
+    jq -r '.tree[].path
+           | select(startswith("src/foreman/backends/") and endswith(".sh"))
+           | ltrimstr("src/foreman/backends/")' | sort -u)"
+
+if [ -z "$shipped" ]; then
+    echo "no *.sh adapters found under src/foreman/backends/ at ${ref} — the path may have moved upstream (indeterminate, not a pass)" >&2
+    exit 2
+fi
+
+declared="$(jq -r '.foreman_adapters[].source_file' "$registry" | sort -u)"
+
+only_foreman="$(comm -23 <(printf '%s\n' "$shipped") <(printf '%s\n' "$declared"))"
+only_registry="$(comm -13 <(printf '%s\n' "$shipped") <(printf '%s\n' "$declared"))"
+
+if [ -z "$only_foreman" ] && [ -z "$only_registry" ]; then
+    echo "Foreman ${ref} adapters match agent-registry.json foreman_adapters:"
+    printf '%s\n' "$shipped" | sed 's/^/  /'
+    exit 0
+fi
+
+echo "DRIFT: registry foreman_adapters disagree with Foreman ${ref}." >&2
+if [ -n "$only_foreman" ]; then
+    echo "  shipped by Foreman ${ref} but NOT in the registry:" >&2
+    printf '%s\n' "$only_foreman" | sed 's/^/    /' >&2
+    echo "    -> add each as a foreman_adapters entry in ${registry} (set classification/provision_label deliberately)." >&2
+fi
+if [ -n "$only_registry" ]; then
+    echo "  declared in the registry but NOT shipped by Foreman ${ref}:" >&2
+    printf '%s\n' "$only_registry" | sed 's/^/    /' >&2
+    echo "    -> remove the stale entry from ${registry}, or bump FOREMAN_VERSION to a release that ships it." >&2
+fi
+exit 1

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -53,10 +53,15 @@ if [ -z "$repo" ]; then
     exit 2
 fi
 
-if ! command -v gh >/dev/null 2>&1; then
-    echo "Required tool not found: gh" >&2
-    exit 1
-fi
+for tool in gh node; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "Required tool not found: $tool" >&2
+        exit 1
+    fi
+done
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+labels_helper="$script_dir/agent-registry-labels.mjs"
 
 # name|hex-color|description — one per line. Color encodes the family.
 labels="
@@ -82,37 +87,45 @@ layer:integration|1D76DB|External boundary: webhooks, API clients, credentials
 domain:auth|FBCA04|Authentication and authorization
 domain:billing|FBCA04|Billing and payments
 domain:platform|FBCA04|CI, build, test infra, and tooling in this repo
-agent:claude-code|006B75|Claimed by Claude Code
-agent:codex|006B75|Claimed by Codex
-agent:gemini-cli|006B75|Claimed by Gemini CLI
-agent:qwen-code|006B75|Claimed by Qwen Code
-agent:deepseek|006B75|Claimed by DeepSeek
-agent:kimi-k2|006B75|Claimed by Kimi K2
-agent:glm|006B75|Claimed by GLM
-agent:github-copilot|006B75|Claimed by GitHub Copilot
 "
 
+# The model-centric agent vocabulary — `suggest:<family>` (advisory routing) and
+# `claim:<family>` (live ownership) — is rendered from the machine-readable agent
+# registry (agent-registry.json), NOT hand-listed here, so this script and the
+# registry cannot fork (ADR 0005; test:registry-drift gates the two together).
+# The retired `agent:*` family is intentionally gone; only family-level labels
+# are seeded (model-level `suggest:/claim:<family>:<model>` are created on demand).
+#
+# TRANSITION: this stops SEEDING agent:* but never deletes existing labels, so a
+# repo that already has agent:claude-code keeps it (claims still work there). Two
+# follow-ups complete the cutover and are the reason this stays additive: the
+# vendored /claim skill still adds agent:claude-code until harmon-devkit ships the
+# claim:* vocabulary (harmon-init #663, harmon-devkit #321), and live agent:*/stale
+# foreman:* selectors on existing repos are retired by the migration unit (#663),
+# not by a permanent migration here. Do not release this to consumers ahead of the
+# devkit skill migration, or a freshly generated repo will provision claim:* while
+# its /claim skill still looks for agent:claude-code.
+labels="$labels
+$(node "$labels_helper" suggest-claim)"
+
 # Foreman arming labels (--foreman): human inputs for label-mode arming
-# (ponderousdev/foreman). `foreman:<backend>` selects the backend and implies
-# approval; the rest are foreman's own workflow-state protocol. Distinct from
-# the `agent:*` claim family above: a claim says which agent IS working an
-# issue, a `foreman:*` selector arms it for dispatch. Colors/descriptions
-# mirror ponderousdev/foreman's own labels.
+# (ponderousdev/foreman). The `foreman:<adapter>` SELECTORS are rendered from the
+# agent registry below — provisioned ONLY for adapters that exist in the pinned
+# Foreman release (a selector with no production adapter can strand armed work,
+# ADR 0005 D11). The labels here are foreman's own workflow-state protocol, not
+# adapter selectors, so they are registry-independent. Distinct from the
+# `claim:*` family above: a claim says which agent IS working an issue, a
+# `foreman:*` selector arms it for dispatch. Colors/descriptions mirror
+# ponderousdev/foreman's own labels.
 foreman_labels="
 foreman:approved|1D76DB|Arm with the repo default backend
-foreman:claude|1D76DB|Arm this issue for foreman dispatch with the claude backend
-foreman:codex|1D76DB|Arm this issue for foreman dispatch with the codex backend
-foreman:gemini|1D76DB|Arm this issue for foreman dispatch with the gemini backend
-foreman:deepseek|1D76DB|Arm this issue for foreman dispatch with the deepseek backend
-foreman:glm|1D76DB|Arm this issue for foreman dispatch with the glm backend
-foreman:kimi|1D76DB|Arm this issue for foreman dispatch with the kimi backend
-foreman:copilot|1D76DB|Arm this issue for foreman dispatch with the copilot backend
 foreman:hold|D93F0B|Exclude from foreman dispatch (always wins)
 foreman:satisfied|0E8A16|Human override: treat this dependency as satisfied
 foreman:external|BFDADC|External dependency: satisfied when closed as completed
 "
 if [ "$foreman" = 1 ]; then
-    labels="$labels$foreman_labels"
+    labels="$labels$foreman_labels
+$(node "$labels_helper" foreman-adapters)"
 fi
 
 printf '%s\n' "$labels" | while IFS='|' read -r name color desc; do

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -886,7 +886,19 @@ if [[ "${SECTION}" == "setup" ]]; then
                     # only when the repo uses foreman — the wrapper taskfile is
                     # its render-time marker), so expect it only there or a
                     # non-foreman repo reports 11 permanently-missing labels.
-                    want_labels="$(sed -n -E 's/^([A-Za-z0-9:._-]+)\|[0-9A-Fa-f]{6}\|.*/\1/p' scripts/setup-github-labels.sh)"
+                    #
+                    # The suggest:/claim:/foreman:<adapter> families are NOT
+                    # literal `name|color|desc` lines in the setup script — it
+                    # renders them from the agent registry — so parse the same
+                    # renderer here too, or this check would silently ignore
+                    # every registry-driven label and call an unsynced repo green.
+                    want_labels="$(
+                        sed -n -E 's/^([A-Za-z0-9:._-]+)\|[0-9A-Fa-f]{6}\|.*/\1/p' scripts/setup-github-labels.sh
+                        if [ -f scripts/agent-registry-labels.mjs ] && command -v node >/dev/null 2>&1; then
+                            node scripts/agent-registry-labels.mjs all 2>/dev/null |
+                                sed -n -E 's/^([A-Za-z0-9:._-]+)\|[0-9A-Fa-f]{6}\|.*/\1/p'
+                        fi
+                    )"
                     if [ ! -f taskfiles/foreman.yml ]; then
                         want_labels="$(printf '%s\n' "${want_labels}" | grep -v '^foreman:')"
                     fi

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -892,6 +892,13 @@ if [[ "${SECTION}" == "setup" ]]; then
                     # renders them from the agent registry — so parse the same
                     # renderer here too, or this check would silently ignore
                     # every registry-driven label and call an unsynced repo green.
+                    # If the registry ships but node is missing we CANNOT enumerate
+                    # those labels, so the inventory is incomplete: report unknown
+                    # rather than grading the reduced set as "all seeded".
+                    registry_incomplete=0
+                    if [ -f scripts/agent-registry-labels.mjs ] && ! command -v node >/dev/null 2>&1; then
+                        registry_incomplete=1
+                    fi
                     want_labels="$(
                         sed -n -E 's/^([A-Za-z0-9:._-]+)\|[0-9A-Fa-f]{6}\|.*/\1/p' scripts/setup-github-labels.sh
                         if [ -f scripts/agent-registry-labels.mjs ] && command -v node >/dev/null 2>&1; then
@@ -910,7 +917,9 @@ if [[ "${SECTION}" == "setup" ]]; then
                         printf '%s\n' "${have_labels}" | grep -qxF "${want}" ||
                             missing_count=$((missing_count + 1))
                     done
-                    if [ -z "${have_labels}" ] || [ "${want_count}" -eq 0 ]; then
+                    if [ "${registry_incomplete}" -eq 1 ]; then
+                        checkline unknown "Starter labels" "node unavailable — registry labels unchecked"
+                    elif [ -z "${have_labels}" ] || [ "${want_count}" -eq 0 ]; then
                         checkline no "Starter labels" "run task setup:github-labels"
                     elif [ "${missing_count}" -eq 0 ]; then
                         checkline ok "Starter labels" "all ${want_count} seeded"

--- a/scripts/test-registry-drift.sh
+++ b/scripts/test-registry-drift.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# test-registry-drift.sh — the OFFLINE drift gate that binds label provisioning,
+# provider wrappers, and Foreman adapter selectors to the machine-readable agent
+# registry (agent-registry.json). Runs in `task verify` / `task ci` (ADR 0005
+# D11: "later drift checks bind provisioning, wrappers, and the pinned upstream
+# adapter roster to the same contract").
+#
+# The registry's SCHEMA and semantic invariants are the job of test-agent-registry.sh;
+# this check adds the bindings between the registry and the things that consume it:
+#
+#   1. schema        — the registry still validates (fail fast before comparing).
+#   2. label output  — the rendered suggest:/claim:/foreman: labels are exactly
+#                      the family-level + provisionable set the registry implies
+#                      (no agent:*, no seeded model-level, no non-production adapter).
+#   3. provisioning  — setup-github-labels.sh renders those labels from the
+#                      registry instead of hand-listing a forkable copy.
+#   4. wrappers      — every claude-<family> provider wrapper maps to a
+#                      provider-rewired harness registered in agent-registry.json.
+#   5. adapters      — the provisionable Foreman adapters are internally coherent;
+#                      the LIVE comparison against the pinned Foreman release is
+#                      `task foreman:audit-adapters` (network — out of this gate).
+#
+# Dimensions 3 and 4 target files that only some render profiles ship
+# (setup-github-labels.sh, claude-providers.sh); each is skipped, loudly, when
+# its file is absent so the check passes across the whole render matrix.
+#
+# Every failure names the offending registry row / file and the remediation.
+set -euo pipefail
+
+repo="$(git rev-parse --show-toplevel)"
+cd "$repo"
+
+registry="${1:-agent-registry.json}"
+schema="${2:-agent-registry.schema.json}"
+validator="scripts/validate-agent-registry.mjs"
+renderer="scripts/agent-registry-labels.mjs"
+labels_script="scripts/setup-github-labels.sh"
+# The provider wrappers live under whichever devcontainer path the profile
+# rendered; there is at most one.
+wrappers_glob=".devcontainer/config/claude-providers.sh"
+
+fails=0
+fail() {
+    echo "DRIFT: $*" >&2
+    fails=$((fails + 1))
+}
+
+for required in "$registry" "$schema" "$validator" "$renderer"; do
+    [ -f "$required" ] || {
+        echo "TEST FAIL: missing required registry asset: $required" >&2
+        exit 1
+    }
+done
+for tool in node jq; do
+    command -v "$tool" >/dev/null 2>&1 || {
+        echo "TEST FAIL: $tool is required to check registry drift" >&2
+        exit 1
+    }
+done
+
+# ── 1. schema ──────────────────────────────────────────────────────────────
+node "$validator" "$registry" "$schema" ||
+    fail "registry fails its own schema — fix agent-registry.json before the bindings can be trusted"
+
+# ── 2. label output ────────────────────────────────────────────────────────
+# Render every label the registry implies and check the invariants the
+# provisioning contract promises. jq reads the registry directly so the
+# expectations are derived from the source of truth, not restated.
+rendered="$(node "$renderer" all "$registry")"
+names="$(printf '%s\n' "$rendered" | sed -n 's/|.*//p')"
+
+# 2a. No retired agent:* labels may appear anywhere in the rendered set.
+if printf '%s\n' "$names" | grep -q '^agent:'; then
+    fail "rendered labels still contain a retired agent:* label — the agent vocabulary is now suggest:/claim: (ADR 0005 D6)"
+fi
+
+# 2b. Only FAMILY-level suggest:/claim: are seeded (exactly one colon in the
+# name); a two-colon name would be a seeded model-level label.
+if printf '%s\n' "$names" | grep -Eq '^(suggest|claim):[a-z0-9-]+:'; then
+    fail "a model-level suggest:/claim: label is being seeded — model-level labels are created on demand, only family-level are provisioned (AC2)"
+fi
+
+# 2c. The suggest:/claim: names are EXACTLY one per registered family slug.
+# Compare the derived name sets, not just counts: a renderer that emitted
+# `suggest:claude` nine times would satisfy a count check (and collapse under a
+# later sort -u) while provisioning only one of the nine expected families.
+for ns in suggest claim; do
+    want_ns="$(jq -r --arg p "$ns" '.families[].slug | $p + ":" + .' "$registry" | sort -u)"
+    got_ns="$(printf '%s\n' "$names" | grep "^${ns}:" | sort -u || true)"
+    [ "$want_ns" = "$got_ns" ] ||
+        fail "rendered ${ns}:* labels [$(echo "$got_ns" | tr '\n' ' ')] != one-per-family expected [$(echo "$want_ns" | tr '\n' ' ')] — regenerate from agent-registry.json"
+done
+
+# 2d. foreman:<adapter> selectors are provisioned for EXACTLY the adapters the
+# registry marks provision_label — no more (phantom selector), no fewer.
+want_foreman="$(jq -r '.foreman_adapters[] | select(.provision_label == true) | "foreman:" + .slug' "$registry" | sort)"
+got_foreman="$(printf '%s\n' "$names" | grep '^foreman:' | sort || true)"
+if [ "$want_foreman" != "$got_foreman" ]; then
+    fail "provisioned foreman:<adapter> selectors [$(echo "$got_foreman" | tr '\n' ' ')] != registry provision_label adapters [$(echo "$want_foreman" | tr '\n' ' ')] — a selector without a production adapter can strand armed work (ADR 0005 D11)"
+fi
+
+# ── 3. provisioning script ─────────────────────────────────────────────────
+if [ -f "$labels_script" ]; then
+    # It must delegate to the renderer, not carry a forkable hand-list.
+    grep -q 'agent-registry-labels.mjs' "$labels_script" ||
+        fail "$labels_script does not render its agent labels from the registry (missing agent-registry-labels.mjs call) — hand-listed labels fork from agent-registry.json"
+    # No hardcoded agent:* / suggest:* / claim:* / foreman:<family> selector
+    # lines (the leading `word:` of a `name|color|desc` label line).
+    if grep -Eq '^agent:[a-z0-9-]+\|' "$labels_script"; then
+        fail "$labels_script still hard-lists a retired agent:* label line — remove it; the agent vocabulary is registry-rendered suggest:/claim: (ADR 0005 D6)"
+    fi
+    if grep -Eq '^(suggest|claim):[a-z0-9-]+\|' "$labels_script"; then
+        fail "$labels_script hard-lists a suggest:/claim: label line — these must come from agent-registry-labels.mjs so they cannot fork from the registry"
+    fi
+    # Behavioral binding: actually RUN the provisioning script with `gh` stubbed
+    # to just echo the label name, and confirm every registry-rendered label is
+    # emitted. A filename grep alone would pass if a future edit called the wrong
+    # renderer mode (suggest-claim vs foreman-adapters) or dropped a delegation;
+    # running it observes what would really be provisioned. --foreman exercises
+    # both renderer modes regardless of whether this profile arms Foreman.
+    stub_dir="$(mktemp -d)"
+    cat >"$stub_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = label ] && { shift 2; printf '%s\n' "$1"; exit 0; }
+exit 0
+STUB
+    chmod +x "$stub_dir/gh"
+    emitted="$(PATH="$stub_dir:$PATH" bash "$labels_script" --repo drift/check --foreman 2>/dev/null | sort -u)"
+    rm -rf "$stub_dir"
+    missing="$(comm -23 <(printf '%s\n' "$names" | sort -u) <(printf '%s\n' "$emitted"))"
+    if [ -n "$missing" ]; then
+        fail "$labels_script did not provision registry label(s) [$(echo "$missing" | tr '\n' ' ')] when run — it must render every mode (suggest-claim AND foreman-adapters) from agent-registry-labels.mjs"
+    fi
+    # ...and the REVERSE direction: the script must not emit a registry-namespace
+    # label the registry does not define. suggest:/claim: are wholly registry-owned;
+    # in foreman:, only the <adapter> selectors are — the four protocol labels are
+    # foreman's own workflow state and are legitimately static. Without this, a
+    # re-added hardcoded phantom selector (e.g. `foreman:codex` with no adapter)
+    # would sail through, which is the exact failure this gate exists to stop.
+    # `extra` = emitted registry-namespace labels minus {protocol} minus {registry}.
+    extra="$(printf '%s\n' "$emitted" | grep -E '^(suggest|claim|foreman):' |
+        grep -vxF -e foreman:approved -e foreman:hold -e foreman:satisfied -e foreman:external |
+        grep -vxF -f <(printf '%s\n' "$names") || true)"
+    if [ -n "$extra" ]; then
+        fail "$labels_script provisions registry-namespace label(s) [$(echo "$extra" | tr '\n' ' ')] the registry does not define — a hardcoded selector (e.g. a re-added phantom foreman:<adapter>) bypasses the registry (ADR 0005 D11)"
+    fi
+else
+    echo "note: $labels_script not present in this profile — skipping the provisioning-script binding" >&2
+fi
+
+# ── 4. provider-wrapper inventory ──────────────────────────────────────────
+# Every claude-<family> wrapper that ships MUST correspond to a provider-rewired
+# harness claude-code-<family> in the registry (no orphan wrappers). The reverse
+# is allowed: the registry may declare a provider-rewired harness ahead of its
+# wrapper (e.g. claude-code-minimax before a claude-minimax launcher exists).
+if [ -f "$wrappers_glob" ]; then
+    wrappers="$(sed -n -E 's/^(claude-[a-z0-9-]+)\(\)[[:space:]]*\{.*/\1/p' "$wrappers_glob")"
+    for fn in $wrappers; do
+        family="${fn#claude-}"
+        harness="claude-code-${family}"
+        ok="$(jq -r --arg h "$harness" --arg f "$family" '
+            [.harnesses[]
+             | select(.slug == $h
+                      and .provider_rewired == true
+                      and .family_constraint.kind == "fixed"
+                      and .family_constraint.family == $f)] | length' "$registry")"
+        fam_ok="$(jq -r --arg f "$family" '[.families[] | select(.slug == $f)] | length' "$registry")"
+        if [ "$ok" != 1 ] || [ "$fam_ok" -lt 1 ]; then
+            fail "provider wrapper '$fn' in $wrappers_glob has no matching registry row — add a provider-rewired harness '$harness' (family_constraint fixed→$family) and a family '$family' to agent-registry.json, or remove the wrapper"
+        fi
+    done
+else
+    echo "note: no provider-wrapper file ($wrappers_glob) in this profile — skipping the wrapper binding" >&2
+fi
+
+# ── 5. Foreman adapter internal coherence ──────────────────────────────────
+# The live comparison against the pinned Foreman release is task
+# audit:foreman-adapters (network). Here we assert the provisionable adapters
+# are self-consistent so a bad row is caught offline too.
+bad_provision="$(jq -r '
+    .foreman_adapters[]
+    | select(.provision_label == true
+             and (.classification != "production"
+                  or .production_dispatchable != true
+                  or .harness == null))
+    | .slug' "$registry")"
+if [ -n "$bad_provision" ]; then
+    fail "foreman adapter(s) [$(echo "$bad_provision" | tr '\n' ' ')] set provision_label:true but are not a production, dispatchable, harness-mapped adapter — a public selector must map to real production machinery (ADR 0005 D11)"
+fi
+
+# The arming label is foreman:<slug>, but Foreman resolves it to the backend
+# FILE, so a row whose slug differs from its source_file stem (e.g. slug "typo"
+# with source_file "codex.sh") provisions a selector that arms nothing. Slugs are
+# already unique (schema), so requiring slug == stem also makes source_files
+# unique — closing the duplicate-source_file case the live audit's sort -u hides.
+stem_mismatch="$(jq -r '
+    .foreman_adapters[]
+    | select((.source_file | rtrimstr(".sh")) != .slug)
+    | "\(.slug)(->\(.source_file))"' "$registry")"
+if [ -n "$stem_mismatch" ]; then
+    fail "foreman adapter slug != source_file stem [$(echo "$stem_mismatch" | tr '\n' ' ')] — foreman:<slug> would not resolve to its backend file; rename the slug or the source_file so they match"
+fi
+
+if [ "$fails" -ne 0 ]; then
+    echo "test-registry-drift: $fails drift finding(s) above." >&2
+    echo "Live Foreman adapter roster check (network, non-gating): task foreman:audit-adapters" >&2
+    exit 1
+fi
+
+echo "test-registry-drift: registry, labels, provisioning, wrappers, and adapters agree."
+echo "  (live Foreman roster check is task foreman:audit-adapters — network, not part of this gate)"

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -64,12 +64,6 @@ err() {
 # from the field they actually belong to rather than from anywhere in the file.
 # Any non-quote name matches: a name this misses would be silently absent from
 # the set comparison below, turning a drift failure into a false pass.
-# Field option name -> label suffix: lowercase, spaces to hyphens. Keeps the
-# sets sorted after the rewrite so an exact comparison stays valid.
-slugify() {
-    tr '[:upper:] ' '[:lower:]-' | sort -u
-}
-
 opt_names() {
     awk -v start="$2" '
         $0 ~ start { inblock = 1; next }
@@ -248,6 +242,27 @@ fi
 if [ -f .github/workflows/build.yml ]; then
     grep -qF 'task test:agent-registry' .github/workflows/build.yml ||
         err "required CI does not run test:agent-registry"
+fi
+
+# The offline registry-drift gate binds label provisioning, provider wrappers,
+# and Foreman adapter selectors to the registry. It ships unconditionally and
+# must pass on EVERY profile — including ones with no setup-github-labels.sh or
+# claude-providers.sh, which it skips loudly rather than failing on.
+if [ ! -x scripts/test-registry-drift.sh ]; then
+    err "registry-drift gate is missing or not executable"
+elif ! ./scripts/test-registry-drift.sh; then
+    err "rendered registry drifts from agent-registry.json (labels/wrappers/adapters)"
+fi
+if have task; then
+    grep -qF './scripts/test-registry-drift.sh' \
+        <<<"$(task --color=false --dry verify 2>&1 || true)" ||
+        err "task verify does not reach test:registry-drift"
+else
+    required task "registry-drift verify reachability" || fail=1
+fi
+if [ -f .github/workflows/build.yml ]; then
+    grep -qF 'task test:registry-drift' .github/workflows/build.yml ||
+        err "required CI does not run test:registry-drift"
 fi
 
 # ── 1b. Free security policy renders as a coherent stack ───────────
@@ -732,7 +747,11 @@ full) # project_management=github; github_org=test-org (an org repo)
     # somewhere in the file: `auth` living under Domain must not satisfy a
     # `layer:auth` label) and in both directions (a field option with no label is
     # drift too).
-    for pair in layer:Layer domain:Domain agent:Agent; do
+    # The agent vocabulary is no longer a label/field pair here: it moved to
+    # registry-driven suggest:/claim: labels (checked by test:registry-drift),
+    # and removal of the `Agent` field is tracked separately (#662). Only the
+    # Layer/Domain taxonomy is cross-checked across labels + fields now.
+    for pair in layer:Layer domain:Domain; do
         fam="${pair%%:*}"
         field="${pair##*:}"
         # Each source's option set for this family, one name per line, sorted.
@@ -745,14 +764,8 @@ full) # project_management=github; github_org=test-org (an org repo)
         # Layer and Domain are compared EXACTLY: their option names and label
         # suffixes are meant to be character-identical, and normalizing would
         # let `Domain: Auth` pass against `domain:auth` — drift this guard has
-        # always caught. Only Agent is slugged, because its options are
-        # multi-word display names ("Claude Code") whose labels are kebab-case
-        # by convention (`agent:claude-code`); there the mapping, not the
-        # string, is the invariant.
-        case "$fam" in
-        agent) normalize=slugify ;;
-        *) normalize=cat ;;
-        esac
+        # always caught.
+        normalize=cat
         fld_set="$(opt_names scripts/setup-github-issue-fields.sh "^${fam}_opts='" | "$normalize")"
         prj_set="$(opt_names scripts/setup-github-project.sh "^create_single_select \"${field}\" '" | "$normalize")"
         [ -n "$lbl_set" ] || err "no ${fam}: labels found in setup-github-labels.sh"
@@ -903,9 +916,17 @@ iac | full)
     grep -q 'expected_login' .foreman.toml || err ".foreman.toml missing expected_login"
     ! grep -q '^verify_command' .foreman.toml || err ".foreman.toml still ships the v1 verify_command key"
     # Arming labels are human inputs foreman never auto-creates: the label
-    # script must render and the Taskfile must pass it --foreman.
+    # script must render and the Taskfile must pass it --foreman. The protocol
+    # selectors (approved/hold/satisfied/external) are literal in the script; the
+    # foreman:<adapter> selectors are rendered from the agent registry (only for
+    # adapters the pinned Foreman release ships), so check both the literal
+    # family and that the registry still renders the production `claude` adapter.
     [ -f scripts/setup-github-labels.sh ] || err "setup-github-labels.sh missing for use_foreman=true"
-    grep -q '^foreman:claude|' scripts/setup-github-labels.sh || err "label script lacks the foreman arming-label family"
+    grep -q '^foreman:approved|' scripts/setup-github-labels.sh || err "label script lacks the foreman protocol arming labels"
+    grep -q 'agent-registry-labels.mjs' scripts/setup-github-labels.sh ||
+        err "label script does not render foreman:<adapter> selectors from the registry"
+    node scripts/agent-registry-labels.mjs foreman-adapters | grep -q '^foreman:claude|' ||
+        err "registry no longer renders the foreman:claude adapter selector"
     grep -q 'setup-github-labels.sh --repo "{{.REPO}}" --foreman' Taskfile.yml || err "setup:github-labels does not pass --foreman (use_foreman=true)"
     ! grep -q '^review_sender_trust\|^required_review_bots\|^require_codex_cloud_review' .foreman.toml ||
         err ".foreman.toml still ships v1-only keys the v2 CLI ignores"

--- a/taskfiles/foreman.yml
+++ b/taskfiles/foreman.yml
@@ -64,3 +64,12 @@ tasks:
     desc: "Prune worktrees + foreman-created branches for closed units (in-flight untouched)"
     cmds:
       - "{{.FOREMAN}} cleanup {{.CLI_ARGS}}"
+
+  audit-adapters:
+    # NOT a Foreman CLI wrapper: compares agent-registry.json's declared adapter
+    # roster against the backends the PINNED Foreman release actually ships. Needs
+    # the network, so it is deliberately out of `verify`/`ci` (the offline gate is
+    # `task test:registry-drift`); run it after bumping FOREMAN_VERSION.
+    desc: "Audit the registry's foreman_adapters against the pinned Foreman release (network; not in verify/ci)"
+    cmds:
+      - "./scripts/audit-foreman-adapters.sh --foreman-version {{.FOREMAN_VERSION}}"

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -50,6 +50,7 @@ jobs:
 [% endif %]
       - run: task test:tasks
       - run: task test:agent-registry
+      - run: task test:registry-drift
 [% if use_codex_review %]
       - run: task test:codex-review
 [% endif %]

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -104,6 +104,7 @@ tasks:
 [% endif %]
       - task: validate
       - task: test:agent-registry
+      - task: test:registry-drift
       - task: test:tasks
       - task: test:ci-results
       - task: test:status
@@ -636,6 +637,11 @@ tasks:
     desc: Schema-check the machine-readable agent registry and its cross-record invariants
     cmds:
       - ./scripts/test-agent-registry.sh
+
+  test:registry-drift:
+    desc: Bind label provisioning, provider wrappers, and Foreman adapters to the agent registry (offline drift gate)
+    cmds:
+      - ./scripts/test-registry-drift.sh
 
   test:tasks:
     desc: Guard the Taskfile itself (compiles; setup tasks are safe no-ops)

--- a/template/[% if use_foreman %]taskfiles[% endif %]/foreman.yml
+++ b/template/[% if use_foreman %]taskfiles[% endif %]/foreman.yml
@@ -64,3 +64,12 @@ tasks:
     desc: "Prune worktrees + foreman-created branches for closed units (in-flight untouched)"
     cmds:
       - "{{.FOREMAN}} cleanup {{.CLI_ARGS}}"
+
+  audit-adapters:
+    # NOT a Foreman CLI wrapper: compares agent-registry.json's declared adapter
+    # roster against the backends the PINNED Foreman release actually ships. Needs
+    # the network, so it is deliberately out of `verify`/`ci` (the offline gate is
+    # `task test:registry-drift`); run it after bumping FOREMAN_VERSION.
+    desc: "Audit the registry's foreman_adapters against the pinned Foreman release (network; not in verify/ci)"
+    cmds:
+      - "./scripts/audit-foreman-adapters.sh --foreman-version {{.FOREMAN_VERSION}}"

--- a/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
@@ -53,10 +53,15 @@ if [ -z "$repo" ]; then
     exit 2
 fi
 
-if ! command -v gh >/dev/null 2>&1; then
-    echo "Required tool not found: gh" >&2
-    exit 1
-fi
+for tool in gh node; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "Required tool not found: $tool" >&2
+        exit 1
+    fi
+done
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+labels_helper="$script_dir/agent-registry-labels.mjs"
 
 # name|hex-color|description — one per line. Color encodes the family.
 labels="
@@ -82,37 +87,45 @@ layer:integration|1D76DB|External boundary: webhooks, API clients, credentials
 domain:auth|FBCA04|Authentication and authorization
 domain:billing|FBCA04|Billing and payments
 domain:platform|FBCA04|CI, build, test infra, and tooling in this repo
-agent:claude-code|006B75|Claimed by Claude Code
-agent:codex|006B75|Claimed by Codex
-agent:gemini-cli|006B75|Claimed by Gemini CLI
-agent:qwen-code|006B75|Claimed by Qwen Code
-agent:deepseek|006B75|Claimed by DeepSeek
-agent:kimi-k2|006B75|Claimed by Kimi K2
-agent:glm|006B75|Claimed by GLM
-agent:github-copilot|006B75|Claimed by GitHub Copilot
 "
 
+# The model-centric agent vocabulary — `suggest:<family>` (advisory routing) and
+# `claim:<family>` (live ownership) — is rendered from the machine-readable agent
+# registry (agent-registry.json), NOT hand-listed here, so this script and the
+# registry cannot fork (ADR 0005; test:registry-drift gates the two together).
+# The retired `agent:*` family is intentionally gone; only family-level labels
+# are seeded (model-level `suggest:/claim:<family>:<model>` are created on demand).
+#
+# TRANSITION: this stops SEEDING agent:* but never deletes existing labels, so a
+# repo that already has agent:claude-code keeps it (claims still work there). Two
+# follow-ups complete the cutover and are the reason this stays additive: the
+# vendored /claim skill still adds agent:claude-code until harmon-devkit ships the
+# claim:* vocabulary (harmon-init #663, harmon-devkit #321), and live agent:*/stale
+# foreman:* selectors on existing repos are retired by the migration unit (#663),
+# not by a permanent migration here. Do not release this to consumers ahead of the
+# devkit skill migration, or a freshly generated repo will provision claim:* while
+# its /claim skill still looks for agent:claude-code.
+labels="$labels
+$(node "$labels_helper" suggest-claim)"
+
 # Foreman arming labels (--foreman): human inputs for label-mode arming
-# (ponderousdev/foreman). `foreman:<backend>` selects the backend and implies
-# approval; the rest are foreman's own workflow-state protocol. Distinct from
-# the `agent:*` claim family above: a claim says which agent IS working an
-# issue, a `foreman:*` selector arms it for dispatch. Colors/descriptions
-# mirror ponderousdev/foreman's own labels.
+# (ponderousdev/foreman). The `foreman:<adapter>` SELECTORS are rendered from the
+# agent registry below — provisioned ONLY for adapters that exist in the pinned
+# Foreman release (a selector with no production adapter can strand armed work,
+# ADR 0005 D11). The labels here are foreman's own workflow-state protocol, not
+# adapter selectors, so they are registry-independent. Distinct from the
+# `claim:*` family above: a claim says which agent IS working an issue, a
+# `foreman:*` selector arms it for dispatch. Colors/descriptions mirror
+# ponderousdev/foreman's own labels.
 foreman_labels="
 foreman:approved|1D76DB|Arm with the repo default backend
-foreman:claude|1D76DB|Arm this issue for foreman dispatch with the claude backend
-foreman:codex|1D76DB|Arm this issue for foreman dispatch with the codex backend
-foreman:gemini|1D76DB|Arm this issue for foreman dispatch with the gemini backend
-foreman:deepseek|1D76DB|Arm this issue for foreman dispatch with the deepseek backend
-foreman:glm|1D76DB|Arm this issue for foreman dispatch with the glm backend
-foreman:kimi|1D76DB|Arm this issue for foreman dispatch with the kimi backend
-foreman:copilot|1D76DB|Arm this issue for foreman dispatch with the copilot backend
 foreman:hold|D93F0B|Exclude from foreman dispatch (always wins)
 foreman:satisfied|0E8A16|Human override: treat this dependency as satisfied
 foreman:external|BFDADC|External dependency: satisfied when closed as completed
 "
 if [ "$foreman" = 1 ]; then
-    labels="$labels$foreman_labels"
+    labels="$labels$foreman_labels
+$(node "$labels_helper" foreman-adapters)"
 fi
 
 printf '%s\n' "$labels" | while IFS='|' read -r name color desc; do

--- a/template/scripts/[% if use_foreman %]audit-foreman-adapters.sh[% endif %]
+++ b/template/scripts/[% if use_foreman %]audit-foreman-adapters.sh[% endif %]
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# audit-foreman-adapters.sh — compare the registry's declared Foreman adapter
+# roster (agent-registry.json → foreman_adapters[].source_file) against the
+# backend scripts the PINNED Foreman release actually ships.
+#
+# This is the LIVE half of the drift contract and it needs the network (it reads
+# ponderousdev/foreman over the GitHub API), so it is deliberately NOT part of
+# `task verify` / `task ci` — those stay offline and reproducible. The offline
+# gate (test-registry-drift.sh) checks everything derivable from the registry
+# alone; this task is what catches the registry lagging a new Foreman release.
+# Run it after bumping FOREMAN_VERSION, or on demand:  task foreman:audit-adapters
+#
+# Exit: 0 agree · 1 the rosters differ (remediation printed) · 2 could not read
+# the pinned release (indeterminate — not a pass).
+set -euo pipefail
+
+registry="agent-registry.json"
+foreman_version=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --foreman-version)
+        [ "$#" -ge 2 ] || {
+            echo "Missing value for $1" >&2
+            exit 2
+        }
+        foreman_version="$2"
+        shift 2
+        ;;
+    --registry)
+        [ "$#" -ge 2 ] || {
+            echo "Missing value for $1" >&2
+            exit 2
+        }
+        registry="$2"
+        shift 2
+        ;;
+    *)
+        echo "Unknown argument: $1" >&2
+        exit 2
+        ;;
+    esac
+done
+
+if [ -z "$foreman_version" ]; then
+    echo "Usage: $0 --foreman-version <x.y.z> [--registry <path>]" >&2
+    exit 2
+fi
+for tool in gh jq; do
+    command -v "$tool" >/dev/null 2>&1 || {
+        echo "Required tool not found: $tool" >&2
+        exit 2
+    }
+done
+[ -f "$registry" ] || {
+    echo "registry not found: $registry" >&2
+    exit 2
+}
+
+ref="v${foreman_version}"
+# The backend adapters are hermetic *.sh scripts under this path in the Foreman
+# source tree; a recursive tree read avoids paging the contents API.
+tree_json="$(gh api "repos/ponderousdev/foreman/git/trees/${ref}?recursive=1" 2>/dev/null)" || {
+    echo "could not read Foreman tree at ${ref} — check the tag exists and gh is authenticated (indeterminate, not a pass)" >&2
+    exit 2
+}
+
+# A truncated tree is a PARTIAL listing: GitHub caps recursive Trees responses,
+# so an adapter could be silently absent and we would wrongly flag a live
+# registry entry as stale. Refuse to compare against an incomplete list.
+if [ "$(printf '%s' "$tree_json" | jq -r '.truncated')" = "true" ]; then
+    echo "Foreman tree at ${ref} was truncated by the GitHub API — cannot enumerate adapters completely (indeterminate, not a pass)" >&2
+    exit 2
+fi
+
+shipped="$(printf '%s' "$tree_json" |
+    jq -r '.tree[].path
+           | select(startswith("src/foreman/backends/") and endswith(".sh"))
+           | ltrimstr("src/foreman/backends/")' | sort -u)"
+
+if [ -z "$shipped" ]; then
+    echo "no *.sh adapters found under src/foreman/backends/ at ${ref} — the path may have moved upstream (indeterminate, not a pass)" >&2
+    exit 2
+fi
+
+declared="$(jq -r '.foreman_adapters[].source_file' "$registry" | sort -u)"
+
+only_foreman="$(comm -23 <(printf '%s\n' "$shipped") <(printf '%s\n' "$declared"))"
+only_registry="$(comm -13 <(printf '%s\n' "$shipped") <(printf '%s\n' "$declared"))"
+
+if [ -z "$only_foreman" ] && [ -z "$only_registry" ]; then
+    echo "Foreman ${ref} adapters match agent-registry.json foreman_adapters:"
+    printf '%s\n' "$shipped" | sed 's/^/  /'
+    exit 0
+fi
+
+echo "DRIFT: registry foreman_adapters disagree with Foreman ${ref}." >&2
+if [ -n "$only_foreman" ]; then
+    echo "  shipped by Foreman ${ref} but NOT in the registry:" >&2
+    printf '%s\n' "$only_foreman" | sed 's/^/    /' >&2
+    echo "    -> add each as a foreman_adapters entry in ${registry} (set classification/provision_label deliberately)." >&2
+fi
+if [ -n "$only_registry" ]; then
+    echo "  declared in the registry but NOT shipped by Foreman ${ref}:" >&2
+    printf '%s\n' "$only_registry" | sed 's/^/    /' >&2
+    echo "    -> remove the stale entry from ${registry}, or bump FOREMAN_VERSION to a release that ships it." >&2
+fi
+exit 1

--- a/template/scripts/agent-registry-labels.mjs
+++ b/template/scripts/agent-registry-labels.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// agent-registry-labels.mjs — render the agent-vocabulary GitHub labels from the
+// machine-readable agent registry (agent-registry.json). This is the SINGLE
+// source of the `suggest:*`, `claim:*`, and `foreman:<adapter>` label lines:
+// setup-github-labels.sh provisions them and test-registry-drift.sh checks them,
+// both by calling this file, so the two can never disagree.
+//
+// Output: one `name|hex-color|description` line per label (the format
+// setup-github-labels.sh consumes). Only FAMILY-LEVEL suggest/claim labels are
+// emitted — model-level `suggest:<family>:<model>` / `claim:<family>:<model>`
+// are created on demand, never seeded (an unbounded roster otherwise). Foreman
+// adapter selectors are emitted only for adapters the registry marks
+// `provision_label` (a selector without a production adapter can strand armed
+// work — ADR 0005 D11), so `mock` never yields a `foreman:mock` label.
+//
+// Usage: node agent-registry-labels.mjs <mode> [registry-path]
+//   mode = suggest-claim | foreman-adapters | all
+// Registry defaults to ../agent-registry.json relative to this file.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+// Colors mirror setup-github-labels.sh's family grouping: claim inherits the
+// retired agent:* teal (it answers the same "who is working this" question);
+// suggest is a softer advisory blue; foreman selectors share the arming blue.
+const COLOR_SUGGEST = 'BFD4F2'
+const COLOR_CLAIM = '006B75'
+const COLOR_FOREMAN = '1D76DB'
+
+const MODES = new Set(['suggest-claim', 'foreman-adapters', 'all'])
+
+const mode = process.argv[2]
+if (!MODES.has(mode)) {
+  console.error(
+    `agent-registry-labels: mode must be one of ${[...MODES].join(', ')} (got ${mode ?? '<none>'})`
+  )
+  process.exit(2)
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const registryPath = path.resolve(process.argv[3] ?? path.join(here, '..', 'agent-registry.json'))
+
+let registry
+try {
+  registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'))
+} catch (error) {
+  console.error(
+    `agent-registry-labels: cannot read valid JSON from ${registryPath}: ${error.message}`
+  )
+  process.exit(1)
+}
+
+// Output is one `name|color|desc` label RECORD per line, consumed by a
+// line-and-pipe-splitting shell loop. A slug or display_name carrying a newline
+// or a `|` would split into extra/garbled records — a schema-valid display_name
+// like "Claude\nrogue|FFFFFF|x" would inject a whole label. The slug pattern
+// already forbids both, but display_name is a free string, so fail closed on any
+// field that could break the transport rather than emitting a smuggled record.
+const field = (value, where) => {
+  if (/[\n\r|]/.test(value)) {
+    console.error(
+      `agent-registry-labels: ${where} contains a newline or '|' (${JSON.stringify(value)}); ` +
+        `it would corrupt the label record stream — fix agent-registry.json`
+    )
+    process.exit(1)
+  }
+  return value
+}
+
+// GitHub caps label names at 50 characters. A schema-valid slug can render a
+// longer `<prefix>:<slug>` label, and `gh label create` fails ONLY on that
+// label — after earlier ones were already provisioned (a partial run). Fail
+// closed here so the whole set is rejected before any of it reaches GitHub.
+const GH_LABEL_NAME_MAX = 50
+const labelName = (prefix, slug) => {
+  const name = `${prefix}:${slug}`
+  if (name.length > GH_LABEL_NAME_MAX) {
+    console.error(
+      `agent-registry-labels: label '${name}' is ${name.length} chars, over GitHub's ` +
+        `${GH_LABEL_NAME_MAX}-char limit — shorten the slug in agent-registry.json`
+    )
+    process.exit(1)
+  }
+  return name
+}
+
+const lines = []
+
+if (mode === 'suggest-claim' || mode === 'all') {
+  for (const family of registry.families ?? []) {
+    const slug = field(family.slug, `family slug`)
+    const name = field(family.display_name, `family '${slug}' display_name`)
+    lines.push(
+      `${labelName('suggest', slug)}|${COLOR_SUGGEST}|Suggested for the ${name} family (advisory)`
+    )
+    lines.push(`${labelName('claim', slug)}|${COLOR_CLAIM}|Claimed by ${name}`)
+  }
+}
+
+if (mode === 'foreman-adapters' || mode === 'all') {
+  for (const adapter of registry.foreman_adapters ?? []) {
+    if (adapter.provision_label !== true) continue
+    const slug = field(adapter.slug, `foreman adapter slug`)
+    const name = field(adapter.display_name, `foreman adapter '${slug}' display_name`)
+    lines.push(
+      `${labelName('foreman', slug)}|${COLOR_FOREMAN}|Arm this issue for foreman dispatch with the ${name} backend`
+    )
+  }
+}
+
+process.stdout.write(lines.join('\n') + (lines.length ? '\n' : ''))

--- a/template/scripts/agent-registry-labels.mjs
+++ b/template/scripts/agent-registry-labels.mjs
@@ -69,11 +69,13 @@ const field = (value, where) => {
   return value
 }
 
-// GitHub caps label names at 50 characters. A schema-valid slug can render a
-// longer `<prefix>:<slug>` label, and `gh label create` fails ONLY on that
-// label — after earlier ones were already provisioned (a partial run). Fail
-// closed here so the whole set is rejected before any of it reaches GitHub.
+// GitHub caps label NAMES at 50 and DESCRIPTIONS at 100 characters. A schema-
+// valid slug/display_name can render a longer name or description, and
+// `gh label create` then fails ONLY on that label — after earlier ones were
+// already provisioned (a partial run). Fail closed on BOTH limits here so the
+// whole set is rejected before any of it reaches GitHub.
 const GH_LABEL_NAME_MAX = 50
+const GH_LABEL_DESC_MAX = 100
 const labelName = (prefix, slug) => {
   const name = `${prefix}:${slug}`
   if (name.length > GH_LABEL_NAME_MAX) {
@@ -85,6 +87,16 @@ const labelName = (prefix, slug) => {
   }
   return name
 }
+const record = (name, color, description) => {
+  if (description.length > GH_LABEL_DESC_MAX) {
+    console.error(
+      `agent-registry-labels: label '${name}' description is ${description.length} chars, over ` +
+        `GitHub's ${GH_LABEL_DESC_MAX}-char limit — shorten the display_name in agent-registry.json`
+    )
+    process.exit(1)
+  }
+  return `${name}|${color}|${description}`
+}
 
 const lines = []
 
@@ -93,9 +105,13 @@ if (mode === 'suggest-claim' || mode === 'all') {
     const slug = field(family.slug, `family slug`)
     const name = field(family.display_name, `family '${slug}' display_name`)
     lines.push(
-      `${labelName('suggest', slug)}|${COLOR_SUGGEST}|Suggested for the ${name} family (advisory)`
+      record(
+        labelName('suggest', slug),
+        COLOR_SUGGEST,
+        `Suggested for the ${name} family (advisory)`
+      )
     )
-    lines.push(`${labelName('claim', slug)}|${COLOR_CLAIM}|Claimed by ${name}`)
+    lines.push(record(labelName('claim', slug), COLOR_CLAIM, `Claimed by ${name}`))
   }
 }
 
@@ -105,7 +121,11 @@ if (mode === 'foreman-adapters' || mode === 'all') {
     const slug = field(adapter.slug, `foreman adapter slug`)
     const name = field(adapter.display_name, `foreman adapter '${slug}' display_name`)
     lines.push(
-      `${labelName('foreman', slug)}|${COLOR_FOREMAN}|Arm this issue for foreman dispatch with the ${name} backend`
+      record(
+        labelName('foreman', slug),
+        COLOR_FOREMAN,
+        `Arm this issue for foreman dispatch with the ${name} backend`
+      )
     )
   }
 }

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -886,7 +886,19 @@ if [[ "${SECTION}" == "setup" ]]; then
                     # only when the repo uses foreman — the wrapper taskfile is
                     # its render-time marker), so expect it only there or a
                     # non-foreman repo reports 11 permanently-missing labels.
-                    want_labels="$(sed -n -E 's/^([A-Za-z0-9:._-]+)\|[0-9A-Fa-f]{6}\|.*/\1/p' scripts/setup-github-labels.sh)"
+                    #
+                    # The suggest:/claim:/foreman:<adapter> families are NOT
+                    # literal `name|color|desc` lines in the setup script — it
+                    # renders them from the agent registry — so parse the same
+                    # renderer here too, or this check would silently ignore
+                    # every registry-driven label and call an unsynced repo green.
+                    want_labels="$(
+                        sed -n -E 's/^([A-Za-z0-9:._-]+)\|[0-9A-Fa-f]{6}\|.*/\1/p' scripts/setup-github-labels.sh
+                        if [ -f scripts/agent-registry-labels.mjs ] && command -v node >/dev/null 2>&1; then
+                            node scripts/agent-registry-labels.mjs all 2>/dev/null |
+                                sed -n -E 's/^([A-Za-z0-9:._-]+)\|[0-9A-Fa-f]{6}\|.*/\1/p'
+                        fi
+                    )"
                     if [ ! -f taskfiles/foreman.yml ]; then
                         want_labels="$(printf '%s\n' "${want_labels}" | grep -v '^foreman:')"
                     fi

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -892,6 +892,13 @@ if [[ "${SECTION}" == "setup" ]]; then
                     # renders them from the agent registry — so parse the same
                     # renderer here too, or this check would silently ignore
                     # every registry-driven label and call an unsynced repo green.
+                    # If the registry ships but node is missing we CANNOT enumerate
+                    # those labels, so the inventory is incomplete: report unknown
+                    # rather than grading the reduced set as "all seeded".
+                    registry_incomplete=0
+                    if [ -f scripts/agent-registry-labels.mjs ] && ! command -v node >/dev/null 2>&1; then
+                        registry_incomplete=1
+                    fi
                     want_labels="$(
                         sed -n -E 's/^([A-Za-z0-9:._-]+)\|[0-9A-Fa-f]{6}\|.*/\1/p' scripts/setup-github-labels.sh
                         if [ -f scripts/agent-registry-labels.mjs ] && command -v node >/dev/null 2>&1; then
@@ -910,7 +917,9 @@ if [[ "${SECTION}" == "setup" ]]; then
                         printf '%s\n' "${have_labels}" | grep -qxF "${want}" ||
                             missing_count=$((missing_count + 1))
                     done
-                    if [ -z "${have_labels}" ] || [ "${want_count}" -eq 0 ]; then
+                    if [ "${registry_incomplete}" -eq 1 ]; then
+                        checkline unknown "Starter labels" "node unavailable — registry labels unchecked"
+                    elif [ -z "${have_labels}" ] || [ "${want_count}" -eq 0 ]; then
                         checkline no "Starter labels" "run task setup:github-labels"
                     elif [ "${missing_count}" -eq 0 ]; then
                         checkline ok "Starter labels" "all ${want_count} seeded"

--- a/template/scripts/test-registry-drift.sh
+++ b/template/scripts/test-registry-drift.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# test-registry-drift.sh — the OFFLINE drift gate that binds label provisioning,
+# provider wrappers, and Foreman adapter selectors to the machine-readable agent
+# registry (agent-registry.json). Runs in `task verify` / `task ci` (ADR 0005
+# D11: "later drift checks bind provisioning, wrappers, and the pinned upstream
+# adapter roster to the same contract").
+#
+# The registry's SCHEMA and semantic invariants are the job of test-agent-registry.sh;
+# this check adds the bindings between the registry and the things that consume it:
+#
+#   1. schema        — the registry still validates (fail fast before comparing).
+#   2. label output  — the rendered suggest:/claim:/foreman: labels are exactly
+#                      the family-level + provisionable set the registry implies
+#                      (no agent:*, no seeded model-level, no non-production adapter).
+#   3. provisioning  — setup-github-labels.sh renders those labels from the
+#                      registry instead of hand-listing a forkable copy.
+#   4. wrappers      — every claude-<family> provider wrapper maps to a
+#                      provider-rewired harness registered in agent-registry.json.
+#   5. adapters      — the provisionable Foreman adapters are internally coherent;
+#                      the LIVE comparison against the pinned Foreman release is
+#                      `task foreman:audit-adapters` (network — out of this gate).
+#
+# Dimensions 3 and 4 target files that only some render profiles ship
+# (setup-github-labels.sh, claude-providers.sh); each is skipped, loudly, when
+# its file is absent so the check passes across the whole render matrix.
+#
+# Every failure names the offending registry row / file and the remediation.
+set -euo pipefail
+
+repo="$(git rev-parse --show-toplevel)"
+cd "$repo"
+
+registry="${1:-agent-registry.json}"
+schema="${2:-agent-registry.schema.json}"
+validator="scripts/validate-agent-registry.mjs"
+renderer="scripts/agent-registry-labels.mjs"
+labels_script="scripts/setup-github-labels.sh"
+# The provider wrappers live under whichever devcontainer path the profile
+# rendered; there is at most one.
+wrappers_glob=".devcontainer/config/claude-providers.sh"
+
+fails=0
+fail() {
+    echo "DRIFT: $*" >&2
+    fails=$((fails + 1))
+}
+
+for required in "$registry" "$schema" "$validator" "$renderer"; do
+    [ -f "$required" ] || {
+        echo "TEST FAIL: missing required registry asset: $required" >&2
+        exit 1
+    }
+done
+for tool in node jq; do
+    command -v "$tool" >/dev/null 2>&1 || {
+        echo "TEST FAIL: $tool is required to check registry drift" >&2
+        exit 1
+    }
+done
+
+# ── 1. schema ──────────────────────────────────────────────────────────────
+node "$validator" "$registry" "$schema" ||
+    fail "registry fails its own schema — fix agent-registry.json before the bindings can be trusted"
+
+# ── 2. label output ────────────────────────────────────────────────────────
+# Render every label the registry implies and check the invariants the
+# provisioning contract promises. jq reads the registry directly so the
+# expectations are derived from the source of truth, not restated.
+rendered="$(node "$renderer" all "$registry")"
+names="$(printf '%s\n' "$rendered" | sed -n 's/|.*//p')"
+
+# 2a. No retired agent:* labels may appear anywhere in the rendered set.
+if printf '%s\n' "$names" | grep -q '^agent:'; then
+    fail "rendered labels still contain a retired agent:* label — the agent vocabulary is now suggest:/claim: (ADR 0005 D6)"
+fi
+
+# 2b. Only FAMILY-level suggest:/claim: are seeded (exactly one colon in the
+# name); a two-colon name would be a seeded model-level label.
+if printf '%s\n' "$names" | grep -Eq '^(suggest|claim):[a-z0-9-]+:'; then
+    fail "a model-level suggest:/claim: label is being seeded — model-level labels are created on demand, only family-level are provisioned (AC2)"
+fi
+
+# 2c. The suggest:/claim: names are EXACTLY one per registered family slug.
+# Compare the derived name sets, not just counts: a renderer that emitted
+# `suggest:claude` nine times would satisfy a count check (and collapse under a
+# later sort -u) while provisioning only one of the nine expected families.
+for ns in suggest claim; do
+    want_ns="$(jq -r --arg p "$ns" '.families[].slug | $p + ":" + .' "$registry" | sort -u)"
+    got_ns="$(printf '%s\n' "$names" | grep "^${ns}:" | sort -u || true)"
+    [ "$want_ns" = "$got_ns" ] ||
+        fail "rendered ${ns}:* labels [$(echo "$got_ns" | tr '\n' ' ')] != one-per-family expected [$(echo "$want_ns" | tr '\n' ' ')] — regenerate from agent-registry.json"
+done
+
+# 2d. foreman:<adapter> selectors are provisioned for EXACTLY the adapters the
+# registry marks provision_label — no more (phantom selector), no fewer.
+want_foreman="$(jq -r '.foreman_adapters[] | select(.provision_label == true) | "foreman:" + .slug' "$registry" | sort)"
+got_foreman="$(printf '%s\n' "$names" | grep '^foreman:' | sort || true)"
+if [ "$want_foreman" != "$got_foreman" ]; then
+    fail "provisioned foreman:<adapter> selectors [$(echo "$got_foreman" | tr '\n' ' ')] != registry provision_label adapters [$(echo "$want_foreman" | tr '\n' ' ')] — a selector without a production adapter can strand armed work (ADR 0005 D11)"
+fi
+
+# ── 3. provisioning script ─────────────────────────────────────────────────
+if [ -f "$labels_script" ]; then
+    # It must delegate to the renderer, not carry a forkable hand-list.
+    grep -q 'agent-registry-labels.mjs' "$labels_script" ||
+        fail "$labels_script does not render its agent labels from the registry (missing agent-registry-labels.mjs call) — hand-listed labels fork from agent-registry.json"
+    # No hardcoded agent:* / suggest:* / claim:* / foreman:<family> selector
+    # lines (the leading `word:` of a `name|color|desc` label line).
+    if grep -Eq '^agent:[a-z0-9-]+\|' "$labels_script"; then
+        fail "$labels_script still hard-lists a retired agent:* label line — remove it; the agent vocabulary is registry-rendered suggest:/claim: (ADR 0005 D6)"
+    fi
+    if grep -Eq '^(suggest|claim):[a-z0-9-]+\|' "$labels_script"; then
+        fail "$labels_script hard-lists a suggest:/claim: label line — these must come from agent-registry-labels.mjs so they cannot fork from the registry"
+    fi
+    # Behavioral binding: actually RUN the provisioning script with `gh` stubbed
+    # to just echo the label name, and confirm every registry-rendered label is
+    # emitted. A filename grep alone would pass if a future edit called the wrong
+    # renderer mode (suggest-claim vs foreman-adapters) or dropped a delegation;
+    # running it observes what would really be provisioned. --foreman exercises
+    # both renderer modes regardless of whether this profile arms Foreman.
+    stub_dir="$(mktemp -d)"
+    cat >"$stub_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = label ] && { shift 2; printf '%s\n' "$1"; exit 0; }
+exit 0
+STUB
+    chmod +x "$stub_dir/gh"
+    emitted="$(PATH="$stub_dir:$PATH" bash "$labels_script" --repo drift/check --foreman 2>/dev/null | sort -u)"
+    rm -rf "$stub_dir"
+    missing="$(comm -23 <(printf '%s\n' "$names" | sort -u) <(printf '%s\n' "$emitted"))"
+    if [ -n "$missing" ]; then
+        fail "$labels_script did not provision registry label(s) [$(echo "$missing" | tr '\n' ' ')] when run — it must render every mode (suggest-claim AND foreman-adapters) from agent-registry-labels.mjs"
+    fi
+    # ...and the REVERSE direction: the script must not emit a registry-namespace
+    # label the registry does not define. suggest:/claim: are wholly registry-owned;
+    # in foreman:, only the <adapter> selectors are — the four protocol labels are
+    # foreman's own workflow state and are legitimately static. Without this, a
+    # re-added hardcoded phantom selector (e.g. `foreman:codex` with no adapter)
+    # would sail through, which is the exact failure this gate exists to stop.
+    # `extra` = emitted registry-namespace labels minus {protocol} minus {registry}.
+    extra="$(printf '%s\n' "$emitted" | grep -E '^(suggest|claim|foreman):' |
+        grep -vxF -e foreman:approved -e foreman:hold -e foreman:satisfied -e foreman:external |
+        grep -vxF -f <(printf '%s\n' "$names") || true)"
+    if [ -n "$extra" ]; then
+        fail "$labels_script provisions registry-namespace label(s) [$(echo "$extra" | tr '\n' ' ')] the registry does not define — a hardcoded selector (e.g. a re-added phantom foreman:<adapter>) bypasses the registry (ADR 0005 D11)"
+    fi
+else
+    echo "note: $labels_script not present in this profile — skipping the provisioning-script binding" >&2
+fi
+
+# ── 4. provider-wrapper inventory ──────────────────────────────────────────
+# Every claude-<family> wrapper that ships MUST correspond to a provider-rewired
+# harness claude-code-<family> in the registry (no orphan wrappers). The reverse
+# is allowed: the registry may declare a provider-rewired harness ahead of its
+# wrapper (e.g. claude-code-minimax before a claude-minimax launcher exists).
+if [ -f "$wrappers_glob" ]; then
+    wrappers="$(sed -n -E 's/^(claude-[a-z0-9-]+)\(\)[[:space:]]*\{.*/\1/p' "$wrappers_glob")"
+    for fn in $wrappers; do
+        family="${fn#claude-}"
+        harness="claude-code-${family}"
+        ok="$(jq -r --arg h "$harness" --arg f "$family" '
+            [.harnesses[]
+             | select(.slug == $h
+                      and .provider_rewired == true
+                      and .family_constraint.kind == "fixed"
+                      and .family_constraint.family == $f)] | length' "$registry")"
+        fam_ok="$(jq -r --arg f "$family" '[.families[] | select(.slug == $f)] | length' "$registry")"
+        if [ "$ok" != 1 ] || [ "$fam_ok" -lt 1 ]; then
+            fail "provider wrapper '$fn' in $wrappers_glob has no matching registry row — add a provider-rewired harness '$harness' (family_constraint fixed→$family) and a family '$family' to agent-registry.json, or remove the wrapper"
+        fi
+    done
+else
+    echo "note: no provider-wrapper file ($wrappers_glob) in this profile — skipping the wrapper binding" >&2
+fi
+
+# ── 5. Foreman adapter internal coherence ──────────────────────────────────
+# The live comparison against the pinned Foreman release is task
+# audit:foreman-adapters (network). Here we assert the provisionable adapters
+# are self-consistent so a bad row is caught offline too.
+bad_provision="$(jq -r '
+    .foreman_adapters[]
+    | select(.provision_label == true
+             and (.classification != "production"
+                  or .production_dispatchable != true
+                  or .harness == null))
+    | .slug' "$registry")"
+if [ -n "$bad_provision" ]; then
+    fail "foreman adapter(s) [$(echo "$bad_provision" | tr '\n' ' ')] set provision_label:true but are not a production, dispatchable, harness-mapped adapter — a public selector must map to real production machinery (ADR 0005 D11)"
+fi
+
+# The arming label is foreman:<slug>, but Foreman resolves it to the backend
+# FILE, so a row whose slug differs from its source_file stem (e.g. slug "typo"
+# with source_file "codex.sh") provisions a selector that arms nothing. Slugs are
+# already unique (schema), so requiring slug == stem also makes source_files
+# unique — closing the duplicate-source_file case the live audit's sort -u hides.
+stem_mismatch="$(jq -r '
+    .foreman_adapters[]
+    | select((.source_file | rtrimstr(".sh")) != .slug)
+    | "\(.slug)(->\(.source_file))"' "$registry")"
+if [ -n "$stem_mismatch" ]; then
+    fail "foreman adapter slug != source_file stem [$(echo "$stem_mismatch" | tr '\n' ' ')] — foreman:<slug> would not resolve to its backend file; rename the slug or the source_file so they match"
+fi
+
+if [ "$fails" -ne 0 ]; then
+    echo "test-registry-drift: $fails drift finding(s) above." >&2
+    echo "Live Foreman adapter roster check (network, non-gating): task foreman:audit-adapters" >&2
+    exit 1
+fi
+
+echo "test-registry-drift: registry, labels, provisioning, wrappers, and adapters agree."
+echo "  (live Foreman roster check is task foreman:audit-adapters — network, not part of this gate)"


### PR DESCRIPTION
## Summary

Implements **#661** (part of the **#620** unified label strategy): label
provisioning is now driven by the machine-readable agent registry
(`agent-registry.json`) instead of hand-maintained lists, and a gated drift
check binds the registry to everything that consumes it. Realizes ADR 0005 D11
("later drift checks bind provisioning, wrappers, and the pinned upstream
adapter roster to the same contract").

## What changed

- **`agent-registry-labels.mjs`** (new, both layers) — the single renderer for
  `suggest:<family>`, `claim:<family>`, and `foreman:<adapter>` labels. Both the
  provisioning script and the drift check call it, so they cannot fork. Fails
  closed on fields that would corrupt the `name|color|desc` record stream or
  exceed GitHub's 50-char label-name limit.
- **`setup-github-labels.sh`** (both layers) — renders family-level
  `suggest:`/`claim:` from the registry and **stops seeding the retired
  `agent:*` family**; `foreman:<adapter>` selectors are provisioned only for
  adapters the pinned Foreman release ships (today just `foreman:claude`),
  dropping the phantom `foreman:codex/gemini/deepseek/glm/kimi/copilot` set.
  Model-level labels stay on-demand.
- **`test:registry-drift`** (new; in `verify` + `ci`, both layers) — the offline
  gate. Binds: registry schema, label output, the provisioning script's *actual
  emitted labels* (run with `gh` stubbed), the provider-wrapper inventory, and
  Foreman-adapter coherence — all to the registry, with remediation-naming
  failures. Skips file-specific dimensions loudly when a profile omits the file.
- **`foreman:audit-adapters`** (new; network, **non-gating**) — compares the
  registry's declared adapters against the pinned Foreman release. Keeps
  `verify`/`ci` offline-reproducible (the chosen offline-gate + networked-audit
  split) while catching the registry lagging a Foreman release.
- **`status.sh`** (both layers) — derives its expected-label inventory from the
  same renderer, so `status:setup` no longer reports registry labels as
  "all seeded".
- `test-template.sh` runs the drift check on every render profile and asserts
  `verify`/CI reachability; its foreman-label and Layer/Domain vocabulary guards
  are updated for the registry-driven mechanism (the `agent:Agent` row is retired
  — that field is #662).

## Acceptance criteria

- [x] Both layers provision family-level `suggest:*`/`claim:*` from the registry; stop provisioning `agent:*`
- [x] Model-level labels remain on-demand, not a seed list
- [x] `foreman:*` selectors only for production adapters in the pinned release; `mock` stays test-only
- [x] A named drift check covers schema, label output, wrapper inventory, and (offline coherence + networked audit) pinned-adapter inventory; runs in `verify`/`ci`
- [x] Root/template parity and the full render matrix pass
- [x] Failure output identifies the mismatched registry row + remediation

## Design note for reviewers

**Pinned-adapter dimension is split offline/network by design.** The gating
`test:registry-drift` asserts everything derivable from the registry offline
(so `verify`/`ci` stay reproducible); the live comparison against
`ponderousdev/foreman@vFOREMAN_VERSION` is `task foreman:audit-adapters`
(network, non-gating), documented as the AGENTS.md CI-only-infra style
exception. It agrees with v2.1.0 today (`claude.sh` + `mock.sh`).

## ⚠️ Release sequencing (maintainer decision)

Per AC1 this **stops seeding `agent:*`** but never deletes labels. Two follow-ups
complete the cutover by design (ADR 0005 — units land separately):
`harmon-devkit #321` migrates the vendored `/claim` skill to `claim:*`, and
**#663** syncs that release and retires live `agent:*`/stale `foreman:*` labels.
**Do not release this to consumers ahead of the devkit skill migration**, or a
freshly generated repo would provision `claim:*` while its `/claim` skill still
probes `agent:claude-code`. `harmon-init` itself is unaffected (its
`agent:claude-code` persists — the script is additive). This is documented in
`setup-github-labels.sh`.

## Second-model review (Codex)

Local `task challenge` (2 rounds) and `task review` (2 rounds) both reached a
clean P0/P1 pass. Adjudication:

| Finding | Pri | Disposition |
|---|---|---|
| Dropping `agent:*` breaks fresh-repo claim labeling | P1 | By-design; owned by devkit#321/#663 per #620 ACs + ADR 0005. Transition documented in-code; sequencing surfaced above. |
| Stale live `foreman:*` selectors not retired | P1 | By-design; live-label migration is #663 (umbrella HUMAN AC); no permanent migration added (AGENTS.md). |
| Newline/`\|` injection via `display_name` | P2 | **Fixed** — renderer fails closed. |
| Drift test grepped filename, not behavior | P2 | **Fixed** — runs the script `gh`-stubbed, asserts emitted labels (bidirectional). |
| Truncated Git tree → false "stale" | P2 | **Fixed** — audit exits 2 (indeterminate). |
| Slug ≠ `source_file` stem could not resolve | P2 | **Fixed** — enforced offline. |
| Count-only family comparison | P2 | **Fixed** — exact jq-derived name set. |
| `status:setup` blind to registry labels | P1 | **Fixed** — `status.sh` derives from the renderer. |
| Label-name >50 chars breaks provisioning | P2 | **Fixed** — renderer fails closed on the limit. |
| Audit `--flag` with no value exits silently | P2 | **Fixed** — explicit diagnostic + exit 2. |

## Deferred findings

- [x] `scripts/status.sh` node-absent honesty — **fixed in 28de042**: `status:setup` now reports the Starter-labels check as `unknown` ("node unavailable — registry labels unchecked") instead of grading the reduced static set as "all seeded", consistent with the section's existing `unknown` states.
- [x] `scripts/audit-foreman-adapters.sh` offline unit coverage — **filed as #677**. The audit is network-only and non-gating; manually verified on v2.1.0 (agree) + a bogus tag (indeterminate). #677 tracks durable fixture-based coverage.

## Verification

`task verify`, `task challenge`, `task review`, and `task ci` all green locally.
Every drift dimension was mutation-tested to confirm it catches its fault.

Closes #661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
