### PR TITLE
feat(template): resolve dev-loop round caps from .devflow.toml rigor tiers

### DIFF
--- a/.devflow.toml
+++ b/.devflow.toml
@@ -1,0 +1,54 @@
+# .devflow.toml — round caps for the Dev Loop stages defined in AGENTS.md.
+#
+# The numbers live here rather than in prose because prose cannot be checked.
+# This file has a byte-identical twin at template/.devflow.toml, so
+# `task test:dogfood-parity` fails if only one side is edited — the caps are
+# now mechanically protected in a way eight scattered paragraphs never were.
+#
+# Resolution order (AGENTS.md states this rule; only this file states numbers):
+#
+#   explicit instruction in the session
+#     > a rigor:* label on the issue
+#       > default_rigor below
+#         > 4 / 4 / 4 if this file is absent
+#
+# Announce the resolved triple on entering the Dev Loop — "rigor: deep (label)
+# -> challenge <=5, review <=5, shepherd 4" — and carry it into the PR body, so
+# the choice is auditable rather than recalled.
+#
+# These are ceilings, not quotas. A stage exits the moment its exit condition
+# in AGENTS.md is met: two consecutive rounds adjudicated to zero P0/P1, or any
+# single round with no findings at all. Nothing here obliges a round to be run.
+#
+# `challenge` and `review` are inert wherever no second-model reviewer is
+# configured (`use_codex_review = false`): those stages never run, so their
+# caps have nothing to bound. `shepherd` always applies.
+
+default_rigor = "standard"
+
+# `shepherd` is deliberately 4 in every tier, and is not a knob to turn down.
+#
+# `challenge` and `review` bound work the agent generates itself — each round's
+# fixes are the next round's input — which is exactly what makes capping them
+# low safe. `shepherd` bounds *other people's* findings: CI failures, human
+# review, Codex. Lowering it does not reduce effort spent; it abandons reviews
+# that are already unanswered, and the readiness gate then refuses to promote
+# the PR anyway. The key is present so that a tier is one consistent shape.
+
+# Trivial, low-blast-radius work: doc touch-ups, mechanical bumps, typo fixes.
+[rigor.light]
+challenge = 2 # 2 is the floor, never 1: the exit condition needs two
+review    = 2 # consecutive adjudicated-clean rounds, so a cap of 1 turns any
+shepherd  = 4 # single finding into an immediate escalation.
+
+# The default for ordinary changes.
+[rigor.standard]
+challenge = 3
+review    = 3
+shepherd  = 4
+
+# Security, migrations, data paths — anything with an irreversible failure mode.
+[rigor.deep]
+challenge = 5
+review    = 5
+shepherd  = 4

--- a/.devflow.toml
+++ b/.devflow.toml
@@ -1,28 +1,38 @@
 # .devflow.toml — round caps for the Dev Loop stages defined in AGENTS.md.
 #
-# The numbers live here rather than in prose because prose cannot be checked.
-# This file has a byte-identical twin at template/.devflow.toml, so
-# `task test:dogfood-parity` fails if only one side is edited — the caps are
-# now mechanically protected in a way eight scattered paragraphs never were.
+# The numbers live here rather than in prose so that there is exactly one place
+# to change them and one place to read them.
 #
-# Resolution order (AGENTS.md states this rule; only this file states numbers):
+# Resolution order (AGENTS.md states the rule; only this file states numbers):
 #
 #   explicit instruction in the session
-#     > a rigor:* label on the issue
+#     > a rigor:* label on the issue, where the repo provisions them
 #       > default_rigor below
 #         > 4 / 4 / 4 if this file is absent
 #
-# Announce the resolved triple on entering the Dev Loop — "rigor: deep (label)
-# -> challenge <=5, review <=5, shepherd 4" — and carry it into the PR body, so
-# the choice is auditable rather than recalled.
+# Announce the resolved caps on entering the Dev Loop and carry them into the
+# PR body, so the budget a change was reviewed under is on the record rather
+# than recalled.
+#
+# When the change under review edits THIS FILE, resolve its caps from the
+# merge-base copy rather than the branch copy — otherwise a branch can lower
+# the very gate it is changing. An explicit human instruction still overrides.
 #
 # These are ceilings, not quotas. A stage exits the moment its exit condition
 # in AGENTS.md is met: two consecutive rounds adjudicated to zero P0/P1, or any
 # single round with no findings at all. Nothing here obliges a round to be run.
 #
+# Retuning these is expected. The Dev Loop assumes four invariants, and nothing
+# at runtime will tell you if an edit breaks one:
+#   - every tier defines challenge, review and shepherd, all integers
+#   - challenge and review are >= 2, because the exit condition needs two
+#     consecutive adjudicated-clean rounds; at 1, one finding is an escalation
+#   - shepherd is the same in every tier (see below)
+#   - default_rigor names a tier that exists here
+#
 # `challenge` and `review` are inert wherever no second-model reviewer is
-# configured (`use_codex_review = false`): those stages never run, so their
-# caps have nothing to bound. `shepherd` always applies.
+# configured: those stages never run, so their caps bound nothing. `shepherd`
+# always applies.
 
 default_rigor = "standard"
 

--- a/.devflow.toml
+++ b/.devflow.toml
@@ -8,7 +8,7 @@
 #   explicit instruction in the session
 #     > a rigor:* label on the issue, where the repo provisions them
 #       > default_rigor below
-#         > 4 / 4 / 4 if this file is absent
+#         > the built-in fallback stated in AGENTS.md, if this file is absent
 #
 # Announce the resolved caps on entering the Dev Loop and carry them into the
 # PR body, so the budget a change was reviewed under is on the record rather

--- a/.devflow.toml
+++ b/.devflow.toml
@@ -18,9 +18,12 @@
 # merge-base copy rather than the branch copy — otherwise a branch can lower
 # the very gate it is changing. An explicit human instruction still overrides.
 #
-# These are ceilings, not quotas. A stage exits the moment its exit condition
-# in AGENTS.md is met: two consecutive rounds adjudicated to zero P0/P1, or any
-# single round with no findings at all. Nothing here obliges a round to be run.
+# These are ceilings, not quotas. A stage exits the moment any of its exit
+# conditions in AGENTS.md is met: two consecutive rounds adjudicated to zero
+# P0/P1, any single round with no findings at all, or a round that hits the cap
+# below having adjudicated to zero P0/P1 — the confirming round it would
+# otherwise owe is one the cap forbids, so a clean last round is convergence,
+# not grounds to escalate. Nothing here obliges a round to be run.
 #
 # Retuning these is expected. The Dev Loop assumes four invariants, and nothing
 # at runtime will tell you if an edit breaks one:

--- a/.devflow.toml
+++ b/.devflow.toml
@@ -26,7 +26,8 @@
 
 default_rigor = "standard"
 
-# `shepherd` is deliberately 4 in every tier, and is not a knob to turn down.
+# `shepherd` is deliberately identical in every tier, and is not a knob to
+# turn down.
 #
 # `challenge` and `review` bound work the agent generates itself — each round's
 # fixes are the next round's input — which is exactly what makes capping them

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,11 +249,19 @@ live in [`.devflow.toml`](.devflow.toml) as `rigor` tiers, so there is one
 place to change them and a parity gate that catches a change made on only one
 side. Resolve in this order — an explicit instruction in this session, then a
 `rigor:*` label on the issue, then `default_rigor`, then a built-in 4 / 4 / 4
-if the file is absent. **Announce the resolved triple on entering the loop** —
-"rigor: deep (label) → challenge ≤5, review ≤5, shepherd 4" — and carry it into
-the PR body, so a later round or a different session can see which budget it is
-spending instead of inferring one. Everything else about these stages is
-policy rather than a parameter and does not vary by tier: the exit condition,
+if the file is absent. GitHub labels are multi-select and nothing stops an
+issue carrying two, so resolve a conflict fail-safe: **the deepest tier present
+wins**, which errs toward more review rather than less, and a `rigor:` value
+that names no tier in the file is ignored rather than guessed at. An agent
+never applies one of these labels to itself — lowering rigor weakens a safety
+gate, so it takes an attributable human actor, which is also why the tier rides
+a label rather than a project field. **Announce the resolved triple on entering
+the loop** — "rigor: `<tier>` (`<source>`) → challenge ≤`<n>`, review ≤`<n>`,
+shepherd `<n>`", filled in by reading the file rather than from memory — and
+carry it into the PR body, so a later round or a different session can see
+which budget it is spending instead of inferring one. Everything else about
+these stages is policy rather than a parameter and does not vary by tier: the
+exit condition,
 the round-2 scaffolding checkpoint, the escalation rule, and the deferred-P2
 sidecar all hold identically at every rigor. A cap is a ceiling, never a quota
 — a stage that meets its exit condition on round 1 is done, whatever the tier

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,12 +250,16 @@ place to change them and a parity gate that catches a change made on only one
 side. Resolve in this order — an explicit instruction in this session, then a
 `rigor:*` label on the issue, then `default_rigor`, then a built-in 4 / 4 / 4
 if the file is absent. GitHub labels are multi-select and nothing stops an
