### PR TITLE
fix: gitignore .claude/worktrees so agent worktrees never break renders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,14 @@ __pycache__/
 
 # Git worktrees
 .worktrees/
+# Agent-tool worktree isolation dir. A registered worktree is recorded as a
+# gitlink with no `.gitmodules` entry, and copier's dirty-tree wip commit stages
+# with `git add -A`, so an unignored one is swept into every local render — the
+# nested clone then dies with `fatal: No url found for submodule path …`, an
+# error naming submodules in a repo that has none. Anchored by its embedded
+# slash (git anchors any pattern containing a non-trailing `/`), so it matches
+# only the root `.claude/` and never `template/.claude/`.
+.claude/worktrees/
 
 # Design handoff bundles (Claude Design exports) live as specs/ subdirectories
 # while being implemented and are deleted at sign-off — never committed.

--- a/scripts/test-copier-validators.sh
+++ b/scripts/test-copier-validators.sh
@@ -28,6 +28,17 @@ fail() {
     failures=$((failures + 1))
 }
 
+# Name the real cause when a render dies on copier's dirty-tree wip commit
+# having swept in a registered git worktree (e.g. an agent worktree under
+# .claude/worktrees/). Such a directory is a gitlink with no `.gitmodules`
+# entry, so the nested clone reports a submodule error in a repo with no
+# submodules — and the operator's diff is usually nowhere near it.
+hint_stale_worktree() {
+    if grep -q 'No url found for submodule path' "$work/render.log"; then
+        echo "      hint: a registered git worktree inside this checkout was staged as a gitlink by copier's dirty-tree commit (this repo has no submodules). Gitignore it, or remove it with 'git worktree remove' / 'git worktree prune'." >&2
+    fi
+}
+
 # One render attempt. Echoes nothing; returns copier's exit status.
 render() {
     local answer="$1" out="$2"
@@ -52,6 +63,7 @@ for bad in "/tmp/Vault: Work" "~/Bob's Vault" '~/say "hi"' '~/a$b' '~/a#b' '~/a`
     else
         fail "rejected $bad, but not by the validator — copier failed for another reason"
         sed 's/^/      /' "$work/render.log" >&2
+        hint_stale_worktree
     fi
 done
 
@@ -70,6 +82,7 @@ if render '~/Fine Vault' "$work/good"; then
 else
     fail "rejected a valid path containing a space"
     sed 's/^/      /' "$work/render.log" >&2
+    hint_stale_worktree
 fi
 
 if [ "$failures" -gt 0 ]; then

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -208,6 +208,19 @@ if [ -x scripts/lint-hygiene.sh ]; then
     ./scripts/lint-hygiene.sh || err "rendered output fails its own lint:hygiene gate"
 fi
 
+# ── 0b. Agent worktrees are ignored in BOTH layers ──────────────────
+# A registered git worktree under .claude/worktrees/ is a gitlink with no
+# `.gitmodules` entry. Left unignored it is swept into copier's dirty-tree wip
+# commit (`git add -A`), and the nested clone then dies on a submodule it cannot
+# resolve — the failure this ignore rule exists to prevent (#716). Nothing else
+# gates the rule: the jinja dogfood check compares structure, not lines. Global
+# excludes are switched off so a machine-level `.claude/` ignore cannot make a
+# missing rule look present.
+git -c core.excludesFile=/dev/null check-ignore -q .claude/worktrees/agent-x ||
+    err "rendered .gitignore does not ignore .claude/worktrees/ (see #716)"
+grep -qx '\.claude/worktrees/' "$repo_root/.gitignore" ||
+    err "root .gitignore does not ignore .claude/worktrees/ (see #716)"
+
 # ── 0. AGENTS.md is canonical; CLAUDE.md/GEMINI.md + copilot-instructions.md
 #       symlink to it (copilot's canonical file lives under .github/). ──
 if [ ! -f AGENTS.md ]; then

--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -47,6 +47,13 @@ node_modules/
 
 # Git worktrees
 .worktrees/
+# Agent-tool worktree isolation dir. A registered worktree is recorded as a
+# gitlink with no `.gitmodules` entry, so leaving it untracked-but-unignored
+# dirties `git status` and lets any tool that stages with `git add -A` commit a
+# submodule-shaped entry that later clones cannot resolve. Anchored by its
+# embedded slash (git anchors any pattern containing a non-trailing `/`), so it
+# matches only the repository-root `.claude/`.
+.claude/worktrees/
 
 # Design handoff bundles (Claude Design exports) live as specs/ subdirectories
 # while being implemented and are deleted at sign-off — never committed.


### PR DESCRIPTION
## What

Gitignore the Agent-tool worktree isolation directory in both layers, cover the
rule with a regression assertion, and make the validator harness name the real
cause when a worktree gitlink does reach a render.

- Root `.gitignore` and its template twin `template/.gitignore.jinja` gain
  `.claude/worktrees/`, with a comment explaining the gitlink / `git add -A`
  mechanism in the style of the file's other hazard notes.
- `scripts/test-template.sh` asserts, on every render profile, that the rendered
  `.gitignore` ignores `.claude/worktrees/` and that the root `.gitignore`
  carries the anchored rule.
- `scripts/test-copier-validators.sh` grows `hint_stale_worktree`: when a render
  log carries `No url found for submodule path`, it prints one line naming the
  stale-worktree cause instead of leaving the operator to debug submodules in a
  repo that has none.

## Why

A registered `git worktree` under `.claude/worktrees/` is untracked but was not
gitignored, so copier's `--vcs-ref=HEAD` dirty-tree flow (the `DirtyLocalWarning`
throwaway commit, staged with `git add -A`) swept the gitlink into the render. A
gitlink with no `.gitmodules` entry then kills the validator harness's nested
clone with `fatal: No url found for submodule path '.claude/worktrees/…' in
.gitmodules`, failing `task test:copier-validators` — and `task verify` — on any
dirty-tree render, on whatever unrelated branch happened to run next.

Ignoring it removes the class (option 1 in the issue); the harness hint is
option 3, kept as a diagnosability backstop for a registered worktree anywhere
else in the tree.

Dogfood parity: generated repos get the same Agent-tool behaviour, so the
template twin carries the same entry. `scripts/test-template.sh` is root-only
(the template ships no counterpart), so it has no twin to update.

## Pattern choice

`.claude/worktrees/` contains a non-trailing `/`, so git anchors it to the
`.gitignore`'s own directory. That matters here: an unanchored `.claude` would
also match `template/.claude/` and silently drop it from copier's dirty-tree wip
commit — the same global-gitignore hazard the file already documents for `.meta`
and `.vscode`.

## Verification

- `task verify` green (twice — before and after the regression assertions).
- `task ci` green.
- `task challenge` — round 1 clean of P0/P1 (one P2, fixed in `6968001`); round 2
  clean of P0/P1/P2.
- `task review` — clean, no findings.
- Mutation test: with the rule stripped from both layers,
  `task test:template:minimal` fails with both new assertions
  (`rendered .gitignore does not ignore …`, `root .gitignore does not ignore …`);
  files restored from `cp` backups afterwards.
- Scratch-repo check confirming the anchor: `.claude/worktrees/x/f` is ignored
  (attributed by `git check-ignore -v` to the new line) while
  `template/.claude/keep` still stages.
- `PR_TITLE=… BASE_SHA=main task guard:release-title` passes.

## Deferred findings

None outstanding — the single P2 raised (no regression coverage for the ignore
rule) was fixed in this PR rather than deferred.

Closes #716
