### PR TITLE
fix: complete the claim vocabulary transition and prepare the live agent label migration

### DIFF
--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -235,12 +235,16 @@ this comment. -->
       `agent:qwen-code` → `claim:qwen`, `agent:github-copilot` →
       `claim:copilot` — taking the target names from
       `node scripts/agent-registry-labels.mjs suggest-claim`. A rename whose
-      target already exists is rejected by GitHub: re-label those issues by hand
-      and delete the empty legacy label instead. Check for in-flight claims first
-      (`gh issue list --label agent:… --state all --limit 200`): a claim record
-      naming the old label will not release the renamed one, so settle or amend
-      those records in the same sitting. Re-read `gh label list --limit 200`
-      afterwards — no `agent:*` should remain.
+      target already exists is rejected by GitHub — migrate that one by hand,
+      and enumerate **`gh pr list` as well as `gh issue list`**: labels apply to
+      pull requests too and `gh issue list` never returns them, so deleting the
+      legacy label afterwards would drop exactly the associations the re-labelling
+      missed — the loss this whole item exists to avoid. Check for in-flight
+      claims first (`gh issue list --label agent:… --state all --limit 200`,
+      plus the `gh pr list` equivalent): a claim record naming the old label will
+      not release the renamed one, so settle or amend those records in the same
+      sitting. Re-read `gh label list --limit 200` afterwards — no `agent:*`
+      should remain.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,
       so this is a one-time manual step. Filters/layouts are in

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -218,9 +218,13 @@ this comment. -->
       it in each repo; org default labels (org Settings → Repository, UI-only) only
       seed new repos.
 - [ ] **[human-only] Retire any legacy `agent:*` claim labels** — needed only
-      where `gh label list` still shows the harness-named family
+      where `gh label list --limit 200` still shows the harness-named family
       (`agent:claude-code`, `agent:gemini-cli`, …) a pre-registry harmon-init
-      seeded. `setup-github-labels` never deletes a label, so the old family
+      seeded. **Pass an explicit `--limit` to every `gh label list` and
+      `gh issue list` in this step**: both default to 30, the starter set alone
+      is over 40 labels, and an unbounded read reports a clean repo — or a
+      finished migration — while legacy labels and in-flight claims remain.
+      `setup-github-labels` never deletes a label, so the old family
       survives beside the registry-rendered `claim:*` one, and every reader
       tolerates both — this is cleanup, not a fix for something broken.
       **Rename, never re-create**: `gh label edit agent:claude-code --name
@@ -233,12 +237,10 @@ this comment. -->
       `node scripts/agent-registry-labels.mjs suggest-claim`. A rename whose
       target already exists is rejected by GitHub: re-label those issues by hand
       and delete the empty legacy label instead. Check for in-flight claims first
-      (`gh issue list --label agent:… --state all --limit 200` — the default
-      returns only 30, which would hide exactly the claims you are looking for):
-      a claim record naming the old
-      label will not release the renamed one, so settle or amend those records in
-      the same sitting. Re-read `gh label list` afterwards — no `agent:*` should
-      remain.
+      (`gh issue list --label agent:… --state all --limit 200`): a claim record
+      naming the old label will not release the renamed one, so settle or amend
+      those records in the same sitting. Re-read `gh label list --limit 200`
+      afterwards — no `agent:*` should remain.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,
       so this is a one-time manual step. Filters/layouts are in

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -220,10 +220,11 @@ this comment. -->
 - [ ] **[human-only] Retire any legacy `agent:*` claim labels** — needed only
       where `gh label list --limit 200` still shows the harness-named family
       (`agent:claude-code`, `agent:gemini-cli`, …) a pre-registry harmon-init
-      seeded. **Pass an explicit `--limit` to every `gh label list` and
-      `gh issue list` in this step**: both default to 30, the starter set alone
-      is over 40 labels, and an unbounded read reports a clean repo — or a
-      finished migration — while legacy labels and in-flight claims remain.
+      seeded. **Pass an explicit `--limit` to every `gh label list`,
+      `gh issue list`, and `gh pr list` in this step**: all three default to 30,
+      the starter set alone is over 40 labels, and an unbounded read reports a
+      clean repo — or a finished migration — while legacy labels, in-flight
+      claims, and labelled pull requests remain.
       `setup-github-labels` never deletes a label, so the old family
       survives beside the registry-rendered `claim:*` one, and every reader
       tolerates both — this is cleanup, not a fix for something broken.
@@ -240,10 +241,10 @@ this comment. -->
       pull requests too and `gh issue list` never returns them, so deleting the
       legacy label afterwards would drop exactly the associations the re-labelling
       missed — the loss this whole item exists to avoid. Check for in-flight
-      claims first (`gh issue list --label agent:… --state all --limit 200`,
-      plus the `gh pr list` equivalent): a claim record naming the old label will
-      not release the renamed one, so settle or amend those records in the same
-      sitting. Re-read `gh label list --limit 200` afterwards — no `agent:*`
+      claims first — `gh issue list --label agent:… --state all --limit 200`
+      **and** `gh pr list --label agent:… --state all --limit 200`: a claim
+      record naming the old label will not release the renamed one, so settle or
+      amend those records in the same sitting. Re-read `gh label list --limit 200` afterwards — no `agent:*`
       should remain.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -233,7 +233,9 @@ this comment. -->
       `node scripts/agent-registry-labels.mjs suggest-claim`. A rename whose
       target already exists is rejected by GitHub: re-label those issues by hand
       and delete the empty legacy label instead. Check for in-flight claims first
-      (`gh issue list --label agent:… --state all`): a claim record naming the old
+      (`gh issue list --label agent:… --state all --limit 200` — the default
+      returns only 30, which would hide exactly the claims you are looking for):
+      a claim record naming the old
       label will not release the renamed one, so settle or amend those records in
       the same sitting. Re-read `gh label list` afterwards — no `agent:*` should
       remain.

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -217,6 +217,26 @@ this comment. -->
       [project-management.md](project-management.md)). Labels are per-repo, so run
       it in each repo; org default labels (org Settings → Repository, UI-only) only
       seed new repos.
+- [ ] **[human-only] Retire any legacy `agent:*` claim labels** — needed only
+      where `gh label list` still shows the harness-named family
+      (`agent:claude-code`, `agent:gemini-cli`, …) a pre-registry harmon-init
+      seeded. `setup-github-labels` never deletes a label, so the old family
+      survives beside the registry-rendered `claim:*` one, and every reader
+      tolerates both — this is cleanup, not a fix for something broken.
+      **Rename, never re-create**: `gh label edit agent:claude-code --name
+      claim:claude --repo <owner/repo>` edits the label object in place, so every
+      issue and PR carrying it keeps it, where create-then-delete would silently
+      drop those associations. Map by **model family, not harness** —
+      `agent:gemini-cli` → `claim:gemini`, `agent:kimi-k2` → `claim:kimi`,
+      `agent:qwen-code` → `claim:qwen`, `agent:github-copilot` →
+      `claim:copilot` — taking the target names from
+      `node scripts/agent-registry-labels.mjs suggest-claim`. A rename whose
+      target already exists is rejected by GitHub: re-label those issues by hand
+      and delete the empty legacy label instead. Check for in-flight claims first
+      (`gh issue list --label agent:… --state all`): a claim record naming the old
+      label will not release the renamed one, so settle or amend those records in
+      the same sitting. Re-read `gh label list` afterwards — no `agent:*` should
+      remain.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,
       so this is a one-time manual step. Filters/layouts are in

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -451,8 +451,13 @@ in the vendored `track-work` skill.
 > check rather than assume:
 >
 > ```sh
