### PR TITLE
feat(status): surface local credential checks at session start

### DIFF
--- a/.claude/hooks/session-start-context.sh
+++ b/.claude/hooks/session-start-context.sh
@@ -3,11 +3,12 @@
 #
 # Re-injects orienting context every time a Claude session starts or its
 # context window is compacted: current branch, recent commits, working-tree
-# status, open PRs/issues, and a short reminder of repo conventions. Uses
-# `task status:git` + `task status:gh` (the fine-grained dashboard sections
-# from scripts/status.sh) so the payload stays small and fast — `status:site`
-# and `status:code` are intentionally skipped because they hit the network
-# and the local build respectively.
+# status, open PRs/issues, local logins, and a short reminder of repo
+# conventions. Uses `task status:git` + `task status:gh` + `task status:creds`
+# (the fine-grained dashboard sections from scripts/status.sh) so the payload
+# stays small and fast — `status:site` and `status:code` are intentionally
+# skipped because they hit the network and the local build respectively, and
+# `status:setup` because it is a network-heavy audit.
 set -euo pipefail
 
 cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
@@ -21,6 +22,13 @@ strip_ansi() { sed -E 's/\x1B\[''[0-9;]*[A-Za-z]//g'; }
 # spends up to NETWORK_TIMEOUT (5s) on the auth probe and then up to another 5s
 # on the PR/run probes it launches in parallel — 10s worst case, so 12 here.
 # status:git makes no network calls at all.
+#
+# status:creds is budgeted from its own probes rather than by copying a
+# neighbour's number: it makes NO network call (that is why it can be here at
+# all — status:gh already spends this startup's only auth round trip), and runs
+# two LOCAL probes back to back, each bounded at 3s inside status.sh — 6s worst
+# case, so 8 here for the `task` and shell startup around them. The three run in
+# parallel, so it adds nothing to the wall clock the gh deadline already allows.
 remote_url="$(git config --get remote.origin.url 2>/dev/null || echo '')"
 host_owner="$(echo "$remote_url" | sed -E 's/^(https?:\/\/|git@)([^:\/]+)[:\/]([^\/]+)\/[^\/]+(\.git)?$/\2 \3/')"
 host="${host_owner% *}"
@@ -31,6 +39,7 @@ if [ "$host" = "github.com" ]; then
     "evanharmon1" | "harmonops" | "ponderousdev")
         git_out="$(mktemp)"
         gh_out="$(mktemp)"
+        creds_out="$(mktemp)"
         timeout_cmd="timeout"
         if command -v gtimeout >/dev/null 2>&1; then
             timeout_cmd="gtimeout"
@@ -39,11 +48,15 @@ if [ "$host" = "github.com" ]; then
         git_pid=$!
         "$timeout_cmd" 12 task status:gh >"$gh_out" 2>/dev/null &
         gh_pid=$!
+        "$timeout_cmd" 8 task status:creds >"$creds_out" 2>/dev/null &
+        creds_pid=$!
 
         git_rc=0
         wait $git_pid || git_rc=$?
         gh_rc=0
         wait $gh_pid || gh_rc=$?
+        creds_rc=0
+        wait $creds_pid || creds_rc=$?
 
         if [ $git_rc -ne 0 ] || [ ! -s "$git_out" ]; then
             git_status="(task status:git unavailable or failed)"
@@ -56,24 +69,31 @@ if [ "$host" = "github.com" ]; then
         else
             gh_status="$(cat "$gh_out" | strip_ansi)"
         fi
-        rm -f "$git_out" "$gh_out"
+        if [ $creds_rc -ne 0 ] || [ ! -s "$creds_out" ]; then
+            creds_status="(task status:creds unavailable or failed)"
+        else
+            creds_status="$(cat "$creds_out" | strip_ansi)"
+        fi
+        rm -f "$git_out" "$gh_out" "$creds_out"
         ;;
     *)
         git_status="(task status:git skipped - untrusted repository)"
         gh_status="(task status:gh skipped - untrusted repository)"
+        creds_status="(task status:creds skipped - untrusted repository)"
         ;;
     esac
 else
     git_status="(task status:git skipped - untrusted repository)"
     gh_status="(task status:gh skipped - untrusted repository)"
+    creds_status="(task status:creds skipped - untrusted repository)"
 fi
 
 branch="$(git branch --show-current 2>/dev/null || echo 'unknown')"
 
 reminder=$'Repo conventions:\n- Run `task verify` before committing (lint + build + validate + test).\n- Conventional Commits required (feat/fix/docs/style/refactor/perf/test/chore/ci/build/revert).\n- Never bypass git hooks with --no-verify; fix the underlying issue.\n- Use lefthook for git hooks (not pre-commit).\n- See docs/conventions.md (and AGENTS.md) for the authoritative conventions catalog.'
 
-context="$(printf 'Branch: %s\n\n=== task status:git ===\n%s\n\n=== task status:gh ===\n%s\n\n%s\n' \
-    "$branch" "$git_status" "$gh_status" "$reminder")"
+context="$(printf 'Branch: %s\n\n=== task status:git ===\n%s\n\n=== task status:gh ===\n%s\n\n=== task status:creds ===\n%s\n\n%s\n' \
+    "$branch" "$git_status" "$gh_status" "$creds_status" "$reminder")"
 
 # Emit as JSON so Claude Code injects it as additionalContext.
 jq -n --arg ctx "$context" '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'

--- a/.claude/hooks/session-start-context.sh
+++ b/.claude/hooks/session-start-context.sh
@@ -26,8 +26,8 @@ strip_ansi() { sed -E 's/\x1B\[''[0-9;]*[A-Za-z]//g'; }
 # status:creds is budgeted from its own probes rather than by copying a
 # neighbour's number: it makes NO network call (that is why it can be here at
 # all — status:gh already spends this startup's only auth round trip), and runs
-# two LOCAL probes back to back, each bounded at 3s inside status.sh — 6s worst
-# case, so 8 here for the `task` and shell startup around them. The three run in
+# three LOCAL probes back to back, each bounded at 3s inside status.sh — 9s
+# worst case, so 11 here for the `task` and shell startup around them. The three run in
 # parallel, so it adds nothing to the wall clock the gh deadline already allows.
 remote_url="$(git config --get remote.origin.url 2>/dev/null || echo '')"
 host_owner="$(echo "$remote_url" | sed -E 's/^(https?:\/\/|git@)([^:\/]+)[:\/]([^\/]+)\/[^\/]+(\.git)?$/\2 \3/')"
@@ -48,7 +48,7 @@ if [ "$host" = "github.com" ]; then
         git_pid=$!
         "$timeout_cmd" 12 task status:gh >"$gh_out" 2>/dev/null &
         gh_pid=$!
-        "$timeout_cmd" 8 task status:creds >"$creds_out" 2>/dev/null &
+        "$timeout_cmd" 11 task status:creds >"$creds_out" 2>/dev/null &
         creds_pid=$!
 
         git_rc=0

