### PR TITLE
fix: gate project-automation board writes on head repository and reviewDecision

### DIFF
--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -239,7 +239,7 @@ What is automated, and by which of the three:
 | PR opened / pushed to / reopened | **Verifying** | Actions (`project-automation.yml`) |
 | Build run completes without failing | **In Review** | Actions (`project-automation.yml`) — any conclusion outside `failure`/`cancelled`/`timed_out`/`action_required` counts, so `skipped`, `neutral` and `startup_failure` advance the card too |
 | Build run concludes `failure`, `cancelled`, `timed_out` or `action_required` | **Verifying** (stays) | Actions (`project-automation.yml`) |
-| Review submitted as approved | **Ready to Merge** | Actions (`project-automation.yml`) |
+| Review submitted as approved | **Ready to Merge** | Actions (`project-automation.yml`) — only when the PR's head repo is this repository *and* the reviewer's association is `OWNER`, `MEMBER` or `COLLABORATOR` |
 | PR merged | **Done** | Actions (`project-automation.yml`) + built-in |
 | Issue closed, for any reason | *(nothing)* | not automated — see below |
 | PR closed unmerged | *(nothing)* | deliberately not automated |
@@ -270,8 +270,14 @@ the PR body.
 **Only this repository's own branches move the board.** The branch name is the
 routing key and its author chooses it, so a fork pushing `claude/issue-N` would
 otherwise steer issue N's card. Trust comes from the head *repository*
-instead: a `pull_request` or `workflow_run` event whose head repo is not this
-repository is not acted on.
+instead: a `pull_request`, `workflow_run` or `pull_request_review` event whose
+head repo is not this repository is not acted on. The review path carries a
+second condition, because approving is not a repository permission — anyone can
+approve a public PR, while GitHub's own `reviewDecision` counts only required
+reviewers. So an approving review moves the card only when the reviewer's
+`author_association` is `OWNER`, `MEMBER` or `COLLABORATOR`. The board write is
+advisory state and merging stays ruleset-protected either way; this keeps the
+card honest, it is not the merge security.
 
 The status write itself is `continue-on-error`, so a board that cannot be
 written never fails a build. That tolerance starts *after* the App token is

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -239,7 +239,7 @@ What is automated, and by which of the three:
 | PR opened / pushed to / reopened | **Verifying** | Actions (`project-automation.yml`) |
 | Build run completes without failing | **In Review** | Actions (`project-automation.yml`) — any conclusion outside `failure`/`cancelled`/`timed_out`/`action_required` counts, so `skipped`, `neutral` and `startup_failure` advance the card too |
 | Build run concludes `failure`, `cancelled`, `timed_out` or `action_required` | **Verifying** (stays) | Actions (`project-automation.yml`) |
-| Review submitted as approved | **Ready to Merge** | Actions (`project-automation.yml`) — only when the PR's head repo is this repository *and* the reviewer's association is `OWNER`, `MEMBER` or `COLLABORATOR` |
+| Review submitted as approved | **Ready to Merge** | Actions (`project-automation.yml`) — only when the PR's `reviewDecision` is `APPROVED`; head repo and reviewer association are pre-filters |
 | PR merged | **Done** | Actions (`project-automation.yml`) + built-in |
 | Issue closed, for any reason | *(nothing)* | not automated — see below |
 | PR closed unmerged | *(nothing)* | deliberately not automated |
@@ -271,13 +271,22 @@ the PR body.
 routing key and its author chooses it, so a fork pushing `claude/issue-N` would
 otherwise steer issue N's card. Trust comes from the head *repository*
 instead: a `pull_request`, `workflow_run` or `pull_request_review` event whose
