### PR TITLE
fix(template): document settle instead of the manual disposition workaround

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,7 +390,11 @@ non-draft PR must always mean the automated work is done.
   reply-based adjudication path cannot reach it and findings outrank a later
   clean result on the same head. Record its disposition with the checker's
   `settle` subcommand: answer the finding on the PR as usual (fix it, decline
-  it with evidence, or file it), then run the checker's `settle` with the
+  it with evidence, or file it) — and note that only two of those three end
+  here. **Fixing** it means a push, which moves the head and starts a fresh
+  cycle that reviews the fix on its own merits; `settle` neither applies nor
+  accepts that disposition. It records the two answers that leave the code
+  alone, and for those you run the checker's `settle` with the
   cycle's own state file — `.claude/skills/shepherd/assets/check-codex-cloud-review.sh
   settle --state "$state" --actor-id 199175422 --surface comment|review --id
   <id> --disposition declined|filed --note "<why, or the issue filed>"` —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,17 +385,21 @@ non-draft PR must always mean the automated work is done.
   before accepting the result or reporting green, re-`check` the cycle and
   re-read `headRefOid`; a changed head invalidates the result and starts
   a new current-head cycle.
-  One disposition the script cannot express is settled in prose: a badged
-  finding stated **outside an inline thread** — in a top-level comment or in
-  a review's own body — has no reply linkage, so once it lands, no
-  adjudication can make that head's `check` come back clean: findings outrank
-  a later clean result on the same head, and the script's settled set reaches
-  only inline comments. When every
-  such finding is adjudicated without a code change (declined with evidence,
-  or filed as follow-up work), record each disposition as a PR comment and
-  treat the cycle as **terminal with findings settled** for that head; the
-  readiness gate reads those recorded adjudications where a checker exit 0 is
-  unreachable. Any push starts a fresh cycle as usual.
+  A badged finding stated **outside an inline thread** — in a top-level
+  comment or in a review's own body — has no reply linkage, so the
+  reply-based adjudication path cannot reach it and findings outrank a later
+  clean result on the same head. Record its disposition with the checker's
+  `settle` subcommand: answer the finding on the PR as usual (fix it, decline
+  it with evidence, or file it), then `settle --surface comment|review --id N
+  --disposition declined|filed --note …`, adding `--covers <n>` where the
+  target states more than one finding. `check` then treats that finding as
+  answered and the cycle reaches terminal-clean, reported with a detail
+  naming the disposition applied. The record is durable and head-bound: it is
+  fingerprinted against the body it settled, so a finding Codex edits
+  afterwards blocks again while the superseded entry survives as the record
+  of what was decided about the earlier text. Any push starts a fresh cycle
+  as usual. Settling is not a substitute for answering — it records an
+  adjudication a human wrote, which is why the note is required.
   Shepherd is **externally driven** — CI results and other people's comments
   are its input, so it cannot manufacture a round on its own. A round is one
   fix push, or one no-change cycle where everything is answered and nothing
@@ -447,8 +451,8 @@ review only when **all** of the following hold for its current `headRefOid`:
   *indeterminate*, not a pass — GitHub populates it asynchronously, so a read
   taken moments after the push reports nothing having run rather than nothing
   to run.
-- The current-head Codex cycle above is terminal and clean, or terminal with
-  every finding settled under the no-thread disposition rule above (Codex review is
+- The current-head Codex cycle above is terminal and clean — including clean
+  by way of dispositions recorded with `settle` (Codex review is
   enabled here; where it is off, this condition drops out).
 - Every review finding is fixed, declined with evidence, or filed as follow-up
   work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,9 +390,14 @@ non-draft PR must always mean the automated work is done.
   reply-based adjudication path cannot reach it and findings outrank a later
   clean result on the same head. Record its disposition with the checker's
   `settle` subcommand: answer the finding on the PR as usual (fix it, decline
-  it with evidence, or file it), then `settle --surface comment|review --id N
-  --disposition declined|filed --note …`, adding `--covers <n>` where the
-  target states more than one finding. `check` then treats that finding as
+  it with evidence, or file it), then run the checker's `settle` with the
+  cycle's own state file — `.claude/skills/shepherd/assets/check-codex-cloud-review.sh
+  settle --state "$state" --actor-id 199175422 --surface comment|review --id
+  <id> --disposition declined|filed --note "<why, or the issue filed>"` —
+  adding `--covers <n>` where the target states more than one finding.
+  `--state` and `--actor-id` are both required; the invocation fails without
+  them, which is the whole point of the state being durable and the actor
+  pinned. `check` then treats that finding as
   answered and the cycle reaches terminal-clean, reported with a detail
   naming the disposition applied. The record is durable and head-bound: it is
   fingerprinted against the body it settled, so a finding Codex edits

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,27 +388,23 @@ non-draft PR must always mean the automated work is done.
   A badged finding stated **outside an inline thread** — in a top-level
   comment or in a review's own body — has no reply linkage, so the
   reply-based adjudication path cannot reach it and findings outrank a later
-  clean result on the same head. Record its disposition with the checker's
-  `settle` subcommand: answer the finding on the PR as usual (fix it, decline
-  it with evidence, or file it) — and note that only two of those three end
-  here. **Fixing** it means a push, which moves the head and starts a fresh
-  cycle that reviews the fix on its own merits; `settle` neither applies nor
-  accepts that disposition. It records the two answers that leave the code
-  alone, and for those you run the checker's `settle` with the
-  cycle's own state file — `.claude/skills/shepherd/assets/check-codex-cloud-review.sh
-  settle --state "$state" --actor-id 199175422 --surface comment|review --id
-  <id> --disposition declined|filed --note "<why, or the issue filed>"` —
-  adding `--covers <n>` where the target states more than one finding.
-  `--state` and `--actor-id` are both required; the invocation fails without
-  them, which is the whole point of the state being durable and the actor
-  pinned. `check` then treats that finding as
-  answered and the cycle reaches terminal-clean, reported with a detail
-  naming the disposition applied. The record is durable and head-bound: it is
-  fingerprinted against the body it settled, so a finding Codex edits
-  afterwards blocks again while the superseded entry survives as the record
-  of what was decided about the earlier text. Any push starts a fresh cycle
-  as usual. Settling is not a substitute for answering — it records an
-  adjudication a human wrote, which is why the note is required.
+  clean result on the same head. The checker's `settle` subcommand records the
+  disposition instead; its exact invocation lives with the recipe in
+  `.claude/skills/shepherd/SKILL.md`, which this file deliberately does not
+  restate — the same reason it routes you to the checker rather than
+  describing how to poll.
+  What belongs here is when it applies. Answer the finding on the PR as usual,
+  and note that only two of the three answers end with `settle`: **fixing** it
+  means a push, which moves the head and starts a fresh cycle that reviews the
+  fix on its own merits, and `settle` neither applies nor accepts that
+  disposition. It records the two answers that leave the code alone —
+  declining with evidence, or filing it as follow-up work — and requires a
+  note for exactly that reason: the record is a human's adjudication, not a
+  suppression. It is head-bound and fingerprinted against the body it settled,
+  so a finding Codex edits afterwards blocks again while the superseded entry
+  survives as the record of what was decided about the earlier text. Once
+  every non-thread finding on the head carries one, `check` reports clean with
+  a detail naming the disposition applied.
   Shepherd is **externally driven** — CI results and other people's comments
   are its input, so it cannot manufacture a round on its own. A round is one
   fix push, or one no-change cycle where everything is answered and nothing

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -289,29 +289,22 @@ error silently reverts the lifecycle rather than fixing anything.
   A badged finding stated **outside an inline thread** — in a top-level
   comment or in a review's own body — has no reply linkage, so the
   reply-based adjudication path cannot reach it and findings outrank a later
-  clean result on the same head. Where the vendored checker is present,
-  record its disposition with `settle`. Answer the finding on the PR as usual
-  first — and note that only two of the three answers end here. **Fixing** it
-  means a push, which moves the head and starts a fresh cycle that reviews the
-  fix on its own merits; `settle` neither applies nor accepts that
-  disposition. For the two answers that leave the code alone — declining with
-  evidence, or filing it as follow-up work — run the checker with the cycle's
-  own state file: `.claude/skills/shepherd/assets/check-codex-cloud-review.sh
-  settle --state "$state" --actor-id 199175422 --surface comment|review --id
-  <id> --disposition declined|filed --note "<why, or the issue filed>"` —
-  adding `--covers <n>` where the target states more than one finding.
-  `--state` and `--actor-id` are both required; the invocation fails without
-  them, which is the whole point of the state being durable and the actor
-  pinned. `check` then
-  treats that finding as answered and the cycle reaches terminal-clean,
-  reported with a detail naming the disposition applied. The record is
-  durable and head-bound: it is fingerprinted against the body it settled, so
-  a finding Codex edits afterwards blocks again while the superseded entry
-  survives as the record of what was decided about the earlier text. Without
-  the checker, record each disposition as a PR comment instead and treat the
-  cycle as terminal with its findings settled. Either way a push starts a
-  fresh cycle, and settling is not a substitute for answering — it records an
-  adjudication a human wrote, which is why the note is required.
+  clean result on the same head. Where the vendored checker is present, its
+  `settle` subcommand records the disposition; the exact invocation lives with
+  the recipe in `.claude/skills/shepherd/SKILL.md`, which this file
+  deliberately does not restate. Without the checker, record each disposition
+  as a PR comment instead and treat the cycle as terminal with its findings
+  settled.
+  What belongs here is when it applies. Answer the finding on the PR as usual,
+  and note that only two of the three answers end with a disposition:
+  **fixing** it means a push, which moves the head and starts a fresh cycle
+  that reviews the fix on its own merits. A disposition records the two
+  answers that leave the code alone — declining with evidence, or filing it as
+  follow-up work — and carries a note for exactly that reason: it is a
+  human's adjudication, not a suppression. With the checker the record is
+  head-bound and fingerprinted against the body it settled, so a finding Codex
+  edits afterwards blocks again while the superseded entry survives as the
+  record of what was decided about the earlier text.
 [% endif %]
   Shepherd is **externally driven** — CI results and other people's comments
   are its input, so it cannot manufacture a round on its own. A round is one

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -286,17 +286,23 @@ error silently reverts the lifecycle rather than fixing anything.
   before accepting the result or reporting green, re-check the cycle and
   re-read `headRefOid`; a changed head invalidates the result and starts
   a new current-head cycle.
-  One disposition the checker cannot express is settled in prose: a badged
-  finding stated **outside an inline thread** — in a top-level comment or in
-  a review's own body — has no reply linkage, so once it lands, no
-  adjudication can make that head's `check` come back clean: findings outrank
-  a later clean result on the same head, and the checker's settled set
-  reaches only inline comments. When every
-  such finding is adjudicated without a code change (declined with evidence,
-  or filed as follow-up work), record each disposition as a PR comment and
-  treat the cycle as **terminal with findings settled** for that head; the
-  readiness gate reads those recorded adjudications where a checker exit 0 is
-  unreachable. Any push starts a fresh cycle as usual.
+  A badged finding stated **outside an inline thread** — in a top-level
+  comment or in a review's own body — has no reply linkage, so the
+  reply-based adjudication path cannot reach it and findings outrank a later
+  clean result on the same head. Where the vendored checker is present,
+  record its disposition with `settle`: answer the finding on the PR as usual
+  (fix it, decline it with evidence, or file it), then `settle --surface
+  comment|review --id N --disposition declined|filed --note …`, adding
+  `--covers <n>` where the target states more than one finding. `check` then
+  treats that finding as answered and the cycle reaches terminal-clean,
+  reported with a detail naming the disposition applied. The record is
+  durable and head-bound: it is fingerprinted against the body it settled, so
+  a finding Codex edits afterwards blocks again while the superseded entry
+  survives as the record of what was decided about the earlier text. Without
+  the checker, record each disposition as a PR comment instead and treat the
+  cycle as terminal with its findings settled. Either way a push starts a
+  fresh cycle, and settling is not a substitute for answering — it records an
+  adjudication a human wrote, which is why the note is required.
 [% endif %]
   Shepherd is **externally driven** — CI results and other people's comments
   are its input, so it cannot manufacture a round on its own. A round is one
@@ -357,8 +363,9 @@ its current `headRefOid`:
   taken moments after the push reports nothing having run rather than nothing
   to run.
 [% if use_codex_cloud_review %]
-- The current-head Codex cycle above is terminal and clean, or terminal with
-  every finding settled under the no-thread disposition rule above.
+- The current-head Codex cycle above is terminal and clean — including clean
+  by way of dispositions recorded with `settle`, or the recorded-comment
+  equivalent where the checker is absent.
 [% endif %]
 - Every review finding is fixed, declined with evidence, or filed as follow-up
   work.

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -290,9 +290,13 @@ error silently reverts the lifecycle rather than fixing anything.
   comment or in a review's own body — has no reply linkage, so the
   reply-based adjudication path cannot reach it and findings outrank a later
   clean result on the same head. Where the vendored checker is present,
-  record its disposition with `settle`: answer the finding on the PR as usual
-  (fix it, decline it with evidence, or file it), then run the checker with
-  the cycle's own state file — `.claude/skills/shepherd/assets/check-codex-cloud-review.sh
+  record its disposition with `settle`. Answer the finding on the PR as usual
+  first — and note that only two of the three answers end here. **Fixing** it
+  means a push, which moves the head and starts a fresh cycle that reviews the
+  fix on its own merits; `settle` neither applies nor accepts that
+  disposition. For the two answers that leave the code alone — declining with
+  evidence, or filing it as follow-up work — run the checker with the cycle's
+  own state file: `.claude/skills/shepherd/assets/check-codex-cloud-review.sh
   settle --state "$state" --actor-id 199175422 --surface comment|review --id
   <id> --disposition declined|filed --note "<why, or the issue filed>"` —
   adding `--covers <n>` where the target states more than one finding.

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -291,9 +291,14 @@ error silently reverts the lifecycle rather than fixing anything.
   reply-based adjudication path cannot reach it and findings outrank a later
   clean result on the same head. Where the vendored checker is present,
   record its disposition with `settle`: answer the finding on the PR as usual