--- a/.devcontainer/config/claude-hooks/session-start-context.sh
+++ b/.devcontainer/config/claude-hooks/session-start-context.sh
@@ -28,9 +28,57 @@ strip_ansi() { sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'; }
 # all — status:gh already spends this startup's only auth round trip), and runs
 # two LOCAL probes back to back, each bounded at 3s inside status.sh — 6s worst
 # case, so 8 here for the `task` and shell startup around them.
-git_status="$(timeout 5 task status:git 2>/dev/null | strip_ansi || echo '(task status:git unavailable)')"
-gh_status="$(timeout 12 task status:gh 2>/dev/null | strip_ansi || echo '(task status:gh unavailable)')"
-creds_status="$(timeout 8 task status:creds 2>/dev/null | strip_ansi || echo '(task status:creds unavailable)')"
+#
+# There is a SECOND deadline above all of these: the `timeout` on the
+# SessionStart entries in claude-settings.json, which Claude Code applies to this
+# whole script. Overrunning it is worse than any single section overrunning its
+# own bound — the hook is killed before `jq` emits anything, so the entire
+# payload is lost rather than one section of it. The sections are therefore run
+# in PARALLEL: the hook's wall clock is then the LONGEST deadline (12s), which
+# fits inside that outer timeout, where the sum (25s) would not.
+git_out="$(mktemp)"
+gh_out="$(mktemp)"
+creds_out="$(mktemp)"
+trap 'rm -f "${git_out}" "${gh_out}" "${creds_out}"' EXIT
+
+timeout 5 task status:git >"$git_out" 2>/dev/null &
+git_pid=$!
+timeout 12 task status:gh >"$gh_out" 2>/dev/null &
+gh_pid=$!
+timeout 8 task status:creds >"$creds_out" 2>/dev/null &
+creds_pid=$!
+
+# `wait` on each, with the failure recorded rather than propagated: `set -e`
+# would otherwise take the whole hook down over one section's deadline, which is
+# the payload-loss failure this structure exists to avoid.
+git_rc=0
+wait $git_pid || git_rc=$?
+gh_rc=0
+wait $gh_pid || gh_rc=$?
+creds_rc=0
+wait $creds_pid || creds_rc=$?
+
+# An empty file counts as a failure too: `timeout` kills status.sh mid-section,
+# and section_box buffers a section before printing it, so a killed run leaves
+# nothing rather than a partial section.
+if [ $git_rc -ne 0 ] || [ ! -s "$git_out" ]; then
+    git_status="(task status:git unavailable or failed)"
+else
+    git_status="$(strip_ansi <"$git_out")"
+fi
+
+if [ $gh_rc -ne 0 ] || [ ! -s "$gh_out" ]; then
+    gh_status="(task status:gh unavailable or failed)"
+else
+    gh_status="$(strip_ansi <"$gh_out")"
+fi
+
+if [ $creds_rc -ne 0 ] || [ ! -s "$creds_out" ]; then
+    creds_status="(task status:creds unavailable or failed)"
+else
+    creds_status="$(strip_ansi <"$creds_out")"
+fi
+
 branch="$(git branch --show-current 2>/dev/null || echo 'unknown')"
 
 reminder=$'Repo conventions:\n- Run `task verify` before committing (lint + build + validate + test).\n- Conventional Commits required (feat/fix/docs/style/refactor/perf/test/chore/ci/build/change/remove/revert).\n- Never bypass git hooks with --no-verify; fix the underlying issue.\n- Use lefthook for git hooks (not pre-commit).\n- See docs/conventions.md (and AGENTS.md) for the authoritative conventions catalog.'

--- a/.devcontainer/config/claude-hooks/session-start-context.sh
+++ b/.devcontainer/config/claude-hooks/session-start-context.sh
@@ -3,11 +3,12 @@
 #
 # Re-injects orienting context every time a Claude session starts or its
 # context window is compacted: current branch, recent commits, working-tree
-# status, open PRs/issues, and a short reminder of repo conventions. Uses
-# `task status:git` + `task status:gh` (the fine-grained dashboard sections
-# from scripts/status.sh) so the payload stays small and fast — `status:site`
-# and `status:code` are intentionally skipped because they hit the network
-# and the local build respectively.
+# status, open PRs/issues, local logins, and a short reminder of repo
+# conventions. Uses `task status:git` + `task status:gh` + `task status:creds`
+# (the fine-grained dashboard sections from scripts/status.sh) so the payload
+# stays small and fast — `status:site` and `status:code` are intentionally
+# skipped because they hit the network and the local build respectively, and
+# `status:setup` because it is a network-heavy audit.
 set -euo pipefail
 
 cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
@@ -21,14 +22,21 @@ strip_ansi() { sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'; }
 # spends up to NETWORK_TIMEOUT (5s) on the auth probe and then up to another 5s
 # on the PR/run probes it launches in parallel — 10s worst case, so 12 here.
 # status:git makes no network calls at all.
+#
+# status:creds is budgeted from its own probes rather than by copying a
+# neighbour's number: it makes NO network call (that is why it can be here at
+# all — status:gh already spends this startup's only auth round trip), and runs
+# two LOCAL probes back to back, each bounded at 3s inside status.sh — 6s worst
+# case, so 8 here for the `task` and shell startup around them.
 git_status="$(timeout 5 task status:git 2>/dev/null | strip_ansi || echo '(task status:git unavailable)')"
 gh_status="$(timeout 12 task status:gh 2>/dev/null | strip_ansi || echo '(task status:gh unavailable)')"
+creds_status="$(timeout 8 task status:creds 2>/dev/null | strip_ansi || echo '(task status:creds unavailable)')"
 branch="$(git branch --show-current 2>/dev/null || echo 'unknown')"
 
 reminder=$'Repo conventions:\n- Run `task verify` before committing (lint + build + validate + test).\n- Conventional Commits required (feat/fix/docs/style/refactor/perf/test/chore/ci/build/change/remove/revert).\n- Never bypass git hooks with --no-verify; fix the underlying issue.\n- Use lefthook for git hooks (not pre-commit).\n- See docs/conventions.md (and AGENTS.md) for the authoritative conventions catalog.'
 
-context="$(printf 'Branch: %s\n\n=== task status:git ===\n%s\n\n=== task status:gh ===\n%s\n\n%s\n' \
-    "$branch" "$git_status" "$gh_status" "$reminder")"
+context="$(printf 'Branch: %s\n\n=== task status:git ===\n%s\n\n=== task status:gh ===\n%s\n\n=== task status:creds ===\n%s\n\n%s\n' \
+    "$branch" "$git_status" "$gh_status" "$creds_status" "$reminder")"
 
 # Emit as JSON so Claude Code injects it as additionalContext.
 jq -n --arg ctx "$context" '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'

--- a/.devcontainer/config/claude-hooks/session-start-context.sh
+++ b/.devcontainer/config/claude-hooks/session-start-context.sh
@@ -26,8 +26,8 @@ strip_ansi() { sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'; }
 # status:creds is budgeted from its own probes rather than by copying a
 # neighbour's number: it makes NO network call (that is why it can be here at
 # all — status:gh already spends this startup's only auth round trip), and runs
-# two LOCAL probes back to back, each bounded at 3s inside status.sh — 6s worst
-# case, so 8 here for the `task` and shell startup around them.
+# three LOCAL probes back to back, each bounded at 3s inside status.sh — 9s
+# worst case, so 11 here for the `task` and shell startup around them.
 #
 # There is a SECOND deadline above all of these: the `timeout` on the
 # SessionStart entries in claude-settings.json, which Claude Code applies to this
@@ -45,7 +45,7 @@ timeout 5 task status:git >"$git_out" 2>/dev/null &
 git_pid=$!
 timeout 12 task status:gh >"$gh_out" 2>/dev/null &
 gh_pid=$!
-timeout 8 task status:creds >"$creds_out" 2>/dev/null &
+timeout 11 task status:creds >"$creds_out" 2>/dev/null &
 creds_pid=$!
 
 # `wait` on each, with the failure recorded rather than propagated: `set -e`

--- a/README.md
+++ b/README.md
@@ -188,5 +188,6 @@ and canonical AGENTS.md. Projects generated from v2 should be re-templated
 | `task codex:gate:enable` | Automatic Claude → Codex stop-gate for this repo + machine (also `:disable` / `:status`) |
 | `task install` | Brewfile deps + lefthook hooks |
 | `task release:patch` | Tag + GitHub release (also `:minor`/`:major`) |
-| `task status` | Project dashboard (also `status:git`/`:gh`/`:code`/`:env`) |
+| `task status` | Project dashboard (also `status:git`/`:gh`/`:creds`/`:code`/`:env`) |
+| `task status:creds` | Local credential logins (gh, Codex) — local probes, no network; also run at session start |
 | `task status:setup` | Setup audit: local credentials, GitHub config, toolchain, devcontainer, dev env |

--- a/README.md
+++ b/README.md
@@ -189,5 +189,5 @@ and canonical AGENTS.md. Projects generated from v2 should be re-templated
 | `task install` | Brewfile deps + lefthook hooks |
 | `task release:patch` | Tag + GitHub release (also `:minor`/`:major`) |
 | `task status` | Project dashboard (also `status:git`/`:gh`/`:creds`/`:code`/`:env`) |
-| `task status:creds` | Local credential logins (gh, Codex) — local probes, no network; also run at session start |
+| `task status:creds` | Local credential logins (gh, Codex, Claude Code) — local probes, no network; also run at session start |
 | `task status:setup` | Setup audit: local credentials, GitHub config, toolchain, devcontainer, dev env |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -760,6 +760,11 @@ tasks:
     cmds:
       - ./scripts/status.sh gh
 
+  status:creds:
+    desc: Local credential section (gh, Codex logins — local probes, no network)
+    cmds:
+      - ./scripts/status.sh creds
+
   status:code:
     desc: Codebase stats section
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -761,7 +761,7 @@ tasks:
       - ./scripts/status.sh gh
 
   status:creds:
-    desc: Local credential section (gh, Codex logins — local probes, no network)
+    desc: Local credential section (gh, Codex, Claude Code logins — local probes, no network)
     cmds:
       - ./scripts/status.sh creds
 

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -617,20 +617,46 @@ render_local_credentials() {
         else
             checkline no "GitHub CLI (gh)" "gh auth login"
         fi
-    elif run_timeout 3 gh auth token --hostname "$(gh_target_host)" \
-        >/dev/null 2>&1; then
+    else
         # Standalone `status:creds`: nothing probed the API, and this section is
         # not allowed to. `gh auth token` resolves the credential gh would use
         # from local config and the environment WITHOUT calling GitHub, which
         # answers the only question this line exists to answer — is there a login
-        # at all. Its validity is `status:gh`'s to report, and the wording says
-        # so rather than claiming an authentication that was never checked.
-        # Redirected to /dev/null because the token itself is the output: this
-        # reads the exit code only and never captures, prints, or logs the value.
-        checkline ok "GitHub CLI (gh)" \
-            "credential stored for $(gh_target_host) (not validated)"
-    else
-        checkline no "GitHub CLI (gh)" "gh auth login"
+        # at all. Its validity is `status:gh`'s to report, and the wording below
+        # says so rather than claiming an authentication that was never checked.
+        #
+        # `2>&1 >/dev/null` — in that order — captures STDERR while sending
+        # stdout to /dev/null. The order is load-bearing and not interchangeable
+        # with `>/dev/null 2>&1`: this command's stdout IS the token, so the
+        # value must never enter a variable, and only its diagnostic goes into
+        # one. Nothing captured here is ever printed either way.
+        #
+        # Non-zero is then classified rather than assumed to mean logged out,
+        # the same distinction the Codex probe below draws: a locked keychain or
+        # an unreadable hosts.yml also exits non-zero, and `gh auth login` cannot
+        # repair either. Only gh's documented no-credential wording earns that
+        # remedy; everything else is unknown.
+        gh_token_rc=0
+        gh_token_err="$(run_timeout 3 gh auth token \
+            --hostname "$(gh_target_host)" 2>&1 >/dev/null)" || gh_token_rc=$?
+        case "${gh_token_rc}" in
+        0)
+            checkline ok "GitHub CLI (gh)" \
+                "credential stored for $(gh_target_host) (not validated)"
+            ;;
+        124) checkline unknown "GitHub CLI (gh)" "credential probe timed out" ;;
+        *)
+            case "$(printf '%s' "${gh_token_err}" | tr '[:upper:]' '[:lower:]')" in
+            *"no oauth token"* | *"not logged in"*)
+                checkline no "GitHub CLI (gh)" "gh auth login"
+                ;;
+            *)
+                checkline unknown "GitHub CLI (gh)" \
+                    "credential probe failed (exit ${gh_token_rc}) — check the gh CLI's config"
+                ;;
+            esac
+            ;;
+        esac
     fi
 
     # Codex gates `task challenge` and `task review` only where the repo opted

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -707,6 +707,46 @@ render_local_credentials() {
         checkline na "Codex CLI" "no second-model review configured"
     fi
 
+    # Claude Code is the agent this repo's Dev Loop is written for, and a logged
+    # out CLI stops it at the first `claude` invocation. `claude auth status
+    # --json` reads STORED credential state: it answers identically with every
+    # egress pointed at a dead port, so it belongs in this group rather than
+    # behind NETWORK_TIMEOUT.
+    #
+    # Not-installed reads n/a rather than missing, which is the one place this
+    # group departs from the gh and Codex lines above. Those two have a marker on
+    # disk for "this repo expects it" — codex-review.sh is rendered only under
+    # `use_codex_review`, and gh backs the whole GitHub half of the template.
+    # There is no equivalent marker here: the template ships .claude/ to every
+    # repo whether or not its author drives it with Claude Code, so an absent CLI
+    # cannot be distinguished from a deliberate choice of a different agent, and
+    # a red ✗ prescribing an install to somebody who chose Codex is noise they
+    # cannot act on.
+    if ! command -v claude >/dev/null 2>&1; then
+        checkline na "Claude Code CLI" "claude CLI not installed"
+    else
+        # The verdict is the `loggedIn` field, not the exit code: a logged-out
+        # CLI is a normal, successful report, and a `claude` too old for
+        # `auth status` exits non-zero with no field at all — which is unknown,
+        # not logged out. Whitespace is stripped so the match survives either
+        # JSON formatting, and stderr is discarded because only the field is
+        # read. The captured text is only ever matched, never printed.
+        claude_rc=0
+        claude_out="$(run_timeout 3 claude auth status --json 2>/dev/null)" ||
+            claude_rc=$?
+        case "$(printf '%s' "${claude_out}" | tr -d ' \n\t')" in
+        *'"loggedIn":true'*) checkline ok "Claude Code CLI" "logged in" ;;
+        *'"loggedIn":false'*) checkline no "Claude Code CLI" "claude auth login" ;;
+        *)
+            case "${claude_rc}" in
+            124) checkline unknown "Claude Code CLI" "auth status timed out" ;;
+            *) checkline unknown "Claude Code CLI" \
+                "auth status reported nothing readable (exit ${claude_rc})" ;;
+            esac
+            ;;
+        esac
+    fi
+
     # Hand this group's tallies to the setup summary (see the caller there).
     # Guarded, and deliberately last: with `pipefail` set, a failed write here
     # would become the whole pipeline's status and `set -e` would take the script

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -5,7 +5,7 @@ REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 PROJECT_NAME="$(basename "${REPO_ROOT}")"
 
-# Section filter: empty = show all, or "git", "gh", "code", "env"
+# Section filter: empty = show all, or "git", "gh", "creds", "code", "env"
 SECTION="${1:-}"
 
 # Temp directory for parallel data collection
@@ -231,10 +231,21 @@ GH_AUTH_FILE="${TMPDIR_STATUS}/auth.txt"
 : >"${GH_AUTH_FILE}"
 GH_AUTHED=false
 GH_AUTH_TIMEDOUT=false
+# Whether the bounded probe below actually ran. The credentials group reports the
+# validated answer when it did and falls back to a network-free local read when it
+# did not — see render_local_credentials. A flag rather than "is GH_AUTH_FILE
+# empty", because a failed probe legitimately leaves that file empty too.
+GH_AUTH_PROBED=false
 # The setup section needs this too — it reports the same credential's ability to
 # read the board, and used to run its own `gh auth status` to decide whether to
 # render at all. One probe, two consumers.
+#
+# Deliberately NOT extended to `SECTION == creds`: that section is invoked on its
+# own from the session-start hook, which already runs `status:gh` in the same
+# startup, and a second `gh auth status` there would be a net-new network call in
+# the one path whose whole budget argument is that it makes none.
 if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
+    GH_AUTH_PROBED=true
     gh_auth_rc=0
     # `gh auth status` reports every account on every host, and the scope line
     # read below cannot tell them apart — so narrow it to one credential from
@@ -557,6 +568,133 @@ if should_show "env"; then
     } | section_box
 fi
 
+# ── Local credentials ───────────────────────────────────────────────────────
+# The logins the Dev Loop gates on, read from LOCAL state only — no API call and
+# no network — so this renders in any auth state and costs nothing.
+#
+# It is a section of its own AND a group inside the setup audit, from this one
+# function so the probes are written once. Two callers, two reasons:
+#
+#   * `task status:creds` — the session-start hook runs it alongside status:git
+#     and status:gh, so a missing login is reported when a session opens rather
+#     than only on the explicit `task status:setup` a distracted session skips.
+#     That is the whole point: the audit it used to live in is network-heavy and
+#     excluded from the default board, while these probes are not.
+#   * `task status:setup` — rendered BEFORE the gh gate there rather than inside
+#     it. That gate skips the ENTIRE remaining audit when gh is logged out, so a
+#     credentials group living there would surface a missing codex login only
+#     after the reader had fixed gh and re-run: two round trips to learn what one
+#     run can say, which is the interruption this group exists to remove.
+#
+# `should_show` also puts it on the bare `task status` board, alongside every
+# other local section. The setup audit stays off that board because it is
+# network-heavy; this group is not, so the reason to exclude it does not apply.
+#
+# Every probe here is bounded by the short LOCAL bound (3s), never by
+# NETWORK_TIMEOUT — nothing in it may reach the network, or the session-start
+# path inherits a cost its budget was not derived for.
+render_local_credentials() {
+    # Not-installed is tested FIRST because it makes every other branch
+    # meaningless: with no gh on PATH the shared probe above exits 127, which
+    # lands in the same "not authenticated" bucket as a real logout and would
+    # prescribe `gh auth login` — a command the reader does not have. Same
+    # distinction the Codex check below draws, and the same remedy style as the
+    # 1Password and direnv lines further down.
+    if ! command -v gh >/dev/null 2>&1; then
+        checkline no "GitHub CLI (gh)" "brew install gh"
+    elif [[ "${GH_AUTH_PROBED}" == true ]]; then
+        # Reuses the single bounded probe from the top of this script instead of
+        # calling `gh auth status` again, and inherits its distinction between a
+        # deadline and a missing login — telling an authenticated reader to run
+        # `gh auth login` because GitHub was slow sends them to fix the wrong
+        # thing. The setup section's skip line stays as it is: it explains the
+        # absence of everything after it, which this line does not.
+        if [[ "${GH_AUTH_TIMEDOUT}" == true ]]; then
+            checkline unknown "GitHub CLI (gh)" \
+                "auth probe timed out after ${NETWORK_TIMEOUT}s"
+        elif [[ "${GH_AUTHED}" == true ]]; then
+            checkline ok "GitHub CLI (gh)" "authenticated to $(gh_target_host)"
+        else
+            checkline no "GitHub CLI (gh)" "gh auth login"
+        fi
+    elif run_timeout 3 gh auth token --hostname "$(gh_target_host)" \
+        >/dev/null 2>&1; then
+        # Standalone `status:creds`: nothing probed the API, and this section is
+        # not allowed to. `gh auth token` resolves the credential gh would use
+        # from local config and the environment WITHOUT calling GitHub, which
+        # answers the only question this line exists to answer — is there a login
+        # at all. Its validity is `status:gh`'s to report, and the wording says
+        # so rather than claiming an authentication that was never checked.
+        # Redirected to /dev/null because the token itself is the output: this
+        # reads the exit code only and never captures, prints, or logs the value.
+        checkline ok "GitHub CLI (gh)" \
+            "credential stored for $(gh_target_host) (not validated)"
+    else
+        checkline no "GitHub CLI (gh)" "gh auth login"
+    fi
+
+    # Codex gates `task challenge` and `task review` only where the repo opted
+    # into second-model review, and scripts/codex-review.sh is that opt-in's
+    # marker on disk — the template renders it only under `use_codex_review`.
+    # Same each-script-is-its-own-marker rule the GitHub configuration checks
+    # below use, and read off the filesystem rather than .copier-answers.yml:
+    # nothing else in this script reads that file, and a generated repo may keep
+    # it somewhere else. `codex login status` reads local credential state, so
+    # the bound here is the short local one (as with `op account list`), never
+    # NETWORK_TIMEOUT.
+    if [ -f scripts/codex-review.sh ]; then
+        if command -v codex >/dev/null 2>&1; then
+            # The exit code is the primary signal, but it cannot tell "no
+            # credentials" from "the CLI could not run": a malformed config.toml
+            # also exits non-zero, and `codex login` cannot repair that. So keep
+            # the documented logged-out phrase as the only thing that earns the
+            # login remedy, and report every other failure as unknown rather than
+            # sending the reader to re-authenticate a session that was never the
+            # problem.
+            #
+            # Captured with 2>&1 because the shipped CLI writes BOTH verdicts to
+            # stderr and leaves stdout empty — reading stdout alone would silently
+            # demote every genuine logout to "unknown". Folding the streams also
+            # picks up unrelated stderr chatter (a models-cache ERROR line appears
+            # on some installs while the command still exits 0), which is exactly
+            # why the match is on the phrase and the verdict on the exit code,
+            # never on stderr being non-empty. The captured text is only ever
+            # matched, never printed.
+            codex_rc=0
+            codex_out="$(run_timeout 3 codex login status 2>&1)" || codex_rc=$?
+            case "${codex_rc}" in
+            0) checkline ok "Codex CLI" "logged in" ;;
+            124) checkline unknown "Codex CLI" "login status timed out" ;;
+            *)
+                case "${codex_out}" in
+                *"Not logged in"*) checkline no "Codex CLI" "codex login" ;;
+                *) checkline unknown "Codex CLI" \
+                    "login status failed (exit ${codex_rc}) — check the codex CLI's config" ;;
+                esac
+                ;;
+            esac
+        else
+            checkline no "Codex CLI" \
+                "brew install --cask codex, or npm install -g @openai/codex"
+        fi
+    else
+        checkline na "Codex CLI" "no second-model review configured"
+    fi
+
+    # Hand this group's tallies to the setup summary (see the caller there).
+    # Guarded, and deliberately last: with `pipefail` set, a failed write here
+    # would become the whole pipeline's status and `set -e` would take the script
+    # down over a status board's bookkeeping.
+    printf '%s %s %s %s\n' \
+        "${SETUP_OK}" "${SETUP_NO}" "${SETUP_UNKNOWN}" "${SETUP_NA}" \
+        >"${TMPDIR_STATUS}/cred-counts" 2>/dev/null || true
+}
+
+if should_show "creds"; then
+    section_header "Local Credentials"
+    render_local_credentials | section_box
+fi
+
 # ── Setup Completeness ──────────────────────────────────────────────────────
 # Audits the repo against docs/CHECKLIST.md — which GitHub-side configuration
 # the template expects has actually been applied. Network-heavy, so it is NOT
