### PR TITLE
fix(template): stop forcing CLAUDE_CODE_EFFORT_LEVEL=max in devcontainers

### DIFF
--- a/.devcontainer/config/claude-providers.sh
+++ b/.devcontainer/config/claude-providers.sh
@@ -71,7 +71,6 @@ claude-kimi() {
         export ENABLE_CLAUDEAI_MCP_SERVERS="false"
         export ENABLE_TOOL_SEARCH="false"
         export CLAUDE_CODE_AUTO_COMPACT_WINDOW="1048576"
-        export CLAUDE_CODE_EFFORT_LEVEL="max"
         command claude "$@"
     )
 }
@@ -116,7 +115,6 @@ claude-deepseek() {
         export ANTHROPIC_DEFAULT_FABLE_MODEL="deepseek-v4-pro[1m]"
         export CLAUDE_CODE_SUBAGENT_MODEL="deepseek-v4-flash"
         export ENABLE_CLAUDEAI_MCP_SERVERS="false"
-        export CLAUDE_CODE_EFFORT_LEVEL="max"
         command claude "$@"
     )
 }
@@ -162,7 +160,6 @@ claude-glm() {
         export ENABLE_CLAUDEAI_MCP_SERVERS="false"
         export ENABLE_TOOL_SEARCH="false"
         export CLAUDE_CODE_AUTO_COMPACT_WINDOW="1048576"
-        export CLAUDE_CODE_EFFORT_LEVEL="max"
         export API_TIMEOUT_MS="3000000"
         command claude "$@"
     )

--- a/.devcontainer/dev/devcontainer.json
+++ b/.devcontainer/dev/devcontainer.json
@@ -58,12 +58,6 @@
     "source=shell-history-evanharmon1-harmon-init-dev,target=/home/vscode/.shell-history,type=volume",
     "source=zoxide-data-evanharmon1-harmon-init-dev,target=/home/vscode/.local/share/zoxide,type=volume"
   ],
-  // CLAUDE_CODE_EFFORT_LEVEL: default Claude Code thinking effort. Set here
-  // (not in settings.json) because Claude Code's settings schema only accepts
-  // low|medium|high for the persisted effortLevel field, while the env var
-  // accepts low|medium|high|max. Resolution order at runtime: env var >
-  // settings.json effortLevel > model default.
-  //
   // GITHUB_TOKEN and the enterprise aliases are blanked because dropping
   // GH_TOKEN alone does not finish the job: gh's precedence is GH_TOKEN >
   // GITHUB_TOKEN > GH_ENTERPRISE_TOKEN > GITHUB_ENTERPRISE_TOKEN > the stored