-> grep -rl 'agent:claude-code' .claude/skills/claim/ .claude/skills/wrap/
+> grep -rlE 'claim:claude|agent:claude-code' .claude/skills/claim/ .claude/skills/wrap/
 > ```
+>
+> Both vocabularies are matched on purpose: the skills moved from the retired
+> `agent:*` family to `claim:*` in harmon-devkit v0.23.0, and a pin older than
+> that automates claiming just as well under the old name — so probing for one
+> name alone reports half the supported pins as un-automated.
 >
 > A match means claiming is automated end to end. No match means the claim
 > labels above are applied by hand, and no *skill* will move the card. On an

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -97,14 +97,17 @@ domain:platform|FBCA04|CI, build, test infra, and tooling in this repo
 # are seeded (model-level `suggest:/claim:<family>:<model>` are created on demand).
 #
 # TRANSITION: this stops SEEDING agent:* but never deletes existing labels, so a
-# repo that already has agent:claude-code keeps it (claims still work there). Two
-# follow-ups complete the cutover and are the reason this stays additive: the
-# vendored /claim skill still adds agent:claude-code until harmon-devkit ships the
-# claim:* vocabulary (harmon-init #663, harmon-devkit #321), and live agent:*/stale
-# foreman:* selectors on existing repos are retired by the migration unit (#663),
-# not by a permanent migration here. Do not release this to consumers ahead of the
-# devkit skill migration, or a freshly generated repo will provision claim:* while
-# its /claim skill still looks for agent:claude-code.
+# repo that already has agent:claude-code keeps it and its claims keep working.
+# The skill half of the cutover has shipped: the vendored /claim adds a claim:*
+# label where the repo has that family and falls back to a live agent:* one only
+# where provisioning has not migrated, while /wrap and release-claim.sh recognize
+# BOTH families. That is exactly why this stays additive — seeding claim:* beside
+# a surviving agent:* label strands no in-flight claim either way.
+# What is left is a one-time, per-repo rename of the LIVE labels
+# (`gh label edit agent:<harness> --name claim:<family>`, which preserves issue
+# associations) — a human operator step in docs/CHECKLIST.md, deliberately not a
+# permanent migration in this script. Until an operator runs it, a repo simply
+# carries both families, which the readers above already tolerate.
 labels="$labels
 $(node "$labels_helper" suggest-claim)"
 

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -288,7 +288,9 @@ config, toolchain, devcontainer, and dev environment — against the items below
       `node scripts/agent-registry-labels.mjs suggest-claim`. A rename whose
       target already exists is rejected by GitHub: re-label those issues by hand
       and delete the empty legacy label instead. Check for in-flight claims first
-      (`gh issue list --label agent:… --state all`): a claim record naming the old
+      (`gh issue list --label agent:… --state all --limit 200` — the default
+      returns only 30, which would hide exactly the claims you are looking for):
+      a claim record naming the old
       label will not release the renamed one, so settle or amend those records in
       the same sitting. Re-read `gh label list` afterwards — no `agent:*` should
       remain.

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -273,9 +273,13 @@ config, toolchain, devcontainer, and dev environment — against the items below
       it in each repo; org default labels (org Settings → Repository, UI-only) only
       seed new repos.
 - [ ] **[human-only] Retire any legacy `agent:*` claim labels** — needed only
-      where `gh label list` still shows the harness-named family
+      where `gh label list --limit 200` still shows the harness-named family
       (`agent:claude-code`, `agent:gemini-cli`, …) a pre-registry harmon-init
-      seeded. `setup-github-labels` never deletes a label, so the old family
+      seeded. **Pass an explicit `--limit` to every `gh label list` and
+      `gh issue list` in this step**: both default to 30, the starter set alone
+      is over 40 labels, and an unbounded read reports a clean repo — or a
+      finished migration — while legacy labels and in-flight claims remain.
+      `setup-github-labels` never deletes a label, so the old family
       survives beside the registry-rendered `claim:*` one, and every reader
       tolerates both — this is cleanup, not a fix for something broken.
       **Rename, never re-create**: `gh label edit agent:claude-code --name