@@ -589,15 +727,9 @@ if [[ "${SECTION}" == "setup" ]]; then
         fi
     } | section_box
 
-    # ── Local credentials ───────────────────────────────────────────────────
-    # The logins the Dev Loop gates on, read from LOCAL state only — no API call
-    # and no network — so this renders in any auth state and costs nothing.
-    #
-    # Deliberately placed BEFORE the gh gate below rather than inside it. That
-    # gate skips the ENTIRE remaining audit when gh is logged out, so a
-    # credentials group living there would surface a missing codex login only
-    # after the reader had fixed gh and re-run: two round trips to learn what one
-    # run can say, which is the interruption this group exists to remove.
+    # Rendered here as a group inside the audit (see render_local_credentials
+    # above for why it is also its own section, and why it sits BEFORE the gh
+    # gate below).
     #
     # Its own { } group means its own copy of the SETUP_* counters: checkline
     # mutates them inside the subshell that `| section_box` creates, so they
@@ -609,85 +741,7 @@ if [[ "${SECTION}" == "setup" ]]; then
     # is a worse defect than the file is.
     {
         subhead "Local credentials"
-
-        # Reuses the single bounded probe from the top of this script instead of
-        # calling `gh auth status` again, and inherits its distinction between a
-        # deadline and a missing login — telling an authenticated reader to run
-        # `gh auth login` because GitHub was slow sends them to fix the wrong
-        # thing. The skip line below stays as it is: it explains the absence of
-        # everything after it, which this line does not.
-        # Not-installed is tested FIRST because it makes the other three
-        # meaningless: with no gh on PATH the shared probe above exits 127, which
-        # lands in the same "not authenticated" bucket as a real logout and would
-        # prescribe `gh auth login` — a command the reader does not have. Same
-        # distinction the Codex check below draws, and the same remedy style as
-        # the 1Password and direnv lines further down.
-        if ! command -v gh >/dev/null 2>&1; then
-            checkline no "GitHub CLI (gh)" "brew install gh"
-        elif [[ "${GH_AUTH_TIMEDOUT}" == true ]]; then
-            checkline unknown "GitHub CLI (gh)" \
-                "auth probe timed out after ${NETWORK_TIMEOUT}s"
-        elif [[ "${GH_AUTHED}" == true ]]; then
-            checkline ok "GitHub CLI (gh)" "authenticated to $(gh_target_host)"
-        else
-            checkline no "GitHub CLI (gh)" "gh auth login"
-        fi
-
-        # Codex gates `task challenge` and `task review` only where the repo
-        # opted into second-model review, and scripts/codex-review.sh is that
-        # opt-in's marker on disk — the template renders it only under
-        # `use_codex_review`. Same each-script-is-its-own-marker rule the GitHub
-        # configuration checks below use, and read off the filesystem rather than
-        # .copier-answers.yml: nothing else in this script reads that file, and a
-        # generated repo may keep it somewhere else. `codex login status` reads
-        # local credential state, so the bound here is the short local one (as
-        # with `op account list`), never NETWORK_TIMEOUT.
-        if [ -f scripts/codex-review.sh ]; then
-            if command -v codex >/dev/null 2>&1; then
-                # The exit code is the primary signal, but it cannot tell "no
-                # credentials" from "the CLI could not run": a malformed
-                # config.toml also exits non-zero, and `codex login` cannot
-                # repair that. So keep the documented logged-out phrase as the
-                # only thing that earns the login remedy, and report every other
-                # failure as unknown rather than sending the reader to
-                # re-authenticate a session that was never the problem.
-                #
-                # Captured with 2>&1 because the shipped CLI writes BOTH verdicts
-                # to stderr and leaves stdout empty — reading stdout alone would
-                # silently demote every genuine logout to "unknown". Folding the
-                # streams also picks up unrelated stderr chatter (a models-cache
-                # ERROR line appears on some installs while the command still
-                # exits 0), which is exactly why the match is on the phrase and
-                # the verdict on the exit code, never on stderr being non-empty.
-                # The captured text is only ever matched, never printed.
-                codex_rc=0
-                codex_out="$(run_timeout 3 codex login status 2>&1)" || codex_rc=$?
-                case "${codex_rc}" in
-                0) checkline ok "Codex CLI" "logged in" ;;
-                124) checkline unknown "Codex CLI" "login status timed out" ;;
-                *)
-                    case "${codex_out}" in
-                    *"Not logged in"*) checkline no "Codex CLI" "codex login" ;;
-                    *) checkline unknown "Codex CLI" \
-                        "login status failed (exit ${codex_rc}) — check the codex CLI's config" ;;
-                    esac
-                    ;;
-                esac
-            else
-                checkline no "Codex CLI" \
-                    "brew install --cask codex, or npm install -g @openai/codex"
-            fi
-        else
-            checkline na "Codex CLI" "no second-model review configured"
-        fi
-
-        # Hand this group's tallies to the summary (see the header comment).
-        # Guarded, and deliberately last: with `pipefail` set, a failed write
-        # here would become the whole pipeline's status and `set -e` would take
-        # the script down over a status board's bookkeeping.
-        printf '%s %s %s %s\n' \
-            "${SETUP_OK}" "${SETUP_NO}" "${SETUP_UNKNOWN}" "${SETUP_NA}" \
-            >"${TMPDIR_STATUS}/cred-counts" 2>/dev/null || true
+        render_local_credentials
     } | section_box
 
     # Reuses the single bounded probe above rather than making a second,

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -188,6 +188,14 @@ make_stub() {
             echo '    sleep 30'
             echo '    exit 0'
             ;;
+        broken-token-store)
+            # Authenticated as far as the API is concerned, but the LOCAL
+            # credential read fails for a reason `gh auth login` cannot repair —
+            # a locked keychain, an unreadable hosts.yml. Deliberately does NOT
+            # carry gh's no-credential wording: that is the whole distinction.
+            echo "    echo \"  - Token scopes: 'gist', 'project', 'repo'\""
+            echo '    exit 0'
+            ;;
         *) fail "unknown stub scenario: ${scenario}" ;;
         esac
         echo 'fi'
@@ -206,6 +214,10 @@ make_stub() {
         hangs)
             echo '    sleep 30'
             echo '    exit 0'
+            ;;
+        broken-token-store)
+            echo '    echo "error: failed to read keyring: interaction denied" >&2'
+            echo '    exit 1'
             ;;
         *)
             echo '    echo "STUB-TOKEN-MUST-NEVER-BE-PRINTED"'
@@ -818,6 +830,35 @@ case "$out" in
 *"[ ] GitHub CLI (gh) — gh auth login"*) ;;
 *) fail "expected a missing-login line from status:creds, got: ${out}" ;;
 esac
+
+echo "==> a local token read that fails for another reason reads unknown"
+# Non-zero is not the same as logged out, exactly as for the Codex probe: a
+# locked keychain exits non-zero too, and `gh auth login` cannot repair it — the
+# reader would be sent to fix the wrong thing. Only gh's documented
+# no-credential wording earns that remedy.
+make_codex_stub in
+out="$(run_creds_section broken-token-store)"
+case "$out" in
+*"[ ] GitHub CLI (gh)"*) fail "a broken credential store must not read as logged out: ${out}" ;;
+*"gh auth login"*) fail "a broken credential store must not prescribe re-authentication: ${out}" ;;
+*"[?] GitHub CLI (gh)"*"credential probe failed"*) ;;
+*) fail "expected an unknown gh credential line, got: ${out}" ;;
+esac
+
+echo "==> a local token read that outlives its deadline reads unknown too"
+# The probe is bounded, which makes a wedged credential helper look exactly like
+# a missing login unless the deadline is classified apart from it.
+if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
+    make_codex_stub in
+    out="$(run_creds_section hangs)"
+    case "$out" in
+    *"[ ] GitHub CLI (gh)"*) fail "a timeout must not read as a missing login: ${out}" ;;
+    *"[?] GitHub CLI (gh)"*"timed out"*) ;;
+    *) fail "expected a timeout notice from status:creds, got: ${out}" ;;
+    esac
+else
+    echo "    (skipped: no timeout binary — the probe is unbounded here)"
+fi
 
 echo "==> status:creds reports a logged-out codex too"
 make_codex_stub out

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -917,4 +917,50 @@ else
     echo "    (skipped: no devcontainer hook in this profile)"
 fi
 
+echo "==> the session-start hook fits inside its managed SessionStart deadline"
+# The deadline ABOVE the per-section ones: Claude Code applies the `timeout` on
+# the SessionStart entries to the whole hook, and overrunning it is worse than
+# overrunning a section bound — the hook is killed before `jq` emits anything,
+# so the entire payload is lost rather than one section of it. Adding a section
+# is exactly when that ceiling gets forgotten, so derive both sides from the
+# files: the sections run in parallel, which makes the hook's wall clock the
+# LONGEST section deadline rather than their sum.
+settings=".devcontainer/config/claude-settings.json"
+if [ -f "$hook" ] && [ -f "$settings" ]; then
+    managed="$(jq -r '
+        [.hooks.SessionStart[]?.hooks[]?
+         | select(.command | test("session-start-context"))
+         | .timeout // empty]
+        | min // empty
+    ' "$settings")"
+    [ -n "$managed" ] ||
+        fail "could not read the SessionStart hook timeout out of ${settings}"
+
+    # Every bounded section launch in the hook, and whether it was backgrounded.
+    section_bounds="$(sed -n -E 's/^[[:space:]]*timeout ([0-9]+) task status:[a-z]+ .*/\1/p' "$hook")"
+    backgrounded="$(sed -n -E 's/^[[:space:]]*timeout [0-9]+ task status:[a-z]+ .*&$/&/p' "$hook" | wc -l | tr -d ' ')"
+    n_sections="$(printf '%s\n' "$section_bounds" | grep -c '[0-9]' || true)"
+    [ "${n_sections:-0}" -ge 2 ] ||
+        fail "found ${n_sections:-0} bounded status sections in ${hook} — the ceiling below would assert nothing"
+
+    longest=0
+    total=0
+    for b in $section_bounds; do
+        total=$((total + b))
+        [ "$b" -gt "$longest" ] && longest="$b"
+    done
+
+    if [ "$backgrounded" -eq "$n_sections" ]; then
+        wall="$longest"
+        shape="in parallel"
+    else
+        wall="$total"
+        shape="sequentially"
+    fi
+    [ "$managed" -gt "$wall" ] ||
+        fail "the hook runs its ${n_sections} sections ${shape} (${wall}s worst case) but claude-settings.json kills it at ${managed}s — the whole payload is discarded, not one section"
+else
+    echo "    (skipped: no devcontainer hook/settings in this profile)"
+fi
+
 echo "status.sh tests passed"

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -4,10 +4,12 @@
 #   * "Project board writes" (`task status:gh`) — the token scope the claim
 #     lifecycle needs, reported from the section session-start orientation
 #     actually runs, in every scope state.
-#   * "Local credentials" (`task status:setup`) — the gh and Codex logins the
-#     Dev Loop gates on, in every state including not-installed, rendering
-#     BEFORE the gate that skips the rest of that audit, and counted by the
-#     summary at the end of it.
+#   * "Local credentials" (`task status:creds` and `task status:setup`) — the gh
+#     and Codex logins the Dev Loop gates on, in every state including
+#     not-installed, rendered as its own section for the session-start hook AND
+#     inside the setup audit BEFORE the gate that skips the rest of it, counted
+#     by the summary at the end of that audit, and — standalone — making no
+#     network call at all.
 #
 # Run via `task test:status`.
 #
@@ -78,6 +80,11 @@ make_stub() {
     mkdir -p "${TMP}/bin"
     {
         echo '#!/usr/bin/env bash'
+        # A call log, so a case can assert on which gh calls a section made
+        # rather than only on what it printed. The standalone credentials
+        # section's contract is "no network call", and the only way to see a
+        # network call that a stub happily answers is to look at the log.
+        echo 'if [ -n "${STUB_CALLS:-}" ]; then echo "$*" >>"$STUB_CALLS"; fi'
         echo 'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then'
         case "$scenario" in
         project)
@@ -182,6 +189,28 @@ make_stub() {
             echo '    exit 0'
             ;;
         *) fail "unknown stub scenario: ${scenario}" ;;
+        esac
+        echo 'fi'
+        # `gh auth token` is the standalone credentials section's LOCAL read: it
+        # prints the stored/environment credential without calling GitHub. The
+        # stub answers it from the same scenario as `auth status` so the two
+        # cannot disagree, and prints a placeholder rather than nothing because
+        # the real command's output IS the token — a probe that captured or
+        # echoed it would show up as this string in the assertions.
+        echo 'if [ "$1" = "auth" ] && [ "$2" = "token" ]; then'
+        case "$scenario" in
+        unauthenticated)
+            echo '    echo "no oauth token" >&2'
+            echo '    exit 1'
+            ;;
+        hangs)
+            echo '    sleep 30'
+            echo '    exit 0'
+            ;;
+        *)
+            echo '    echo "STUB-TOKEN-MUST-NEVER-BE-PRINTED"'
+            echo '    exit 0'
+            ;;
         esac
         echo 'fi'
         echo 'case "$*" in'
