### PR TITLE
fix(devcontainer): disable the Claude Code auto-updater in the shared image

### DIFF
--- a/docs/architecture/devcontainer-image.md
+++ b/docs/architecture/devcontainer-image.md
@@ -27,6 +27,9 @@ The image:
 - carries OCI source, revision, version, description, and license labels;
 - contains `/usr/local/share/harmon-devcontainer/manifest.json` with its source
   revision, architecture, and important tool versions;
+- pins the agent CLI versions it ships and disables Claude Code's auto-updater
+  (`DISABLE_AUTOUPDATER=1`), so a running container cannot drift off the tested
+  version — upgrades arrive by rebuilding the image and moving the consumer pin;
 - contains `/usr/local/sbin/install-harmon-repo-config`, the stable contract by
   which a consumer installs its checked-in policy overlay;
 - contains no repository checkout, project dependencies, credentials, secrets,

--- a/images/devcontainer/Dockerfile
+++ b/images/devcontainer/Dockerfile
@@ -342,6 +342,18 @@ RUN npm install -g \
         "dmux@${DMUX_VERSION}" \
     && npm cache clean --force
 
+# Claude Code is installed globally as root above, but containers run as
+# `vscode`, so its in-place auto-updater can never write to
+# /usr/lib/node_modules/@anthropic-ai/claude-code and fails every attempt with
+# `no_permissions` -- surfacing a warning in `claude doctor` that no consumer
+# can act on. Self-update is also unwanted here: the version is pinned by
+# CLAUDE_CODE_VERSION above (Renovate-managed) and rolled out by rebuilding
+# this image and bumping the digest consumers pin, so a container that updated
+# itself would silently drift off the tested, reviewed version. Disabling it
+# makes `claude doctor` report an accurate "disabled by env" status instead.
+# Set after the npm layer so toggling it does not bust that cache.
+ENV DISABLE_AUTOUPDATER=1
+
 # ---------- image/overlay contract ----------
 COPY generate-manifest.sh smoke.sh /usr/local/sbin/
 COPY install-repo-config.sh /usr/local/sbin/install-harmon-repo-config

--- a/images/devcontainer/smoke.sh
+++ b/images/devcontainer/smoke.sh
@@ -84,6 +84,12 @@ for tool in workmux dmux; do
     esac
 done
 
+# Claude Code's global install is root-owned while containers run as vscode, so
+# its auto-updater can only ever fail; the Dockerfile disables it. Assert the
+# env var survives, otherwise the warning silently returns to every consumer.
+[ "${DISABLE_AUTOUPDATER:-}" = "1" ] ||
+    fail "DISABLE_AUTOUPDATER is not set to 1 in the image environment"
+
 task_version="$(task --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
 [ "$task_version" = "$(jq -r '.tools.task' "$manifest")" ] ||
     fail "task $task_version does not match the manifest"


### PR DESCRIPTION
## What

Set `DISABLE_AUTOUPDATER=1` in the shared devcontainer image, assert it in the
image smoke test, and record it as an artifact-contract guarantee.

## Why

`claude doctor` reports `Last update attempt: failed (no_permissions)` in every
container built on this image. The cause is structural, not a broken install:

- `images/devcontainer/Dockerfile` installs Claude Code globally **as root**;
  npm's global prefix is `/usr`, so it lands in
  `/usr/lib/node_modules/@anthropic-ai/claude-code`, owned `root:root`, mode `755`.
- Containers run as `vscode` (uid 1000).
- Claude Code's auto-updater rewrites that directory **in place**, so it can
  never succeed — it fails identically on every run, forever.

Self-update is also **unwanted** here. `CLAUDE_CODE_VERSION` is Renovate-managed
and rolled out by rebuilding the image and moving the digest consumers pin, so a
container that updated itself would silently drift off the version
`publish-harmon-devcontainer.yml` actually validated.

Disabling it replaces a permanent, unactionable warning with an accurate
"disabled by env" status. The env var takes precedence over the `autoUpdates`
settings key in Claude Code's own resolution order, which is why it is preferred
over a managed-settings entry.

## Scope notes

- **Root-only change; no template twin.** `images/devcontainer/` is the
  root-only producer for the shared image and has no `template/` counterpart.
  Generated repos inherit the `ENV` because their `.devcontainer/Dockerfile`
  (a verbatim twin) `FROM`s this image. Confirmed nothing overrides it —
  neither profile's `containerEnv` sets `DISABLE_AUTOUPDATER`.
- **Not user-visible until the pin moves.** This fixes the image source; running
  containers pin digest `sha-dedd863e…`, which predates it. The warning clears
  after: merge → image republish → consumer-pin PR → rebuild.
- **Sibling CLIs left alone.** `@openai/codex` and `@google/gemini-cli` share the
  same root-owned layer, so they would hit the same wall *if* they self-update in
  place. I grepped both and found no in-place updater, but that is absence of
  evidence rather than proof — deliberately out of scope here.
- **Version drift is separate and untouched.** Running 2.1.219, image `ARG` says
  2.1.220, npm `latest` is 2.1.226. That is Renovate's lane.
- **Pre-existing gap noticed, not fixed:** `hadolint` is installed in the image
  and the Dockerfile carries a `# hadolint ignore=` directive, but no task or
  workflow actually runs it. Ran it manually here (clean).

## Verification

| Gate | Result |
|---|---|
| `task verify` | pass (exit 0) |
| `task challenge` | pass — no P0/P1, round 1 clean |
| `task review` | pass — no P0/P1 |
| `task ci` | pass (exit 0) |
| `hadolint images/devcontainer/Dockerfile` | clean (run manually; not CI-wired) |
| `PR_TITLE=… task guard:release-title` | pass — no `template/` paths changed |

The smoke assertion is exercised by both existing invocations
(`scripts/test-devcontainer-image.sh` and the arm64 QEMU job), which run
`docker run <image> /usr/local/sbin/smoke.sh` — image `ENV` is inherited there.

## Deferred findings

None — challenge and review both returned no P0/P1, and neither reported a P2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)