-issue carrying two, so resolve a conflict fail-safe: **the deepest tier present
-wins**, which errs toward more review rather than less, and a `rigor:` value
-that names no tier in the file is ignored rather than guessed at. An agent
-never applies one of these labels to itself — lowering rigor weakens a safety
-gate, so it takes an attributable human actor, which is also why the tier rides
-a label rather than a project field. **Announce the resolved triple on entering
+issue carrying two, so resolution is **per stage, taking the highest cap
+present**: a conflict can then only ever buy more review, never less, and no
+ranking of the tier names has to be agreed on anywhere. A `rigor:` value that
+names no tier in the file is ignored rather than guessed at. Treat the label as
+advisory input carrying exactly the authority of repo write access — anyone who
+can label an issue can retune its budget, the same way anyone who can push can
+edit `.devflow.toml`. An agent never applies one to itself, and **says so in
+the announcement and in the PR body whenever the resolved tier is below
+`default_rigor`**, so a reduced budget is visible to the human reviewer instead
+of silent. **Announce the resolved triple on entering
 the loop** — "rigor: `<tier>` (`<source>`) → challenge ≤`<n>`, review ≤`<n>`,
 shepherd `<n>`", filled in by reading the file rather than from memory — and
 carry it into the PR body, so a later round or a different session can see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,14 @@ live in [`.devflow.toml`](.devflow.toml) as `rigor` tiers, so there is one
 place to change them and a parity gate that catches a change made on only one
 side. Resolve in this order — an explicit instruction in this session, then a
 `rigor:*` label on the issue, then `default_rigor`, then a built-in 4 / 4 / 4
-if the file is absent. GitHub labels are multi-select and nothing stops an
+if the file is absent. When the change under review **edits `.devflow.toml`
+itself**, resolve its caps from the **merge-base** copy rather than the branch
+copy: otherwise a branch can lower the very gate it is changing — dropping every
+tier and `default_rigor` together passes the validator and evades the
+below-default disclosure, because nothing is left to be below. An explicit
+instruction from Evan still overrides, since that is an attributable human
+decision rather than the branch deciding for itself. GitHub labels are
+multi-select and nothing stops an
 issue carrying two, so resolution is **per stage, taking the highest cap
 present**: a conflict can then only ever buy more review, never less, and no
 ranking of the tier names has to be agreed on anywhere. Because that is per

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,22 @@ Creating the draft is a phase transition, not a terminal state, and every stop
 short of the readiness gate leaves the PR **draft** with a blocker report — a
 non-draft PR must always mean the automated work is done.
 
+**Round caps are resolved, not stated here.** The challenge, review, and
+shepherd stages below are each capped, but this file names no numbers: they
+live in [`.devflow.toml`](.devflow.toml) as `rigor` tiers, so there is one
+place to change them and a parity gate that catches a change made on only one
+side. Resolve in this order — an explicit instruction in this session, then a
+`rigor:*` label on the issue, then `default_rigor`, then a built-in 4 / 4 / 4
+if the file is absent. **Announce the resolved triple on entering the loop** —
+"rigor: deep (label) → challenge ≤5, review ≤5, shepherd 4" — and carry it into
+the PR body, so a later round or a different session can see which budget it is
+spending instead of inferring one. Everything else about these stages is
+policy rather than a parameter and does not vary by tier: the exit condition,
+the round-2 scaffolding checkpoint, the escalation rule, and the deferred-P2
+sidecar all hold identically at every rigor. A cap is a ceiling, never a quota
+— a stage that meets its exit condition on round 1 is done, whatever the tier
+allowed.
+
 - **Branch** — feature branch off `main`; never commit directly to `main`. For
   parallel or isolated work, take the branch in its own worktree via
   **`task worktree:new -- <name>`** (and `task worktree:rm -- <name>` when
@@ -275,8 +291,9 @@ non-draft PR must always mean the automated work is done.
   them to the PR (see "Deferring P2s" below). This loop is
   **self-referential** — the fixes you make in response to a round become the
   next round's input, so it can generate its own work indefinitely — and that
-  is what the cap defends against: max **4** challenge → fix → re-challenge
-  rounds; if P0/P1 findings persist, stop and escalate to Evan. A capped
+  is what the cap defends against: the resolved **challenge cap** bounds the
+  challenge → fix → re-challenge rounds; if P0/P1 findings persist at it, stop
+  and escalate to Evan. A capped
   final round that adjudicates to zero P0/P1 ends the stage by itself — its
   confirmation would be a run the cap forbids, and a clean last round is
   convergence, not the persisting disagreement escalation exists for.
@@ -296,8 +313,9 @@ non-draft PR must always mean the automated work is done.
 - **`task review`** — verification-checkpoint review; same adjudication, the
   same two-consecutive-adjudicated-clean exit condition counted over its own
   rounds, the same self-referential shape and so the
-  same reason for a cap, and the same background-and-poll handling, with its
-  own max **4** rounds. The two stages are counted separately: a converged
+  same reason for a cap, and the same background-and-poll handling, under
+  its own resolved **review cap**. The two stages are counted separately — and
+  capped separately, even where the tier gives them equal numbers: a converged
   challenge says nothing about review.
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the draft PR** — conventional commit, push the branch,
@@ -317,7 +335,8 @@ non-draft PR must always mean the automated work is done.
   `git -c credential.helper= -c credential.helper='!gh auth git-credential' -c url."https://github.com/".insteadOf="git@github.com:" -c url."https://github.com/".insteadOf="ssh://git@github.com/" -c url."https://github.com/".insteadOf="ssh://git@ssh.github.com:443/" -c url."https://github.com/".insteadOf="ssh://git@ssh.github.com/" push`
   (a credential helper only applies to HTTPS, and `insteadOf` is prefix
   matching — every SSH form needs its own mapping, hence all four).
-- **Shepherd the draft to ready for review (`/shepherd`, max 4 rounds).**
+- **Shepherd the draft to ready for review (`/shepherd`, under the resolved
+  shepherd cap).**
   `gh pr create --draft` returning is
   the trigger for this stage, not the end of the work — enter it deliberately
   instead of judging for yourself when the PR is finished. The PR stays draft
@@ -425,8 +444,10 @@ non-draft PR must always mean the automated work is done.
   resolve halts the whole change rather than one loop, so it is not a licence
   to move on to the next stage either — a persistent P0/P1 at the challenge or
   review cap means wait for Evan, not open the PR anyway.
-  If checks still fail or findings remain after 4 rounds, stop and
-  summarize what's unresolved on the PR for Evan.
+  If checks still fail or findings remain at the shepherd cap, stop and
+  summarize what's unresolved on the PR for Evan. That cap does not vary by
+  rigor tier — it bounds other people's findings, not your own work, so
+  lowering it would abandon unanswered reviews rather than save effort.
   Where a **vendored** skill (`/shepherd`)
   states a different cap or exit condition, **this file wins** — the skills
   are synced from harmon-devkit on its own release cadence and can lag a
@@ -719,8 +740,9 @@ practice could spend every remaining round re-proving a change nobody still
 disputed. Two things ride along with the exit: every P2
 deferred during the stage must already be recorded in the sidecar (an exit
 that drops a P2 is not an exit), and round 2 owes the scaffolding checkpoint
-above. The caps are unchanged at **4** challenge iterations and **4** review
-iterations (challenge → fix → re-challenge, and likewise for review); if
+above. Each stage's cap is the one resolved from `.devflow.toml` per "Round
+caps are resolved, not stated here" in the Dev Loop above (challenge → fix →
+re-challenge, and likewise for review), counted separately per stage; if
 P0/P1 disagreement persists at the cap, stop and surface it to Evan instead
 of iterating further — escalation at the cap is for P0/P1 that **persist**,
 nothing else. Evan may always ask for more rounds — convergence is a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,14 +252,18 @@ side. Resolve in this order — an explicit instruction in this session, then a
 if the file is absent. GitHub labels are multi-select and nothing stops an
 issue carrying two, so resolution is **per stage, taking the highest cap
 present**: a conflict can then only ever buy more review, never less, and no
-ranking of the tier names has to be agreed on anywhere. A `rigor:` value that
-names no tier in the file is ignored rather than guessed at. Treat the label as
-advisory input carrying exactly the authority of repo write access — anyone who
-can label an issue can retune its budget, the same way anyone who can push can
-edit `.devflow.toml`. An agent never applies one to itself, and **says so in
-the announcement and in the PR body whenever the resolved tier is below
-`default_rigor`**, so a reduced budget is visible to the human reviewer instead
-of silent. **Announce the resolved triple on entering
+ranking of the tier names has to be agreed on anywhere. Because that is per
+stage, two retuned tiers can yield caps belonging to no single tier — so what
+you announce is the **caps**, naming a tier only when one supplied all of them,
+and the disclosure below compares caps rather than tier names. A `rigor:` value
+that names no tier in the file is ignored rather than guessed at. Treat the
+label as advisory: it is applied by people and verified by nothing, and
+GitHub's **triage** role can label an issue with no push access at all — so a
+budget can be retuned by someone who could not edit `.devflow.toml`. An agent
+never applies one to itself, and **says so in the announcement and in the PR
+body whenever any resolved cap is below what `default_rigor` would give**, so a
+reduced budget is visible to the human reviewer instead of silent.
+**Announce the resolved caps on entering
 the loop** — "rigor: `<tier>` (`<source>`) → challenge ≤`<n>`, review ≤`<n>`,
 shepherd `<n>`", filled in by reading the file rather than from memory — and
 carry it into the PR body, so a later round or a different session can see

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -96,6 +96,7 @@ tasks:
       - task: test:tag-hygiene
       - task: test:dogfood-parity
       - task: test:dogfood-structure
+      - task: test:devflow-config
       - task: test:starship-glyphs
       - task: test:template-independence
       - task: test:category-gates
@@ -365,6 +366,11 @@ tasks:
     desc: Unit-test the fail-closed CI aggregate result helper
     cmds:
       - ./scripts/test-ci-results.sh
