### PR TITLE
feat: remove the Agent field and re-key agent-queue planning on suggest:* labels

### DIFF
--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -203,7 +203,7 @@ this comment. -->
       `evanharmon1 Project`) and idempotently sync its `Status` pipeline and
       `Size` number field — see
       [project-management.md](project-management.md).
-      On a personal account it also creates Priority/Product/Agent/Domain/Layer/
+      On a personal account it also creates Priority/Product/Domain/Layer/
       Size as project fields (issue fields are org-only); status automation is a
       separate follow-up — the board is set up, but issue/PR status isn't
       auto-synced yet. `Domain` is seeded with `auth`/`billing`/`platform` only —

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -340,14 +340,13 @@ families, color-coded by family; the starter set is created by
 > **Transition — the retired `agent:*` family.** Repos seeded before the
 > registry-driven vocabulary carry `agent:claude-code`-style labels instead of
 > `claim:*`. Setup never deletes labels, and the vendored claim/release skills
-> still read and write `agent:*` until the devkit migration lands
-> ([#663](https://github.com/evanharmon1/harmon-init/issues/663)) — so where
-> `agent:*` already exists it stays the live claim vocabulary, and everything
-> below about the claim label applies to it unchanged. Do not seed `agent:*`
-> into new repos. A repo generated fresh before that migration sits in
-> between: its labels are `claim:*` but its vendored skills still look for
-> `agent:*` and skip the label when the family is absent — a claim there
-> rests on the assignee and the claim comment until the skill pin moves.
+> (harmon-devkit v0.23.0+) prefer `claim:*` and fall back to `agent:*` where
+> only the legacy family exists — so existing claims keep working while live
+> labels migrate
+> ([#663](https://github.com/evanharmon1/harmon-init/issues/663)), and
+> everything below about the claim label applies to whichever family a repo
+> carries. Do not seed `agent:*` into new repos; a repo carrying neither
+> family tracks a claim by assignee and claim comment alone.
 
 The `layer:` and `domain:` families offer the same options as the **Layer** and
 **Domain** fields above — same names, same meanings, but no per-issue sync (see

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -332,7 +332,10 @@ families, color-coded by family; the starter set is created by
 - **Suggest** — `suggest:claude`, `suggest:codex`, … (registry-driven; see
   `agent-registry.json`) — which agent family *should* implement the issue,
   set at triage. Advisory only: it routes nothing by itself and must never be
-  read as Foreman arming (that is the `foreman:*` family)
+  read as Foreman arming (that is the `foreman:*` family). A model-level
+  label (`suggest:claude:opus`, created on demand) **refines** the family
+  label, never replaces it — apply both, so views filtered on the family
+  labels keep seeing the issue
 
 > **Transition — the retired `agent:*` family.** Repos seeded before the
 > registry-driven vocabulary carry `agent:claude-code`-style labels instead of

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -286,19 +286,25 @@ the setup scripts are additive-only by design, so deleting the live field is an
 explicit operator step, and reviewing its values comes first — deleting a field
 destroys every value on it, unrecoverably.
 
-1. List what it holds: every issue or board item with `Agent` set — including
-   **draft items**, which can carry the project field but can never carry a
-   label. Convert any draft whose assignment you want to keep into an issue
-   first; a draft you leave as-is loses its assignment with the field.
-2. Carry each assignment you still want over as the matching `suggest:*` label
+1. Provision the replacement vocabulary first: run `task setup:github-labels`
+   in every repository whose issues carry the field — a `suggest:*` label must
+   exist in a repo before an assignment can be copied onto its issues.
+2. List what the field holds: every issue or board item with `Agent` set —
+   including **draft items**, which can carry the project field but can never
+   carry a label. Convert any draft whose assignment you want to keep into an
+   issue first; a draft you leave as-is loses its assignment with the field.
+3. Carry each assignment you still want over as the matching `suggest:*` label
    on the issue (e.g. `Agent: Claude Code` → `suggest:claude`).
-3. Re-point the saved **Agent queue** view (below) at the new predicate —
+4. Re-point the saved **Agent queue** view (below) at the new predicate —
    filter on the `suggest:*` labels instead of the `Agent` field. A view still
    filtered on the field loses its routing predicate the moment the field is
    deleted.
-4. Only then delete the field — Project settings → the field → *Delete field*
-   on a personal project; org **Settings → Planning → Issue fields** on an
-   organization.
+5. Only then delete the field — Project settings → the field → *Delete field*
+   on a personal project. On an organization the field is **org-wide**:
+   deleting it under **Settings → Planning → Issue fields** removes the value
+   from every issue in every repository and project the org owns, not just
+   this board — repeat steps 2–3 across the whole organization before
+   deleting.
 
 On a personal account there are no issue fields, so `task setup:github-project`
 creates **Priority, Product, Domain, Layer, and Size** as project fields.
@@ -335,7 +341,10 @@ families, color-coded by family; the starter set is created by
 > ([#663](https://github.com/evanharmon1/harmon-init/issues/663)) — so where
 > `agent:*` already exists it stays the live claim vocabulary, and everything
 > below about the claim label applies to it unchanged. Do not seed `agent:*`
-> into new repos.
+> into new repos. A repo generated fresh before that migration sits in
+> between: its labels are `claim:*` but its vendored skills still look for
+> `agent:*` and skip the label when the family is absent — a claim there
+> rests on the assignee and the claim comment until the skill pin moves.
 
 The `layer:` and `domain:` families offer the same options as the **Layer** and
 **Domain** fields above — same names, same meanings, but no per-issue sync (see
@@ -646,9 +655,12 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   **`needs-triage`**, grouped by **Type** (Bug / Feature / Task / Research) so you
   see the shape of the inbox. This is your grooming session — it exists so
   untriaged work can't hide; empty it regularly and it stays useful.
-- **Agent queue** — board, filtered to issues carrying a **`suggest:*`** label,
-  showing only the in-flight `Status` columns (**Ready, Agent Queue, In Progress,
-  Verifying, In Review, Ready to Merge**), sorted by `Priority`.
+- **Agent queue** — board, filtered to issues carrying a **`suggest:*`** label
+  (Projects label filters match **concrete** values, not prefixes — enumerate
+  the seeded family labels in the filter, and extend it when the registry
+  gains a family), showing only the in-flight `Status` columns (**Ready, Agent
+  Queue, In Progress, Verifying, In Review, Ready to Merge**), sorted by
+  `Priority`.
 - **Planning** — table, grouped by **`Product`** (or `Type`), sorted by
   `Priority`, with the **`Size` field summed in each group header**. The "how
   big is the pile, and what's the plan" view, and a **dates-free roadmap

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -67,7 +67,7 @@ Projects permission at all — that row of the PAT table is organization-scoped,
 and a user-owned board has no equivalent setting to hand a second account. So an
 agent running as the bot **cannot move a card**, and there is no permission to
 raise: the board is moved by you, while the claim stays visible through the
-`agent:*` label and the assignee — see
+claim label and the assignee — see
 [Claiming](#claiming--making-an-agents-work-visible-while-it-happens), which is
 exactly why a claim writes all three signals instead of relying on the board
 alone. To have claims move cards here, run the agent under your own `gh` login
@@ -286,10 +286,17 @@ the setup scripts are additive-only by design, so deleting the live field is an
 explicit operator step, and reviewing its values comes first — deleting a field
 destroys every value on it, unrecoverably.
 
-1. List what it holds: every issue or board item with `Agent` set.
+1. List what it holds: every issue or board item with `Agent` set — including
+   **draft items**, which can carry the project field but can never carry a
+   label. Convert any draft whose assignment you want to keep into an issue
+   first; a draft you leave as-is loses its assignment with the field.
 2. Carry each assignment you still want over as the matching `suggest:*` label
    on the issue (e.g. `Agent: Claude Code` → `suggest:claude`).
-3. Only then delete the field — Project settings → the field → *Delete field*
+3. Re-point the saved **Agent queue** view (below) at the new predicate —
+   filter on the `suggest:*` labels instead of the `Agent` field. A view still
+   filtered on the field loses its routing predicate the moment the field is
+   deleted.
+4. Only then delete the field — Project settings → the field → *Delete field*
    on a personal project; org **Settings → Planning → Issue fields** on an
    organization.
 
@@ -313,14 +320,22 @@ families, color-coded by family; the starter set is created by
 - **Layer** — `layer:ui`, `layer:logic`, `layer:data`, `layer:integration`
 - **Domain** — start with `domain:auth`, `domain:billing`, `domain:platform`;
   grow from your ERD entities
-- **Agent** — `agent:claude-code`, `agent:codex`, `agent:gemini-cli`,
-  `agent:qwen-code`, `agent:deepseek`, `agent:kimi-k2`, `agent:glm`,
-  `agent:github-copilot` — which agent is working the issue *right now* (see
-  **Claiming** below)
+- **Claim** — `claim:claude`, `claim:codex`, … (registry-driven; see
+  `agent-registry.json`) — which agent family is working the issue *right
+  now*, written by the agent itself (see **Claiming** below)
 - **Suggest** — `suggest:claude`, `suggest:codex`, … (registry-driven; see
   `agent-registry.json`) — which agent family *should* implement the issue,
   set at triage. Advisory only: it routes nothing by itself and must never be
   read as Foreman arming (that is the `foreman:*` family)
+
+> **Transition — the retired `agent:*` family.** Repos seeded before the
+> registry-driven vocabulary carry `agent:claude-code`-style labels instead of
+> `claim:*`. Setup never deletes labels, and the vendored claim/release skills
+> still read and write `agent:*` until the devkit migration lands
+> ([#663](https://github.com/evanharmon1/harmon-init/issues/663)) — so where
+> `agent:*` already exists it stays the live claim vocabulary, and everything
+> below about the claim label applies to it unchanged. Do not seed `agent:*`
+> into new repos.
 
 The `layer:` and `domain:` families offer the same options as the **Layer** and
 **Domain** fields above — same names, same meanings, but no per-issue sync (see
@@ -328,8 +343,8 @@ Fields). Use the label when you want it on the issue list and in
 `gh issue list --label`, the field when you want to group a board view by it,
 and extend both together so the option sets stay identical.
 
-The `agent:` and `suggest:` families share a vocabulary and *nothing else*.
-`suggest:` is the planned implementer, `agent:` is the active one — see
+The `claim:` and `suggest:` families share a vocabulary and *nothing else*.
+`suggest:` is the planned implementer, `claim:` is the active one — see
 **Claiming** below. Never treat one as a copy of the other: rewriting the
 suggestion to match the claim overwrites a planning decision.
 
@@ -355,7 +370,7 @@ each is blind where the others see:
 | Signal | Answers | Shows up in |
 |---|---|---|
 | `Status` = `In Progress` | where it is in delivery | the board |
-| `agent:*` label | which agent is working it **right now** | the issue page, `gh issue list --label` |
+| claim label (`claim:*`; `agent:*` pre-migration) | which agent is working it **right now** | the issue page, `gh issue list --label` |
 | assignee | that *someone* has it | notifications, `gh issue list --assignee` |
 
 **`suggest:*` is not on that list, and a claim must not write it.** The two
@@ -364,7 +379,7 @@ look like the same fact and are not:
 | | Means | Set by | When |
 |---|---|---|---|
 | **`suggest:*`** label | which agent *should* implement it | whoever plans/triages | at planning, before the work starts |
-| **`agent:*`** label | which agent *is* implementing it | the agent itself | at claim, released at hand-off |
+| **`claim:*`** label | which agent *is* implementing it | the agent itself | at claim, released at hand-off |
 
 They share one vocabulary — the agent-registry families — but they answer
 different questions. Rewriting the suggestion at claim time would destroy the
@@ -427,7 +442,7 @@ in the vendored `track-work` skill.
 > grep -rl 'agent:claude-code' .claude/skills/claim/ .claude/skills/wrap/
 > ```
 >
-> A match means claiming is automated end to end. No match means the `agent:`
+> A match means claiming is automated end to end. No match means the claim
 > labels above are applied by hand, and no *skill* will move the card. On an
 > organization `project-automation.yml` still syncs `Status` from PR and CI
 > events, so that is not the same as nothing moving it — check what the
@@ -656,7 +671,7 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   **`Domain`** to focus a product area, by **`Layer`** to focus a slice of the
   stack. One board, many lenses — and how multiple products stay legible in one
   aggregating project instead of fragmenting into project-per-product. (The
-  agent split is a label question — `suggest:*`/`agent:*` — filter, don't
+  agent split is a label question — `suggest:*`/`claim:*` — filter, don't
   slice.)
 
 ## Notes

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -113,12 +113,13 @@ Archived-items view), so aged `Done` items leave the board automatically instead
 of sitting in an "Archived" column.
 
 **Agent Queue is the hand-off lane to AI coding agents.** An item lands there once
-it's shaped and ready for an *agent* rather than a human to implement — the
-**Agent** field says which one (and effort / model). Today the hand-off is manual:
-assign the agent and trigger it (a `claude-*` workflow, or point Claude Code at the
-item). The lane is built for future automation, though — an agent can watch *Agent
-Queue + Agent-set + priority* (the Agent-queue view below) and pull the top item on
-its own — and either way the item moves to **In Progress** once work starts.
+it's shaped and ready for an *agent* rather than a human to implement — a
+**`suggest:*`** label says which family (and optionally model) should take it.
+Today the hand-off is manual: suggest the agent and trigger it (a `claude-*`
+workflow, or point Claude Code at the item). The lane is built for future
+automation, though — an agent can watch *Agent Queue + suggest-labelled +
+priority* (the Agent-queue view below) and pull the top item on its own — and
+either way the item moves to **In Progress** once work starts.
 
 > **Foreman is that automation** for issue-driven delivery: arm the issue with
 > a `foreman:*` label (label arming is the supported mode — issue-field arming
@@ -243,8 +244,6 @@ The work-metadata fields:
 - **Size** — estimation points on the Fibonacci ladder (1 / 2 / 3 / 5 / 8 / 13 / 21),
   a project **number** field so a view can sum it per group
 - **Product** — which product/area it belongs to (free text)
-- **Agent** — which agent should implement it (Claude Code, Codex, Gemini CLI,
-  Qwen Code, DeepSeek, Kimi K2, GLM, GitHub Copilot) and how (effort level, model)
 - **Domain** — which part of the *product* it belongs to. Ships as a starter
   single-select (`auth`, `billing`, `platform`); the real vocabulary comes from
   your ERD entities — add options as the product grows
@@ -276,8 +275,26 @@ them in step afterwards. Two things to know before you extend either:
   is in public preview, so if its update endpoint rejects the change, the script
   names the missing options to add by hand rather than failing the run.
 
+There is deliberately **no `Agent` field**. Which agent *should* take an issue
+is the `suggest:*` label family plus the `Status: Agent Queue` lane; which agent
+*is* working it is the claim label (see **Claiming** below). A field could carry
+neither answer without duplicating the label vocabulary, and on an organization
+the Projects V2 API could not even write it (ADR 0005, D4).
+
+**Migrating a board that still has one** (set up before the field was retired):
+the setup scripts are additive-only by design, so deleting the live field is an
+explicit operator step, and reviewing its values comes first — deleting a field
+destroys every value on it, unrecoverably.
+
+1. List what it holds: every issue or board item with `Agent` set.
+2. Carry each assignment you still want over as the matching `suggest:*` label
+   on the issue (e.g. `Agent: Claude Code` → `suggest:claude`).
+3. Only then delete the field — Project settings → the field → *Delete field*
+   on a personal project; org **Settings → Planning → Issue fields** on an
+   organization.
+
 On a personal account there are no issue fields, so `task setup:github-project`
-creates **Priority, Product, Agent, Domain, Layer, and Size** as project fields.
+creates **Priority, Product, Domain, Layer, and Size** as project fields.
 
 TODO: finalize each field's options/values.
 
@@ -300,6 +317,10 @@ families, color-coded by family; the starter set is created by
   `agent:qwen-code`, `agent:deepseek`, `agent:kimi-k2`, `agent:glm`,
   `agent:github-copilot` — which agent is working the issue *right now* (see
   **Claiming** below)
+- **Suggest** — `suggest:claude`, `suggest:codex`, … (registry-driven; see
+  `agent-registry.json`) — which agent family *should* implement the issue,
+  set at triage. Advisory only: it routes nothing by itself and must never be
+  read as Foreman arming (that is the `foreman:*` family)
 
 The `layer:` and `domain:` families offer the same options as the **Layer** and
 **Domain** fields above — same names, same meanings, but no per-issue sync (see
@@ -307,11 +328,10 @@ Fields). Use the label when you want it on the issue list and in
 `gh issue list --label`, the field when you want to group a board view by it,
 and extend both together so the option sets stay identical.
 
-The `agent:` family shares the **Agent** field's option names and *nothing
-else*. The field is the planned implementer, the label is the active one — see
-**Claiming** below. Extend the two lists together, but never treat one as a
-copy of the other: writing the field to match the label overwrites a planning
-decision.
+The `agent:` and `suggest:` families share a vocabulary and *nothing else*.
+`suggest:` is the planned implementer, `agent:` is the active one — see
+**Claiming** below. Never treat one as a copy of the other: rewriting the
+suggestion to match the claim overwrites a planning decision.
 
 GitHub labels live per-repository (there's no shared org label pool).
 `setup-github-labels` seeds the set into one repo — run it in each, or set the
@@ -338,29 +358,27 @@ each is blind where the others see:
 | `agent:*` label | which agent is working it **right now** | the issue page, `gh issue list --label` |
 | assignee | that *someone* has it | notifications, `gh issue list --assignee` |
 
-**`Agent` is not on that list, and a claim must not write it.** The two look
-like the same fact and are not:
+**`suggest:*` is not on that list, and a claim must not write it.** The two
+look like the same fact and are not:
 
 | | Means | Set by | When |
 |---|---|---|---|
-| **`Agent`** field | which agent *should* implement it | whoever plans/triages | at planning, before the work starts |
+| **`suggest:*`** label | which agent *should* implement it | whoever plans/triages | at planning, before the work starts |
 | **`agent:*`** label | which agent *is* implementing it | the agent itself | at claim, released at hand-off |
 
-They share one vocabulary — the same eight option names, which is why the two
-lists are extended together — but they answer different questions. Overwriting
-`Agent` at claim time would destroy the planning assignment the **Agent queue**
-view is built on (that view lists issues *whose `Agent` field is set*), and
-would silently reassign work planned for one agent to whichever agent happened
-to pick it up.
+They share one vocabulary — the agent-registry families — but they answer
+different questions. Rewriting the suggestion at claim time would destroy the
+planning assignment the **Agent queue** view is built on (that view lists
+issues *carrying a `suggest:*` label*), and would silently reassign work
+planned for one agent to whichever agent happened to pick it up.
 
-So a claim writes the **label**. If the label and the field disagree, that is
-information, not drift: it means a different agent picked up work planned for
-another one. Worth noticing, not worth auto-correcting.
+So a claim writes the **claim label only**. If the claim and the suggestion
+disagree, that is information, not drift: it means a different agent picked up
+work planned for another one. Worth noticing, not worth auto-correcting.
 
-This also removes an owner-type problem: on an organization `Agent` is an org
-**issue field** that the Projects V2 API cannot write anyway, so a claim that
-depended on it would have been impossible there. The label works identically on
-both owner types.
+Both being labels, the model works identically on both owner types — there is
+no org issue field in the claim path for the Projects V2 API to be unable to
+write.
 
 **A board write can fail without anyone learning.** Every `Status` write in the
 lifecycle needs the [`project` scope](#token-scopes). Without it each one exits
@@ -613,7 +631,7 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   **`needs-triage`**, grouped by **Type** (Bug / Feature / Task / Research) so you
   see the shape of the inbox. This is your grooming session — it exists so
   untriaged work can't hide; empty it regularly and it stays useful.
-- **Agent queue** — board, filtered to issues whose **`Agent`** field is set,
+- **Agent queue** — board, filtered to issues carrying a **`suggest:*`** label,
   showing only the in-flight `Status` columns (**Ready, Agent Queue, In Progress,
   Verifying, In Review, Ready to Merge**), sorted by `Priority`.
 - **Planning** — table, grouped by **`Product`** (or `Type`), sorted by
@@ -633,12 +651,13 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   otherwise reach for an Epic type to get — the payoff of choosing **sub-issues
   over Epics**: structure without the "Feature or Epic?" tax. Still preview, so
   expect rough edges.
-- **Slice the board** — rather than separate per-product / per-layer / per-agent
-  saved views, slice the one board: by **`Product`** when you go multi-product, by
+- **Slice the board** — rather than separate per-product / per-layer saved
+  views, slice the one board: by **`Product`** when you go multi-product, by
   **`Domain`** to focus a product area, by **`Layer`** to focus a slice of the
-  stack, by **`Agent`** to see the split. One
-  board, many lenses — and how multiple products stay legible in one aggregating
-  project instead of fragmenting into project-per-product.
+  stack. One board, many lenses — and how multiple products stay legible in one
+  aggregating project instead of fragmenting into project-per-product. (The
+  agent split is a label question — `suggest:*`/`agent:*` — filter, don't
+  slice.)
 
 ## Notes
 

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -303,8 +303,9 @@ destroys every value on it, unrecoverably.
    on a personal project. On an organization the field is **org-wide**:
    deleting it under **Settings → Planning → Issue fields** removes the value
    from every issue in every repository and project the org owns, not just
-   this board — repeat steps 2–3 across the whole organization before
-   deleting.
+   this board — repeat steps 2–4 across the whole organization before
+   deleting, including step 4 for **every** Project whose saved views filter
+   on the field, not just the board being migrated.
 
 On a personal account there are no issue fields, so `task setup:github-project`
 creates **Priority, Product, Domain, Layer, and Size** as project fields.

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -6,9 +6,9 @@
 # because only project number fields sum in view group headers (issue-field
 # columns can group/filter/sort, not sum). The other metadata on an ORGANIZATION
 # are org-level ISSUE fields (Priority/Effort are GitHub built-ins, left at
-# their defaults; setup-github-issue-fields.sh adds Product, Agent, Domain, and
+# their defaults; setup-github-issue-fields.sh adds Product, Domain, and
 # Layer); on a personal account (no org issue fields) this script creates
-# Priority/Product/Agent/Domain/Layer as project fields too.
+# Priority/Product/Domain/Layer as project fields too.
 #
 # Safe to re-run and safe to run from every repo the owner controls: it looks the
 # project up by title, so the first run creates it and later runs just reconcile
@@ -478,11 +478,11 @@ create_number "Size"
 # Other metadata: on an ORGANIZATION these are org-level ISSUE fields (durable —
 # the value is on the issue, shared across every project; see
 # docs/project-management.md). Priority is a GitHub built-in;
-# setup-github-issue-fields.sh adds Product, Agent, Domain, and Layer. A personal
+# setup-github-issue-fields.sh adds Product, Domain, and Layer. A personal
 # account has no org issue fields, so fall back to creating them as project
 # fields here.
 if [ "$owner_type" = "Organization" ]; then
-    echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product/Agent/Domain/Layer)"
+    echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product/Domain/Layer)"
     report_incompatible
     echo "==> Done — project #$project_number: $title"
     exit 0
@@ -496,24 +496,11 @@ create_single_select "Priority" '[
   {"name":"Low","color":"GRAY","description":""}
 ]'
 create_text "Product"
-# Agent shares its option names with the `agent:` label family in
-# setup-github-labels.sh, so extend both together — but they answer different
-# questions and nothing syncs them. This FIELD is planning metadata: which agent
-# SHOULD implement the issue, set at triage, and what the Agent-queue view
-# filters on. The LABEL is the live claim: which agent IS working it, written by
-# the agent itself. A claim must never write this field, or it overwrites the
-# plan and changes what appears in the queue (docs/project-management.md,
-# "Claiming").
-create_single_select "Agent" '[
-  {"name":"Claude Code","color":"ORANGE","description":""},
-  {"name":"Codex","color":"BLUE","description":""},
-  {"name":"Gemini CLI","color":"PURPLE","description":""},
-  {"name":"Qwen Code","color":"GREEN","description":""},
-  {"name":"DeepSeek","color":"RED","description":""},
-  {"name":"Kimi K2","color":"YELLOW","description":""},
-  {"name":"GLM","color":"PINK","description":""},
-  {"name":"GitHub Copilot","color":"GRAY","description":""}
-]'
+# There is deliberately no Agent field. Advisory agent routing is the
+# `suggest:*` label family (registry-driven via setup-github-labels.sh) plus
+# the `Status: Agent Queue` lane; the live claim is a `claim:*` label written
+# by the agent itself. A single-select field could carry neither answer without
+# duplicating the label vocabulary (docs/project-management.md, ADR 0005 D4).
 # Domain (what part of the product) and Layer (which slice of the stack) mirror
 # the `domain:` / `layer:` label families in setup-github-labels.sh — keep the
 # lists in step. Domain is a starter set; real domains come from your product's

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -945,14 +945,17 @@ if [[ "${SECTION}" == "setup" ]]; then
                     field_rows="$(jq -r '(if type == "object" then (.issue_fields // []) elif type == "array" then . else [] end) | .[] | "\(.name)\t\(.data_type // "")"' "${d}/issue-fields.json" 2>/dev/null || echo "")"
                     # Every non-built-in field setup-github-issue-fields.sh creates
                     # must be present AND of the right type: an org set up before
-                    # Domain and Layer joined the set already has Product + Agent,
-                    # and one that happens to own a text field named `Domain` can
-                    # never get the taxonomy options (GitHub cannot change a
-                    # field's data type in place). Reporting either as done would
-                    # hide exactly what the setup script warns about.
+                    # Domain and Layer joined the set already has Product, and one
+                    # that happens to own a text field named `Domain` can never get
+                    # the taxonomy options (GitHub cannot change a field's data
+                    # type in place). Reporting either as done would hide exactly
+                    # what the setup script warns about. The retired Agent field is
+                    # deliberately NOT wanted here: the setup script no longer
+                    # creates it, so requiring it would report a permanent false
+                    # failure on every fresh org (#662).
                     missing_fields=""
                     wrong_fields=""
-                    for want in Product:text Agent:single_select Domain:single_select Layer:single_select; do
+                    for want in Product:text Domain:single_select Layer:single_select; do
                         wname="${want%%:*}"
                         wtype="${want##*:}"
                         htype="$(printf '%s\n' "${field_rows}" | awk -F'\t' -v n="${wname}" '$1 == n { print $2; exit }')"
@@ -967,7 +970,7 @@ if [[ "${SECTION}" == "setup" ]]; then
                     elif [ -n "${wrong_fields}" ]; then
                         checkline no "Org issue fields" "wrong type: ${wrong_fields} — rename/delete, then re-run task setup:github-issue-fields"
                     elif [ -z "${missing_fields}" ]; then
-                        checkline ok "Org issue fields" "Product + Agent + Domain + Layer"
+                        checkline ok "Org issue fields" "Product + Domain + Layer"
                     else
                         checkline no "Org issue fields" "missing ${missing_fields} — run task setup:github-issue-fields"
                     fi

--- a/scripts/test-setup-github-project.sh
+++ b/scripts/test-setup-github-project.sh
@@ -101,15 +101,6 @@ complete='{"data":{"node":{"fields":{"nodes":[
    {"id":"p2","name":"High","color":"ORANGE","description":""},
    {"id":"p3","name":"Medium","color":"YELLOW","description":""},
    {"id":"p4","name":"Low","color":"GRAY","description":""}]},
- {"id":"F_agt","name":"Agent","dataType":"SINGLE_SELECT","options":[
-   {"id":"a1","name":"Claude Code","color":"ORANGE","description":""},
-   {"id":"a2","name":"Codex","color":"BLUE","description":""},
-   {"id":"a3","name":"Gemini CLI","color":"PURPLE","description":""},
-   {"id":"a4","name":"Qwen Code","color":"GREEN","description":""},
-   {"id":"a5","name":"DeepSeek","color":"RED","description":""},
-   {"id":"a6","name":"Kimi K2","color":"YELLOW","description":""},
-   {"id":"a7","name":"GLM","color":"PINK","description":""},
-   {"id":"a8","name":"GitHub Copilot","color":"GRAY","description":""}]},
  {"id":"F_dom","name":"Domain","dataType":"SINGLE_SELECT","options":[
    {"id":"d1","name":"auth","color":"PURPLE","description":"Authentication and authorization"},
    {"id":"d2","name":"billing","color":"GREEN","description":"Billing and payments"},
@@ -125,6 +116,14 @@ echo "==> a re-run against an already-synced project writes nothing"
 run_with "$complete"
 [ "$(updates)" = 0 ] || fail "expected no mutations on an unchanged project, got $(updates)"
 grep -q "leaving it as-is" "$tmp/out" || fail "expected 'leaving it as-is' output"
+
+echo "==> the retired Agent field is never created"
+# The fixture above deliberately has no Agent field, so any mutation naming one
+# is the script recreating it. Advisory routing is the suggest:* label family
+# plus Status: Agent Queue; the live claim is a claim:* label (ADR 0005 D4).
+case "$(cat "$MUTATIONS")" in
+*'name:"Agent"'*) fail "the retired Agent field was created — routing lives in suggest:*/claim:* labels" ;;
+esac
 
 echo "==> a field missing a starter option gains ONLY that option"
 # Domain lacks `billing` and carries an owner-added `crm`.

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -749,8 +749,13 @@ full) # project_management=github; github_org=test-org (an org repo)
     # drift too).
     # The agent vocabulary is no longer a label/field pair here: it moved to
     # registry-driven suggest:/claim: labels (checked by test:registry-drift),
-    # and removal of the `Agent` field is tracked separately (#662). Only the
-    # Layer/Domain taxonomy is cross-checked across labels + fields now.
+    # and the Agent field is retired (#662) — the rendered scripts must not
+    # recreate it. Only the Layer/Domain taxonomy is cross-checked across
+    # labels + fields now.
+    ! grep -q 'create_field "Agent"' scripts/setup-github-issue-fields.sh ||
+        err "rendered setup-github-issue-fields.sh recreates the retired Agent field (#662)"
+    ! grep -q 'create_single_select "Agent"' scripts/setup-github-project.sh ||
+        err "rendered setup-github-project.sh recreates the retired Agent field (#662)"
     for pair in layer:Layer domain:Domain; do
         fam="${pair%%:*}"
         field="${pair##*:}"

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -988,7 +988,7 @@ tasks:
 
   setup:github-issue-fields:
     desc: >-
-      Idempotently add the org's Product + Agent + Domain + Layer issue fields
+      Idempotently add the org's Product + Domain + Layer issue fields
       (Priority/Effort are GitHub built-ins, left at defaults; the numeric Size
       estimate is a project field via setup:github-project). Additive, org-wide:
       creates what is missing and appends starter options an existing

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -238,7 +238,7 @@ config, toolchain, devcontainer, and dev environment — against the items below
       project-automation.yml and the claude-* workflows read (they fall back to
       the project title).
 - [ ] Org issue fields: run `task setup:github-issue-fields` (needs `gh` with the
-      `admin:org` scope) to add the org's **Product**, **Agent**, **Domain**, and
+      `admin:org` scope) to add the org's **Product**, **Domain**, and
       **Layer** issue fields.
       Priority/Effort (and the date fields) are GitHub built-in issue fields, left
       at their defaults — tune options in the org's issue-field settings if you

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -257,7 +257,7 @@ config, toolchain, devcontainer, and dev environment — against the items below
       `integration`) is product-independent and normally needs no edits. See
       [project-management.md](project-management.md).
 [% else %]
-      On a personal account it also creates Priority/Product/Agent/Domain/Layer/
+      On a personal account it also creates Priority/Product/Domain/Layer/
       Size as project fields (issue fields are org-only); status automation is a
       separate follow-up — the board is set up, but issue/PR status isn't
       auto-synced yet. `Domain` is seeded with `auth`/`billing`/`platform` only —

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -399,14 +399,12 @@ families, color-coded by family; the starter set is created by
 > **Transition — the retired `agent:*` family.** Repos seeded before the
 > registry-driven vocabulary carry `agent:claude-code`-style labels instead of
 > `claim:*`. Setup never deletes labels, and the vendored claim/release skills
-> still read and write `agent:*` until the devkit migration lands
-> (harmon-init#663) — so where `agent:*` already exists it stays the live
-> claim vocabulary, and everything below about the claim label applies to it
-> unchanged. Do not seed `agent:*` into new repos. A repo generated fresh
-> before that migration sits in between: its labels are `claim:*` but its
-> vendored skills still look for `agent:*` and skip the label when the family
-> is absent — a claim there rests on the assignee and the claim comment until
-> the skill pin moves.
+> (harmon-devkit v0.23.0+) prefer `claim:*` and fall back to `agent:*` where
+> only the legacy family exists — so existing claims keep working while live
+> labels migrate (harmon-init#663), and everything below about the claim
+> label applies to whichever family a repo carries. Do not seed `agent:*`
+> into new repos; a repo carrying neither family tracks a claim by assignee
+> and claim comment alone.
 
 The `layer:` and `domain:` families offer the same options as the **Layer** and
 **Domain** fields above — same names, same meanings, but no per-issue sync (see

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -122,12 +122,13 @@ Archived-items view), so aged `Done` items leave the board automatically instead
 of sitting in an "Archived" column.
 
 **Agent Queue is the hand-off lane to AI coding agents.** An item lands there once
-it's shaped and ready for an *agent* rather than a human to implement — the
-**Agent** field says which one (and effort / model). Today the hand-off is manual:
-assign the agent and trigger it (a `claude-*` workflow, or point Claude Code at the
-item). The lane is built for future automation, though — an agent can watch *Agent
-Queue + Agent-set + priority* (the Agent-queue view below) and pull the top item on
-its own — and either way the item moves to **In Progress** once work starts.
+it's shaped and ready for an *agent* rather than a human to implement — a
+**`suggest:*`** label says which family (and optionally model) should take it.
+Today the hand-off is manual: suggest the agent and trigger it (a `claude-*`
+workflow, or point Claude Code at the item). The lane is built for future
+automation, though — an agent can watch *Agent Queue + suggest-labelled +
+priority* (the Agent-queue view below) and pull the top item on its own — and
+either way the item moves to **In Progress** once work starts.
 [% if use_foreman %]
 
 > **Foreman is that automation** for issue-driven delivery: arm the issue with
@@ -258,8 +259,6 @@ The work-metadata fields:
 - **Size** — estimation points on the Fibonacci ladder (1 / 2 / 3 / 5 / 8 / 13 / 21),
   a project **number** field so a view can sum it per group
 - **Product** — which product/area it belongs to (free text)
-- **Agent** — which agent should implement it (Claude Code, Codex, Gemini CLI,
-  Qwen Code, DeepSeek, Kimi K2, GLM, GitHub Copilot) and how (effort level, model)
 - **Domain** — which part of the *product* it belongs to. Ships as a starter
   single-select (`auth`, `billing`, `platform`); the real vocabulary comes from
   your ERD entities — add options as the product grows
@@ -291,14 +290,32 @@ them in step afterwards. Two things to know before you extend either:
   is in public preview, so if its update endpoint rejects the change, the script
   names the missing options to add by hand rather than failing the run.
 
+There is deliberately **no `Agent` field**. Which agent *should* take an issue
+is the `suggest:*` label family plus the `Status: Agent Queue` lane; which agent
+*is* working it is the claim label (see **Claiming** below). A field could carry
+neither answer without duplicating the label vocabulary, and on an organization
+the Projects V2 API could not even write it.
+
+**Migrating a board that still has one** (set up before the field was retired):
+the setup scripts are additive-only by design, so deleting the live field is an
+explicit operator step, and reviewing its values comes first — deleting a field
+destroys every value on it, unrecoverably.
+
+1. List what it holds: every issue or board item with `Agent` set.
+2. Carry each assignment you still want over as the matching `suggest:*` label
+   on the issue (e.g. `Agent: Claude Code` → `suggest:claude`).
+3. Only then delete the field — Project settings → the field → *Delete field*
+   on a personal project; org **Settings → Planning → Issue fields** on an
+   organization.
+
 [% if github_org != author_git_provider_username %]
-**Priority, Product, Agent, Domain, and Layer are org issue fields**: org-level,
+**Priority, Product, Domain, and Layer are org issue fields**: org-level,
 defined once, and — unlike a project field — the value lives on the **issue**,
 stays consistent across every project the issue belongs to, and shows in the issue
 timeline. GitHub ships **Priority** and **Effort** (plus **Start date** /
 **Target date**) built in, left at their defaults, so
-`task setup:github-issue-fields` only adds **Product**, **Agent**, **Domain**,
-and **Layer**.
+`task setup:github-issue-fields` only adds **Product**, **Domain**, and
+**Layer**.
 
 Because issue fields are org-level, `Domain`'s option list is shared by every
 repo in the org — expect it to accumulate the union of your products' domains.
@@ -314,7 +331,7 @@ its default (a coarse gut-check) and put points in `Size`.
 
 [% else %]
 On a personal account there are no issue fields, so `task setup:github-project`
-creates **Priority, Product, Agent, Domain, Layer, and Size** as project fields.
+creates **Priority, Product, Domain, Layer, and Size** as project fields.
 
 [% endif %]
 TODO: finalize each field's options/values.
@@ -359,6 +376,10 @@ families, color-coded by family; the starter set is created by
   `agent:qwen-code`, `agent:deepseek`, `agent:kimi-k2`, `agent:glm`,
   `agent:github-copilot` — which agent is working the issue *right now* (see
   **Claiming** below)
+- **Suggest** — `suggest:claude`, `suggest:codex`, … (registry-driven; see
+  `agent-registry.json`) — which agent family *should* implement the issue,
+  set at triage. Advisory only: it routes nothing by itself[% if use_foreman %] and must never be
+  read as Foreman arming (that is the `foreman:*` family)[% endif %]
 
 The `layer:` and `domain:` families offer the same options as the **Layer** and
 **Domain** fields above — same names, same meanings, but no per-issue sync (see
@@ -366,11 +387,10 @@ Fields). Use the label when you want it on the issue list and in
 `gh issue list --label`, the field when you want to group a board view by it,
 and extend both together so the option sets stay identical.
 
-The `agent:` family shares the **Agent** field's option names and *nothing
-else*. The field is the planned implementer, the label is the active one — see
-**Claiming** below. Extend the two lists together, but never treat one as a
-copy of the other: writing the field to match the label overwrites a planning
-decision.
+The `agent:` and `suggest:` families share a vocabulary and *nothing else*.
+`suggest:` is the planned implementer, `agent:` is the active one — see
+**Claiming** below. Never treat one as a copy of the other: rewriting the
+suggestion to match the claim overwrites a planning decision.
 
 GitHub labels live per-repository (there's no shared org label pool).
 `setup-github-labels` seeds the set into one repo — run it in each, or set the
@@ -397,29 +417,27 @@ each is blind where the others see:
 | `agent:*` label | which agent is working it **right now** | the issue page, `gh issue list --label` |
 | assignee | that *someone* has it | notifications, `gh issue list --assignee` |
 
-**`Agent` is not on that list, and a claim must not write it.** The two look
-like the same fact and are not:
+**`suggest:*` is not on that list, and a claim must not write it.** The two
+look like the same fact and are not:
 
 | | Means | Set by | When |
 |---|---|---|---|
-| **`Agent`** field | which agent *should* implement it | whoever plans/triages | at planning, before the work starts |
+| **`suggest:*`** label | which agent *should* implement it | whoever plans/triages | at planning, before the work starts |
 | **`agent:*`** label | which agent *is* implementing it | the agent itself | at claim, released at hand-off |
 
-They share one vocabulary — the same option names, which is why the two lists
-are extended together — but they answer different questions. Overwriting
-`Agent` at claim time would destroy the planning assignment the **Agent queue**
-view is built on (that view lists issues *whose `Agent` field is set*), and
-would silently reassign work planned for one agent to whichever agent happened
-to pick it up.
+They share one vocabulary — the agent-registry families — but they answer
+different questions. Rewriting the suggestion at claim time would destroy the
+planning assignment the **Agent queue** view is built on (that view lists
+issues *carrying a `suggest:*` label*), and would silently reassign work
+planned for one agent to whichever agent happened to pick it up.
 
-So a claim writes the **label**. If the label and the field disagree, that is
-information, not drift: it means a different agent picked up work planned for
-another one. Worth noticing, not worth auto-correcting.
+So a claim writes the **claim label only**. If the claim and the suggestion
+disagree, that is information, not drift: it means a different agent picked up
+work planned for another one. Worth noticing, not worth auto-correcting.
 
-This also removes an owner-type problem: on an organization `Agent` is an org
-**issue field** that the Projects V2 API cannot write anyway, so a claim that
-depended on it would have been impossible there. The label works identically on
-both owner types.
+Both being labels, the model works identically on both owner types — there is
+no org issue field in the claim path for the Projects V2 API to be unable to
+write.
 
 These labels ship with `task setup:github-labels`, which is generated only for
 `project_management: github`. A repo on `none` or `linear` gets no label
@@ -683,7 +701,7 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   **`needs-triage`**, grouped by **Type** (Bug / Feature / Task / Research) so you
   see the shape of the inbox. This is your grooming session — it exists so
   untriaged work can't hide; empty it regularly and it stays useful.
-- **Agent queue** — board, filtered to issues whose **`Agent`** field is set,
+- **Agent queue** — board, filtered to issues carrying a **`suggest:*`** label,
   showing only the in-flight `Status` columns (**Ready, Agent Queue, In Progress,
   Verifying, In Review, Ready to Merge**), sorted by `Priority`.
 - **Planning** — table, grouped by **`Product`** (or `Type`), sorted by
@@ -703,12 +721,13 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   otherwise reach for an Epic type to get — the payoff of choosing **sub-issues
   over Epics**: structure without the "Feature or Epic?" tax. Still preview, so
   expect rough edges.
-- **Slice the board** — rather than separate per-product / per-layer / per-agent
-  saved views, slice the one board: by **`Product`** when you go multi-product, by
+- **Slice the board** — rather than separate per-product / per-layer saved
+  views, slice the one board: by **`Product`** when you go multi-product, by
   **`Domain`** to focus a product area, by **`Layer`** to focus a slice of the
-  stack, by **`Agent`** to see the split. One
-  board, many lenses — and how multiple products stay legible in one aggregating
-  project instead of fragmenting into project-per-product.
+  stack. One board, many lenses — and how multiple products stay legible in one
+  aggregating project instead of fragmenting into project-per-product. (The
+  agent split is a label question — `suggest:*`/`agent:*` — filter, don't
+  slice.)
 
 ## Notes
 

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -77,7 +77,7 @@ is exactly such a token. On a personal account it is granted no Projects
 permission at all — that row of the PAT table is organization-scoped, and a
 user-owned board has no equivalent setting to hand a second account. So an agent
 running as the bot **cannot move a card**, and there is no permission to raise:
-the board is moved by you, while the claim stays visible through the `agent:*`
+the board is moved by you, while the claim stays visible through the claim
 label and the assignee — see
 [Claiming](#claiming--making-an-agents-work-visible-while-it-happens), which is
 exactly why a claim writes all three signals instead of relying on the board
@@ -301,10 +301,17 @@ the setup scripts are additive-only by design, so deleting the live field is an
 explicit operator step, and reviewing its values comes first — deleting a field
 destroys every value on it, unrecoverably.
 
-1. List what it holds: every issue or board item with `Agent` set.
+1. List what it holds: every issue or board item with `Agent` set — including
+   **draft items**, which can carry the project field but can never carry a
+   label. Convert any draft whose assignment you want to keep into an issue
+   first; a draft you leave as-is loses its assignment with the field.
 2. Carry each assignment you still want over as the matching `suggest:*` label
    on the issue (e.g. `Agent: Claude Code` → `suggest:claude`).
-3. Only then delete the field — Project settings → the field → *Delete field*
+3. Re-point the saved **Agent queue** view (below) at the new predicate —
+   filter on the `suggest:*` labels instead of the `Agent` field. A view still
+   filtered on the field loses its routing predicate the moment the field is
+   deleted.
+4. Only then delete the field — Project settings → the field → *Delete field*
    on a personal project; org **Settings → Planning → Issue fields** on an
    organization.
 
@@ -372,14 +379,21 @@ families, color-coded by family; the starter set is created by
 - **Layer** — `layer:ui`, `layer:logic`, `layer:data`, `layer:integration`
 - **Domain** — start with `domain:auth`, `domain:billing`, `domain:platform`;
   grow from your ERD entities
-- **Agent** — `agent:claude-code`, `agent:codex`, `agent:gemini-cli`,
-  `agent:qwen-code`, `agent:deepseek`, `agent:kimi-k2`, `agent:glm`,
-  `agent:github-copilot` — which agent is working the issue *right now* (see
-  **Claiming** below)
+- **Claim** — `claim:claude`, `claim:codex`, … (registry-driven; see
+  `agent-registry.json`) — which agent family is working the issue *right
+  now*, written by the agent itself (see **Claiming** below)
 - **Suggest** — `suggest:claude`, `suggest:codex`, … (registry-driven; see
   `agent-registry.json`) — which agent family *should* implement the issue,
   set at triage. Advisory only: it routes nothing by itself[% if use_foreman %] and must never be
   read as Foreman arming (that is the `foreman:*` family)[% endif %]
+
+> **Transition — the retired `agent:*` family.** Repos seeded before the
+> registry-driven vocabulary carry `agent:claude-code`-style labels instead of
+> `claim:*`. Setup never deletes labels, and the vendored claim/release skills
+> still read and write `agent:*` until the devkit migration lands
+> (harmon-init#663) — so where `agent:*` already exists it stays the live
+> claim vocabulary, and everything below about the claim label applies to it
+> unchanged. Do not seed `agent:*` into new repos.
 
 The `layer:` and `domain:` families offer the same options as the **Layer** and
 **Domain** fields above — same names, same meanings, but no per-issue sync (see
@@ -387,8 +401,8 @@ Fields). Use the label when you want it on the issue list and in
 `gh issue list --label`, the field when you want to group a board view by it,
 and extend both together so the option sets stay identical.
 
-The `agent:` and `suggest:` families share a vocabulary and *nothing else*.
-`suggest:` is the planned implementer, `agent:` is the active one — see
+The `claim:` and `suggest:` families share a vocabulary and *nothing else*.
+`suggest:` is the planned implementer, `claim:` is the active one — see
 **Claiming** below. Never treat one as a copy of the other: rewriting the
 suggestion to match the claim overwrites a planning decision.
 
@@ -414,7 +428,7 @@ each is blind where the others see:
 | Signal | Answers | Shows up in |
 |---|---|---|
 | `Status` = `In Progress` | where it is in delivery | the board |
-| `agent:*` label | which agent is working it **right now** | the issue page, `gh issue list --label` |
+| claim label (`claim:*`; `agent:*` pre-migration) | which agent is working it **right now** | the issue page, `gh issue list --label` |
 | assignee | that *someone* has it | notifications, `gh issue list --assignee` |
 
 **`suggest:*` is not on that list, and a claim must not write it.** The two
@@ -423,7 +437,7 @@ look like the same fact and are not:
 | | Means | Set by | When |
 |---|---|---|---|
 | **`suggest:*`** label | which agent *should* implement it | whoever plans/triages | at planning, before the work starts |
-| **`agent:*`** label | which agent *is* implementing it | the agent itself | at claim, released at hand-off |
+| **`claim:*`** label | which agent *is* implementing it | the agent itself | at claim, released at hand-off |
 
 They share one vocabulary — the agent-registry families — but they answer
 different questions. Rewriting the suggestion at claim time would destroy the
@@ -496,7 +510,7 @@ with no closing keyword, an unmerged fork PR), are in
 > grep -rl 'agent:claude-code' .claude/skills/claim/ .claude/skills/wrap/
 > ```
 >
-> A match means claiming is automated end to end. No match means the `agent:`
+> A match means claiming is automated end to end. No match means the claim
 > labels above are yours to apply by hand, and no *skill* will move the card.
 > That is not the same as nothing moving it: on an organization
 > `project-automation.yml` still syncs `Status` from PR and CI events, so check
@@ -726,7 +740,7 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   **`Domain`** to focus a product area, by **`Layer`** to focus a slice of the
   stack. One board, many lenses — and how multiple products stay legible in one
   aggregating project instead of fragmenting into project-per-product. (The
-  agent split is a label question — `suggest:*`/`agent:*` — filter, don't
+  agent split is a label question — `suggest:*`/`claim:*` — filter, don't
   slice.)
 
 ## Notes

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -391,7 +391,10 @@ families, color-coded by family; the starter set is created by
 - **Suggest** — `suggest:claude`, `suggest:codex`, … (registry-driven; see
   `agent-registry.json`) — which agent family *should* implement the issue,
   set at triage. Advisory only: it routes nothing by itself[% if use_foreman %] and must never be
-  read as Foreman arming (that is the `foreman:*` family)[% endif %]
+  read as Foreman arming (that is the `foreman:*` family)[% endif %]. A model-level
+  label (`suggest:claude:opus`, created on demand) **refines** the family
+  label, never replaces it — apply both, so views filtered on the family
+  labels keep seeing the issue
 
 > **Transition — the retired `agent:*` family.** Repos seeded before the
 > registry-driven vocabulary carry `agent:claude-code`-style labels instead of

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -301,19 +301,25 @@ the setup scripts are additive-only by design, so deleting the live field is an
 explicit operator step, and reviewing its values comes first — deleting a field
 destroys every value on it, unrecoverably.
 
-1. List what it holds: every issue or board item with `Agent` set — including
-   **draft items**, which can carry the project field but can never carry a
-   label. Convert any draft whose assignment you want to keep into an issue
-   first; a draft you leave as-is loses its assignment with the field.
-2. Carry each assignment you still want over as the matching `suggest:*` label
+1. Provision the replacement vocabulary first: run `task setup:github-labels`
+   in every repository whose issues carry the field — a `suggest:*` label must
+   exist in a repo before an assignment can be copied onto its issues.
+2. List what the field holds: every issue or board item with `Agent` set —
+   including **draft items**, which can carry the project field but can never
+   carry a label. Convert any draft whose assignment you want to keep into an
+   issue first; a draft you leave as-is loses its assignment with the field.
+3. Carry each assignment you still want over as the matching `suggest:*` label
    on the issue (e.g. `Agent: Claude Code` → `suggest:claude`).
-3. Re-point the saved **Agent queue** view (below) at the new predicate —
+4. Re-point the saved **Agent queue** view (below) at the new predicate —
    filter on the `suggest:*` labels instead of the `Agent` field. A view still
    filtered on the field loses its routing predicate the moment the field is
    deleted.
-4. Only then delete the field — Project settings → the field → *Delete field*
-   on a personal project; org **Settings → Planning → Issue fields** on an
-   organization.
+5. Only then delete the field — Project settings → the field → *Delete field*
+   on a personal project. On an organization the field is **org-wide**:
+   deleting it under **Settings → Planning → Issue fields** removes the value
+   from every issue in every repository and project the org owns, not just
+   this board — repeat steps 2–3 across the whole organization before
+   deleting.
 
 [% if github_org != author_git_provider_username %]
 **Priority, Product, Domain, and Layer are org issue fields**: org-level,
@@ -393,7 +399,11 @@ families, color-coded by family; the starter set is created by
 > still read and write `agent:*` until the devkit migration lands
 > (harmon-init#663) — so where `agent:*` already exists it stays the live
 > claim vocabulary, and everything below about the claim label applies to it
-> unchanged. Do not seed `agent:*` into new repos.
+> unchanged. Do not seed `agent:*` into new repos. A repo generated fresh
+> before that migration sits in between: its labels are `claim:*` but its
+> vendored skills still look for `agent:*` and skip the label when the family
+> is absent — a claim there rests on the assignee and the claim comment until
+> the skill pin moves.
 
 The `layer:` and `domain:` families offer the same options as the **Layer** and
 **Domain** fields above — same names, same meanings, but no per-issue sync (see
@@ -715,9 +725,12 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   **`needs-triage`**, grouped by **Type** (Bug / Feature / Task / Research) so you
   see the shape of the inbox. This is your grooming session — it exists so
   untriaged work can't hide; empty it regularly and it stays useful.
-- **Agent queue** — board, filtered to issues carrying a **`suggest:*`** label,
-  showing only the in-flight `Status` columns (**Ready, Agent Queue, In Progress,
-  Verifying, In Review, Ready to Merge**), sorted by `Priority`.
+- **Agent queue** — board, filtered to issues carrying a **`suggest:*`** label
+  (Projects label filters match **concrete** values, not prefixes — enumerate
+  the seeded family labels in the filter, and extend it when the registry
+  gains a family), showing only the in-flight `Status` columns (**Ready, Agent
+  Queue, In Progress, Verifying, In Review, Ready to Merge**), sorted by
+  `Priority`.
 - **Planning** — table, grouped by **`Product`** (or `Type`), sorted by
   `Priority`, with the **`Size` field summed in each group header**. The "how
   big is the pile, and what's the plan" view, and a **dates-free roadmap

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -318,8 +318,9 @@ destroys every value on it, unrecoverably.
    on a personal project. On an organization the field is **org-wide**:
    deleting it under **Settings → Planning → Issue fields** removes the value
    from every issue in every repository and project the org owns, not just
-   this board — repeat steps 2–3 across the whole organization before
-   deleting.
+   this board — repeat steps 2–4 across the whole organization before
+   deleting, including step 4 for **every** Project whose saved views filter
+   on the field, not just the board being migrated.
 
 [% if github_org != author_git_provider_username %]
 **Priority, Product, Domain, and Layer are org issue fields**: org-level,

--- a/template/docs/[% if project_management == 'linear' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'linear' %]project-management.md[% endif %].jinja
@@ -5,4 +5,4 @@ How work is tracked for [[ project_name ]] in **Linear**.
 TODO: document the Linear workflow — teams, workflow states (Linear's status
 groups map cleanly onto delivery: Backlog / Unstarted / Started / Completed /
 Canceled), cycles, triage, automations, and custom fields (Priority, Estimate,
-Product, Agent).
+Product).

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -6,9 +6,9 @@
 # because only project number fields sum in view group headers (issue-field
 # columns can group/filter/sort, not sum). The other metadata on an ORGANIZATION
 # are org-level ISSUE fields (Priority/Effort are GitHub built-ins, left at
-# their defaults; setup-github-issue-fields.sh adds Product, Agent, Domain, and
+# their defaults; setup-github-issue-fields.sh adds Product, Domain, and
 # Layer); on a personal account (no org issue fields) this script creates
-# Priority/Product/Agent/Domain/Layer as project fields too.
+# Priority/Product/Domain/Layer as project fields too.
 #
 # Safe to re-run and safe to run from every repo the owner controls: it looks the
 # project up by title, so the first run creates it and later runs just reconcile
@@ -478,11 +478,11 @@ create_number "Size"
 # Other metadata: on an ORGANIZATION these are org-level ISSUE fields (durable —
 # the value is on the issue, shared across every project; see
 # docs/project-management.md). Priority is a GitHub built-in;
-# setup-github-issue-fields.sh adds Product, Agent, Domain, and Layer. A personal
+# setup-github-issue-fields.sh adds Product, Domain, and Layer. A personal
 # account has no org issue fields, so fall back to creating them as project
 # fields here.
 if [ "$owner_type" = "Organization" ]; then
-    echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product/Agent/Domain/Layer)"
+    echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product/Domain/Layer)"
     report_incompatible
     echo "==> Done — project #$project_number: $title"
     exit 0
@@ -496,24 +496,11 @@ create_single_select "Priority" '[
   {"name":"Low","color":"GRAY","description":""}
 ]'
 create_text "Product"
-# Agent shares its option names with the `agent:` label family in
-# setup-github-labels.sh, so extend both together — but they answer different
-# questions and nothing syncs them. This FIELD is planning metadata: which agent
-# SHOULD implement the issue, set at triage, and what the Agent-queue view
-# filters on. The LABEL is the live claim: which agent IS working it, written by
-# the agent itself. A claim must never write this field, or it overwrites the
-# plan and changes what appears in the queue (docs/project-management.md,
-# "Claiming").
-create_single_select "Agent" '[
-  {"name":"Claude Code","color":"ORANGE","description":""},
-  {"name":"Codex","color":"BLUE","description":""},
-  {"name":"Gemini CLI","color":"PURPLE","description":""},
-  {"name":"Qwen Code","color":"GREEN","description":""},
-  {"name":"DeepSeek","color":"RED","description":""},
-  {"name":"Kimi K2","color":"YELLOW","description":""},
-  {"name":"GLM","color":"PINK","description":""},
-  {"name":"GitHub Copilot","color":"GRAY","description":""}
-]'
+# There is deliberately no Agent field. Advisory agent routing is the
+# `suggest:*` label family (registry-driven via setup-github-labels.sh) plus
+# the `Status: Agent Queue` lane; the live claim is a `claim:*` label written
+# by the agent itself. A single-select field could carry neither answer without
+# duplicating the label vocabulary (docs/project-management.md, ADR 0005 D4).
 # Domain (what part of the product) and Layer (which slice of the stack) mirror
 # the `domain:` / `layer:` label families in setup-github-labels.sh — keep the
 # lists in step. Domain is a starter set; real domains come from your product's

--- a/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
@@ -101,15 +101,6 @@ complete='{"data":{"node":{"fields":{"nodes":[
    {"id":"p2","name":"High","color":"ORANGE","description":""},
    {"id":"p3","name":"Medium","color":"YELLOW","description":""},
    {"id":"p4","name":"Low","color":"GRAY","description":""}]},
- {"id":"F_agt","name":"Agent","dataType":"SINGLE_SELECT","options":[
-   {"id":"a1","name":"Claude Code","color":"ORANGE","description":""},
-   {"id":"a2","name":"Codex","color":"BLUE","description":""},
-   {"id":"a3","name":"Gemini CLI","color":"PURPLE","description":""},
-   {"id":"a4","name":"Qwen Code","color":"GREEN","description":""},
-   {"id":"a5","name":"DeepSeek","color":"RED","description":""},
-   {"id":"a6","name":"Kimi K2","color":"YELLOW","description":""},
-   {"id":"a7","name":"GLM","color":"PINK","description":""},
-   {"id":"a8","name":"GitHub Copilot","color":"GRAY","description":""}]},
  {"id":"F_dom","name":"Domain","dataType":"SINGLE_SELECT","options":[
    {"id":"d1","name":"auth","color":"PURPLE","description":"Authentication and authorization"},
    {"id":"d2","name":"billing","color":"GREEN","description":"Billing and payments"},
@@ -125,6 +116,14 @@ echo "==> a re-run against an already-synced project writes nothing"
 run_with "$complete"
 [ "$(updates)" = 0 ] || fail "expected no mutations on an unchanged project, got $(updates)"
 grep -q "leaving it as-is" "$tmp/out" || fail "expected 'leaving it as-is' output"
+
+echo "==> the retired Agent field is never created"
+# The fixture above deliberately has no Agent field, so any mutation naming one
+# is the script recreating it. Advisory routing is the suggest:* label family
+# plus Status: Agent Queue; the live claim is a claim:* label (ADR 0005 D4).
+case "$(cat "$MUTATIONS")" in
+*'name:"Agent"'*) fail "the retired Agent field was created — routing lives in suggest:*/claim:* labels" ;;
+esac
 
 echo "==> a field missing a starter option gains ONLY that option"
 # Domain lacks `billing` and carries an owner-added `crm`.

--- a/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # setup-github-issue-fields.sh — idempotently add the org ISSUE FIELDS that are
-# NOT GitHub built-ins: Product, Agent, Domain, and Layer. GitHub already ships
+# NOT GitHub built-ins: Product, Domain, and Layer. GitHub already ships
 # Priority, Effort, Start date, and Target date as built-in issue fields, and we
 # never recreate or modify those (leave them at their defaults).
 # Additive only; it never renames or deletes a field or an option — so the
@@ -67,20 +67,14 @@ done
 # Preview REST API version for issue fields; bump if GitHub moves the endpoint.
 api_version="2026-03-10"
 
-# Agent single-select options. Colors are GitHub's palette: gray, blue, green,
-# yellow, orange, red, pink, purple. `priority` (1-based) is REQUIRED per option
-# on this preview endpoint and sets the display order (1 shows first).
-agent_opts='[
-  {"name":"Claude Code","color":"orange","description":"","priority":1},
-  {"name":"Codex","color":"blue","description":"","priority":2},
-  {"name":"Gemini CLI","color":"purple","description":"","priority":3},
-  {"name":"Qwen Code","color":"green","description":"","priority":4},
-  {"name":"DeepSeek","color":"red","description":"","priority":5},
-  {"name":"Kimi K2","color":"yellow","description":"","priority":6},
-  {"name":"GLM","color":"pink","description":"","priority":7},
-  {"name":"GitHub Copilot","color":"gray","description":"","priority":8}
-]'
-
+# There is deliberately no Agent field: advisory agent routing is the
+# `suggest:*` label family plus the `Status: Agent Queue` lane, and the live
+# claim is a `claim:*` label (docs/project-management.md, ADR 0005 D4).
+#
+# Colors are GitHub's palette: gray, blue, green, yellow, orange, red, pink,
+# purple. `priority` (1-based) is REQUIRED per option on this preview endpoint
+# and sets the display order (1 shows first).
+#
 # Domain (what part of the product) and Layer (which slice of the stack) are
 # orthogonal to each other and to Type/Status — an issue normally carries one of
 # each. Both mirror the `domain:` / `layer:` label families in
@@ -256,7 +250,6 @@ create_field() {
 }
 
 create_field "Product" "text" "Which product/area it belongs to"
-create_field "Agent" "single_select" "Which agent should implement it" "$agent_opts"
 create_field "Domain" "single_select" "Which part of the product it belongs to" "$domain_opts"
 create_field "Layer" "single_select" "Which slice of the stack it changes" "$layer_opts"
 
@@ -273,5 +266,5 @@ if [ -n "$incompatible" ] || [ -n "$missing_options" ]; then
         echo "    Add each one by hand in the org's issue-field settings (Settings -> Planning -> Issue fields)." >&2
     fi
 else
-    echo "==> Done — added issue fields on '$org': Product, Agent, Domain, Layer (Priority/Effort/dates are GitHub built-ins)"
+    echo "==> Done — added issue fields on '$org': Product, Domain, Layer (Priority/Effort/dates are GitHub built-ins)"
 fi

--- a/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]test-setup-github-issue-fields.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]test-setup-github-issue-fields.sh[% endif %]
@@ -72,19 +72,10 @@ run_with() {
 
 patches() { grep -c . "$PATCHES" || true; }
 
-agent_full='{"id":9,"name":"Claude Code","color":"orange","description":"","priority":1},
- {"id":10,"name":"Codex","color":"blue","description":"","priority":2},
- {"id":11,"name":"Gemini CLI","color":"purple","description":"","priority":3},
- {"id":12,"name":"Qwen Code","color":"green","description":"","priority":4},
- {"id":13,"name":"DeepSeek","color":"red","description":"","priority":5},
- {"id":14,"name":"Kimi K2","color":"yellow","description":"","priority":6},
- {"id":15,"name":"GLM","color":"pink","description":"","priority":7},
- {"id":16,"name":"GitHub Copilot","color":"gray","description":"","priority":8}'
-
-# Every field present and complete.
+# Every field present and complete. Deliberately no Agent field: it is retired
+# (advisory routing is suggest:* labels + Status: Agent Queue; ADR 0005 D4).
 complete='[
  {"id":1,"name":"Product","data_type":"text"},
- {"id":2,"name":"Agent","data_type":"single_select","options":['"$agent_full"']},
  {"id":3,"name":"Domain","data_type":"single_select","options":[
    {"id":20,"name":"auth","color":"purple","description":"","priority":1},
    {"id":21,"name":"billing","color":"green","description":"","priority":2},
@@ -100,6 +91,13 @@ echo "==> a re-run against an already-synced org writes nothing"
 run_with "$complete"
 [ "$(patches)" = 0 ] || fail "expected no PATCH on an unchanged org, got $(patches)"
 [ ! -s "$POSTS" ] || fail "expected no field creation on an unchanged org"
+
+echo "==> the retired Agent field is never created"
+# The fixture has no Agent field, so a POST naming one is the script recreating
+# it. Also covered by the empty-POSTS check above, but this names the intent so
+# a reintroduction fails with the right message.
+grep -q '"name":"Agent"' "$POSTS" &&
+    fail "the retired Agent field was created — routing lives in suggest:*/claim:* labels"
 
 echo "==> a field missing a starter option is PATCHed with the full merged list"
 # Domain lacks `billing` but carries an owner-added `crm`.

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -945,14 +945,17 @@ if [[ "${SECTION}" == "setup" ]]; then
                     field_rows="$(jq -r '(if type == "object" then (.issue_fields // []) elif type == "array" then . else [] end) | .[] | "\(.name)\t\(.data_type // "")"' "${d}/issue-fields.json" 2>/dev/null || echo "")"
                     # Every non-built-in field setup-github-issue-fields.sh creates
                     # must be present AND of the right type: an org set up before
-                    # Domain and Layer joined the set already has Product + Agent,
-                    # and one that happens to own a text field named `Domain` can
-                    # never get the taxonomy options (GitHub cannot change a
-                    # field's data type in place). Reporting either as done would
-                    # hide exactly what the setup script warns about.
+                    # Domain and Layer joined the set already has Product, and one
+                    # that happens to own a text field named `Domain` can never get
+                    # the taxonomy options (GitHub cannot change a field's data
+                    # type in place). Reporting either as done would hide exactly
+                    # what the setup script warns about. The retired Agent field is
+                    # deliberately NOT wanted here: the setup script no longer
+                    # creates it, so requiring it would report a permanent false
+                    # failure on every fresh org (#662).
                     missing_fields=""
                     wrong_fields=""
-                    for want in Product:text Agent:single_select Domain:single_select Layer:single_select; do
+                    for want in Product:text Domain:single_select Layer:single_select; do
                         wname="${want%%:*}"
                         wtype="${want##*:}"
                         htype="$(printf '%s\n' "${field_rows}" | awk -F'\t' -v n="${wname}" '$1 == n { print $2; exit }')"
@@ -967,7 +970,7 @@ if [[ "${SECTION}" == "setup" ]]; then
                     elif [ -n "${wrong_fields}" ]; then
                         checkline no "Org issue fields" "wrong type: ${wrong_fields} — rename/delete, then re-run task setup:github-issue-fields"
                     elif [ -z "${missing_fields}" ]; then
-                        checkline ok "Org issue fields" "Product + Agent + Domain + Layer"
+                        checkline ok "Org issue fields" "Product + Domain + Layer"
                     else
                         checkline no "Org issue fields" "missing ${missing_fields} — run task setup:github-issue-fields"
                     fi


### PR DESCRIPTION
## What

Implements #662 (leaf of the #620 unified-label-strategy umbrella, ADR 0005 D4): the `Agent` single-select field is retired from every setup path, and agent-queue planning re-keys on the model-centric label vocabulary.

- `setup-github-project.sh` (both layers) no longer creates `Agent` as a personal-project field; `setup-github-issue-fields.sh` (template, org-only) no longer creates it as an org issue field.
- `status.sh` (both twins) drops `Agent:single_select` from the org issue-field contract — previously a fresh org would permanently report "missing Agent" for a field setup never creates.
- Regression coverage: both test twins assert the retired field is never recreated; `test-template.sh` asserts the same against the rendered scripts.
- Docs (both layers): `project-management.md` re-keys the Agent-queue view and claiming rules on `suggest:*` + `Status: Agent Queue`, names `claim:*` as the seeded claim vocabulary with an explicit `agent:*` transition note (live until #663), documents that model-level labels refine — never replace — family labels, and gains the operator migration checklist (label provisioning first, drafts converted, saved view re-pointed, org-wide inventory before the org-wide field deletion). `CHECKLIST.md` + the Linear stub + the org Taskfile description updated to match.

## Why

Planning ("which agent should take this") and claiming ("which agent has it") had three unsynced vocabularies; #620 committed to labels for both. The `Agent` field could serve neither: labels need no project scope, work on both owner types, and are timeline-attributable — and on an org the Projects V2 API cannot write the field at all.

## Out of scope (sequenced by #620)

- Live `agent:*` label migration — #663. (The devkit v0.23.0 pin with the claim-aware skills and the aligned standardize-repo catalog landed on main and is included via rebase.)
- Deleting the live `Agent` field from boards — explicit operator step per the migration checklist; scripts stay additive-only.

## Verification

- `task verify` green after every round (full render matrix); `task ci` green (verify + network skills drift + devcontainer permission assert + security).
- `task challenge`: 4 rounds; 7 findings confirmed+fixed (status contract, org-wide deletion scope, vocabulary consistency, saved-view/draft-item/label-provisioning migration gaps, model-label filter visibility). One recurring P1 declined as sequenced work: the pinned standardize-repo catalog still describes the field — the fix is already on devkit main (devkit#320) and ships via the #663 pin sync; vendored skills are never hand-edited; Evan accepted the decline before proceeding. Resolved on the current head: the rebase brought the devkit v0.23.0 pin, whose catalog marks the field as pre-rollout behavior and whose claim skills prefer claim:* with an agent:* fallback.
- `task review`: clean pass round 1 (no P0/P1).

## Deferred findings

- [x] scripts/status.sh:958 (org issue-fields branch) — P2 from task review: no hermetic test exercises the org branch's want-list; reintroducing `Agent:single_select` there would pass verify while permanently reporting correctly provisioned orgs incomplete. Add a status fixture whose issue-fields response omits Agent (covers both twins). — filed as #698

Refs #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)