@@ -308,6 +337,16 @@ run_setup_section() {
     make_stub "$1"
     local script="${2:-${WITH_CODEX}}"
     PATH="${TMP}/bin:${PATH}" NO_COLOR=1 "${script}" setup 2>&1
+}
+
+# run_creds_section GH_SCENARIO [SCRIPT] — status.sh's standalone credentials
+# section (`task status:creds`, the one the session-start hook runs) with the
+# stubs on PATH. SCRIPT defaults to the with-codex fixture, the profile in which
+# the Codex login is a gate.
+run_creds_section() {
+    make_stub "$1"
+    local script="${2:-${WITH_CODEX}}"
+    PATH="${TMP}/bin:${PATH}" NO_COLOR=1 "${script}" creds 2>&1
 }
 
 # run_setup_without MISSING [SCRIPT] — the same, with MISSING genuinely absent
@@ -719,6 +758,122 @@ if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; th
     esac
 else
     echo "    (skipped: no timeout binary — the probe is unbounded here)"
+fi
+
+echo "==> status:creds renders the credentials group on its own"
+# The gap this section exists to close: the group used to render only inside
+# status:setup, which the session-start hook does not run — so a missing login
+# surfaced only on the explicit audit a distracted session skips.
+make_codex_stub in
+out="$(run_creds_section project)"
+case "$out" in
+*"GitHub CLI (gh)"*) ;;
+*) fail "expected a gh credential line from status:creds, got: ${out}" ;;
+esac
+case "$out" in
+*"[x] Codex CLI"*) ;;
+*) fail "expected a Codex credential line from status:creds, got: ${out}" ;;
+esac
+
+echo "==> status:creds makes no network call"
+# The acceptance criterion the session-start budget rests on. `gh auth status`
+# validates the token against the API; `gh auth token` reads local config and
+# the environment. The hook already spends this startup's one auth round trip in
+# status:gh, so this section must add none — and a stub that answers `auth
+# status` perfectly well would hide a second one from every output assertion.
+STUB_CALLS="${TMP}/creds-calls.txt"
+export STUB_CALLS
+: >"${STUB_CALLS}"
+make_codex_stub in
+out="$(run_creds_section project)"
+if grep -q 'auth status' "${STUB_CALLS}"; then
+    fail "status:creds called 'gh auth status' — that is a network probe: $(tr '\n' ' ' <"${STUB_CALLS}")"
+fi
+grep -q 'auth token' "${STUB_CALLS}" ||
+    fail "status:creds made no local credential read at all: $(tr '\n' ' ' <"${STUB_CALLS}")"
+unset STUB_CALLS
+
+echo "==> status:creds never prints the token it reads"
+# `gh auth token` writes the credential to stdout — the value is the output. The
+# probe reads its exit code only, so the stub's placeholder must not reach the
+# board (nor, by the same redirect, a log or the session-start payload).
+case "$out" in
+*STUB-TOKEN-MUST-NEVER-BE-PRINTED*) fail "the credential value reached the board: ${out}" ;;
+esac
+
+echo "==> status:creds does not claim an authentication it never checked"
+# It reports that a credential EXISTS. Whether GitHub still accepts it is
+# status:gh's answer, and wording this line as "authenticated" would assert
+# something no probe here established.
+case "$out" in
+*"authenticated to"*) fail "a local-only read must not claim authentication: ${out}" ;;
+*"not validated"*) ;;
+*) fail "expected the stored-credential wording, got: ${out}" ;;
+esac
+
+echo "==> status:creds reports a logged-out gh with the login remedy"
+make_codex_stub in
+out="$(run_creds_section unauthenticated)"
+case "$out" in
+*"[ ] GitHub CLI (gh) — gh auth login"*) ;;
+*) fail "expected a missing-login line from status:creds, got: ${out}" ;;
+esac
+
+echo "==> status:creds reports a logged-out codex too"
+make_codex_stub out
+out="$(run_creds_section project)"
+case "$out" in
+*"[x] Codex CLI"*) fail "a logged-out codex must not read as ok: ${out}" ;;
+*"[ ] Codex CLI — codex login"*) ;;
+*) fail "expected a logged-out codex line from status:creds, got: ${out}" ;;
+esac
+
+echo "==> status:creds omits the setup audit it was carved out of"
+# It is a section, not a shortcut into the network-heavy audit: a status:creds
+# that dragged the checklist bar or the GitHub configuration checks along would
+# put exactly the cost back into session start that this split removed.
+case "$out" in
+*"Setup Completeness"*) fail "status:creds rendered the setup audit: ${out}" ;;
+*"Checklist"*) fail "status:creds rendered the checklist progress: ${out}" ;;
+esac
+
+echo "==> gh missing from PATH still names an install remedy in status:creds"
+make_stub project
+make_codex_stub in
+make_isolated_bin gh
+out="$(PATH="${TMP}/bin-iso" NO_COLOR=1 "${WITH_CODEX}" creds 2>&1)"
+case "$out" in
+*"GitHub CLI (gh) — gh auth login"*) fail "an absent gh must not be told to log in: ${out}" ;;
+*"[ ] GitHub CLI (gh) — brew install gh"*) ;;
+*) fail "expected an install remedy for a missing gh, got: ${out}" ;;
+esac
+
+echo "==> the session-start hook allows more time than status:creds can spend"
+# The same coupling as the status:gh assertion above, and the same total failure
+# mode — but budgeted from THIS section's own probes rather than inherited from
+# its neighbour's. Both bounds are read out of the files, so adding a probe to
+# the credentials group without widening the hook fails here.
+if [ -f "$hook" ]; then
+    creds_budget="$(sed -n -E 's/.*timeout ([0-9]+) task status:creds.*/\1/p' "$hook" | head -1)"
+    creds_worst="$(awk '
+        /^render_local_credentials\(\) \{/ { inf = 1 }
+        inf && /^\}/ { inf = 0 }
+        inf {
+            line = $0
+            while (match(line, /run_timeout [0-9]+ /)) {
+                total += substr(line, RSTART + 12, RLENGTH - 13) + 0
+                line = substr(line, RSTART + RLENGTH)
+            }
+        }
+        END { print total + 0 }
+    ' "${status}")"
+    [ -n "$creds_budget" ] || fail "could not read the status:creds timeout out of ${hook}"
+    [ "$creds_worst" -gt 0 ] ||
+        fail "found no bounded probes in render_local_credentials — the budget below would assert nothing"
+    [ "$creds_budget" -gt "$creds_worst" ] ||
+        fail "hook allows ${creds_budget}s but the credentials section can spend ${creds_worst}s on probes alone — the whole group is lost first"
+else
+    echo "    (skipped: no devcontainer hook in this profile)"
 fi
 
 echo "status.sh tests passed"

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -287,11 +287,49 @@ make_codex_stub() {
     chmod +x "${TMP}/bin/codex"
 }
 
-# The setup section probes codex on every invocation now, so stub it before the
-# first case runs — a case that reached the real CLI would pass or fail on
+# make_claude_stub STATE — write $TMP/bin/claude answering `auth status --json`.
+#   in      — logged in
+#   out     — logged out: a NORMAL, successful report carrying loggedIn:false,
+#             which is why the check reads the field and not the exit code
+#   ancient — a `claude` predating `auth status`: a usage error with no field,
+#             which must read as unknown rather than as a logout
+# Any other call fails loudly: this probe must read local login state and nothing
+# else, so a second call — or a network one — shows up here instead of passing
+# silently.
+make_claude_stub() {
+    local state="$1"
+    mkdir -p "${TMP}/bin"
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then'
+        case "$state" in
+        in)
+            echo '    echo "{ \"loggedIn\": true, \"authMethod\": \"claude.ai\" }"'
+            echo '    exit 0'
+            ;;
+        out)
+            echo '    echo "{ \"loggedIn\": false }"'
+            echo '    exit 0'
+            ;;
+        ancient)
+            echo '    echo "error: unknown command auth" >&2'
+            echo '    exit 1'
+            ;;
+        *) fail "unknown claude stub state: ${state}" ;;
+        esac
+        echo 'fi'
+        echo 'echo "stub: unexpected claude call: $*" >&2'
+        echo 'exit 1'
+    } >"${TMP}/bin/claude"
+    chmod +x "${TMP}/bin/claude"
+}
+
+# The credentials group probes codex and claude on every invocation, so stub both
+# before the first case runs — a case that reached the real CLI would pass or fail on
 # whether the developer happens to be logged in, which is worse than no test at
 # all.
 make_codex_stub in
+make_claude_stub in
 
 # ISOLATED_TOOLS — the external commands status.sh needs, both to reach the
 # credentials group and to run the audit past the gh gate. The not-installed case
@@ -316,7 +354,7 @@ make_isolated_bin() {
             ln -s "${resolved}" "${TMP}/bin-iso/${tool}"
         fi
     done
-    for tool in gh codex; do
+    for tool in gh codex claude; do
         if [ "${tool}" != "${missing}" ] && [ -f "${TMP}/bin/${tool}" ]; then
             cp "${TMP}/bin/${tool}" "${TMP}/bin-iso/${tool}"
         fi
@@ -867,6 +905,46 @@ case "$out" in
 *"[x] Codex CLI"*) fail "a logged-out codex must not read as ok: ${out}" ;;
 *"[ ] Codex CLI — codex login"*) ;;
 *) fail "expected a logged-out codex line from status:creds, got: ${out}" ;;
+esac
+
+echo "==> a logged-out Claude Code CLI is reported, and names its remedy"
+# The third login #733 requires at session start. The field is the verdict, not
+# the exit code: a logged-out CLI reports it successfully.
+make_codex_stub in
+make_claude_stub out
+out="$(run_creds_section project)"
+case "$out" in
+*"[x] Claude Code CLI"*) fail "a logged-out claude must not read as ok: ${out}" ;;
+*"[ ] Claude Code CLI — claude auth login"*) ;;
+*) fail "expected a logged-out claude line, got: ${out}" ;;
+esac
+
+echo "==> a claude too old for 'auth status' reads unknown, not logged out"
+# No field at all is not the same as loggedIn:false, and `claude auth login`
+# cannot repair a CLI that has no such command.
+make_claude_stub ancient
+out="$(run_creds_section project)"
+case "$out" in
+*"[ ] Claude Code CLI"*) fail "an unreadable report must not read as a logout: ${out}" ;;
+*"claude auth login"*) fail "an unreadable report must not prescribe re-authentication: ${out}" ;;
+*"[?] Claude Code CLI"*) ;;
+*) fail "expected an unknown claude line, got: ${out}" ;;
+esac
+
+echo "==> claude missing from PATH reads n/a, not missing"
+# Unlike gh and Codex there is no marker on disk for "this repo expects Claude
+# Code" — the template ships .claude/ everywhere — so an absent CLI cannot be
+# told apart from an author who drives this repo with a different agent, and a
+# red line prescribing an install would be noise they cannot act on.
+make_stub project
+make_codex_stub in
+make_claude_stub in
+make_isolated_bin claude
+out="$(PATH="${TMP}/bin-iso" NO_COLOR=1 "${WITH_CODEX}" creds 2>&1)"
+case "$out" in
+*"[ ] Claude Code CLI"*) fail "an absent claude must not read as a missing login: ${out}" ;;
+*"[-] Claude Code CLI"*) ;;
+*) fail "expected an n/a claude line, got: ${out}" ;;
 esac
 
 echo "==> status:creds omits the setup audit it was carved out of"

--- a/template/.claude/hooks/session-start-context.sh.jinja
+++ b/template/.claude/hooks/session-start-context.sh.jinja
@@ -26,8 +26,8 @@ strip_ansi() { sed -E 's/\x1B\[''[0-9;]*[A-Za-z]//g'; }
 # status:creds is budgeted from its own probes rather than by copying a
 # neighbour's number: it makes NO network call (that is why it can be here at
 # all — status:gh already spends this startup's only auth round trip), and runs
-# two LOCAL probes back to back, each bounded at 3s inside status.sh — 6s worst
-# case, so 8 here for the `task` and shell startup around them. The three run in
+# three LOCAL probes back to back, each bounded at 3s inside status.sh — 9s
+# worst case, so 11 here for the `task` and shell startup around them. The three run in
 # parallel, so it adds nothing to the wall clock the gh deadline already allows.
 remote_url="$(git config --get remote.origin.url 2>/dev/null || echo '')"
 host_owner="$(echo "$remote_url" | sed -E 's/^(https?:\/\/|git@)([^:\/]+)[:\/]([^\/]+)\/[^\/]+(\.git)?$/\2 \3/')"
@@ -48,7 +48,7 @@ if [ "$host" = "github.com" ]; then
     git_pid=$!
     "$timeout_cmd" 12 task status:gh >"$gh_out" 2>/dev/null &
     gh_pid=$!
-    "$timeout_cmd" 8 task status:creds >"$creds_out" 2>/dev/null &
+    "$timeout_cmd" 11 task status:creds >"$creds_out" 2>/dev/null &
     creds_pid=$!
 
     git_rc=0

--- a/template/.claude/hooks/session-start-context.sh.jinja
+++ b/template/.claude/hooks/session-start-context.sh.jinja
@@ -3,11 +3,12 @@
 #
 # Re-injects orienting context every time a Claude session starts or its
 # context window is compacted: current branch, recent commits, working-tree