+
+  test:devflow-config:
+    desc: Validate the Dev Loop round-cap tiers in .devflow.toml (both copies)
+    cmds:
+      - ./scripts/test-devflow-config.sh
 
   test:status:
     desc: Unit-test the status board-writes + local-credential checks (stubbed CLIs, no network)

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -249,12 +249,12 @@ gate that ends them — is defined in AGENTS.md ("Dev Loop"). The PR is a
 is the one signal that the automated work is finished.
 
 The caps are not written down here, or in AGENTS.md. They live in
-[`.devflow.toml`](../../.devflow.toml) as `rigor` tiers — `light`, `standard`,
-`deep` — and are resolved per change: an explicit instruction in the session,
-else a `rigor:*` label on the issue, else `default_rigor`. Only `challenge` and
-`review` vary by tier; the shepherd cap is fixed, because it bounds other
-people's findings rather than self-generated work. Announce the resolved
-triple when you enter the loop.
+[`.devflow.toml`](../../.devflow.toml) as `rigor` tiers, and **AGENTS.md alone
+defines how a change resolves one** — restating that chain here would only give
+it a second place to drift from, and which inputs are even available depends on
+how the repository is set up. Only `challenge` and `review` vary by tier; the
+shepherd cap is fixed, because it bounds other people's findings rather than
+self-generated work. Announce the resolved caps when you enter the loop.
 
 If Codex cloud review is connected to the repo, PRs
 get a cloud pass too: inline comments only for high-priority findings, a

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -231,11 +231,14 @@ task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
                 # until TWO CONSECUTIVE rounds adjudicate to zero P0/P1
-                # (any round with no findings at all ends it), ≤4 rounds
-task review     # verification checkpoint — same convergence rule, ≤4 rounds
+                # (any round with no findings at all ends it), under the
+                # challenge cap resolved from .devflow.toml
+task review     # verification checkpoint — same convergence rule, under its
+                # own resolved review cap
 task ci         # full CI mirror
 # → open a DRAFT PR, then shepherd it: watch CI + reviews, settle the deferred