@@ -91,7 +85,6 @@
   "containerEnv": {
     "CODER": "${localEnv:CODER}",
     "DEVCONTAINER_TAILSCALE": "true",
-    "CLAUDE_CODE_EFFORT_LEVEL": "max",
     "GITHUB_TOKEN": "",
     "GH_ENTERPRISE_TOKEN": "",
     "GITHUB_ENTERPRISE_TOKEN": ""

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,17 +57,10 @@
   // when the host shell doesn't export them, which overrides the env-file
   // values (Docker --env takes precedence over --env-file).
   //
-  // CLAUDE_CODE_EFFORT_LEVEL: default Claude Code thinking effort. Set here
-  // (not in settings.json) because Claude Code's settings schema only accepts
-  // low|medium|high for the persisted effortLevel field, while the env var
-  // accepts low|medium|high|max. Resolution order at runtime: env var >
-  // settings.json effortLevel > model default.
-  //
   // FOREMAN_DEVCONTAINER: foreman's D2 startup tripwire — it refuses to run
   // anywhere this marker is not "bot" (only the bot profile sets it).
   "containerEnv": {
     "CODER": "${localEnv:CODER}",
-    "CLAUDE_CODE_EFFORT_LEVEL": "max",
     "AGY_CLI_DISABLE_AUTO_UPDATE": "true",
     "FOREMAN_DEVCONTAINER": "bot"
   },

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -1214,6 +1214,20 @@ else
         ! grep -q 'features/go-task' "$dc_cfg" ||
             err "rendered $dc_cfg installs task via a devcontainer Feature (harmon-init#427)"
     done
+    # No profile or provider wrapper may force CLAUDE_CODE_EFFORT_LEVEL: the
+    # env var outranks Claude Code's settings.json, so a pinned value silently
+    # overrides the user's saved effort and mid-session /model changes. The pin
+    # was removed deliberately; asserted on the rendered output for the same
+    # reason as the go-task Feature above — these twins are jinja, so the
+    # parity gates cannot stop template/ from reintroducing the override while
+    # the root copy stays correct. The providers wrapper renders only when
+    # use_alternative_claude_providers is on, hence the existence guard.
+    for dc_file in .devcontainer/devcontainer.json .devcontainer/dev/devcontainer.json \
+        .devcontainer/config/claude-providers.sh; do
+        [ -f "$dc_file" ] || continue
+        ! grep -q 'CLAUDE_CODE_EFFORT_LEVEL' "$dc_file" ||
+            err "rendered $dc_file forces CLAUDE_CODE_EFFORT_LEVEL — effort selection belongs to Claude Code settings"
+    done
     # The rendered Dockerfile must be a thin consumer of the shared image:
     # exactly the approved immutable tag@digest reference, the overlay
     # installer, and no consumer-side toolchain pins (those live only in

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/[% if use_alternative_claude_providers %]claude-providers.sh[% endif %]
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/[% if use_alternative_claude_providers %]claude-providers.sh[% endif %]
@@ -71,7 +71,6 @@ claude-kimi() {
         export ENABLE_CLAUDEAI_MCP_SERVERS="false"
         export ENABLE_TOOL_SEARCH="false"
         export CLAUDE_CODE_AUTO_COMPACT_WINDOW="1048576"
-        export CLAUDE_CODE_EFFORT_LEVEL="max"
         command claude "$@"
     )
 }
@@ -116,7 +115,6 @@ claude-deepseek() {
         export ANTHROPIC_DEFAULT_FABLE_MODEL="deepseek-v4-pro[1m]"
         export CLAUDE_CODE_SUBAGENT_MODEL="deepseek-v4-flash"
         export ENABLE_CLAUDEAI_MCP_SERVERS="false"
-        export CLAUDE_CODE_EFFORT_LEVEL="max"
         command claude "$@"
     )
 }
@@ -162,7 +160,6 @@ claude-glm() {
         export ENABLE_CLAUDEAI_MCP_SERVERS="false"
         export ENABLE_TOOL_SEARCH="false"
         export CLAUDE_CODE_AUTO_COMPACT_WINDOW="1048576"
-        export CLAUDE_CODE_EFFORT_LEVEL="max"
         export API_TIMEOUT_MS="3000000"
         command claude "$@"
     )

--- a/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
@@ -70,12 +70,6 @@
     "source=shell-history-[[ github_org ]]-[[ project_slug ]]-dev,target=/home/vscode/.shell-history,type=volume",
     "source=zoxide-data-[[ github_org ]]-[[ project_slug ]]-dev,target=/home/vscode/.local/share/zoxide,type=volume"
   ],
-  // CLAUDE_CODE_EFFORT_LEVEL: default Claude Code thinking effort. Set here
-  // (not in settings.json) because Claude Code's settings schema only accepts
-  // low|medium|high for the persisted effortLevel field, while the env var
-  // accepts low|medium|high|max. Resolution order at runtime: env var >
-  // settings.json effortLevel > model default.
-  //
   // GITHUB_TOKEN and the enterprise aliases are blanked because dropping
   // GH_TOKEN alone does not finish the job: gh's precedence is GH_TOKEN >
   // GITHUB_TOKEN > GH_ENTERPRISE_TOKEN > GITHUB_ENTERPRISE_TOKEN > the stored