-# status, open PRs/issues, and a short reminder of repo conventions. Uses
-# `task status:git` + `task status:gh` (the fine-grained dashboard sections
-# from scripts/status.sh) so the payload stays small and fast — `status:site`
-# and `status:code` are intentionally skipped because they hit the network
-# and the local build respectively.
+# status, open PRs/issues, local logins, and a short reminder of repo
+# conventions. Uses `task status:git` + `task status:gh` + `task status:creds`
+# (the fine-grained dashboard sections from scripts/status.sh) so the payload
+# stays small and fast — `status:site` and `status:code` are intentionally
+# skipped because they hit the network and the local build respectively, and
+# `status:setup` because it is a network-heavy audit.
 set -euo pipefail
 
 cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
@@ -21,6 +22,13 @@ strip_ansi() { sed -E 's/\x1B\[''[0-9;]*[A-Za-z]//g'; }
 # spends up to NETWORK_TIMEOUT (5s) on the auth probe and then up to another 5s
 # on the PR/run probes it launches in parallel — 10s worst case, so 12 here.
 # status:git makes no network calls at all.
+#
+# status:creds is budgeted from its own probes rather than by copying a
+# neighbour's number: it makes NO network call (that is why it can be here at
+# all — status:gh already spends this startup's only auth round trip), and runs
+# two LOCAL probes back to back, each bounded at 3s inside status.sh — 6s worst
+# case, so 8 here for the `task` and shell startup around them. The three run in
+# parallel, so it adds nothing to the wall clock the gh deadline already allows.
 remote_url="$(git config --get remote.origin.url 2>/dev/null || echo '')"
 host_owner="$(echo "$remote_url" | sed -E 's/^(https?:\/\/|git@)([^:\/]+)[:\/]([^\/]+)\/[^\/]+(\.git)?$/\2 \3/')"
 host="${host_owner% *}"
@@ -31,6 +39,7 @@ if [ "$host" = "github.com" ]; then
 "[[ github_org ]]" | "evanharmon1" | "harmonops" | "ponderousdev")
     git_out="$(mktemp)"
     gh_out="$(mktemp)"
+    creds_out="$(mktemp)"
     timeout_cmd="timeout"
     if command -v gtimeout >/dev/null 2>&1; then
         timeout_cmd="gtimeout"
@@ -39,11 +48,15 @@ if [ "$host" = "github.com" ]; then
     git_pid=$!
     "$timeout_cmd" 12 task status:gh >"$gh_out" 2>/dev/null &
     gh_pid=$!
+    "$timeout_cmd" 8 task status:creds >"$creds_out" 2>/dev/null &
+    creds_pid=$!
 
     git_rc=0
     wait $git_pid || git_rc=$?
     gh_rc=0
     wait $gh_pid || gh_rc=$?
+    creds_rc=0
+    wait $creds_pid || creds_rc=$?
 
     if [ $git_rc -ne 0 ] || [ ! -s "$git_out" ]; then
         git_status="(task status:git unavailable or failed)"
@@ -56,24 +69,31 @@ if [ "$host" = "github.com" ]; then
     else
         gh_status="$(cat "$gh_out" | strip_ansi)"
     fi
-    rm -f "$git_out" "$gh_out"
+    if [ $creds_rc -ne 0 ] || [ ! -s "$creds_out" ]; then
+        creds_status="(task status:creds unavailable or failed)"
+    else
+        creds_status="$(cat "$creds_out" | strip_ansi)"
+    fi
+    rm -f "$git_out" "$gh_out" "$creds_out"
     ;;
     *)
         git_status="(task status:git skipped - untrusted repository)"
         gh_status="(task status:gh skipped - untrusted repository)"
+        creds_status="(task status:creds skipped - untrusted repository)"
         ;;
     esac
 else
     git_status="(task status:git skipped - untrusted repository)"
     gh_status="(task status:gh skipped - untrusted repository)"
+    creds_status="(task status:creds skipped - untrusted repository)"
 fi
 
 branch="$(git branch --show-current 2>/dev/null || echo 'unknown')"
 
 reminder=$'Repo conventions:\n- Run `task verify` before committing (lint + build + validate + test).\n- Conventional Commits required (feat/fix/docs/style/refactor/perf/test/chore/ci/build/revert).\n- Never bypass git hooks with --no-verify; fix the underlying issue.\n- Use lefthook for git hooks (not pre-commit).\n- See docs/conventions.md (and AGENTS.md) for the authoritative conventions catalog.'
 
-context="$(printf 'Branch: %s\n\n=== task status:git ===\n%s\n\n=== task status:gh ===\n%s\n\n%s\n' \
-    "$branch" "$git_status" "$gh_status" "$reminder")"
+context="$(printf 'Branch: %s\n\n=== task status:git ===\n%s\n\n=== task status:gh ===\n%s\n\n=== task status:creds ===\n%s\n\n%s\n' \
+    "$branch" "$git_status" "$gh_status" "$creds_status" "$reminder")"
 
 # Emit as JSON so Claude Code injects it as additionalContext.
 jq -n --arg ctx "$context" '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -123,7 +123,8 @@ See [DESIGN.md](DESIGN.md) for visual/UX direction.
 | `task codex:gate:enable` | Automatic Claude → Codex stop-gate for this repo + machine (also `:disable` / `:status`) |
 [% endif %]
 | `task release:patch` | Tag + GitHub release (also `:minor` / `:major`) |
-| `task status` | Project status dashboard (also `status:git`/`:gh`/`:code`/`:env`) |
+| `task status` | Project status dashboard (also `status:git`/`:gh`/`:creds`/`:code`/`:env`) |
+| `task status:creds` | Local credential logins (gh, Codex) — local probes, no network; also run at session start |
 | `task status:setup` | Setup audit: local credentials, GitHub config, toolchain, devcontainer, dev env |
 
 ## Testing

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -124,7 +124,7 @@ See [DESIGN.md](DESIGN.md) for visual/UX direction.
 [% endif %]
 | `task release:patch` | Tag + GitHub release (also `:minor` / `:major`) |
 | `task status` | Project status dashboard (also `status:git`/`:gh`/`:creds`/`:code`/`:env`) |
-| `task status:creds` | Local credential logins (gh, Codex) — local probes, no network; also run at session start |
+| `task status:creds` | Local credential logins (gh, Codex, Claude Code) — local probes, no network; also run at session start |
 | `task status:setup` | Setup audit: local credentials, GitHub config, toolchain, devcontainer, dev env |
 
 ## Testing

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -1145,7 +1145,7 @@ tasks:
       - ./scripts/status.sh gh
 
   status:creds:
-    desc: Local credential section (gh, Codex logins — local probes, no network)
+    desc: Local credential section (gh, Codex, Claude Code logins — local probes, no network)
     cmds:
       - ./scripts/status.sh creds
 

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -1144,6 +1144,11 @@ tasks:
     cmds:
       - ./scripts/status.sh gh
 
+  status:creds:
+    desc: Local credential section (gh, Codex logins — local probes, no network)
+    cmds:
+      - ./scripts/status.sh creds
+
   status:code:
     desc: Codebase stats section
     cmds:

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-hooks/session-start-context.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-hooks/session-start-context.sh
@@ -28,9 +28,57 @@ strip_ansi() { sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'; }
 # all — status:gh already spends this startup's only auth round trip), and runs
 # two LOCAL probes back to back, each bounded at 3s inside status.sh — 6s worst
 # case, so 8 here for the `task` and shell startup around them.
-git_status="$(timeout 5 task status:git 2>/dev/null | strip_ansi || echo '(task status:git unavailable)')"
-gh_status="$(timeout 12 task status:gh 2>/dev/null | strip_ansi || echo '(task status:gh unavailable)')"
-creds_status="$(timeout 8 task status:creds 2>/dev/null | strip_ansi || echo '(task status:creds unavailable)')"
+#
+# There is a SECOND deadline above all of these: the `timeout` on the
+# SessionStart entries in claude-settings.json, which Claude Code applies to this
+# whole script. Overrunning it is worse than any single section overrunning its
+# own bound — the hook is killed before `jq` emits anything, so the entire
+# payload is lost rather than one section of it. The sections are therefore run
+# in PARALLEL: the hook's wall clock is then the LONGEST deadline (12s), which
+# fits inside that outer timeout, where the sum (25s) would not.
+git_out="$(mktemp)"
+gh_out="$(mktemp)"
+creds_out="$(mktemp)"
+trap 'rm -f "${git_out}" "${gh_out}" "${creds_out}"' EXIT
+
+timeout 5 task status:git >"$git_out" 2>/dev/null &
+git_pid=$!
+timeout 12 task status:gh >"$gh_out" 2>/dev/null &
+gh_pid=$!
+timeout 8 task status:creds >"$creds_out" 2>/dev/null &
+creds_pid=$!
+
+# `wait` on each, with the failure recorded rather than propagated: `set -e`
+# would otherwise take the whole hook down over one section's deadline, which is
+# the payload-loss failure this structure exists to avoid.
+git_rc=0
+wait $git_pid || git_rc=$?
+gh_rc=0
+wait $gh_pid || gh_rc=$?
+creds_rc=0
+wait $creds_pid || creds_rc=$?
+
+# An empty file counts as a failure too: `timeout` kills status.sh mid-section,
+# and section_box buffers a section before printing it, so a killed run leaves
+# nothing rather than a partial section.
+if [ $git_rc -ne 0 ] || [ ! -s "$git_out" ]; then
+    git_status="(task status:git unavailable or failed)"
+else
+    git_status="$(strip_ansi <"$git_out")"
+fi
+
+if [ $gh_rc -ne 0 ] || [ ! -s "$gh_out" ]; then
+    gh_status="(task status:gh unavailable or failed)"
+else
+    gh_status="$(strip_ansi <"$gh_out")"
+fi
+
+if [ $creds_rc -ne 0 ] || [ ! -s "$creds_out" ]; then
+    creds_status="(task status:creds unavailable or failed)"
+else
+    creds_status="$(strip_ansi <"$creds_out")"
+fi
+
 branch="$(git branch --show-current 2>/dev/null || echo 'unknown')"
 
 reminder=$'Repo conventions:\n- Run `task verify` before committing (lint + build + validate + test).\n- Conventional Commits required (feat/fix/docs/style/refactor/perf/test/chore/ci/build/change/remove/revert).\n- Never bypass git hooks with --no-verify; fix the underlying issue.\n- Use lefthook for git hooks (not pre-commit).\n- See docs/conventions.md (and AGENTS.md) for the authoritative conventions catalog.'

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-hooks/session-start-context.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-hooks/session-start-context.sh
@@ -3,11 +3,12 @@
 #
 # Re-injects orienting context every time a Claude session starts or its
 # context window is compacted: current branch, recent commits, working-tree
-# status, open PRs/issues, and a short reminder of repo conventions. Uses
-# `task status:git` + `task status:gh` (the fine-grained dashboard sections
-# from scripts/status.sh) so the payload stays small and fast — `status:site`
-# and `status:code` are intentionally skipped because they hit the network
-# and the local build respectively.
+# status, open PRs/issues, local logins, and a short reminder of repo
+# conventions. Uses `task status:git` + `task status:gh` + `task status:creds`
+# (the fine-grained dashboard sections from scripts/status.sh) so the payload
+# stays small and fast — `status:site` and `status:code` are intentionally
+# skipped because they hit the network and the local build respectively, and
+# `status:setup` because it is a network-heavy audit.
 set -euo pipefail
 
 cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
@@ -21,14 +22,21 @@ strip_ansi() { sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'; }
 # spends up to NETWORK_TIMEOUT (5s) on the auth probe and then up to another 5s
 # on the PR/run probes it launches in parallel — 10s worst case, so 12 here.
 # status:git makes no network calls at all.
+#
+# status:creds is budgeted from its own probes rather than by copying a
+# neighbour's number: it makes NO network call (that is why it can be here at
+# all — status:gh already spends this startup's only auth round trip), and runs
+# two LOCAL probes back to back, each bounded at 3s inside status.sh — 6s worst
+# case, so 8 here for the `task` and shell startup around them.
 git_status="$(timeout 5 task status:git 2>/dev/null | strip_ansi || echo '(task status:git unavailable)')"
 gh_status="$(timeout 12 task status:gh 2>/dev/null | strip_ansi || echo '(task status:gh unavailable)')"
+creds_status="$(timeout 8 task status:creds 2>/dev/null | strip_ansi || echo '(task status:creds unavailable)')"
 branch="$(git branch --show-current 2>/dev/null || echo 'unknown')"
 
 reminder=$'Repo conventions:\n- Run `task verify` before committing (lint + build + validate + test).\n- Conventional Commits required (feat/fix/docs/style/refactor/perf/test/chore/ci/build/change/remove/revert).\n- Never bypass git hooks with --no-verify; fix the underlying issue.\n- Use lefthook for git hooks (not pre-commit).\n- See docs/conventions.md (and AGENTS.md) for the authoritative conventions catalog.'
 
-context="$(printf 'Branch: %s\n\n=== task status:git ===\n%s\n\n=== task status:gh ===\n%s\n\n%s\n' \
-    "$branch" "$git_status" "$gh_status" "$reminder")"
+context="$(printf 'Branch: %s\n\n=== task status:git ===\n%s\n\n=== task status:gh ===\n%s\n\n=== task status:creds ===\n%s\n\n%s\n' \
+    "$branch" "$git_status" "$gh_status" "$creds_status" "$reminder")"
 
 # Emit as JSON so Claude Code injects it as additionalContext.
 jq -n --arg ctx "$context" '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-hooks/session-start-context.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-hooks/session-start-context.sh
@@ -26,8 +26,8 @@ strip_ansi() { sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'; }
 # status:creds is budgeted from its own probes rather than by copying a
 # neighbour's number: it makes NO network call (that is why it can be here at
 # all — status:gh already spends this startup's only auth round trip), and runs
-# two LOCAL probes back to back, each bounded at 3s inside status.sh — 6s worst
-# case, so 8 here for the `task` and shell startup around them.
+# three LOCAL probes back to back, each bounded at 3s inside status.sh — 9s
+# worst case, so 11 here for the `task` and shell startup around them.
 #
 # There is a SECOND deadline above all of these: the `timeout` on the
 # SessionStart entries in claude-settings.json, which Claude Code applies to this
@@ -45,7 +45,7 @@ timeout 5 task status:git >"$git_out" 2>/dev/null &
 git_pid=$!
 timeout 12 task status:gh >"$gh_out" 2>/dev/null &
 gh_pid=$!
-timeout 8 task status:creds >"$creds_out" 2>/dev/null &
+timeout 11 task status:creds >"$creds_out" 2>/dev/null &
 creds_pid=$!
 
 # `wait` on each, with the failure recorded rather than propagated: `set -e`

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -617,20 +617,46 @@ render_local_credentials() {
         else
             checkline no "GitHub CLI (gh)" "gh auth login"
         fi
-    elif run_timeout 3 gh auth token --hostname "$(gh_target_host)" \
-        >/dev/null 2>&1; then
+    else
         # Standalone `status:creds`: nothing probed the API, and this section is
         # not allowed to. `gh auth token` resolves the credential gh would use
         # from local config and the environment WITHOUT calling GitHub, which
         # answers the only question this line exists to answer — is there a login
-        # at all. Its validity is `status:gh`'s to report, and the wording says
-        # so rather than claiming an authentication that was never checked.
-        # Redirected to /dev/null because the token itself is the output: this
-        # reads the exit code only and never captures, prints, or logs the value.
-        checkline ok "GitHub CLI (gh)" \
-            "credential stored for $(gh_target_host) (not validated)"
-    else
-        checkline no "GitHub CLI (gh)" "gh auth login"
+        # at all. Its validity is `status:gh`'s to report, and the wording below
+        # says so rather than claiming an authentication that was never checked.
+        #
+        # `2>&1 >/dev/null` — in that order — captures STDERR while sending
+        # stdout to /dev/null. The order is load-bearing and not interchangeable
+        # with `>/dev/null 2>&1`: this command's stdout IS the token, so the
+        # value must never enter a variable, and only its diagnostic goes into
+        # one. Nothing captured here is ever printed either way.
+        #
+        # Non-zero is then classified rather than assumed to mean logged out,
+        # the same distinction the Codex probe below draws: a locked keychain or
+        # an unreadable hosts.yml also exits non-zero, and `gh auth login` cannot
+        # repair either. Only gh's documented no-credential wording earns that
+        # remedy; everything else is unknown.
+        gh_token_rc=0
+        gh_token_err="$(run_timeout 3 gh auth token \
+            --hostname "$(gh_target_host)" 2>&1 >/dev/null)" || gh_token_rc=$?
+        case "${gh_token_rc}" in
+        0)
+            checkline ok "GitHub CLI (gh)" \
+                "credential stored for $(gh_target_host) (not validated)"
+            ;;
+        124) checkline unknown "GitHub CLI (gh)" "credential probe timed out" ;;
+        *)
+            case "$(printf '%s' "${gh_token_err}" | tr '[:upper:]' '[:lower:]')" in
+            *"no oauth token"* | *"not logged in"*)
+                checkline no "GitHub CLI (gh)" "gh auth login"
+                ;;
+            *)
+                checkline unknown "GitHub CLI (gh)" \
+                    "credential probe failed (exit ${gh_token_rc}) — check the gh CLI's config"
+                ;;
+            esac
+            ;;
+        esac
     fi
 
     # Codex gates `task challenge` and `task review` only where the repo opted

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -707,6 +707,46 @@ render_local_credentials() {
         checkline na "Codex CLI" "no second-model review configured"
     fi
 
+    # Claude Code is the agent this repo's Dev Loop is written for, and a logged
+    # out CLI stops it at the first `claude` invocation. `claude auth status
+    # --json` reads STORED credential state: it answers identically with every
+    # egress pointed at a dead port, so it belongs in this group rather than
+    # behind NETWORK_TIMEOUT.
+    #
+    # Not-installed reads n/a rather than missing, which is the one place this
+    # group departs from the gh and Codex lines above. Those two have a marker on
+    # disk for "this repo expects it" — codex-review.sh is rendered only under
+    # `use_codex_review`, and gh backs the whole GitHub half of the template.
+    # There is no equivalent marker here: the template ships .claude/ to every
+    # repo whether or not its author drives it with Claude Code, so an absent CLI
+    # cannot be distinguished from a deliberate choice of a different agent, and
+    # a red ✗ prescribing an install to somebody who chose Codex is noise they
+    # cannot act on.
+    if ! command -v claude >/dev/null 2>&1; then
+        checkline na "Claude Code CLI" "claude CLI not installed"
+    else
+        # The verdict is the `loggedIn` field, not the exit code: a logged-out
+        # CLI is a normal, successful report, and a `claude` too old for
+        # `auth status` exits non-zero with no field at all — which is unknown,
+        # not logged out. Whitespace is stripped so the match survives either
+        # JSON formatting, and stderr is discarded because only the field is
+        # read. The captured text is only ever matched, never printed.
+        claude_rc=0
+        claude_out="$(run_timeout 3 claude auth status --json 2>/dev/null)" ||
+            claude_rc=$?
+        case "$(printf '%s' "${claude_out}" | tr -d ' \n\t')" in
+        *'"loggedIn":true'*) checkline ok "Claude Code CLI" "logged in" ;;
+        *'"loggedIn":false'*) checkline no "Claude Code CLI" "claude auth login" ;;
+        *)
+            case "${claude_rc}" in
+            124) checkline unknown "Claude Code CLI" "auth status timed out" ;;
+            *) checkline unknown "Claude Code CLI" \
+                "auth status reported nothing readable (exit ${claude_rc})" ;;
+            esac
+            ;;
+        esac
+    fi
+
     # Hand this group's tallies to the setup summary (see the caller there).
     # Guarded, and deliberately last: with `pipefail` set, a failed write here
     # would become the whole pipeline's status and `set -e` would take the script

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -5,7 +5,7 @@ REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 PROJECT_NAME="$(basename "${REPO_ROOT}")"
 