-#   P2s, adjudicate → fix → push, ≤4 rounds (independent of the loops above)
+#   P2s, adjudicate → fix → push, under the shepherd cap (independent of the
+#   loops above)
 # → readiness gate passes → gh pr ready (the handoff to a human)
 # → merging stays a human decision
 ```
@@ -244,6 +247,14 @@ The full staged loop — including the PR-shepherding rounds and the readiness
 gate that ends them — is defined in AGENTS.md ("Dev Loop"). The PR is a
 **draft** for every stage above: it is the agent's workbench, and promoting it
 is the one signal that the automated work is finished.
+
+The caps are not written down here, or in AGENTS.md. They live in
+[`.devflow.toml`](../../.devflow.toml) as `rigor` tiers — `light`, `standard`,
+`deep` — and are resolved per change: an explicit instruction in the session,
+else a `rigor:*` label on the issue, else `default_rigor`. Only `challenge` and
+`review` vary by tier; the shepherd cap is fixed, because it bounds other
+people's findings rather than self-generated work. Announce the resolved
+triple when you enter the loop.
 
 If Codex cloud review is connected to the repo, PRs
 get a cloud pass too: inline comments only for high-priority findings, a
@@ -292,7 +303,8 @@ left to re-raise and counts toward convergence. Reflexively hardening the
 previous round's fix is the failure mode; naming it on the table is the
 check.
 
-Two things do not move. The **4-round cap** per stage stands, and persistent
+Two things do not move. The **per-stage cap** stands — whatever rigor tier
+resolved it — and persistent
 P0/P1 disagreement at the cap is escalated rather than iterated on. And the
 deferred-P2 chain is a **precondition** of the exit, not a casualty of it:
 every P2 open at convergence must already be in the sidecar below, so

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -413,6 +413,12 @@ families, color-coded by family; the starter set is created by
 - **Layer** — `layer:ui`, `layer:logic`, `layer:data`, `layer:integration`
 - **Domain** — start with `domain:auth`, `domain:billing`, `domain:platform`;
   grow from your ERD entities
+- **Rigor** — `rigor:light`, `rigor:standard`, `rigor:deep`: which round-cap
+  tier in [`.devflow.toml`](../.devflow.toml) an agent works the issue under
+  (AGENTS.md, "Round caps are resolved, not stated here"). A human input an
+  agent reads and never self-applies — lowering rigor weakens a safety gate,
+  so it needs an attributable actor, which is also why it is a label and not a
+  project field. Two present resolves fail-safe: the deepest wins.
 
 Two more families name **model intelligence** rather than a facet of the work,
 and their vocabulary is not hand-listed anywhere: it is rendered from
@@ -525,6 +531,7 @@ it creates it on demand, and provisioning deliberately leaves it alone.
 | `needs-triage`, `needs-requirements`, `blocked`, `waiting`, `needs-decision`, `needs-response`, `needs-communication` | humans, at triage | humans, the Triage view | provisioned; inert | transient — removed as soon as the state clears |
 | `layer:{ui,logic,data,integration}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; mirrors the `Layer` field, with no sync between them |
 | `domain:{auth,billing,platform,…}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; mirrors the `Domain` field, with no sync between them |
+| `rigor:{light,standard,deep}` | humans, at triage — **never an agent on itself** | agents, when entering the Dev Loop | provisioned; **read by agents** — selects a round-cap tier, arms nothing | set when the default budget is wrong for the change; survives the work |
 | `suggest:<family>` | humans, at planning | humans, the Agent queue view | provisioned from the registry (family level only); advisory — arms nothing | set at planning; survives the work and is never rewritten by a claim |
 | `suggest:<family>:<model>` | humans | humans | **tool-owned, created on demand** — seeding every model would be an unbounded roster | refines the family label; apply both |
 | `claim:<family>` | the agent itself — a vendored claim skill, or a Claude Actions run | humans; the Claude Actions claim gate; `claim-release.yml` | provisioned from the registry; a **gate**, never a trigger | added at claim, removed at release — by the workflow's `always()` step, or by `claim-release.yml` on close |

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -416,11 +416,12 @@ families, color-coded by family; the starter set is created by
 - **Rigor** — `rigor:light`, `rigor:standard`, `rigor:deep`: which round-cap
   tier in [`.devflow.toml`](../.devflow.toml) an agent works the issue under
   (AGENTS.md, "Round caps are resolved, not stated here"). An agent reads it
-  and never self-applies one. Its authority is exactly repo write access, so
-  it is advisory rather than an authenticated gate — AGENTS.md requires a tier
-  below `default_rigor` to be stated in the PR body, keeping a reduced budget
-  visible to the reviewer. Two present resolve per stage to the highest cap,
-  so a conflict can only ever buy more review.
+  and never self-applies one. It is advisory rather than an authenticated
+  gate: nothing verifies who applied it, and the **triage** role can label an
+  issue with no push access — so AGENTS.md requires any cap resolving below
+  `default_rigor` to be stated in the PR body, keeping a reduced budget visible
+  to the reviewer. Two present resolve per stage to the highest cap, so a
+  conflict can only ever buy more review.
 
 Two more families name **model intelligence** rather than a facet of the work,
 and their vocabulary is not hand-listed anywhere: it is rendered from

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -415,10 +415,12 @@ families, color-coded by family; the starter set is created by
   grow from your ERD entities
 - **Rigor** — `rigor:light`, `rigor:standard`, `rigor:deep`: which round-cap
   tier in [`.devflow.toml`](../.devflow.toml) an agent works the issue under
-  (AGENTS.md, "Round caps are resolved, not stated here"). A human input an
-  agent reads and never self-applies — lowering rigor weakens a safety gate,
-  so it needs an attributable actor, which is also why it is a label and not a
-  project field. Two present resolves fail-safe: the deepest wins.
+  (AGENTS.md, "Round caps are resolved, not stated here"). An agent reads it
+  and never self-applies one. Its authority is exactly repo write access, so
+  it is advisory rather than an authenticated gate — AGENTS.md requires a tier
+  below `default_rigor` to be stated in the PR body, keeping a reduced budget
+  visible to the reviewer. Two present resolve per stage to the highest cap,
+  so a conflict can only ever buy more review.
 
 Two more families name **model intelligence** rather than a facet of the work,
 and their vocabulary is not hand-listed anywhere: it is rendered from

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -87,7 +87,19 @@ layer:integration|1D76DB|External boundary: webhooks, API clients, credentials
 domain:auth|FBCA04|Authentication and authorization
 domain:billing|FBCA04|Billing and payments
 domain:platform|FBCA04|CI, build, test infra, and tooling in this repo
+rigor:light|D4C5F9|Dev Loop caps: trivial, low-blast-radius change
+rigor:standard|D4C5F9|Dev Loop caps: the default budget
+rigor:deep|D4C5F9|Dev Loop caps: security, migrations, irreversible paths
 "
+
+# The `rigor:*` family selects which round-cap tier in `.devflow.toml` an agent
+# works an issue under (AGENTS.md, "Round caps are resolved, not stated here").
+# It is a human input, like the foreman arming labels: an agent READS it and
+# never applies one to itself, because lowering rigor weakens a safety gate and
+# so needs an attributable actor. That is also why it is a label rather than a
+# project field — GitHub exposes no actor for a field change (ADR 0002 D-arming).
+# Labels are multi-select and nothing stops two being applied, so AGENTS.md
+# resolves a conflict fail-safe: the DEEPEST tier present wins.
 
 # The model-centric agent vocabulary — `suggest:<family>` (advisory routing) and
 # `claim:<family>` (live ownership) — is rendered from the machine-readable agent

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -94,11 +94,12 @@ rigor:deep|D4C5F9|Dev Loop caps: security, migrations, irreversible paths
 
 # The `rigor:*` family selects which round-cap tier in `.devflow.toml` an agent
 # works an issue under (AGENTS.md, "Round caps are resolved, not stated here").
-# It is an input an agent READS and never applies to itself. Its authority is
-# exactly repo write access — anyone who can label an issue can retune its
-# budget — so it is advisory, not an authenticated gate; AGENTS.md requires a
-# resolved tier below `default_rigor` to be stated in the PR body, which keeps
-# a reduced budget visible to the human reviewer.
+# It is an input an agent READS and never applies to itself. It is advisory,
+# not an authenticated gate: nothing verifies who applied it, and GitHub's
+# triage role can label an issue with no push access at all — so a budget can
+# be retuned by someone who could not edit `.devflow.toml`. AGENTS.md requires
+# any cap resolving below `default_rigor` to be stated in the PR body, which
+# keeps a reduced budget visible to the human reviewer.
 # Labels are multi-select and nothing stops two being applied, so AGENTS.md
 # resolves per stage by taking the HIGHEST cap present: a conflict can only
 # ever buy more review, never less, and no ranking of tier names is needed.

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -94,12 +94,14 @@ rigor:deep|D4C5F9|Dev Loop caps: security, migrations, irreversible paths
 
 # The `rigor:*` family selects which round-cap tier in `.devflow.toml` an agent
 # works an issue under (AGENTS.md, "Round caps are resolved, not stated here").
-# It is a human input, like the foreman arming labels: an agent READS it and
-# never applies one to itself, because lowering rigor weakens a safety gate and
-# so needs an attributable actor. That is also why it is a label rather than a
-# project field — GitHub exposes no actor for a field change (ADR 0002 D-arming).
+# It is an input an agent READS and never applies to itself. Its authority is
+# exactly repo write access — anyone who can label an issue can retune its
+# budget — so it is advisory, not an authenticated gate; AGENTS.md requires a
+# resolved tier below `default_rigor` to be stated in the PR body, which keeps
+# a reduced budget visible to the human reviewer.
 # Labels are multi-select and nothing stops two being applied, so AGENTS.md
-# resolves a conflict fail-safe: the DEEPEST tier present wins.
+# resolves per stage by taking the HIGHEST cap present: a conflict can only
+# ever buy more review, never less, and no ranking of tier names is needed.
 
 # The model-centric agent vocabulary — `suggest:<family>` (advisory routing) and
 # `claim:<family>` (live ownership) — is rendered from the machine-readable agent

--- a/scripts/test-devflow-config.sh
+++ b/scripts/test-devflow-config.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# test-devflow-config.sh — validate the Dev Loop round-cap config.
+#
+# `.devflow.toml` is the single source of the challenge/review/shepherd caps
+# (AGENTS.md, "Round caps are resolved, not stated here"). Nothing at runtime
+# parses it — an agent reads it — so a typo has no natural failure mode: it
+# would simply make cap resolution undefined while every other gate stays
+# green. test:dogfood-parity only proves the root and template copies are
+# byte-identical, which two identically-broken files also satisfy.
+#
+# This checks the invariants the prose promises, on BOTH copies, plus the one
+# cross-file invariant that byte-equality cannot see: every tier must have a
+# provisioned `rigor:<tier>` label, or the documented label resolution path
+# names something GitHub cannot apply.
+#
+# Root-only by design (no template twin): it guards what harmon-init SHIPS.
+# A consumer retuning their own tiers is editing their policy, the same way
+# they may edit their AGENTS.md, and owes no gate here.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+LABELS_SCRIPT="scripts/setup-github-labels.sh"
+
+for f in .devflow.toml template/.devflow.toml; do
+    [ -f "$f" ] || {
+        echo "FAIL: missing ${f}" >&2
+        exit 1
+    }
+done
+
+python3 - "$LABELS_SCRIPT" .devflow.toml template/.devflow.toml <<'PY'
+import re
+import sys
+import tomllib
+
+labels_script, *config_paths = sys.argv[1:]
+STAGES = ("challenge", "review", "shepherd")
+# The floor is 2, not 1: a stage exits on two consecutive adjudicated-clean
+# rounds, so a cap of 1 makes any single finding an instant escalation.
+FLOOR = {"challenge": 2, "review": 2, "shepherd": 1}
+
+provisioned = set(re.findall(r"^rigor:([A-Za-z0-9_-]+)\|", open(labels_script).read(), re.M))
+
+failures = []
+
+for path in config_paths:
+    with open(path, "rb") as fh:
+        try:
+            cfg = tomllib.load(fh)
+        except tomllib.TOMLDecodeError as exc:
+            failures.append(f"{path}: not valid TOML — {exc}")
+            continue
+
+    tiers = cfg.get("rigor")
+    if not isinstance(tiers, dict) or not tiers:
+        failures.append(f"{path}: no [rigor.*] tiers defined")
+        continue
+
+    default = cfg.get("default_rigor")
+    if not isinstance(default, str):
+        failures.append(f"{path}: default_rigor is missing or not a string")
+    elif default not in tiers:
+        failures.append(
+            f"{path}: default_rigor={default!r} names no tier "
+            f"(have: {', '.join(sorted(tiers))})"
+        )
+
+    shepherd_values = set()
+    for name, caps in sorted(tiers.items()):
+        if not isinstance(caps, dict):
+            failures.append(f"{path}: [rigor.{name}] is not a table")
+            continue
+        missing = [s for s in STAGES if s not in caps]
+        if missing:
+            failures.append(f"{path}: [rigor.{name}] missing {', '.join(missing)}")
+        extra = [k for k in caps if k not in STAGES]
+        if extra:
+            failures.append(f"{path}: [rigor.{name}] has unknown key(s) {', '.join(extra)}")
+        for stage in STAGES:
+            value = caps.get(stage)
+            if value is None:
+                continue
+            # bool is an int subclass in Python; `challenge = true` must fail.
+            if not isinstance(value, int) or isinstance(value, bool):
+                failures.append(f"{path}: rigor.{name}.{stage}={value!r} is not an integer")
+            elif value < FLOOR[stage]:
+                failures.append(
+                    f"{path}: rigor.{name}.{stage}={value} is below the floor of {FLOOR[stage]}"
+                )
+        if isinstance(caps.get("shepherd"), int) and not isinstance(caps.get("shepherd"), bool):
+            shepherd_values.add(caps["shepherd"])
+
+        if name not in provisioned:
+            failures.append(
+                f"{path}: tier {name!r} has no rigor:{name} label in {labels_script} — "
+                "the documented label resolution path cannot select it"
+            )
+
+    # shepherd bounds other people's findings, not self-generated work, so it
+    # is fixed across tiers by design (AGENTS.md). Catch a tier-varying edit.
+    if len(shepherd_values) > 1:
+        failures.append(
+            f"{path}: shepherd varies by tier ({sorted(shepherd_values)}) — it is "
+            "fixed by design; lowering it abandons unanswered reviews"
+        )
+
+if failures:
+    for line in failures:
+        print(f"FAIL: {line}", file=sys.stderr)
+    sys.exit(1)
+
+with open(config_paths[0], "rb") as fh:
+    cfg = tomllib.load(fh)
+tiers = cfg["rigor"]
+summary = "; ".join(
+    f"{n}={t['challenge']}/{t['review']}/{t['shepherd']}" for n, t in sorted(tiers.items())
+)
+print(f"devflow config OK: default={cfg['default_rigor']} — {summary}")
+print("  (challenge/review/shepherd; both copies valid, every tier has a rigor:* label)")
+PY

--- a/scripts/test-devflow-config.sh
+++ b/scripts/test-devflow-config.sh
@@ -20,6 +20,12 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 LABELS_SCRIPT="scripts/setup-github-labels.sh"
+# The fallback applies when .devflow.toml is ABSENT, so it cannot live in that
+# file — it has to be stated in the policy, on both sides of the dogfood. That
+# is two prose copies no other gate compares: test:dogfood-structure comes
+# closest and deliberately checks headings and tasks, not paragraph bodies.
+AGENTS_ROOT="AGENTS.md"
+AGENTS_TEMPLATE="template/AGENTS.md.jinja"
 
 for f in .devflow.toml template/.devflow.toml; do
     [ -f "$f" ] || {
@@ -28,12 +34,13 @@ for f in .devflow.toml template/.devflow.toml; do
     }
 done
 
-python3 - "$LABELS_SCRIPT" .devflow.toml template/.devflow.toml <<'PY'
+python3 - "$LABELS_SCRIPT" "$AGENTS_ROOT" "$AGENTS_TEMPLATE" \
+    .devflow.toml template/.devflow.toml <<'PY'
 import re
 import sys
 import tomllib
 
-labels_script, *config_paths = sys.argv[1:]
+labels_script, agents_root, agents_template, *config_paths = sys.argv[1:]
 STAGES = ("challenge", "review", "shepherd")
 # The floor is 2, not 1: a stage exits on two consecutive adjudicated-clean
 # rounds, so a cap of 1 makes any single finding an instant escalation.
@@ -103,6 +110,24 @@ for path in config_paths:
             f"{path}: shepherd varies by tier ({sorted(shepherd_values)}) — it is "
             "fixed by design; lowering it abandons unanswered reviews"
         )
+
+FALLBACK_RE = re.compile(r"built-in (\d+ / \d+ / \d+)")
+fallbacks = {}
+for path in (agents_root, agents_template):
+    found = set(FALLBACK_RE.findall(open(path).read()))
+    if len(found) != 1:
+        failures.append(
+            f"{path}: expected exactly one 'built-in N / N / N' fallback, found "
+            f"{sorted(found) if found else 'none'} — the resolution rule needs it"
+        )
+    else:
+        fallbacks[path] = found.pop()
+if len(set(fallbacks.values())) > 1:
+    failures.append(
+        "the fallback caps disagree across the dogfood: "
+        + "; ".join(f"{p} says {v}" for p, v in sorted(fallbacks.items()))
+        + " — root and generated agents would use different caps"
+    )
 
 if failures:
     for line in failures:

--- a/template/.devflow.toml
+++ b/template/.devflow.toml
@@ -1,0 +1,54 @@
+# .devflow.toml — round caps for the Dev Loop stages defined in AGENTS.md.
+#
+# The numbers live here rather than in prose because prose cannot be checked.
+# This file has a byte-identical twin at template/.devflow.toml, so
+# `task test:dogfood-parity` fails if only one side is edited — the caps are
+# now mechanically protected in a way eight scattered paragraphs never were.
+#
+# Resolution order (AGENTS.md states this rule; only this file states numbers):
+#
+#   explicit instruction in the session
+#     > a rigor:* label on the issue
+#       > default_rigor below
+#         > 4 / 4 / 4 if this file is absent
+#
+# Announce the resolved triple on entering the Dev Loop — "rigor: deep (label)
+# -> challenge <=5, review <=5, shepherd 4" — and carry it into the PR body, so
+# the choice is auditable rather than recalled.
+#
+# These are ceilings, not quotas. A stage exits the moment its exit condition
+# in AGENTS.md is met: two consecutive rounds adjudicated to zero P0/P1, or any
+# single round with no findings at all. Nothing here obliges a round to be run.
+#
+# `challenge` and `review` are inert wherever no second-model reviewer is
+# configured (`use_codex_review = false`): those stages never run, so their
+# caps have nothing to bound. `shepherd` always applies.
+
+default_rigor = "standard"
+
+# `shepherd` is deliberately 4 in every tier, and is not a knob to turn down.
+#
+# `challenge` and `review` bound work the agent generates itself — each round's
+# fixes are the next round's input — which is exactly what makes capping them
+# low safe. `shepherd` bounds *other people's* findings: CI failures, human
+# review, Codex. Lowering it does not reduce effort spent; it abandons reviews
+# that are already unanswered, and the readiness gate then refuses to promote
+# the PR anyway. The key is present so that a tier is one consistent shape.
+
+# Trivial, low-blast-radius work: doc touch-ups, mechanical bumps, typo fixes.
+[rigor.light]
+challenge = 2 # 2 is the floor, never 1: the exit condition needs two
+review    = 2 # consecutive adjudicated-clean rounds, so a cap of 1 turns any
+shepherd  = 4 # single finding into an immediate escalation.
+
+# The default for ordinary changes.
+[rigor.standard]
+challenge = 3
+review    = 3
+shepherd  = 4
+
+# Security, migrations, data paths — anything with an irreversible failure mode.
+[rigor.deep]
+challenge = 5
+review    = 5
+shepherd  = 4

--- a/template/.devflow.toml
+++ b/template/.devflow.toml
@@ -1,28 +1,38 @@
 # .devflow.toml — round caps for the Dev Loop stages defined in AGENTS.md.
 #
-# The numbers live here rather than in prose because prose cannot be checked.
-# This file has a byte-identical twin at template/.devflow.toml, so
-# `task test:dogfood-parity` fails if only one side is edited — the caps are
-# now mechanically protected in a way eight scattered paragraphs never were.
+# The numbers live here rather than in prose so that there is exactly one place
+# to change them and one place to read them.
 #
-# Resolution order (AGENTS.md states this rule; only this file states numbers):
+# Resolution order (AGENTS.md states the rule; only this file states numbers):
 #
 #   explicit instruction in the session
-#     > a rigor:* label on the issue
+#     > a rigor:* label on the issue, where the repo provisions them
 #       > default_rigor below
 #         > 4 / 4 / 4 if this file is absent
 #
-# Announce the resolved triple on entering the Dev Loop — "rigor: deep (label)
-# -> challenge <=5, review <=5, shepherd 4" — and carry it into the PR body, so
-# the choice is auditable rather than recalled.
+# Announce the resolved caps on entering the Dev Loop and carry them into the
+# PR body, so the budget a change was reviewed under is on the record rather
+# than recalled.
+#
+# When the change under review edits THIS FILE, resolve its caps from the
+# merge-base copy rather than the branch copy — otherwise a branch can lower
+# the very gate it is changing. An explicit human instruction still overrides.
 #
 # These are ceilings, not quotas. A stage exits the moment its exit condition
 # in AGENTS.md is met: two consecutive rounds adjudicated to zero P0/P1, or any
 # single round with no findings at all. Nothing here obliges a round to be run.
 #
+# Retuning these is expected. The Dev Loop assumes four invariants, and nothing
+# at runtime will tell you if an edit breaks one:
+#   - every tier defines challenge, review and shepherd, all integers
+#   - challenge and review are >= 2, because the exit condition needs two
+#     consecutive adjudicated-clean rounds; at 1, one finding is an escalation
+#   - shepherd is the same in every tier (see below)
+#   - default_rigor names a tier that exists here
+#
 # `challenge` and `review` are inert wherever no second-model reviewer is
-# configured (`use_codex_review = false`): those stages never run, so their
-# caps have nothing to bound. `shepherd` always applies.
+# configured: those stages never run, so their caps bound nothing. `shepherd`
+# always applies.
 
 default_rigor = "standard"
 

--- a/template/.devflow.toml
+++ b/template/.devflow.toml
@@ -8,7 +8,7 @@
 #   explicit instruction in the session
 #     > a rigor:* label on the issue, where the repo provisions them
 #       > default_rigor below
-#         > 4 / 4 / 4 if this file is absent
+#         > the built-in fallback stated in AGENTS.md, if this file is absent
 #
 # Announce the resolved caps on entering the Dev Loop and carry them into the
 # PR body, so the budget a change was reviewed under is on the record rather

--- a/template/.devflow.toml
+++ b/template/.devflow.toml
@@ -18,9 +18,12 @@
 # merge-base copy rather than the branch copy — otherwise a branch can lower
 # the very gate it is changing. An explicit human instruction still overrides.
 #
-# These are ceilings, not quotas. A stage exits the moment its exit condition
-# in AGENTS.md is met: two consecutive rounds adjudicated to zero P0/P1, or any
-# single round with no findings at all. Nothing here obliges a round to be run.
+# These are ceilings, not quotas. A stage exits the moment any of its exit
+# conditions in AGENTS.md is met: two consecutive rounds adjudicated to zero
+# P0/P1, any single round with no findings at all, or a round that hits the cap
+# below having adjudicated to zero P0/P1 — the confirming round it would
+# otherwise owe is one the cap forbids, so a clean last round is convergence,
+# not grounds to escalate. Nothing here obliges a round to be run.
 #
 # Retuning these is expected. The Dev Loop assumes four invariants, and nothing
 # at runtime will tell you if an edit breaks one:

--- a/template/.devflow.toml
+++ b/template/.devflow.toml
@@ -26,7 +26,8 @@
 
 default_rigor = "standard"
 
-# `shepherd` is deliberately 4 in every tier, and is not a knob to turn down.
+# `shepherd` is deliberately identical in every tier, and is not a knob to
+# turn down.
 #
 # `challenge` and `review` bound work the agent generates itself — each round's
 # fixes are the next round's input — which is exactly what makes capping them

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -141,15 +141,23 @@ capped, but this file names no numbers: the caps live in
 [`.devflow.toml`](.devflow.toml) as `rigor` tiers, so there is one place to
 change them and one place to read them. Resolve in this order — an explicit
 instruction in this session, then a `rigor:*` label on the issue, then
-`default_rigor`, then a built-in 4 / 4 / 4 if the file is absent. **Announce
-the resolved triple on entering the loop** — "rigor: deep (label) → [% if use_codex_review %]challenge
-≤5, review ≤5, [% endif %]shepherd 4" — and carry it into the PR body, so a later round or
-a different session can see which budget it is spending instead of inferring
-one. Everything else about these stages is policy rather than a parameter and
-does not vary by tier: the exit condition, the round-2 scaffolding checkpoint,
-the escalation rule, and the deferred-P2 sidecar all hold identically at every
-rigor. A cap is a ceiling, never a quota — a stage that meets its exit
-condition on round 1 is done, whatever the tier allowed.
+`default_rigor`, then a built-in 4 / 4 / 4 if the file is absent. GitHub labels
+are multi-select and nothing stops an issue carrying two, so resolve a conflict
+fail-safe: **the deepest tier present wins**, which errs toward more review
+rather than less, and a `rigor:` value that names no tier in the file is
+ignored rather than guessed at. An agent never applies one of these labels to
+itself — lowering rigor weakens a safety gate, so it takes an attributable
+human actor, which is also why the tier rides a label rather than a project
+field. **Announce the resolved triple on entering the loop** — "rigor:
+`<tier>` (`<source>`) → [% if use_codex_review %]challenge ≤`<n>`, review ≤`<n>`, [% endif %]shepherd `<n>`", filled in
+by reading the file rather than from memory — and carry it into the PR body, so
+a later round or a different session can see which budget it is spending
+instead of inferring one. Everything else about these stages is policy rather
+than a parameter and does not vary by tier: the exit condition, the escalation
+rule, [% if use_codex_review %]the round-2 scaffolding checkpoint, the deferred-P2 sidecar, [% endif %]and the
+readiness gate all hold identically at every rigor. A cap is a ceiling, never a
+quota — a stage that meets its exit condition on round 1 is done, whatever the
+tier allowed.
 
 - **Branch** — feature branch off `main`; never commit directly to `main`. For
   parallel or isolated work, take the branch in its own worktree via

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -141,7 +141,12 @@ capped, but this file names no numbers: the caps live in
 [`.devflow.toml`](.devflow.toml) as `rigor` tiers, so there is one place to
 change them and one place to read them. Resolve in this order — an explicit
 instruction in this session, then [% if project_management == 'github' or use_foreman %]a `rigor:*` label on the issue, then [% endif %]`default_rigor`,
-then a built-in 4 / 4 / 4 if the file is absent.
+then a built-in 4 / 4 / 4 if the file is absent. When the change under review
+**edits `.devflow.toml` itself**, resolve its caps from the **merge-base** copy
+rather than the branch copy: otherwise a branch can lower the very gate it is
+changing, and dropping every tier together evades the below-default disclosure
+because nothing is left to be below. An explicit human instruction still
+overrides.
 [% if project_management == 'github' or use_foreman %]Labels are multi-select and nothing stops an issue carrying two, so resolution
 is **per stage, taking the highest cap present**: a conflict can then only ever
 buy more review, never less, and no ranking of the tier names has to be agreed

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -136,6 +136,21 @@ private repositories to paid plans (docs/CHECKLIST.md). If `gh pr create
 --draft` is rejected, stop and report it — dropping `--draft` to get past the
 error silently reverts the lifecycle rather than fixing anything.
 
+**Round caps are resolved, not stated here.** The stages below are each
+capped, but this file names no numbers: the caps live in
+[`.devflow.toml`](.devflow.toml) as `rigor` tiers, so there is one place to
+change them and one place to read them. Resolve in this order — an explicit
+instruction in this session, then a `rigor:*` label on the issue, then
+`default_rigor`, then a built-in 4 / 4 / 4 if the file is absent. **Announce
+the resolved triple on entering the loop** — "rigor: deep (label) → [% if use_codex_review %]challenge
+≤5, review ≤5, [% endif %]shepherd 4" — and carry it into the PR body, so a later round or
+a different session can see which budget it is spending instead of inferring
+one. Everything else about these stages is policy rather than a parameter and
+does not vary by tier: the exit condition, the round-2 scaffolding checkpoint,
+the escalation rule, and the deferred-P2 sidecar all hold identically at every
+rigor. A cap is a ceiling, never a quota — a stage that meets its exit
+condition on round 1 is done, whatever the tier allowed.
+
 - **Branch** — feature branch off `main`; never commit directly to `main`. For
   parallel or isolated work, take the branch in its own worktree via
   **`task worktree:new -- <name>`** (and `task worktree:rm -- <name>` when
@@ -168,8 +183,9 @@ error silently reverts the lifecycle rather than fixing anything.
   them to the PR (see "Deferring P2s" below). This loop is
   **self-referential** — the fixes you make in response to a round become the
   next round's input, so it can generate its own work indefinitely — and that
-  is what the cap defends against: max **4** challenge → fix → re-challenge
-  rounds; if P0/P1 findings persist, stop and escalate to the maintainer. A
+  is what the cap defends against: the resolved **challenge cap** bounds the
+  challenge → fix → re-challenge rounds; if P0/P1 findings persist at it, stop
+  and escalate to the maintainer. A
   capped final round that adjudicates to zero P0/P1 ends the stage by itself — its
   confirmation would be a run the cap forbids, and a clean last round is
   convergence, not the persisting disagreement escalation exists for.
@@ -189,8 +205,9 @@ error silently reverts the lifecycle rather than fixing anything.
 - **`task review`** — verification-checkpoint review; same adjudication, the
   same two-consecutive-adjudicated-clean exit condition counted over its own
   rounds, the same self-referential shape and so the
-  same reason for a cap, and the same background-and-poll handling, with its
-  own max **4** rounds. The two stages are counted separately: a converged
+  same reason for a cap, and the same background-and-poll handling, under
+  its own resolved **review cap**. The two stages are counted separately — and
+  capped separately, even where the tier gives them equal numbers: a converged
   challenge says nothing about review.
 [% endif %]
 - **`task ci`** — the full CI mirror; fix anything it catches.
@@ -210,7 +227,8 @@ error silently reverts the lifecycle rather than fixing anything.
   `git -c credential.helper= -c credential.helper='!gh auth git-credential' -c url."https://github.com/".insteadOf="git@github.com:" -c url."https://github.com/".insteadOf="ssh://git@github.com/" -c url."https://github.com/".insteadOf="ssh://git@ssh.github.com:443/" -c url."https://github.com/".insteadOf="ssh://git@ssh.github.com/" push`
   (a credential helper only applies to HTTPS, and `insteadOf` is prefix
   matching — every SSH form needs its own mapping, hence all four).
-- **Shepherd the draft to ready for review (`/shepherd`, max 4 rounds).**
+- **Shepherd the draft to ready for review (`/shepherd`, under the resolved
+  shepherd cap).**
   `gh pr create --draft` returning is
   the trigger for this stage, not the end of the work — enter it deliberately
   instead of judging for yourself when the PR is finished. The PR stays draft
@@ -326,8 +344,11 @@ error silently reverts the lifecycle rather than fixing anything.
   resolve halts the whole change rather than one loop, so it is not a licence
   to move on to the next stage either — escalate and wait, do not open the PR
   anyway.
-  If checks still fail or findings remain after 4 rounds,
-  stop and summarize what's unresolved on the PR for the maintainer. Where a
+  If checks still fail or findings remain at the shepherd cap,
+  stop and summarize what's unresolved on the PR for the maintainer. That cap
+  does not vary by rigor tier — it bounds other people's findings, not your
+  own work, so lowering it would abandon unanswered reviews rather than save
+  effort. Where a
   **vendored** skill (`/shepherd`) states a different cap or exit condition,
   **this file wins** — vendored skills are synced on their own release
   cadence and can lag a policy change made here.
@@ -616,8 +637,9 @@ practice could spend every remaining round re-proving a change nobody still
 disputed. Two things ride along with the exit: every P2
 deferred during the stage must already be recorded in the sidecar (an exit
 that drops a P2 is not an exit), and round 2 owes the scaffolding checkpoint
-above. The caps are unchanged at **4** challenge iterations and **4** review
-iterations (challenge → fix → re-challenge, and likewise for review); if
+above. Each stage's cap is the one resolved from `.devflow.toml` per "Round
+caps are resolved, not stated here" in the Dev Loop above (challenge → fix →
+re-challenge, and likewise for review), counted separately per stage; if
 P0/P1 disagreement persists at the cap, stop and surface it to the maintainer
 instead of iterating further — escalation at the cap is for P0/P1 that
 **persist**, nothing else. The maintainer may always ask for more rounds —

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -145,14 +145,18 @@ then a built-in 4 / 4 / 4 if the file is absent.
 [% if project_management == 'github' or use_foreman %]Labels are multi-select and nothing stops an issue carrying two, so resolution
 is **per stage, taking the highest cap present**: a conflict can then only ever
 buy more review, never less, and no ranking of the tier names has to be agreed
-on anywhere. A `rigor:` value naming no tier in the file is ignored rather than
-guessed at. Treat the label as advisory input carrying exactly the authority of
-repo write access — anyone who can label an issue can retune its budget, the
-same way anyone who can push can edit `.devflow.toml`. An agent never applies
-one to itself, and **says so in the announcement and in the PR body whenever
-the resolved tier is below `default_rigor`**, so a reduced budget is visible to
-the human reviewer instead of silent.
-[% endif %]**Announce the resolved triple on entering the loop** — "rigor:
+on anywhere. Because that is per stage, two retuned tiers can yield caps
+belonging to no single tier — so what you announce is the **caps**, naming a
+tier only when one supplied all of them, and the disclosure below compares caps
+rather than tier names. A `rigor:` value naming no tier in the file is ignored
+rather than guessed at. Treat the label as advisory: it is applied by people and
+verified by nothing, and GitHub's **triage** role can label an issue with no
+push access at all — so a budget can be retuned by someone who could not edit
+`.devflow.toml`. An agent never applies one to itself, and **says so in the
+announcement and in the PR body whenever any resolved cap is below what
+`default_rigor` would give**, so a reduced budget is visible to the human
+reviewer instead of silent.
+[% endif %]**Announce the resolved caps on entering the loop** — "rigor:
 `<tier>` (`<source>`) → [% if use_codex_review %]challenge ≤`<n>`, review ≤`<n>`, [% endif %]shepherd `<n>`", filled in
 by reading the file rather than from memory — and carry it into the PR body, so
 a later round or a different session can see which budget it is spending

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -140,15 +140,19 @@ error silently reverts the lifecycle rather than fixing anything.
 capped, but this file names no numbers: the caps live in
 [`.devflow.toml`](.devflow.toml) as `rigor` tiers, so there is one place to
 change them and one place to read them. Resolve in this order — an explicit
-instruction in this session, then a `rigor:*` label on the issue, then
-`default_rigor`, then a built-in 4 / 4 / 4 if the file is absent. GitHub labels
-are multi-select and nothing stops an issue carrying two, so resolve a conflict
-fail-safe: **the deepest tier present wins**, which errs toward more review
-rather than less, and a `rigor:` value that names no tier in the file is
-ignored rather than guessed at. An agent never applies one of these labels to
-itself — lowering rigor weakens a safety gate, so it takes an attributable
-human actor, which is also why the tier rides a label rather than a project
-field. **Announce the resolved triple on entering the loop** — "rigor:
+instruction in this session, then [% if project_management == 'github' or use_foreman %]a `rigor:*` label on the issue, then [% endif %]`default_rigor`,
+then a built-in 4 / 4 / 4 if the file is absent.
+[% if project_management == 'github' or use_foreman %]Labels are multi-select and nothing stops an issue carrying two, so resolution
+is **per stage, taking the highest cap present**: a conflict can then only ever
+buy more review, never less, and no ranking of the tier names has to be agreed
+on anywhere. A `rigor:` value naming no tier in the file is ignored rather than
+guessed at. Treat the label as advisory input carrying exactly the authority of
+repo write access — anyone who can label an issue can retune its budget, the
+same way anyone who can push can edit `.devflow.toml`. An agent never applies
+one to itself, and **says so in the announcement and in the PR body whenever
+the resolved tier is below `default_rigor`**, so a reduced budget is visible to
+the human reviewer instead of silent.
+[% endif %]**Announce the resolved triple on entering the loop** — "rigor:
 `<tier>` (`<source>`) → [% if use_codex_review %]challenge ≤`<n>`, review ≤`<n>`, [% endif %]shepherd `<n>`", filled in
 by reading the file rather than from memory — and carry it into the PR body, so
 a later round or a different session can see which budget it is spending

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -484,6 +484,12 @@ families, color-coded by family; the starter set is created by
 - **Layer** — `layer:ui`, `layer:logic`, `layer:data`, `layer:integration`
 - **Domain** — start with `domain:auth`, `domain:billing`, `domain:platform`;
   grow from your ERD entities
+- **Rigor** — `rigor:light`, `rigor:standard`, `rigor:deep`: which round-cap
+  tier in [`.devflow.toml`](../.devflow.toml) an agent works the issue under
+  (AGENTS.md, "Round caps are resolved, not stated here"). A human input an
+  agent reads and never self-applies — lowering rigor weakens a safety gate,
+  so it needs an attributable actor, which is also why it is a label and not a
+  project field. Two present resolves fail-safe: the deepest wins.
 
 Two more families name **model intelligence** rather than a facet of the work,
 and their vocabulary is not hand-listed anywhere: it is rendered from
@@ -606,6 +612,7 @@ it creates it on demand, and provisioning deliberately leaves it alone.
 | `needs-triage`, `needs-requirements`, `blocked`, `waiting`, `needs-decision`, `needs-response`, `needs-communication` | humans, at triage | humans, the Triage view | provisioned; inert | transient — removed as soon as the state clears |
 | `layer:{ui,logic,data,integration}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; mirrors the `Layer` field, with no sync between them |
 | `domain:{auth,billing,platform,…}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; mirrors the `Domain` field, with no sync between them |
+| `rigor:{light,standard,deep}` | humans, at triage — **never an agent on itself** | agents, when entering the Dev Loop | provisioned; **read by agents** — selects a round-cap tier, arms nothing | set when the default budget is wrong for the change; survives the work |
 | `suggest:<family>` | humans, at planning | humans, the Agent queue view | provisioned from the registry (family level only); advisory — arms nothing | set at planning; survives the work and is never rewritten by a claim |
 | `suggest:<family>:<model>` | humans | humans | **tool-owned, created on demand** — seeding every model would be an unbounded roster | refines the family label; apply both |
 | `claim:<family>` | the agent itself — a vendored claim skill, or a Claude Actions run | humans; the Claude Actions claim gate[% if claim_release_available %]; `claim-release.yml`[% endif %] | provisioned from the registry; a **gate**, never a trigger | added at claim, removed at release — by the workflow's `always()` step[% if claim_release_available %], or by `claim-release.yml` on close[% endif %] |

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -487,11 +487,12 @@ families, color-coded by family; the starter set is created by
 - **Rigor** — `rigor:light`, `rigor:standard`, `rigor:deep`: which round-cap
   tier in [`.devflow.toml`](../.devflow.toml) an agent works the issue under
   (AGENTS.md, "Round caps are resolved, not stated here"). An agent reads it
-  and never self-applies one. Its authority is exactly repo write access, so
-  it is advisory rather than an authenticated gate — AGENTS.md requires a tier
-  below `default_rigor` to be stated in the PR body, keeping a reduced budget
-  visible to the reviewer. Two present resolve per stage to the highest cap,
-  so a conflict can only ever buy more review.
+  and never self-applies one. It is advisory rather than an authenticated
+  gate: nothing verifies who applied it, and the **triage** role can label an
+  issue with no push access — so AGENTS.md requires any cap resolving below
+  `default_rigor` to be stated in the PR body, keeping a reduced budget visible
+  to the reviewer. Two present resolve per stage to the highest cap, so a
+  conflict can only ever buy more review.
 
 Two more families name **model intelligence** rather than a facet of the work,
 and their vocabulary is not hand-listed anywhere: it is rendered from

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -486,10 +486,12 @@ families, color-coded by family; the starter set is created by
   grow from your ERD entities
 - **Rigor** — `rigor:light`, `rigor:standard`, `rigor:deep`: which round-cap
   tier in [`.devflow.toml`](../.devflow.toml) an agent works the issue under
-  (AGENTS.md, "Round caps are resolved, not stated here"). A human input an
-  agent reads and never self-applies — lowering rigor weakens a safety gate,
-  so it needs an attributable actor, which is also why it is a label and not a
-  project field. Two present resolves fail-safe: the deepest wins.
+  (AGENTS.md, "Round caps are resolved, not stated here"). An agent reads it
+  and never self-applies one. Its authority is exactly repo write access, so
+  it is advisory rather than an authenticated gate — AGENTS.md requires a tier
+  below `default_rigor` to be stated in the PR body, keeping a reduced budget
+  visible to the reviewer. Two present resolve per stage to the highest cap,
+  so a conflict can only ever buy more review.
 
 Two more families name **model intelligence** rather than a facet of the work,
 and their vocabulary is not hand-listed anywhere: it is rendered from

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -249,12 +249,12 @@ gate that ends them — is defined in AGENTS.md ("Dev Loop"). The PR is a
 is the one signal that the automated work is finished.
 
 The caps are not written down here, or in AGENTS.md. They live in
-[`.devflow.toml`](../../.devflow.toml) as `rigor` tiers — `light`, `standard`,
-`deep` — and are resolved per change: an explicit instruction in the session,
-else a `rigor:*` label on the issue, else `default_rigor`. Only `challenge` and
-`review` vary by tier; the shepherd cap is fixed, because it bounds other
-people's findings rather than self-generated work. Announce the resolved
-triple when you enter the loop.
+[`.devflow.toml`](../../.devflow.toml) as `rigor` tiers, and **AGENTS.md alone
+defines how a change resolves one** — restating that chain here would only give
+it a second place to drift from, and which inputs are even available depends on
+how the repository is set up. Only `challenge` and `review` vary by tier; the
+shepherd cap is fixed, because it bounds other people's findings rather than
+self-generated work. Announce the resolved caps when you enter the loop.
 
 If Codex cloud review is connected to the repo, PRs
 get a cloud pass too: inline comments only for high-priority findings, a

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -231,11 +231,14 @@ task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
                 # until TWO CONSECUTIVE rounds adjudicate to zero P0/P1
-                # (any round with no findings at all ends it), ≤4 rounds
-task review     # verification checkpoint — same convergence rule, ≤4 rounds
+                # (any round with no findings at all ends it), under the
+                # challenge cap resolved from .devflow.toml
+task review     # verification checkpoint — same convergence rule, under its
+                # own resolved review cap
 task ci         # full CI mirror
 # → open a DRAFT PR, then shepherd it: watch CI + reviews, settle the deferred
-#   P2s, adjudicate → fix → push, ≤4 rounds (independent of the loops above)
+#   P2s, adjudicate → fix → push, under the shepherd cap (independent of the
+#   loops above)
 # → readiness gate passes → gh pr ready (the handoff to a human)
 # → merging stays a human decision
 ```