-  (fix it, decline it with evidence, or file it), then `settle --surface
-  comment|review --id N --disposition declined|filed --note …`, adding
-  `--covers <n>` where the target states more than one finding. `check` then
+  (fix it, decline it with evidence, or file it), then run the checker with
+  the cycle's own state file — `.claude/skills/shepherd/assets/check-codex-cloud-review.sh
+  settle --state "$state" --actor-id 199175422 --surface comment|review --id
+  <id> --disposition declined|filed --note "<why, or the issue filed>"` —
+  adding `--covers <n>` where the target states more than one finding.
+  `--state` and `--actor-id` are both required; the invocation fails without
+  them, which is the whole point of the state being durable and the actor
+  pinned. `check` then
   treats that finding as answered and the cycle reaches terminal-clean,
   reported with a detail naming the disposition applied. The record is
   durable and head-bound: it is fingerprinted against the body it settled, so


### PR DESCRIPTION
## What

harmon-init now vendors harmon-devkit v0.29.0, whose checker gained a `settle`
subcommand (evanharmon1/harmon-devkit#391). Both AGENTS layers still told
agents this disposition **"cannot be expressed by the checker"** and to
improvise a manual terminal exception — accurate when written, actively
misleading now: an agent following it bypasses the durable, head-bound state
the checker maintains.

Both layers now document `settle`: the complete invocation, `--covers <n>` for
a target stating more than one finding, the fingerprint that re-blocks when
Codex edits a settled body, and the superseded entry that survives as the
record of the earlier adjudication. The readiness gate's Codex condition is
simplified to match — clean, including clean by way of recorded dispositions.

The template twin words it as a runtime presence check with the
recorded-comment fallback, because a generated repo can enable
`use_codex_cloud_review` without `use_skills_sync`, and gating template text
on `skill_categories` is forbidden.

## Two P1s the local loops caught, both in this new prose

1. **The invocation could not run.** It showed `settle --surface … --id …
   --disposition … --note …` with no helper path, no `--state`, and no
   `--actor-id` — the last two are rejected outright. An agent copying it
   would fail immediately and leave the finding unsettled, deadlocking the
   gate this text exists to unblock.
2. **"Fix it, then settle" is impossible.** `--disposition` accepts only
   `declined|filed`, and a fix means a push, which moves the head and starts a
   fresh cycle. Both layers now separate the paths: fixing means push and let
   the new head be reviewed on its own merits; `settle` records the two
   answers that leave the code alone.

**The same defective wording shipped upstream** in harmon-devkit's AGENTS.md
and shepherd SKILL.md (released in v0.29.0) and is filed there as
evanharmon1/harmon-devkit#427. This repo's copy is corrected here rather than
waiting on that release.

## Verification

`task check`, `test:dogfood-parity` (112 verbatim twins), `test:dogfood-structure`
(207 sections), and `test:template:minimal` all pass — the render proves the
jinja twin is still valid after the edits.

**The full `task verify` could not complete locally**: `test:worktree`
deadlocks in lefthook (#792), which recurred twice more during this change. CI
runs the same targets, so the gap is covered there. Stated plainly so CI-only
validation is not mistaken for an oversight.

Refs evanharmon1/harmon-devkit#391