-# Section filter: empty = show all, or "git", "gh", "code", "env"
+# Section filter: empty = show all, or "git", "gh", "creds", "code", "env"
 SECTION="${1:-}"
 
 # Temp directory for parallel data collection
@@ -231,10 +231,21 @@ GH_AUTH_FILE="${TMPDIR_STATUS}/auth.txt"
 : >"${GH_AUTH_FILE}"
 GH_AUTHED=false
 GH_AUTH_TIMEDOUT=false
+# Whether the bounded probe below actually ran. The credentials group reports the
+# validated answer when it did and falls back to a network-free local read when it
+# did not — see render_local_credentials. A flag rather than "is GH_AUTH_FILE
+# empty", because a failed probe legitimately leaves that file empty too.
+GH_AUTH_PROBED=false
 # The setup section needs this too — it reports the same credential's ability to
 # read the board, and used to run its own `gh auth status` to decide whether to
 # render at all. One probe, two consumers.
+#
+# Deliberately NOT extended to `SECTION == creds`: that section is invoked on its
+# own from the session-start hook, which already runs `status:gh` in the same
+# startup, and a second `gh auth status` there would be a net-new network call in
+# the one path whose whole budget argument is that it makes none.
 if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
+    GH_AUTH_PROBED=true
     gh_auth_rc=0
     # `gh auth status` reports every account on every host, and the scope line
     # read below cannot tell them apart — so narrow it to one credential from
@@ -557,6 +568,133 @@ if should_show "env"; then
     } | section_box
 fi
 
+# ── Local credentials ───────────────────────────────────────────────────────
+# The logins the Dev Loop gates on, read from LOCAL state only — no API call and
+# no network — so this renders in any auth state and costs nothing.
+#
+# It is a section of its own AND a group inside the setup audit, from this one
+# function so the probes are written once. Two callers, two reasons:
+#
+#   * `task status:creds` — the session-start hook runs it alongside status:git
+#     and status:gh, so a missing login is reported when a session opens rather
+#     than only on the explicit `task status:setup` a distracted session skips.
+#     That is the whole point: the audit it used to live in is network-heavy and
+#     excluded from the default board, while these probes are not.
+#   * `task status:setup` — rendered BEFORE the gh gate there rather than inside
+#     it. That gate skips the ENTIRE remaining audit when gh is logged out, so a
+#     credentials group living there would surface a missing codex login only
+#     after the reader had fixed gh and re-run: two round trips to learn what one
+#     run can say, which is the interruption this group exists to remove.
+#
+# `should_show` also puts it on the bare `task status` board, alongside every
+# other local section. The setup audit stays off that board because it is
+# network-heavy; this group is not, so the reason to exclude it does not apply.
+#
+# Every probe here is bounded by the short LOCAL bound (3s), never by
+# NETWORK_TIMEOUT — nothing in it may reach the network, or the session-start
+# path inherits a cost its budget was not derived for.
+render_local_credentials() {
+    # Not-installed is tested FIRST because it makes every other branch
+    # meaningless: with no gh on PATH the shared probe above exits 127, which
+    # lands in the same "not authenticated" bucket as a real logout and would
+    # prescribe `gh auth login` — a command the reader does not have. Same
+    # distinction the Codex check below draws, and the same remedy style as the
+    # 1Password and direnv lines further down.
+    if ! command -v gh >/dev/null 2>&1; then
+        checkline no "GitHub CLI (gh)" "brew install gh"
+    elif [[ "${GH_AUTH_PROBED}" == true ]]; then
+        # Reuses the single bounded probe from the top of this script instead of
+        # calling `gh auth status` again, and inherits its distinction between a
+        # deadline and a missing login — telling an authenticated reader to run
+        # `gh auth login` because GitHub was slow sends them to fix the wrong
+        # thing. The setup section's skip line stays as it is: it explains the
+        # absence of everything after it, which this line does not.
+        if [[ "${GH_AUTH_TIMEDOUT}" == true ]]; then
+            checkline unknown "GitHub CLI (gh)" \
+                "auth probe timed out after ${NETWORK_TIMEOUT}s"
+        elif [[ "${GH_AUTHED}" == true ]]; then
+            checkline ok "GitHub CLI (gh)" "authenticated to $(gh_target_host)"
+        else
+            checkline no "GitHub CLI (gh)" "gh auth login"
+        fi
+    elif run_timeout 3 gh auth token --hostname "$(gh_target_host)" \
+        >/dev/null 2>&1; then
+        # Standalone `status:creds`: nothing probed the API, and this section is
+        # not allowed to. `gh auth token` resolves the credential gh would use
+        # from local config and the environment WITHOUT calling GitHub, which
+        # answers the only question this line exists to answer — is there a login
+        # at all. Its validity is `status:gh`'s to report, and the wording says
+        # so rather than claiming an authentication that was never checked.
+        # Redirected to /dev/null because the token itself is the output: this
+        # reads the exit code only and never captures, prints, or logs the value.
+        checkline ok "GitHub CLI (gh)" \
+            "credential stored for $(gh_target_host) (not validated)"
+    else
+        checkline no "GitHub CLI (gh)" "gh auth login"
+    fi
+
+    # Codex gates `task challenge` and `task review` only where the repo opted
+    # into second-model review, and scripts/codex-review.sh is that opt-in's
+    # marker on disk — the template renders it only under `use_codex_review`.
+    # Same each-script-is-its-own-marker rule the GitHub configuration checks
+    # below use, and read off the filesystem rather than .copier-answers.yml:
+    # nothing else in this script reads that file, and a generated repo may keep
+    # it somewhere else. `codex login status` reads local credential state, so
+    # the bound here is the short local one (as with `op account list`), never
+    # NETWORK_TIMEOUT.
+    if [ -f scripts/codex-review.sh ]; then
+        if command -v codex >/dev/null 2>&1; then
+            # The exit code is the primary signal, but it cannot tell "no
+            # credentials" from "the CLI could not run": a malformed config.toml
+            # also exits non-zero, and `codex login` cannot repair that. So keep
+            # the documented logged-out phrase as the only thing that earns the
+            # login remedy, and report every other failure as unknown rather than
+            # sending the reader to re-authenticate a session that was never the
+            # problem.
+            #
+            # Captured with 2>&1 because the shipped CLI writes BOTH verdicts to
+            # stderr and leaves stdout empty — reading stdout alone would silently
+            # demote every genuine logout to "unknown". Folding the streams also
+            # picks up unrelated stderr chatter (a models-cache ERROR line appears
+            # on some installs while the command still exits 0), which is exactly
+            # why the match is on the phrase and the verdict on the exit code,
+            # never on stderr being non-empty. The captured text is only ever
+            # matched, never printed.
+            codex_rc=0
+            codex_out="$(run_timeout 3 codex login status 2>&1)" || codex_rc=$?
+            case "${codex_rc}" in
+            0) checkline ok "Codex CLI" "logged in" ;;
+            124) checkline unknown "Codex CLI" "login status timed out" ;;
+            *)
+                case "${codex_out}" in
+                *"Not logged in"*) checkline no "Codex CLI" "codex login" ;;
+                *) checkline unknown "Codex CLI" \
+                    "login status failed (exit ${codex_rc}) — check the codex CLI's config" ;;
+                esac
+                ;;
+            esac
+        else
+            checkline no "Codex CLI" \
+                "brew install --cask codex, or npm install -g @openai/codex"
+        fi
+    else
+        checkline na "Codex CLI" "no second-model review configured"
+    fi
+
+    # Hand this group's tallies to the setup summary (see the caller there).
+    # Guarded, and deliberately last: with `pipefail` set, a failed write here
+    # would become the whole pipeline's status and `set -e` would take the script
+    # down over a status board's bookkeeping.
+    printf '%s %s %s %s\n' \
+        "${SETUP_OK}" "${SETUP_NO}" "${SETUP_UNKNOWN}" "${SETUP_NA}" \
+        >"${TMPDIR_STATUS}/cred-counts" 2>/dev/null || true
+}
+
+if should_show "creds"; then
+    section_header "Local Credentials"
+    render_local_credentials | section_box
+fi
+
 # ── Setup Completeness ──────────────────────────────────────────────────────
 # Audits the repo against docs/CHECKLIST.md — which GitHub-side configuration
 # the template expects has actually been applied. Network-heavy, so it is NOT
@@ -589,15 +727,9 @@ if [[ "${SECTION}" == "setup" ]]; then
         fi
     } | section_box
 