@@ -288,12 +292,10 @@ config, toolchain, devcontainer, and dev environment — against the items below
       `node scripts/agent-registry-labels.mjs suggest-claim`. A rename whose
       target already exists is rejected by GitHub: re-label those issues by hand
       and delete the empty legacy label instead. Check for in-flight claims first
-      (`gh issue list --label agent:… --state all --limit 200` — the default
-      returns only 30, which would hide exactly the claims you are looking for):
-      a claim record naming the old
-      label will not release the renamed one, so settle or amend those records in
-      the same sitting. Re-read `gh label list` afterwards — no `agent:*` should
-      remain.
+      (`gh issue list --label agent:… --state all --limit 200`): a claim record
+      naming the old label will not release the renamed one, so settle or amend
+      those records in the same sitting. Re-read `gh label list --limit 200`
+      afterwards — no `agent:*` should remain.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,
       so this is a one-time manual step. Filters/layouts are in

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -272,6 +272,26 @@ config, toolchain, devcontainer, and dev environment — against the items below
       [project-management.md](project-management.md)). Labels are per-repo, so run
       it in each repo; org default labels (org Settings → Repository, UI-only) only
       seed new repos.
+- [ ] **[human-only] Retire any legacy `agent:*` claim labels** — needed only
+      where `gh label list` still shows the harness-named family
+      (`agent:claude-code`, `agent:gemini-cli`, …) a pre-registry harmon-init
+      seeded. `setup-github-labels` never deletes a label, so the old family
+      survives beside the registry-rendered `claim:*` one, and every reader
+      tolerates both — this is cleanup, not a fix for something broken.
+      **Rename, never re-create**: `gh label edit agent:claude-code --name
+      claim:claude --repo <owner/repo>` edits the label object in place, so every
+      issue and PR carrying it keeps it, where create-then-delete would silently
+      drop those associations. Map by **model family, not harness** —
+      `agent:gemini-cli` → `claim:gemini`, `agent:kimi-k2` → `claim:kimi`,
+      `agent:qwen-code` → `claim:qwen`, `agent:github-copilot` →
+      `claim:copilot` — taking the target names from
+      `node scripts/agent-registry-labels.mjs suggest-claim`. A rename whose
+      target already exists is rejected by GitHub: re-label those issues by hand
+      and delete the empty legacy label instead. Check for in-flight claims first
+      (`gh issue list --label agent:… --state all`): a claim record naming the old
+      label will not release the renamed one, so settle or amend those records in
+      the same sitting. Re-read `gh label list` afterwards — no `agent:*` should
+      remain.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,
       so this is a one-time manual step. Filters/layouts are in

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -275,10 +275,11 @@ config, toolchain, devcontainer, and dev environment — against the items below
 - [ ] **[human-only] Retire any legacy `agent:*` claim labels** — needed only
       where `gh label list --limit 200` still shows the harness-named family
       (`agent:claude-code`, `agent:gemini-cli`, …) a pre-registry harmon-init
-      seeded. **Pass an explicit `--limit` to every `gh label list` and
-      `gh issue list` in this step**: both default to 30, the starter set alone
-      is over 40 labels, and an unbounded read reports a clean repo — or a
-      finished migration — while legacy labels and in-flight claims remain.
+      seeded. **Pass an explicit `--limit` to every `gh label list`,
+      `gh issue list`, and `gh pr list` in this step**: all three default to 30,
+      the starter set alone is over 40 labels, and an unbounded read reports a
+      clean repo — or a finished migration — while legacy labels, in-flight
+      claims, and labelled pull requests remain.
       `setup-github-labels` never deletes a label, so the old family
       survives beside the registry-rendered `claim:*` one, and every reader
       tolerates both — this is cleanup, not a fix for something broken.
@@ -295,10 +296,10 @@ config, toolchain, devcontainer, and dev environment — against the items below
       pull requests too and `gh issue list` never returns them, so deleting the
       legacy label afterwards would drop exactly the associations the re-labelling
       missed — the loss this whole item exists to avoid. Check for in-flight
-      claims first (`gh issue list --label agent:… --state all --limit 200`,
-      plus the `gh pr list` equivalent): a claim record naming the old label will
-      not release the renamed one, so settle or amend those records in the same
-      sitting. Re-read `gh label list --limit 200` afterwards — no `agent:*`
+      claims first — `gh issue list --label agent:… --state all --limit 200`
+      **and** `gh pr list --label agent:… --state all --limit 200`: a claim
+      record naming the old label will not release the renamed one, so settle or
+      amend those records in the same sitting. Re-read `gh label list --limit 200` afterwards — no `agent:*`
       should remain.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -290,12 +290,16 @@ config, toolchain, devcontainer, and dev environment — against the items below
       `agent:qwen-code` → `claim:qwen`, `agent:github-copilot` →
       `claim:copilot` — taking the target names from
       `node scripts/agent-registry-labels.mjs suggest-claim`. A rename whose
-      target already exists is rejected by GitHub: re-label those issues by hand
-      and delete the empty legacy label instead. Check for in-flight claims first
-      (`gh issue list --label agent:… --state all --limit 200`): a claim record
-      naming the old label will not release the renamed one, so settle or amend
-      those records in the same sitting. Re-read `gh label list --limit 200`
-      afterwards — no `agent:*` should remain.
+      target already exists is rejected by GitHub — migrate that one by hand,
+      and enumerate **`gh pr list` as well as `gh issue list`**: labels apply to
+      pull requests too and `gh issue list` never returns them, so deleting the
+      legacy label afterwards would drop exactly the associations the re-labelling
+      missed — the loss this whole item exists to avoid. Check for in-flight
+      claims first (`gh issue list --label agent:… --state all --limit 200`,
+      plus the `gh pr list` equivalent): a claim record naming the old label will
+      not release the renamed one, so settle or amend those records in the same
+      sitting. Re-read `gh label list --limit 200` afterwards — no `agent:*`
+      should remain.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,
       so this is a one-time manual step. Filters/layouts are in

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -519,8 +519,13 @@ with no closing keyword, an unmerged fork PR), are in
 > its own schedule, via the automated devkit-release sync:
 >
 > ```sh
-> grep -rl 'agent:claude-code' .claude/skills/claim/ .claude/skills/wrap/
+> grep -rlE 'claim:claude|agent:claude-code' .claude/skills/claim/ .claude/skills/wrap/
 > ```
