### PR TITLE
fix: add osvVulnerabilityAlerts so transitive advisories reach Renovate without Dependabot

### DIFF
--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -43,9 +43,12 @@ every rule type and is the GitHub-native way to apply an exported ruleset.
 ## Dependabot and Renovate
 
 Routine updates and vulnerability-remediation PRs are owned by **Renovate**
-(`renovate.json`, with `vulnerabilityAlerts.enabled=true`) — do not add a
+(`renovate.json`, with `vulnerabilityAlerts.enabled=true` and
+`osvVulnerabilityAlerts=true`) — do not add a
 `dependabot.yml`, which would create competing update PRs. Dependabot still owns
-the GitHub-native advisory feed; enable these in Settings → Advanced Security:
+the GitHub-native advisory feed; `osvVulnerabilityAlerts` is the second,
+visibility-independent feed that keeps remediation PRs flowing when the settings
+below are off. Enable these in Settings → Advanced Security:
 
 - Dependabot alerts
 - Private vulnerability reporting (used by `.github/SECURITY.md`)

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -46,9 +46,10 @@ Routine updates and vulnerability-remediation PRs are owned by **Renovate**
 (`renovate.json`, with `vulnerabilityAlerts.enabled=true` and
 `osvVulnerabilityAlerts=true`) — do not add a
 `dependabot.yml`, which would create competing update PRs. Dependabot still owns
-the GitHub-native advisory feed; `osvVulnerabilityAlerts` is the second,
-visibility-independent feed that keeps remediation PRs flowing when the settings
-below are off. Enable these in Settings → Advanced Security:
+the GitHub-native advisory feed, and it is the only one of the two that reaches
+**transitive** dependencies, so the alert setting below is load-bearing rather
+than optional — `osvVulnerabilityAlerts` covers direct dependencies only. Enable
+these in Settings → Advanced Security:
 
 - Dependabot alerts
 - Private vulnerability reporting (used by `.github/SECURITY.md`)

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -102,15 +102,28 @@ and alert-remediation PRs (`vulnerabilityAlerts.enabled=true`). Do not add a
 Renovate would create competing automation. Package-manager audits remain in CI
 as an immediate, provider-independent check.
 
-Detection runs on **two** feeds, deliberately. `vulnerabilityAlerts` reacts to
-GitHub's Dependabot alerts, so it produces nothing on a repository where that
-feature is switched off — and being switched off is invisible in the config,
-which still reads `enabled=true`. `osvVulnerabilityAlerts=true` queries the OSV
-database directly, independent of repository visibility and of any GitHub
-Advanced Security setting, so a transitive advisory is surfaced as a Renovate PR
-even when the Dependabot feed is unavailable. Without it, the first signal is a
-red `pnpm audit` in CI, which arrives whenever someone next opens a PR rather
-than when the advisory is published.
+Detection runs on two feeds with **different reach**, and the difference decides
+what each is good for:
+
+- `vulnerabilityAlerts` reacts to GitHub's Dependabot alerts, which read the
+  full resolved dependency graph and therefore cover **transitive** packages —
+  where nearly every advisory that actually bites a lockfile lives. It produces
+  nothing when Dependabot alerts are switched off for the repository, and being
+  switched off is invisible from the config, which still reads `enabled=true`.
+  Verify the feature itself, not the config: `gh api
+  repos/<owner>/<repo>/vulnerability-alerts` returns `204` when enabled and
+  `404` when not.
+- `osvVulnerabilityAlerts=true` queries `osv.dev` independently of repository
+  visibility and of any GitHub Advanced Security setting, but Renovate
+  [surfaces OSV alerts for **direct dependencies only**](https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts).
+  It is a second feed for first-party dependencies, **not** a fallback for
+  transitive ones.
+
+So a repository with Dependabot alerts disabled has no continuous transitive
+coverage at all, whatever `renovate.json` says. Its first signal is a red
+package-manager audit in CI, which arrives when somebody next opens a PR rather
+than when the advisory is published. Enabling the Dependabot alert feed is what
+closes that gap; OSV narrows the direct-dependency window alongside it.
 
 ### Snyk second opinion and scheduling
 

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -102,6 +102,16 @@ and alert-remediation PRs (`vulnerabilityAlerts.enabled=true`). Do not add a
 Renovate would create competing automation. Package-manager audits remain in CI
 as an immediate, provider-independent check.
 