-    # ── Local credentials ───────────────────────────────────────────────────
-    # The logins the Dev Loop gates on, read from LOCAL state only — no API call
-    # and no network — so this renders in any auth state and costs nothing.
-    #
-    # Deliberately placed BEFORE the gh gate below rather than inside it. That
-    # gate skips the ENTIRE remaining audit when gh is logged out, so a
-    # credentials group living there would surface a missing codex login only
-    # after the reader had fixed gh and re-run: two round trips to learn what one
-    # run can say, which is the interruption this group exists to remove.
+    # Rendered here as a group inside the audit (see render_local_credentials
+    # above for why it is also its own section, and why it sits BEFORE the gh
+    # gate below).
     #
     # Its own { } group means its own copy of the SETUP_* counters: checkline
     # mutates them inside the subshell that `| section_box` creates, so they
@@ -609,85 +741,7 @@ if [[ "${SECTION}" == "setup" ]]; then
     # is a worse defect than the file is.
     {
         subhead "Local credentials"
-
-        # Reuses the single bounded probe from the top of this script instead of
-        # calling `gh auth status` again, and inherits its distinction between a
-        # deadline and a missing login — telling an authenticated reader to run
-        # `gh auth login` because GitHub was slow sends them to fix the wrong
-        # thing. The skip line below stays as it is: it explains the absence of
-        # everything after it, which this line does not.
-        # Not-installed is tested FIRST because it makes the other three
-        # meaningless: with no gh on PATH the shared probe above exits 127, which
-        # lands in the same "not authenticated" bucket as a real logout and would
-        # prescribe `gh auth login` — a command the reader does not have. Same
-        # distinction the Codex check below draws, and the same remedy style as
-        # the 1Password and direnv lines further down.
-        if ! command -v gh >/dev/null 2>&1; then
-            checkline no "GitHub CLI (gh)" "brew install gh"
-        elif [[ "${GH_AUTH_TIMEDOUT}" == true ]]; then
-            checkline unknown "GitHub CLI (gh)" \
-                "auth probe timed out after ${NETWORK_TIMEOUT}s"
-        elif [[ "${GH_AUTHED}" == true ]]; then
-            checkline ok "GitHub CLI (gh)" "authenticated to $(gh_target_host)"
-        else
-            checkline no "GitHub CLI (gh)" "gh auth login"
-        fi
-
-        # Codex gates `task challenge` and `task review` only where the repo
-        # opted into second-model review, and scripts/codex-review.sh is that
-        # opt-in's marker on disk — the template renders it only under
-        # `use_codex_review`. Same each-script-is-its-own-marker rule the GitHub
-        # configuration checks below use, and read off the filesystem rather than
-        # .copier-answers.yml: nothing else in this script reads that file, and a
-        # generated repo may keep it somewhere else. `codex login status` reads
-        # local credential state, so the bound here is the short local one (as
-        # with `op account list`), never NETWORK_TIMEOUT.
-        if [ -f scripts/codex-review.sh ]; then
-            if command -v codex >/dev/null 2>&1; then
-                # The exit code is the primary signal, but it cannot tell "no
-                # credentials" from "the CLI could not run": a malformed
-                # config.toml also exits non-zero, and `codex login` cannot
-                # repair that. So keep the documented logged-out phrase as the
-                # only thing that earns the login remedy, and report every other
-                # failure as unknown rather than sending the reader to
-                # re-authenticate a session that was never the problem.
-                #
-                # Captured with 2>&1 because the shipped CLI writes BOTH verdicts
-                # to stderr and leaves stdout empty — reading stdout alone would
-                # silently demote every genuine logout to "unknown". Folding the
-                # streams also picks up unrelated stderr chatter (a models-cache
-                # ERROR line appears on some installs while the command still
-                # exits 0), which is exactly why the match is on the phrase and
-                # the verdict on the exit code, never on stderr being non-empty.
-                # The captured text is only ever matched, never printed.
-                codex_rc=0
-                codex_out="$(run_timeout 3 codex login status 2>&1)" || codex_rc=$?
-                case "${codex_rc}" in
-                0) checkline ok "Codex CLI" "logged in" ;;
-                124) checkline unknown "Codex CLI" "login status timed out" ;;
-                *)
-                    case "${codex_out}" in
-                    *"Not logged in"*) checkline no "Codex CLI" "codex login" ;;
-                    *) checkline unknown "Codex CLI" \
-                        "login status failed (exit ${codex_rc}) — check the codex CLI's config" ;;
-                    esac
-                    ;;
-                esac
-            else
-                checkline no "Codex CLI" \
-                    "brew install --cask codex, or npm install -g @openai/codex"
-            fi
-        else
-            checkline na "Codex CLI" "no second-model review configured"
-        fi
-
-        # Hand this group's tallies to the summary (see the header comment).
-        # Guarded, and deliberately last: with `pipefail` set, a failed write
-        # here would become the whole pipeline's status and `set -e` would take
-        # the script down over a status board's bookkeeping.
-        printf '%s %s %s %s\n' \
-            "${SETUP_OK}" "${SETUP_NO}" "${SETUP_UNKNOWN}" "${SETUP_NA}" \
-            >"${TMPDIR_STATUS}/cred-counts" 2>/dev/null || true
+        render_local_credentials
     } | section_box
 
     # Reuses the single bounded probe above rather than making a second,

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -188,6 +188,14 @@ make_stub() {
             echo '    sleep 30'
             echo '    exit 0'
             ;;
+        broken-token-store)
+            # Authenticated as far as the API is concerned, but the LOCAL
+            # credential read fails for a reason `gh auth login` cannot repair —
+            # a locked keychain, an unreadable hosts.yml. Deliberately does NOT
+            # carry gh's no-credential wording: that is the whole distinction.
+            echo "    echo \"  - Token scopes: 'gist', 'project', 'repo'\""
+            echo '    exit 0'
+            ;;
         *) fail "unknown stub scenario: ${scenario}" ;;
         esac
         echo 'fi'
@@ -206,6 +214,10 @@ make_stub() {
         hangs)
             echo '    sleep 30'
             echo '    exit 0'
+            ;;
+        broken-token-store)
+            echo '    echo "error: failed to read keyring: interaction denied" >&2'
+            echo '    exit 1'
             ;;
         *)
             echo '    echo "STUB-TOKEN-MUST-NEVER-BE-PRINTED"'
@@ -818,6 +830,35 @@ case "$out" in
 *"[ ] GitHub CLI (gh) — gh auth login"*) ;;
 *) fail "expected a missing-login line from status:creds, got: ${out}" ;;
 esac
+
+echo "==> a local token read that fails for another reason reads unknown"
+# Non-zero is not the same as logged out, exactly as for the Codex probe: a
+# locked keychain exits non-zero too, and `gh auth login` cannot repair it — the
+# reader would be sent to fix the wrong thing. Only gh's documented
+# no-credential wording earns that remedy.
+make_codex_stub in
+out="$(run_creds_section broken-token-store)"
+case "$out" in
+*"[ ] GitHub CLI (gh)"*) fail "a broken credential store must not read as logged out: ${out}" ;;
+*"gh auth login"*) fail "a broken credential store must not prescribe re-authentication: ${out}" ;;
+*"[?] GitHub CLI (gh)"*"credential probe failed"*) ;;
+*) fail "expected an unknown gh credential line, got: ${out}" ;;
+esac
+
+echo "==> a local token read that outlives its deadline reads unknown too"
+# The probe is bounded, which makes a wedged credential helper look exactly like
+# a missing login unless the deadline is classified apart from it.
+if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
+    make_codex_stub in
+    out="$(run_creds_section hangs)"
+    case "$out" in
+    *"[ ] GitHub CLI (gh)"*) fail "a timeout must not read as a missing login: ${out}" ;;
+    *"[?] GitHub CLI (gh)"*"timed out"*) ;;
+    *) fail "expected a timeout notice from status:creds, got: ${out}" ;;
+    esac
+else
+    echo "    (skipped: no timeout binary — the probe is unbounded here)"
+fi
 
 echo "==> status:creds reports a logged-out codex too"
 make_codex_stub out

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -917,4 +917,50 @@ else
     echo "    (skipped: no devcontainer hook in this profile)"
 fi
 
+echo "==> the session-start hook fits inside its managed SessionStart deadline"
+# The deadline ABOVE the per-section ones: Claude Code applies the `timeout` on
+# the SessionStart entries to the whole hook, and overrunning it is worse than
+# overrunning a section bound — the hook is killed before `jq` emits anything,
+# so the entire payload is lost rather than one section of it. Adding a section
+# is exactly when that ceiling gets forgotten, so derive both sides from the
+# files: the sections run in parallel, which makes the hook's wall clock the
+# LONGEST section deadline rather than their sum.
+settings=".devcontainer/config/claude-settings.json"
+if [ -f "$hook" ] && [ -f "$settings" ]; then
+    managed="$(jq -r '
+        [.hooks.SessionStart[]?.hooks[]?
+         | select(.command | test("session-start-context"))
+         | .timeout // empty]
+        | min // empty
+    ' "$settings")"
+    [ -n "$managed" ] ||
+        fail "could not read the SessionStart hook timeout out of ${settings}"
+
+    # Every bounded section launch in the hook, and whether it was backgrounded.
+    section_bounds="$(sed -n -E 's/^[[:space:]]*timeout ([0-9]+) task status:[a-z]+ .*/\1/p' "$hook")"
+    backgrounded="$(sed -n -E 's/^[[:space:]]*timeout [0-9]+ task status:[a-z]+ .*&$/&/p' "$hook" | wc -l | tr -d ' ')"
+    n_sections="$(printf '%s\n' "$section_bounds" | grep -c '[0-9]' || true)"
+    [ "${n_sections:-0}" -ge 2 ] ||
+        fail "found ${n_sections:-0} bounded status sections in ${hook} — the ceiling below would assert nothing"
+
+    longest=0
+    total=0
+    for b in $section_bounds; do
+        total=$((total + b))
+        [ "$b" -gt "$longest" ] && longest="$b"
+    done
+
+    if [ "$backgrounded" -eq "$n_sections" ]; then
+        wall="$longest"
+        shape="in parallel"
+    else
+        wall="$total"
+        shape="sequentially"
+    fi
+    [ "$managed" -gt "$wall" ] ||
+        fail "the hook runs its ${n_sections} sections ${shape} (${wall}s worst case) but claude-settings.json kills it at ${managed}s — the whole payload is discarded, not one section"
+else
+    echo "    (skipped: no devcontainer hook/settings in this profile)"
+fi
+
 echo "status.sh tests passed"

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -4,10 +4,12 @@
 #   * "Project board writes" (`task status:gh`) — the token scope the claim
 #     lifecycle needs, reported from the section session-start orientation
 #     actually runs, in every scope state.
-#   * "Local credentials" (`task status:setup`) — the gh and Codex logins the
-#     Dev Loop gates on, in every state including not-installed, rendering
-#     BEFORE the gate that skips the rest of that audit, and counted by the
-#     summary at the end of it.
+#   * "Local credentials" (`task status:creds` and `task status:setup`) — the gh
+#     and Codex logins the Dev Loop gates on, in every state including
+#     not-installed, rendered as its own section for the session-start hook AND
+#     inside the setup audit BEFORE the gate that skips the rest of it, counted
+#     by the summary at the end of that audit, and — standalone — making no
+#     network call at all.
 #
 # Run via `task test:status`.
 #
@@ -78,6 +80,11 @@ make_stub() {
     mkdir -p "${TMP}/bin"
     {
         echo '#!/usr/bin/env bash'
+        # A call log, so a case can assert on which gh calls a section made
+        # rather than only on what it printed. The standalone credentials
+        # section's contract is "no network call", and the only way to see a
+        # network call that a stub happily answers is to look at the log.
+        echo 'if [ -n "${STUB_CALLS:-}" ]; then echo "$*" >>"$STUB_CALLS"; fi'
         echo 'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then'
         case "$scenario" in
         project)
@@ -182,6 +189,28 @@ make_stub() {
             echo '    exit 0'
             ;;
         *) fail "unknown stub scenario: ${scenario}" ;;
+        esac
+        echo 'fi'
+        # `gh auth token` is the standalone credentials section's LOCAL read: it
+        # prints the stored/environment credential without calling GitHub. The
+        # stub answers it from the same scenario as `auth status` so the two
+        # cannot disagree, and prints a placeholder rather than nothing because
+        # the real command's output IS the token — a probe that captured or
+        # echoed it would show up as this string in the assertions.
+        echo 'if [ "$1" = "auth" ] && [ "$2" = "token" ]; then'
+        case "$scenario" in
+        unauthenticated)
+            echo '    echo "no oauth token" >&2'
+            echo '    exit 1'
+            ;;
+        hangs)
+            echo '    sleep 30'
+            echo '    exit 0'
+            ;;
+        *)
+            echo '    echo "STUB-TOKEN-MUST-NEVER-BE-PRINTED"'
+            echo '    exit 0'
+            ;;
         esac
         echo 'fi'
         echo 'case "$*" in'
@@ -308,6 +337,16 @@ run_setup_section() {
     make_stub "$1"
     local script="${2:-${WITH_CODEX}}"
     PATH="${TMP}/bin:${PATH}" NO_COLOR=1 "${script}" setup 2>&1
+}
+
+# run_creds_section GH_SCENARIO [SCRIPT] — status.sh's standalone credentials
+# section (`task status:creds`, the one the session-start hook runs) with the
+# stubs on PATH. SCRIPT defaults to the with-codex fixture, the profile in which
+# the Codex login is a gate.
+run_creds_section() {
+    make_stub "$1"
+    local script="${2:-${WITH_CODEX}}"
+    PATH="${TMP}/bin:${PATH}" NO_COLOR=1 "${script}" creds 2>&1
 }
 
 # run_setup_without MISSING [SCRIPT] — the same, with MISSING genuinely absent
@@ -719,6 +758,122 @@ if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; th
     esac
 else
     echo "    (skipped: no timeout binary — the probe is unbounded here)"