@@ -244,6 +247,14 @@ The full staged loop — including the PR-shepherding rounds and the readiness
 gate that ends them — is defined in AGENTS.md ("Dev Loop"). The PR is a
 **draft** for every stage above: it is the agent's workbench, and promoting it
 is the one signal that the automated work is finished.
+
+The caps are not written down here, or in AGENTS.md. They live in
+[`.devflow.toml`](../../.devflow.toml) as `rigor` tiers — `light`, `standard`,
+`deep` — and are resolved per change: an explicit instruction in the session,
+else a `rigor:*` label on the issue, else `default_rigor`. Only `challenge` and
+`review` vary by tier; the shepherd cap is fixed, because it bounds other
+people's findings rather than self-generated work. Announce the resolved
+triple when you enter the loop.
 
 If Codex cloud review is connected to the repo, PRs
 get a cloud pass too: inline comments only for high-priority findings, a
@@ -292,7 +303,8 @@ left to re-raise and counts toward convergence. Reflexively hardening the
 previous round's fix is the failure mode; naming it on the table is the
 check.
 
-Two things do not move. The **4-round cap** per stage stands, and persistent
+Two things do not move. The **per-stage cap** stands — whatever rigor tier
+resolved it — and persistent
 P0/P1 disagreement at the cap is escalated rather than iterated on. And the
 deferred-P2 chain is a **precondition** of the exit, not a casualty of it:
 every P2 open at convergence must already be in the sidecar below, so