@@ -103,7 +97,6 @@
   "containerEnv": {
     "CODER": "${localEnv:CODER}",
     "DEVCONTAINER_TAILSCALE": "true",
-    "CLAUDE_CODE_EFFORT_LEVEL": "max",
     "GITHUB_TOKEN": "",
     "GH_ENTERPRISE_TOKEN": "",
     "GITHUB_ENTERPRISE_TOKEN": ""

--- a/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
@@ -69,17 +69,10 @@
   // when the host shell doesn't export them, which overrides the env-file
   // values (Docker --env takes precedence over --env-file).
   //
-  // CLAUDE_CODE_EFFORT_LEVEL: default Claude Code thinking effort. Set here
-  // (not in settings.json) because Claude Code's settings schema only accepts
-  // low|medium|high for the persisted effortLevel field, while the env var
-  // accepts low|medium|high|max. Resolution order at runtime: env var >
-  // settings.json effortLevel > model default.
-  //
   // FOREMAN_DEVCONTAINER: foreman's D2 startup tripwire — it refuses to run
   // anywhere this marker is not "bot" (only the bot profile sets it).
   "containerEnv": {
     "CODER": "${localEnv:CODER}",
-    "CLAUDE_CODE_EFFORT_LEVEL": "max",
 [% if use_antigravity_cli %]
     "AGY_CLI_DISABLE_AUTO_UPDATE": "true",
 [% endif %]


### PR DESCRIPTION
## What

Remove the forced `CLAUDE_CODE_EFFORT_LEVEL: max` from both devcontainer
profiles (`containerEnv`) and from the three alt-provider launcher wrappers
(`claude-kimi` / `claude-deepseek` / `claude-glm`) — root and `template/` twins
edited in lockstep — and add a rendered-output regression assertion so a
parity-preserving edit cannot silently reintroduce the override.

## Why

The env var outranks Claude Code's own `settings.json` resolution, so every
session in these containers ran at **max** effort regardless of the user's
saved `effortLevel` — and mid-session `/model` effort changes printed a
confirmation and then silently never applied. The pin's original rationale
(the settings schema at the time could not persist `max`) no longer justifies
overriding user choice invisibly; effort selection now belongs to Claude
Code's own precedence (`/model`, `settings.json`, model default). Users who
want a pinned effort can still set the env var themselves at launch.

The regression test lives with the other rendered-output assertions in
`scripts/test-template.sh` (§9e) for the same reason as the go-task Feature
check: the devcontainer twins are jinja, so the parity gates cannot catch a
`template/`-only reintroduction.

## Verification

- `task verify` green (full render matrix, including the new absence
  assertion across both profiles and the provider wrapper).
- `task challenge`: 3 rounds. Round-2 P2 (missing regression coverage) fixed
  in `4027689`. The recurring P1 is the cross-repo catalog coordination —
  deferred below with its remediation already prepared; inside this repo the
  vendored copy is sync-managed and must not be hand-edited.
- `task review`: clean round-1 pass (no P0/P1 findings).
- `task ci` green locally.

## Coordination

The `standardize-repo` standards catalog previously **mandated** this pin
(§1.6 bot profile). The canonical fix is harmon-devkit PR https://github.com/evanharmon1/harmon-devkit/pull/353; the
vendored copy and pins in this repo then update through the normal
`bot/sync-harmon-devkit` rolling PR after the next harmon-devkit release.
Merge order is free: `copier update` cannot reintroduce the var (the template
no longer carries it), so the only window is audit-time noise until both land.

## Deferred findings

- [x] `.claude/skills/standardize-repo/references/standards-catalog.md:305` —
  [P1, challenge r1–r3] Vendored catalog still mandates
  `CLAUDE_CODE_EFFORT_LEVEL: max` for the bot profile, so a `standardize-repo`
  AUDIT flags this removal as drift until the catalog ships. Canonical fix:
  harmon-devkit PR https://github.com/evanharmon1/harmon-devkit/pull/353; vendored copy + pins follow via the
  automated `bot/sync-harmon-devkit` PR after the next devkit release.
  Hand-editing the vendored copy is forbidden (`.SKILLS_PROVENANCE` managed).
  Note: an audit can *flag* the removal, but `copier update` cannot *restore*
  it — only the audit-noise half of the finding holds.
  **Disposition:** filed as harmon-devkit#353 (catalog rule rewritten to cover both
  profiles and version-gated to the release containing the removal, so audits of
  older baselines stay correct); the vendored copy re-syncs via the automated
  `bot/sync-harmon-devkit` PR after the next devkit release.