+fi
+
+echo "==> status:creds renders the credentials group on its own"
+# The gap this section exists to close: the group used to render only inside
+# status:setup, which the session-start hook does not run — so a missing login
+# surfaced only on the explicit audit a distracted session skips.
+make_codex_stub in
+out="$(run_creds_section project)"
+case "$out" in
+*"GitHub CLI (gh)"*) ;;
+*) fail "expected a gh credential line from status:creds, got: ${out}" ;;
+esac
+case "$out" in
+*"[x] Codex CLI"*) ;;
+*) fail "expected a Codex credential line from status:creds, got: ${out}" ;;
+esac
+
+echo "==> status:creds makes no network call"
+# The acceptance criterion the session-start budget rests on. `gh auth status`
+# validates the token against the API; `gh auth token` reads local config and
+# the environment. The hook already spends this startup's one auth round trip in
+# status:gh, so this section must add none — and a stub that answers `auth
+# status` perfectly well would hide a second one from every output assertion.
+STUB_CALLS="${TMP}/creds-calls.txt"
+export STUB_CALLS
+: >"${STUB_CALLS}"
+make_codex_stub in
+out="$(run_creds_section project)"
+if grep -q 'auth status' "${STUB_CALLS}"; then
+    fail "status:creds called 'gh auth status' — that is a network probe: $(tr '\n' ' ' <"${STUB_CALLS}")"
+fi
+grep -q 'auth token' "${STUB_CALLS}" ||
+    fail "status:creds made no local credential read at all: $(tr '\n' ' ' <"${STUB_CALLS}")"
+unset STUB_CALLS
+
+echo "==> status:creds never prints the token it reads"
+# `gh auth token` writes the credential to stdout — the value is the output. The
+# probe reads its exit code only, so the stub's placeholder must not reach the
+# board (nor, by the same redirect, a log or the session-start payload).
+case "$out" in
+*STUB-TOKEN-MUST-NEVER-BE-PRINTED*) fail "the credential value reached the board: ${out}" ;;
+esac
+
+echo "==> status:creds does not claim an authentication it never checked"
+# It reports that a credential EXISTS. Whether GitHub still accepts it is
+# status:gh's answer, and wording this line as "authenticated" would assert
+# something no probe here established.
+case "$out" in
+*"authenticated to"*) fail "a local-only read must not claim authentication: ${out}" ;;
+*"not validated"*) ;;
+*) fail "expected the stored-credential wording, got: ${out}" ;;
+esac
+
+echo "==> status:creds reports a logged-out gh with the login remedy"
+make_codex_stub in
+out="$(run_creds_section unauthenticated)"
+case "$out" in
+*"[ ] GitHub CLI (gh) — gh auth login"*) ;;
+*) fail "expected a missing-login line from status:creds, got: ${out}" ;;
+esac
+
+echo "==> status:creds reports a logged-out codex too"
+make_codex_stub out
+out="$(run_creds_section project)"
+case "$out" in
+*"[x] Codex CLI"*) fail "a logged-out codex must not read as ok: ${out}" ;;
+*"[ ] Codex CLI — codex login"*) ;;
+*) fail "expected a logged-out codex line from status:creds, got: ${out}" ;;
+esac
+
+echo "==> status:creds omits the setup audit it was carved out of"
+# It is a section, not a shortcut into the network-heavy audit: a status:creds
+# that dragged the checklist bar or the GitHub configuration checks along would
+# put exactly the cost back into session start that this split removed.
+case "$out" in
+*"Setup Completeness"*) fail "status:creds rendered the setup audit: ${out}" ;;
+*"Checklist"*) fail "status:creds rendered the checklist progress: ${out}" ;;
+esac
+
+echo "==> gh missing from PATH still names an install remedy in status:creds"
+make_stub project
+make_codex_stub in
+make_isolated_bin gh
+out="$(PATH="${TMP}/bin-iso" NO_COLOR=1 "${WITH_CODEX}" creds 2>&1)"
+case "$out" in
+*"GitHub CLI (gh) — gh auth login"*) fail "an absent gh must not be told to log in: ${out}" ;;
+*"[ ] GitHub CLI (gh) — brew install gh"*) ;;
+*) fail "expected an install remedy for a missing gh, got: ${out}" ;;
+esac
+
+echo "==> the session-start hook allows more time than status:creds can spend"
+# The same coupling as the status:gh assertion above, and the same total failure
+# mode — but budgeted from THIS section's own probes rather than inherited from
+# its neighbour's. Both bounds are read out of the files, so adding a probe to
+# the credentials group without widening the hook fails here.
+if [ -f "$hook" ]; then
+    creds_budget="$(sed -n -E 's/.*timeout ([0-9]+) task status:creds.*/\1/p' "$hook" | head -1)"
+    creds_worst="$(awk '
+        /^render_local_credentials\(\) \{/ { inf = 1 }
+        inf && /^\}/ { inf = 0 }
+        inf {
+            line = $0
+            while (match(line, /run_timeout [0-9]+ /)) {
+                total += substr(line, RSTART + 12, RLENGTH - 13) + 0
+                line = substr(line, RSTART + RLENGTH)
+            }
+        }
+        END { print total + 0 }
+    ' "${status}")"
+    [ -n "$creds_budget" ] || fail "could not read the status:creds timeout out of ${hook}"
+    [ "$creds_worst" -gt 0 ] ||
+        fail "found no bounded probes in render_local_credentials — the budget below would assert nothing"
+    [ "$creds_budget" -gt "$creds_worst" ] ||
+        fail "hook allows ${creds_budget}s but the credentials section can spend ${creds_worst}s on probes alone — the whole group is lost first"
+else
+    echo "    (skipped: no devcontainer hook in this profile)"
 fi
 
 echo "status.sh tests passed"

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -287,11 +287,49 @@ make_codex_stub() {
     chmod +x "${TMP}/bin/codex"
 }
 
-# The setup section probes codex on every invocation now, so stub it before the
-# first case runs — a case that reached the real CLI would pass or fail on
+# make_claude_stub STATE — write $TMP/bin/claude answering `auth status --json`.
+#   in      — logged in
+#   out     — logged out: a NORMAL, successful report carrying loggedIn:false,
+#             which is why the check reads the field and not the exit code
+#   ancient — a `claude` predating `auth status`: a usage error with no field,
+#             which must read as unknown rather than as a logout
+# Any other call fails loudly: this probe must read local login state and nothing
+# else, so a second call — or a network one — shows up here instead of passing
+# silently.
+make_claude_stub() {
+    local state="$1"
+    mkdir -p "${TMP}/bin"
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then'
+        case "$state" in
+        in)
+            echo '    echo "{ \"loggedIn\": true, \"authMethod\": \"claude.ai\" }"'
+            echo '    exit 0'
+            ;;
+        out)
+            echo '    echo "{ \"loggedIn\": false }"'
+            echo '    exit 0'
+            ;;
+        ancient)
+            echo '    echo "error: unknown command auth" >&2'
+            echo '    exit 1'
+            ;;
+        *) fail "unknown claude stub state: ${state}" ;;
+        esac
+        echo 'fi'
+        echo 'echo "stub: unexpected claude call: $*" >&2'
+        echo 'exit 1'
+    } >"${TMP}/bin/claude"
+    chmod +x "${TMP}/bin/claude"
+}
+
+# The credentials group probes codex and claude on every invocation, so stub both
+# before the first case runs — a case that reached the real CLI would pass or fail on
 # whether the developer happens to be logged in, which is worse than no test at
 # all.
 make_codex_stub in
+make_claude_stub in
 
 # ISOLATED_TOOLS — the external commands status.sh needs, both to reach the
 # credentials group and to run the audit past the gh gate. The not-installed case
@@ -316,7 +354,7 @@ make_isolated_bin() {
             ln -s "${resolved}" "${TMP}/bin-iso/${tool}"
         fi
     done
-    for tool in gh codex; do
+    for tool in gh codex claude; do
         if [ "${tool}" != "${missing}" ] && [ -f "${TMP}/bin/${tool}" ]; then
             cp "${TMP}/bin/${tool}" "${TMP}/bin-iso/${tool}"
         fi
@@ -867,6 +905,46 @@ case "$out" in
 *"[x] Codex CLI"*) fail "a logged-out codex must not read as ok: ${out}" ;;
 *"[ ] Codex CLI — codex login"*) ;;
 *) fail "expected a logged-out codex line from status:creds, got: ${out}" ;;
+esac
+
+echo "==> a logged-out Claude Code CLI is reported, and names its remedy"
+# The third login #733 requires at session start. The field is the verdict, not
+# the exit code: a logged-out CLI reports it successfully.
+make_codex_stub in
+make_claude_stub out
+out="$(run_creds_section project)"
+case "$out" in
+*"[x] Claude Code CLI"*) fail "a logged-out claude must not read as ok: ${out}" ;;
+*"[ ] Claude Code CLI — claude auth login"*) ;;
+*) fail "expected a logged-out claude line, got: ${out}" ;;
+esac
+
+echo "==> a claude too old for 'auth status' reads unknown, not logged out"
+# No field at all is not the same as loggedIn:false, and `claude auth login`
+# cannot repair a CLI that has no such command.
+make_claude_stub ancient
+out="$(run_creds_section project)"
+case "$out" in
+*"[ ] Claude Code CLI"*) fail "an unreadable report must not read as a logout: ${out}" ;;
+*"claude auth login"*) fail "an unreadable report must not prescribe re-authentication: ${out}" ;;
+*"[?] Claude Code CLI"*) ;;
+*) fail "expected an unknown claude line, got: ${out}" ;;
+esac
+
+echo "==> claude missing from PATH reads n/a, not missing"
+# Unlike gh and Codex there is no marker on disk for "this repo expects Claude
+# Code" — the template ships .claude/ everywhere — so an absent CLI cannot be
+# told apart from an author who drives this repo with a different agent, and a
+# red line prescribing an install would be noise they cannot act on.
+make_stub project
+make_codex_stub in
+make_claude_stub in
+make_isolated_bin claude
+out="$(PATH="${TMP}/bin-iso" NO_COLOR=1 "${WITH_CODEX}" creds 2>&1)"
+case "$out" in
+*"[ ] Claude Code CLI"*) fail "an absent claude must not read as a missing login: ${out}" ;;
+*"[-] Claude Code CLI"*) ;;
+*) fail "expected an n/a claude line, got: ${out}" ;;
 esac
 
 echo "==> status:creds omits the setup audit it was carved out of"


### PR DESCRIPTION
## What

Promotes the **Local credentials** group out of `task status:setup` into its own
addressable section (`task status:creds`) and runs it at session start.

- `scripts/status.sh` grows `render_local_credentials`, called by both a new
  `SECTION == creds` section and the setup audit — one copy of the probe logic,
  two call sites. `should_show "creds"` also puts it on the bare `task status`
  board, alongside every other local section.
- The group now covers all three logins #733 names: **gh**, **Codex**, and
  **Claude Code** (the last is new — the group promoted from #650 carried only
  the first two).
- `task status:creds` in both Taskfile layers (`cmds:` stays trivial).
- Both session-start hooks — `.devcontainer/config/claude-hooks/` and
  `.claude/hooks/` — run it alongside `status:git` / `status:gh`.
- `scripts/test-status.sh` covers the new section (12 new cases).
- README rows in both layers.

## Why

# 650 added the credentials group so "a missing login surfaces at session start
rather than partway through a change" — but session start does not run
`status:setup`. That audit is network-heavy and deliberately off the default
board, so the group only ever rendered on the explicit run a distracted session
skips. #733 is that gap.

## No net-new network call in the session-start path

The acceptance criterion the budget rests on.

- `gh auth status` validates the token against the API — the hook already spends
  that one round trip inside `status:gh`, so the shared probe is deliberately
  **not** extended to `SECTION == creds`. Standalone, the section reads the
  credential locally with `gh auth token` and reports
  `credential stored … (not validated)` rather than claiming an authentication it
  never checked. The token value is that command's stdout: it is captured
  nowhere — stderr alone is read, via `2>&1 >/dev/null` in that order — and a
  test asserts the placeholder never reaches the board.
- `claude auth status --json` reads stored credential state. Verified
  network-free: it answers identically with `HTTPS_PROXY`, `HTTP_PROXY`, and
  `ANTHROPIC_BASE_URL` all pointed at a dead port.
- `codex login status` was already local.

`task status:creds` therefore makes **zero** network calls, asserted via a stub
call log rather than trusting the output.

## Timeout budget, re-derived

Not inherited from a neighbour: `status:creds` runs three **local** probes, each
bounded at 3s inside `status.sh` — 9s worst case, so 11s outer, and the
documented arithmetic in both hooks says so.

`task challenge` also caught a real ceiling above those: Claude Code applies the
`timeout` on the SessionStart entries in `claude-settings.json` (15s) to the
whole hook, and the devcontainer hook ran its sections **sequentially** — 5 + 12
= 17s before this branch, 28s with the new one. Overrunning it loses the entire
payload, not one section. The devcontainer hook now runs its sections in
parallel, as the `.claude/hooks` variant already did, so its wall clock is the
longest bound (12s). `test-status.sh` derives both couplings from the files
(section bounds vs. the managed timeout, and whether the launches are actually
backgrounded), mutation-checked by removing one `&`.

## Upstream companion

The `/kickoff` + `/claim` half of #733 is upstream work: those skills are
vendored here from harmon-devkit, which AGENTS.md forbids hand-editing. Filed as
**evanharmon1/harmon-devkit#393**, which satisfies that acceptance criterion.

## Verification

- `task verify` — green
- `task ci` — green
- `task challenge` — 4 rounds; exits clean (no P0/P1). Round 2 found the
  SessionStart-ceiling P1, round 3 the missing Claude probe P1; both fixed, both
  with regression tests.
- `task review` — 4 rounds; exits clean (no P0/P1). Round 1's P2 (a failed local
  credential read reading as "logged out") fixed in place; round 4's P2 (doc
  strings) fixed in place.
- `task test:status` — 51 cases
- `task test:dogfood-parity` / `test:dogfood-structure` — green (twins in
  lockstep: `status.sh`, `test-status.sh`, both hooks, Taskfile, README)
- Manual: `NO_COLOR=1 ./scripts/status.sh creds` and `… setup` both render the
  group

## Deferred findings

- [x] `scripts/status.sh:617-618` — when the shared `gh auth status` probe ran
      (`task status` / `task status:setup`), any *non-timeout* failure of it
      (proxy, TLS, API, or config error) falls through the credentials group as a
      missing login and prescribes `gh auth login`. The standalone
      `status:creds` path now distinguishes absent credentials from unknown probe
      failures; the shared-probe branch does not. Pre-existing behaviour from
      #650/#735 — the fix belongs in the shared probe's own classification
      (`GH_AUTHED`/`GH_AUTH_TIMEDOUT` would need a third "probe failed" state that
      every consumer then reads), not in this group. (`task challenge` round 4, P2) — **filed as #774**

Closes #733