--- a/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
@@ -87,7 +87,19 @@ layer:integration|1D76DB|External boundary: webhooks, API clients, credentials
 domain:auth|FBCA04|Authentication and authorization
 domain:billing|FBCA04|Billing and payments
 domain:platform|FBCA04|CI, build, test infra, and tooling in this repo
+rigor:light|D4C5F9|Dev Loop caps: trivial, low-blast-radius change
+rigor:standard|D4C5F9|Dev Loop caps: the default budget
+rigor:deep|D4C5F9|Dev Loop caps: security, migrations, irreversible paths
 "
+
+# The `rigor:*` family selects which round-cap tier in `.devflow.toml` an agent
+# works an issue under (AGENTS.md, "Round caps are resolved, not stated here").
+# It is a human input, like the foreman arming labels: an agent READS it and
+# never applies one to itself, because lowering rigor weakens a safety gate and
+# so needs an attributable actor. That is also why it is a label rather than a
+# project field — GitHub exposes no actor for a field change (ADR 0002 D-arming).
+# Labels are multi-select and nothing stops two being applied, so AGENTS.md
+# resolves a conflict fail-safe: the DEEPEST tier present wins.
 
 # The model-centric agent vocabulary — `suggest:<family>` (advisory routing) and
 # `claim:<family>` (live ownership) — is rendered from the machine-readable agent