+>
+> Both vocabularies are matched on purpose: the skills moved from the retired
+> `agent:*` family to `claim:*` in harmon-devkit v0.23.0, and a pin older than
+> that automates claiming just as well under the old name — so probing for one
+> name alone reports half the supported pins as un-automated.
 >
 > A match means claiming is automated end to end. No match means the claim
 > labels above are yours to apply by hand, and no *skill* will move the card.

--- a/template/docs/architecture/ci-cd.md.jinja
+++ b/template/docs/architecture/ci-cd.md.jinja
@@ -41,7 +41,7 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
 [% if claim_release_available %]
 - `claim-release.yml` — on `issues closed` and on `pull_request closed`
   **unmerged**, releases the claim markers an agent session left on an issue
-  (assignee, `agent:*` label, and the `Claiming —` comment's supersede). It
+  (assignee, `claim:*` label, and the `Claiming —` comment's supersede). It
   holds `issues: write` and parses attacker-writable comment bodies, so it
   always checks out the **default branch** and never a PR head. It only wires
   events to `release-claim.sh` in the vendored `track-work` skill, so it

--- a/template/docs/architecture/ci-cd.md.jinja
+++ b/template/docs/architecture/ci-cd.md.jinja
@@ -41,7 +41,8 @@ plus an aggregate **`verify`** job; branch protection requires `verify` +
 [% if claim_release_available %]
 - `claim-release.yml` — on `issues closed` and on `pull_request closed`
   **unmerged**, releases the claim markers an agent session left on an issue
-  (assignee, `claim:*` label, and the `Claiming —` comment's supersede). It
+  (assignee, `claim:*` label — or a legacy `agent:*` one, both of which
+  `release-claim.sh` accepts — and the `Claiming —` comment's supersede). It
   holds `issues: write` and parses attacker-writable comment bodies, so it
   always checks out the **default branch** and never a PR head. It only wires
   events to `release-claim.sh` in the vendored `track-work` skill, so it

--- a/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
@@ -97,14 +97,17 @@ domain:platform|FBCA04|CI, build, test infra, and tooling in this repo
 # are seeded (model-level `suggest:/claim:<family>:<model>` are created on demand).
 #
 # TRANSITION: this stops SEEDING agent:* but never deletes existing labels, so a
-# repo that already has agent:claude-code keeps it (claims still work there). Two
-# follow-ups complete the cutover and are the reason this stays additive: the
-# vendored /claim skill still adds agent:claude-code until harmon-devkit ships the
-# claim:* vocabulary (harmon-init #663, harmon-devkit #321), and live agent:*/stale
-# foreman:* selectors on existing repos are retired by the migration unit (#663),
-# not by a permanent migration here. Do not release this to consumers ahead of the
-# devkit skill migration, or a freshly generated repo will provision claim:* while
-# its /claim skill still looks for agent:claude-code.
+# repo that already has agent:claude-code keeps it and its claims keep working.
+# The skill half of the cutover has shipped: the vendored /claim adds a claim:*
+# label where the repo has that family and falls back to a live agent:* one only
+# where provisioning has not migrated, while /wrap and release-claim.sh recognize
+# BOTH families. That is exactly why this stays additive — seeding claim:* beside
+# a surviving agent:* label strands no in-flight claim either way.
+# What is left is a one-time, per-repo rename of the LIVE labels
+# (`gh label edit agent:<harness> --name claim:<family>`, which preserves issue
+# associations) — a human operator step in docs/CHECKLIST.md, deliberately not a
+# permanent migration in this script. Until an operator runs it, a repo simply
+# carries both families, which the readers above already tolerate.
 labels="$labels
 $(node "$labels_helper" suggest-claim)"
 


### PR DESCRIPTION
## What

Finishes the *shipped-prose* half of the claim-vocabulary transition, and
prepares — but does not execute — the live `agent:*` → `claim:*` label rename.

- `scripts/setup-github-labels.sh` (+ its byte-identical template twin) — rewrite
  the `TRANSITION` comment. It still claimed the vendored `/claim` skill "still
  adds `agent:claude-code` until harmon-devkit ships the `claim:*` vocabulary",
  and told a maintainer not to release ahead of that migration. harmon-devkit
  **v0.23.0** shipped it and both layers already pin and vendor it (the pin is
  now v0.23.1, a later release of the same vocabulary), so the comment was
  guarding against a world that no longer exists. The new text
  justifies the additive stance by what is actually true — every vendored reader
  tolerates both families — and names the one remaining step (the live rename)
  as an operator task.
- `docs/CHECKLIST.md` (+ jinja twin) — a new `[human-only]` operator item for
  retiring legacy `agent:*` labels in any repo that has them, using the
  association-preserving `gh label edit --name` rename and the registry for the
  target names. This is the reusable form of the runbook below; the runbook is
  this repository's instance of it.
- `docs/project-management.md` (+ jinja twin) — one fix: the "is claiming
  automated?" probe still grepped the vendored skills for `agent:claude-code`
  alone, so a v0.23.0+ pin (which uses `claim:claude`) would be reported as
  *not* automated. It now matches either vocabulary.
- `template/docs/architecture/ci-cd.md.jinja` — `claim-release.yml` releases a
  `claim:*` label, not an `agent:*` one.

**Rebased onto #697.** That PR (the sibling `Agent`-field unit) landed the
broader `agent:*` → `claim:*`/`suggest:*` re-key of `project-management.md`
while this branch was in review, including the transition callout that points
here. Everything this branch had duplicated there was dropped in the rebase
rather than re-resolved, leaving only the skills-probe correction that #697 did
not cover — see the conflict note below.

The `claude-*` workflow trigger labels and the wider taxonomy documentation pass
are deliberately untouched — they belong to their own units.

## Why

`agent-registry.json` and `agent-registry-labels.mjs` already make `claim:*` the
seeded live-claim vocabulary, and `test:registry-drift` fails on any rendered
`agent:*` label. What was left was the provisioning script's own comments — the
last place still instructing a maintainer to hold the release for a devkit
migration that has already shipped — plus a stale skills probe, and the absence
of any written procedure for the live rename this issue exists to perform.

## Verification

- `task verify` — green after the rebase. 93 verbatim root↔template twins
  byte-identical, 195 rendered sections present in the root layer, all six
  render profiles (minimal / iac / meta / full / webapp / web) PASS.
- `task verify:skills` — green against the `v0.23.1` pin (skills **and** agents).
- `task ci` — green (verify + skills drift + devcontainer assert + security).
- `PR_TITLE=… BASE_SHA=main task guard:release-title` — releasing type, ok.
- `check-closing-keywords.sh` over the title, body, and commits — no closing
  keywords, so merging this cannot close the issue while its `[HUMAN]` criteria
  are open.
- No live label write of any kind was performed by this branch.

### Evidence for the `[CI]` acceptance criteria (all three ticked on the issue)

1. **Pins** — root `.skills-sync.yaml` and
   `template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja` read the
   **same** tag, `ref: v0.23.1`. The claim vocabulary landed in v0.23.0 (devkit
   #321, session suite on `claim:*`; devkit #320, registry-aligned
   `standardize-repo` catalog), and v0.23.1 is a later release of the same line,
   so the criterion's "same released tag containing devkit #320 and #321" holds.
   The tag moved from v0.23.0 to v0.23.1 mid-review when #704 landed on `main`;
   this branch was rebased onto it and the pins were re-read after the rebase,
   not carried over from the earlier check.
2. **Vendored vocabulary + legacy compat** — `.claude/skills` at that pin uses
   `claim:*` and documents the compatibility explicitly:
   `track-work/assets/release-claim.sh` accepts *both* families in
   `valid_label()` (`agent:* | claim:*`) and its legacy `yes` record fallback
   sweeps "every live `agent:*` AND `claim:*` label";
   `track-work/references/claim-lifecycle.md` records the transition contract;
   `/claim` prefers `claim:<family>` and falls back to a live `agent:*` label
   where provisioning has not migrated. `task verify:skills` is green.
3. **Drift + render matrix** — `test:dogfood-parity`, `test:dogfood-structure`,
   `test:registry-drift`, and the six-profile `test:template` matrix all pass
   inside `task verify` above.
## Live label migration runbook (operator steps — [HUMAN])

Prepared, not executed. This PR performs **no** live label write. Running the
steps below satisfies the two `[HUMAN]` acceptance criteria on the issue; the
three `[CI]` ones are already ticked from this branch.

`REPO=evanharmon1/harmon-init` throughout.

### Why rename instead of create-and-delete

`gh label edit <old> --name <new>` is `PATCH /repos/{owner}/{repo}/labels/{name}`:
it mutates the **same label object**, so every issue and PR that carries it keeps
carrying it under the new name. Create-then-delete would instead detach the label
from every issue it was on — the exact loss the acceptance criterion forbids.
`gh label edit` takes `--name`, `--color`, and `--description`; only `--name` is
needed here, because the legacy colour is already `006B75`, which is what
`agent-registry-labels.mjs` renders for the `claim:` family (`COLOR_CLAIM`).

### 1. Pre-checks

```sh
REPO=evanharmon1/harmon-init

# a. Snapshot the current label set (keep this output).
gh label list --repo "$REPO" --limit 200 --json name,color,description > labels-before.json

# b. No target name may already exist — GitHub rejects a rename onto an
#    existing label with a validation error, stopping the run part-way.
gh label list --repo "$REPO" --limit 200 --json name \
  --jq '[.[].name] | map(select(startswith("claim:") or startswith("suggest:")))'
#    Expected: []   (verified empty 2026-08-09)
#    If it is NOT empty, stop: the affected pair cannot be renamed. Move its
#    issues AND pull requests onto the surviving label by hand before deleting
#    the legacy one — `gh issue list` does not return PRs, so an issues-only
#    sweep followed by a delete is exactly how associations get lost.

# c. What carries each legacy label (association evidence, before + after).
#    BOTH commands: labels apply to pull requests too, and `gh issue list`
#    never returns them.
for l in agent:claude-code agent:codex agent:deepseek agent:gemini-cli \
         agent:github-copilot agent:glm agent:kimi-k2 agent:qwen-code; do
  printf '%s issues=' "$l"
  gh issue list --repo "$REPO" --label "$l" --state all --limit 200 \
    --json number --jq '[.[].number] | join(", ")'
  printf '%s prs=' "$l"
  gh pr list --repo "$REPO" --label "$l" --state all --limit 200 \
    --json number --jq '[.[].number] | join(", ")'
done
#    Observed 2026-08-09:  agent:claude-code -> issues 662, 663, no PRs;
#    every other legacy label -> no issues and no PRs.

# d. Confirm the target names against the registry, not against this document.
node scripts/agent-registry-labels.mjs suggest-claim
```

### 2. Mapping — legacy live label → registry `claim:<family>`

Targets come from `agent-registry.json` via
`node scripts/agent-registry-labels.mjs suggest-claim`; the registry is
authoritative and this table only records the reasoning per label.

| Legacy live label | Carried by (issues + PRs) | New name | Why (registry evidence) |
|---|---|---|---|
| `agent:claude-code` | **662, 663** | `claim:claude` | Old name was the **harness** (`harnesses[].slug: claude-code`, "Claude Code CLI"). Claims are keyed on the model family; that harness's `family_constraint` is `fixed → claude`, and `families[].slug: claude`. |
| `agent:codex` | — | `claim:codex` | Family slug is already `codex` (display `OpenAI Codex`); the `codex-cli` harness is fixed to it. Shape unchanged, description changes. |
| `agent:deepseek` | — | `claim:deepseek` | Already family-named; `families[].slug: deepseek`. |
| `agent:gemini-cli` | — | `claim:gemini` | Old name carried a harness suffix. The registry has no `gemini-cli` harness at all — Gemini's harness is `antigravity` (`fixed → gemini`) — so the `-cli` segment named a tool that no longer exists in the vocabulary. Family slug is `gemini`. |
| `agent:github-copilot` | — | `claim:copilot` | Old name was the **product**. Family slug is `copilot` (display `GitHub Copilot`), harness `copilot-cli`. The display name keeps "GitHub"; the slug does not. |
| `agent:glm` | — | `claim:glm` | Already family-named. Model-level `claim:glm:5-2` exists in the registry but is created on demand, never seeded. |
| `agent:kimi-k2` | — | `claim:kimi` | Old name pinned a **model** (`k2`). Family-level is the seeded scope, so the family slug `kimi` is the target. The registry's current Kimi model is `k3`, so carrying `k2` forward would pin a model the registry no longer lists; model pinning, if ever wanted, is `claim:kimi:k3` created on demand. |
| `agent:qwen-code` | — | `claim:qwen` | Old name was the harness (`harnesses[].slug: qwen-code`, "Qwen Code CLI"). Family slug is `qwen` (model `coder` → `claim:qwen:coder` on demand). |

`claim:minimax` has no legacy counterpart — the `minimax` family is new in the
registry and is seeded in step 5, not renamed.

### 3. The renames

Association-preserving, one label per command, safe to run one at a time:

```sh
REPO=evanharmon1/harmon-init

gh label edit agent:codex          --name claim:codex     --repo "$REPO"
gh label edit agent:deepseek       --name claim:deepseek   --repo "$REPO"
gh label edit agent:gemini-cli     --name claim:gemini     --repo "$REPO"
gh label edit agent:github-copilot --name claim:copilot    --repo "$REPO"
gh label edit agent:glm            --name claim:glm        --repo "$REPO"
gh label edit agent:kimi-k2        --name claim:kimi       --repo "$REPO"
gh label edit agent:qwen-code      --name claim:qwen       --repo "$REPO"

# Left for last so it sits next to the one hazard in this migration — step 4.
# (Ordering is presentational; the rename itself is independent of the others.)
gh label edit agent:claude-code    --name claim:claude     --repo "$REPO"
```

Descriptions are intentionally not passed: step 5 reconciles every one of them
from the registry in a single run.

### 4. The two in-flight claims on `agent:claude-code` (662, 663)

Renaming a label under a live claim is safe for the **label** — issues 662 and
663 keep it, now reading `claim:claude`. It is not automatically safe for the
**claim record**, and that is the one ordering hazard in this migration:

- Both claim comments carry a v1 record whose line is
  `` `agent:` label added by this claim: agent:claude-code ``.
- `release-claim.sh` (vendored, v0.23.0) parses that value to exactly
  `agent:claude-code` (`extract_value` takes the first whitespace token), then
  removes the label **only if it is still applied**:
  `if jq -e --arg l "$label_added" '.labels[] | select(.name == $l)'`.
- After the rename that test fails — the issue carries `claim:claude`, not
  `agent:claude-code` — so the release removes nothing and still posts the
  `Claim released —` supersede comment. That is precisely the stranded-marker
  outcome the script's own header warns about: "posting it over a surviving
  marker would tell every future sweep the claim is settled while stale state
  remains." `/wrap` has the same shape (it removes "the exact label the record
  says the claim added").
- The legacy `yes` fallback is **not** affected — it sweeps every live
  `agent:*` *and* `claim:*` label — but neither of these two records uses it.

Waiting the hazard out is not available: issue 663 is this migration, so its own
claim is live while the rename happens. Pick one of these, per issue:

**Option A (preferred) — amend the record to name the new label.** The record is
the contract; making it true again fixes both `/wrap` and the workflow release.
The comment author (repo owner) stays the same, so the trust gate is unaffected.

Preview first — this prints the amended body and writes nothing:

```sh
REPO=evanharmon1/harmon-init
NEWLINE='- `claim:` label added by this claim: claim:claude (renamed from agent:claude-code by this migration)'

for n in 662 663; do
  cid=$(gh api "repos/$REPO/issues/$n/comments" \
        --jq 'map(select(.body | startswith("Claiming —"))) | last | .id')
  echo "== $n (comment $cid) =="
  gh api "repos/$REPO/issues/comments/$cid" --jq .body \
    | sed "s|^- \`agent:\` label added by this claim: .*\$|$NEWLINE|"
done
```

Dry-run output verified on 2026-08-09 — both records become
`` - `claim:` label added by this claim: claim:claude (renamed from agent:claude-code by this migration) ``,
which `extract_value` parses to exactly `claim:claude` (it takes the first
whitespace token, so the parenthetical is inert). The whole line is replaced
rather than the substring, so 663's long trailing justification — which
predicted this rename — does not survive as self-contradicting prose; GitHub
keeps the original in the comment's edit history.

When the preview looks right, add the write:

```sh
  ... | gh api "repos/$REPO/issues/comments/$cid" -X PATCH -F 'body=@-'
```

Then re-read one comment and confirm the record line reads `claim:claude`.

**Option B — remove the stranded label by hand.** If you would rather not touch
the comments, remove the renamed label yourself when each claim is settled:
`gh issue edit <n> --repo "$REPO" --remove-label claim:claude`. This works, but
it is a reminder you have to keep: the automated release will report success
with the label still applied.

### 5. Seed the rest of the registry vocabulary

The renames cover only the eight labels that already existed. The advisory
`suggest:*` family, `claim:minimax`, and the corrected descriptions on the
renamed labels all come from one idempotent run (`gh label create --force` is
create-or-update, so it fixes the descriptions the rename left behind — e.g.
`claim:kimi` still says "Claimed by Kimi K2" until this runs):

```sh
task setup:github-labels        # registry-driven since the label-rendering unit
```

This is an operator step, not part of this PR.

### 6. Post-checks (the two `[HUMAN]` acceptance criteria)

```sh
REPO=evanharmon1/harmon-init

# a. No agent:* labels remain.
gh label list --repo "$REPO" --limit 200 --json name \
  --jq '[.[].name] | map(select(startswith("agent:")))'
#    Expected: []

# b. No retired Claude trigger labels. (Already absent on 2026-08-09 — this
#    verifies absence; creating or retiring them is the trigger-label unit's
#    scope, and .github/workflows/claude-{plan,implement,review}.yml still name
#    them as label_trigger inputs.)
gh label list --repo "$REPO" --limit 200 --json name \
  --jq '[.[].name] | map(select(. == "claude-plan" or . == "claude-implement" or . == "claude-review"))'
#    Expected: []

# c. Associations survived the rename — issues AND pull requests.
gh issue list --repo "$REPO" --label claim:claude --state all --limit 200 \
  --json number,title
gh pr list --repo "$REPO" --label claim:claude --state all --limit 200 \
  --json number,title
#    Expected: exactly the set step 1c recorded for agent:claude-code
#    (issues 662 and 663; no PRs), unchanged.

# d. Every registry claim:/suggest: label exists with the registry's own text.
diff <(node scripts/agent-registry-labels.mjs suggest-claim | sort) \
     <(gh label list --repo "$REPO" --limit 200 --json name,color,description \
        --jq '.[] | select(.name | startswith("claim:") or startswith("suggest:"))
              | [.name, (.color | ascii_upcase), .description] | join("|")' | sort)
#    Expected: no output. A model-level label somebody created on demand
#    (claim:claude:opus) would show as a legitimate extra `>` line — those are
#    never seeded, so the renderer does not know about them.
```

### Rollback

Each rename is reversible with the inverse `gh label edit` (same object, same
associations), and `labels-before.json` from step 1a holds the original names,
colours, and descriptions. Step 5 only adds and updates; it never deletes, so
nothing it does needs undoing.

## Second-model review

| Stage | Rounds | P0 | P1 | P2 | Outcome |
|---|---|---|---|---|---|
| `task challenge` | 1 of 4 | 0 | 0 | 1 | Clean pass on round 1. |
| `task review` | 1 of 4 | 0 | 0 | 0 | Clean pass on round 1; no findings at any priority. |
| Shepherd (Codex cloud, current-head) | 4 of 4 | 0 | 0 | 5 | r1 label-limit; r2 rebase onto #697 (no findings — an external conflict); r3 PR associations + legacy family; r4 `gh pr list` limit + a gating finding filed as follow-up. A fifth finding landed after the cap and was adjudicated without a fix round. |

No P0 or P1 was raised at any stage. Every finding was verified against the
actual command help or the vendored script before being acted on, and each has a
per-thread reply on its own review comment.

**On the shape of the shepherd rounds.** Five of the six findings are about one
sentence — the enumeration bound in the migration checklist item — each round
correctly tightening what the previous round wrote: no `--limit` on
`gh issue list` → none on `gh label list` → PRs missing entirely → `gh pr list`
not named in the rule → `--limit 200` is a cap rather than pagination. That is
the pattern AGENTS.md names ("a round whose findings are all about the previous
round's fix is the tell"), which is what the four-round cap defends against. The
first four were fixed because each was terminal and cheap; the fifth was
adjudicated and filed rather than starting a fifth rewrite of the same line.

| Finding | Priority | Classification | Evidence | Action |
|---|---|---|---|---|
| Legacy-claim scan `gh issue list --label agent:… --state all` has no `--limit`, returns 30, can hide in-flight claims right before the rename that strands their records | P2 (`challenge` r1) | **Confirmed** | `gh issue list --help`: `--limit` defaults to 30. The vendored `claim-lifecycle.md` and `/kickoff` call this out for the same sweep | Fixed — `--limit 200`, both layers. |
| Same unbounded-read problem on `gh label list`, in both the eligibility check and the post-migration verification | P2 (Codex, head `ba18b798bf`) | **Confirmed** | `gh label list --help`: `-L, --limit int … (default 30)`. This repo carries 52 labels; the starter set alone is over 40. The post-migration read is the worse half — it would report the cleanup finished while `agent:*` labels sat past the cutoff | Fixed — rule stated once for the whole item, `--limit 200` on both label reads, both layers. |
| Collision fallback re-labels only *issues* before deleting the legacy label, silently dropping PR associations — contradicting the association-preservation guarantee two sentences above it | P2 (Codex, head `2226932dd5`) | **Confirmed** | GitHub labels apply to PRs; `gh issue list` is "List issues in a GitHub repository" and never returns them | Fixed — enumerate `gh pr list` alongside `gh issue list`, with the reason inline. Also propagated to the runbook's pre-check, collision guidance, and post-check. |
| `claim-release.yml`'s description was narrowed to a `claim:*` label, but `release-claim.sh` accepts and removes **both** families — inaccurate for exactly the transition state this change documents | P2 (Codex, head `2226932dd5`) | **Confirmed** | `release-claim.sh` `valid_label()` accepts `agent:* \| claim:*`; the legacy `yes` fallback sweeps "every live `agent:*` AND `claim:*` label" | Fixed — both families named, with the reason. Root `docs/architecture/ci-cd.md` needs no twin edit: its bullet never enumerated the family. |
| `gh pr list` also defaults to 30, and the limit rule named only the other two commands | P2 (Codex, head `d8f47ac478`) | **Confirmed** | `gh pr list --help`: `-L, --limit int … (default 30)` | Fixed — all three commands named in the rule, PR command spelled out in full. **Noted as a fix-of-a-fix**: it is about the previous round's edit, not the change itself. Terminal (no fourth command), so fixed rather than deferred, and no further self-generated work opened on it. |
| The checklist item is gated `project_management == 'github'`, but `setup:github-labels` renders under `project_management == 'github' or use_foreman` — so the `iac` profile ships the task with no checklist coverage | P2 (Codex, head `d8f47ac478`) | **Confirmed** | `template/Taskfile.yml.jinja:978` vs. the block opening at `template/docs/CHECKLIST.md.jinja:230`; `scripts/test-template.sh` documents `iac` as "the pm=none + use_foreman=true case" and asserts the script renders there | **Filed as evanharmon1/harmon-init#702**, not fixed here. The same gate encloses the *pre-existing* label-seeding item; re-gating only the newer one would leave `iac` told how to retire legacy labels but never told to seed any — half-right in a way that reads as deliberate. |
| `--limit 200` is a result cap, not pagination, so a label with more than 200 associations truncates and the delete drops what the sweep never saw | P2 (Codex, head `65c6c5bda9`) | **Confirmed** | `gh issue list --help`: "Maximum number of issues to fetch"; `gh pr list --help` equivalent | **Filed as evanharmon1/harmon-init#703**, not fixed here — it arrived after the round cap as the fifth consecutive finding on this sentence (see the note above). #703 records both candidate remedies and recommends the cheaper one: a clause telling the operator to raise the limit when a count comes back *at* it, rather than replacing followable one-liners with `gh api --paginate` plumbing. Exposure today is nil: `agent:claude-code` is on 2 issues and 0 PRs, the other seven legacy labels on nothing. |

### Rebase notes

`main` moved twice during this PR's review, and both reconciliations are branch
maintenance rather than shepherd fix rounds — the readiness gate refuses a
`mergeStateStatus` of `DIRTY` or `BEHIND`, so a PR whose base keeps moving must
be allowed to follow it or the gate could never be satisfied.

1. **#697** (the sibling `Agent`-field unit) re-keyed `project-management.md` to
   the `claim:*`/`suggest:*` vocabulary — the same prose this branch had been
   rewriting. GitHub reported `DIRTY` and ran no checks on that head. Resolved by
   rebasing and **taking `main`'s text wholesale** for both
   `project-management.md` layers rather than merging the two rewrites: #697's is
   more thorough and is now the base. Only the piece it did not cover — the
   skills-vocabulary probe — was re-applied on top.
2. **#701, #704, #700** (release 4.23.0) left the branch `BEHIND`. Rebased
   again; no conflicts. #704 bumped the devkit pin from `v0.23.0` to `v0.23.1`,
   so the AC1/AC2 evidence above was re-derived against the new pin rather than
   restated — `task verify:skills` is green at v0.23.1, and the vendored
   legacy-compat quotes were re-read there.

### Relationship to #683

# 683 ("template ci-cd.md.jinja still names the retired `agent:*` label") is
satisfied in substance by the `ci-cd.md.jinja` change here, in the shape its own
AC1 blesses — `claim:*` named, "retaining … a note that legacy `agent:*` claims
are still recognized". Note that its AC3 (`grep -n 'agent:\*'` returns no
output) is in tension with AC1 and with the Codex finding above: keeping the
legacy note means the grep still prints. Left open for Evan to adjudicate and
close rather than auto-closed from here.

## Deferred findings

None outstanding. Every P2 raised against this branch is adjudicated in the
table above — five fixed in place, one filed as
evanharmon1/harmon-init#702 — and `task review` returned no findings at any
priority. Nothing was carried into the shepherd stage from the local loops.

- [x] `docs/CHECKLIST.md` / twin — unbounded `gh issue list` in the legacy-claim scan — fixed in `2a8d4d3`
- [x] `docs/CHECKLIST.md:220` / twin — unbounded `gh label list` in both label reads — fixed in `6da0fcf`
- [x] `docs/CHECKLIST.md:239` / twin — collision fallback drops PR label associations — fixed in `2afe845`
- [x] `template/docs/architecture/ci-cd.md.jinja:44` — legacy `agent:*` family dropped from the claim-release description — fixed in `2afe845`
- [x] `docs/CHECKLIST.md:244` / twin — unbounded `gh pr list` in the PR sweep — fixed in `1f94736`
- [x] `template/docs/CHECKLIST.md.jinja:275` — label items gated github-only while the task renders for `use_foreman` too — filed as evanharmon1/harmon-init#702
- [x] `template/docs/CHECKLIST.md.jinja:300` — `--limit 200` caps rather than paginates the association sweep — filed as evanharmon1/harmon-init#703

The `fixed in` shas are the post-rebase commits this PR currently contains; the
review heads named in the adjudication table (`ba18b798bf`, `2226932dd5`,
`d8f47ac478`, `65c6c5bda9`) are the SHAs Codex actually reviewed and are left as
the historical record.

Orphan sweep: `$(git rev-parse --git-path deferred-findings)` resolves to
`.git/worktrees/agent-a2982048079ebad27/deferred-findings` and does not exist —
no notes were written, and none were stranded under another branch name in this
worktree.

## Refs

Refs #663
Part of #620

Deliberately **not** closing: the two `[HUMAN]` acceptance criteria on the issue
are Evan's to execute and tick.