+Detection runs on **two** feeds, deliberately. `vulnerabilityAlerts` reacts to
+GitHub's Dependabot alerts, so it produces nothing on a repository where that
+feature is switched off — and being switched off is invisible in the config,
+which still reads `enabled=true`. `osvVulnerabilityAlerts=true` queries the OSV
+database directly, independent of repository visibility and of any GitHub
+Advanced Security setting, so a transitive advisory is surfaced as a Renovate PR
+even when the Dependabot feed is unavailable. Without it, the first signal is a
+red `pnpm audit` in CI, which arrives whenever someone next opens a PR rather
+than when the advisory is published.
+
 ### Snyk second opinion and scheduling
 
 Snyk is not installed by default and is not part of `task security` or required

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -106,8 +106,12 @@ Detection runs on two feeds with **different reach**, and the difference decides
 what each is good for:
 
 - `vulnerabilityAlerts` reacts to GitHub's Dependabot alerts, which read the
-  full resolved dependency graph and therefore cover **transitive** packages —
-  where nearly every advisory that actually bites a lockfile lives. It produces
+  dependency graph and therefore reach **transitive** packages — where nearly
+  every advisory that actually bites a lockfile lives — wherever GitHub's
+  dependency graph extracts transitive dependencies for that ecosystem, which
+  for a committed `pnpm-lock.yaml` / `uv.lock` it does. Ecosystems and manifests
+  outside that support resolve to direct dependencies only, so confirm the
+  graph before relying on the reach. It produces
   nothing when Dependabot alerts are switched off for the repository, and being
   switched off is invisible from the config, which still reads `enabled=true`.
   Verify the feature itself, not the config: `gh api

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -131,14 +131,22 @@ Renovate feed, whatever `renovate.json` says — nothing there will open a
 remediation PR for a transitive advisory. Enabling the Dependabot alert feed is
 what closes that gap; OSV narrows the direct-dependency window alongside it.
 
-Two other checks can catch a transitive advisory, and neither replaces the feed.
-The package-manager audit in CI is immediate but PR-triggered, so it reports
-when somebody next opens a PR rather than when the advisory is published — which
-is exactly how a batch of transitive advisories can surface inside an unrelated
-change. A scheduled Snyk SCA scan (`snyk_scan_schedule` set to `weekly` or
-`daily`, see below) does run on its own clock and does see transitive packages,
-so on those profiles it, not the audit, is usually the first signal — but it is
-off by default and needs `SNYK_TOKEN` configured to run at all.
+Two other checks can also surface a transitive advisory, and neither replaces
+the feed. The package-manager audit in CI is PR-triggered, so it reports when
+somebody next opens a PR rather than when the advisory is published — which is
+exactly how a batch of unrelated advisories turns up inside somebody's docs
+change. A scheduled Snyk SCA scan (`snyk_scan_schedule`, see below) runs on its
+own clock, but it is off by default and needs `SNYK_TOKEN` to run at all.
+
+**Do not assume any of these three reach your whole dependency tree.** Each
+one's depth is a property of the specific ecosystem, manifest, and vendor plan
+in play, not of the setting being switched on — GitHub's graph extracts
+transitive dependencies for some ecosystems and not others, and Snyk gates some
+of its own package-manager support behind plan tier and preview flags (its `uv`
+support, for one, requires an Enterprise plan with the uv Preview feature
+enabled, so a Python project on the free posture gets far less than the setting
+implies). Establish the real depth for the stack you actually ship, per tool,
+and treat a green run as evidence only for what you confirmed it inspects.
 
 ### Snyk second opinion and scheduling
 

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -112,7 +112,10 @@ what each is good for:
   switched off is invisible from the config, which still reads `enabled=true`.
   Verify the feature itself, not the config: `gh api
   repos/<owner>/<repo>/vulnerability-alerts` returns `204` when enabled and
-  `404` when not.
+  `404` when not. Read that `404` carefully — the endpoint needs
+  Administration-read, which the machine-user PAT deliberately omits, so an
+  under-privileged token returns `404` as well. Check it with an admin-capable
+  credential, or read the state from Settings → Advanced Security instead.
 - `osvVulnerabilityAlerts=true` queries `osv.dev` independently of repository
   visibility and of any GitHub Advanced Security setting, but Renovate
   [surfaces OSV alerts for **direct dependencies only**](https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts).
@@ -120,10 +123,18 @@ what each is good for:
   transitive ones.
 
 So a repository with Dependabot alerts disabled has no continuous transitive
-coverage at all, whatever `renovate.json` says. Its first signal is a red
-package-manager audit in CI, which arrives when somebody next opens a PR rather
-than when the advisory is published. Enabling the Dependabot alert feed is what
-closes that gap; OSV narrows the direct-dependency window alongside it.
+Renovate feed, whatever `renovate.json` says — nothing there will open a
+remediation PR for a transitive advisory. Enabling the Dependabot alert feed is
+what closes that gap; OSV narrows the direct-dependency window alongside it.
+
+Two other checks can catch a transitive advisory, and neither replaces the feed.
+The package-manager audit in CI is immediate but PR-triggered, so it reports
+when somebody next opens a PR rather than when the advisory is published — which
+is exactly how a batch of transitive advisories can surface inside an unrelated
+change. A scheduled Snyk SCA scan (`snyk_scan_schedule` set to `weekly` or
+`daily`, see below) does run on its own clock and does see transitive packages,
+so on those profiles it, not the audit, is usually the first signal — but it is
+off by default and needs `SNYK_TOKEN` configured to run at all.
 
 ### Snyk second opinion and scheduling
 

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   "vulnerabilityAlerts": {
     "enabled": true
   },
+  "osvVulnerabilityAlerts": true,
   "customManagers": [
     {
       "customType": "regex",

--- a/scripts/test-renovate-pins.sh
+++ b/scripts/test-renovate-pins.sh
@@ -332,6 +332,23 @@ if tmpl_off and resolve_group(tmpl_off, "scripts/run-semgrep.sh", "semgrep", "py
         "should be ungrouped when no Devcontainer rule is rendered"
     )
 
+# Both vulnerability feeds, asserted on BOTH layers. test-template.sh checks the
+# rendered project and so cannot see the root copy — exactly the root drift
+# AGENTS.md warns test:template will not catch — and this is a security setting
+# whose absence is silent: osvVulnerabilityAlerts defaults to false in
+# Renovate's schema, so dropping the field disables the feed with every gate
+# still green. The two feeds have different reach (Dependabot's carries
+# transitive advisories; OSV is direct-only), so neither substitutes for the
+# other and both are required.
+root_cfg = json.loads(pathlib.Path("renovate.json").read_text())
+for label, cfg in [("renovate.json", root_cfg), ("template/renovate.json.jinja", tmpl_on)]:
+    if cfg is None:
+        continue
+    if cfg.get("osvVulnerabilityAlerts") is not True:
+        errors.append(f"{label}: osvVulnerabilityAlerts must be true")
+    if cfg.get("vulnerabilityAlerts", {}).get("enabled") is not True:
+        errors.append(f"{label}: vulnerabilityAlerts.enabled must be true")
+
 if errors:
     for e in errors:
         print(f"FAIL: {e}", file=sys.stderr)

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -459,6 +459,14 @@ fi
 grep -q 'task security:sast' .github/workflows/build.yml || err "build workflow is missing the Semgrep SAST route"
 jq -e '.vulnerabilityAlerts.enabled == true' renovate.json >/dev/null ||
     err "Renovate vulnerability-alert remediation must be enabled"
+# Asserted separately from the field above because the two feeds have different
+# reach and neither substitutes for the other: the Dependabot feed carries
+# transitive advisories, OSV covers direct dependencies without depending on
+# GitHub Advanced Security. Its schema default is false, so a dropped field
+# silently disables the feed — and the jinja structure gate compares headings
+# and tasks, not JSON fields, so nothing else here would notice.
+jq -e '.osvVulnerabilityAlerts == true' renovate.json >/dev/null ||
+    err "Renovate OSV vulnerability alerts must be enabled"
 grep -q '^use_codeql:' .copier-answers.yml || err "answers file does not persist explicit use_codeql intent"
 grep -q '^codeql_languages:' .copier-answers.yml || err "answers file does not persist explicit codeql_languages"
 grep -q 'task test:ci-results' .github/workflows/build.yml ||

--- a/template/docs/architecture/branch-protection.md.jinja
+++ b/template/docs/architecture/branch-protection.md.jinja
@@ -43,9 +43,12 @@ every rule type and is the GitHub-native way to apply an exported ruleset.
 ## Dependabot and Renovate
 
 Routine updates and vulnerability-remediation PRs are owned by **Renovate**
-(`renovate.json`, with `vulnerabilityAlerts.enabled=true`) — do not add a
+(`renovate.json`, with `vulnerabilityAlerts.enabled=true` and
+`osvVulnerabilityAlerts=true`) — do not add a
 `dependabot.yml`, which would create competing update PRs. Dependabot still owns
-the GitHub-native advisory feed; enable these in Settings → Advanced Security:
+the GitHub-native advisory feed; `osvVulnerabilityAlerts` is the second,
+visibility-independent feed that keeps remediation PRs flowing when the settings
+below are off. Enable these in Settings → Advanced Security:
 
 - Dependabot alerts
 - Private vulnerability reporting (used by `.github/SECURITY.md`)

--- a/template/docs/architecture/branch-protection.md.jinja
+++ b/template/docs/architecture/branch-protection.md.jinja
@@ -46,9 +46,10 @@ Routine updates and vulnerability-remediation PRs are owned by **Renovate**
 (`renovate.json`, with `vulnerabilityAlerts.enabled=true` and
 `osvVulnerabilityAlerts=true`) — do not add a
 `dependabot.yml`, which would create competing update PRs. Dependabot still owns
-the GitHub-native advisory feed; `osvVulnerabilityAlerts` is the second,
-visibility-independent feed that keeps remediation PRs flowing when the settings
-below are off. Enable these in Settings → Advanced Security:
+the GitHub-native advisory feed, and it is the only one of the two that reaches
+**transitive** dependencies, so the alert setting below is load-bearing rather
+than optional — `osvVulnerabilityAlerts` covers direct dependencies only. Enable
+these in Settings → Advanced Security:
 
 - Dependabot alerts
 - Private vulnerability reporting (used by `.github/SECURITY.md`)

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -115,6 +115,16 @@ alert-remediation PRs (`vulnerabilityAlerts.enabled=true`). Do not add a
 `dependabot.yml`: Dependabot update PRs would compete with Renovate. The
 package-manager audit remains in CI as an immediate provider-independent check.
 
+Detection runs on **two** feeds, deliberately. `vulnerabilityAlerts` reacts to
+GitHub's Dependabot alerts, so it produces nothing on a repository where that
+feature is switched off — and being switched off is invisible in the config,
+which still reads `enabled=true`. `osvVulnerabilityAlerts=true` queries the OSV
+database directly, independent of repository visibility and of any GitHub
+Advanced Security setting, so a transitive advisory is surfaced as a Renovate PR
+even when the Dependabot feed is unavailable. Without it, the first signal is a
+red audit in CI, which arrives whenever someone next opens a PR rather than when
+the advisory is published.
+
 ### Snyk second opinion and scheduling
 
 Snyk is not installed by default and is not part of `task security` or required

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -144,21 +144,29 @@ Renovate feed, whatever `renovate.json` says — nothing there will open a
 remediation PR for a transitive advisory. Enabling the Dependabot alert feed is
 what closes that gap; OSV narrows the direct-dependency window alongside it.
 
-Two other checks can catch a transitive advisory, and neither replaces the feed.
-The package-manager audit in CI is immediate but PR-triggered, so it reports
-when somebody next opens a PR rather than when the advisory is published — which
-is exactly how a batch of transitive advisories can surface inside an unrelated
+Two other checks can also surface a transitive advisory, and neither replaces
+the feed. The package-manager audit in CI is PR-triggered, so it reports when
+somebody next opens a PR rather than when the advisory is published — which is
+exactly how a batch of unrelated advisories turns up inside somebody's docs
 change.
 [% if snyk_scan_schedule != 'off' %]
 A scheduled Snyk SCA scan (`snyk_scan_schedule` is `[[ snyk_scan_schedule ]]`
-here, see below) does run on its own clock and does see transitive packages, so
-it is usually the first signal — but it needs `SNYK_TOKEN` configured to run at
-all.
+here, see below) runs on its own clock, but it needs `SNYK_TOKEN` configured to
+run at all.
 [% else %]
-A scheduled Snyk SCA scan would run on its own clock and would see transitive
-packages, but `snyk_scan_schedule` is `off` for this project, so no such scan
-exists here.
+A scheduled Snyk SCA scan would run on its own clock, but `snyk_scan_schedule`
+is `off` for this project, so no such scan exists here.
 [% endif %]
+
+**Do not assume any of these three reach your whole dependency tree.** Each
+one's depth is a property of the specific ecosystem, manifest, and vendor plan
+in play, not of the setting being switched on — GitHub's graph extracts
+transitive dependencies for some ecosystems and not others, and Snyk gates some
+of its own package-manager support behind plan tier and preview flags (its `uv`
+support, for one, requires an Enterprise plan with the uv Preview feature
+enabled, so a Python project on the free posture gets far less than the setting
+implies). Establish the real depth for the stack you actually ship, per tool,
+and treat a green run as evidence only for what you confirmed it inspects.
 
 ### Snyk second opinion and scheduling
 

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -115,15 +115,28 @@ alert-remediation PRs (`vulnerabilityAlerts.enabled=true`). Do not add a
 `dependabot.yml`: Dependabot update PRs would compete with Renovate. The
 package-manager audit remains in CI as an immediate provider-independent check.
 
-Detection runs on **two** feeds, deliberately. `vulnerabilityAlerts` reacts to
-GitHub's Dependabot alerts, so it produces nothing on a repository where that
-feature is switched off — and being switched off is invisible in the config,
-which still reads `enabled=true`. `osvVulnerabilityAlerts=true` queries the OSV
-database directly, independent of repository visibility and of any GitHub
-Advanced Security setting, so a transitive advisory is surfaced as a Renovate PR
-even when the Dependabot feed is unavailable. Without it, the first signal is a
-red audit in CI, which arrives whenever someone next opens a PR rather than when
-the advisory is published.
+Detection runs on two feeds with **different reach**, and the difference decides
+what each is good for:
+
+- `vulnerabilityAlerts` reacts to GitHub's Dependabot alerts, which read the
+  full resolved dependency graph and therefore cover **transitive** packages —
+  where nearly every advisory that actually bites a lockfile lives. It produces
+  nothing when Dependabot alerts are switched off for the repository, and being
+  switched off is invisible from the config, which still reads `enabled=true`.
+  Verify the feature itself, not the config: `gh api
+  repos/<owner>/<repo>/vulnerability-alerts` returns `204` when enabled and
+  `404` when not.
+- `osvVulnerabilityAlerts=true` queries `osv.dev` independently of repository
+  visibility and of any GitHub Advanced Security setting, but Renovate
+  [surfaces OSV alerts for **direct dependencies only**](https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts).
+  It is a second feed for first-party dependencies, **not** a fallback for
+  transitive ones.
+
+So a repository with Dependabot alerts disabled has no continuous transitive
+coverage at all, whatever `renovate.json` says. Its first signal is a red
+package-manager audit in CI, which arrives when somebody next opens a PR rather
+than when the advisory is published. Enabling the Dependabot alert feed is what
+closes that gap; OSV narrows the direct-dependency window alongside it.
 
 ### Snyk second opinion and scheduling
 

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -125,7 +125,10 @@ what each is good for:
   switched off is invisible from the config, which still reads `enabled=true`.
   Verify the feature itself, not the config: `gh api
   repos/<owner>/<repo>/vulnerability-alerts` returns `204` when enabled and
-  `404` when not.
+  `404` when not. Read that `404` carefully — the endpoint needs
+  Administration-read, which the machine-user PAT deliberately omits, so an
+  under-privileged token returns `404` as well. Check it with an admin-capable
+  credential, or read the state from Settings → Advanced Security instead.
 - `osvVulnerabilityAlerts=true` queries `osv.dev` independently of repository
   visibility and of any GitHub Advanced Security setting, but Renovate
   [surfaces OSV alerts for **direct dependencies only**](https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts).
@@ -133,10 +136,25 @@ what each is good for:
   transitive ones.
 
 So a repository with Dependabot alerts disabled has no continuous transitive
-coverage at all, whatever `renovate.json` says. Its first signal is a red
-package-manager audit in CI, which arrives when somebody next opens a PR rather
-than when the advisory is published. Enabling the Dependabot alert feed is what
-closes that gap; OSV narrows the direct-dependency window alongside it.
+Renovate feed, whatever `renovate.json` says — nothing there will open a
+remediation PR for a transitive advisory. Enabling the Dependabot alert feed is
+what closes that gap; OSV narrows the direct-dependency window alongside it.
+
+Two other checks can catch a transitive advisory, and neither replaces the feed.
+The package-manager audit in CI is immediate but PR-triggered, so it reports
+when somebody next opens a PR rather than when the advisory is published — which
+is exactly how a batch of transitive advisories can surface inside an unrelated
+change.
+[% if snyk_scan_schedule != 'off' %]
+A scheduled Snyk SCA scan (`snyk_scan_schedule` is `[[ snyk_scan_schedule ]]`
+here, see below) does run on its own clock and does see transitive packages, so
+it is usually the first signal — but it needs `SNYK_TOKEN` configured to run at
+all.
+[% else %]
+A scheduled Snyk SCA scan would run on its own clock and would see transitive
+packages, but `snyk_scan_schedule` is `off` for this project, so no such scan
+exists here.
+[% endif %]
 
 ### Snyk second opinion and scheduling
 

--- a/template/docs/architecture/security.md.jinja
+++ b/template/docs/architecture/security.md.jinja
@@ -119,8 +119,12 @@ Detection runs on two feeds with **different reach**, and the difference decides
 what each is good for:
 
 - `vulnerabilityAlerts` reacts to GitHub's Dependabot alerts, which read the
-  full resolved dependency graph and therefore cover **transitive** packages —
-  where nearly every advisory that actually bites a lockfile lives. It produces
+  dependency graph and therefore reach **transitive** packages — where nearly
+  every advisory that actually bites a lockfile lives — wherever GitHub's
+  dependency graph extracts transitive dependencies for that ecosystem, which
+  for a committed `pnpm-lock.yaml` / `uv.lock` it does. Ecosystems and manifests
+  outside that support resolve to direct dependencies only, so confirm the
+  graph before relying on the reach. It produces
   nothing when Dependabot alerts are switched off for the repository, and being
   switched off is invisible from the config, which still reads `enabled=true`.
   Verify the feature itself, not the config: `gh api

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -9,6 +9,7 @@
   "vulnerabilityAlerts": {
     "enabled": true
   },