--- a/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
@@ -94,11 +94,12 @@ rigor:deep|D4C5F9|Dev Loop caps: security, migrations, irreversible paths
 
 # The `rigor:*` family selects which round-cap tier in `.devflow.toml` an agent
 # works an issue under (AGENTS.md, "Round caps are resolved, not stated here").
-# It is an input an agent READS and never applies to itself. Its authority is
-# exactly repo write access — anyone who can label an issue can retune its
-# budget — so it is advisory, not an authenticated gate; AGENTS.md requires a
-# resolved tier below `default_rigor` to be stated in the PR body, which keeps
-# a reduced budget visible to the human reviewer.
+# It is an input an agent READS and never applies to itself. It is advisory,
+# not an authenticated gate: nothing verifies who applied it, and GitHub's
+# triage role can label an issue with no push access at all — so a budget can
+# be retuned by someone who could not edit `.devflow.toml`. AGENTS.md requires
+# any cap resolving below `default_rigor` to be stated in the PR body, which
+# keeps a reduced budget visible to the human reviewer.
 # Labels are multi-select and nothing stops two being applied, so AGENTS.md
 # resolves per stage by taking the HIGHEST cap present: a conflict can only
 # ever buy more review, never less, and no ranking of tier names is needed.

--- a/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
@@ -94,12 +94,14 @@ rigor:deep|D4C5F9|Dev Loop caps: security, migrations, irreversible paths
 
 # The `rigor:*` family selects which round-cap tier in `.devflow.toml` an agent
 # works an issue under (AGENTS.md, "Round caps are resolved, not stated here").
