### PR TITLE
fix: isolate each template-test job in its own temp root

### DIFF
--- a/scripts/test-template-update.sh
+++ b/scripts/test-template-update.sh
@@ -25,8 +25,24 @@ export GIT_CONFIG_KEY_0=gc.auto GIT_CONFIG_VALUE_0=0
 export GIT_CONFIG_KEY_1=gc.autoDetach GIT_CONFIG_VALUE_1=false
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
-work="$(mktemp -d -t harmon-init-update-XXXXXX)"
-trap 'rm -rf "$work"' EXIT
+
+# Per-job temp root. `task test:template:all` runs this test concurrently with
+# six profile renders, and every job's subprocesses — copier's own
+# `copier._vcs.clone.*` dirs above all — drop scratch directories straight into
+# the shared $TMPDIR. Owning a private root and pointing TMPDIR at it means no
+# sibling job can create, write, or remove a path this job holds: isolation by
+# construction rather than by unique naming, and one `rm -rf` reclaims all of
+# it. See issue #476.
+job_tmp="$(mktemp -d -t harmon-init-update-XXXXXX)"
+trap 'rm -rf "$job_tmp"' EXIT
+TMPDIR="$job_tmp/tmp"
+export TMPDIR
+mkdir -p "$TMPDIR"
+
+# Fixtures live beside $TMPDIR, not inside it, so tool scratch never lands in
+# the template source or the generated repo this test asserts over.
+work="$job_tmp/work"
+mkdir -p "$work"
 
 have() { command -v "$1" >/dev/null 2>&1; }
 for t in copier git rsync; do

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -22,10 +22,37 @@ set -euo pipefail
 # (actionlint then fails with "no project was found"). Sanitize unconditionally.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
+# git's auto-gc detaches and prunes loose objects. When it fires inside one of
+# the throwaway repos this script (and copier) creates, it can delete objects
+# out from under a concurrent reader — a local `git clone` hardlinking
+# objects/, or Python's rmtree of a temp clone. Disable it for every git this
+# script spawns; GIT_CONFIG_* env is inherited by copier's git subprocesses.
+# scripts/test-template-update.sh carries the same guard.
+export GIT_CONFIG_COUNT=2
+export GIT_CONFIG_KEY_0=gc.auto GIT_CONFIG_VALUE_0=0
+export GIT_CONFIG_KEY_1=gc.autoDetach GIT_CONFIG_VALUE_1=false
+
 profile="${1:-minimal}"
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
-dest="$(mktemp -d -t harmon-init-test-XXXXXX)"
-trap 'rm -rf "$dest"' EXIT
+
+# Per-job temp root. `task test:template:all` runs six of these renders and the
+# update test concurrently, and every job's subprocesses — copier's own
+# `copier._vcs.clone.*` dirs above all — drop scratch directories straight into
+# the shared $TMPDIR. Owning a private root and pointing TMPDIR at it means no
+# sibling job can create, write, or remove a path this job holds: isolation by
+# construction rather than by unique naming, and one `rm -rf` reclaims all of
+# it. See issue #476.
+job_tmp="$(mktemp -d -t harmon-init-test-XXXXXX)"
+trap 'rm -rf "$job_tmp"' EXIT
+TMPDIR="$job_tmp/tmp"
+export TMPDIR
+mkdir -p "$TMPDIR"
+
+# The render target is a sibling of $TMPDIR, not $TMPDIR itself, so scratch
+# dirs created by the tools this script runs never land inside the rendered
+# project (where its own validators would see them).
+dest="$job_tmp/render"
+mkdir -p "$dest"
 
 have() { command -v "$1" >/dev/null 2>&1; }
 


### PR DESCRIPTION
## What

`task test:template:all` fans out six profile renders plus the `copier update`
test in parallel. Each of those jobs now owns a **private temp root**:

- `mktemp -d` creates one root per job; a single `trap … EXIT` reclaims it.
- `TMPDIR` is exported into `$root/tmp`, so everything the job's subprocesses
  create — copier's own `copier._vcs.clone.*` clone dirs above all, plus git's
  and Python's scratch — lands inside that root instead of the shared system
  temp dir.
- The render target / fixture tree is a *sibling* of that `TMPDIR`
  (`$root/render`, `$root/work`), so tool scratch never appears inside the
  rendered project the validators then walk.

Applied to `scripts/test-template.sh` **and** `scripts/test-template-update.sh`.
`test-template.sh` additionally picks up the `gc.auto=0` / `gc.autoDetach=false`
guard `test-template-update.sh` already carried.

No serialising `deps:` was added — that would hide the collision, not remove it,
and would slow every run.

## Why — cause analysis

The issue lists three candidate causes. Taking them in turn:

**(b) the harness's own `harmon-init-*-XXXXXX` dirs — ruled out.** Each job's
root came from its own `mktemp -d`, and each `trap` removed only that path. No
sibling could name it, let alone remove it.

**(c) a trap/cleanup removing a path another job still holds — ruled out.**
Same argument for the harness, and copier's own cleanup
(`Template._cleanup`, copier 9.16 `_template.py`) `rmtree`s exactly
`self._temp_clone_path` — no prefix sweep, no glob over the temp dir.

**(a) copier's internal `copier._vcs.clone.*` paths — what's left.** These are
created by `mkdtemp(prefix=CLONE_PREFIX)` (`copier/_vcs.py`) directly in the
**shared** `$TMPDIR` root, which is the only namespace all seven jobs write to.
That is where the failure landed, and it is the one part of the system the
harness previously did not own.

Two further observations shaped the fix:

1. **The reported error does not prove the destination vanished.** Git emits
   `fatal: failed to copy file to '<dest>'` from `copy_or_link_directory()`
   (`builtin/clone.c`) whenever `copy_file()` returns non-zero — and
   `copy_file()` fails with `ENOENT` when it cannot open the **source** object
   either. The local-clone path only reaches `copy_file()` after `link()` has
   already failed, which `ENOENT` on either side explains. So the observed
   failure is consistent with *either* a destination entry disappearing from
   the shared root *or* a source loose object being pruned mid-clone. The fix
   closes both: per-job `TMPDIR` removes the shared namespace, and the auto-gc
   guard removes the one process that legitimately deletes loose objects out
   from under a concurrent reader (a detached `git gc --auto`). The same
   mechanism, in its other guise, is what commit `0a984de` already fixed for
   the update test ("`OSError: Directory not empty: 'objects'`").
2. **The shared root does accumulate foreign state.** While instrumenting this
   change I found a `copier._vcs.clone.z1iy2poo` directory left behind in the
   system temp dir by an earlier interrupted run — evidence that copier's clone
   dirs both live in, and can leak into, the namespace every job shares.

The correctness argument is the isolation itself, not the run count below: a
job cannot be disturbed through a directory no other job can name, create in,
write to, or remove.

## `template/` twins

Checked — `template/` ships **no** counterpart of either script (`find template
-iname '*test-template*'` is empty; `scripts/test-dogfood-parity.sh` reports no
twin for them). The issue's note that "both are verbatim twins" is stale: these
are root-only maintenance scripts, so there is nothing to keep in lockstep.
This PR touches no `template/` path.

## Verification

- `task verify` — green.
- `task ci` — green.
- `task challenge` — clean round, no findings.
- `task review` — clean round, no findings.
- The issue's loop: `task test:template:all` ×10 → **0 failed runs**, and
  `grep -l 'failed to copy file to'` matched **no** log. As the issue itself
  says, absence across ten runs is weak evidence of absence — it is a
  regression check on the fix, not the argument for it.
- Isolation check: sampling the outer `$TMPDIR` once per second across those
  ten parallel runs found **no new** `copier._vcs.clone.*` entry there (only
  the pre-existing leaked one from before the change). Copier's clone dirs are
  now inside the per-job roots.

Closes #476
