### PR TITLE
feat: refresh agent registry for 2026 model lineups, gpt/mai renames, qwen wrappers, broker harnesses

### DIFF
--- a/.devcontainer/config/claude-providers.sh
+++ b/.devcontainer/config/claude-providers.sh
@@ -10,8 +10,10 @@
 # by setting ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN (+ per-tier model env vars) in
 # a subshell, leaving the parent shell untouched. The API key is read from the env
 # (the devcontainer env-file: KIMI_API_KEY/MOONSHOT_API_KEY, DEEPSEEK_API_KEY,
-# ZAI_API_KEY); if absent, it falls back to `op run` against
+# ZAI_API_KEY, QWEN_API_KEY); if absent, it falls back to `op run` against
 # $CLAUDE_PROVIDERS_ENV_FILE (dev profile only — the bot has no 1Password CLI).
+# claude-qwen-local is the exception: it targets a LOCAL Anthropic-compatible
+# endpoint (Ollama/LM Studio), so it needs no secret at all.
 #
 # CONTAINER ADAPTATIONS vs the host wrappers:
 #   1. The `op run` re-exec re-sources THIS file's baked path
@@ -58,7 +60,7 @@ claude-kimi() {
     fi
 
     (
-        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY
+        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY
         unset CLAUDE_PROVIDERS_OP_RUN_ACTIVE
         export ANTHROPIC_BASE_URL="https://api.moonshot.ai/anthropic"
         export ANTHROPIC_AUTH_TOKEN="$api_key"
@@ -104,7 +106,7 @@ claude-deepseek() {
     fi
 
     (
-        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY
+        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY
         unset CLAUDE_PROVIDERS_OP_RUN_ACTIVE
         export ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
         export ANTHROPIC_AUTH_TOKEN="$api_key"
@@ -147,7 +149,7 @@ claude-glm() {
     fi
 
     (
-        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY
+        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY
         unset CLAUDE_PROVIDERS_OP_RUN_ACTIVE
         export ANTHROPIC_BASE_URL="https://api.z.ai/api/anthropic"
         export ANTHROPIC_AUTH_TOKEN="$api_key"
@@ -161,6 +163,79 @@ claude-glm() {
         export ENABLE_TOOL_SEARCH="false"
         export CLAUDE_CODE_AUTO_COMPACT_WINDOW="1048576"
         export API_TIMEOUT_MS="3000000"
+        command claude "$@"
+    )
+}
+
+# Launch Claude Code with Qwen3.7-Max for the main/reasoning roles and
+# Qwen3-Coder-Plus for the coding/subagent roles, without changing the parent
+# shell environment. Uses an existing QWEN_API_KEY, otherwise loads it from
+# $CLAUDE_PROVIDERS_ENV_FILE through `op run` (dev profile only — bot has no op).
+claude-qwen() {
+    local api_key="${QWEN_API_KEY:-}"
+    local provider_env_file="${CLAUDE_PROVIDERS_ENV_FILE:-$HOME/.config/claude-providers.env}"
+
+    if [ -z "$api_key" ]; then
+        if [ "${CLAUDE_PROVIDERS_OP_RUN_ACTIVE:-}" = "1" ]; then
+            echo "claude-qwen: $provider_env_file did not provide QWEN_API_KEY" >&2
+            return 1
+        fi
+        if ! command -v op >/dev/null 2>&1; then
+            echo "claude-qwen: op is not installed and QWEN_API_KEY is not set" >&2
+            return 1
+        fi
+        if [ ! -r "$provider_env_file" ]; then
+            echo "claude-qwen: cannot read $provider_env_file" >&2
+            return 1
+        fi
+
+        CLAUDE_PROVIDERS_OP_RUN_ACTIVE=1 \
+            op run --no-masking --env-file="$provider_env_file" -- "${SHELL:-/bin/zsh}" -c \
+            'source /usr/local/share/devcontainer-config/claude-providers.sh; claude-qwen "$@"' -- "$@"
+        return
+    fi
+
+    (
+        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY
+        unset CLAUDE_PROVIDERS_OP_RUN_ACTIVE
+        export ANTHROPIC_BASE_URL="https://dashscope.aliyuncs.com/api/anthropic"
+        export ANTHROPIC_AUTH_TOKEN="$api_key"
+        export ANTHROPIC_MODEL="qwen3.7-max"
+        export ANTHROPIC_DEFAULT_OPUS_MODEL="qwen3.7-max"
+        export ANTHROPIC_DEFAULT_FABLE_MODEL="qwen3.7-max"
+        export ANTHROPIC_DEFAULT_SONNET_MODEL="qwen3-coder-plus"
+        export ANTHROPIC_DEFAULT_HAIKU_MODEL="qwen3-coder-plus"
+        export CLAUDE_CODE_SUBAGENT_MODEL="qwen3-coder-plus"
+        export ENABLE_CLAUDEAI_MCP_SERVERS="false"
+        export ENABLE_TOOL_SEARCH="false"
+        export CLAUDE_CODE_AUTO_COMPACT_WINDOW="1048576"
+        command claude "$@"
+    )
+}
+
+# Launch Claude Code against a LOCAL Anthropic-compatible endpoint (Ollama or
+# LM Studio) serving qwen3-coder:30b, without changing the parent shell
+# environment. No provider secret is required — this is a local-only lane —
+# but ANTHROPIC_AUTH_TOKEN must still be non-empty for the SDK, so a
+# placeholder value is sent; it is meaningless to a local endpoint, and no
+# real secret is ever read or exported by this function. Set
+# QWEN_LOCAL_BASE_URL to point at a non-default host/port (defaults to
+# Ollama's local Anthropic-compatible route).
+claude-qwen-local() {
+    local base_url="${QWEN_LOCAL_BASE_URL:-http://localhost:11434/anthropic}"
+
+    (
+        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY
+        unset CLAUDE_PROVIDERS_OP_RUN_ACTIVE
+        export ANTHROPIC_BASE_URL="$base_url"
+        export ANTHROPIC_AUTH_TOKEN="local"
+        export ANTHROPIC_MODEL="qwen3-coder:30b"
+        export ANTHROPIC_DEFAULT_OPUS_MODEL="qwen3-coder:30b"
+        export ANTHROPIC_DEFAULT_SONNET_MODEL="qwen3-coder:30b"
+        export ANTHROPIC_DEFAULT_HAIKU_MODEL="qwen3-coder:30b"
+        export ANTHROPIC_DEFAULT_FABLE_MODEL="qwen3-coder:30b"
+        export CLAUDE_CODE_SUBAGENT_MODEL="qwen3-coder:30b"
+        export ENABLE_CLAUDEAI_MCP_SERVERS="false"
         command claude "$@"
     )
 }

--- a/.devcontainer/config/claude-providers.sh
+++ b/.devcontainer/config/claude-providers.sh
@@ -234,10 +234,12 @@ claude-qwen() {
 # QWEN_LOCAL_BASE_URL directly; it always overrides either default. On native
 # Linux the DNS mapping alone is not enough: stock Ollama binds
 # 127.0.0.1:11434, which is loopback-only and unreachable from the container
-# even once host.docker.internal resolves — set OLLAMA_HOST=0.0.0.0 (a
-# systemd override for the `ollama` service, or the env var before `ollama
-# serve`) so it listens on every interface, or point QWEN_LOCAL_BASE_URL at a
-# reachable one.
+# even once host.docker.internal resolves. Do NOT bind 0.0.0.0 — Ollama has no
+# auth, so that exposes it to the whole LAN. Instead set
+# OLLAMA_HOST=<docker0-bridge-IP> (`ip addr show docker0`, typically
+# 172.17.0.1) to scope it to the Docker bridge, or firewall 11434 to that
+# bridge if it must stay on 0.0.0.0 for other reasons — or point
+# QWEN_LOCAL_BASE_URL at an already-reachable endpoint.
 #
 # No /anthropic (or other) path suffix on the default: unlike the hosted
 # wrappers below, Ollama's and LM Studio's Anthropic-compatible servers expose

--- a/.devcontainer/config/claude-providers.sh
+++ b/.devcontainer/config/claude-providers.sh
@@ -218,11 +218,24 @@ claude-qwen() {
 # environment. No provider secret is required — this is a local-only lane —
 # but ANTHROPIC_AUTH_TOKEN must still be non-empty for the SDK, so a
 # placeholder value is sent; it is meaningless to a local endpoint, and no
-# real secret is ever read or exported by this function. Set
-# QWEN_LOCAL_BASE_URL to point at a non-default host/port (defaults to
-# Ollama's local Anthropic-compatible route).
+# real secret is ever read or exported by this function.
+#
+# The default HOST is chosen, not hardcoded: "localhost" inside a container
+# resolves to the container itself, not the developer's machine, where Ollama/
+# LM Studio actually listen — but this file also sources un-containerized (the
+# host wrappers), where "localhost" IS correct. So the default probes for
+# host.docker.internal (Docker Desktop resolves it out of the box; a Linux
+# container needs `--add-host=host.docker.internal:host-gateway` on the
+# container run, which the devcontainer JSON would need to set) and only falls
+# back to "localhost" when that name does not resolve. QWEN_LOCAL_BASE_URL
+# always overrides either default — set it directly if neither guess reaches
+# your endpoint.
 claude-qwen-local() {
-    local base_url="${QWEN_LOCAL_BASE_URL:-http://localhost:11434/anthropic}"
+    local default_host="localhost"
+    if command -v getent >/dev/null 2>&1 && getent hosts host.docker.internal >/dev/null 2>&1; then
+        default_host="host.docker.internal"
+    fi
+    local base_url="${QWEN_LOCAL_BASE_URL:-http://${default_host}:11434/anthropic}"
 
     (
         unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY

--- a/.devcontainer/config/claude-providers.sh
+++ b/.devcontainer/config/claude-providers.sh
@@ -231,13 +231,25 @@ claude-qwen() {
 # primary path resolves there even on native Linux (Docker Desktop resolves it
 # without any mapping). Outside those profiles — a hand-rolled `docker run`, a
 # different devcontainer config — add the same --add-host yourself, or just set
-# QWEN_LOCAL_BASE_URL directly; it always overrides either default.
+# QWEN_LOCAL_BASE_URL directly; it always overrides either default. On native
+# Linux the DNS mapping alone is not enough: stock Ollama binds
+# 127.0.0.1:11434, which is loopback-only and unreachable from the container
+# even once host.docker.internal resolves — set OLLAMA_HOST=0.0.0.0 (a
+# systemd override for the `ollama` service, or the env var before `ollama
+# serve`) so it listens on every interface, or point QWEN_LOCAL_BASE_URL at a
+# reachable one.
+#
+# No /anthropic (or other) path suffix on the default: unlike the hosted
+# wrappers below, Ollama's and LM Studio's Anthropic-compatible servers expose
+# /v1/messages etc. from the SERVER ROOT, and the Claude Code SDK appends that
+# API path to ANTHROPIC_BASE_URL itself — a base URL ending in /anthropic here
+# would double up to /anthropic/v1/messages and 404.
 claude-qwen-local() {
     local default_host="localhost"
     if command -v getent >/dev/null 2>&1 && getent hosts host.docker.internal >/dev/null 2>&1; then
         default_host="host.docker.internal"
     fi
-    local base_url="${QWEN_LOCAL_BASE_URL:-http://${default_host}:11434/anthropic}"
+    local base_url="${QWEN_LOCAL_BASE_URL:-http://${default_host}:11434}"
 
     (
         unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY

--- a/.devcontainer/config/claude-providers.sh
+++ b/.devcontainer/config/claude-providers.sh
@@ -224,12 +224,14 @@ claude-qwen() {
 # resolves to the container itself, not the developer's machine, where Ollama/
 # LM Studio actually listen — but this file also sources un-containerized (the
 # host wrappers), where "localhost" IS correct. So the default probes for
-# host.docker.internal (Docker Desktop resolves it out of the box; a Linux
-# container needs `--add-host=host.docker.internal:host-gateway` on the
-# container run, which the devcontainer JSON would need to set) and only falls
-# back to "localhost" when that name does not resolve. QWEN_LOCAL_BASE_URL
-# always overrides either default — set it directly if neither guess reaches
-# your endpoint.
+# host.docker.internal and only falls back to "localhost" when that name does
+# not resolve. Both shipped devcontainer profiles
+# (.devcontainer/devcontainer.json, .devcontainer/dev/devcontainer.json) add
+# `--add-host=host.docker.internal:host-gateway` to runArgs, so the probe's
+# primary path resolves there even on native Linux (Docker Desktop resolves it
+# without any mapping). Outside those profiles — a hand-rolled `docker run`, a
+# different devcontainer config — add the same --add-host yourself, or just set
+# QWEN_LOCAL_BASE_URL directly; it always overrides either default.
 claude-qwen-local() {
     local default_host="localhost"
     if command -v getent >/dev/null 2>&1 && getent hosts host.docker.internal >/dev/null 2>&1; then

--- a/.devcontainer/dev/devcontainer.env.example
+++ b/.devcontainer/dev/devcontainer.env.example
@@ -7,3 +7,4 @@ AGENT_DECK_TELEGRAM_KEY=example-changeme
 KIMI_API_KEY=example-changeme
 DEEPSEEK_API_KEY=example-changeme
 ZAI_API_KEY=example-changeme
+QWEN_API_KEY=example-changeme

--- a/.devcontainer/dev/devcontainer.json
+++ b/.devcontainer/dev/devcontainer.json
@@ -35,6 +35,12 @@
     "--init",
     "--shm-size=2g",
     "--device=/dev/net/tun",
+    // Linux hosts don't resolve host.docker.internal by default (unlike Docker
+    // Desktop on mac/win/WSL2); this mapping makes it resolve everywhere,
+    // which claude-qwen-local() (.devcontainer/config/claude-providers.sh)
+    // relies on to reach an Ollama/LM Studio endpoint on the host. Supported
+    // since Docker 20.10, harmless where the platform already resolves it.
+    "--add-host=host.docker.internal:host-gateway",
     "--env-file",
     ".devcontainer/dev/devcontainer.env"
   ],

--- a/.devcontainer/dev/devcontainer.json
+++ b/.devcontainer/dev/devcontainer.json
@@ -30,7 +30,7 @@
   // Alternative-model provider keys (KIMI/DEEPSEEK/ZAI) are opt-in via
   // use_alternative_claude_providers; when on they land in this env-file so the
   // claude-kimi/deepseek/glm wrappers (and the op fallback) work here.
-  "initializeCommand": "bash .devcontainer/scripts/init-env.sh .devcontainer/dev/devcontainer.env TS_AUTHKEY CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY",
+  "initializeCommand": "bash .devcontainer/scripts/init-env.sh .devcontainer/dev/devcontainer.env TS_AUTHKEY CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY",
   "runArgs": [
     "--init",
     "--shm-size=2g",

--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -7,3 +7,4 @@ AGENT_DECK_TELEGRAM_KEY=example-changeme
 KIMI_API_KEY=example-changeme
 DEEPSEEK_API_KEY=example-changeme
 ZAI_API_KEY=example-changeme
+QWEN_API_KEY=example-changeme

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
   // Alternative-model provider keys (KIMI/DEEPSEEK/ZAI) are opt-in via
   // use_alternative_claude_providers; when on they land in this env-file too,
   // so a headless/bypass bot can read them — a deliberate posture extension.
-  "initializeCommand": "bash .devcontainer/scripts/init-env.sh .devcontainer/devcontainer.env GH_TOKEN FOREMAN_AGENT_GH_TOKEN CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY",
+  "initializeCommand": "bash .devcontainer/scripts/init-env.sh .devcontainer/devcontainer.env GH_TOKEN FOREMAN_AGENT_GH_TOKEN CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY",
   "runArgs": [
     "--init",
     "--shm-size=2g",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,6 +27,12 @@
   "runArgs": [
     "--init",
     "--shm-size=2g",
+    // Linux hosts don't resolve host.docker.internal by default (unlike Docker
+    // Desktop on mac/win/WSL2); this mapping makes it resolve everywhere,
+    // which claude-qwen-local() (.devcontainer/config/claude-providers.sh)
+    // relies on to reach an Ollama/LM Studio endpoint on the host. Supported
+    // since Docker 20.10, harmless where the platform already resolves it.
+    "--add-host=host.docker.internal:host-gateway",
     "--env-file",
     ".devcontainer/devcontainer.env"
   ],

--- a/.devcontainer/scripts/init-env.sh
+++ b/.devcontainer/scripts/init-env.sh
@@ -59,7 +59,7 @@ shift || true
 # dispatched agents as their GH_TOKEN (required before any dispatch); only
 # the bot profile allow-lists it, so it is evicted from dev/ like GH_TOKEN.
 BASE_MANAGED_VARS=(TS_AUTHKEY GH_TOKEN FOREMAN_AGENT_GH_TOKEN CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY)
-OPT_IN_PROVIDER_KEYS=(KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY)
+OPT_IN_PROVIDER_KEYS=(KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY)
 # KNOWN_VARS: every var this script recognizes. The filter below restricts the
 # caller's allow-list to this set, so a positional arg can't smuggle an unknown
 # var into the env-file. Includes the opt-in keys so an opted-in profile can

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -93,7 +93,7 @@ jobs:
       # issue with no marker saying so, which is the failure both rules exist
       # to prevent. The test is a `claim:`/`agent:` PREFIX, not the exact
       # `claim:claude` string: an exact match would miss the model-pinned
-      # `claim:claude:opus` form, another family's `claim:codex`, and the
+      # `claim:claude:opus` form, another family's `claim:gpt`, and the
       # `agent:*` labels generated repos still carry through the rolling
       # transition. `suggest:*` is deliberately NOT matched — it is advice
       # about who should do the work, never ownership of it. The read asks for

--- a/.github/workflows/claude-plan.yml
+++ b/.github/workflows/claude-plan.yml
@@ -92,7 +92,7 @@ jobs:
       # issue with no marker saying so, which is the failure both rules exist
       # to prevent. The test is a `claim:`/`agent:` PREFIX, not the exact
       # `claim:claude` string: an exact match would miss the model-pinned
-      # `claim:claude:opus` form, another family's `claim:codex`, and the
+      # `claim:claude:opus` form, another family's `claim:gpt`, and the
       # `agent:*` labels generated repos still carry through the rolling
       # transition. `suggest:*` is deliberately NOT matched — it is advice
       # about who should do the work, never ownership of it. The read asks for

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -101,7 +101,7 @@ jobs:
       # issue with no marker saying so, which is the failure both rules exist
       # to prevent. The test is a `claim:`/`agent:` PREFIX, not the exact
       # `claim:claude` string: an exact match would miss the model-pinned
-      # `claim:claude:opus` form, another family's `claim:codex`, and the
+      # `claim:claude:opus` form, another family's `claim:gpt`, and the
       # `agent:*` labels generated repos still carry through the rolling
       # transition. `suggest:*` is deliberately NOT matched — it is advice
       # about who should do the work, never ownership of it. The read asks for

--- a/agent-registry.json
+++ b/agent-registry.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./agent-registry.schema.json",
-  "schema_version": 1,
+  "schema_version": 2,
   "labels": {
     "suggest": {
       "prefix": "suggest",
@@ -20,39 +20,80 @@
       "slug": "claude",
       "display_name": "Claude",
       "models": [
+        { "slug": "fable", "display_name": "Fable" },
         { "slug": "opus", "display_name": "Opus" },
         { "slug": "sonnet", "display_name": "Sonnet" },
         { "slug": "haiku", "display_name": "Haiku" }
       ]
     },
     {
-      "slug": "codex",
-      "display_name": "OpenAI Codex",
+      "slug": "gpt",
+      "display_name": "GPT",
       "models": [
         { "slug": "sol", "display_name": "Sol" },
         { "slug": "terra", "display_name": "Terra" },
         { "slug": "luna", "display_name": "Luna" }
       ]
     },
-    { "slug": "copilot", "display_name": "GitHub Copilot", "models": [] },
+    {
+      "slug": "mai",
+      "display_name": "MAI",
+      "models": [
+        { "slug": "code-1-flash", "display_name": "Code-1-Flash" },
+        { "slug": "thinking-1", "display_name": "Thinking-1" }
+      ]
+    },
     {
       "slug": "qwen",
       "display_name": "Qwen",
-      "models": [{ "slug": "coder", "display_name": "Coder" }]
+      "models": [
+        { "slug": "max", "display_name": "3.7 Max" },
+        { "slug": "coder-plus", "display_name": "3 Coder Plus" },
+        { "slug": "coder", "display_name": "3 Coder" },
+        { "slug": "coder-next", "display_name": "3 Coder Next" },
+        { "slug": "coder-30b", "display_name": "3 Coder 30B" }
+      ]
     },
-    { "slug": "deepseek", "display_name": "DeepSeek", "models": [] },
+    {
+      "slug": "deepseek",
+      "display_name": "DeepSeek",
+      "models": [
+        { "slug": "v4-pro", "display_name": "V4 Pro" },
+        { "slug": "v4-flash", "display_name": "V4 Flash" }
+      ]
+    },
     {
       "slug": "glm",
       "display_name": "GLM",
-      "models": [{ "slug": "5-2", "display_name": "5.2" }]
+      "models": [
+        { "slug": "5-2", "display_name": "5.2" },
+        { "slug": "4-7-flash", "display_name": "4.7 Flash" }
+      ]
     },
     {
       "slug": "kimi",
       "display_name": "Kimi",
       "models": [{ "slug": "k3", "display_name": "K3" }]
     },
-    { "slug": "minimax", "display_name": "MiniMax", "models": [] },
-    { "slug": "gemini", "display_name": "Gemini", "models": [] }
+    {
+      "slug": "minimax",
+      "display_name": "MiniMax",
+      "models": [{ "slug": "m3", "display_name": "M3" }]
+    },
+    {
+      "slug": "gemini",
+      "display_name": "Gemini",
+      "models": [
+        { "slug": "3-1-pro", "display_name": "3.1 Pro" },
+        { "slug": "3-6-flash", "display_name": "3.6 Flash" },
+        { "slug": "3-5-flash-lite", "display_name": "3.5 Flash-Lite" }
+      ]
+    },
+    {
+      "slug": "mistral",
+      "display_name": "Mistral",
+      "models": [{ "slug": "devstral-small-2", "display_name": "Devstral Small 2" }]
+    }
   ],
   "harnesses": [
     {
@@ -122,13 +163,35 @@
       "provider_rewired": true
     },
     {
+      "slug": "claude-code-qwen",
+      "display_name": "Claude Code with Qwen",
+      "product": "Claude Code provider wrapper",
+      "family_constraint": { "kind": "fixed", "family": "qwen" },
+      "model_resolution": {
+        "owner": "provider-wrapper",
+        "details": "The provider-rewired wrapper fixes the family; per-role model env vars select Qwen3.7-Max for the main/reasoning roles and Qwen3-Coder-Plus for the coding/subagent roles."
+      },
+      "provider_rewired": true
+    },
+    {
+      "slug": "claude-code-qwen-local",
+      "display_name": "Claude Code with Qwen (local)",
+      "product": "Claude Code provider wrapper",
+      "family_constraint": { "kind": "fixed", "family": "qwen" },
+      "model_resolution": {
+        "owner": "provider-wrapper",
+        "details": "The provider-rewired wrapper points at a local Anthropic-compatible endpoint (Ollama or LM Studio) serving qwen3-coder:30b."
+      },
+      "provider_rewired": true
+    },
+    {
       "slug": "codex-cli",
       "display_name": "OpenAI Codex CLI",
       "product": "OpenAI Codex CLI",
-      "family_constraint": { "kind": "fixed", "family": "codex" },
+      "family_constraint": { "kind": "fixed", "family": "gpt" },
       "model_resolution": {
         "owner": "runner-config",
-        "details": "The runner or CLI invocation selects the Codex model."
+        "details": "The runner or CLI invocation selects the GPT model."
       },
       "provider_rewired": false
     },
@@ -136,10 +199,10 @@
       "slug": "copilot-cli",
       "display_name": "GitHub Copilot CLI",
       "product": "GitHub Copilot CLI",
-      "family_constraint": { "kind": "fixed", "family": "copilot" },
+      "family_constraint": { "kind": "broker", "default_family": "mai" },
       "model_resolution": {
-        "owner": "runner-config",
-        "details": "The runner or Copilot configuration selects the model."
+        "owner": "harness-runtime",
+        "details": "Copilot's picker selects among MAI and brokered third-party models at runtime."
       },
       "provider_rewired": false
     },
@@ -169,7 +232,7 @@
       "slug": "opencode",
       "display_name": "OpenCode",
       "product": "OpenCode",
-      "family_constraint": { "kind": "none" },
+      "family_constraint": { "kind": "broker" },
       "model_resolution": {
         "owner": "harness-runtime",
         "details": "The multi-provider harness selects both provider family and model at runtime."
@@ -180,7 +243,29 @@
       "slug": "pi",
       "display_name": "Pi",
       "product": "Pi",
-      "family_constraint": { "kind": "none" },
+      "family_constraint": { "kind": "broker" },
+      "model_resolution": {
+        "owner": "harness-runtime",
+        "details": "The multi-provider harness selects both provider family and model at runtime."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "goose",
+      "display_name": "Goose",
+      "product": "Block Goose",
+      "family_constraint": { "kind": "broker" },
+      "model_resolution": {
+        "owner": "harness-runtime",
+        "details": "The multi-provider harness selects both provider family and model at runtime."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "cline",
+      "display_name": "Cline",
+      "product": "Cline",
+      "family_constraint": { "kind": "broker" },
       "model_resolution": {
         "owner": "harness-runtime",
         "details": "The multi-provider harness selects both provider family and model at runtime."

--- a/agent-registry.schema.json
+++ b/agent-registry.schema.json
@@ -7,7 +7,7 @@
   "required": ["$schema", "schema_version", "labels", "families", "harnesses", "foreman_adapters"],
   "properties": {
     "$schema": { "const": "./agent-registry.schema.json" },
-    "schema_version": { "const": 1 },
+    "schema_version": { "const": 2 },
     "labels": {
       "type": "object",
       "additionalProperties": false,
@@ -82,8 +82,9 @@
       "additionalProperties": false,
       "required": ["kind"],
       "properties": {
-        "kind": { "enum": ["fixed", "none"] },
-        "family": { "$ref": "#/$defs/slug" }
+        "kind": { "enum": ["fixed", "broker"] },
+        "family": { "$ref": "#/$defs/slug" },
+        "default_family": { "$ref": "#/$defs/slug" }
       }
     },
     "modelResolution": {

--- a/copier.yml
+++ b/copier.yml
@@ -289,18 +289,22 @@ use_antigravity_cli:
 use_alternative_claude_providers:
   type: bool
   help: >-
-    ALT MODELS: Add claude-kimi / claude-deepseek / claude-glm wrapper functions
-    that launch Claude Code against alternative Anthropic-compatible model
-    providers (Moonshot Kimi K3, DeepSeek V4, Z.AI GLM-5.2)? Each requires an
-    account + a PAID per-token API key (KIMI_API_KEY/MOONSHOT_API_KEY,
-    DEEPSEEK_API_KEY, ZAI_API_KEY) supplied via the devcontainer env-file — there
+    ALT MODELS: Add claude-kimi / claude-deepseek / claude-glm / claude-qwen
+    wrapper functions that launch Claude Code against alternative
+    Anthropic-compatible model providers (Moonshot Kimi K3, DeepSeek V4, Z.AI
+    GLM-5.2, Alibaba Qwen3.7-Max/Qwen3-Coder-Plus)? Each requires an account +
+    a PAID per-token API key (KIMI_API_KEY/MOONSHOT_API_KEY, DEEPSEEK_API_KEY,
+    ZAI_API_KEY, QWEN_API_KEY) supplied via the devcontainer env-file — there
     is no guaranteed free tier, only limited trial credit that may be offered at
     signup (verify current terms at each provider). DATA-HANDLING: each wrapper
-    sends your prompts and code to that third party (Moonshot, DeepSeek, or
-    Z.AI), so for private/proprietary repos review each provider's data-retention
-    and model-training policy before opting in. The wrappers are inert without
-    keys. Routes the keys into BOTH bot and dev env-files: the bot runs
-    bypassPermissions, so a headless agent there can read them.
+    sends your prompts and code to that third party (Moonshot, DeepSeek, Z.AI,
+    or Alibaba), so for private/proprietary repos review each provider's
+    data-retention and model-training policy before opting in. A local Qwen
+    lane (claude-qwen-local) is also included, targeting your own
+    Ollama/LM Studio endpoint — no third party or key involved there. The
+    wrappers are inert without keys. Routes the keys into BOTH bot and dev
+    env-files: the bot runs bypassPermissions, so a headless agent there can
+    read them.
   default: no
   when: "[[ devcontainer ]]"
 

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -239,9 +239,23 @@ this comment. -->
       `agent:gemini-cli` → `claim:gemini`, `agent:kimi-k2` → `claim:kimi`,
       `agent:qwen-code` → `claim:qwen`, `agent:github-copilot` →
       `claim:mai` — taking the target names from
-      `node scripts/agent-registry-labels.mjs suggest-claim`. A rename whose
-      target already exists is rejected by GitHub — migrate that one by hand,
-      and enumerate **`gh pr list` as well as `gh issue list`**: labels apply to
+      `node scripts/agent-registry-labels.mjs suggest-claim`.
+      **Destination-collision procedure**: a rename whose target already
+      exists is rejected by GitHub (`gh label edit` errors: the destination
+      name is already in use — e.g. `claim:claude` already exists from a prior
+      `setup-github-labels` run). When that happens, migrate ASSOCIATIONS
+      instead of the label object: for every issue and PR carrying the old
+      label, add the destination label and remove the old one
+      (`gh issue edit <number> --add-label claim:claude --remove-label
+      agent:claude-code --repo <owner/repo>`; the same `--add-label
+      X --remove-label Y` pair works on `gh pr edit`), then delete the
+      now-empty old label (`gh label delete agent:claude-code --repo
+      <owner/repo> --yes`) once a re-read of `gh issue list --label
+      agent:claude-code --state all --limit 200` **and** the equivalent
+      `gh pr list` both return nothing — only then is it safe to delete; the
+      other checklist items below that reference this procedure reuse it
+      verbatim. Enumerate **`gh pr list` as well as `gh issue list`**
+      throughout, collision or not: labels apply to
       pull requests too and `gh issue list` never returns them, so deleting the
       legacy label afterwards would drop exactly the associations the re-labelling
       missed — the loss this whole item exists to avoid. Check for in-flight
@@ -261,7 +275,13 @@ this comment. -->
       `agent:*` item above: `gh label edit suggest:codex --name suggest:gpt
       --repo <owner/repo>` (repeat for `claim:codex`, `suggest:copilot`,
       `claim:copilot` → `suggest:mai`/`claim:mai`), which preserves issue/PR
-      associations instead of dropping them. Check for in-flight claims first
+      associations instead of dropping them. **If the destination already
+      exists** — a `setup-github-labels` re-run already created `suggest:gpt`/
+      `claim:mai` before this cleanup runs — `gh label edit` is rejected the
+      same way; use the **destination-collision procedure from the `agent:*`
+      item above** (add the new label to every issue/PR carrying the old one,
+      remove the old, then delete the old label once empty) instead of trying
+      to rename over it. Check for in-flight claims first
       — `gh issue list --label claim:codex --state all --limit 200` **and**
       `gh pr list --label claim:codex --state all --limit 200` (repeat for
       `claim:copilot`) — and settle or amend any that name the old label
@@ -284,8 +304,13 @@ this comment. -->
       per label before renaming it
       (`gh issue list --label suggest:codex:sol --state all --limit 200` /
       `gh pr list --label suggest:codex:sol --state all --limit 200`, one pair
-      per label found). Re-run the `grep` above afterwards — it should return
-      nothing.
+      per label found). **Collisions use the same destination-collision
+      procedure too** — a model-level label can already exist for the same
+      reason a family-level one can (an on-demand `suggest:gpt:sol` created
+      before this cleanup ran) — migrate associations from `suggest:codex:sol`
+      to `suggest:gpt:sol` and delete `suggest:codex:sol` once it carries no
+      issues or PRs, rather than renaming over the existing one. Re-run the
+      `grep` above afterwards — it should return nothing.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,
       so this is a one-time manual step. Filters/layouts are in

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -268,6 +268,24 @@ this comment. -->
       before renaming it out from under them. Re-read `gh label list --limit
       200` afterwards — no `suggest:codex`/`claim:codex`/`suggest:copilot`/
       `claim:copilot` should remain.
+      **Also check for model-level labels naming the old family** —
+      `suggest:codex:<model>` / `claim:codex:<model>` /
+      `suggest:copilot:<model>` / `claim:copilot:<model>` (`suggest:codex:sol`,
+      `claim:copilot:code-1-flash`, …). Those are created on demand rather than
+      seeded, so `gh label list --limit 200`'s default page can miss them
+      entirely if this repo has many labels — enumerate with the family prefix
+      instead of eyeballing the page: `gh label list --repo <owner/repo>
+      --limit 1000 --json name --jq '.[].name' | grep -E
+      '^(suggest|claim):(codex|copilot):'`. Rename each the same
+      rename-never-recreate way, **preserving its model suffix**
+      (`suggest:codex:sol` → `suggest:gpt:sol`, `claim:copilot:code-1-flash` →
+      `claim:mai:code-1-flash` — the model slugs are unchanged by the rename,
+      only the family segment moves), and run the same in-flight-claim check
+      per label before renaming it
+      (`gh issue list --label suggest:codex:sol --state all --limit 200` /
+      `gh pr list --label suggest:codex:sol --state all --limit 200`, one pair
+      per label found). Re-run the `grep` above afterwards — it should return
+      nothing.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,
       so this is a one-time manual step. Filters/layouts are in

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -237,8 +237,19 @@ this comment. -->
       issue and PR carrying it keeps it, where create-then-delete would silently
       drop those associations. Map by **model family, not harness** —
       `agent:gemini-cli` → `claim:gemini`, `agent:kimi-k2` → `claim:kimi`,
-      `agent:qwen-code` → `claim:qwen`, `agent:github-copilot` →
-      `claim:mai` — taking the target names from
+      `agent:qwen-code` → `claim:qwen` — these three are fixed-family
+      harnesses, so the mapping is unconditional. `agent:github-copilot` is
+      **not**: Copilot is a broker (registry `family_constraint.kind:
+      "broker"`, default `mai`), so an old claim under that label may
+      actually have run GPT, Claude, or another brokered family — check the
+      claim/session record for which one before renaming, and rename to
+      `claim:<actual-family>` (only `claim:mai` when the record confirms
+      MAI). When the actual family can't be recovered: for a live claim,
+      settle it with its owner first rather than guess; for a
+      released/historical one, just delete the stale `agent:github-copilot`
+      label off that issue/PR instead of renaming it — a guessed family is
+      worse than none, since the claim label's whole meaning is the family.
+      Target names otherwise come from
       `node scripts/agent-registry-labels.mjs suggest-claim`.
       **Destination-collision procedure**: a rename whose target already
       exists is rejected by GitHub (`gh label edit` errors: the destination

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -276,50 +276,76 @@ this comment. -->
       amend those records in the same sitting. Re-read `gh label list --limit 200` afterwards — no `agent:*`
       should remain.
 - [ ] **[human-only] Retire pre-2026-refresh `codex`/`copilot` agent labels** —
-      needed only where `gh label list --limit 200` still shows
-      `suggest:codex`/`claim:codex` or `suggest:copilot`/`claim:copilot`:
-      harmon-init issue #751 renamed those families to `gpt` and `mai` (Codex
-      and Copilot are harnesses, not families — the same harness/family split
-      D9 already made elsewhere; see ADR 0005 D8). A `setup-github-labels`
-      re-run never deletes the old family, so it survives beside the new
-      registry-rendered one. **Rename, never re-create**, the same way as the
-      `agent:*` item above: `gh label edit suggest:codex --name suggest:gpt
-      --repo <owner/repo>` (repeat for `claim:codex`, `suggest:copilot`,
-      `claim:copilot` → `suggest:mai`/`claim:mai`), which preserves issue/PR
-      associations instead of dropping them. **If the destination already
-      exists** — a `setup-github-labels` re-run already created `suggest:gpt`/
-      `claim:mai` before this cleanup runs — `gh label edit` is rejected the
-      same way; use the **destination-collision procedure from the `agent:*`
-      item above** (add the new label to every issue/PR carrying the old one,
-      remove the old, then delete the old label once empty) instead of trying
-      to rename over it. Check for in-flight claims first
-      — `gh issue list --label claim:codex --state all --limit 200` **and**
-      `gh pr list --label claim:codex --state all --limit 200` (repeat for
-      `claim:copilot`) — and settle or amend any that name the old label
-      before renaming it out from under them. Re-read `gh label list --limit
-      200` afterwards — no `suggest:codex`/`claim:codex`/`suggest:copilot`/
-      `claim:copilot` should remain.
+      needed only where an explicit enumeration shows
+      `suggest:codex`/`claim:codex` or `suggest:copilot`/`claim:copilot`
+      still exist: `gh label list --repo <owner/repo> --limit 1000 --json
+      name --jq '.[].name' | grep -E '^(suggest|claim):(codex|copilot)$'`
+      (the default `gh label list --limit 200` paged listing can miss these
+      on a repo with many labels — use this enumeration, not the paged form,
+      everywhere in this item). harmon-init issue #751 renamed those families
+      to `gpt` and `mai` (Codex and Copilot are harnesses, not families — the
+      same harness/family split D9 already made elsewhere; see ADR 0005 D8).
+      A `setup-github-labels` re-run never deletes the old family, so it
+      survives beside the new registry-rendered one.
+
+      **`codex` → `gpt` is a fixed mapping** (Codex only ever ran GPT) —
+      **rename, never re-create**, the same way as the `agent:*` item above:
+      `gh label edit suggest:codex --name suggest:gpt --repo <owner/repo>`
+      (repeat for `claim:codex`), which preserves issue/PR associations
+      instead of dropping them.
+
+      **`copilot` is NOT a fixed mapping — apply the same broker caution as
+      the `agent:github-copilot` entry in the `agent:*` item above, not a
+      blanket rename to `mai`.** Copilot is a broker (registry
+      `family_constraint.kind: "broker"`, default `mai`): a `claim:copilot`
+      may have actually run GPT, Claude, or another brokered family, and
+      `suggest:copilot` only ever named a harness preference, never an MAI
+      one. For `claim:copilot`, follow the `agent:*` item's procedure exactly
+      — check the claim/session record for the actual family and rename to
+      `claim:<actual-family>` (only `claim:mai` when the record confirms
+      MAI); when unrecoverable, settle a live claim with its owner first, or
+      delete the stale label from a released/historical issue/PR instead of
+      guessing. For `suggest:copilot`, there is no rename to make: re-express
+      the intent by re-labelling each issue with whichever family it actually
+      meant, or drop the label, rather than mechanically renaming a harness
+      name into a family slot it never occupied.
+
+      **If the destination already exists** — a `setup-github-labels` re-run
+      already created `suggest:gpt`/`claim:mai` before this cleanup runs —
+      `gh label edit` is rejected the same way; use the **destination-collision
+      procedure from the `agent:*` item above** (add the new label to every
+      issue/PR carrying the old one, remove the old, then delete the old label
+      once empty) instead of trying to rename over it. Check for in-flight
+      claims first — `gh issue list --label claim:codex --state all --limit
+      1000` **and** `gh pr list --label claim:codex --state all --limit
+      1000` (repeat for `claim:copilot`, remembering the broker caution above
+      governs what you rename it to) — and settle or amend any that name the
+      old label before renaming it out from under them. Re-run the
+      enumeration above afterwards — it should return nothing.
+
       **Also check for model-level labels naming the old family** —
       `suggest:codex:<model>` / `claim:codex:<model>` /
       `suggest:copilot:<model>` / `claim:copilot:<model>` (`suggest:codex:sol`,
       `claim:copilot:code-1-flash`, …). Those are created on demand rather than
-      seeded, so `gh label list --limit 200`'s default page can miss them
-      entirely if this repo has many labels — enumerate with the family prefix
-      instead of eyeballing the page: `gh label list --repo <owner/repo>
-      --limit 1000 --json name --jq '.[].name' | grep -E
-      '^(suggest|claim):(codex|copilot):'`. Rename each the same
-      rename-never-recreate way, **preserving its model suffix**
-      (`suggest:codex:sol` → `suggest:gpt:sol`, `claim:copilot:code-1-flash` →
-      `claim:mai:code-1-flash` — the model slugs are unchanged by the rename,
-      only the family segment moves), and run the same in-flight-claim check
-      per label before renaming it
-      (`gh issue list --label suggest:codex:sol --state all --limit 200` /
-      `gh pr list --label suggest:codex:sol --state all --limit 200`, one pair
-      per label found). **Collisions use the same destination-collision
-      procedure too** — a model-level label can already exist for the same
-      reason a family-level one can (an on-demand `suggest:gpt:sol` created
-      before this cleanup ran) — migrate associations from `suggest:codex:sol`
-      to `suggest:gpt:sol` and delete `suggest:codex:sol` once it carries no
+      seeded, so the same paged-listing gap applies — enumerate with the
+      family prefix: `gh label list --repo <owner/repo> --limit 1000 --json
+      name --jq '.[].name' | grep -E '^(suggest|claim):(codex|copilot):'`.
+      Rename each `codex:<model>` label the same fixed-mapping way,
+      **preserving its model suffix** (`suggest:codex:sol` →
+      `suggest:gpt:sol` — the model slug is unchanged, only the family
+      segment moves), and run the same in-flight-claim check per label before
+      renaming it (`gh issue list --label suggest:codex:sol --state all
+      --limit 1000` / `gh pr list --label suggest:codex:sol --state all
+      --limit 1000`, one pair per label found). **`copilot:<model>` labels get
+      the same broker treatment as the family-level ones above** — determine
+      the actual family per label from its claim/session record and rename
+      preserving the suffix (`claim:copilot:code-1-flash` →
+      `claim:<actual-family>:code-1-flash`), or remove/re-express rather than
+      assume `mai`. **Collisions use the same destination-collision procedure
+      too** — a model-level label can already exist for the same reason a
+      family-level one can (an on-demand `suggest:gpt:sol` created before this
+      cleanup ran) — migrate associations from `suggest:codex:sol` to
+      `suggest:gpt:sol` and delete `suggest:codex:sol` once it carries no
       issues or PRs, rather than renaming over the existing one. Re-run the
       `grep` above afterwards — it should return nothing.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -238,7 +238,7 @@ this comment. -->
       drop those associations. Map by **model family, not harness** —
       `agent:gemini-cli` → `claim:gemini`, `agent:kimi-k2` → `claim:kimi`,
       `agent:qwen-code` → `claim:qwen`, `agent:github-copilot` →
-      `claim:copilot` — taking the target names from
+      `claim:mai` — taking the target names from
       `node scripts/agent-registry-labels.mjs suggest-claim`. A rename whose
       target already exists is rejected by GitHub — migrate that one by hand,
       and enumerate **`gh pr list` as well as `gh issue list`**: labels apply to
@@ -250,6 +250,24 @@ this comment. -->
       record naming the old label will not release the renamed one, so settle or
       amend those records in the same sitting. Re-read `gh label list --limit 200` afterwards — no `agent:*`
       should remain.
+- [ ] **[human-only] Retire pre-2026-refresh `codex`/`copilot` agent labels** —
+      needed only where `gh label list --limit 200` still shows
+      `suggest:codex`/`claim:codex` or `suggest:copilot`/`claim:copilot`:
+      harmon-init issue #751 renamed those families to `gpt` and `mai` (Codex
+      and Copilot are harnesses, not families — the same harness/family split
+      D9 already made elsewhere; see ADR 0005 D8). A `setup-github-labels`
+      re-run never deletes the old family, so it survives beside the new
+      registry-rendered one. **Rename, never re-create**, the same way as the
+      `agent:*` item above: `gh label edit suggest:codex --name suggest:gpt
+      --repo <owner/repo>` (repeat for `claim:codex`, `suggest:copilot`,
+      `claim:copilot` → `suggest:mai`/`claim:mai`), which preserves issue/PR
+      associations instead of dropping them. Check for in-flight claims first
+      — `gh issue list --label claim:codex --state all --limit 200` **and**
+      `gh pr list --label claim:codex --state all --limit 200` (repeat for
+      `claim:copilot`) — and settle or amend any that name the old label
+      before renaming it out from under them. Re-read `gh label list --limit
+      200` afterwards — no `suggest:codex`/`claim:codex`/`suggest:copilot`/
+      `claim:copilot` should remain.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,
       so this is a one-time manual step. Filters/layouts are in

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -16,7 +16,7 @@ current — it is the reference for "where do secrets live and who can do what".
   `AGENT_DECK_TELEGRAM_KEY` in both profiles, `GH_TOKEN` in the bot profile only,
   `TS_AUTHKEY` in the dev profile only, plus the
   alt-model provider keys (`KIMI_API_KEY`/`MOONSHOT_API_KEY`, `DEEPSEEK_API_KEY`,
-  `ZAI_API_KEY`) when opted in — see
+  `ZAI_API_KEY`, `QWEN_API_KEY`) when opted in — see
   [../guides/devcontainers.md](../guides/devcontainers.md).
   TODO: list the 1Password vault/items this project uses.
 - **Auditable changes.** `main` is protected; changes land via reviewed PRs

--- a/docs/decisions/0005-unified-agent-vocabulary.md
+++ b/docs/decisions/0005-unified-agent-vocabulary.md
@@ -56,16 +56,39 @@ The following decisions are adopted together:
 7. **D7 — Foreman selectors name harness adapters.** `foreman:<adapter>` selects
    executable machinery. The registry maps that adapter to a harness and states
    who selects the model. The family and harness axes are intentionally distinct.
-8. **D8 — Codex's family slug is `codex`.** Model segments, such as `sol` or
-   `luna`, live below that stable family slug.
-9. **D9 — Harness slugs follow product and collision rules.** Product names are
-   lowercase slugs (`antigravity`, `opencode`, `pi`). A product qualifier avoids
-   a family collision (`claude-code`, `codex-cli`, `copilot-cli`, `qwen-code`).
-   Provider-rewired variants use `<harness>-<family>`, including
-   `claude-code-deepseek`, `claude-code-glm`, `claude-code-kimi`, and
-   `claude-code-minimax`. MiniMax's family is `minimax`; `minimax` is never a
-   harness slug. A venue is not a harness, so the GitHub Action is
-   `claude-code-action`, not `gh-action`.
+8. **D8 — Family slugs name vendor intelligence, never the harness product.**
+   OpenAI's family slug is `gpt`; model segments, such as `sol` or `luna`, live
+   below that stable family slug, and `codex-cli` is the *harness* that runs
+   it. Microsoft AI's family slug is `mai`; `copilot-cli` is a *harness* — a
+   broker (D9 amendment below) whose picker defaults to `mai` but can route
+   to other families. **Amended 2026-08-10**: the family slug was originally
+   `codex`, and `copilot` was originally recorded as a family with no models.
+   Both were the exact product-vs-family mistake D9 already fixed for
+   `codex-cli` itself — Codex and Copilot are products/harnesses, GPT and MAI
+   are the vendor intelligence underneath them. Renaming families is a
+   registry-and-label change, not a live-data migration: existing
+   `suggest:codex*`/`claim:codex*` and `suggest:copilot*`/`claim:copilot*`
+   labels are not deleted or auto-renamed (`setup-github-labels` is additive,
+   same as the `agent:*` → `claim:*` cutover D4 already established), so a
+   repo carrying pre-refresh labels does a one-time human rename —
+   documented as a CHECKLIST.md item next to the equivalent `agent:*` step —
+   rather than a scripted live-data rewrite.
+9. **D9 — Harness slugs follow product, collision, and endpoint-variant
+   rules.** Product names are lowercase slugs (`antigravity`, `opencode`,
+   `pi`). A product qualifier avoids a family collision (`claude-code`,
+   `codex-cli`, `copilot-cli`, `qwen-code`). Provider-rewired variants use
+   `<harness>-<family>`, including `claude-code-deepseek`, `claude-code-glm`,
+   `claude-code-kimi`, `claude-code-minimax`, and `claude-code-qwen`.
+   MiniMax's family is `minimax`; `minimax` is never a harness slug. A venue
+   is not a harness, so the GitHub Action is `claude-code-action`, not
+   `gh-action`. **Amended 2026-08-10 — sanction the `-local` endpoint-variant
+   suffix**: a provider-rewired harness may append `-local` to mark a variant
+   that talks to a local endpoint instead of the family's hosted one, while
+   staying fixed to the *same* family — `claude-code-qwen-local` is family
+   `qwen`, not a separate `qwen-local` family. The suffix names an endpoint,
+   not intelligence, so it never appears in a family slug or as a
+   `family_constraint.family` value; the next local-lane wrapper reuses this
+   rule rather than improvising a new one.
 10. **D10 — Project-management documentation is the human authority.** It must
     explain the label security boundary, the label-versus-field rule, Claude
     workflow behavior, the full label taxonomy, and registry-derived family and
@@ -80,6 +103,47 @@ The following decisions are adopted together:
     model labels on the harness axis, and production-dispatchable adapters without
     a harness mapping. Later drift checks bind provisioning, wrappers, and the
     pinned upstream adapter roster to the same contract.
+12. **D12 — `family_constraint` has an explicit `broker` kind (added
+    2026-08-10).** A harness whose model picker routes across families
+    (`opencode`, `pi`, `goose`, `cline`, `copilot-cli`) declares
+    `{ "kind": "broker" }`, optionally with a `default_family` naming which
+    family it picks absent other input (`copilot-cli`'s is `mai`). This
+    replaces overloading the `none` kind — schema v1's "unconstrained" escape
+    hatch — for the same meaning: a `none` constraint could not name a
+    default, so `copilot-cli` could only be recorded `runner-config`-owned
+    with no way to say *which* family it defaults to, which undersold what
+    the picker actually does. `kind: "broker"` is a distinct, self-describing
+    value rather than "`fixed` with nothing fixed", and `default_family`,
+    when present, is validated against the family roster like any other
+    family reference. Schema `schema_version` moved to `2` for the shape
+    change; the validator and its mutation tests cover the new kind
+    (rejecting a plain `family` on a broker, an unknown `default_family`, and
+    a `default_family` on a `fixed` constraint).
+13. **D13 — `Model selected by` renders as one definition list, not a
+    per-row sentence (added 2026-08-10).** The harness table's last column
+    used to repeat a full sentence per row for what is structurally a
+    4-value enum (`agent-registry.schema.json`'s `modelResolution.owner`:
+    `runner-config`, `workflow-config`, `provider-wrapper`,
+    `harness-runtime`). `agent-registry-labels.mjs`'s `docs-tables` mode now
+    renders each harness's bare `owner` code in the column and prints the
+    four definitions once, above the table. The registry's per-harness
+    `model_resolution.details` field is unchanged and still schema-validated
+    (tooling and future prose may still want it) — it is simply not spliced
+    into the generated table anymore, since every occurrence was restating
+    one of the four fixed sentences with a harness name attached.
+14. **D14 — Model-slug conventions (recorded 2026-08-10).** Family and tier
+    slugs are lowercase words. A version that gets its own slug is
+    hyphenated with a dotted display name (slug `5-2`, display `5.2`) —
+    dots are declined *in slugs* because registry slugs feed
+    `suggest:`/`claim:` label segments, and a `.` there would either break
+    label-name syntax or need escaping every consumer would have to
+    remember. A model slug names either a durable capability *tier* the
+    vendor itself supports across versions (`claude`'s `opus`/`sonnet`/
+    `haiku`/`fable`, `gpt`'s `sol`/`terra`/`luna`) or a *version* where the
+    vendor does not offer that abstraction (`glm`'s `5-2`, `kimi`'s `k3`).
+    A provider-rewired local-endpoint variant's harness slug may append
+    `-local` per the D9 amendment above; it stays a harness-slug suffix, and
+    is never folded into a model or family slug.
 
 Foreman's legacy production adapter `claude.sh` maps to harness `claude-code`.
 Its `mock.sh` adapter is a hermetic test seam only: it has no harness mapping,
@@ -118,3 +182,11 @@ label.
 - Provisioning, workflow migration, vendored-skill migration, Foreman lifecycle
   changes, and final documentation remain separate rollout units. The registry
   establishes their shared contract without prematurely rewriting each consumer.
+- A family rename (D8 amendment) is additive at the registry/label-provisioning
+  level — no GitHub write runs automatically — so a repo seeded before
+  2026-08-10 keeps its pre-refresh `suggest:codex*`/`claim:codex*`/
+  `suggest:copilot*`/`claim:copilot*` labels until an operator runs the
+  documented rename (docs/CHECKLIST.md, next to the equivalent `agent:*` step).
+  `task test:registry-drift` only binds this repository's own provisioning
+  script and wrappers to the current registry; it has no visibility into any
+  other repository's live label set and cannot detect that a rename is owed.

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -389,9 +389,12 @@ host gateway via `runArgs`, so it resolves even on native Linux) and falls
 back to `localhost` when that name doesn't resolve — set `QWEN_LOCAL_BASE_URL`
 to override either guess. **On native Linux, the DNS mapping alone is not
 enough**: stock Ollama binds `127.0.0.1:11434` (loopback-only), so it refuses
-the container's connection regardless — set `OLLAMA_HOST=0.0.0.0` (env var or
-a systemd override for the `ollama` service) so it listens on every interface,
-or point `QWEN_LOCAL_BASE_URL` at an endpoint that already does.
+the container's connection regardless. Do **not** bind `0.0.0.0` — Ollama has
+no auth, so that exposes it to the whole LAN. Instead set
+`OLLAMA_HOST=<docker0-bridge-IP>` (`ip addr show docker0`, typically
+`172.17.0.1`) to scope it to the Docker bridge, firewall port `11434` to that
+bridge if it must stay on `0.0.0.0` for other reasons, or point
+`QWEN_LOCAL_BASE_URL` at an endpoint that's already reachable.
 
 The provider API keys flow through the same env-file pipeline as everything else
 (`init-env.sh` allow-list → `devcontainer.env` → `--env-file`), so add them to your

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -295,7 +295,7 @@ Variables per profile:
 | `CLAUDE_CODE_OAUTH_TOKEN` | ✅ | ✅ | Claude Code |
 | `AGENT_DECK_TELEGRAM_KEY` | ✅ | ✅ | agent-deck bridge (optional) |
 | `TS_AUTHKEY` | — | ✅ | Tailscale (dev only) |
-| `KIMI_API_KEY` / `MOONSHOT_API_KEY`, `DEEPSEEK_API_KEY`, `ZAI_API_KEY` | ✅ | ✅ | alt-model wrappers (opt-in: `use_alternative_claude_providers`) |
+| `KIMI_API_KEY` / `MOONSHOT_API_KEY`, `DEEPSEEK_API_KEY`, `ZAI_API_KEY`, `QWEN_API_KEY` | ✅ | ✅ | alt-model wrappers (opt-in: `use_alternative_claude_providers`) |
 
 `ANTHROPIC_API_KEY` is deliberately **forbidden** — it silently overrides
 `CLAUDE_CODE_OAUTH_TOKEN`, so `init-env.sh` strips it from the env-file.
@@ -363,16 +363,35 @@ the app is the fix. Where an org genuinely cannot, the fallback is
 fine-grained one. A fine-grained PAT has exactly one resource owner, so using one
 here would reintroduce the single-org ceiling this arrangement exists to remove.
 
-### Alternative model providers (`claude-kimi` / `claude-deepseek` / `claude-glm`)
+### Alternative model providers (`claude-kimi` / `claude-deepseek` / `claude-glm` / `claude-qwen` / `claude-qwen-local`)
 
 Opt in with the `use_alternative_claude_providers` Copier answer (default off;
 asked only when `devcontainer=true`) to ship the `claude-kimi`, `claude-deepseek`,
-and `claude-glm` shell functions. They mirror the equivalent host wrappers:
-each launches `claude` in a subshell with `ANTHROPIC_BASE_URL` +
-`ANTHROPIC_AUTH_TOKEN` pointed at a provider's native Anthropic-compatible
-`/anthropic` endpoint (Moonshot Kimi K3, DeepSeek V4, Z.AI GLM-5.2 — no proxy),
-plus the per-tier `ANTHROPIC_*_MODEL` vars. The functions live in
+`claude-glm`, `claude-qwen`, and `claude-qwen-local` shell functions. The hosted
+four mirror the equivalent host wrappers: each launches `claude` in a subshell
+with `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` pointed at a provider's
+native Anthropic-compatible endpoint under a vendor-documented path prefix
+(Moonshot Kimi K3, DeepSeek V4, Z.AI GLM-5.2, Alibaba DashScope Qwen3.7-Max /
+Qwen3-Coder-Plus — no proxy), plus the per-tier `ANTHROPIC_*_MODEL` vars
+(`claude-qwen` uses Qwen3.7-Max for the main/reasoning roles and
+Qwen3-Coder-Plus for coding/subagent roles). The functions live in
 `.devcontainer/config/claude-providers.sh` and are sourced from `shell-aliases.sh`.
+
+`claude-qwen-local` is different: it targets your **own** Ollama/LM Studio
+endpoint serving `qwen3-coder:30b`, so it needs no API key and no
+1Password entry — `ANTHROPIC_AUTH_TOKEN` is a meaningless placeholder value.
+Its default `ANTHROPIC_BASE_URL` has **no** path suffix (`http://<host>:11434`,
+not `.../anthropic`) — unlike the hosted providers, Ollama and LM Studio serve
+their Anthropic-compatible API from the server root, and the client already
+appends the API path itself. The default host is chosen at launch: it probes
+`host.docker.internal` (which both shipped devcontainer profiles map to the
+host gateway via `runArgs`, so it resolves even on native Linux) and falls
+back to `localhost` when that name doesn't resolve — set `QWEN_LOCAL_BASE_URL`
+to override either guess. **On native Linux, the DNS mapping alone is not
+enough**: stock Ollama binds `127.0.0.1:11434` (loopback-only), so it refuses
+the container's connection regardless — set `OLLAMA_HOST=0.0.0.0` (env var or
+a systemd override for the `ollama` service) so it listens on every interface,
+or point `QWEN_LOCAL_BASE_URL` at an endpoint that already does.
 
 The provider API keys flow through the same env-file pipeline as everything else
 (`init-env.sh` allow-list → `devcontainer.env` → `--env-file`), so add them to your
@@ -452,7 +471,8 @@ repo** (one template serves every repo). To stand this repo up in Coder:
      `GH_TOKEN` **for a bot workspace only** — a dev workspace runs
      `gh auth login` instead (+ `TS_AUTHKEY` if you want Tailscale);
      `KIMI_API_KEY`/`MOONSHOT_API_KEY`,
-     `DEEPSEEK_API_KEY`, `ZAI_API_KEY` for the alt-model wrappers. Coder passes these
+     `DEEPSEEK_API_KEY`, `ZAI_API_KEY`, `QWEN_API_KEY` for the alt-model wrappers
+     (`claude-qwen-local` needs no key — see below). Coder passes these
      into the workspace's host environment, where `init-env.sh` picks them up.
 
    Coder is the case where this matters most: there is no 1Password app in the

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -419,13 +419,13 @@ and their vocabulary is not hand-listed anywhere: it is rendered from
 `agent-registry.json` (see [Agent families and harnesses](#agent-families-and-harnesses)),
 so provisioning and documentation cannot fork from each other.
 
-- **Suggest** — `suggest:claude`, `suggest:codex`, … — which agent family
+- **Suggest** — `suggest:claude`, `suggest:gpt`, … — which agent family
   *should* implement the issue, set at triage. Advisory only: it routes
   nothing by itself and must never be read as Foreman arming (that is the
   `foreman:*` family). A model-level label (`suggest:claude:opus`, created on
   demand) **refines** the family label, never replaces it — apply both, so
   views filtered on the family labels keep seeing the issue
-- **Claim** — `claim:claude`, `claim:codex`, … — which agent family is working
+- **Claim** — `claim:claude`, `claim:gpt`, … — which agent family is working
   the issue *right now*, written by the agent itself (see **Claiming** below).
   Model-level (`claim:claude:opus`) refines it the same way
 
@@ -573,32 +573,44 @@ with no adapter behind it is a false capability that can strand armed work.
 
 | Family | Name | Models |
 | --- | --- | --- |
-| `claude` | Claude | `opus`, `sonnet`, `haiku` |
-| `codex` | OpenAI Codex | `sol`, `terra`, `luna` |
-| `copilot` | GitHub Copilot | — |
-| `qwen` | Qwen | `coder` |
-| `deepseek` | DeepSeek | — |
-| `glm` | GLM | `5-2` |
+| `claude` | Claude | `fable`, `opus`, `sonnet`, `haiku` |
+| `gpt` | GPT | `sol`, `terra`, `luna` |
+| `mai` | MAI | `code-1-flash`, `thinking-1` |
+| `qwen` | Qwen | `max`, `coder-plus`, `coder`, `coder-next`, `coder-30b` |
+| `deepseek` | DeepSeek | `v4-pro`, `v4-flash` |
+| `glm` | GLM | `5-2`, `4-7-flash` |
 | `kimi` | Kimi | `k3` |
-| `minimax` | MiniMax | — |
-| `gemini` | Gemini | — |
+| `minimax` | MiniMax | `m3` |
+| `gemini` | Gemini | `3-1-pro`, `3-6-flash`, `3-5-flash-lite` |
+| `mistral` | Mistral | `devstral-small-2` |
+
+`Model selected by` values:
+
+- `runner-config` — the runner or repository/CLI configuration selects the model; labels do not.
+- `workflow-config` — the GitHub Actions workflow input selects the model.
+- `provider-wrapper` — the provider-rewired wrapper fixes the family; its runtime configuration selects the model.
+- `harness-runtime` — the harness selects both provider family and model at runtime.
 
 #### Harnesses
 
 | Harness | Product | Family | Foreman adapter | Model selected by |
 | --- | --- | --- | --- | --- |
-| `claude-code` | Claude Code CLI | `claude` | `foreman:claude` — production, dispatchable | `runner-config` — The runner or repository configuration selects the Claude model; labels do not. |
-| `claude-code-action` | claude-code-action | `claude` | — | `workflow-config` — The GitHub Actions workflow input selects the Claude model. |
-| `claude-code-deepseek` | Claude Code provider wrapper | `deepseek` | `claude-code-deepseek` — production, not dispatchable, no label | `provider-wrapper` — The provider-rewired wrapper fixes the family and its runtime configuration selects the model. |
-| `claude-code-glm` | Claude Code provider wrapper | `glm` | — | `provider-wrapper` — The provider-rewired wrapper fixes the family and its runtime configuration selects the model. |
-| `claude-code-kimi` | Claude Code provider wrapper | `kimi` | — | `provider-wrapper` — The provider-rewired wrapper fixes the family and its runtime configuration selects the model. |
-| `claude-code-minimax` | Claude Code provider wrapper | `minimax` | — | `provider-wrapper` — The provider-rewired wrapper fixes the family and its runtime configuration selects the model. |
-| `codex-cli` | OpenAI Codex CLI | `codex` | — | `runner-config` — The runner or CLI invocation selects the Codex model. |
-| `copilot-cli` | GitHub Copilot CLI | `copilot` | — | `runner-config` — The runner or Copilot configuration selects the model. |
-| `qwen-code` | Qwen Code CLI | `qwen` | — | `runner-config` — The runner or Qwen Code configuration selects the Qwen model. |
-| `antigravity` | Google Antigravity | `gemini` | — | `harness-runtime` — The Antigravity session selects the Gemini model. |
-| `opencode` | OpenCode | any (multi-provider) | — | `harness-runtime` — The multi-provider harness selects both provider family and model at runtime. |
-| `pi` | Pi | any (multi-provider) | — | `harness-runtime` — The multi-provider harness selects both provider family and model at runtime. |
+| `claude-code` | Claude Code CLI | `claude` | `foreman:claude` — production, dispatchable | `runner-config` |
+| `claude-code-action` | claude-code-action | `claude` | — | `workflow-config` |
+| `claude-code-deepseek` | Claude Code provider wrapper | `deepseek` | `claude-code-deepseek` — production, not dispatchable, no label | `provider-wrapper` |
+| `claude-code-glm` | Claude Code provider wrapper | `glm` | — | `provider-wrapper` |
+| `claude-code-kimi` | Claude Code provider wrapper | `kimi` | — | `provider-wrapper` |
+| `claude-code-minimax` | Claude Code provider wrapper | `minimax` | — | `provider-wrapper` |
+| `claude-code-qwen` | Claude Code provider wrapper | `qwen` | — | `provider-wrapper` |
+| `claude-code-qwen-local` | Claude Code provider wrapper | `qwen` | — | `provider-wrapper` |
+| `codex-cli` | OpenAI Codex CLI | `gpt` | — | `runner-config` |
+| `copilot-cli` | GitHub Copilot CLI | any (multi-provider; default `mai`) | — | `harness-runtime` |
+| `qwen-code` | Qwen Code CLI | `qwen` | — | `runner-config` |
+| `antigravity` | Google Antigravity | `gemini` | — | `harness-runtime` |
+| `opencode` | OpenCode | any (multi-provider) | — | `harness-runtime` |
+| `pi` | Pi | any (multi-provider) | — | `harness-runtime` |
+| `goose` | Block Goose | any (multi-provider) | — | `harness-runtime` |
+| `cline` | Cline | any (multi-provider) | — | `harness-runtime` |
 <!-- registry-tables:end -->
 
 ## Claiming — making an agent's work visible while it happens

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -589,7 +589,7 @@ with no adapter behind it is a false capability that can strand armed work.
 - `runner-config` — the runner or repository/CLI configuration selects the model; labels do not.
 - `workflow-config` — the GitHub Actions workflow input selects the model.
 - `provider-wrapper` — the provider-rewired wrapper fixes the family; its runtime configuration selects the model.
-- `harness-runtime` — the harness selects both provider family and model at runtime.
+- `harness-runtime` — the harness selects the model at runtime; for broker harnesses it selects the provider family too.
 
 #### Harnesses
 

--- a/scripts/agent-registry-labels.mjs
+++ b/scripts/agent-registry-labels.mjs
@@ -175,7 +175,21 @@ if (mode === 'docs-tables') {
     lines.push(`| ${code(slug)} | ${name} | ${models || '—'} |`)
   }
 
+  // `Model selected by` values are defined ONCE here rather than repeating a
+  // sentence per harness row: every harness's model_resolution.owner is one of
+  // these four enum values (agent-registry.schema.json), so the meaning is
+  // fixed regardless of which harness carries it. Per-harness `details` text
+  // still lives in the registry for tooling/validation but is not rendered
+  // per row — it would just restate one of these four sentences with a
+  // harness name spliced in.
   lines.push(
+    '',
+    '`Model selected by` values:',
+    '',
+    '- `runner-config` — the runner or repository/CLI configuration selects the model; labels do not.',
+    '- `workflow-config` — the GitHub Actions workflow input selects the model.',
+    '- `provider-wrapper` — the provider-rewired wrapper fixes the family; its runtime configuration selects the model.',
+    '- `harness-runtime` — the harness selects both provider family and model at runtime.',
     '',
     '#### Harnesses',
     '',
@@ -186,10 +200,15 @@ if (mode === 'docs-tables') {
     const slug = cell(harness.slug, 'harness slug')
     const product = cell(harness.product, `harness '${slug}' product`)
     const constraint = harness.family_constraint ?? {}
-    const family =
-      constraint.kind === 'fixed'
-        ? code(cell(constraint.family, `harness '${slug}' family_constraint.family`))
-        : 'any (multi-provider)'
+    let family = 'any (multi-provider)'
+    if (constraint.kind === 'fixed') {
+      family = code(cell(constraint.family, `harness '${slug}' family_constraint.family`))
+    } else if (constraint.kind === 'broker' && constraint.default_family) {
+      const defaultFamily = code(
+        cell(constraint.default_family, `harness '${slug}' family_constraint.default_family`)
+      )
+      family = `any (multi-provider; default ${defaultFamily})`
+    }
     const adapters = adaptersByHarness.get(harness.slug) ?? []
     const adapterCell =
       adapters
@@ -202,10 +221,7 @@ if (mode === 'docs-tables') {
         .join('; ') || '—'
     const resolution = harness.model_resolution ?? {}
     const owner = code(cell(resolution.owner, `harness '${slug}' model_resolution.owner`))
-    const details = cell(resolution.details, `harness '${slug}' model_resolution.details`)
-    lines.push(
-      `| ${code(slug)} | ${product} | ${family} | ${adapterCell} | ${owner} — ${details} |`
-    )
+    lines.push(`| ${code(slug)} | ${product} | ${family} | ${adapterCell} | ${owner} |`)
   }
 }
 

--- a/scripts/agent-registry-labels.mjs
+++ b/scripts/agent-registry-labels.mjs
@@ -189,7 +189,7 @@ if (mode === 'docs-tables') {
     '- `runner-config` — the runner or repository/CLI configuration selects the model; labels do not.',
     '- `workflow-config` — the GitHub Actions workflow input selects the model.',
     '- `provider-wrapper` — the provider-rewired wrapper fixes the family; its runtime configuration selects the model.',
-    '- `harness-runtime` — the harness selects both provider family and model at runtime.',
+    '- `harness-runtime` — the harness selects the model at runtime; for broker harnesses it selects the provider family too.',
     '',
     '#### Harnesses',
     '',

--- a/scripts/test-agent-registry.sh
+++ b/scripts/test-agent-registry.sh
@@ -53,10 +53,24 @@ switch (mutation) {
   case 'unknown-fixed-family':
     registry.harnesses[0].family_constraint.family = 'unknown'
     break
-  case 'family-on-none':
+  case 'family-on-broker':
     for (const entry of registry.harnesses) {
-      if (entry.family_constraint.kind === 'none') entry.family_constraint.family = 'claude'
+      if (entry.family_constraint.kind === 'broker') entry.family_constraint.family = 'claude'
     }
+    break
+  case 'unknown-default-family':
+    for (const entry of registry.harnesses) {
+      if (entry.family_constraint.kind === 'broker') {
+        entry.family_constraint.default_family = 'unknown'
+        break
+      }
+    }
+    break
+  case 'default-family-on-fixed':
+    registry.harnesses[0].family_constraint.default_family = 'claude'
+    break
+  case 'bad-local-suffix':
+    harness('claude-code-minimax').slug = 'claude-code-minimax-local-extra'
     break
   case 'production-without-harness':
     adapter('claude').harness = null
@@ -190,9 +204,18 @@ rejects "missing model-resolution ownership" \
 rejects "unknown fixed-family constraints" \
     'unknown-fixed-family' \
     'references unknown family unknown'
-rejects "family values on unconstrained harnesses" \
-    'family-on-none' \
-    'with a none constraint'
+rejects "family values on broker harnesses" \
+    'family-on-broker' \
+    'did you mean default_family'
+rejects "a broker default_family referencing an unknown family" \
+    'unknown-default-family' \
+    'default_family references unknown family unknown'
+rejects "a default_family on a fixed constraint" \
+    'default-family-on-fixed' \
+    'default_family on a fixed constraint'
+rejects "a provider-rewired harness slug with an unsanctioned suffix" \
+    'bad-local-suffix' \
+    'must be named claude-code-<fixed-family> or claude-code-<fixed-family>-local'
 rejects "production adapters without a harness mapping" \
     'production-without-harness' \
     'needs a production harness mapping'

--- a/scripts/test-registry-drift.sh
+++ b/scripts/test-registry-drift.sh
@@ -149,15 +149,21 @@ else
 fi
 
 # ── 4. provider-wrapper inventory ──────────────────────────────────────────
-# Every claude-<family> wrapper that ships MUST correspond to a provider-rewired
-# harness claude-code-<family> in the registry (no orphan wrappers). The reverse
-# is allowed: the registry may declare a provider-rewired harness ahead of its
-# wrapper (e.g. claude-code-minimax before a claude-minimax launcher exists).
+# Every claude-<family>[-local] wrapper that ships MUST correspond to a
+# provider-rewired harness claude-code-<family>[-local] in the registry (no
+# orphan wrappers). The -local suffix is a sanctioned endpoint-variant marker
+# (ADR 0005 D9 amendment) for a wrapper of the SAME family, not a distinct
+# "<family>-local" family — claude-qwen-local() maps to family "qwen", not
+# "qwen-local" — so it is stripped before the family lookup but kept in the
+# harness slug. The reverse mapping is allowed: the registry may declare a
+# provider-rewired harness ahead of its wrapper (e.g. claude-code-minimax
+# before a claude-minimax launcher exists).
 if [ -f "$wrappers_glob" ]; then
     wrappers="$(sed -n -E 's/^(claude-[a-z0-9-]+)\(\)[[:space:]]*\{.*/\1/p' "$wrappers_glob")"
     for fn in $wrappers; do
-        family="${fn#claude-}"
-        harness="claude-code-${family}"
+        stem="${fn#claude-}"
+        family="${stem%-local}"
+        harness="claude-code-${stem}"
         ok="$(jq -r --arg h "$harness" --arg f "$family" '
             [.harnesses[]
              | select(.slug == $h

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -1431,7 +1431,7 @@ fi
 
 # ── 9e2. alt-model providers render per use_alternative_claude_providers ──
 # Only `full` opts in; every other devcontainer-on profile uses the default
-# (off). The provider launcher file is jinja-gated by filename, and the four
+# (off). The provider launcher file is jinja-gated by filename, and the five
 # API keys are gated inside each devcontainer.json initializeCommand — assert
 # both appear/disappear together so a broken gate can't ship paid-provider
 # wiring into opted-out repos, where the bypassPermissions bot would then read
@@ -1443,7 +1443,7 @@ if [ -d .devcontainer ]; then
             err ".devcontainer/config/claude-providers.sh missing (use_alternative_claude_providers=true)"
         for dc_cfg in .devcontainer/devcontainer.json .devcontainer/dev/devcontainer.json; do
             [ -f "$dc_cfg" ] || continue
-            grep -q 'KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY' "$dc_cfg" ||
+            grep -q 'KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY' "$dc_cfg" ||
                 err "$dc_cfg initializeCommand omits the provider keys (use_alternative_claude_providers=true)"
         done
     else
@@ -1451,7 +1451,7 @@ if [ -d .devcontainer ]; then
             err ".devcontainer/config/claude-providers.sh rendered but use_alternative_claude_providers is off"
         for dc_cfg in .devcontainer/devcontainer.json .devcontainer/dev/devcontainer.json; do
             [ -f "$dc_cfg" ] || continue
-            ! grep -q 'KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY' "$dc_cfg" ||
+            ! grep -q 'KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY' "$dc_cfg" ||
                 err "$dc_cfg initializeCommand includes provider keys but use_alternative_claude_providers is off"
         done
     fi

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -1451,8 +1451,14 @@ if [ -d .devcontainer ]; then
             err ".devcontainer/config/claude-providers.sh rendered but use_alternative_claude_providers is off"
         for dc_cfg in .devcontainer/devcontainer.json .devcontainer/dev/devcontainer.json; do
             [ -f "$dc_cfg" ] || continue
-            ! grep -q 'KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY' "$dc_cfg" ||
-                err "$dc_cfg initializeCommand includes provider keys but use_alternative_claude_providers is off"
+            # Each key checked independently, not as one contiguous string: a
+            # whole-sequence grep only catches all five keys leaking together,
+            # so a single leaked key (e.g. only QWEN_API_KEY, if a future edit
+            # ever regressed just its own gate) would pass silently.
+            for leaked_key in KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY; do
+                ! grep -q "$leaked_key" "$dc_cfg" ||
+                    err "$dc_cfg initializeCommand includes $leaked_key but use_alternative_claude_providers is off"
+            done
         done
     fi
 fi

--- a/scripts/validate-agent-registry.mjs
+++ b/scripts/validate-agent-registry.mjs
@@ -365,7 +365,10 @@ if (errors.length === 0) {
           `harness ${harness.slug} has family ${constraint.family} on a broker constraint — did you mean default_family?`
         )
       }
-      if (Object.hasOwn(constraint, 'default_family') && !familySlugs.has(constraint.default_family)) {
+      if (
+        Object.hasOwn(constraint, 'default_family') &&
+        !familySlugs.has(constraint.default_family)
+      ) {
         semanticError(
           `harness ${harness.slug} broker default_family references unknown family ${constraint.default_family}`
         )

--- a/scripts/validate-agent-registry.mjs
+++ b/scripts/validate-agent-registry.mjs
@@ -354,16 +354,36 @@ if (errors.length === 0) {
       } else if (!familySlugs.has(constraint.family)) {
         semanticError(`harness ${harness.slug} references unknown family ${constraint.family}`)
       }
-    } else if (Object.hasOwn(constraint, 'family')) {
-      semanticError(
-        `harness ${harness.slug} has family ${constraint.family} with a none constraint`
-      )
+      if (Object.hasOwn(constraint, 'default_family')) {
+        semanticError(
+          `harness ${harness.slug} has a default_family on a fixed constraint — fixed constraints use family, not default_family`
+        )
+      }
+    } else if (constraint.kind === 'broker') {
+      if (Object.hasOwn(constraint, 'family')) {
+        semanticError(
+          `harness ${harness.slug} has family ${constraint.family} on a broker constraint — did you mean default_family?`
+        )
+      }
+      if (Object.hasOwn(constraint, 'default_family') && !familySlugs.has(constraint.default_family)) {
+        semanticError(
+          `harness ${harness.slug} broker default_family references unknown family ${constraint.default_family}`
+        )
+      }
     }
 
+    // Provider-rewired harnesses are named claude-code-<fixed-family>, optionally
+    // with a -local suffix for a local-endpoint variant of the same family (ADR
+    // 0005 D9 amendment) — claude-code-qwen-local stays fixed to family "qwen",
+    // not a separate "qwen-local" family.
     if (harness.provider_rewired) {
-      if (constraint.kind !== 'fixed' || harness.slug !== `claude-code-${constraint.family}`) {
+      const expected = constraint.kind === 'fixed' ? `claude-code-${constraint.family}` : null
+      if (
+        constraint.kind !== 'fixed' ||
+        (harness.slug !== expected && harness.slug !== `${expected}-local`)
+      ) {
         semanticError(
-          `provider-rewired harness ${harness.slug} must be named claude-code-<fixed-family>`
+          `provider-rewired harness ${harness.slug} must be named claude-code-<fixed-family> or claude-code-<fixed-family>-local`
         )
       }
       if (harness.model_resolution.owner !== 'provider-wrapper') {

--- a/template/.github/workflows/claude-implement.yml.jinja
+++ b/template/.github/workflows/claude-implement.yml.jinja
@@ -96,7 +96,7 @@ jobs:
       # issue with no marker saying so, which is the failure both rules exist
       # to prevent. The test is a `claim:`/`agent:` PREFIX, not the exact
       # `claim:claude` string: an exact match would miss the model-pinned
-      # `claim:claude:opus` form, another family's `claim:codex`, and the
+      # `claim:claude:opus` form, another family's `claim:gpt`, and the
       # `agent:*` labels generated repos still carry through the rolling
       # transition. `suggest:*` is deliberately NOT matched — it is advice
       # about who should do the work, never ownership of it. The read asks for

--- a/template/.github/workflows/claude-plan.yml.jinja
+++ b/template/.github/workflows/claude-plan.yml.jinja
@@ -95,7 +95,7 @@ jobs:
       # issue with no marker saying so, which is the failure both rules exist
       # to prevent. The test is a `claim:`/`agent:` PREFIX, not the exact
       # `claim:claude` string: an exact match would miss the model-pinned
-      # `claim:claude:opus` form, another family's `claim:codex`, and the
+      # `claim:claude:opus` form, another family's `claim:gpt`, and the
       # `agent:*` labels generated repos still carry through the rolling
       # transition. `suggest:*` is deliberately NOT matched — it is advice
       # about who should do the work, never ownership of it. The read asks for

--- a/template/.github/workflows/claude-review.yml.jinja
+++ b/template/.github/workflows/claude-review.yml.jinja
@@ -103,7 +103,7 @@ jobs:
       # issue with no marker saying so, which is the failure both rules exist
       # to prevent. The test is a `claim:`/`agent:` PREFIX, not the exact
       # `claim:claude` string: an exact match would miss the model-pinned
-      # `claim:claude:opus` form, another family's `claim:codex`, and the
+      # `claim:claude:opus` form, another family's `claim:gpt`, and the
       # `agent:*` labels generated repos still carry through the rolling
       # transition. `suggest:*` is deliberately NOT matched — it is advice
       # about who should do the work, never ownership of it. The read asks for

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/[% if use_alternative_claude_providers %]claude-providers.sh[% endif %]
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/[% if use_alternative_claude_providers %]claude-providers.sh[% endif %]
@@ -10,8 +10,10 @@
 # by setting ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN (+ per-tier model env vars) in
 # a subshell, leaving the parent shell untouched. The API key is read from the env
 # (the devcontainer env-file: KIMI_API_KEY/MOONSHOT_API_KEY, DEEPSEEK_API_KEY,
-# ZAI_API_KEY); if absent, it falls back to `op run` against
+# ZAI_API_KEY, QWEN_API_KEY); if absent, it falls back to `op run` against
 # $CLAUDE_PROVIDERS_ENV_FILE (dev profile only — the bot has no 1Password CLI).
+# claude-qwen-local is the exception: it targets a LOCAL Anthropic-compatible
+# endpoint (Ollama/LM Studio), so it needs no secret at all.
 #
 # CONTAINER ADAPTATIONS vs the host wrappers:
 #   1. The `op run` re-exec re-sources THIS file's baked path
@@ -58,7 +60,7 @@ claude-kimi() {
     fi
 
     (
-        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY
+        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY
         unset CLAUDE_PROVIDERS_OP_RUN_ACTIVE
         export ANTHROPIC_BASE_URL="https://api.moonshot.ai/anthropic"
         export ANTHROPIC_AUTH_TOKEN="$api_key"
@@ -104,7 +106,7 @@ claude-deepseek() {
     fi
 
     (
-        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY
+        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY
         unset CLAUDE_PROVIDERS_OP_RUN_ACTIVE
         export ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
         export ANTHROPIC_AUTH_TOKEN="$api_key"
@@ -147,7 +149,7 @@ claude-glm() {
     fi
 
     (
-        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY
+        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY
         unset CLAUDE_PROVIDERS_OP_RUN_ACTIVE
         export ANTHROPIC_BASE_URL="https://api.z.ai/api/anthropic"
         export ANTHROPIC_AUTH_TOKEN="$api_key"
@@ -161,6 +163,79 @@ claude-glm() {
         export ENABLE_TOOL_SEARCH="false"
         export CLAUDE_CODE_AUTO_COMPACT_WINDOW="1048576"
         export API_TIMEOUT_MS="3000000"
+        command claude "$@"
+    )
+}
+
+# Launch Claude Code with Qwen3.7-Max for the main/reasoning roles and
+# Qwen3-Coder-Plus for the coding/subagent roles, without changing the parent
+# shell environment. Uses an existing QWEN_API_KEY, otherwise loads it from
+# $CLAUDE_PROVIDERS_ENV_FILE through `op run` (dev profile only — bot has no op).
+claude-qwen() {
+    local api_key="${QWEN_API_KEY:-}"
+    local provider_env_file="${CLAUDE_PROVIDERS_ENV_FILE:-$HOME/.config/claude-providers.env}"
+
+    if [ -z "$api_key" ]; then
+        if [ "${CLAUDE_PROVIDERS_OP_RUN_ACTIVE:-}" = "1" ]; then
+            echo "claude-qwen: $provider_env_file did not provide QWEN_API_KEY" >&2
+            return 1
+        fi
+        if ! command -v op >/dev/null 2>&1; then
+            echo "claude-qwen: op is not installed and QWEN_API_KEY is not set" >&2
+            return 1
+        fi
+        if [ ! -r "$provider_env_file" ]; then
+            echo "claude-qwen: cannot read $provider_env_file" >&2
+            return 1
+        fi
+
+        CLAUDE_PROVIDERS_OP_RUN_ACTIVE=1 \
+            op run --no-masking --env-file="$provider_env_file" -- "${SHELL:-/bin/zsh}" -c \
+            'source /usr/local/share/devcontainer-config/claude-providers.sh; claude-qwen "$@"' -- "$@"
+        return
+    fi
+
+    (
+        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY
+        unset CLAUDE_PROVIDERS_OP_RUN_ACTIVE
+        export ANTHROPIC_BASE_URL="https://dashscope.aliyuncs.com/api/anthropic"
+        export ANTHROPIC_AUTH_TOKEN="$api_key"
+        export ANTHROPIC_MODEL="qwen3.7-max"
+        export ANTHROPIC_DEFAULT_OPUS_MODEL="qwen3.7-max"
+        export ANTHROPIC_DEFAULT_FABLE_MODEL="qwen3.7-max"
+        export ANTHROPIC_DEFAULT_SONNET_MODEL="qwen3-coder-plus"
+        export ANTHROPIC_DEFAULT_HAIKU_MODEL="qwen3-coder-plus"
+        export CLAUDE_CODE_SUBAGENT_MODEL="qwen3-coder-plus"
+        export ENABLE_CLAUDEAI_MCP_SERVERS="false"
+        export ENABLE_TOOL_SEARCH="false"
+        export CLAUDE_CODE_AUTO_COMPACT_WINDOW="1048576"
+        command claude "$@"
+    )
+}
+
+# Launch Claude Code against a LOCAL Anthropic-compatible endpoint (Ollama or
+# LM Studio) serving qwen3-coder:30b, without changing the parent shell
+# environment. No provider secret is required — this is a local-only lane —
+# but ANTHROPIC_AUTH_TOKEN must still be non-empty for the SDK, so a
+# placeholder value is sent; it is meaningless to a local endpoint, and no
+# real secret is ever read or exported by this function. Set
+# QWEN_LOCAL_BASE_URL to point at a non-default host/port (defaults to
+# Ollama's local Anthropic-compatible route).
+claude-qwen-local() {
+    local base_url="${QWEN_LOCAL_BASE_URL:-http://localhost:11434/anthropic}"
+
+    (
+        unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY
+        unset CLAUDE_PROVIDERS_OP_RUN_ACTIVE
+        export ANTHROPIC_BASE_URL="$base_url"
+        export ANTHROPIC_AUTH_TOKEN="local"
+        export ANTHROPIC_MODEL="qwen3-coder:30b"
+        export ANTHROPIC_DEFAULT_OPUS_MODEL="qwen3-coder:30b"
+        export ANTHROPIC_DEFAULT_SONNET_MODEL="qwen3-coder:30b"
+        export ANTHROPIC_DEFAULT_HAIKU_MODEL="qwen3-coder:30b"
+        export ANTHROPIC_DEFAULT_FABLE_MODEL="qwen3-coder:30b"
+        export CLAUDE_CODE_SUBAGENT_MODEL="qwen3-coder:30b"
+        export ENABLE_CLAUDEAI_MCP_SERVERS="false"
         command claude "$@"
     )
 }

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/[% if use_alternative_claude_providers %]claude-providers.sh[% endif %]
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/[% if use_alternative_claude_providers %]claude-providers.sh[% endif %]
@@ -234,10 +234,12 @@ claude-qwen() {
 # QWEN_LOCAL_BASE_URL directly; it always overrides either default. On native
 # Linux the DNS mapping alone is not enough: stock Ollama binds
 # 127.0.0.1:11434, which is loopback-only and unreachable from the container
-# even once host.docker.internal resolves — set OLLAMA_HOST=0.0.0.0 (a
-# systemd override for the `ollama` service, or the env var before `ollama
-# serve`) so it listens on every interface, or point QWEN_LOCAL_BASE_URL at a
-# reachable one.
+# even once host.docker.internal resolves. Do NOT bind 0.0.0.0 — Ollama has no
+# auth, so that exposes it to the whole LAN. Instead set
+# OLLAMA_HOST=<docker0-bridge-IP> (`ip addr show docker0`, typically
+# 172.17.0.1) to scope it to the Docker bridge, or firewall 11434 to that
+# bridge if it must stay on 0.0.0.0 for other reasons — or point
+# QWEN_LOCAL_BASE_URL at an already-reachable endpoint.
 #
 # No /anthropic (or other) path suffix on the default: unlike the hosted
 # wrappers below, Ollama's and LM Studio's Anthropic-compatible servers expose

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/[% if use_alternative_claude_providers %]claude-providers.sh[% endif %]
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/[% if use_alternative_claude_providers %]claude-providers.sh[% endif %]
@@ -218,11 +218,24 @@ claude-qwen() {
 # environment. No provider secret is required — this is a local-only lane —
 # but ANTHROPIC_AUTH_TOKEN must still be non-empty for the SDK, so a
 # placeholder value is sent; it is meaningless to a local endpoint, and no
-# real secret is ever read or exported by this function. Set
-# QWEN_LOCAL_BASE_URL to point at a non-default host/port (defaults to
-# Ollama's local Anthropic-compatible route).
+# real secret is ever read or exported by this function.
+#
+# The default HOST is chosen, not hardcoded: "localhost" inside a container
+# resolves to the container itself, not the developer's machine, where Ollama/
+# LM Studio actually listen — but this file also sources un-containerized (the
+# host wrappers), where "localhost" IS correct. So the default probes for
+# host.docker.internal (Docker Desktop resolves it out of the box; a Linux
+# container needs `--add-host=host.docker.internal:host-gateway` on the
+# container run, which the devcontainer JSON would need to set) and only falls
+# back to "localhost" when that name does not resolve. QWEN_LOCAL_BASE_URL
+# always overrides either default — set it directly if neither guess reaches
+# your endpoint.
 claude-qwen-local() {
-    local base_url="${QWEN_LOCAL_BASE_URL:-http://localhost:11434/anthropic}"
+    local default_host="localhost"
+    if command -v getent >/dev/null 2>&1 && getent hosts host.docker.internal >/dev/null 2>&1; then
+        default_host="host.docker.internal"
+    fi
+    local base_url="${QWEN_LOCAL_BASE_URL:-http://${default_host}:11434/anthropic}"
 
     (
         unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/[% if use_alternative_claude_providers %]claude-providers.sh[% endif %]
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/[% if use_alternative_claude_providers %]claude-providers.sh[% endif %]
@@ -231,13 +231,25 @@ claude-qwen() {
 # primary path resolves there even on native Linux (Docker Desktop resolves it
 # without any mapping). Outside those profiles — a hand-rolled `docker run`, a
 # different devcontainer config — add the same --add-host yourself, or just set
-# QWEN_LOCAL_BASE_URL directly; it always overrides either default.
+# QWEN_LOCAL_BASE_URL directly; it always overrides either default. On native
+# Linux the DNS mapping alone is not enough: stock Ollama binds
+# 127.0.0.1:11434, which is loopback-only and unreachable from the container
+# even once host.docker.internal resolves — set OLLAMA_HOST=0.0.0.0 (a
+# systemd override for the `ollama` service, or the env var before `ollama
+# serve`) so it listens on every interface, or point QWEN_LOCAL_BASE_URL at a
+# reachable one.
+#
+# No /anthropic (or other) path suffix on the default: unlike the hosted
+# wrappers below, Ollama's and LM Studio's Anthropic-compatible servers expose
+# /v1/messages etc. from the SERVER ROOT, and the Claude Code SDK appends that
+# API path to ANTHROPIC_BASE_URL itself — a base URL ending in /anthropic here
+# would double up to /anthropic/v1/messages and 404.
 claude-qwen-local() {
     local default_host="localhost"
     if command -v getent >/dev/null 2>&1 && getent hosts host.docker.internal >/dev/null 2>&1; then
         default_host="host.docker.internal"
     fi
-    local base_url="${QWEN_LOCAL_BASE_URL:-http://${default_host}:11434/anthropic}"
+    local base_url="${QWEN_LOCAL_BASE_URL:-http://${default_host}:11434}"
 
     (
         unset ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/[% if use_alternative_claude_providers %]claude-providers.sh[% endif %]
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/[% if use_alternative_claude_providers %]claude-providers.sh[% endif %]
@@ -224,12 +224,14 @@ claude-qwen() {
 # resolves to the container itself, not the developer's machine, where Ollama/
 # LM Studio actually listen — but this file also sources un-containerized (the
 # host wrappers), where "localhost" IS correct. So the default probes for
-# host.docker.internal (Docker Desktop resolves it out of the box; a Linux
-# container needs `--add-host=host.docker.internal:host-gateway` on the
-# container run, which the devcontainer JSON would need to set) and only falls
-# back to "localhost" when that name does not resolve. QWEN_LOCAL_BASE_URL
-# always overrides either default — set it directly if neither guess reaches
-# your endpoint.
+# host.docker.internal and only falls back to "localhost" when that name does
+# not resolve. Both shipped devcontainer profiles
+# (.devcontainer/devcontainer.json, .devcontainer/dev/devcontainer.json) add
+# `--add-host=host.docker.internal:host-gateway` to runArgs, so the probe's
+# primary path resolves there even on native Linux (Docker Desktop resolves it
+# without any mapping). Outside those profiles — a hand-rolled `docker run`, a
+# different devcontainer config — add the same --add-host yourself, or just set
+# QWEN_LOCAL_BASE_URL directly; it always overrides either default.
 claude-qwen-local() {
     local default_host="localhost"
     if command -v getent >/dev/null 2>&1 && getent hosts host.docker.internal >/dev/null 2>&1; then

--- a/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.env.example
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.env.example
@@ -7,3 +7,4 @@ AGENT_DECK_TELEGRAM_KEY=example-changeme
 KIMI_API_KEY=example-changeme
 DEEPSEEK_API_KEY=example-changeme
 ZAI_API_KEY=example-changeme
+QWEN_API_KEY=example-changeme

--- a/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
@@ -30,7 +30,7 @@
   // Alternative-model provider keys (KIMI/DEEPSEEK/ZAI) are opt-in via
   // use_alternative_claude_providers; when on they land in this env-file so the
   // claude-kimi/deepseek/glm wrappers (and the op fallback) work here.
-  "initializeCommand": "bash .devcontainer/scripts/init-env.sh .devcontainer/dev/devcontainer.env TS_AUTHKEY CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY[% if use_alternative_claude_providers %] KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY[% endif %]",
+  "initializeCommand": "bash .devcontainer/scripts/init-env.sh .devcontainer/dev/devcontainer.env TS_AUTHKEY CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY[% if use_alternative_claude_providers %] KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY[% endif %]",
   "runArgs": [
     "--init",
     "--shm-size=2g",

--- a/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
@@ -35,6 +35,12 @@
     "--init",
     "--shm-size=2g",
     "--device=/dev/net/tun",
+    // Linux hosts don't resolve host.docker.internal by default (unlike Docker
+    // Desktop on mac/win/WSL2); this mapping makes it resolve everywhere,
+    // which claude-qwen-local() (.devcontainer/config/claude-providers.sh)
+    // relies on to reach an Ollama/LM Studio endpoint on the host. Supported
+    // since Docker 20.10, harmless where the platform already resolves it.
+    "--add-host=host.docker.internal:host-gateway",
     "--env-file",
     ".devcontainer/dev/devcontainer.env"
   ],

--- a/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/dev/devcontainer.json.jinja
@@ -35,12 +35,14 @@
     "--init",
     "--shm-size=2g",
     "--device=/dev/net/tun",
+[% if use_alternative_claude_providers %]
     // Linux hosts don't resolve host.docker.internal by default (unlike Docker
     // Desktop on mac/win/WSL2); this mapping makes it resolve everywhere,
     // which claude-qwen-local() (.devcontainer/config/claude-providers.sh)
     // relies on to reach an Ollama/LM Studio endpoint on the host. Supported
     // since Docker 20.10, harmless where the platform already resolves it.
     "--add-host=host.docker.internal:host-gateway",
+[% endif %]
     "--env-file",
     ".devcontainer/dev/devcontainer.env"
   ],

--- a/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.env.example
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.env.example
@@ -7,3 +7,4 @@ AGENT_DECK_TELEGRAM_KEY=example-changeme
 KIMI_API_KEY=example-changeme
 DEEPSEEK_API_KEY=example-changeme
 ZAI_API_KEY=example-changeme
+QWEN_API_KEY=example-changeme

--- a/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
@@ -27,12 +27,14 @@
   "runArgs": [
     "--init",
     "--shm-size=2g",
+[% if use_alternative_claude_providers %]
     // Linux hosts don't resolve host.docker.internal by default (unlike Docker
     // Desktop on mac/win/WSL2); this mapping makes it resolve everywhere,
     // which claude-qwen-local() (.devcontainer/config/claude-providers.sh)
     // relies on to reach an Ollama/LM Studio endpoint on the host. Supported
     // since Docker 20.10, harmless where the platform already resolves it.
     "--add-host=host.docker.internal:host-gateway",
+[% endif %]
     "--env-file",
     ".devcontainer/devcontainer.env"
   ],

--- a/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
@@ -27,6 +27,12 @@
   "runArgs": [
     "--init",
     "--shm-size=2g",
+    // Linux hosts don't resolve host.docker.internal by default (unlike Docker
+    // Desktop on mac/win/WSL2); this mapping makes it resolve everywhere,
+    // which claude-qwen-local() (.devcontainer/config/claude-providers.sh)
+    // relies on to reach an Ollama/LM Studio endpoint on the host. Supported
+    // since Docker 20.10, harmless where the platform already resolves it.
+    "--add-host=host.docker.internal:host-gateway",
     "--env-file",
     ".devcontainer/devcontainer.env"
   ],

--- a/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/devcontainer.json.jinja
@@ -23,7 +23,7 @@
   // Alternative-model provider keys (KIMI/DEEPSEEK/ZAI) are opt-in via
   // use_alternative_claude_providers; when on they land in this env-file too,
   // so a headless/bypass bot can read them — a deliberate posture extension.
-  "initializeCommand": "bash .devcontainer/scripts/init-env.sh .devcontainer/devcontainer.env GH_TOKEN[% if use_foreman %] FOREMAN_AGENT_GH_TOKEN[% endif %] CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY[% if use_alternative_claude_providers %] KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY[% endif %]",
+  "initializeCommand": "bash .devcontainer/scripts/init-env.sh .devcontainer/devcontainer.env GH_TOKEN[% if use_foreman %] FOREMAN_AGENT_GH_TOKEN[% endif %] CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY[% if use_alternative_claude_providers %] KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY[% endif %]",
   "runArgs": [
     "--init",
     "--shm-size=2g",

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/init-env.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/init-env.sh
@@ -59,7 +59,7 @@ shift || true
 # dispatched agents as their GH_TOKEN (required before any dispatch); only
 # the bot profile allow-lists it, so it is evicted from dev/ like GH_TOKEN.
 BASE_MANAGED_VARS=(TS_AUTHKEY GH_TOKEN FOREMAN_AGENT_GH_TOKEN CLAUDE_CODE_OAUTH_TOKEN AGENT_DECK_TELEGRAM_KEY)
-OPT_IN_PROVIDER_KEYS=(KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY)
+OPT_IN_PROVIDER_KEYS=(KIMI_API_KEY MOONSHOT_API_KEY DEEPSEEK_API_KEY ZAI_API_KEY QWEN_API_KEY)
 # KNOWN_VARS: every var this script recognizes. The filter below restricts the
 # caller's allow-list to this set, so a positional arg can't smuggle an unknown
 # var into the env-file. Includes the opt-in keys so an opted-in profile can

--- a/template/agent-registry.json
+++ b/template/agent-registry.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./agent-registry.schema.json",
-  "schema_version": 1,
+  "schema_version": 2,
   "labels": {
     "suggest": {
       "prefix": "suggest",
@@ -20,39 +20,80 @@
       "slug": "claude",
       "display_name": "Claude",
       "models": [
+        { "slug": "fable", "display_name": "Fable" },
         { "slug": "opus", "display_name": "Opus" },
         { "slug": "sonnet", "display_name": "Sonnet" },
         { "slug": "haiku", "display_name": "Haiku" }
       ]
     },
     {
-      "slug": "codex",
-      "display_name": "OpenAI Codex",
+      "slug": "gpt",
+      "display_name": "GPT",
       "models": [
         { "slug": "sol", "display_name": "Sol" },
         { "slug": "terra", "display_name": "Terra" },
         { "slug": "luna", "display_name": "Luna" }
       ]
     },
-    { "slug": "copilot", "display_name": "GitHub Copilot", "models": [] },
+    {
+      "slug": "mai",
+      "display_name": "MAI",
+      "models": [
+        { "slug": "code-1-flash", "display_name": "Code-1-Flash" },
+        { "slug": "thinking-1", "display_name": "Thinking-1" }
+      ]
+    },
     {
       "slug": "qwen",
       "display_name": "Qwen",
-      "models": [{ "slug": "coder", "display_name": "Coder" }]
+      "models": [
+        { "slug": "max", "display_name": "3.7 Max" },
+        { "slug": "coder-plus", "display_name": "3 Coder Plus" },
+        { "slug": "coder", "display_name": "3 Coder" },
+        { "slug": "coder-next", "display_name": "3 Coder Next" },
+        { "slug": "coder-30b", "display_name": "3 Coder 30B" }
+      ]
     },
-    { "slug": "deepseek", "display_name": "DeepSeek", "models": [] },
+    {
+      "slug": "deepseek",
+      "display_name": "DeepSeek",
+      "models": [
+        { "slug": "v4-pro", "display_name": "V4 Pro" },
+        { "slug": "v4-flash", "display_name": "V4 Flash" }
+      ]
+    },
     {
       "slug": "glm",
       "display_name": "GLM",
-      "models": [{ "slug": "5-2", "display_name": "5.2" }]
+      "models": [
+        { "slug": "5-2", "display_name": "5.2" },
+        { "slug": "4-7-flash", "display_name": "4.7 Flash" }
+      ]
     },
     {
       "slug": "kimi",
       "display_name": "Kimi",
       "models": [{ "slug": "k3", "display_name": "K3" }]
     },
-    { "slug": "minimax", "display_name": "MiniMax", "models": [] },
-    { "slug": "gemini", "display_name": "Gemini", "models": [] }
+    {
+      "slug": "minimax",
+      "display_name": "MiniMax",
+      "models": [{ "slug": "m3", "display_name": "M3" }]
+    },
+    {
+      "slug": "gemini",
+      "display_name": "Gemini",
+      "models": [
+        { "slug": "3-1-pro", "display_name": "3.1 Pro" },
+        { "slug": "3-6-flash", "display_name": "3.6 Flash" },
+        { "slug": "3-5-flash-lite", "display_name": "3.5 Flash-Lite" }
+      ]
+    },
+    {
+      "slug": "mistral",
+      "display_name": "Mistral",
+      "models": [{ "slug": "devstral-small-2", "display_name": "Devstral Small 2" }]
+    }
   ],
   "harnesses": [
     {
@@ -122,13 +163,35 @@
       "provider_rewired": true
     },
     {
+      "slug": "claude-code-qwen",
+      "display_name": "Claude Code with Qwen",
+      "product": "Claude Code provider wrapper",
+      "family_constraint": { "kind": "fixed", "family": "qwen" },
+      "model_resolution": {
+        "owner": "provider-wrapper",
+        "details": "The provider-rewired wrapper fixes the family; per-role model env vars select Qwen3.7-Max for the main/reasoning roles and Qwen3-Coder-Plus for the coding/subagent roles."
+      },
+      "provider_rewired": true
+    },
+    {
+      "slug": "claude-code-qwen-local",
+      "display_name": "Claude Code with Qwen (local)",
+      "product": "Claude Code provider wrapper",
+      "family_constraint": { "kind": "fixed", "family": "qwen" },
+      "model_resolution": {
+        "owner": "provider-wrapper",
+        "details": "The provider-rewired wrapper points at a local Anthropic-compatible endpoint (Ollama or LM Studio) serving qwen3-coder:30b."
+      },
+      "provider_rewired": true
+    },
+    {
       "slug": "codex-cli",
       "display_name": "OpenAI Codex CLI",
       "product": "OpenAI Codex CLI",
-      "family_constraint": { "kind": "fixed", "family": "codex" },
+      "family_constraint": { "kind": "fixed", "family": "gpt" },
       "model_resolution": {
         "owner": "runner-config",
-        "details": "The runner or CLI invocation selects the Codex model."
+        "details": "The runner or CLI invocation selects the GPT model."
       },
       "provider_rewired": false
     },
@@ -136,10 +199,10 @@
       "slug": "copilot-cli",
       "display_name": "GitHub Copilot CLI",
       "product": "GitHub Copilot CLI",
-      "family_constraint": { "kind": "fixed", "family": "copilot" },
+      "family_constraint": { "kind": "broker", "default_family": "mai" },
       "model_resolution": {
-        "owner": "runner-config",
-        "details": "The runner or Copilot configuration selects the model."
+        "owner": "harness-runtime",
+        "details": "Copilot's picker selects among MAI and brokered third-party models at runtime."
       },
       "provider_rewired": false
     },
@@ -169,7 +232,7 @@
       "slug": "opencode",
       "display_name": "OpenCode",
       "product": "OpenCode",
-      "family_constraint": { "kind": "none" },
+      "family_constraint": { "kind": "broker" },
       "model_resolution": {
         "owner": "harness-runtime",
         "details": "The multi-provider harness selects both provider family and model at runtime."
@@ -180,7 +243,29 @@
       "slug": "pi",
       "display_name": "Pi",
       "product": "Pi",
-      "family_constraint": { "kind": "none" },
+      "family_constraint": { "kind": "broker" },
+      "model_resolution": {
+        "owner": "harness-runtime",
+        "details": "The multi-provider harness selects both provider family and model at runtime."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "goose",
+      "display_name": "Goose",
+      "product": "Block Goose",
+      "family_constraint": { "kind": "broker" },
+      "model_resolution": {
+        "owner": "harness-runtime",
+        "details": "The multi-provider harness selects both provider family and model at runtime."
+      },
+      "provider_rewired": false
+    },
+    {
+      "slug": "cline",
+      "display_name": "Cline",
+      "product": "Cline",
+      "family_constraint": { "kind": "broker" },
       "model_resolution": {
         "owner": "harness-runtime",
         "details": "The multi-provider harness selects both provider family and model at runtime."

--- a/template/agent-registry.schema.json
+++ b/template/agent-registry.schema.json
@@ -7,7 +7,7 @@
   "required": ["$schema", "schema_version", "labels", "families", "harnesses", "foreman_adapters"],
   "properties": {
     "$schema": { "const": "./agent-registry.schema.json" },
-    "schema_version": { "const": 1 },
+    "schema_version": { "const": 2 },
     "labels": {
       "type": "object",
       "additionalProperties": false,
@@ -82,8 +82,9 @@
       "additionalProperties": false,
       "required": ["kind"],
       "properties": {
-        "kind": { "enum": ["fixed", "none"] },
-        "family": { "$ref": "#/$defs/slug" }
+        "kind": { "enum": ["fixed", "broker"] },
+        "family": { "$ref": "#/$defs/slug" },
+        "default_family": { "$ref": "#/$defs/slug" }
       }
     },
     "modelResolution": {

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -327,50 +327,76 @@ config, toolchain, devcontainer, and dev environment — against the items below
       amend those records in the same sitting. Re-read `gh label list --limit 200` afterwards — no `agent:*`
       should remain.
 - [ ] **[human-only] Retire pre-2026-refresh `codex`/`copilot` agent labels** —
-      needed only where `gh label list --limit 200` still shows
-      `suggest:codex`/`claim:codex` or `suggest:copilot`/`claim:copilot`:
-      harmon-init issue #751 renamed those families to `gpt` and `mai` (Codex
-      and Copilot are harnesses, not families — the same harness/family split
-      D9 already made elsewhere; see ADR 0005 D8). A `setup-github-labels`
-      re-run never deletes the old family, so it survives beside the new
-      registry-rendered one. **Rename, never re-create**, the same way as the
-      `agent:*` item above: `gh label edit suggest:codex --name suggest:gpt
-      --repo <owner/repo>` (repeat for `claim:codex`, `suggest:copilot`,
-      `claim:copilot` → `suggest:mai`/`claim:mai`), which preserves issue/PR
-      associations instead of dropping them. **If the destination already
-      exists** — a `setup-github-labels` re-run already created `suggest:gpt`/
-      `claim:mai` before this cleanup runs — `gh label edit` is rejected the
-      same way; use the **destination-collision procedure from the `agent:*`
-      item above** (add the new label to every issue/PR carrying the old one,
-      remove the old, then delete the old label once empty) instead of trying
-      to rename over it. Check for in-flight claims first
-      — `gh issue list --label claim:codex --state all --limit 200` **and**
-      `gh pr list --label claim:codex --state all --limit 200` (repeat for
-      `claim:copilot`) — and settle or amend any that name the old label
-      before renaming it out from under them. Re-read `gh label list --limit
-      200` afterwards — no `suggest:codex`/`claim:codex`/`suggest:copilot`/
-      `claim:copilot` should remain.
+      needed only where an explicit enumeration shows
+      `suggest:codex`/`claim:codex` or `suggest:copilot`/`claim:copilot`
+      still exist: `gh label list --repo <owner/repo> --limit 1000 --json
+      name --jq '.[].name' | grep -E '^(suggest|claim):(codex|copilot)$'`
+      (the default `gh label list --limit 200` paged listing can miss these
+      on a repo with many labels — use this enumeration, not the paged form,
+      everywhere in this item). harmon-init issue #751 renamed those families
+      to `gpt` and `mai` (Codex and Copilot are harnesses, not families — the
+      same harness/family split D9 already made elsewhere; see ADR 0005 D8).
+      A `setup-github-labels` re-run never deletes the old family, so it
+      survives beside the new registry-rendered one.
+
+      **`codex` → `gpt` is a fixed mapping** (Codex only ever ran GPT) —
+      **rename, never re-create**, the same way as the `agent:*` item above:
+      `gh label edit suggest:codex --name suggest:gpt --repo <owner/repo>`
+      (repeat for `claim:codex`), which preserves issue/PR associations
+      instead of dropping them.
+
+      **`copilot` is NOT a fixed mapping — apply the same broker caution as
+      the `agent:github-copilot` entry in the `agent:*` item above, not a
+      blanket rename to `mai`.** Copilot is a broker (registry
+      `family_constraint.kind: "broker"`, default `mai`): a `claim:copilot`
+      may have actually run GPT, Claude, or another brokered family, and
+      `suggest:copilot` only ever named a harness preference, never an MAI
+      one. For `claim:copilot`, follow the `agent:*` item's procedure exactly
+      — check the claim/session record for the actual family and rename to
+      `claim:<actual-family>` (only `claim:mai` when the record confirms
+      MAI); when unrecoverable, settle a live claim with its owner first, or
+      delete the stale label from a released/historical issue/PR instead of
+      guessing. For `suggest:copilot`, there is no rename to make: re-express
+      the intent by re-labelling each issue with whichever family it actually
+      meant, or drop the label, rather than mechanically renaming a harness
+      name into a family slot it never occupied.
+
+      **If the destination already exists** — a `setup-github-labels` re-run
+      already created `suggest:gpt`/`claim:mai` before this cleanup runs —
+      `gh label edit` is rejected the same way; use the **destination-collision
+      procedure from the `agent:*` item above** (add the new label to every
+      issue/PR carrying the old one, remove the old, then delete the old label
+      once empty) instead of trying to rename over it. Check for in-flight
+      claims first — `gh issue list --label claim:codex --state all --limit
+      1000` **and** `gh pr list --label claim:codex --state all --limit
+      1000` (repeat for `claim:copilot`, remembering the broker caution above
+      governs what you rename it to) — and settle or amend any that name the
+      old label before renaming it out from under them. Re-run the
+      enumeration above afterwards — it should return nothing.
+
       **Also check for model-level labels naming the old family** —
       `suggest:codex:<model>` / `claim:codex:<model>` /
       `suggest:copilot:<model>` / `claim:copilot:<model>` (`suggest:codex:sol`,
       `claim:copilot:code-1-flash`, …). Those are created on demand rather than
-      seeded, so `gh label list --limit 200`'s default page can miss them
-      entirely if this repo has many labels — enumerate with the family prefix
-      instead of eyeballing the page: `gh label list --repo <owner/repo>
-      --limit 1000 --json name --jq '.[].name' | grep -E
-      '^(suggest|claim):(codex|copilot):'`. Rename each the same
-      rename-never-recreate way, **preserving its model suffix**
-      (`suggest:codex:sol` → `suggest:gpt:sol`, `claim:copilot:code-1-flash` →
-      `claim:mai:code-1-flash` — the model slugs are unchanged by the rename,
-      only the family segment moves), and run the same in-flight-claim check
-      per label before renaming it
-      (`gh issue list --label suggest:codex:sol --state all --limit 200` /
-      `gh pr list --label suggest:codex:sol --state all --limit 200`, one pair
-      per label found). **Collisions use the same destination-collision
-      procedure too** — a model-level label can already exist for the same
-      reason a family-level one can (an on-demand `suggest:gpt:sol` created
-      before this cleanup ran) — migrate associations from `suggest:codex:sol`
-      to `suggest:gpt:sol` and delete `suggest:codex:sol` once it carries no
+      seeded, so the same paged-listing gap applies — enumerate with the
+      family prefix: `gh label list --repo <owner/repo> --limit 1000 --json
+      name --jq '.[].name' | grep -E '^(suggest|claim):(codex|copilot):'`.
+      Rename each `codex:<model>` label the same fixed-mapping way,
+      **preserving its model suffix** (`suggest:codex:sol` →
+      `suggest:gpt:sol` — the model slug is unchanged, only the family
+      segment moves), and run the same in-flight-claim check per label before
+      renaming it (`gh issue list --label suggest:codex:sol --state all
+      --limit 1000` / `gh pr list --label suggest:codex:sol --state all
+      --limit 1000`, one pair per label found). **`copilot:<model>` labels get
+      the same broker treatment as the family-level ones above** — determine
+      the actual family per label from its claim/session record and rename
+      preserving the suffix (`claim:copilot:code-1-flash` →
+      `claim:<actual-family>:code-1-flash`), or remove/re-express rather than
+      assume `mai`. **Collisions use the same destination-collision procedure
+      too** — a model-level label can already exist for the same reason a
+      family-level one can (an on-demand `suggest:gpt:sol` created before this
+      cleanup ran) — migrate associations from `suggest:codex:sol` to
+      `suggest:gpt:sol` and delete `suggest:codex:sol` once it carries no
       issues or PRs, rather than renaming over the existing one. Re-run the
       `grep` above afterwards — it should return nothing.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -290,9 +290,23 @@ config, toolchain, devcontainer, and dev environment — against the items below
       `agent:gemini-cli` → `claim:gemini`, `agent:kimi-k2` → `claim:kimi`,
       `agent:qwen-code` → `claim:qwen`, `agent:github-copilot` →
       `claim:mai` — taking the target names from
-      `node scripts/agent-registry-labels.mjs suggest-claim`. A rename whose
-      target already exists is rejected by GitHub — migrate that one by hand,
-      and enumerate **`gh pr list` as well as `gh issue list`**: labels apply to
+      `node scripts/agent-registry-labels.mjs suggest-claim`.
+      **Destination-collision procedure**: a rename whose target already
+      exists is rejected by GitHub (`gh label edit` errors: the destination
+      name is already in use — e.g. `claim:claude` already exists from a prior
+      `setup-github-labels` run). When that happens, migrate ASSOCIATIONS
+      instead of the label object: for every issue and PR carrying the old
+      label, add the destination label and remove the old one
+      (`gh issue edit <number> --add-label claim:claude --remove-label
+      agent:claude-code --repo <owner/repo>`; the same `--add-label
+      X --remove-label Y` pair works on `gh pr edit`), then delete the
+      now-empty old label (`gh label delete agent:claude-code --repo
+      <owner/repo> --yes`) once a re-read of `gh issue list --label
+      agent:claude-code --state all --limit 200` **and** the equivalent
+      `gh pr list` both return nothing — only then is it safe to delete; the
+      other checklist items below that reference this procedure reuse it
+      verbatim. Enumerate **`gh pr list` as well as `gh issue list`**
+      throughout, collision or not: labels apply to
       pull requests too and `gh issue list` never returns them, so deleting the
       legacy label afterwards would drop exactly the associations the re-labelling
       missed — the loss this whole item exists to avoid. Check for in-flight
@@ -312,7 +326,13 @@ config, toolchain, devcontainer, and dev environment — against the items below
       `agent:*` item above: `gh label edit suggest:codex --name suggest:gpt
       --repo <owner/repo>` (repeat for `claim:codex`, `suggest:copilot`,
       `claim:copilot` → `suggest:mai`/`claim:mai`), which preserves issue/PR
-      associations instead of dropping them. Check for in-flight claims first
+      associations instead of dropping them. **If the destination already
+      exists** — a `setup-github-labels` re-run already created `suggest:gpt`/
+      `claim:mai` before this cleanup runs — `gh label edit` is rejected the
+      same way; use the **destination-collision procedure from the `agent:*`
+      item above** (add the new label to every issue/PR carrying the old one,
+      remove the old, then delete the old label once empty) instead of trying
+      to rename over it. Check for in-flight claims first
       — `gh issue list --label claim:codex --state all --limit 200` **and**
       `gh pr list --label claim:codex --state all --limit 200` (repeat for
       `claim:copilot`) — and settle or amend any that name the old label
@@ -335,8 +355,13 @@ config, toolchain, devcontainer, and dev environment — against the items below
       per label before renaming it
       (`gh issue list --label suggest:codex:sol --state all --limit 200` /
       `gh pr list --label suggest:codex:sol --state all --limit 200`, one pair
-      per label found). Re-run the `grep` above afterwards — it should return
-      nothing.
+      per label found). **Collisions use the same destination-collision
+      procedure too** — a model-level label can already exist for the same
+      reason a family-level one can (an on-demand `suggest:gpt:sol` created
+      before this cleanup ran) — migrate associations from `suggest:codex:sol`
+      to `suggest:gpt:sol` and delete `suggest:codex:sol` once it carries no
+      issues or PRs, rather than renaming over the existing one. Re-run the
+      `grep` above afterwards — it should return nothing.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,
       so this is a one-time manual step. Filters/layouts are in

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -288,8 +288,19 @@ config, toolchain, devcontainer, and dev environment — against the items below
       issue and PR carrying it keeps it, where create-then-delete would silently
       drop those associations. Map by **model family, not harness** —
       `agent:gemini-cli` → `claim:gemini`, `agent:kimi-k2` → `claim:kimi`,
-      `agent:qwen-code` → `claim:qwen`, `agent:github-copilot` →
-      `claim:mai` — taking the target names from
+      `agent:qwen-code` → `claim:qwen` — these three are fixed-family
+      harnesses, so the mapping is unconditional. `agent:github-copilot` is
+      **not**: Copilot is a broker (registry `family_constraint.kind:
+      "broker"`, default `mai`), so an old claim under that label may
+      actually have run GPT, Claude, or another brokered family — check the
+      claim/session record for which one before renaming, and rename to
+      `claim:<actual-family>` (only `claim:mai` when the record confirms
+      MAI). When the actual family can't be recovered: for a live claim,
+      settle it with its owner first rather than guess; for a
+      released/historical one, just delete the stale `agent:github-copilot`
+      label off that issue/PR instead of renaming it — a guessed family is
+      worse than none, since the claim label's whole meaning is the family.
+      Target names otherwise come from
       `node scripts/agent-registry-labels.mjs suggest-claim`.
       **Destination-collision procedure**: a rename whose target already
       exists is rejected by GitHub (`gh label edit` errors: the destination

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -289,7 +289,7 @@ config, toolchain, devcontainer, and dev environment — against the items below
       drop those associations. Map by **model family, not harness** —
       `agent:gemini-cli` → `claim:gemini`, `agent:kimi-k2` → `claim:kimi`,
       `agent:qwen-code` → `claim:qwen`, `agent:github-copilot` →
-      `claim:copilot` — taking the target names from
+      `claim:mai` — taking the target names from
       `node scripts/agent-registry-labels.mjs suggest-claim`. A rename whose
       target already exists is rejected by GitHub — migrate that one by hand,
       and enumerate **`gh pr list` as well as `gh issue list`**: labels apply to
@@ -301,6 +301,24 @@ config, toolchain, devcontainer, and dev environment — against the items below
       record naming the old label will not release the renamed one, so settle or
       amend those records in the same sitting. Re-read `gh label list --limit 200` afterwards — no `agent:*`
       should remain.
+- [ ] **[human-only] Retire pre-2026-refresh `codex`/`copilot` agent labels** —
+      needed only where `gh label list --limit 200` still shows
+      `suggest:codex`/`claim:codex` or `suggest:copilot`/`claim:copilot`:
+      harmon-init issue #751 renamed those families to `gpt` and `mai` (Codex
+      and Copilot are harnesses, not families — the same harness/family split
+      D9 already made elsewhere; see ADR 0005 D8). A `setup-github-labels`
+      re-run never deletes the old family, so it survives beside the new
+      registry-rendered one. **Rename, never re-create**, the same way as the
+      `agent:*` item above: `gh label edit suggest:codex --name suggest:gpt
+      --repo <owner/repo>` (repeat for `claim:codex`, `suggest:copilot`,
+      `claim:copilot` → `suggest:mai`/`claim:mai`), which preserves issue/PR
+      associations instead of dropping them. Check for in-flight claims first
+      — `gh issue list --label claim:codex --state all --limit 200` **and**
+      `gh pr list --label claim:codex --state all --limit 200` (repeat for
+      `claim:copilot`) — and settle or amend any that name the old label
+      before renaming it out from under them. Re-read `gh label list --limit
+      200` afterwards — no `suggest:codex`/`claim:codex`/`suggest:copilot`/
+      `claim:copilot` should remain.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,
       so this is a one-time manual step. Filters/layouts are in

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -319,6 +319,24 @@ config, toolchain, devcontainer, and dev environment — against the items below
       before renaming it out from under them. Re-read `gh label list --limit
       200` afterwards — no `suggest:codex`/`claim:codex`/`suggest:copilot`/
       `claim:copilot` should remain.
+      **Also check for model-level labels naming the old family** —
+      `suggest:codex:<model>` / `claim:codex:<model>` /
+      `suggest:copilot:<model>` / `claim:copilot:<model>` (`suggest:codex:sol`,
+      `claim:copilot:code-1-flash`, …). Those are created on demand rather than
+      seeded, so `gh label list --limit 200`'s default page can miss them
+      entirely if this repo has many labels — enumerate with the family prefix
+      instead of eyeballing the page: `gh label list --repo <owner/repo>
+      --limit 1000 --json name --jq '.[].name' | grep -E
+      '^(suggest|claim):(codex|copilot):'`. Rename each the same
+      rename-never-recreate way, **preserving its model suffix**
+      (`suggest:codex:sol` → `suggest:gpt:sol`, `claim:copilot:code-1-flash` →
+      `claim:mai:code-1-flash` — the model slugs are unchanged by the rename,
+      only the family segment moves), and run the same in-flight-claim check
+      per label before renaming it
+      (`gh issue list --label suggest:codex:sol --state all --limit 200` /
+      `gh pr list --label suggest:codex:sol --state all --limit 200`, one pair
+      per label found). Re-run the `grep` above afterwards — it should return
+      nothing.
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,
       so this is a one-time manual step. Filters/layouts are in

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -490,13 +490,13 @@ and their vocabulary is not hand-listed anywhere: it is rendered from
 `agent-registry.json` (see [Agent families and harnesses](#agent-families-and-harnesses)),
 so provisioning and documentation cannot fork from each other.
 
-- **Suggest** — `suggest:claude`, `suggest:codex`, … — which agent family
+- **Suggest** — `suggest:claude`, `suggest:gpt`, … — which agent family
   *should* implement the issue, set at triage. Advisory only: it routes
   nothing by itself[% if use_foreman %] and must never be read as Foreman arming (that is the
   `foreman:*` family)[% endif %]. A model-level label (`suggest:claude:opus`, created on
   demand) **refines** the family label, never replaces it — apply both, so
   views filtered on the family labels keep seeing the issue
-- **Claim** — `claim:claude`, `claim:codex`, … — which agent family is working
+- **Claim** — `claim:claude`, `claim:gpt`, … — which agent family is working
   the issue *right now*, written by the agent itself (see **Claiming** below).
   Model-level (`claim:claude:opus`) refines it the same way
 
@@ -666,32 +666,44 @@ dispatch".
 
 | Family | Name | Models |
 | --- | --- | --- |
-| `claude` | Claude | `opus`, `sonnet`, `haiku` |
-| `codex` | OpenAI Codex | `sol`, `terra`, `luna` |
-| `copilot` | GitHub Copilot | — |
-| `qwen` | Qwen | `coder` |
-| `deepseek` | DeepSeek | — |
-| `glm` | GLM | `5-2` |
+| `claude` | Claude | `fable`, `opus`, `sonnet`, `haiku` |
+| `gpt` | GPT | `sol`, `terra`, `luna` |
+| `mai` | MAI | `code-1-flash`, `thinking-1` |
+| `qwen` | Qwen | `max`, `coder-plus`, `coder`, `coder-next`, `coder-30b` |
+| `deepseek` | DeepSeek | `v4-pro`, `v4-flash` |
+| `glm` | GLM | `5-2`, `4-7-flash` |
 | `kimi` | Kimi | `k3` |
-| `minimax` | MiniMax | — |
-| `gemini` | Gemini | — |
+| `minimax` | MiniMax | `m3` |
+| `gemini` | Gemini | `3-1-pro`, `3-6-flash`, `3-5-flash-lite` |
+| `mistral` | Mistral | `devstral-small-2` |
+
+`Model selected by` values:
+
+- `runner-config` — the runner or repository/CLI configuration selects the model; labels do not.
+- `workflow-config` — the GitHub Actions workflow input selects the model.
+- `provider-wrapper` — the provider-rewired wrapper fixes the family; its runtime configuration selects the model.
+- `harness-runtime` — the harness selects both provider family and model at runtime.
 
 #### Harnesses
 
 | Harness | Product | Family | Foreman adapter | Model selected by |
 | --- | --- | --- | --- | --- |
-| `claude-code` | Claude Code CLI | `claude` | `foreman:claude` — production, dispatchable | `runner-config` — The runner or repository configuration selects the Claude model; labels do not. |
-| `claude-code-action` | claude-code-action | `claude` | — | `workflow-config` — The GitHub Actions workflow input selects the Claude model. |
-| `claude-code-deepseek` | Claude Code provider wrapper | `deepseek` | `claude-code-deepseek` — production, not dispatchable, no label | `provider-wrapper` — The provider-rewired wrapper fixes the family and its runtime configuration selects the model. |
-| `claude-code-glm` | Claude Code provider wrapper | `glm` | — | `provider-wrapper` — The provider-rewired wrapper fixes the family and its runtime configuration selects the model. |
-| `claude-code-kimi` | Claude Code provider wrapper | `kimi` | — | `provider-wrapper` — The provider-rewired wrapper fixes the family and its runtime configuration selects the model. |
-| `claude-code-minimax` | Claude Code provider wrapper | `minimax` | — | `provider-wrapper` — The provider-rewired wrapper fixes the family and its runtime configuration selects the model. |
-| `codex-cli` | OpenAI Codex CLI | `codex` | — | `runner-config` — The runner or CLI invocation selects the Codex model. |
-| `copilot-cli` | GitHub Copilot CLI | `copilot` | — | `runner-config` — The runner or Copilot configuration selects the model. |
-| `qwen-code` | Qwen Code CLI | `qwen` | — | `runner-config` — The runner or Qwen Code configuration selects the Qwen model. |
-| `antigravity` | Google Antigravity | `gemini` | — | `harness-runtime` — The Antigravity session selects the Gemini model. |
-| `opencode` | OpenCode | any (multi-provider) | — | `harness-runtime` — The multi-provider harness selects both provider family and model at runtime. |
-| `pi` | Pi | any (multi-provider) | — | `harness-runtime` — The multi-provider harness selects both provider family and model at runtime. |
+| `claude-code` | Claude Code CLI | `claude` | `foreman:claude` — production, dispatchable | `runner-config` |
+| `claude-code-action` | claude-code-action | `claude` | — | `workflow-config` |
+| `claude-code-deepseek` | Claude Code provider wrapper | `deepseek` | `claude-code-deepseek` — production, not dispatchable, no label | `provider-wrapper` |
+| `claude-code-glm` | Claude Code provider wrapper | `glm` | — | `provider-wrapper` |
+| `claude-code-kimi` | Claude Code provider wrapper | `kimi` | — | `provider-wrapper` |
+| `claude-code-minimax` | Claude Code provider wrapper | `minimax` | — | `provider-wrapper` |
+| `claude-code-qwen` | Claude Code provider wrapper | `qwen` | — | `provider-wrapper` |
+| `claude-code-qwen-local` | Claude Code provider wrapper | `qwen` | — | `provider-wrapper` |
+| `codex-cli` | OpenAI Codex CLI | `gpt` | — | `runner-config` |
+| `copilot-cli` | GitHub Copilot CLI | any (multi-provider; default `mai`) | — | `harness-runtime` |
+| `qwen-code` | Qwen Code CLI | `qwen` | — | `runner-config` |
+| `antigravity` | Google Antigravity | `gemini` | — | `harness-runtime` |
+| `opencode` | OpenCode | any (multi-provider) | — | `harness-runtime` |
+| `pi` | Pi | any (multi-provider) | — | `harness-runtime` |
+| `goose` | Block Goose | any (multi-provider) | — | `harness-runtime` |
+| `cline` | Cline | any (multi-provider) | — | `harness-runtime` |
 <!-- registry-tables:end -->
 
 ## Claiming — making an agent's work visible while it happens

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -682,7 +682,7 @@ dispatch".
 - `runner-config` — the runner or repository/CLI configuration selects the model; labels do not.
 - `workflow-config` — the GitHub Actions workflow input selects the model.
 - `provider-wrapper` — the provider-rewired wrapper fixes the family; its runtime configuration selects the model.
-- `harness-runtime` — the harness selects both provider family and model at runtime.
+- `harness-runtime` — the harness selects the model at runtime; for broker harnesses it selects the provider family too.
 
 #### Harnesses
 

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -17,7 +17,7 @@ current — it is the reference for "where do secrets live and who can do what".
   `AGENT_DECK_TELEGRAM_KEY` in both profiles, `GH_TOKEN` in the bot profile only,
   `TS_AUTHKEY` in the dev profile only[% if use_alternative_claude_providers %], plus the
   alt-model provider keys (`KIMI_API_KEY`/`MOONSHOT_API_KEY`, `DEEPSEEK_API_KEY`,
-  `ZAI_API_KEY`) when opted in[% endif %] — see
+  `ZAI_API_KEY`, `QWEN_API_KEY`) when opted in[% endif %] — see
   [../guides/devcontainers.md](../guides/devcontainers.md).
 [% endif %]
   TODO: list the 1Password vault/items this project uses.

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -396,9 +396,12 @@ host gateway via `runArgs`, so it resolves even on native Linux) and falls
 back to `localhost` when that name doesn't resolve — set `QWEN_LOCAL_BASE_URL`
 to override either guess. **On native Linux, the DNS mapping alone is not
 enough**: stock Ollama binds `127.0.0.1:11434` (loopback-only), so it refuses
-the container's connection regardless — set `OLLAMA_HOST=0.0.0.0` (env var or
-a systemd override for the `ollama` service) so it listens on every interface,
-or point `QWEN_LOCAL_BASE_URL` at an endpoint that already does.
+the container's connection regardless. Do **not** bind `0.0.0.0` — Ollama has
+no auth, so that exposes it to the whole LAN. Instead set
+`OLLAMA_HOST=<docker0-bridge-IP>` (`ip addr show docker0`, typically
+`172.17.0.1`) to scope it to the Docker bridge, firewall port `11434` to that
+bridge if it must stay on `0.0.0.0` for other reasons, or point
+`QWEN_LOCAL_BASE_URL` at an endpoint that's already reachable.
 
 The provider API keys flow through the same env-file pipeline as everything else
 (`init-env.sh` allow-list → `devcontainer.env` → `--env-file`), so add them to your

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -301,7 +301,7 @@ Variables per profile:
 | `AGENT_DECK_TELEGRAM_KEY` | ✅ | ✅ | agent-deck bridge (optional) |
 | `TS_AUTHKEY` | — | ✅ | Tailscale (dev only) |
 [% if use_alternative_claude_providers %]
-| `KIMI_API_KEY` / `MOONSHOT_API_KEY`, `DEEPSEEK_API_KEY`, `ZAI_API_KEY` | ✅ | ✅ | alt-model wrappers (opt-in: `use_alternative_claude_providers`) |
+| `KIMI_API_KEY` / `MOONSHOT_API_KEY`, `DEEPSEEK_API_KEY`, `ZAI_API_KEY`, `QWEN_API_KEY` | ✅ | ✅ | alt-model wrappers (opt-in: `use_alternative_claude_providers`) |
 [% endif %]
 
 `ANTHROPIC_API_KEY` is deliberately **forbidden** — it silently overrides
@@ -370,16 +370,35 @@ fine-grained one. A fine-grained PAT has exactly one resource owner, so using on
 here would reintroduce the single-org ceiling this arrangement exists to remove.
 [% if use_alternative_claude_providers %]
 
-### Alternative model providers (`claude-kimi` / `claude-deepseek` / `claude-glm`)
+### Alternative model providers (`claude-kimi` / `claude-deepseek` / `claude-glm` / `claude-qwen` / `claude-qwen-local`)
 
 Opt in with the `use_alternative_claude_providers` Copier answer (default off;
 asked only when `devcontainer=true`) to ship the `claude-kimi`, `claude-deepseek`,
-and `claude-glm` shell functions. They mirror the equivalent host wrappers:
-each launches `claude` in a subshell with `ANTHROPIC_BASE_URL` +
-`ANTHROPIC_AUTH_TOKEN` pointed at a provider's native Anthropic-compatible
-`/anthropic` endpoint (Moonshot Kimi K3, DeepSeek V4, Z.AI GLM-5.2 — no proxy),
-plus the per-tier `ANTHROPIC_*_MODEL` vars. The functions live in
+`claude-glm`, `claude-qwen`, and `claude-qwen-local` shell functions. The hosted
+four mirror the equivalent host wrappers: each launches `claude` in a subshell
+with `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` pointed at a provider's
+native Anthropic-compatible endpoint under a vendor-documented path prefix
+(Moonshot Kimi K3, DeepSeek V4, Z.AI GLM-5.2, Alibaba DashScope Qwen3.7-Max /
+Qwen3-Coder-Plus — no proxy), plus the per-tier `ANTHROPIC_*_MODEL` vars
+(`claude-qwen` uses Qwen3.7-Max for the main/reasoning roles and
+Qwen3-Coder-Plus for coding/subagent roles). The functions live in
 `.devcontainer/config/claude-providers.sh` and are sourced from `shell-aliases.sh`.
+
+`claude-qwen-local` is different: it targets your **own** Ollama/LM Studio
+endpoint serving `qwen3-coder:30b`, so it needs no API key and no
+1Password entry — `ANTHROPIC_AUTH_TOKEN` is a meaningless placeholder value.
+Its default `ANTHROPIC_BASE_URL` has **no** path suffix (`http://<host>:11434`,
+not `.../anthropic`) — unlike the hosted providers, Ollama and LM Studio serve
+their Anthropic-compatible API from the server root, and the client already
+appends the API path itself. The default host is chosen at launch: it probes
+`host.docker.internal` (which both shipped devcontainer profiles map to the
+host gateway via `runArgs`, so it resolves even on native Linux) and falls
+back to `localhost` when that name doesn't resolve — set `QWEN_LOCAL_BASE_URL`
+to override either guess. **On native Linux, the DNS mapping alone is not
+enough**: stock Ollama binds `127.0.0.1:11434` (loopback-only), so it refuses
+the container's connection regardless — set `OLLAMA_HOST=0.0.0.0` (env var or
+a systemd override for the `ollama` service) so it listens on every interface,
+or point `QWEN_LOCAL_BASE_URL` at an endpoint that already does.
 
 The provider API keys flow through the same env-file pipeline as everything else
 (`init-env.sh` allow-list → `devcontainer.env` → `--env-file`), so add them to your
@@ -460,7 +479,8 @@ repo** (one template serves every repo). To stand this repo up in Coder:
      `GH_TOKEN` **for a bot workspace only** — a dev workspace runs
      `gh auth login` instead
      (+ `TS_AUTHKEY` if you want Tailscale)[% if use_alternative_claude_providers %]; `KIMI_API_KEY`/`MOONSHOT_API_KEY`,
-     `DEEPSEEK_API_KEY`, `ZAI_API_KEY` for the alt-model wrappers[% endif %]. Coder passes these
+     `DEEPSEEK_API_KEY`, `ZAI_API_KEY`, `QWEN_API_KEY` for the alt-model wrappers
+     (`claude-qwen-local` needs no key — see below)[% endif %]. Coder passes these
      into the workspace's host environment, where `init-env.sh` picks them up.
 
    Coder is the case where this matters most: there is no 1Password app in the

--- a/template/scripts/agent-registry-labels.mjs
+++ b/template/scripts/agent-registry-labels.mjs
@@ -175,7 +175,21 @@ if (mode === 'docs-tables') {
     lines.push(`| ${code(slug)} | ${name} | ${models || '—'} |`)
   }
 
+  // `Model selected by` values are defined ONCE here rather than repeating a
+  // sentence per harness row: every harness's model_resolution.owner is one of
+  // these four enum values (agent-registry.schema.json), so the meaning is
+  // fixed regardless of which harness carries it. Per-harness `details` text
+  // still lives in the registry for tooling/validation but is not rendered
+  // per row — it would just restate one of these four sentences with a
+  // harness name spliced in.
   lines.push(
+    '',
+    '`Model selected by` values:',
+    '',
+    '- `runner-config` — the runner or repository/CLI configuration selects the model; labels do not.',
+    '- `workflow-config` — the GitHub Actions workflow input selects the model.',
+    '- `provider-wrapper` — the provider-rewired wrapper fixes the family; its runtime configuration selects the model.',
+    '- `harness-runtime` — the harness selects both provider family and model at runtime.',
     '',
     '#### Harnesses',
     '',
@@ -186,10 +200,15 @@ if (mode === 'docs-tables') {
     const slug = cell(harness.slug, 'harness slug')
     const product = cell(harness.product, `harness '${slug}' product`)
     const constraint = harness.family_constraint ?? {}
-    const family =
-      constraint.kind === 'fixed'
-        ? code(cell(constraint.family, `harness '${slug}' family_constraint.family`))
-        : 'any (multi-provider)'
+    let family = 'any (multi-provider)'
+    if (constraint.kind === 'fixed') {
+      family = code(cell(constraint.family, `harness '${slug}' family_constraint.family`))
+    } else if (constraint.kind === 'broker' && constraint.default_family) {
+      const defaultFamily = code(
+        cell(constraint.default_family, `harness '${slug}' family_constraint.default_family`)
+      )
+      family = `any (multi-provider; default ${defaultFamily})`
+    }
     const adapters = adaptersByHarness.get(harness.slug) ?? []
     const adapterCell =
       adapters
@@ -202,10 +221,7 @@ if (mode === 'docs-tables') {
         .join('; ') || '—'
     const resolution = harness.model_resolution ?? {}
     const owner = code(cell(resolution.owner, `harness '${slug}' model_resolution.owner`))
-    const details = cell(resolution.details, `harness '${slug}' model_resolution.details`)
-    lines.push(
-      `| ${code(slug)} | ${product} | ${family} | ${adapterCell} | ${owner} — ${details} |`
-    )
+    lines.push(`| ${code(slug)} | ${product} | ${family} | ${adapterCell} | ${owner} |`)
   }
 }
 

--- a/template/scripts/agent-registry-labels.mjs
+++ b/template/scripts/agent-registry-labels.mjs
@@ -189,7 +189,7 @@ if (mode === 'docs-tables') {
     '- `runner-config` — the runner or repository/CLI configuration selects the model; labels do not.',
     '- `workflow-config` — the GitHub Actions workflow input selects the model.',
     '- `provider-wrapper` — the provider-rewired wrapper fixes the family; its runtime configuration selects the model.',
-    '- `harness-runtime` — the harness selects both provider family and model at runtime.',
+    '- `harness-runtime` — the harness selects the model at runtime; for broker harnesses it selects the provider family too.',
     '',
     '#### Harnesses',
     '',

--- a/template/scripts/test-agent-registry.sh
+++ b/template/scripts/test-agent-registry.sh
@@ -53,10 +53,24 @@ switch (mutation) {
   case 'unknown-fixed-family':
     registry.harnesses[0].family_constraint.family = 'unknown'
     break
-  case 'family-on-none':
+  case 'family-on-broker':
     for (const entry of registry.harnesses) {
-      if (entry.family_constraint.kind === 'none') entry.family_constraint.family = 'claude'
+      if (entry.family_constraint.kind === 'broker') entry.family_constraint.family = 'claude'
     }
+    break
+  case 'unknown-default-family':
+    for (const entry of registry.harnesses) {
+      if (entry.family_constraint.kind === 'broker') {
+        entry.family_constraint.default_family = 'unknown'
+        break
+      }
+    }
+    break
+  case 'default-family-on-fixed':
+    registry.harnesses[0].family_constraint.default_family = 'claude'
+    break
+  case 'bad-local-suffix':
+    harness('claude-code-minimax').slug = 'claude-code-minimax-local-extra'
     break
   case 'production-without-harness':
     adapter('claude').harness = null
@@ -190,9 +204,18 @@ rejects "missing model-resolution ownership" \
 rejects "unknown fixed-family constraints" \
     'unknown-fixed-family' \
     'references unknown family unknown'
-rejects "family values on unconstrained harnesses" \
-    'family-on-none' \
-    'with a none constraint'
+rejects "family values on broker harnesses" \
+    'family-on-broker' \
+    'did you mean default_family'
+rejects "a broker default_family referencing an unknown family" \
+    'unknown-default-family' \
+    'default_family references unknown family unknown'
+rejects "a default_family on a fixed constraint" \
+    'default-family-on-fixed' \
+    'default_family on a fixed constraint'
+rejects "a provider-rewired harness slug with an unsanctioned suffix" \
+    'bad-local-suffix' \
+    'must be named claude-code-<fixed-family> or claude-code-<fixed-family>-local'
 rejects "production adapters without a harness mapping" \
     'production-without-harness' \
     'needs a production harness mapping'

--- a/template/scripts/test-registry-drift.sh
+++ b/template/scripts/test-registry-drift.sh
@@ -149,15 +149,21 @@ else
 fi
 
 # ── 4. provider-wrapper inventory ──────────────────────────────────────────
-# Every claude-<family> wrapper that ships MUST correspond to a provider-rewired
-# harness claude-code-<family> in the registry (no orphan wrappers). The reverse
-# is allowed: the registry may declare a provider-rewired harness ahead of its
-# wrapper (e.g. claude-code-minimax before a claude-minimax launcher exists).
+# Every claude-<family>[-local] wrapper that ships MUST correspond to a
+# provider-rewired harness claude-code-<family>[-local] in the registry (no
+# orphan wrappers). The -local suffix is a sanctioned endpoint-variant marker
+# (ADR 0005 D9 amendment) for a wrapper of the SAME family, not a distinct
+# "<family>-local" family — claude-qwen-local() maps to family "qwen", not
+# "qwen-local" — so it is stripped before the family lookup but kept in the
+# harness slug. The reverse mapping is allowed: the registry may declare a
+# provider-rewired harness ahead of its wrapper (e.g. claude-code-minimax
+# before a claude-minimax launcher exists).
 if [ -f "$wrappers_glob" ]; then
     wrappers="$(sed -n -E 's/^(claude-[a-z0-9-]+)\(\)[[:space:]]*\{.*/\1/p' "$wrappers_glob")"
     for fn in $wrappers; do
-        family="${fn#claude-}"
-        harness="claude-code-${family}"
+        stem="${fn#claude-}"
+        family="${stem%-local}"
+        harness="claude-code-${stem}"
         ok="$(jq -r --arg h "$harness" --arg f "$family" '
             [.harnesses[]
              | select(.slug == $h

--- a/template/scripts/validate-agent-registry.mjs
+++ b/template/scripts/validate-agent-registry.mjs
@@ -365,7 +365,10 @@ if (errors.length === 0) {
           `harness ${harness.slug} has family ${constraint.family} on a broker constraint — did you mean default_family?`
         )
       }
-      if (Object.hasOwn(constraint, 'default_family') && !familySlugs.has(constraint.default_family)) {
+      if (
+        Object.hasOwn(constraint, 'default_family') &&
+        !familySlugs.has(constraint.default_family)
+      ) {
         semanticError(
           `harness ${harness.slug} broker default_family references unknown family ${constraint.default_family}`
         )

--- a/template/scripts/validate-agent-registry.mjs
+++ b/template/scripts/validate-agent-registry.mjs
@@ -354,16 +354,36 @@ if (errors.length === 0) {
       } else if (!familySlugs.has(constraint.family)) {
         semanticError(`harness ${harness.slug} references unknown family ${constraint.family}`)
       }
-    } else if (Object.hasOwn(constraint, 'family')) {
-      semanticError(
-        `harness ${harness.slug} has family ${constraint.family} with a none constraint`
-      )
+      if (Object.hasOwn(constraint, 'default_family')) {
+        semanticError(
+          `harness ${harness.slug} has a default_family on a fixed constraint — fixed constraints use family, not default_family`
+        )
+      }
+    } else if (constraint.kind === 'broker') {
+      if (Object.hasOwn(constraint, 'family')) {
+        semanticError(
+          `harness ${harness.slug} has family ${constraint.family} on a broker constraint — did you mean default_family?`
+        )
+      }
+      if (Object.hasOwn(constraint, 'default_family') && !familySlugs.has(constraint.default_family)) {
+        semanticError(
+          `harness ${harness.slug} broker default_family references unknown family ${constraint.default_family}`
+        )
+      }
     }
 
+    // Provider-rewired harnesses are named claude-code-<fixed-family>, optionally
+    // with a -local suffix for a local-endpoint variant of the same family (ADR
+    // 0005 D9 amendment) — claude-code-qwen-local stays fixed to family "qwen",
+    // not a separate "qwen-local" family.
     if (harness.provider_rewired) {
-      if (constraint.kind !== 'fixed' || harness.slug !== `claude-code-${constraint.family}`) {
+      const expected = constraint.kind === 'fixed' ? `claude-code-${constraint.family}` : null
+      if (
+        constraint.kind !== 'fixed' ||
+        (harness.slug !== expected && harness.slug !== `${expected}-local`)
+      ) {
         semanticError(
-          `provider-rewired harness ${harness.slug} must be named claude-code-<fixed-family>`
+          `provider-rewired harness ${harness.slug} must be named claude-code-<fixed-family> or claude-code-<fixed-family>-local`
         )
       }
       if (harness.model_resolution.owner !== 'provider-wrapper') {


### PR DESCRIPTION
Closes #751

## What

Refreshes the agent registry and everything downstream of it for the mid-2026 model lineups, and fixes the family-vs-product taxonomy per ADR 0005:

- **`agent-registry.json`** (root + `template/` verbatim twins, `schema_version: 2`): `claude` gains `fable`; family `codex` → `gpt`; family `copilot` → `mai` (`code-1-flash`, `thinking-1`); full rosters for `gemini`, `qwen` (incl. `max`), `deepseek`, `glm`, `minimax`; new `mistral` family; new harnesses `claude-code-qwen`, `claude-code-qwen-local`, `goose`, `cline`; `copilot-cli`/`opencode`/`pi` become explicit brokers, `copilot-cli` with `default_family: mai`.
- **Schema + validator + mutation tests**: `family_constraint.kind` is now `fixed | broker` with an optional broker `default_family`, replacing the overloaded `none`; the sanctioned `claude-code-<family>[-local]` naming is validated.
- **`claude-providers.sh`** (both twins): new `claude-qwen` (hosted DashScope, per-role models — Qwen3.7-Max main, Qwen3-Coder-Plus coding/subagents, keys via the env-file/`op run` path) and `claude-qwen-local` (local Anthropic-compatible endpoint, `host.docker.internal` probe, no secret). `QWEN_API_KEY` threaded through `init-env.sh`, both profiles' `initializeCommand`, and env examples; the `--add-host=host.docker.internal:host-gateway` runArg ships gated on the provider opt-in in the template (root dogfoods it on).
- **ADR 0005 amended in place**: D8 (codex→gpt), D9 (`-local` suffix), new D12 (broker kind), D13 (docs enum list), D14 (slug conventions).
- **Docs**: `docs/project-management.md` regenerated (normalized `Model selected by` enum + definition list); `docs/CHECKLIST.md` gains the family-label migration procedure (rename-never-recreate, destination-collision handling, model-qualified labels, broker-aware copilot handling); `docs/guides/devcontainers.md` covers both qwen lanes; `copier.yml`'s provider opt-in discloses Alibaba/Qwen.

## Why

The registry predated the mid-2026 vendor lineups and recorded two products (Codex, Copilot) as model families. Rows exist only where a dispatch path exists or is planned; `llama`/`muse` deliberately excluded, per the issue.

## Verification

- `task verify` green (all six render profiles), `task test:template:all` green standalone.
- `task ci` green (verify + skills drift + devcontainer assert + security; semgrep 0 findings, gitleaks clean).
- `task test:dogfood-parity` (108 twins identical), `test:dogfood-structure`, `test:registry-docs`, `test:registry-drift`, registry mutation tests — all green.
- Second-model review: `task challenge` ran 7 rounds (6 fix batches adjudicated — env-pipeline key threading, container networking/endpoint-shape for the local lane, Ollama LAN-exposure advice, opt-in disclosure, broker-aware label migration, per-key opt-out assertions) and exited clean; `task review` passed round 1 with no P0/P1.

## Deferred findings

- [x] `.github/workflows/claude-{plan,implement,review}.yml` (+ template twins) and the vendored claim-lifecycle doc still present `claim:codex` as current foreign-family vocabulary after the codex→gpt rename; update the workflow twins here, and fix the vendored skill upstream in harmon-devkit before a pin bump (vendored skills are never hand-edited). — workflow twins fixed in 6eabe7c; vendored-skill sweep filed as evanharmon1/harmon-devkit#382
- [x] `.devcontainer/config/claude-providers.sh` (+ twin) — `claude-qwen()`/`claude-qwen-local()` have no execution tests (auth fallback, env isolation, per-role model vars, URL override, host probe); only rendering/key-presence is asserted. Consider stubbed-command (`claude`, `op`, `getent`) execution tests. — filed as #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AeZifAJhh1zwW9dpYE8Yy