-head repo is not this repository is not acted on. The review path carries a
-second condition, because approving is not a repository permission — anyone can
-approve a public PR, while GitHub's own `reviewDecision` counts only required
-reviewers. So an approving review moves the card only when the reviewer's
-`author_association` is `OWNER`, `MEMBER` or `COLLABORATOR`. The board write is
-advisory state and merging stays ruleset-protected either way; this keeps the
-card honest, it is not the merge security.
+head repo is not this repository is not acted on. On the review path that test — plus a reviewer
+`author_association` of `OWNER`, `MEMBER` or `COLLABORATOR` — is only a
+pre-filter, keeping fork events and drive-by approvals from consuming a runner
+and minting the App token. It is not the authorization: association is not a
+permission, and `MEMBER` / `COLLABORATOR` include read-only and triage access.
+
+**Ready to Merge is written only when the PR's `reviewDecision` is `APPROVED`.**
+The event says somebody approved; `reviewDecision` is GitHub's own computation
+of whether the PR *is* approved — required reviewers honoured, dismissals and
+stale reviews accounted for — which is exactly what the status means. Any other
+value logs and writes nothing. That includes an **empty** decision, which is
+what GitHub returns when no required-review rule exists at all, even after a
+genuine approval: this repository's ruleset requires code-owner review, so an
+empty value means the rule is missing rather than the PR being approved. The
+board write is advisory state and merging stays ruleset-protected either way;
+this keeps the card honest, it is not the merge security.
 
 The status write itself is `continue-on-error`, so a board that cannot be
 written never fails a build. That tolerance starts *after* the App token is

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -459,7 +459,12 @@ full)
     # Approving is not a repo permission, so Ready to Merge also needs a trusted reviewer.
     grep -q "github.event.review.author_association" \
         .github/workflows/project-automation.yml ||
-        err "project-automation.yml lost the review author_association trust check"
+        err "project-automation.yml lost the review author_association pre-filter"
+    # The real authorization: association is not permission, so the write itself
+    # requires GitHub's own reviewDecision to say the PR is approved.
+    grep -q 'REVIEW_DECISION" != "APPROVED"' \
+        .github/workflows/project-automation.yml ||
+        err "project-automation.yml lost the reviewDecision==APPROVED authorization check"
     ;;
 meta)
     [ -f .github/workflows/snyk-scheduled.yml ] || err "daily Snyk workflow did not render"

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -449,6 +449,17 @@ full)
     grep -q "workflow_run.head_repository.full_name == github.repository" \
         .github/workflows/project-automation.yml ||
         err "project-automation.yml lost the workflow_run head-repository fork guard"
+    # Same boundary on the review path: a fork PR's review must not move the card.
+    review_clause=$(grep -A1 "github.event_name != 'pull_request_review' ||" \
+        .github/workflows/project-automation.yml || true)
+    case "$review_clause" in
+    *"pull_request.head.repo.full_name == github.repository"*) ;;
+    *) err "project-automation.yml lost the pull_request_review head-repository fork guard" ;;
+    esac
+    # Approving is not a repo permission, so Ready to Merge also needs a trusted reviewer.
+    grep -q "github.event.review.author_association" \
+        .github/workflows/project-automation.yml ||
+        err "project-automation.yml lost the review author_association trust check"
     ;;
 meta)
     [ -f .github/workflows/snyk-scheduled.yml ] || err "daily Snyk workflow did not render"

--- a/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
@@ -15,14 +15,25 @@ on:
 jobs:
   sync-status:
     name: Sync project status
