### PR TITLE
feat: converge review loops on adjudicated severity; route Codex polling to vendored checker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -601,9 +601,12 @@ in the abstract and wrong for the artifact. A documentation guide that has
 grown a hand-rolled process supervisor earns real, defensible P1s about per-run
 state, process-group supervision, and PID reuse; every one of them becomes moot
 when the recipe is deleted instead of hardened. That is not giving up on the
-findings: the stage exits on **rounds that adjudicate to zero P0/P1**, and an
-adjudication does not care whether a finding was answered or made
-inapplicable — a mooted finding adjudicates to nothing left. Name the mooted findings
+findings — and it is not a way to re-score the round that raised them. A
+confirmed P0/P1 keeps its adjudicated priority for its own round whether the
+remedy is a fix or a deletion; the remedy either way is input to the **next**
+round, and only that later round's review of the changed tree counts toward
+convergence. What deletion buys is that the next round finds nothing left to
+re-raise. Name the mooted findings
 in the adjudication table *and* in the message of the commit that removes the
 code — the table is scrollback, but the commit is why the code is gone, and it
 is the record a later round or a different session can still find.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,9 +369,10 @@ non-draft PR must always mean the automated work is done.
   incomplete.
   Give each attempt a full 10–15 minute window. An attempt is **incomplete**
   when its window elapses with no terminal result for the captured head