+  "osvVulnerabilityAlerts": true,
   "customManagers": [
 [% if use_skills_sync %]
     {


### PR DESCRIPTION
## What

Adds `"osvVulnerabilityAlerts": true` to both `renovate.json` layers, with the
security and branch-protection docs updated in lockstep.

## Why

`vulnerabilityAlerts.enabled=true` makes Renovate react to **GitHub's Dependabot
alert feed**. On a repository where Dependabot alerts are switched off, that
setting produces nothing — and the config still reads `enabled=true`, so the gap
is invisible from inside the repo.

Found live during a v4.28.0 standardize run:

| Repo | Dependabot alerts | Result |
|---|---|---|
| `ponderousdev/omator` | **off** (`GET .../vulnerability-alerts` → 404) | 7 transitive advisories accumulated undetected |
| `ponderousdev/lawnomator-site` | on (204) | 4 advisories, also first seen via CI audit |

On omator the advisories (`undici`, `brace-expansion`, `nanoid`, plus four
moderates) first surfaced as a red `pnpm audit` during an unrelated
template-update PR, weeks after publication — the audit is an immediate check,
but it only runs when somebody opens a PR.

`osvVulnerabilityAlerts` queries the OSV database directly, independent of
repository visibility and of any GitHub Advanced Security setting, so
remediation PRs keep flowing on a second feed when the first is unavailable.
Both feeds stay on: OSV is the floor, not a replacement.

Renovate still owns every update PR. No `dependabot.yml` is added and
Dependabot's own security-update PRs stay off, so this creates no competing
automation — the distinction the existing docs draw between the *alert feed*
(keep) and *update PRs* (avoid) is preserved and now stated explicitly.

## Dogfood parity

Both layers changed together: `template/renovate.json.jinja` + root
`renovate.json`, and `template/docs/architecture/{security,branch-protection}.md.jinja`
+ their root twins.

## Verification

- `task verify` — exit 0
- `PR_TITLE=... BASE_SHA=main task guard:release-title` — exit 0 (`fix:` is a
  releasing type; this changes `template/`, so consumers need a release to pick
  it up)
- lefthook pre-commit + commit-msg hooks green

## Related

Filed from the same standardize run: #793, #794, #795, #796.