-    # Trust boundary. `workflow_run` fires for fork-backed runs too, and this job
-    # derives the issue from the head BRANCH NAME — which the fork author picks.
-    # Without the head-repository test, a fork pushing `claude/issue-N` moves
-    # issue N's card using the App token. The head repo is what establishes
-    # trust; the branch name never can. (Deliberate tightening, approved.)
+    # Trust boundary. `workflow_run` and `pull_request_review` fire for
+    # fork-backed PRs too, and this job derives the issue from the head BRANCH
+    # NAME — which the fork author picks. Without the head-repository test, a
+    # fork pushing `claude/issue-N` moves issue N's card using the App token.
+    # Trust comes from the head repository — and, on the review path, the
+    # reviewer's association — never from the event alone; the branch name can
+    # never establish it. The review path also needs the association test
+    # because it advances the card to Ready to Merge on ANY approving review,
+    # while GitHub's own `reviewDecision` honours only required reviewers: a
+    # drive-by approval from an unrelated account must not move the board.
+    # The board write is advisory state and the merge itself stays
+    # ruleset-protected — this guard makes the card honest, it is not the
+    # merge security. (Deliberate tightening, approved.)
     if: >-
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       (github.event_name != 'workflow_run' || github.event.workflow_run.head_repository.full_name == github.repository) &&
+      (github.event_name != 'pull_request_review' ||
+       (github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))) &&
       ((github.event_name == 'pull_request') ||
        (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
        (github.event_name == 'workflow_run'))

--- a/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
+++ b/template/.github/workflows/[% if github_org != author_git_provider_username %]project-automation.yml[% endif %].jinja
@@ -19,15 +19,20 @@ jobs:
     # fork-backed PRs too, and this job derives the issue from the head BRANCH
     # NAME — which the fork author picks. Without the head-repository test, a
     # fork pushing `claude/issue-N` moves issue N's card using the App token.
-    # Trust comes from the head repository — and, on the review path, the
-    # reviewer's association — never from the event alone; the branch name can
-    # never establish it. The review path also needs the association test
-    # because it advances the card to Ready to Merge on ANY approving review,
-    # while GitHub's own `reviewDecision` honours only required reviewers: a
-    # drive-by approval from an unrelated account must not move the board.
+    # Trust comes from the head repository, never from the event alone; the
+    # branch name can never establish it. (Deliberate tightening, approved.)
+    #
+    # These are cheap PRE-FILTERS, not the authorization. They keep fork events
+    # and drive-by approvals from consuming a runner and minting the App token
+    # at all. `author_association` in particular is NOT a permission —
+    # MEMBER/COLLABORATOR includes read-only org members and triage
+    # collaborators — so the review path's real authorization lives in the
+    # resolve step, which requires the PR's `reviewDecision` to be APPROVED
+    # before writing Ready to Merge.
+    #
     # The board write is advisory state and the merge itself stays
-    # ruleset-protected — this guard makes the card honest, it is not the
-    # merge security. (Deliberate tightening, approved.)
+    # ruleset-protected either way — these guards make the card honest, they
+    # are not the merge security.
     if: >-
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       (github.event_name != 'workflow_run' || github.event.workflow_run.head_repository.full_name == github.repository) &&
@@ -66,6 +71,7 @@ jobs:
           ACTION: ${{ github.event.action }}
           MERGED: ${{ github.event.pull_request.merged }}
           REVIEW_STATE: ${{ github.event.review.state }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           BRANCH_PR: ${{ github.event.pull_request.head.ref }}
           BRANCH_WF: ${{ github.event.workflow_run.head_branch }}
           SHA_WF: ${{ github.event.workflow_run.head_sha }}
@@ -87,6 +93,28 @@ jobs:
               ;;
             pull_request_review)
               BRANCH="$BRANCH_PR"
+              # Authorization for this path. The event only says SOMEBODY
+              # approved; `reviewDecision` is GitHub's own computation of
+              # whether the PR *is* approved — required reviewers honoured,
+              # dismissals and stale reviews accounted for — which is exactly
+              # what Ready to Merge ("approved, awaiting merge") means. The
+              # job-level association filter cannot stand in for it: MEMBER and
+              # COLLABORATOR include read-only and triage access, whose
+              # approvals never satisfy reviewDecision. Readable with the App
+              # token minted above: reviewDecision is a field of the PR object,
+              # covered by permission-pull-requests: read.
+              REVIEW_DECISION=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+                --json reviewDecision --jq '.reviewDecision' 2>/dev/null || true)
+              if [ "$REVIEW_DECISION" != "APPROVED" ]; then
+                # Empty is the residual case: with no required-review rule,
+                # GitHub computes no decision at all, even after an approval.
+                # Generated repos' ruleset requires code-owner review, so an
+                # empty value means the rule is missing rather than the PR
+                # being approved — deliberately no write, so Ready to Merge
+                # keeps meaning ruleset-approved.
+                echo "reviewDecision=${REVIEW_DECISION:-<none: required reviews not configured>} is not APPROVED, skipping"
+                exit 0
+              fi
               # Approved but not yet merged — Done is reserved for the merge event
               TARGET_STATUS="Ready to Merge"
               ;;

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -255,7 +255,7 @@ What is automated, and by which of the three:
 | PR opened / pushed to / reopened | **Verifying** | Actions (`project-automation.yml`) |
 | Build run completes without failing | **In Review** | Actions (`project-automation.yml`) — any conclusion outside `failure`/`cancelled`/`timed_out`/`action_required` counts, so `skipped`, `neutral` and `startup_failure` advance the card too |
 | Build run concludes `failure`, `cancelled`, `timed_out` or `action_required` | **Verifying** (stays) | Actions (`project-automation.yml`) |