-  (the script's exit 12). After an incomplete first attempt, post
-  `@codex review` once more for the same head and run one more full window as
-  attempt 2, recording and using the new trigger comment ID. If both attempts
+  (the script's exit 12). After an incomplete first attempt, repeat the
+  reserve-first sequence as attempt 2: `reserve --attempt 2` against the same
+  head, then post `@codex review` once more, then `attach` the comment ID
+  returned for that trigger, and run one more full window. If both attempts
   are incomplete, stop and escalate without reporting green (the script's
   exit 13). Waiting and the
   one allowed re-trigger do not consume a shepherd fix round. Immediately

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,10 +378,12 @@ non-draft PR must always mean the automated work is done.
   before accepting the result or reporting green, re-`check` the cycle and
   re-read `headRefOid`; a changed head invalidates the result and starts
   a new current-head cycle.
-  One disposition the script cannot express is settled in prose: a
-  **top-level** comment carrying a badged finding has no reply linkage, so
-  once it lands, no adjudication can make that head's `check` come back
-  clean — findings outrank a later clean result on the same head. When every
+  One disposition the script cannot express is settled in prose: a badged
+  finding stated **outside an inline thread** — in a top-level comment or in
+  a review's own body — has no reply linkage, so once it lands, no
+  adjudication can make that head's `check` come back clean: findings outrank
+  a later clean result on the same head, and the script's settled set reaches
+  only inline comments. When every
   such finding is adjudicated without a code change (declined with evidence,
   or filed as follow-up work), record each disposition as a PR comment and
   treat the cycle as **terminal with findings settled** for that head; the
@@ -439,7 +441,7 @@ review only when **all** of the following hold for its current `headRefOid`:
   taken moments after the push reports nothing having run rather than nothing
   to run.
 - The current-head Codex cycle above is terminal and clean, or terminal with
-  every finding settled under the top-level disposition rule above (Codex review is
+  every finding settled under the no-thread disposition rule above (Codex review is
   enabled here; where it is off, this condition drops out).
 - Every review finding is fixed, declined with evidence, or filed as follow-up
   work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,13 +336,16 @@ non-draft PR must always mean the automated work is done.
   this stage.
   **Require a current-head Codex result.** On initial shepherd entry and
   immediately after every fix push, capture the PR's current `headRefOid` and
-  the head's push time, then post `@codex review`. Record the request time and
-  the comment ID returned for that trigger.
+  the head's push time.
   **Do not hand-roll the polling.** Run the vendored
-  `.claude/skills/shepherd/assets/check-codex-cloud-review.sh`: `reserve` a
-  cycle against the captured head, `attach` the trigger comment ID, then
-  `check` it, and act on the exit code it returns (0 clean, 10 findings,
-  11 pending, 12 retry, 13 escalate, 2 indeterminate). The script exists
+  `.claude/skills/shepherd/assets/check-codex-cloud-review.sh`, in its order:
+  `reserve` a cycle against the captured head **before** posting the
+  trigger — the durable state must exist before the GitHub write, or an
+  interruption between the two leaves an untracked trigger a resumed session
+  can double-spend — then post `@codex review`, `attach` the comment ID the
+  trigger returned, and `check`, acting on the exit code it returns (0 clean,
+  10 findings, 11 pending, 12 retry, 13 escalate, 2 indeterminate). The
+  script exists
   because ad-hoc pollers fail in one specific, repeatable way — they watch
   reviews and inline comments and miss the **top-level comment** surface, so a
   clean `Reviewed commit:` verdict posted there reads as silence and a
@@ -374,6 +377,15 @@ non-draft PR must always mean the automated work is done.
   before accepting the result or reporting green, re-`check` the cycle and
   re-read `headRefOid`; a changed head invalidates the result and starts
   a new current-head cycle.
+  One disposition the script cannot express is settled in prose: a
+  **top-level** comment carrying a badged finding has no reply linkage, so
+  once it lands, no adjudication can make that head's `check` come back
+  clean — findings outrank a later clean result on the same head. When every
+  such finding is adjudicated without a code change (declined with evidence,
+  or filed as follow-up work), record each disposition as a PR comment and
+  treat the cycle as **terminal with findings settled** for that head; the
+  readiness gate reads those recorded adjudications where a checker exit 0 is
+  unreachable. Any push starts a fresh cycle as usual.
   Shepherd is **externally driven** — CI results and other people's comments
   are its input, so it cannot manufacture a round on its own. A round is one
   fix push, or one no-change cycle where everything is answered and nothing
@@ -425,7 +437,8 @@ review only when **all** of the following hold for its current `headRefOid`:
   *indeterminate*, not a pass — GitHub populates it asynchronously, so a read
   taken moments after the push reports nothing having run rather than nothing
   to run.
-- The current-head Codex cycle above is terminal and clean (Codex review is
+- The current-head Codex cycle above is terminal and clean, or terminal with
+  every finding settled under the top-level disposition rule above (Codex review is
   enabled here; where it is off, this condition drops out).
 - Every review finding is fixed, declined with evidence, or filed as follow-up
   work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,11 +257,11 @@ non-draft PR must always mean the automated work is done.
   P2. Severity is read off the **adjudicated** column of your adjudication
   table, not off the reviewer's label, and nothing further is owed after the
   second such round: the second round *is* the confirmation, so there is no
-  extra clean run to buy. A first round that returns **no findings at all**
-  still ends the stage on its own — one empty round is a stronger signal than
-  two adjudicated-clean ones, and a trivial change should never pay for a
-  second pass. Fixing the findings is still not the exit condition; two
-  consecutive adjudicated-clean rounds are. The exit carries one
+  extra clean run to buy. A round that returns **no findings at all** ends
+  the stage on its own, whenever it comes — an empty round is the old rule's
+  clean re-run, so neither a trivial change nor a clean post-fix re-run pays
+  for a confirmation pass. Fixing the findings is still not the exit
+  condition; adjudicated-clean rounds are. The exit carries one
   precondition: every P2 you deferred during the stage must already be in the
   deferred-findings sidecar (see "Deferring P2s" below) — an exit that drops
   a P2 is not an exit, because nothing downstream will ever see it again.
@@ -270,7 +270,10 @@ non-draft PR must always mean the automated work is done.
   **self-referential** — the fixes you make in response to a round become the
   next round's input, so it can generate its own work indefinitely — and that
   is what the cap defends against: max **4** challenge → fix → re-challenge
-  rounds; if P0/P1 findings persist, stop and escalate to Evan.
+  rounds; if P0/P1 findings persist, stop and escalate to Evan. A capped
+  final round that adjudicates to zero P0/P1 ends the stage by itself — its
+  confirmation would be a run the cap forbids, and a clean last round is
+  convergence, not the persisting disagreement escalation exists for.
   "Between rounds, check what the findings are about" below is how you catch
   the loop feeding on itself before the cap does, and round 2 is where that
   check is owed rather than optional.
@@ -360,12 +363,13 @@ non-draft PR must always mean the automated work is done.
   inline findings, and reactions never count for a newer head. A 👀 is pending,
   not success; if it disappears without a terminal result, the attempt is
   incomplete.
-  Give each attempt a full 10–15 minute window. If the first attempt is
-  incomplete — the script's exit 12 — post `@codex review` once more for the
-  same head and run one more full window as attempt 2, recording and using the
-  new trigger comment ID. If both attempts
-  are incomplete, stop and escalate without reporting green; that is what the
-  script's exit 13 means. Waiting and the
+  Give each attempt a full 10–15 minute window. An attempt is **incomplete**
+  when its window elapses with no terminal result for the captured head
+  (the script's exit 12). After an incomplete first attempt, post
+  `@codex review` once more for the same head and run one more full window as
+  attempt 2, recording and using the new trigger comment ID. If both attempts
+  are incomplete, stop and escalate without reporting green (the script's
+  exit 13). Waiting and the
   one allowed re-trigger do not consume a shepherd fix round. Immediately
   before accepting the result or reporting green, re-`check` the cycle and
   re-read `headRefOid`; a changed head invalidates the result and starts
@@ -666,18 +670,25 @@ ends when **two consecutive rounds adjudicate to zero P0 and zero P1
 findings**, and never on "findings fixed" alone. Those rounds may be empty,
 all-P2 as labeled, or P1-labeled and adjudicated down to P2; what counts is
 the **adjudicated** column of the table, not the reviewer's label, and the
-second such round is itself the confirmation, so no further run is owed. The
-single exception runs the other way: a **first** round with no findings at all
-ends the stage immediately, because one empty round already says more than two
-adjudicated-clean ones and a trivial change should not pay for a second pass.
-This is a strict relaxation — no path now takes more rounds than it did under
-the old clean-re-run rule. Two things ride along with the exit: every P2
+second such round is itself the confirmation, so no further run is owed. Two
+exits are faster still. A round with **no findings at all** ends the stage by
+itself, whenever it comes — an empty round is exactly the old rule's clean
+re-run, so neither a trivial change nor a clean post-fix re-run pays for a
+confirmation pass. And a **capped final round** that adjudicates to zero
+P0/P1 also ends the stage by itself: the confirmation it would otherwise owe
+is a run the cap forbids, and a rule that strands a stage holding a clean
+last round and no valid exit would be wrong — the cap bounds work, it does
+not manufacture escalation. What the rule spends is bounded the other way
+too: a stage pays at most one round confirming convergence, where the old
+practice could spend every remaining round re-proving a change nobody still
+disputed. Two things ride along with the exit: every P2
 deferred during the stage must already be recorded in the sidecar (an exit
 that drops a P2 is not an exit), and round 2 owes the scaffolding checkpoint
 above. The caps are unchanged at **4** challenge iterations and **4** review
 iterations (challenge → fix → re-challenge, and likewise for review); if
-P0/P1 disagreement persists at the cap, stop and surface it to Evan instead of
-iterating further. Evan may always ask for more rounds — convergence is a
+P0/P1 disagreement persists at the cap, stop and surface it to Evan instead
+of iterating further — escalation at the cap is for P0/P1 that **persist**,
+nothing else. Evan may always ask for more rounds — convergence is a
 floor on when you may stop, not a ceiling on what he can order.
 
 One caveat on the automatic stop-gate: the codex plugin's Stop hook applies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,9 +342,10 @@ non-draft PR must always mean the automated work is done.
   `reserve` a cycle against the captured head **before** posting the
   trigger — the durable state must exist before the GitHub write, or an
   interruption between the two leaves an untracked trigger a resumed session
-  can double-spend — then post `@codex review`, `attach` the comment ID the
-  trigger returned, and `check`, acting on the exit code it returns (0 clean,
-  10 findings, 11 pending, 12 retry, 13 escalate, 2 indeterminate). The
+  can double-spend — then post `@codex review`, `attach` the comment ID
+  returned for that trigger, and `check`, acting on the exit code it returns
+  (0 clean, 10 findings, 11 pending, 12 retry, 13 escalate,
+  2 indeterminate). The
   script exists
   because ad-hoc pollers fail in one specific, repeatable way — they watch
   reviews and inline comments and miss the **top-level comment** surface, so a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,16 +251,29 @@ non-draft PR must always mean the automated work is done.
   green; verify is the definition-of-done gate (includes the render matrix).
 - **`task challenge`** — adversarial second-model review. Adjudicate per
   "Second-Model Review" below, fix confirmed findings, re-run `task verify`,
-  then **re-run `task challenge`**. The stage passes only when a re-run comes
-  back with **no confirmed P0 or P1 findings** — fixing the findings is not
-  the exit condition, a clean pass is. **P2s do not gate this stage**: carry
+  then **re-run `task challenge`**. The stage ends when **two consecutive
+  rounds adjudicate to zero P0 and zero P1 findings** — whether those rounds
+  came back empty, all-P2 as labeled, or P1-labeled and adjudicated down to
+  P2. Severity is read off the **adjudicated** column of your adjudication
+  table, not off the reviewer's label, and nothing further is owed after the
+  second such round: the second round *is* the confirmation, so there is no
+  extra clean run to buy. A first round that returns **no findings at all**
+  still ends the stage on its own — one empty round is a stronger signal than
+  two adjudicated-clean ones, and a trivial change should never pay for a
+  second pass. Fixing the findings is still not the exit condition; two
+  consecutive adjudicated-clean rounds are. The exit carries one
+  precondition: every P2 you deferred during the stage must already be in the
+  deferred-findings sidecar (see "Deferring P2s" below) — an exit that drops
+  a P2 is not an exit, because nothing downstream will ever see it again.
+  **P2s do not gate this stage**: carry
   them to the PR (see "Deferring P2s" below). This loop is
   **self-referential** — the fixes you make in response to a round become the
   next round's input, so it can generate its own work indefinitely — and that
   is what the cap defends against: max **4** challenge → fix → re-challenge
   rounds; if P0/P1 findings persist, stop and escalate to Evan.
   "Between rounds, check what the findings are about" below is how you catch
-  the loop feeding on itself before the cap does.
+  the loop feeding on itself before the cap does, and round 2 is where that
+  check is owed rather than optional.
   A `task challenge` round is long — 5–15 minutes is ordinary, past most
   agents' tool-call timeouts — so **run it in the background and poll**
   instead of blocking one call on it. Growing output means running, not hung;
@@ -271,10 +284,12 @@ non-draft PR must always mean the automated work is done.
   fixes first is still tidier, not load-bearing. Details:
   [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
   backgrounding").
-- **`task review`** — verification-checkpoint review; same adjudication, same
-  P0/P1 clean-pass exit condition, the same self-referential shape and so the
+- **`task review`** — verification-checkpoint review; same adjudication, the
+  same two-consecutive-adjudicated-clean exit condition counted over its own
+  rounds, the same self-referential shape and so the
   same reason for a cap, and the same background-and-poll handling, with its
-  own max **4** rounds.
+  own max **4** rounds. The two stages are counted separately: a converged
+  challenge says nothing about review.
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the draft PR** — conventional commit, push the branch,
   **`gh pr create --draft`** with a clear what/why/verification summary (mind
@@ -319,9 +334,22 @@ non-draft PR must always mean the automated work is done.
   **Require a current-head Codex result.** On initial shepherd entry and
   immediately after every fix push, capture the PR's current `headRefOid` and
   the head's push time, then post `@codex review`. Record the request time and
-  the comment ID returned for that trigger. Poll PR reactions, top-level
-  comments, reviews, and inline review comments; fetch trigger reactions by
-  that exact comment ID. A Codex result is terminal for that captured head only
+  the comment ID returned for that trigger.
+  **Do not hand-roll the polling.** Run the vendored
+  `.claude/skills/shepherd/assets/check-codex-cloud-review.sh`: `reserve` a
+  cycle against the captured head, `attach` the trigger comment ID, then
+  `check` it, and act on the exit code it returns (0 clean, 10 findings,
+  11 pending, 12 retry, 13 escalate, 2 indeterminate). The script exists
+  because ad-hoc pollers fail in one specific, repeatable way — they watch
+  reviews and inline comments and miss the **top-level comment** surface, so a
+  clean `Reviewed commit:` verdict posted there reads as silence and a
+  finished cycle is reported incomplete (harmon-devkit#334; seen again on
+  PR #731). It never writes to GitHub, so posting the trigger comment stays
+  yours.
+  The contract below is normative and stays here whatever tooling runs it: it
+  is what "terminal" means, and the script is the implementation you are
+  required to use rather than a substitute definition. A Codex result is
+  terminal for that captured head only
   when it is either: a clean review or top-level comment authored by GitHub
   actor ID `199175422` (`chatgpt-codex-connector[bot]`, type `Bot`) whose
   `Reviewed commit:` identifies that head; a fresh 👍 from that bot on that
@@ -333,12 +361,14 @@ non-draft PR must always mean the automated work is done.
   not success; if it disappears without a terminal result, the attempt is
   incomplete.
   Give each attempt a full 10–15 minute window. If the first attempt is
-  incomplete, post `@codex review` once more for the same head and run one more
-  full window, recording and using the new trigger comment ID. If both attempts
-  are incomplete, stop and escalate without reporting green. Waiting and the
+  incomplete — the script's exit 12 — post `@codex review` once more for the
+  same head and run one more full window as attempt 2, recording and using the
+  new trigger comment ID. If both attempts
+  are incomplete, stop and escalate without reporting green; that is what the
+  script's exit 13 means. Waiting and the
   one allowed re-trigger do not consume a shepherd fix round. Immediately
-  before accepting the result or reporting green, fetch `headRefOid` and all
-  four review surfaces again; a changed head invalidates the result and starts
+  before accepting the result or reporting green, re-`check` the cycle and
+  re-read `headRefOid`; a changed head invalidates the result and starts
   a new current-head cycle.
   Shepherd is **externally driven** — CI results and other people's comments
   are its input, so it cannot manufacture a round on its own. A round is one
@@ -534,21 +564,32 @@ findings are all about the previous round's fix is the tell**, and it is
 visible in round 2 — the first round that can show it. Do not wait for the
 pattern to be unmistakable in round 3, by which point only one round is left.
 
-**Deleting the added code is a legitimate way to reach a clean pass.** When a
+**Round 2 is the checkpoint, not a suggestion.** Under the two-consecutive
+exit the cap is no longer the only thing standing between you and a loop that
+feeds on itself, so the check has to happen where it first can. At round 2,
+for every finding, say on the adjudication table whether its subject exists
+only because an **earlier round of this same stage** added it. A finding that
+does gets adjudicated with one of two dispositions written out: **delete** the
+scaffolding (which moots the finding — see below), or state that it is in
+scope and why the change genuinely needs it. What is not allowed is hardening
+round-1's scaffolding by reflex and letting round 3 attack the result.
+
+**Deleting the added code is a legitimate way to converge.** When a
 round's findings are about scaffolding rather than the change, weigh removing
 that scaffolding against hardening it once more — a remediation can be correct
 in the abstract and wrong for the artifact. A documentation guide that has
 grown a hand-rolled process supervisor earns real, defensible P1s about per-run
 state, process-group supervision, and PID reuse; every one of them becomes moot
 when the recipe is deleted instead of hardened. That is not giving up on the
-findings: the stage exits on a **clean re-run**, and a re-run does not care
-whether a finding was answered or made inapplicable. Name the mooted findings
+findings: the stage exits on **rounds that adjudicate to zero P0/P1**, and an
+adjudication does not care whether a finding was answered or made
+inapplicable — a mooted finding adjudicates to nothing left. Name the mooted findings
 in the adjudication table *and* in the message of the commit that removes the
 code — the table is scrollback, but the commit is why the code is gone, and it
 is the record a later round or a different session can still find.
 
 One endpoint is worth knowing: if the deletion empties the change *entirely*,
-there is no clean pass to reach — `codex-review.sh` refuses an empty scope
+there is no round to converge on — `codex-review.sh` refuses an empty scope
 non-zero by design, so the stage cannot pass and re-running will not change
 that. Treat it as the answer rather than a failure to work around: a change
 that has become empty is abandoned, not reviewed clean.
@@ -578,9 +619,9 @@ before `gh pr create`, so there is usually no PR body to write to yet: append
 it to the file
 `git rev-parse --git-path "deferred-findings/$(git branch --show-current)"`
 names (`mkdir -p` its directory first) — but only if that finding is not
-already listed. A stage exits on a *clean re-run*,
-so an unchanged P2 is reported again by design, in every remaining round and
-again by the next stage; appending blindly would hand the shepherd four copies
+already listed. A P2 you leave open is reported again by design — it is
+unchanged code, so every remaining round of the stage and the next stage after
+it will raise it; appending blindly would hand the shepherd four copies
 of one finding to settle. Match on location plus substance, not exact
 wording — the same finding rarely comes back phrased identically. Then
 move the list into the description when you open the PR (then delete the
@@ -620,16 +661,31 @@ what it still owes without re-adjudicating what is done. That obligation is
 stated here and in the Dev Loop above, and holds whether or not the optional
 `/shepherd` skill is installed to automate it.
 
-**Loop cap and exit:** a stage exits only on a **clean re-run** — no
-confirmed P0 or P1 findings — never on "findings fixed" alone, with at most
-**4** challenge iterations and **4** review iterations (challenge → fix →
-re-challenge, and likewise for review). If P0/P1 disagreement persists at the
-cap, stop and surface it to Evan instead of iterating further.
+**Loop cap and exit:** a stage — challenge and review counted separately —
+ends when **two consecutive rounds adjudicate to zero P0 and zero P1
+findings**, and never on "findings fixed" alone. Those rounds may be empty,
+all-P2 as labeled, or P1-labeled and adjudicated down to P2; what counts is
+the **adjudicated** column of the table, not the reviewer's label, and the
+second such round is itself the confirmation, so no further run is owed. The
+single exception runs the other way: a **first** round with no findings at all
+ends the stage immediately, because one empty round already says more than two
+adjudicated-clean ones and a trivial change should not pay for a second pass.
+This is a strict relaxation — no path now takes more rounds than it did under
+the old clean-re-run rule. Two things ride along with the exit: every P2
+deferred during the stage must already be recorded in the sidecar (an exit
+that drops a P2 is not an exit), and round 2 owes the scaffolding checkpoint
+above. The caps are unchanged at **4** challenge iterations and **4** review
+iterations (challenge → fix → re-challenge, and likewise for review); if
+P0/P1 disagreement persists at the cap, stop and surface it to Evan instead of
+iterating further. Evan may always ask for more rounds — convergence is a
+floor on when you may stop, not a ceiling on what he can order.
 
 One caveat on the automatic stop-gate: the codex plugin's Stop hook applies
 its **own** notion of a material finding and may BLOCK on something you have
 classified P2. Adjudicate it (fix it, or state the reasoning) — **never**
-disable the gate to get past a BLOCK.
+disable the gate to get past a BLOCK. A BLOCK is settled on its own terms and
+against the hook, not against this rule: it neither reopens a stage that has
+already converged nor counts as one of that stage's rounds.
 
 ## Conventions
 

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -284,10 +284,13 @@ The **scaffolding damper** is what replaces the cap as the first line of
 defense. At round 2 — the earliest round that can show the pattern — say on
 the table, for each finding, whether its subject exists only because an earlier
 round of the same stage added it. Where it does, adjudicate it with one of two
-dispositions written down: delete the scaffolding, which moots the finding and
-still counts toward convergence, or state that the code is in scope and why the
-change needs it. Reflexively hardening the previous round's fix is the failure
-mode; naming it on the table is the check.
+dispositions written down: delete the scaffolding, or state that the code is
+in scope and why the change needs it. A deletion does not re-score the round
+that flagged the code — the finding keeps its adjudicated priority there, and
+it is the **next** round, reviewing the tree without it, that finds nothing
+left to re-raise and counts toward convergence. Reflexively hardening the
+previous round's fix is the failure mode; naming it on the table is the
+check.
 
 Two things do not move. The **4-round cap** per stage stands, and persistent
 P0/P1 disagreement at the cap is escalated rather than iterated on. And the

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -262,11 +262,14 @@ rounds may come back empty, all-P2 as labeled, or P1-labeled and adjudicated
 down to
 P2; what counts is the **adjudicated** column of your adjudication table, not
 the label Codex attached. The second such round *is* the confirmation, so no
-extra run is owed after it. One case exits faster still: a **first** round with
-no findings at all ends the stage on the spot, because a single empty round
-already says more than two adjudicated-clean ones and a trivial change should
-not pay for a second pass. Nothing here takes more rounds than the older
-"clean re-run" rule did — it is a relaxation in every direction.
+extra run is owed after it. Two cases exit faster still. A round with **no
+findings at all** ends the stage on the spot, whenever it comes — an empty
+round is exactly the older "clean re-run" exit, so neither a trivial change
+nor a clean post-fix re-run pays for a confirmation pass. And a **capped
+final round** that adjudicates to zero P0/P1 ends the stage by itself: the
+confirmation it would otherwise owe is a run the cap forbids, and escalation
+at the cap is reserved for P0/P1 findings that persist — a clean last round
+is convergence, not disagreement.
 
 The old rule charged for three things it never delivered. A confirmation run
 after an all-P2 round: `harmon-init#725` ran roughly ten gate iterations for a

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -155,7 +155,8 @@ Two things not to change when backgrounding:
   `/codex:adversarial-review --background`: the slash command calls Codex
   directly, so it never receives the P0/P1/P2 scale that
   `scripts/codex-review.sh` writes into the prompt. Fine for an interactive
-  spot-check; it cannot establish the clean pass this loop gates on.
+  spot-check; it cannot establish the adjudicated-clean rounds this loop gates
+  on.
 
 **Then leave the tree alone until it finishes.** `codex-review.sh` captures the
 file manifest at launch, but Codex collects the diffs itself as it runs — so
@@ -229,8 +230,9 @@ release plumbing), disable it for routine development.
 task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
-                # until a CLEAN pass (no P0/P1 findings), ≤4 rounds
-task review     # verification checkpoint — same clean-pass exit, ≤4 rounds
+                # until TWO CONSECUTIVE rounds adjudicate to zero P0/P1
+                # (a first round with no findings at all ends it), ≤4 rounds
+task review     # verification checkpoint — same convergence rule, ≤4 rounds
 task ci         # full CI mirror
 # → open a DRAFT PR, then shepherd it: watch CI + reviews, settle the deferred
 #   P2s, adjudicate → fix → push, ≤4 rounds (independent of the loops above)
@@ -251,6 +253,45 @@ after both the current head was pushed and its review request was created.
 Those requests are explicit and made while the PR is draft — which is why
 Automatic reviews must be off (setup step 6): an automatic review triggered by
 `gh pr ready` would land after the gate that promoted the PR.
+
+## Convergence: when a stage ends
+
+A stage — `challenge` and `review`, counted separately — ends when
+**two consecutive rounds adjudicate to zero P0 and zero P1 findings**. Those
+rounds may come back empty, all-P2 as labeled, or P1-labeled and adjudicated
+down to
+P2; what counts is the **adjudicated** column of your adjudication table, not
+the label Codex attached. The second such round *is* the confirmation, so no
+extra run is owed after it. One case exits faster still: a **first** round with
+no findings at all ends the stage on the spot, because a single empty round
+already says more than two adjudicated-clean ones and a trivial change should
+not pay for a second pass. Nothing here takes more rounds than the older
+"clean re-run" rule did — it is a relaxation in every direction.
+
+The old rule charged for three things it never delivered. A confirmation run
+after an all-P2 round: `harmon-init#725` ran roughly ten gate iterations for a
+six-line documentation fix, most of them re-attesting a change nobody disputed.
+Label inflation: a reviewer-labeled P1 that adjudication settled as a P2 still
+bought a fix-and-re-run cycle, which is how `harmon-init#664`/`#666` spent
+their late rounds — at 30–45 minutes apiece. And scaffolding drift: each round
+of hardening added surface for the next round to attack, and every finding
+along the way was individually defensible.
+
+The **scaffolding damper** is what replaces the cap as the first line of
+defense. At round 2 — the earliest round that can show the pattern — say on
+the table, for each finding, whether its subject exists only because an earlier
+round of the same stage added it. Where it does, adjudicate it with one of two
+dispositions written down: delete the scaffolding, which moots the finding and
+still counts toward convergence, or state that the code is in scope and why the
+change needs it. Reflexively hardening the previous round's fix is the failure
+mode; naming it on the table is the check.
+
+Two things do not move. The **4-round cap** per stage stands, and persistent
+P0/P1 disagreement at the cap is escalated rather than iterated on. And the
+deferred-P2 chain is a **precondition** of the exit, not a casualty of it:
+every P2 open at convergence must already be in the sidecar below, so
+`gh pr create` can move it into the PR body and the shepherd can settle it. An
+exit that drops a P2 is not an exit.
 
 ## Finding priorities
 
@@ -310,9 +351,10 @@ code with backticks or `$(…)`, and inside a double-quoted string the shell
 would run it. Quoting disables expansion, not termination — so pick a
 delimiter the finding text cannot contain.
 
-Check the file before appending: a stage only exits on a *clean re-run*, so an
-unchanged P2 comes back every remaining round and again in the next stage. Add
-it once, matching on location and substance rather than exact wording.
+Check the file before appending: an unchanged P2 is unchanged code, so it comes
+back every remaining round and again in the next stage — deferring it does not
+silence it. Add it once, matching on location and substance rather than exact
+wording.
 
 Move the list into the PR description when you open the PR, then delete the
 file — and sweep the tree for strays while you are there:

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -231,7 +231,7 @@ task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
                 # until TWO CONSECUTIVE rounds adjudicate to zero P0/P1
-                # (a first round with no findings at all ends it), ≤4 rounds
+                # (any round with no findings at all ends it), ≤4 rounds
 task review     # verification checkpoint — same convergence rule, ≤4 rounds
 task ci         # full CI mirror
 # → open a DRAFT PR, then shepherd it: watch CI + reviews, settle the deferred

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -298,8 +298,11 @@ exit that drops a P2 is not an exit.
 
 ## Finding priorities
 
-Both modes ask Codex to label every finding, and the local loops gate on that
-label:
+Both modes ask Codex to label every finding on this scale. The label is the
+reviewer's opening claim; what the local loops gate on is the **adjudicated**
+priority — your verdict after verifying the finding (see "Convergence: when a
+stage ends" above). Adjudication may downgrade a label with evidence, never
+silently drop one:
 
 | Priority | Meaning | Gates `challenge`/`review`? |
 | --- | --- | --- |

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -268,9 +268,12 @@ error silently reverts the lifecycle rather than fixing anything.
   when its window elapses with no terminal result for the captured head —
   with the checker, that is exit 12; without it, elapsed time plus the
   absence of terminal evidence is itself the signal. After an incomplete
-  first attempt, post `@codex review` once more for the same head and run one
-  more full window as attempt 2, recording and using the new trigger comment
-  ID. If both attempts
+  first attempt, run attempt 2 the same way as attempt 1: with the checker,
+  repeat the reserve-first sequence — `reserve --attempt 2` against the same
+  head, then post `@codex review` once more, then `attach` the comment ID
+  returned for that trigger — and without it, post the trigger and record the
+  request time and the comment ID returned for that trigger yourself; either
+  way run one more full window. If both attempts
   are incomplete, stop and escalate without reporting green (with the
   checker, exit 13). Waiting and the
   one allowed re-trigger do not consume a shepherd fix round. Immediately

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -496,9 +496,12 @@ in the abstract and wrong for the artifact. A documentation guide that has
 grown a hand-rolled process supervisor earns real, defensible P1s about per-run
 state, process-group supervision, and PID reuse; every one of them becomes moot
 when the recipe is deleted instead of hardened. That is not giving up on the
-findings: the stage exits on **rounds that adjudicate to zero P0/P1**, and an
-adjudication does not care whether a finding was answered or made
-inapplicable — a mooted finding adjudicates to nothing left. Name the mooted findings
+findings — and it is not a way to re-score the round that raised them. A
+confirmed P0/P1 keeps its adjudicated priority for its own round whether the
+remedy is a fix or a deletion; the remedy either way is input to the **next**
+round, and only that later round's review of the changed tree counts toward
+convergence. What deletion buys is that the next round finds nothing left to
+re-raise. Name the mooted findings
 in the adjudication table *and* in the message of the commit that removes the
 code — the table is scrollback, but the commit is why the code is gone, and it
 is the record a later round or a different session can still find.

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -144,16 +144,29 @@ error silently reverts the lifecycle rather than fixing anything.
 [% if use_codex_review %]
 - **`task challenge`** — adversarial second-model review. Adjudicate per
   "Second-Model Review" below, fix confirmed findings, re-run `task verify`,
-  then **re-run `task challenge`**. The stage passes only when a re-run comes
-  back with **no confirmed P0 or P1 findings** — fixing the findings is not
-  the exit condition, a clean pass is. **P2s do not gate this stage**: carry
+  then **re-run `task challenge`**. The stage ends when **two consecutive
+  rounds adjudicate to zero P0 and zero P1 findings** — whether those rounds
+  came back empty, all-P2 as labeled, or P1-labeled and adjudicated down to
+  P2. Severity is read off the **adjudicated** column of your adjudication
+  table, not off the reviewer's label, and nothing further is owed after the
+  second such round: the second round *is* the confirmation, so there is no
+  extra clean run to buy. A first round that returns **no findings at all**
+  still ends the stage on its own — one empty round is a stronger signal than
+  two adjudicated-clean ones, and a trivial change should never pay for a
+  second pass. Fixing the findings is still not the exit condition; two
+  consecutive adjudicated-clean rounds are. The exit carries one
+  precondition: every P2 you deferred during the stage must already be in the
+  deferred-findings sidecar (see "Deferring P2s" below) — an exit that drops
+  a P2 is not an exit, because nothing downstream will ever see it again.
+  **P2s do not gate this stage**: carry
   them to the PR (see "Deferring P2s" below). This loop is
   **self-referential** — the fixes you make in response to a round become the
   next round's input, so it can generate its own work indefinitely — and that
   is what the cap defends against: max **4** challenge → fix → re-challenge
   rounds; if P0/P1 findings persist, stop and escalate to the maintainer.
   "Between rounds, check what the findings are about" below is how you catch
-  the loop feeding on itself before the cap does.
+  the loop feeding on itself before the cap does, and round 2 is where that
+  check is owed rather than optional.
   A `task challenge` round is long — 5–15 minutes is ordinary, past most
   agents' tool-call timeouts — so **run it in the background and poll**
   instead of blocking one call on it. Growing output means running, not hung;
@@ -164,10 +177,12 @@ error silently reverts the lifecycle rather than fixing anything.
   fixes first is still tidier, not load-bearing. Details:
   [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
   backgrounding").
-- **`task review`** — verification-checkpoint review; same adjudication, same
-  P0/P1 clean-pass exit condition, the same self-referential shape and so the
+- **`task review`** — verification-checkpoint review; same adjudication, the
+  same two-consecutive-adjudicated-clean exit condition counted over its own
+  rounds, the same self-referential shape and so the
   same reason for a cap, and the same background-and-poll handling, with its
-  own max **4** rounds.
+  own max **4** rounds. The two stages are counted separately: a converged
+  challenge says nothing about review.
 [% endif %]
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the draft PR** — conventional commit, push the branch,
@@ -214,9 +229,23 @@ error silently reverts the lifecycle rather than fixing anything.
   **Require a current-head Codex result.** On initial shepherd entry and
   immediately after every fix push, capture the PR's current `headRefOid` and
   the head's push time, then post `@codex review`. Record the request time and
-  the comment ID returned for that trigger. Poll PR reactions, top-level
-  comments, reviews, and inline review comments; fetch trigger reactions by
-  that exact comment ID. A Codex result is terminal for that captured head only
+  the comment ID returned for that trigger.
+  **Do not hand-roll the polling where a checker is available.** If
+  `.claude/skills/shepherd/assets/check-codex-cloud-review.sh` is present —
+  the skills sync vendors it with the shepherd skill — run it: `reserve` a
+  cycle against the captured head, `attach` the trigger comment ID, then
+  `check` it, and act on the exit code it returns (0 clean, 10 findings,
+  11 pending, 12 retry, 13 escalate, 2 indeterminate). It never writes to
+  GitHub, so posting the trigger comment stays yours. Only where that file
+  does not exist do you poll the four surfaces yourself — PR reactions,
+  top-level comments, reviews, and inline review comments, fetching trigger
+  reactions by that exact comment ID — and then watch the surface hand-rolled
+  pollers reliably forget: a clean verdict often lands as a **top-level
+  comment**, not a review, and missing it reports a finished cycle as
+  incomplete.
+  The contract below is normative whatever runs it — it is what "terminal"
+  means, and the checker is an implementation of it, not a substitute
+  definition. A Codex result is terminal for that captured head only
   when it is either: a clean review or top-level comment authored by GitHub
   actor ID `199175422` (`chatgpt-codex-connector[bot]`, type `Bot`) whose
   `Reviewed commit:` identifies that head; a fresh 👍 from that bot on that
@@ -228,12 +257,14 @@ error silently reverts the lifecycle rather than fixing anything.
   not success; if it disappears without a terminal result, the attempt is
   incomplete.
   Give each attempt a full 10–15 minute window. If the first attempt is
-  incomplete, post `@codex review` once more for the same head and run one more
-  full window, recording and using the new trigger comment ID. If both attempts
-  are incomplete, stop and escalate without reporting green. Waiting and the
+  incomplete — the checker's exit 12 — post `@codex review` once more for the
+  same head and run one more full window as attempt 2, recording and using the
+  new trigger comment ID. If both attempts
+  are incomplete, stop and escalate without reporting green; that is what the
+  checker's exit 13 means. Waiting and the
   one allowed re-trigger do not consume a shepherd fix round. Immediately
-  before accepting the result or reporting green, fetch `headRefOid` and all
-  four review surfaces again; a changed head invalidates the result and starts
+  before accepting the result or reporting green, re-check the cycle and
+  re-read `headRefOid`; a changed head invalidates the result and starts
   a new current-head cycle.
 [% endif %]
   Shepherd is **externally driven** — CI results and other people's comments
@@ -425,21 +456,32 @@ findings are all about the previous round's fix is the tell**, and it is
 visible in round 2 — the first round that can show it. Do not wait for the
 pattern to be unmistakable in round 3, by which point only one round is left.
 
-**Deleting the added code is a legitimate way to reach a clean pass.** When a
+**Round 2 is the checkpoint, not a suggestion.** Under the two-consecutive
+exit the cap is no longer the only thing standing between you and a loop that
+feeds on itself, so the check has to happen where it first can. At round 2,
+for every finding, say on the adjudication table whether its subject exists
+only because an **earlier round of this same stage** added it. A finding that
+does gets adjudicated with one of two dispositions written out: **delete** the
+scaffolding (which moots the finding — see below), or state that it is in
+scope and why the change genuinely needs it. What is not allowed is hardening
+round-1's scaffolding by reflex and letting round 3 attack the result.
+
+**Deleting the added code is a legitimate way to converge.** When a
 round's findings are about scaffolding rather than the change, weigh removing
 that scaffolding against hardening it once more — a remediation can be correct
 in the abstract and wrong for the artifact. A documentation guide that has
 grown a hand-rolled process supervisor earns real, defensible P1s about per-run
 state, process-group supervision, and PID reuse; every one of them becomes moot
 when the recipe is deleted instead of hardened. That is not giving up on the
-findings: the stage exits on a **clean re-run**, and a re-run does not care
-whether a finding was answered or made inapplicable. Name the mooted findings
+findings: the stage exits on **rounds that adjudicate to zero P0/P1**, and an
+adjudication does not care whether a finding was answered or made
+inapplicable — a mooted finding adjudicates to nothing left. Name the mooted findings
 in the adjudication table *and* in the message of the commit that removes the
 code — the table is scrollback, but the commit is why the code is gone, and it
 is the record a later round or a different session can still find.
 
 One endpoint is worth knowing: if the deletion empties the change *entirely*,
-there is no clean pass to reach — `codex-review.sh` refuses an empty scope
+there is no round to converge on — `codex-review.sh` refuses an empty scope
 non-zero by design, so the stage cannot pass and re-running will not change
 that. Treat it as the answer rather than a failure to work around: a change
 that has become empty is abandoned, not reviewed clean.
@@ -469,9 +511,9 @@ before `gh pr create`, so there is usually no PR body to write to yet: append
 it to the file
 `git rev-parse --git-path "deferred-findings/$(git branch --show-current)"`
 names (`mkdir -p` its directory first) — but only if that finding is not
-already listed. A stage exits on a *clean re-run*,
-so an unchanged P2 is reported again by design, in every remaining round and
-again by the next stage; appending blindly would hand the shepherd four copies
+already listed. A P2 you leave open is reported again by design — it is
+unchanged code, so every remaining round of the stage and the next stage after
+it will raise it; appending blindly would hand the shepherd four copies
 of one finding to settle. Match on location plus substance, not exact
 wording — the same finding rarely comes back phrased identically. Then
 move the list into the description when you open the PR (then delete the
@@ -511,16 +553,32 @@ what it still owes without re-adjudicating what is done. That obligation is
 stated here and in the Dev Loop above, and holds whether or not the optional
 `/shepherd` skill is installed to automate it.
 
-**Loop cap and exit:** a stage exits only on a **clean re-run** — no
-confirmed P0 or P1 findings — never on "findings fixed" alone, with at most
-**4** challenge iterations and **4** review iterations (challenge → fix →
-re-challenge, and likewise for review). If P0/P1 disagreement persists at the
-cap, stop and surface it to the maintainer instead of iterating further.
+**Loop cap and exit:** a stage — challenge and review counted separately —
+ends when **two consecutive rounds adjudicate to zero P0 and zero P1
+findings**, and never on "findings fixed" alone. Those rounds may be empty,
+all-P2 as labeled, or P1-labeled and adjudicated down to P2; what counts is
+the **adjudicated** column of the table, not the reviewer's label, and the
+second such round is itself the confirmation, so no further run is owed. The
+single exception runs the other way: a **first** round with no findings at all
+ends the stage immediately, because one empty round already says more than two
+adjudicated-clean ones and a trivial change should not pay for a second pass.
+This is a strict relaxation — no path now takes more rounds than it did under
+the old clean-re-run rule. Two things ride along with the exit: every P2
+deferred during the stage must already be recorded in the sidecar (an exit
+that drops a P2 is not an exit), and round 2 owes the scaffolding checkpoint
+above. The caps are unchanged at **4** challenge iterations and **4** review
+iterations (challenge → fix → re-challenge, and likewise for review); if
+P0/P1 disagreement persists at the cap, stop and surface it to the maintainer
+instead of iterating further. The maintainer may always ask for more rounds —
+convergence is a floor on when you may stop, not a ceiling on what they can
+order.
 
 One caveat on the automatic stop-gate: the codex plugin's Stop hook applies
 its **own** notion of a material finding and may BLOCK on something you have
 classified P2. Adjudicate it (fix it, or state the reasoning) — **never**
-disable the gate to get past a BLOCK.
+disable the gate to get past a BLOCK. A BLOCK is settled on its own terms and
+against the hook, not against this rule: it neither reopens a stage that has
+already converged nor counts as one of that stage's rounds.
 
 [% endif %]
 ## Conventions

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -238,12 +238,13 @@ error silently reverts the lifecycle rather than fixing anything.
   `reserve` a cycle against the captured head **before** posting the
   trigger — the durable state must exist before the GitHub write, or an
   interruption between the two leaves an untracked trigger a resumed session
-  can double-spend — then post `@codex review`, `attach` the comment ID the
-  trigger returned, and `check`, acting on the exit code it returns (0 clean,
-  10 findings, 11 pending, 12 retry, 13 escalate, 2 indeterminate). It never
+  can double-spend — then post `@codex review`, `attach` the comment ID
+  returned for that trigger, and `check`, acting on the exit code it returns
+  (0 clean, 10 findings, 11 pending, 12 retry, 13 escalate,
+  2 indeterminate). It never
   writes to GitHub, so posting the trigger comment stays yours. Where the
-  checker is absent, post `@codex review` and record the request time and
-  returned comment ID yourself. Only where that file
+  checker is absent, post `@codex review` and record the request time and the
+  comment ID returned for that trigger yourself. Only where that file
   does not exist do you poll the four surfaces yourself — PR reactions,
   top-level comments, reviews, and inline review comments, fetching trigger
   reactions by that exact comment ID — and then watch the surface hand-rolled

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -277,10 +277,12 @@ error silently reverts the lifecycle rather than fixing anything.
   before accepting the result or reporting green, re-check the cycle and
   re-read `headRefOid`; a changed head invalidates the result and starts
   a new current-head cycle.
-  One disposition the checker cannot express is settled in prose: a
-  **top-level** comment carrying a badged finding has no reply linkage, so
-  once it lands, no adjudication can make that head's `check` come back
-  clean — findings outrank a later clean result on the same head. When every
+  One disposition the checker cannot express is settled in prose: a badged
+  finding stated **outside an inline thread** — in a top-level comment or in
+  a review's own body — has no reply linkage, so once it lands, no
+  adjudication can make that head's `check` come back clean: findings outrank
+  a later clean result on the same head, and the checker's settled set
+  reaches only inline comments. When every
   such finding is adjudicated without a code change (declined with evidence,
   or filed as follow-up work), record each disposition as a PR comment and
   treat the cycle as **terminal with findings settled** for that head; the
@@ -347,7 +349,7 @@ its current `headRefOid`:
   to run.
 [% if use_codex_cloud_review %]
 - The current-head Codex cycle above is terminal and clean, or terminal with
-  every finding settled under the top-level disposition rule above.
+  every finding settled under the no-thread disposition rule above.
 [% endif %]
 - Every review finding is fixed, declined with evidence, or filed as follow-up
   work.

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -150,11 +150,11 @@ error silently reverts the lifecycle rather than fixing anything.
   P2. Severity is read off the **adjudicated** column of your adjudication
   table, not off the reviewer's label, and nothing further is owed after the
   second such round: the second round *is* the confirmation, so there is no
-  extra clean run to buy. A first round that returns **no findings at all**
-  still ends the stage on its own — one empty round is a stronger signal than
-  two adjudicated-clean ones, and a trivial change should never pay for a
-  second pass. Fixing the findings is still not the exit condition; two
-  consecutive adjudicated-clean rounds are. The exit carries one
+  extra clean run to buy. A round that returns **no findings at all** ends
+  the stage on its own, whenever it comes — an empty round is the old rule's
+  clean re-run, so neither a trivial change nor a clean post-fix re-run pays
+  for a confirmation pass. Fixing the findings is still not the exit
+  condition; adjudicated-clean rounds are. The exit carries one
   precondition: every P2 you deferred during the stage must already be in the
   deferred-findings sidecar (see "Deferring P2s" below) — an exit that drops
   a P2 is not an exit, because nothing downstream will ever see it again.
@@ -163,7 +163,10 @@ error silently reverts the lifecycle rather than fixing anything.
   **self-referential** — the fixes you make in response to a round become the
   next round's input, so it can generate its own work indefinitely — and that
   is what the cap defends against: max **4** challenge → fix → re-challenge
-  rounds; if P0/P1 findings persist, stop and escalate to the maintainer.
+  rounds; if P0/P1 findings persist, stop and escalate to the maintainer. A
+  capped final round that adjudicates to zero P0/P1 ends the stage by itself — its
+  confirmation would be a run the cap forbids, and a clean last round is
+  convergence, not the persisting disagreement escalation exists for.
   "Between rounds, check what the findings are about" below is how you catch
   the loop feeding on itself before the cap does, and round 2 is where that
   check is owed rather than optional.
@@ -256,12 +259,15 @@ error silently reverts the lifecycle rather than fixing anything.
   inline findings, and reactions never count for a newer head. A 👀 is pending,
   not success; if it disappears without a terminal result, the attempt is
   incomplete.
-  Give each attempt a full 10–15 minute window. If the first attempt is
-  incomplete — the checker's exit 12 — post `@codex review` once more for the
-  same head and run one more full window as attempt 2, recording and using the
-  new trigger comment ID. If both attempts
-  are incomplete, stop and escalate without reporting green; that is what the
-  checker's exit 13 means. Waiting and the
+  Give each attempt a full 10–15 minute window. An attempt is **incomplete**
+  when its window elapses with no terminal result for the captured head —
+  with the checker, that is exit 12; without it, elapsed time plus the
+  absence of terminal evidence is itself the signal. After an incomplete
+  first attempt, post `@codex review` once more for the same head and run one
+  more full window as attempt 2, recording and using the new trigger comment
+  ID. If both attempts
+  are incomplete, stop and escalate without reporting green (with the
+  checker, exit 13). Waiting and the
   one allowed re-trigger do not consume a shepherd fix round. Immediately
   before accepting the result or reporting green, re-check the cycle and
   re-read `headRefOid`; a changed head invalidates the result and starts
@@ -558,18 +564,25 @@ ends when **two consecutive rounds adjudicate to zero P0 and zero P1
 findings**, and never on "findings fixed" alone. Those rounds may be empty,
 all-P2 as labeled, or P1-labeled and adjudicated down to P2; what counts is
 the **adjudicated** column of the table, not the reviewer's label, and the
-second such round is itself the confirmation, so no further run is owed. The
-single exception runs the other way: a **first** round with no findings at all
-ends the stage immediately, because one empty round already says more than two
-adjudicated-clean ones and a trivial change should not pay for a second pass.
-This is a strict relaxation — no path now takes more rounds than it did under
-the old clean-re-run rule. Two things ride along with the exit: every P2
+second such round is itself the confirmation, so no further run is owed. Two
+exits are faster still. A round with **no findings at all** ends the stage by
+itself, whenever it comes — an empty round is exactly the old rule's clean
+re-run, so neither a trivial change nor a clean post-fix re-run pays for a
+confirmation pass. And a **capped final round** that adjudicates to zero
+P0/P1 also ends the stage by itself: the confirmation it would otherwise owe
+is a run the cap forbids, and a rule that strands a stage holding a clean
+last round and no valid exit would be wrong — the cap bounds work, it does
+not manufacture escalation. What the rule spends is bounded the other way
+too: a stage pays at most one round confirming convergence, where the old
+practice could spend every remaining round re-proving a change nobody still
+disputed. Two things ride along with the exit: every P2
 deferred during the stage must already be recorded in the sidecar (an exit
 that drops a P2 is not an exit), and round 2 owes the scaffolding checkpoint
 above. The caps are unchanged at **4** challenge iterations and **4** review
 iterations (challenge → fix → re-challenge, and likewise for review); if
 P0/P1 disagreement persists at the cap, stop and surface it to the maintainer
-instead of iterating further. The maintainer may always ask for more rounds —
+instead of iterating further — escalation at the cap is for P0/P1 that
+**persist**, nothing else. The maintainer may always ask for more rounds —
 convergence is a floor on when you may stop, not a ceiling on what they can
 order.
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -231,15 +231,19 @@ error silently reverts the lifecycle rather than fixing anything.
 [% if use_codex_cloud_review %]
   **Require a current-head Codex result.** On initial shepherd entry and
   immediately after every fix push, capture the PR's current `headRefOid` and
-  the head's push time, then post `@codex review`. Record the request time and
-  the comment ID returned for that trigger.
+  the head's push time.
   **Do not hand-roll the polling where a checker is available.** If
   `.claude/skills/shepherd/assets/check-codex-cloud-review.sh` is present —
-  the skills sync vendors it with the shepherd skill — run it: `reserve` a
-  cycle against the captured head, `attach` the trigger comment ID, then
-  `check` it, and act on the exit code it returns (0 clean, 10 findings,
-  11 pending, 12 retry, 13 escalate, 2 indeterminate). It never writes to
-  GitHub, so posting the trigger comment stays yours. Only where that file
+  the skills sync vendors it with the shepherd skill — run it, in its order:
+  `reserve` a cycle against the captured head **before** posting the
+  trigger — the durable state must exist before the GitHub write, or an
+  interruption between the two leaves an untracked trigger a resumed session
+  can double-spend — then post `@codex review`, `attach` the comment ID the
+  trigger returned, and `check`, acting on the exit code it returns (0 clean,
+  10 findings, 11 pending, 12 retry, 13 escalate, 2 indeterminate). It never
+  writes to GitHub, so posting the trigger comment stays yours. Where the
+  checker is absent, post `@codex review` and record the request time and
+  returned comment ID yourself. Only where that file
   does not exist do you poll the four surfaces yourself — PR reactions,
   top-level comments, reviews, and inline review comments, fetching trigger
   reactions by that exact comment ID — and then watch the surface hand-rolled
@@ -272,6 +276,15 @@ error silently reverts the lifecycle rather than fixing anything.
   before accepting the result or reporting green, re-check the cycle and
   re-read `headRefOid`; a changed head invalidates the result and starts
   a new current-head cycle.
+  One disposition the checker cannot express is settled in prose: a
+  **top-level** comment carrying a badged finding has no reply linkage, so
+  once it lands, no adjudication can make that head's `check` come back
+  clean — findings outrank a later clean result on the same head. When every
+  such finding is adjudicated without a code change (declined with evidence,
+  or filed as follow-up work), record each disposition as a PR comment and
+  treat the cycle as **terminal with findings settled** for that head; the
+  readiness gate reads those recorded adjudications where a checker exit 0 is
+  unreachable. Any push starts a fresh cycle as usual.
 [% endif %]
   Shepherd is **externally driven** — CI results and other people's comments
   are its input, so it cannot manufacture a round on its own. A round is one
@@ -332,7 +345,8 @@ its current `headRefOid`:
   taken moments after the push reports nothing having run rather than nothing
   to run.
 [% if use_codex_cloud_review %]
-- The current-head Codex cycle above is terminal and clean.
+- The current-head Codex cycle above is terminal and clean, or terminal with
+  every finding settled under the top-level disposition rule above.
 [% endif %]
 - Every review finding is fixed, declined with evidence, or filed as follow-up
   work.

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -284,10 +284,13 @@ The **scaffolding damper** is what replaces the cap as the first line of
 defense. At round 2 — the earliest round that can show the pattern — say on
 the table, for each finding, whether its subject exists only because an earlier
 round of the same stage added it. Where it does, adjudicate it with one of two
-dispositions written down: delete the scaffolding, which moots the finding and
-still counts toward convergence, or state that the code is in scope and why the
-change needs it. Reflexively hardening the previous round's fix is the failure
-mode; naming it on the table is the check.
+dispositions written down: delete the scaffolding, or state that the code is
+in scope and why the change needs it. A deletion does not re-score the round
+that flagged the code — the finding keeps its adjudicated priority there, and
+it is the **next** round, reviewing the tree without it, that finds nothing
+left to re-raise and counts toward convergence. Reflexively hardening the
+previous round's fix is the failure mode; naming it on the table is the
+check.
 
 Two things do not move. The **4-round cap** per stage stands, and persistent
 P0/P1 disagreement at the cap is escalated rather than iterated on. And the

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -262,11 +262,14 @@ rounds may come back empty, all-P2 as labeled, or P1-labeled and adjudicated
 down to
 P2; what counts is the **adjudicated** column of your adjudication table, not
 the label Codex attached. The second such round *is* the confirmation, so no
-extra run is owed after it. One case exits faster still: a **first** round with
-no findings at all ends the stage on the spot, because a single empty round
-already says more than two adjudicated-clean ones and a trivial change should
-not pay for a second pass. Nothing here takes more rounds than the older
-"clean re-run" rule did — it is a relaxation in every direction.
+extra run is owed after it. Two cases exit faster still. A round with **no
+findings at all** ends the stage on the spot, whenever it comes — an empty
+round is exactly the older "clean re-run" exit, so neither a trivial change
+nor a clean post-fix re-run pays for a confirmation pass. And a **capped
+final round** that adjudicates to zero P0/P1 ends the stage by itself: the
+confirmation it would otherwise owe is a run the cap forbids, and escalation
+at the cap is reserved for P0/P1 findings that persist — a clean last round
+is convergence, not disagreement.
 
 The old rule charged for three things it never delivered. A confirmation run
 after an all-P2 round: `harmon-init#725` ran roughly ten gate iterations for a

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -155,7 +155,8 @@ Two things not to change when backgrounding:
   `/codex:adversarial-review --background`: the slash command calls Codex
   directly, so it never receives the P0/P1/P2 scale that
   `scripts/codex-review.sh` writes into the prompt. Fine for an interactive
-  spot-check; it cannot establish the clean pass this loop gates on.
+  spot-check; it cannot establish the adjudicated-clean rounds this loop gates
+  on.
 
 **Then leave the tree alone until it finishes.** `codex-review.sh` captures the
 file manifest at launch, but Codex collects the diffs itself as it runs — so
@@ -229,8 +230,9 @@ release plumbing), disable it for routine development.
 task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
-                # until a CLEAN pass (no P0/P1 findings), ≤4 rounds
-task review     # verification checkpoint — same clean-pass exit, ≤4 rounds
+                # until TWO CONSECUTIVE rounds adjudicate to zero P0/P1
+                # (a first round with no findings at all ends it), ≤4 rounds
+task review     # verification checkpoint — same convergence rule, ≤4 rounds
 task ci         # full CI mirror
 # → open a DRAFT PR, then shepherd it: watch CI + reviews, settle the deferred
 #   P2s, adjudicate → fix → push, ≤4 rounds (independent of the loops above)
@@ -251,6 +253,45 @@ after both the current head was pushed and its review request was created.
 Those requests are explicit and made while the PR is draft — which is why
 Automatic reviews must be off (setup step 6): an automatic review triggered by
 `gh pr ready` would land after the gate that promoted the PR.
+
+## Convergence: when a stage ends
+
+A stage — `challenge` and `review`, counted separately — ends when
+**two consecutive rounds adjudicate to zero P0 and zero P1 findings**. Those
+rounds may come back empty, all-P2 as labeled, or P1-labeled and adjudicated
+down to
+P2; what counts is the **adjudicated** column of your adjudication table, not
+the label Codex attached. The second such round *is* the confirmation, so no
+extra run is owed after it. One case exits faster still: a **first** round with
+no findings at all ends the stage on the spot, because a single empty round
+already says more than two adjudicated-clean ones and a trivial change should
+not pay for a second pass. Nothing here takes more rounds than the older
+"clean re-run" rule did — it is a relaxation in every direction.
+
+The old rule charged for three things it never delivered. A confirmation run
+after an all-P2 round: `harmon-init#725` ran roughly ten gate iterations for a
+six-line documentation fix, most of them re-attesting a change nobody disputed.
+Label inflation: a reviewer-labeled P1 that adjudication settled as a P2 still
+bought a fix-and-re-run cycle, which is how `harmon-init#664`/`#666` spent
+their late rounds — at 30–45 minutes apiece. And scaffolding drift: each round
+of hardening added surface for the next round to attack, and every finding
+along the way was individually defensible.
+
+The **scaffolding damper** is what replaces the cap as the first line of
+defense. At round 2 — the earliest round that can show the pattern — say on
+the table, for each finding, whether its subject exists only because an earlier
+round of the same stage added it. Where it does, adjudicate it with one of two
+dispositions written down: delete the scaffolding, which moots the finding and
+still counts toward convergence, or state that the code is in scope and why the
+change needs it. Reflexively hardening the previous round's fix is the failure
+mode; naming it on the table is the check.
+
+Two things do not move. The **4-round cap** per stage stands, and persistent
+P0/P1 disagreement at the cap is escalated rather than iterated on. And the
+deferred-P2 chain is a **precondition** of the exit, not a casualty of it:
+every P2 open at convergence must already be in the sidecar below, so
+`gh pr create` can move it into the PR body and the shepherd can settle it. An
+exit that drops a P2 is not an exit.
 
 ## Finding priorities
 
@@ -310,9 +351,10 @@ code with backticks or `$(…)`, and inside a double-quoted string the shell
 would run it. Quoting disables expansion, not termination — so pick a
 delimiter the finding text cannot contain.
 
-Check the file before appending: a stage only exits on a *clean re-run*, so an
-unchanged P2 comes back every remaining round and again in the next stage. Add
-it once, matching on location and substance rather than exact wording.
+Check the file before appending: an unchanged P2 is unchanged code, so it comes
+back every remaining round and again in the next stage — deferring it does not
+silence it. Add it once, matching on location and substance rather than exact
+wording.
 
 Move the list into the PR description when you open the PR, then delete the
 file — and sweep the tree for strays while you are there:

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -231,7 +231,7 @@ task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
                 # until TWO CONSECUTIVE rounds adjudicate to zero P0/P1
-                # (a first round with no findings at all ends it), ≤4 rounds
+                # (any round with no findings at all ends it), ≤4 rounds
 task review     # verification checkpoint — same convergence rule, ≤4 rounds
 task ci         # full CI mirror
 # → open a DRAFT PR, then shepherd it: watch CI + reviews, settle the deferred

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -298,8 +298,11 @@ exit that drops a P2 is not an exit.
 
 ## Finding priorities
 
-Both modes ask Codex to label every finding, and the local loops gate on that
-label:
+Both modes ask Codex to label every finding on this scale. The label is the
+reviewer's opening claim; what the local loops gate on is the **adjudicated**
+priority — your verdict after verifying the finding (see "Convergence: when a
+stage ends" above). Adjudication may downgrade a label with evidence, never
+silently drop one:
 
 | Priority | Meaning | Gates `challenge`/`review`? |
 | --- | --- | --- |


### PR DESCRIPTION
## What

Two dev-loop changes, in both layers (root + template twins):

1. **Convergence rule (#753).** The challenge/review stages now end when two
   consecutive rounds adjudicate to zero P0/P1 — read off the adjudicated
   column, not the reviewer's label — with the second round serving as the
   confirmation. Two faster exits: any round with no findings at all ends the
   stage on the spot (the old clean re-run, kept), and a capped final round
   that adjudicates clean ends the stage rather than owing a run the cap
   forbids. The deferred-P2 sidecar chain is an explicit precondition of the
   exit, the scaffolding damper is a mandatory round-2 checkpoint, and the
   4-round caps, escalation path, and Stop-gate caveat are unchanged and
   reconciled. Documented with evidence (#725, #664/#666) in a new
   "Convergence: when a stage ends" section of docs/guides/codex-review.md.

2. **Codex polling routing (#745).** The shepherd stage's current-head cycle
   now directs agents to run the vendored
   `.claude/skills/shepherd/assets/check-codex-cloud-review.sh`
   (`reserve` → `attach` → `check`; exit codes verified against the script
   header) instead of restating a pollable algorithm — hand-rolled pollers
   miss the top-level-comment surface (harmon-devkit#334; repeated on
   PR #731). The normative terminal-result contract stays in AGENTS.md. The
   template twin words the script reference as a runtime presence check with
   a time-and-evidence fallback for renders without the vendored checker —
   never a `skill_categories` gate.

## Why

Recent sessions spent hours of wall clock and large token budgets on
confirmation runs, label-inflation rounds, and scaffolding-drift spirals for
trivial changes (~10 gate iterations for a six-line doc fix on #725), and a
hand-rolled poller reproduced a known false-negative on PR #731. Both fixes
make the standard dev flow spend review time only where it changes the
outcome.

## Verification

- `task verify` green (includes the template render matrix); dogfood parity
  and structure gates green.
- Challenge stage: round 1 found one P1 (cap dead-end in the new rule — 
  confirmed and fixed: any-empty-round exit + capped-clean-round exit) and
  one P2 (checker-less render's retry signals — fixed in place); round 2
  returned zero P0/P1 with one P2 quick-reference inconsistency, fixed in
  place. Clean exit.
- Review stage: round 1 fully clean, zero findings.
- `task ci` (full CI mirror) green locally.
- Both issues' Verify commands now pass: AGENTS.md names the checker script;
  `two consecutive` present in all four files.

## Deferred findings

None — every P2 raised during the local loops was fixed in place.

Closes #745
Closes #753
