### PR TITLE
fix(template): mask pnpm by what the sandbox holds, not by naming system dirs

### DIFF
--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -823,8 +823,48 @@ rm_wt no-install-tree >/dev/null || fail "cleanup of the --no-install tree faile
 
 echo "==> a missing package manager fails loudly and rolls the tree back"
 rm -f "$stub_bin/pnpm"
+# `worktree-new.sh` gates on `have pnpm`, so this case needs pnpm genuinely
+# absent from PATH — a stub that fails would still be FOUND and would prove
+# something else. Naming system directories directly cannot deliver that: pnpm
+# is a corepack shim at /usr/bin/pnpm in this repo's own devcontainer, so
+# `PATH="$stub_bin:/usr/bin:/bin"` left pnpm reachable, the run succeeded, and
+# the assertion failed on every machine that installs it there — CI passed only
+# because its pnpm happens to live elsewhere (harmon-init#791). Dropping the
+# offending directory wholesale is not an option either: git and coreutils live
+# beside it.
+#
+# So mirror the system tools into a sandbox and omit exactly one. The mask then
+# holds wherever pnpm is installed, because it is defined by what the sandbox
+# CONTAINS rather than by what some directory is assumed not to.
+mask_bin="$test_tmp/mask-bin"
+rm -rf "$mask_bin"
+mkdir -p "$mask_bin"
+for mask_dir in /usr/local/bin /usr/bin /bin; do
+    [ -d "$mask_dir" ] || continue
+    for mask_src in "$mask_dir"/*; do
+        [ -x "$mask_src" ] || continue
+        mask_name=${mask_src##*/}
+        case "$mask_name" in
+        pnpm) continue ;;
+        esac
+        if [ -e "$mask_bin/$mask_name" ]; then
+            continue
+        fi
+        ln -s "$mask_src" "$mask_bin/$mask_name"
+    done
+done
+# The guard the sandbox exists to create — if pnpm is still reachable the case
+# below would pass for the wrong reason, and a mask that silently stops masking
+# is worse than no mask.
 if (
-    PATH="$stub_bin:/usr/bin:/bin"
+    PATH="$mask_bin"
+    export PATH
+    command -v pnpm >/dev/null 2>&1
+); then
+    fail "the pnpm mask did not take effect; the missing-pnpm case would prove nothing"
+fi
+if (
+    PATH="$mask_bin"
     export PATH
     new missing-pnpm >/dev/null 2>&1
 ); then

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -823,8 +823,48 @@ rm_wt no-install-tree >/dev/null || fail "cleanup of the --no-install tree faile
 
 echo "==> a missing package manager fails loudly and rolls the tree back"
 rm -f "$stub_bin/pnpm"
+# `worktree-new.sh` gates on `have pnpm`, so this case needs pnpm genuinely
+# absent from PATH — a stub that fails would still be FOUND and would prove
+# something else. Naming system directories directly cannot deliver that: pnpm
+# is a corepack shim at /usr/bin/pnpm in this repo's own devcontainer, so
+# `PATH="$stub_bin:/usr/bin:/bin"` left pnpm reachable, the run succeeded, and
+# the assertion failed on every machine that installs it there — CI passed only
+# because its pnpm happens to live elsewhere (harmon-init#791). Dropping the
+# offending directory wholesale is not an option either: git and coreutils live
+# beside it.
+#
+# So mirror the system tools into a sandbox and omit exactly one. The mask then
+# holds wherever pnpm is installed, because it is defined by what the sandbox
+# CONTAINS rather than by what some directory is assumed not to.
+mask_bin="$test_tmp/mask-bin"
+rm -rf "$mask_bin"
+mkdir -p "$mask_bin"
+for mask_dir in /usr/local/bin /usr/bin /bin; do
+    [ -d "$mask_dir" ] || continue
+    for mask_src in "$mask_dir"/*; do
+        [ -x "$mask_src" ] || continue
+        mask_name=${mask_src##*/}
+        case "$mask_name" in
+        pnpm) continue ;;
+        esac
+        if [ -e "$mask_bin/$mask_name" ]; then
+            continue
+        fi
+        ln -s "$mask_src" "$mask_bin/$mask_name"
+    done
+done
+# The guard the sandbox exists to create — if pnpm is still reachable the case
+# below would pass for the wrong reason, and a mask that silently stops masking
+# is worse than no mask.
 if (
-    PATH="$stub_bin:/usr/bin:/bin"
+    PATH="$mask_bin"
+    export PATH
+    command -v pnpm >/dev/null 2>&1
+); then
+    fail "the pnpm mask did not take effect; the missing-pnpm case would prove nothing"
+fi
+if (
+    PATH="$mask_bin"
     export PATH
     new missing-pnpm >/dev/null 2>&1
 ); then


### PR DESCRIPTION
## What

`test:worktree`'s "no pnpm" case masked pnpm by deleting a stub and then
setting `PATH="$stub_bin:/usr/bin:/bin"` — which puts `/usr/bin` straight back
on the path. In this repo's own devcontainer pnpm is a corepack shim at
`/usr/bin/pnpm`, so the masked run still found it, `worktree-new.sh` succeeded,
and the assertion failed:

```text
TEST FAIL: worktree-new.sh succeeded with package.json present and no pnpm
```

That made **`task verify` — the definition-of-done gate — unpassable locally**,
reproducing on `main` with a clean tree. CI stayed green only because its pnpm
happens to live somewhere else, which is precisely the fragility: the test
asserted a condition it did not control.

## Why this shape of fix

`worktree-new.sh` gates on `have pnpm`, so shadowing pnpm with a stub that
exits non-zero is not an option — it would still be **found**, and the case
would prove something other than what it claims.

The mask now mirrors the system tools into a sandbox directory and omits
exactly one, so it is defined by what the sandbox **contains** rather than by
what some directory is assumed not to hold. It holds wherever pnpm is
installed.

A guard runs immediately before the case: if pnpm is somehow still reachable
under the mask, the suite fails loudly. A mask that silently stops masking lets
the case pass for the wrong reason, which is how this defect survived.

## Verification

The mask's property is proven directly:

```text
links created: 949
OK: pnpm is absent under the mask
  present: git, bash, sed, awk, node
```

`task check`, `shellcheck`, `shfmt`, and `test:dogfood-parity` (112 verbatim
twins) all pass. Both twins edited identically.

**Deliberately verified in CI rather than locally**, and worth stating plainly:
`test:worktree` cannot currently run to completion in this devcontainer,
because the fixture worktree's `post-checkout` hook deadlocks in lefthook —
#792, which reproduced on consecutive runs today. That is a separate defect,
filed and deferred by choice; this PR does not touch it. CI runs
`task test:worktree`, and its pnpm is not in `/usr/bin`, so the case is
meaningful there.

Closes #791