-| Review submitted as approved | **Ready to Merge** | Actions (`project-automation.yml`) — only when the PR's head repo is this repository *and* the reviewer's association is `OWNER`, `MEMBER` or `COLLABORATOR` |
+| Review submitted as approved | **Ready to Merge** | Actions (`project-automation.yml`) — only when the PR's `reviewDecision` is `APPROVED`; head repo and reviewer association are pre-filters |
 | PR merged | **Done** | Actions (`project-automation.yml`) + built-in |
 [% else %]
 | Review requested on a PR | **In Review** | built-in workflow |
@@ -289,13 +289,22 @@ issue from the PR's `claude/issue-N` branch name or a `Closes` / `Fixes` /
 routing key and its author chooses it, so a fork pushing `claude/issue-N` would
 otherwise steer issue N's card. Trust comes from the head *repository*
 instead: a `pull_request`, `workflow_run` or `pull_request_review` event whose
-head repo is not this repository is not acted on. The review path carries a
-second condition, because approving is not a repository permission — anyone can
-approve a public PR, while GitHub's own `reviewDecision` counts only required
-reviewers. So an approving review moves the card only when the reviewer's
-`author_association` is `OWNER`, `MEMBER` or `COLLABORATOR`. The board write is
-advisory state and merging stays ruleset-protected either way; this keeps the
-card honest, it is not the merge security.
+head repo is not this repository is not acted on. On the review path that test — plus a reviewer
+`author_association` of `OWNER`, `MEMBER` or `COLLABORATOR` — is only a
+pre-filter, keeping fork events and drive-by approvals from consuming a runner
+and minting the App token. It is not the authorization: association is not a
+permission, and `MEMBER` / `COLLABORATOR` include read-only and triage access.
+
+**Ready to Merge is written only when the PR's `reviewDecision` is `APPROVED`.**
+The event says somebody approved; `reviewDecision` is GitHub's own computation
+of whether the PR *is* approved — required reviewers honoured, dismissals and
+stale reviews accounted for — which is exactly what the status means. Any other
+value logs and writes nothing. That includes an **empty** decision, which is
+what GitHub returns when no required-review rule exists at all, even after a
+genuine approval: this repository's ruleset requires code-owner review, so an
+empty value means the rule is missing rather than the PR being approved. The
+board write is advisory state and merging stays ruleset-protected either way;
+this keeps the card honest, it is not the merge security.
 
 The status write itself is `continue-on-error`, so a board that cannot be
 written never fails a build. That tolerance starts *after* the App token is

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -255,7 +255,7 @@ What is automated, and by which of the three:
 | PR opened / pushed to / reopened | **Verifying** | Actions (`project-automation.yml`) |
 | Build run completes without failing | **In Review** | Actions (`project-automation.yml`) — any conclusion outside `failure`/`cancelled`/`timed_out`/`action_required` counts, so `skipped`, `neutral` and `startup_failure` advance the card too |
 | Build run concludes `failure`, `cancelled`, `timed_out` or `action_required` | **Verifying** (stays) | Actions (`project-automation.yml`) |