-# It is a human input, like the foreman arming labels: an agent READS it and
-# never applies one to itself, because lowering rigor weakens a safety gate and
-# so needs an attributable actor. That is also why it is a label rather than a
-# project field — GitHub exposes no actor for a field change (ADR 0002 D-arming).
+# It is an input an agent READS and never applies to itself. Its authority is
+# exactly repo write access — anyone who can label an issue can retune its
+# budget — so it is advisory, not an authenticated gate; AGENTS.md requires a
+# resolved tier below `default_rigor` to be stated in the PR body, which keeps
+# a reduced budget visible to the human reviewer.
 # Labels are multi-select and nothing stops two being applied, so AGENTS.md
-# resolves a conflict fail-safe: the DEEPEST tier present wins.
+# resolves per stage by taking the HIGHEST cap present: a conflict can only
+# ever buy more review, never less, and no ranking of tier names is needed.
 
 # The model-centric agent vocabulary — `suggest:<family>` (advisory routing) and
 # `claim:<family>` (live ownership) — is rendered from the machine-readable agent


### PR DESCRIPTION
## What

The challenge, review, and shepherd round caps were prose literals repeated
across **eight passages in four documents**. Nothing read them, nothing checked
them, and `task test:dogfood-structure` compares headings and tasks — not
paragraph bodies — so the root and template copies could silently disagree
about the policy they both stated.

This moves the numbers into `.devflow.toml` as `rigor` tiers and has AGENTS.md
state the *resolution rule* instead of literals.

```toml
default_rigor = "standard"

[rigor.light]     challenge = 2   review = 2   shepherd = 4
[rigor.standard]  challenge = 3   review = 3   shepherd = 4
[rigor.deep]      challenge = 5   review = 5   shepherd = 4
```

The default rises from 4/4 to **3/3** for challenge and review, per the request
that prompted this.

**Resolution order:** explicit instruction in the session › a `rigor:*` label on
the issue › `default_rigor` › a built-in 4/4/4 if the file is absent.

## Why these shapes

- **Tiers, not three free integers.** One decision per issue, meaningful on a
  label, retunable in one place.
- **`light` floors challenge/review at 2, never 1.** The exit condition needs
  two consecutive adjudicated-clean rounds, so a cap of 1 turns any single
  finding into an instant escalation.
- **`shepherd` is fixed across tiers.** Challenge and review bound work the
  agent generates itself, which is what makes capping them low safe. Shepherd
  bounds *other people's* findings (CI, human review, Codex) — lowering it
  abandons unanswered reviews rather than saving effort, and the readiness gate
  then refuses to promote anyway.
- **No `.jinja` suffix on the template copy.** `test-dogfood-parity.sh` scans
  `find template -type f ! -name '*.jinja'`, so the suffix would have dropped
  the file into the looser structure check. Unsuffixed, the twin is
  byte-compared — the caps are mechanically protected for the first time.
- **A label, not a project field.** Labels are timeline-attributable; GitHub
  exposes no actor for a field change, which is the same reason `.foreman.toml`
  refuses field-based arming.

## Notable fixes found during review

- **Self-lowering gate.** Caps were resolved from the branch under review, so a
  change to `.devflow.toml` governed its own review budget: drop every tier and
  `default_rigor` together and the validator still passes while the
  below-default disclosure has nothing left to fire on. Now resolved from the
  **merge base** when that file is in scope.
- **Labels that did not exist.** `setup-github-labels.sh` never provisioned
  `rigor:*`, so the documented path was unusable in a generated repo. Seeded —
  and the label clause is now gated on the same condition as the script, since
  `project_management` defaults to `none` and filename-gates it out entirely.
- **Two false trust claims, deleted rather than hardened.** "Attributable human
  actor" and then "exactly the authority of repo write access" were both wrong:
  GitHub's **triage** role can label an issue with no push access at all. The
  label is now described as what it is — advisory, applied by people, verified
  by nothing.
- **Conflict resolution.** Labels are multi-select; resolution is now **per
  stage, taking the highest cap present**, so a conflict can only ever buy more
  review and no ranking of tier names has to be agreed anywhere.

## Verification

- `task verify` green; `task ci` green
- 113 verbatim root↔template twins byte-identical
- All 6 template profiles PASS; the new paragraph render-checked across all 6
  codex/project-management/foreman combinations
- `test:devflow-config` (new, wired into `verify`) mutation-tested across 8
  branches: bad `default_rigor`, sub-floor cap, string cap, boolean cap,
  missing key, tier-varying shepherd, unlabelled tier, malformed TOML
- Root-only by design — it guards what harmon-init *ships*

## Rigor

**deep (session instruction) → challenge ≤5, review ≤5, shepherd 4.**

Above `default_rigor`, so no reduced-budget disclosure is owed. Escalated from
`standard` mid-change after challenge hit its cap unconverged.

- **Challenge: converged at 5/5** — capped final round, zero adjudicated P0/P1.
  Rounds 2 and 3 each attacked the previous round's fix; both times the answer
  was deletion rather than hardening, and no machinery has been added since
  round 1. Round 4 then found the self-lowering gate.
- **Review: converged at 2/5** — two consecutive adjudicated-clean rounds.

## Deferred findings

All three settled during shepherd round 1.

- [x] `AGENTS.md` (rigor label resolution) — **filed as #809**. The label is
      trusted on presence alone; GitHub's **triage** role can apply it with no
      push access, so the setter need not be able to edit `.devflow.toml` at
      all. Not fixed here: the remedy is either timeline-actor verification or
      making labels raise-only, and both are scope decisions belonging with the
      deferred Phase 3 enforcement work. Mitigated meanwhile by requiring any
      below-default cap to be stated in the PR body.
- [x] `scripts/test-devflow-config.sh` — **filed as #810**. The validator is
      root-only, so a generated repo retuning its tiers has no equivalent
      check. Not fixed here: shipping it puts a python3 dependency into every
      generated repo's verify gate. Mitigated by stating the four invariants in
      the shipped header.
- [x] `AGENTS.md` / `template/AGENTS.md.jinja` / `.devflow.toml` — fixed in 02125fd.
      The `4 / 4 / 4` fallback was stated in three prose places and
      checked in none. Dropped the number from the config header (a file should
      not document what happens when it is absent), leaving two copies that
      `test:devflow-config` now asserts agree. Mutation-tested: twins
      disagreeing fails, a missing fallback fails, changing both together
      passes. Deferred during challenge because adding validator surface after
      that stage converged would have shipped it unreviewed — this push moves
      the head and puts it under a fresh Codex cycle.

## Follow-up (not in this PR)

Phase 2 — creating `rigor:*` on live repos and teaching `/claim` and
`/implement` to read one. Provisioning ships here; **no labels have been created
on any repository**. The skill edits are canonical in harmon-devkit and need a
release cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