-| Review submitted as approved | **Ready to Merge** | Actions (`project-automation.yml`) |
+| Review submitted as approved | **Ready to Merge** | Actions (`project-automation.yml`) — only when the PR's head repo is this repository *and* the reviewer's association is `OWNER`, `MEMBER` or `COLLABORATOR` |
 | PR merged | **Done** | Actions (`project-automation.yml`) + built-in |
 [% else %]
 | Review requested on a PR | **In Review** | built-in workflow |
@@ -288,8 +288,14 @@ issue from the PR's `claude/issue-N` branch name or a `Closes` / `Fixes` /
 **Only this repository's own branches move the board.** The branch name is the
 routing key and its author chooses it, so a fork pushing `claude/issue-N` would
 otherwise steer issue N's card. Trust comes from the head *repository*
-instead: a `pull_request` or `workflow_run` event whose head repo is not this
-repository is not acted on.
+instead: a `pull_request`, `workflow_run` or `pull_request_review` event whose
+head repo is not this repository is not acted on. The review path carries a
+second condition, because approving is not a repository permission — anyone can
+approve a public PR, while GitHub's own `reviewDecision` counts only required
+reviewers. So an approving review moves the card only when the reviewer's
+`author_association` is `OWNER`, `MEMBER` or `COLLABORATOR`. The board write is
+advisory state and merging stays ruleset-protected either way; this keeps the
+card honest, it is not the merge security.
 
 The status write itself is `continue-on-error`, so a board that cannot be
 written never fails a build. That tolerance starts *after* the App token is


### PR DESCRIPTION
## What

Closes the fork-review board-write gap in `project-automation.yml` (template-only, org-gated — no root twin), in two layers of defense:

- **Pre-filters in the job `if:`** — a `pull_request_review` event is skipped outright unless the PR's head repository is this repository *and* the reviewer's `author_association` is OWNER/MEMBER/COLLABORATOR. These stop fork-backed and drive-by events from consuming a runner or minting the App token; they are deliberately not the authorization (`author_association` is not a permission — MEMBER/COLLABORATOR include read-only principals).
- **Authorization in the resolve step** — `Ready to Merge` is written only when the PR's actual `reviewDecision` is `APPROVED`: GitHub's own computation of required-review satisfaction, the same one the merge gate reads, so the card and the ruleset can no longer disagree. `REVIEW_REQUIRED`, `CHANGES_REQUESTED`, and *empty* all log and exit without a write — empty means no required-review rule exists (generated repos' rulesets require code-owner review, so empty means the rule is missing, not that the PR is approved).

Both doc layers' trust paragraph and `Ready to Merge` automations row state the new conditions, and full-profile render assertions pin all three `if:` clauses plus the `reviewDecision` check (the review-path head-repo pin is context-anchored so the identical `pull_request`-clause text can't satisfy it).

## Why

Found while shipping the `workflow_run` fork guard in #727: on a public org repo, any account could approve a fork PR (or drive-by-approve an in-repo one) and push its board card to `Ready to Merge` via the App token. The board write is advisory state and the merge itself stays ruleset-protected — this makes the card honest; it is not the merge security.

## Verification

- `task verify` green (render matrix actionlints the rendered org-profile workflow).
- `task challenge`: round 1 found one P1 (association ≠ permission — the fix that moved authorization to `reviewDecision`); round 2 clean with zero findings at any severity.
- `task review`: round 1 clean.
- `task ci` (full mirror) green.
- App-token permissions unchanged: `pull-requests: read` covers the `reviewDecision` read.

## Deferred findings

None — both review stages exited with nothing deferred.

Closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)
