### PR TITLE
feat(devcontainer): one-command client-side launcher for the Dev Containers attach path

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -105,6 +105,7 @@ tasks:
       - task: test:statusline
       - task: test:link-claude-json
       - task: test:image-staleness
+      - task: test:open-devcontainer
       - task: test:codex-review
       - task: test:template
 
@@ -323,6 +324,11 @@ tasks:
     desc: Unit-test the image-staleness warning (no container needed)
     cmds:
       - ./scripts/test-image-staleness.sh
+
+  test:open-devcontainer:
+    desc: Unit-test the client-side dev container launcher (no VS Code needed)
+    cmds:
+      - ./scripts/test-open-devcontainer.sh
 
   test:devcontainer:image:
     desc: Build and smoke-test the canonical shared image and current repository overlay

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -554,15 +554,26 @@ about which layer makes the *container* hop. The extension path, concretely:
 4. **Every reattach after that is one click**: File → **Open Recent** — the
    entry reading `<repo> [Dev Container: DEV — …]` replays the whole nested
    route (Coder → extension → container) correctly. This is the reattach
-   path; the Coder button is not. From a terminal on the client,
-   `scripts/open-devcontainer.sh <repo-match>` is the same click: it lifts the
-   matching `dev-container+…` folder URI out of VS Code's own recents and runs
-   `code --folder-uri` (no argument lists what is on offer). Wrap it in
-   whatever your fingers already reach for — an alias
-   (`alias devbox='~/src/harmon-init/scripts/open-devcontainer.sh harmon-init'`),
-   a Raycast script command, a Shortcuts action — remembering that it can only
-   replay an entry that exists, so step 3 is still how a repo gets its first
-   one.
+   path; the Coder button is not. `scripts/open-devcontainer.sh <repo-match>`
+   is the same click from a terminal: it lifts the matching `dev-container+…`
+   folder URI out of VS Code's own recents and runs `code --folder-uri` (no
+   argument lists what is on offer, each line ending in a short `[token]` to
+   pass instead of a name when two profiles of one checkout read alike). It
+   belongs on the **client**, which is where that recents database and `code`
+   are — the checkout it ships from is on the workspace host, so install a
+   copy once rather than running it over SSH against the wrong machine's
+   state; the script is deliberately self-contained, so a copy is all it takes:
+
+   ```sh
+   mkdir -p ~/bin
+   curl -fsSL https://raw.githubusercontent.com/evanharmon1/harmon-init/main/scripts/open-devcontainer.sh -o ~/bin/open-devcontainer
+   chmod +x ~/bin/open-devcontainer
+   ```
+
+   Then wrap the installed copy in whatever your fingers already reach for —
+   `alias devbox='~/bin/open-devcontainer harmon-init'`, a Raycast script
+   command, a Shortcuts action — remembering that it can only replay an entry
+   that exists, so step 3 is still how a repo gets its first one.
 5. **Rebuilds** happen from the same window: "Dev Containers: Rebuild
    Container".
 

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -566,9 +566,14 @@ about which layer makes the *container* hop. The extension path, concretely:
 
    ```sh
    mkdir -p ~/bin
-   curl -fsSL https://raw.githubusercontent.com/evanharmon1/harmon-init/main/scripts/open-devcontainer.sh -o ~/bin/open-devcontainer
+   scp <workspace-host>:/workspaces/harmon-init/scripts/open-devcontainer.sh ~/bin/open-devcontainer
    chmod +x ~/bin/open-devcontainer
    ```
+
+   Copying from your own checkout — not `curl`ing a branch — is deliberate:
+   it installs exactly the reviewed version sitting next to the docs you are
+   reading, where a download from `main` would fetch whatever that branch
+   has become since.
 
    Then wrap the installed copy in whatever your fingers already reach for —
    `alias devbox='~/bin/open-devcontainer harmon-init'`, a Raycast script

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -554,7 +554,15 @@ about which layer makes the *container* hop. The extension path, concretely:
 4. **Every reattach after that is one click**: File → **Open Recent** — the
    entry reading `<repo> [Dev Container: DEV — …]` replays the whole nested
    route (Coder → extension → container) correctly. This is the reattach
-   path; the Coder button is not.
+   path; the Coder button is not. From a terminal on the client,
+   `scripts/open-devcontainer.sh <repo-match>` is the same click: it lifts the
+   matching `dev-container+…` folder URI out of VS Code's own recents and runs
+   `code --folder-uri` (no argument lists what is on offer). Wrap it in
+   whatever your fingers already reach for — an alias
+   (`alias devbox='~/src/harmon-init/scripts/open-devcontainer.sh harmon-init'`),
+   a Raycast script command, a Shortcuts action — remembering that it can only
+   replay an entry that exists, so step 3 is still how a repo gets its first
+   one.
 5. **Rebuilds** happen from the same window: "Dev Containers: Rebuild
    Container".
 

--- a/scripts/open-devcontainer.sh
+++ b/scripts/open-devcontainer.sh
@@ -200,7 +200,9 @@ db="${VSCODE_STATE_DB-}"
 if [ -z "$db" ]; then
     case "$(uname -s)" in
     Darwin) db="${HOME}/Library/Application Support/Code/User/globalStorage/state.vscdb" ;;
-    Linux) db="${HOME}/.config/Code/User/globalStorage/state.vscdb" ;;
+    # VS Code honours XDG_CONFIG_HOME on Linux, so hardcoding ~/.config would
+    # miss the database on any client that sets it.
+    Linux) db="${XDG_CONFIG_HOME:-${HOME}/.config}/Code/User/globalStorage/state.vscdb" ;;
     *) die "unsupported platform '$(uname -s)' — set VSCODE_STATE_DB to VS Code's state.vscdb" ;;
     esac
 fi
@@ -227,15 +229,26 @@ case "$rc" in
 *) die "failed to read ${db} (extractor exit ${rc})" ;;
 esac
 
+# Arrays here are written by INDEX and read by index, never with `[@]` and
+# never through `${#arr[@]}`, with an ordinary integer carrying the count.
+# That is not a style preference. bash 3.2 — still the /bin/bash on macOS,
+# the client this script is written for — does not create a variable for
+# `arr=()`, so under `set -u` EVERY expansion of a still-empty array, the
+# length included, aborts with "arr: unbound variable". The empty case is
+# exactly the one that must survive: "recents exist, but none of them is a
+# dev container" and "nothing matched" are the two paths whose whole job is to
+# print a helpful message. Counters have no such edge, on any bash.
 uris=()
 labels=()
+count=0
 while IFS=$'\t' read -r uri label; do
     [ -n "$uri" ] || continue
-    uris+=("$uri")
-    labels+=("$label")
+    uris[count]="$uri"
+    labels[count]="$label"
+    count=$((count + 1))
 done <<<"$extracted"
 
-if [ "${#uris[@]}" -eq 0 ]; then
+if [ "$count" -eq 0 ]; then
     die "no dev-container entries in VS Code's recents — ${manual_flow_hint}"
 fi
 
@@ -243,33 +256,37 @@ fi
 
 if [ -z "$match" ]; then
     echo "dev containers VS Code remembers (pass a substring or a [token] to open one):" >&2
-    for label in "${labels[@]}"; do
-        printf '%s\n' "$label"
+    for ((i = 0; i < count; i++)); do
+        printf '%s\n' "${labels[i]}"
     done
     exit 0
 fi
 
 needle="$(printf '%s' "$match" | tr '[:upper:]' '[:lower:]')"
 hits=()
-for ((i = 0; i < ${#uris[@]}; i++)); do
+hit_count=0
+for ((i = 0; i < count; i++)); do
     # Matched against the LABEL, not the raw URI: the URI's hex blob is a long
     # run of [0-9a-f] in which a short all-hex needle ("added", "cafe") would
     # match nothing meaningful. The label carries the entry's token, so a
     # token is matched by this same pass and needs no special case.
     haystack="$(printf '%s' "${labels[i]}" | tr '[:upper:]' '[:lower:]')"
     case "$haystack" in
-    *"$needle"*) hits+=("$i") ;;
+    *"$needle"*)
+        hits[hit_count]="$i"
+        hit_count=$((hit_count + 1))
+        ;;
     esac
 done
 
-if [ "${#hits[@]}" -eq 0 ]; then
+if [ "$hit_count" -eq 0 ]; then
     die "no dev-container entry matching '${match}' — ${manual_flow_hint}"
 fi
 
-if [ "${#hits[@]}" -gt 1 ]; then
-    echo "open-devcontainer: '${match}' matches ${#hits[@]} entries — narrow by name, or use the [token] at the end of a line:" >&2
-    for i in "${hits[@]}"; do
-        printf '%s\n' "${labels[i]}" >&2
+if [ "$hit_count" -gt 1 ]; then
+    echo "open-devcontainer: '${match}' matches ${hit_count} entries — narrow by name, or use the [token] at the end of a line:" >&2
+    for ((i = 0; i < hit_count; i++)); do
+        printf '%s\n' "${labels[${hits[i]}]}" >&2
     done
     exit 1
 fi

--- a/scripts/open-devcontainer.sh
+++ b/scripts/open-devcontainer.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# open-devcontainer.sh — reopen a repo's dev container in one command.
+#
+# Runs on the CLIENT (your Mac or Linux laptop), NOT inside a container. It
+# reads the folder URIs VS Code already remembers and hands the matching one
+# back to VS Code, so reattaching through the Dev Containers extension is one
+# command instead of connect → Open Folder → Open Recent.
+#
+#   open-devcontainer.sh               # list the dev-container entries
+#   open-devcontainer.sh harmon-init   # launch the one that matches
+#
+# Deliberately recents-based. A Dev Containers window is described by a folder
+# URI of the shape
+#     vscode-remote://dev-container+<hex>@<remote-authority>/<path>
+# where <hex> is a hex-encoded JSON blob the extension owns and changes between
+# versions. Composing one from scratch would be guessing at that schema; the
+# recents entry is authoritative. So the FIRST attach to a repo is still the
+# manual flow documented in docs/guides/devcontainers.md — that is what creates
+# the entry. Every reattach after it is this script.
+#
+# Dependencies: python3 and the `code` CLI. python3 does BOTH jobs — reading
+# VS Code's SQLite state database (stdlib `sqlite3`, opened read-only so a
+# running VS Code is never disturbed) and parsing the recents JSON. That is one
+# dependency instead of three: python3 ships with the macOS command line tools,
+# whereas the sqlite3 CLI and jq are each absent often enough on a client to be
+# worth not requiring. `code` is needed only to launch, never to list.
+set -euo pipefail
+
+# The extraction program. Given the database path, it prints one TAB-separated
+# `<folderUri>\t<label>` line per dev-container entry, newest first (recents
+# order). Exit codes are the failure vocabulary the shell turns into messages:
+# 3 = database unreadable, 4 = no recents key, 5 = recents value is not JSON.
+PY_EXTRACT=$(
+    cat <<'PY'
+import json
+import sqlite3
+import sys
+import urllib.parse
+
+KEY = "history.recentlyOpenedPathsList"
+PREFIXES = ("vscode-remote://dev-container+", "vscode-remote://dev-container%2b")
+
+try:
+    # mode=ro never creates and never writes. quote() is what makes a path with
+    # spaces ("Application Support") a legal URI.
+    uri = "file:" + urllib.parse.quote(sys.argv[1])
+    con = sqlite3.connect(uri + "?mode=ro", uri=True)
+    row = con.execute("SELECT value FROM ItemTable WHERE key = ?", (KEY,)).fetchone()
+except sqlite3.Error:
+    sys.exit(3)
+
+if row is None or row[0] is None or row[0] == "":
+    sys.exit(4)
+
+value = row[0]
+if isinstance(value, (bytes, bytearray)):
+    value = value.decode("utf-8", "replace")
+
+try:
+    data = json.loads(value)
+except ValueError:
+    sys.exit(5)
+
+
+def label_for(folder_uri):
+    """A human-readable one-liner: container path, host path, remote host."""
+    decoded = urllib.parse.unquote(folder_uri)
+    rest = decoded.split("://", 1)[1] if "://" in decoded else decoded
+    authority, _, path = rest.partition("/")
+    blob, _, remote = authority.partition("@")
+    host_path = ""
+    hex_blob = blob.split("+", 1)[1] if "+" in blob else ""
+    try:
+        # The blob is hex-encoded JSON; hostPath is the checkout on the remote
+        # host. Any shape we do not recognize simply costs us the extra detail.
+        info = json.loads(bytes.fromhex(hex_blob).decode("utf-8"))
+        if isinstance(info, dict) and isinstance(info.get("hostPath"), str):
+            host_path = info["hostPath"]
+    except Exception:
+        host_path = ""
+    label = "/" + path if path else decoded
+    extra = []
+    if host_path:
+        extra.append("host " + host_path)
+    if remote:
+        extra.append(remote)
+    if extra:
+        label += "  (" + ", ".join(extra) + ")"
+    # The output is line- and TAB-delimited; never let a label break it.
+    return label.replace("\t", " ").replace("\n", " ").replace("\r", " ")
+
+
+entries = data.get("entries") if isinstance(data, dict) else None
+for entry in entries if isinstance(entries, list) else []:
+    if not isinstance(entry, dict):
+        continue
+    folder_uri = entry.get("folderUri")
+    if not isinstance(folder_uri, str) or not folder_uri:
+        continue
+    if not folder_uri.lower().startswith(PREFIXES):
+        continue
+    sys.stdout.write(folder_uri + "\t" + label_for(folder_uri) + "\n")
+PY
+)
+
+usage() {
+    cat <<'EOF'
+Usage: open-devcontainer.sh [<repo-match>]
+
+  (no argument)  list the dev-container entries VS Code remembers
+  <repo-match>   case-insensitive substring; a unique match is launched with
+                 `code --folder-uri`, several are listed so you can narrow it
+
+Environment:
+  VSCODE_STATE_DB            path to VS Code's state.vscdb (default: per-platform)
+  CODE_BIN                   the VS Code CLI to launch (default: code)
+  PYTHON_BIN                 the Python 3 interpreter to use (default: python3)
+  OPEN_DEVCONTAINER_DRY_RUN  1 = print the launch command instead of running it
+EOF
+}
+
+die() {
+    echo "open-devcontainer: $*" >&2
+    exit 1
+}
+
+manual_flow_hint="open it once via the manual flow — see docs/guides/devcontainers.md (attach paths) — then this launcher can reopen it"
+
+case "${1-}" in
+-h | --help)
+    usage
+    exit 0
+    ;;
+esac
+if [ "$#" -gt 1 ]; then
+    usage >&2
+    exit 2
+fi
+match="${1-}"
+
+# ---- locate the state database -------------------------------------------
+
+db="${VSCODE_STATE_DB-}"
+if [ -z "$db" ]; then
+    case "$(uname -s)" in
+    Darwin) db="${HOME}/Library/Application Support/Code/User/globalStorage/state.vscdb" ;;
+    Linux) db="${HOME}/.config/Code/User/globalStorage/state.vscdb" ;;
+    *) die "unsupported platform '$(uname -s)' — set VSCODE_STATE_DB to VS Code's state.vscdb" ;;
+    esac
+fi
+[ -f "$db" ] || die "no VS Code state database at ${db} — run VS Code on this machine once, or set VSCODE_STATE_DB"
+
+# ---- read it --------------------------------------------------------------
+
+python_bin="${PYTHON_BIN:-python3}"
+# One probe covers both "not installed" and macOS's python3 shim, which exists
+# on PATH but only prints an install prompt until the command line tools are.
+if ! command -v "$python_bin" >/dev/null 2>&1 || ! "$python_bin" -c 'import json, sqlite3' >/dev/null 2>&1; then
+    die "no working python3 (tried '${python_bin}') — install it (macOS: xcode-select --install; Debian/Ubuntu: apt-get install python3) or set PYTHON_BIN"
+fi
+
+set +e
+extracted="$("$python_bin" -c "$PY_EXTRACT" "$db" 2>/dev/null)"
+rc=$?
+set -e
+case "$rc" in
+0) ;;
+3) die "could not read ${db} — is it VS Code's state.vscdb?" ;;
+4) die "no recently-opened list in ${db} — open a folder in VS Code first" ;;
+5) die "VS Code's recently-opened list in ${db} is not valid JSON" ;;
+*) die "failed to read ${db} (extractor exit ${rc})" ;;
+esac
+
+uris=()
+labels=()
+while IFS=$'\t' read -r uri label; do
+    [ -n "$uri" ] || continue
+    uris+=("$uri")
+    labels+=("$label")
+done <<<"$extracted"
+
+if [ "${#uris[@]}" -eq 0 ]; then
+    die "no dev-container entries in VS Code's recents — ${manual_flow_hint}"
+fi
+
+# ---- list, or match and launch --------------------------------------------
+
+if [ -z "$match" ]; then
+    echo "dev containers VS Code remembers (pass a substring to open one):" >&2
+    for label in "${labels[@]}"; do
+        printf '%s\n' "$label"
+    done
+    exit 0
+fi
+
+needle="$(printf '%s' "$match" | tr '[:upper:]' '[:lower:]')"
+hits=()
+for ((i = 0; i < ${#uris[@]}; i++)); do
+    # Matched against the LABEL, not the raw URI: the URI's hex blob is a long
+    # run of [0-9a-f] in which a short all-hex needle ("added", "cafe") would
+    # match nothing meaningful.
+    haystack="$(printf '%s' "${labels[i]}" | tr '[:upper:]' '[:lower:]')"
+    case "$haystack" in
+    *"$needle"*) hits+=("$i") ;;
+    esac
+done
+
+if [ "${#hits[@]}" -eq 0 ]; then
+    die "no dev-container entry matching '${match}' — ${manual_flow_hint}"
+fi
+
+if [ "${#hits[@]}" -gt 1 ]; then
+    echo "open-devcontainer: '${match}' matches ${#hits[@]} entries — narrow it:" >&2
+    for i in "${hits[@]}"; do
+        printf '%s\n' "${labels[i]}" >&2
+    done
+    exit 1
+fi
+
+target="${uris[${hits[0]}]}"
+code_bin="${CODE_BIN:-code}"
+
+if [ "${OPEN_DEVCONTAINER_DRY_RUN-}" = "1" ]; then
+    printf '%s --folder-uri %s\n' "$code_bin" "$target"
+    exit 0
+fi
+
+command -v "$code_bin" >/dev/null 2>&1 ||
+    die "'${code_bin}' not found on PATH — in VS Code run the command palette's \"Shell Command: Install 'code' command in PATH\" (or set CODE_BIN)"
+
+exec "$code_bin" --folder-uri "$target"

--- a/scripts/open-devcontainer.sh
+++ b/scripts/open-devcontainer.sh
@@ -24,6 +24,11 @@
 # dependency instead of three: python3 ships with the macOS command line tools,
 # whereas the sqlite3 CLI and jq are each absent often enough on a client to be
 # worth not requiring. `code` is needed only to launch, never to list.
+#
+# Self-contained on purpose: no `cd` to a repo root, no sibling files, nothing
+# read out of a checkout. The repo it ships from lives on the workspace HOST,
+# while VS Code's recents and the `code` CLI live on the client — so this is a
+# file you copy to the client once and run there, not one you run over SSH.
 set -euo pipefail
 
 # The extraction program. Given the database path, it prints one TAB-separated
@@ -32,6 +37,7 @@ set -euo pipefail
 # 3 = database unreadable, 4 = no recents key, 5 = recents value is not JSON.
 PY_EXTRACT=$(
     cat <<'PY'
+import hashlib
 import json
 import sqlite3
 import sys
@@ -62,30 +68,76 @@ except ValueError:
     sys.exit(5)
 
 
+def config_tail(info):
+    """The devcontainer.json this entry was built from, trimmed to its tail.
+
+    This is what tells one PROFILE of a checkout from another: the bot config
+    at `.devcontainer/devcontainer.json` and the dev config at
+    `.devcontainer/dev/devcontainer.json` produce two recents entries whose
+    container path, host path, and remote authority are all identical. Without
+    this, they are two indistinguishable lines.
+    """
+    config = info.get("configFile")
+    path = ""
+    if isinstance(config, str):
+        path = config
+    elif isinstance(config, dict) and isinstance(config.get("path"), str):
+        # VS Code serializes a URI as {"$mid":…,"path":…,"scheme":…}.
+        path = config["path"]
+    if not path:
+        return ""
+    path = urllib.parse.unquote(path)
+    marker = "/.devcontainer/"
+    at = path.find(marker)
+    if at >= 0:
+        return path[at + 1:]
+    parts = [p for p in path.split("/") if p]
+    return "/".join(parts[-2:])
+
+
+def token_for(folder_uri):
+    """A short, stable handle for an entry.
+
+    The discriminator of last resort. Everything else shown on a line is
+    decoded out of a blob the extension owns, so two entries CAN come back
+    with identical labels — and an ambiguous listing nothing can select is a
+    dead end. This is derived from the whole URI, so it always exists, always
+    differs between different entries, and does not move between runs.
+    """
+    return hashlib.sha256(folder_uri.encode("utf-8")).hexdigest()[:8]
+
+
 def label_for(folder_uri):
-    """A human-readable one-liner: container path, host path, remote host."""
+    """A human-readable one-liner ending in the entry's selection token."""
     decoded = urllib.parse.unquote(folder_uri)
     rest = decoded.split("://", 1)[1] if "://" in decoded else decoded
     authority, _, path = rest.partition("/")
     blob, _, remote = authority.partition("@")
-    host_path = ""
     hex_blob = blob.split("+", 1)[1] if "+" in blob else ""
+    info = {}
     try:
-        # The blob is hex-encoded JSON; hostPath is the checkout on the remote
-        # host. Any shape we do not recognize simply costs us the extra detail.
-        info = json.loads(bytes.fromhex(hex_blob).decode("utf-8"))
-        if isinstance(info, dict) and isinstance(info.get("hostPath"), str):
-            host_path = info["hostPath"]
+        # The blob is hex-encoded JSON. Any shape we do not recognize simply
+        # costs us the extra detail, never the line itself.
+        parsed = json.loads(bytes.fromhex(hex_blob).decode("utf-8"))
+        if isinstance(parsed, dict):
+            info = parsed
     except Exception:
+        info = {}
+    host_path = info.get("hostPath")
+    if not isinstance(host_path, str):
         host_path = ""
     label = "/" + path if path else decoded
     extra = []
     if host_path:
         extra.append("host " + host_path)
+    config = config_tail(info)
+    if config:
+        extra.append("config " + config)
     if remote:
         extra.append(remote)
     if extra:
         label += "  (" + ", ".join(extra) + ")"
+    label += "  [" + token_for(folder_uri) + "]"
     # The output is line- and TAB-delimited; never let a label break it.
     return label.replace("\t", " ").replace("\n", " ").replace("\r", " ")
 
@@ -109,7 +161,11 @@ Usage: open-devcontainer.sh [<repo-match>]
 
   (no argument)  list the dev-container entries VS Code remembers
   <repo-match>   case-insensitive substring; a unique match is launched with
-                 `code --folder-uri`, several are listed so you can narrow it
+                 `code --folder-uri`, several are listed so you can narrow it.
+                 Every listed line ends in a short [token] that is also a
+                 match target — the way to pick between two entries whose
+                 details are identical (the bot and dev profiles of one
+                 checkout, say)
 
 Environment:
   VSCODE_STATE_DB            path to VS Code's state.vscdb (default: per-platform)
@@ -186,7 +242,7 @@ fi
 # ---- list, or match and launch --------------------------------------------
 
 if [ -z "$match" ]; then
-    echo "dev containers VS Code remembers (pass a substring to open one):" >&2
+    echo "dev containers VS Code remembers (pass a substring or a [token] to open one):" >&2
     for label in "${labels[@]}"; do
         printf '%s\n' "$label"
     done
@@ -198,7 +254,8 @@ hits=()
 for ((i = 0; i < ${#uris[@]}; i++)); do
     # Matched against the LABEL, not the raw URI: the URI's hex blob is a long
     # run of [0-9a-f] in which a short all-hex needle ("added", "cafe") would
-    # match nothing meaningful.
+    # match nothing meaningful. The label carries the entry's token, so a
+    # token is matched by this same pass and needs no special case.
     haystack="$(printf '%s' "${labels[i]}" | tr '[:upper:]' '[:lower:]')"
     case "$haystack" in
     *"$needle"*) hits+=("$i") ;;
@@ -210,7 +267,7 @@ if [ "${#hits[@]}" -eq 0 ]; then
 fi
 
 if [ "${#hits[@]}" -gt 1 ]; then
-    echo "open-devcontainer: '${match}' matches ${#hits[@]} entries — narrow it:" >&2
+    echo "open-devcontainer: '${match}' matches ${#hits[@]} entries — narrow by name, or use the [token] at the end of a line:" >&2
     for i in "${hits[@]}"; do
         printf '%s\n' "${labels[i]}" >&2
     done

--- a/scripts/test-open-devcontainer.sh
+++ b/scripts/test-open-devcontainer.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# test-open-devcontainer.sh — unit-test the client-side dev container launcher.
+#
+# The launcher's whole job is reading someone else's data format: VS Code's
+# recents list, a JSON blob inside a SQLite row, holding URIs whose authority
+# is hex-encoded JSON. Everything that can go wrong is in that parse, and none
+# of it needs VS Code — so each case here builds a throwaway state.vscdb with
+# a known recents payload and asserts what the launcher makes of it.
+#
+# Launching is asserted without opening anything: OPEN_DEVCONTAINER_DRY_RUN=1
+# prints the command, and CODE_BIN points at a stub that records its arguments.
+# Run via `task test:open-devcontainer`.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+launcher="scripts/open-devcontainer.sh"
+
+[ -r "$launcher" ] || {
+    echo "TEST FAIL: $launcher not found" >&2
+    exit 1
+}
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+tmp_root="$(mktemp -d -t harmon-open-devcontainer-XXXXXX)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+# hex <string> — hex-encode ASCII in pure bash, so building a fixture URI needs
+# no xxd (absent on stock macOS) and no second language.
+hex() {
+    local s="$1" i out=""
+    for ((i = 0; i < ${#s}; i++)); do
+        out="${out}$(printf '%02x' "'${s:i:1}")"
+    done
+    printf '%s' "$out"
+}
+
+# dc_uri <hostPath> <remote> <container path> [plus] — a dev-container folder
+# URI shaped exactly like the ones VS Code stores. The 4th argument chooses how
+# the `+` after `dev-container` is written: VS Code emits both forms, and the
+# launcher has to accept either.
+dc_uri() {
+    local blob plus="${4-+}"
+    blob="$(hex "{\"hostPath\":\"$1\",\"localDocker\":false}")"
+    printf 'vscode-remote://dev-container%s%s@%s%s' "$plus" "$blob" "$2" "$3"
+}
+
+# make_db <name> <json> — a state.vscdb holding <json> under the recents key.
+# Written with python3's stdlib sqlite3 for the same reason the launcher reads
+# it that way: the sqlite3 CLI is not present on every machine that runs this.
+make_db() {
+    local path="${tmp_root}/$1.vscdb"
+    python3 - "$path" "$2" <<'PY'
+import sqlite3, sys
+con = sqlite3.connect(sys.argv[1])
+con.execute("CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)")
+con.execute("INSERT INTO ItemTable VALUES (?, ?)", ("history.recentlyOpenedPathsList", sys.argv[2]))
+con.commit()
+con.close()
+PY
+    printf '%s' "$path"
+}
+
+# run_launcher <db> [arg…] — capture stdout+stderr and the exit code. Captured
+# explicitly: `set -e` would otherwise abort the suite on the very nonzero exit
+# a case exists to assert.
+out=""
+rc=0
+run_launcher() {
+    local db="$1"
+    shift
+    set +e
+    out="$(VSCODE_STATE_DB="$db" OPEN_DEVCONTAINER_DRY_RUN=1 bash "$launcher" "$@" 2>&1)"
+    rc=$?
+    set -e
+}
+
+uri_init="$(dc_uri /srv/coder/harmon-init ssh-remote+devbox /workspaces/harmon-init)"
+uri_site="$(dc_uri /srv/coder/evanharmon-site ssh-remote+devbox /workspaces/evanharmon-site %2B)"
+recents="{\"entries\":[{\"folderUri\":\"${uri_init}\"},{\"folderUri\":\"file:///srv/coder/notes\"},{\"folderUri\":\"${uri_site}\"}]}"
+db_ok="$(make_db recents "$recents")"
+
+# ---- 1. no argument lists the dev-container entries, and only those ----
+# The ordinary folder entry is the control: a launcher that lists it would send
+# `code --folder-uri` at a path with no container behind it.
+
+echo "==> no argument lists exactly the dev-container entries"
+run_launcher "$db_ok"
+[ "$rc" -eq 0 ] || fail "listing exited ${rc}, not 0"
+listed="$(VSCODE_STATE_DB="$db_ok" bash "$launcher" 2>/dev/null)"
+[ "$(printf '%s\n' "$listed" | grep -c .)" -eq 2 ] ||
+    fail "expected 2 listed entries on stdout, got: ${listed}"
+printf '%s\n' "$listed" | grep -q '/workspaces/harmon-init' ||
+    fail "the harmon-init entry is missing: ${listed}"
+printf '%s\n' "$listed" | grep -q '/workspaces/evanharmon-site' ||
+    fail "the percent-encoded '+' entry is missing: ${listed}"
+if printf '%s\n' "$listed" | grep -q 'notes'; then
+    fail "an ordinary (non-dev-container) folder was listed: ${listed}"
+fi
+# The hex blob is decoded far enough to name the checkout on the host.
+printf '%s\n' "$listed" | grep -q 'host /srv/coder/harmon-init' ||
+    fail "the hostPath was not decoded out of the hex authority: ${listed}"
+
+# ---- 2. a unique match launches that entry, matched case-insensitively ----
+
+echo "==> a unique match launches the right URI"
+run_launcher "$db_ok" HARMON-Init
+[ "$rc" -eq 0 ] || fail "a unique match exited ${rc}, not 0"
+printf '%s\n' "$out" | grep -qF -- "--folder-uri ${uri_init}" ||
+    fail "did not launch the harmon-init URI: ${out}"
+if printf '%s\n' "$out" | grep -qF -- "$uri_site"; then
+    fail "the launch command names the wrong entry too: ${out}"
+fi
+
+echo "==> the launch really execs the code CLI with the URI"
+stub="${tmp_root}/code-stub"
+cat >"$stub" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" >"${tmp_root}/stub-args"
+EOF
+chmod +x "$stub"
+VSCODE_STATE_DB="$db_ok" CODE_BIN="$stub" bash "$launcher" evanharmon-site >/dev/null 2>&1 ||
+    fail "launching through a CODE_BIN stub exited nonzero"
+[ -f "${tmp_root}/stub-args" ] || fail "the code stub was never invoked"
+grep -qxF -- "--folder-uri" "${tmp_root}/stub-args" ||
+    fail "the stub was not passed --folder-uri: $(cat "${tmp_root}/stub-args")"
+grep -qxF -- "$uri_site" "${tmp_root}/stub-args" ||
+    fail "the stub was passed the wrong URI: $(cat "${tmp_root}/stub-args")"
+
+# ---- 3. an ambiguous match refuses, and shows what to choose between ----
+# Silently opening the first of several is the failure mode worth designing
+# against: it is indistinguishable from success until the wrong window opens.
+
+echo "==> an ambiguous match exits 1 and lists the candidates"
+run_launcher "$db_ok" workspaces
+[ "$rc" -eq 1 ] || fail "an ambiguous match exited ${rc}, not 1"
+printf '%s\n' "$out" | grep -q '/workspaces/harmon-init' ||
+    fail "the ambiguous listing omits harmon-init: ${out}"
+printf '%s\n' "$out" | grep -q '/workspaces/evanharmon-site' ||
+    fail "the ambiguous listing omits evanharmon-site: ${out}"
+if printf '%s\n' "$out" | grep -qF -- "--folder-uri"; then
+    fail "an ambiguous match launched something anyway: ${out}"
+fi
+
+# ---- 4. no match points at the flow that would create the entry ----
+# The launcher cannot compose a dev-container URI it has never seen, so this
+# message is the whole remedy — it has to name the manual flow.
+
+echo "==> no match exits 1 with the manual-flow pointer"
+run_launcher "$db_ok" nonesuch
+[ "$rc" -eq 1 ] || fail "an unmatched name exited ${rc}, not 1"
+printf '%s\n' "$out" | grep -q 'docs/guides/devcontainers.md' ||
+    fail "the no-match message does not point at the guide: ${out}"
+
+echo "==> a recents list with no dev-container entries says the same thing"
+db_plain="$(make_db plain '{"entries":[{"folderUri":"file:///srv/coder/notes"}]}')"
+run_launcher "$db_plain" harmon-init
+[ "$rc" -ne 0 ] || fail "a recents list with no dev containers exited 0"
+printf '%s\n' "$out" | grep -q 'docs/guides/devcontainers.md' ||
+    fail "the empty-list message does not point at the guide: ${out}"
+
+# ---- 5. every missing precondition is one specific line, never a trace ----
+
+echo "==> a missing database exits nonzero naming the path"
+run_launcher "${tmp_root}/absent.vscdb"
+[ "$rc" -ne 0 ] || fail "a missing database exited 0"
+printf '%s\n' "$out" | grep -q 'no VS Code state database' ||
+    fail "a missing database did not say so: ${out}"
+if printf '%s\n' "$out" | grep -qi 'line [0-9]\|command not found'; then
+    fail "a missing database produced a bash trace: ${out}"
+fi
+
+echo "==> a database without the recents key exits nonzero"
+db_nokey="${tmp_root}/nokey.vscdb"
+python3 - "$db_nokey" <<'PY'
+import sqlite3, sys
+con = sqlite3.connect(sys.argv[1])
+con.execute("CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)")
+con.commit()
+con.close()
+PY
+run_launcher "$db_nokey"
+[ "$rc" -ne 0 ] || fail "a database without the recents key exited 0"
+printf '%s\n' "$out" | grep -q 'no recently-opened list' ||
+    fail "a database without the recents key did not say so: ${out}"
+
+echo "==> a database that is not a state.vscdb exits nonzero"
+db_junk="${tmp_root}/junk.vscdb"
+printf 'not a database\n' >"$db_junk"
+run_launcher "$db_junk"
+[ "$rc" -ne 0 ] || fail "a non-database file exited 0"
+printf '%s\n' "$out" | grep -q 'could not read' ||
+    fail "a non-database file did not say so: ${out}"
+
+echo "==> a missing python3 exits nonzero saying how to get one"
+set +e
+out="$(VSCODE_STATE_DB="$db_ok" PYTHON_BIN="${tmp_root}/no-such-python" bash "$launcher" 2>&1)"
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "a missing python3 exited 0"
+printf '%s\n' "$out" | grep -q 'no working python3' ||
+    fail "a missing python3 did not say so: ${out}"
+
+echo "open-devcontainer: all cases passed"

--- a/scripts/test-open-devcontainer.sh
+++ b/scripts/test-open-devcontainer.sh
@@ -27,14 +27,16 @@ fail() {
 tmp_root="$(mktemp -d -t harmon-open-devcontainer-XXXXXX)"
 trap 'rm -rf "$tmp_root"' EXIT
 
-# hex <string> — hex-encode ASCII in pure bash, so building a fixture URI needs
-# no xxd (absent on stock macOS) and no second language.
+# hex <string> — hex-encode a fixture blob in one python3 call. The launcher
+# under test already requires python3, so the test may too. What this replaced
+# looped in bash and forked a subshell PER CHARACTER — about 600 of them for
+# the fixtures below. Measured honestly in this Linux devcontainer that is
+# 1.36s before against 1.29s after: noise, because bash forks a subshell for
+# `$(printf …)` without an exec. It is kept for the process count itself,
+# which is real, and because fork is markedly dearer on the macOS client this
+# suite also runs on — not on a promise that `task verify` got faster.
 hex() {
-    local s="$1" i out=""
-    for ((i = 0; i < ${#s}; i++)); do
-        out="${out}$(printf '%02x' "'${s:i:1}")"
-    done
-    printf '%s' "$out"
+    python3 -c 'import sys; sys.stdout.write(sys.argv[1].encode("utf-8").hex())' "$1"
 }
 
 # dc_uri <hostPath> <remote> <container path> [plus] — a dev-container folder
@@ -224,6 +226,59 @@ run_launcher "$db_plain" harmon-init
 [ "$rc" -ne 0 ] || fail "a recents list with no dev containers exited 0"
 printf '%s\n' "$out" | grep -q 'docs/guides/devcontainers.md' ||
     fail "the empty-list message does not point at the guide: ${out}"
+
+echo "==> the no-entries path survives an explicit -u, and lists nothing"
+# Both of the paths above reach their message with EMPTY arrays. On bash 3.2 —
+# the /bin/bash of the macOS client this script targets — `arr=()` creates no
+# variable, so under `set -u` any expansion of a still-empty array (`${arr[@]}`
+# and `${#arr[@]}` alike) aborts with "unbound variable" BEFORE the message is
+# printed. That is the bug this pair of cases guards.
+#
+# Honest limit: bash 3.2 is not installed in this container, and `bash -u` on a
+# modern bash does NOT reproduce the 3.2 semantics — the run below only proves
+# the paths are clean under -u on the bash we have. The structural assertion
+# after it is what actually holds the line, because the 3.2 trap is reachable
+# only through `[@]`-style expansion: the launcher must not contain one.
+set +e
+out="$(VSCODE_STATE_DB="$db_plain" bash -u "$launcher" 2>&1)"
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "the no-entries listing exited 0 under -u"
+printf '%s\n' "$out" | grep -q 'no dev-container entries' ||
+    fail "the no-entries listing did not print its message under -u: ${out}"
+if printf '%s\n' "$out" | grep -q 'unbound variable'; then
+    fail "an empty array was expanded on the no-entries path: ${out}"
+fi
+
+echo "==> the launcher expands no array with [@] or [*]"
+# Comment lines are filtered out: the launcher's own explanation of this rule
+# necessarily spells the forbidden form.
+offenders="$(grep -nE '\$\{#?[A-Za-z_][A-Za-z0-9_]*\[[@*]\]' "$launcher" |
+    grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+[ -z "$offenders" ] ||
+    fail "array expansions unsafe on bash 3.2 + set -u (index them instead): ${offenders}"
+
+# ---- 4b. the Linux default path follows XDG ----
+# VS Code writes its state under XDG_CONFIG_HOME when that is set, so a client
+# that sets it would otherwise get "no VS Code state database" pointing at a
+# ~/.config path nothing ever wrote to.
+
+echo "==> the Linux default path honours XDG_CONFIG_HOME"
+if [ "$(uname -s)" = "Linux" ]; then
+    xdg_root="${tmp_root}/xdg"
+    mkdir -p "${xdg_root}/Code/User/globalStorage"
+    cp "$db_ok" "${xdg_root}/Code/User/globalStorage/state.vscdb"
+    # No VSCODE_STATE_DB here on purpose: the point is the DEFAULT path.
+    set +e
+    out="$(XDG_CONFIG_HOME="$xdg_root" OPEN_DEVCONTAINER_DRY_RUN=1 bash "$launcher" harmon-init 2>&1)"
+    rc=$?
+    set -e
+    [ "$rc" -eq 0 ] || fail "the XDG default path was not consulted (exit ${rc}): ${out}"
+    printf '%s\n' "$out" | grep -qF -- "--folder-uri ${uri_init}" ||
+        fail "the XDG default path found the wrong entry: ${out}"
+else
+    echo "    (skipped: XDG is the Linux branch, and this host is $(uname -s))"
+fi
 
 # ---- 5. every missing precondition is one specific line, never a trace ----
 

--- a/scripts/test-open-devcontainer.sh
+++ b/scripts/test-open-devcontainer.sh
@@ -41,10 +41,23 @@ hex() {
 # URI shaped exactly like the ones VS Code stores. The 4th argument chooses how
 # the `+` after `dev-container` is written: VS Code emits both forms, and the
 # launcher has to accept either.
+# A 5th argument gives the blob a configFile, serialized the way VS Code
+# serializes a URI ({"$mid":…,"path":…,"scheme":…}) — that is the only field
+# that differs between the dev and bot profiles of one checkout.
 dc_uri() {
-    local blob plus="${4-+}"
-    blob="$(hex "{\"hostPath\":\"$1\",\"localDocker\":false}")"
+    local blob json plus="${4-+}"
+    json="{\"hostPath\":\"$1\",\"localDocker\":false"
+    if [ -n "${5-}" ]; then
+        json="${json},\"configFile\":{\"\$mid\":1,\"path\":\"$5\",\"scheme\":\"vscode-fileHost\"}"
+    fi
+    blob="$(hex "${json}}")"
     printf 'vscode-remote://dev-container%s%s@%s%s' "$plus" "$blob" "$2" "$3"
+}
+
+# token_of <line> — the [xxxxxxxx] handle the launcher prints at the end of a
+# listed line.
+token_of() {
+    printf '%s\n' "$1" | sed -n 's/.*\[\([0-9a-f]\{8\}\)\]$/\1/p'
 }
 
 # make_db <name> <json> — a state.vscdb holding <json> under the recents key.
@@ -128,6 +141,57 @@ grep -qxF -- "--folder-uri" "${tmp_root}/stub-args" ||
     fail "the stub was not passed --folder-uri: $(cat "${tmp_root}/stub-args")"
 grep -qxF -- "$uri_site" "${tmp_root}/stub-args" ||
     fail "the stub was passed the wrong URI: $(cat "${tmp_root}/stub-args")"
+
+# ---- 2b. the two profiles of ONE checkout stay distinguishable ----
+# The dev and bot configs of a repo produce two recents entries with the same
+# container path, the same hostPath and the same remote authority — they differ
+# only inside the hex blob. If the listing renders them identically, ambiguity
+# is a dead end: no argument can ever select either one. Two things prevent
+# that, and both are asserted here — the decoded config path, and the token,
+# which exists even when the blob decodes to nothing at all.
+
+echo "==> the dev and bot profiles of one checkout list distinctly"
+uri_dev="$(dc_uri /srv/coder/harmon-init ssh-remote+devbox /workspaces/harmon-init \
+    + /srv/coder/harmon-init/.devcontainer/dev/devcontainer.json)"
+uri_bot="$(dc_uri /srv/coder/harmon-init ssh-remote+devbox /workspaces/harmon-init \
+    + /srv/coder/harmon-init/.devcontainer/devcontainer.json)"
+db_prof="$(make_db profiles "{\"entries\":[{\"folderUri\":\"${uri_dev}\"},{\"folderUri\":\"${uri_bot}\"}]}")"
+profiles="$(VSCODE_STATE_DB="$db_prof" bash "$launcher" 2>/dev/null)"
+[ "$(printf '%s\n' "$profiles" | grep -c .)" -eq 2 ] ||
+    fail "expected both profiles listed, got: ${profiles}"
+line_dev="$(printf '%s\n' "$profiles" | grep 'dev/devcontainer.json' || true)"
+line_bot="$(printf '%s\n' "$profiles" | grep -v 'dev/devcontainer.json' || true)"
+[ -n "$line_dev" ] || fail "the dev profile's config path was not decoded: ${profiles}"
+printf '%s\n' "$line_bot" | grep -q 'config .devcontainer/devcontainer.json' ||
+    fail "the bot profile's config path was not decoded: ${profiles}"
+[ "$line_dev" != "$line_bot" ] || fail "the two profiles rendered identically: ${profiles}"
+
+echo "==> each profile is selectable by its config path"
+run_launcher "$db_prof" dev/devcontainer.json
+[ "$rc" -eq 0 ] || fail "selecting the dev profile by config path exited ${rc}: ${out}"
+printf '%s\n' "$out" | grep -qF -- "--folder-uri ${uri_dev}" ||
+    fail "the config-path match launched the wrong profile: ${out}"
+
+echo "==> each profile is selectable by its token"
+tok_dev="$(token_of "$line_dev")"
+tok_bot="$(token_of "$line_bot")"
+[ -n "$tok_dev" ] || fail "the dev profile's line carries no token: ${profiles}"
+[ -n "$tok_bot" ] || fail "the bot profile's line carries no token: ${profiles}"
+[ "$tok_dev" != "$tok_bot" ] || fail "both profiles carry the same token: ${profiles}"
+# Stable and derived from the URI, not from listing order — a token a human
+# copied out of yesterday's listing has to still mean the same entry.
+[ "$tok_bot" = "$(python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest()[:8])' "$uri_bot")" ] ||
+    fail "the token is not the first 8 hex of sha256(uri): ${tok_bot}"
+run_launcher "$db_prof" "$tok_bot"
+[ "$rc" -eq 0 ] || fail "selecting the bot profile by token exited ${rc}: ${out}"
+printf '%s\n' "$out" | grep -qF -- "--folder-uri ${uri_bot}" ||
+    fail "the token match launched the wrong profile: ${out}"
+
+echo "==> an ambiguity between the profiles points at the token"
+run_launcher "$db_prof" harmon-init
+[ "$rc" -eq 1 ] || fail "the two profiles were not reported as ambiguous (exit ${rc}): ${out}"
+printf '%s\n' "$out" | grep -q 'token' ||
+    fail "the ambiguous message does not mention the token: ${out}"
 
 # ---- 3. an ambiguous match refuses, and shows what to choose between ----
 # Silently opening the first of several is the failure mode worth designing

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -135,6 +135,7 @@ tasks:
       - task: test:statusline
       - task: test:link-claude-json
       - task: test:image-staleness
+      - task: test:open-devcontainer
 [% endif %]
       - task: test
 
@@ -781,6 +782,11 @@ tasks:
     desc: Unit-test the image-staleness warning (no container needed)
     cmds:
       - ./scripts/test-image-staleness.sh
+
+  test:open-devcontainer:
+    desc: Unit-test the client-side dev container launcher (no VS Code needed)
+    cmds:
+      - ./scripts/test-open-devcontainer.sh
 
   test:hooks:
     desc: Round-trip the Taskfile targets the Claude hooks delegate to

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -559,7 +559,15 @@ about which layer makes the *container* hop. The extension path, concretely:
 4. **Every reattach after that is one click**: File → **Open Recent** — the
    entry reading `<repo> [Dev Container: DEV — …]` replays the whole nested
    route (Coder → extension → container) correctly. This is the reattach
-   path; the Coder button is not.
+   path; the Coder button is not. From a terminal on the client,
+   `scripts/open-devcontainer.sh <repo-match>` is the same click: it lifts the
+   matching `dev-container+…` folder URI out of VS Code's own recents and runs
+   `code --folder-uri` (no argument lists what is on offer). Wrap it in
+   whatever your fingers already reach for — an alias
+   (`alias devbox='~/src/[[ project_slug ]]/scripts/open-devcontainer.sh [[ project_slug ]]'`),
+   a Raycast script command, a Shortcuts action — remembering that it can only
+   replay an entry that exists, so step 3 is still how a repo gets its first
+   one.
 5. **Rebuilds** happen from the same window: "Dev Containers: Rebuild
    Container".
 

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -559,15 +559,26 @@ about which layer makes the *container* hop. The extension path, concretely:
 4. **Every reattach after that is one click**: File → **Open Recent** — the
    entry reading `<repo> [Dev Container: DEV — …]` replays the whole nested
    route (Coder → extension → container) correctly. This is the reattach
-   path; the Coder button is not. From a terminal on the client,
-   `scripts/open-devcontainer.sh <repo-match>` is the same click: it lifts the
-   matching `dev-container+…` folder URI out of VS Code's own recents and runs
-   `code --folder-uri` (no argument lists what is on offer). Wrap it in
-   whatever your fingers already reach for — an alias
-   (`alias devbox='~/src/[[ project_slug ]]/scripts/open-devcontainer.sh [[ project_slug ]]'`),
-   a Raycast script command, a Shortcuts action — remembering that it can only
-   replay an entry that exists, so step 3 is still how a repo gets its first
-   one.
+   path; the Coder button is not. `scripts/open-devcontainer.sh <repo-match>`
+   is the same click from a terminal: it lifts the matching `dev-container+…`
+   folder URI out of VS Code's own recents and runs `code --folder-uri` (no
+   argument lists what is on offer, each line ending in a short `[token]` to
+   pass instead of a name when two profiles of one checkout read alike). It
+   belongs on the **client**, which is where that recents database and `code`
+   are — this checkout is on the workspace host, so copy the script to the
+   client once rather than running it over SSH against the wrong machine's
+   state; it is deliberately self-contained, so a copy is all it takes:
+
+   ```sh
+   mkdir -p ~/bin
+   scp <workspace-host>:<checkout>/scripts/open-devcontainer.sh ~/bin/open-devcontainer
+   chmod +x ~/bin/open-devcontainer
+   ```
+
+   Then wrap the installed copy in whatever your fingers already reach for —
+   `alias devbox='~/bin/open-devcontainer <repo-match>'`, a Raycast script
+   command, a Shortcuts action — remembering that it can only replay an entry
+   that exists, so step 3 is still how a repo gets its first one.
 5. **Rebuilds** happen from the same window: "Dev Containers: Rebuild
    Container".
 

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -575,6 +575,11 @@ about which layer makes the *container* hop. The extension path, concretely:
    chmod +x ~/bin/open-devcontainer
    ```
 
+   Copying from your own checkout — not `curl`ing a branch — is deliberate:
+   it installs exactly the reviewed version sitting next to the docs you are
+   reading, where a download from a moving branch would fetch whatever it
+   has become since.
+
    Then wrap the installed copy in whatever your fingers already reach for —
    `alias devbox='~/bin/open-devcontainer <repo-match>'`, a Raycast script
    command, a Shortcuts action — remembering that it can only replay an entry

--- a/template/scripts/[% if devcontainer %]open-devcontainer.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]open-devcontainer.sh[% endif %]
@@ -200,7 +200,9 @@ db="${VSCODE_STATE_DB-}"
 if [ -z "$db" ]; then
     case "$(uname -s)" in
     Darwin) db="${HOME}/Library/Application Support/Code/User/globalStorage/state.vscdb" ;;
-    Linux) db="${HOME}/.config/Code/User/globalStorage/state.vscdb" ;;
+    # VS Code honours XDG_CONFIG_HOME on Linux, so hardcoding ~/.config would
+    # miss the database on any client that sets it.
+    Linux) db="${XDG_CONFIG_HOME:-${HOME}/.config}/Code/User/globalStorage/state.vscdb" ;;
     *) die "unsupported platform '$(uname -s)' — set VSCODE_STATE_DB to VS Code's state.vscdb" ;;
     esac
 fi
@@ -227,15 +229,26 @@ case "$rc" in
 *) die "failed to read ${db} (extractor exit ${rc})" ;;
 esac
 
+# Arrays here are written by INDEX and read by index, never with `[@]` and
+# never through `${#arr[@]}`, with an ordinary integer carrying the count.
+# That is not a style preference. bash 3.2 — still the /bin/bash on macOS,
+# the client this script is written for — does not create a variable for
+# `arr=()`, so under `set -u` EVERY expansion of a still-empty array, the
+# length included, aborts with "arr: unbound variable". The empty case is
+# exactly the one that must survive: "recents exist, but none of them is a
+# dev container" and "nothing matched" are the two paths whose whole job is to
+# print a helpful message. Counters have no such edge, on any bash.
 uris=()
 labels=()
+count=0
 while IFS=$'\t' read -r uri label; do
     [ -n "$uri" ] || continue
-    uris+=("$uri")
-    labels+=("$label")
+    uris[count]="$uri"
+    labels[count]="$label"
+    count=$((count + 1))
 done <<<"$extracted"
 
-if [ "${#uris[@]}" -eq 0 ]; then
+if [ "$count" -eq 0 ]; then
     die "no dev-container entries in VS Code's recents — ${manual_flow_hint}"
 fi
 
@@ -243,33 +256,37 @@ fi
 
 if [ -z "$match" ]; then
     echo "dev containers VS Code remembers (pass a substring or a [token] to open one):" >&2
-    for label in "${labels[@]}"; do
-        printf '%s\n' "$label"
+    for ((i = 0; i < count; i++)); do
+        printf '%s\n' "${labels[i]}"
     done
     exit 0
 fi
 
 needle="$(printf '%s' "$match" | tr '[:upper:]' '[:lower:]')"
 hits=()
-for ((i = 0; i < ${#uris[@]}; i++)); do
+hit_count=0
+for ((i = 0; i < count; i++)); do
     # Matched against the LABEL, not the raw URI: the URI's hex blob is a long
     # run of [0-9a-f] in which a short all-hex needle ("added", "cafe") would
     # match nothing meaningful. The label carries the entry's token, so a
     # token is matched by this same pass and needs no special case.
     haystack="$(printf '%s' "${labels[i]}" | tr '[:upper:]' '[:lower:]')"
     case "$haystack" in
-    *"$needle"*) hits+=("$i") ;;
+    *"$needle"*)
+        hits[hit_count]="$i"
+        hit_count=$((hit_count + 1))
+        ;;
     esac
 done
 
-if [ "${#hits[@]}" -eq 0 ]; then
+if [ "$hit_count" -eq 0 ]; then
     die "no dev-container entry matching '${match}' — ${manual_flow_hint}"
 fi
 
-if [ "${#hits[@]}" -gt 1 ]; then
-    echo "open-devcontainer: '${match}' matches ${#hits[@]} entries — narrow by name, or use the [token] at the end of a line:" >&2
-    for i in "${hits[@]}"; do
-        printf '%s\n' "${labels[i]}" >&2
+if [ "$hit_count" -gt 1 ]; then
+    echo "open-devcontainer: '${match}' matches ${hit_count} entries — narrow by name, or use the [token] at the end of a line:" >&2
+    for ((i = 0; i < hit_count; i++)); do
+        printf '%s\n' "${labels[${hits[i]}]}" >&2
     done
     exit 1
 fi

--- a/template/scripts/[% if devcontainer %]open-devcontainer.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]open-devcontainer.sh[% endif %]
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# open-devcontainer.sh — reopen a repo's dev container in one command.
+#
+# Runs on the CLIENT (your Mac or Linux laptop), NOT inside a container. It
+# reads the folder URIs VS Code already remembers and hands the matching one
+# back to VS Code, so reattaching through the Dev Containers extension is one
+# command instead of connect → Open Folder → Open Recent.
+#
+#   open-devcontainer.sh               # list the dev-container entries
+#   open-devcontainer.sh harmon-init   # launch the one that matches
+#
+# Deliberately recents-based. A Dev Containers window is described by a folder
+# URI of the shape
+#     vscode-remote://dev-container+<hex>@<remote-authority>/<path>
+# where <hex> is a hex-encoded JSON blob the extension owns and changes between
+# versions. Composing one from scratch would be guessing at that schema; the
+# recents entry is authoritative. So the FIRST attach to a repo is still the
+# manual flow documented in docs/guides/devcontainers.md — that is what creates
+# the entry. Every reattach after it is this script.
+#
+# Dependencies: python3 and the `code` CLI. python3 does BOTH jobs — reading
+# VS Code's SQLite state database (stdlib `sqlite3`, opened read-only so a
+# running VS Code is never disturbed) and parsing the recents JSON. That is one
+# dependency instead of three: python3 ships with the macOS command line tools,
+# whereas the sqlite3 CLI and jq are each absent often enough on a client to be
+# worth not requiring. `code` is needed only to launch, never to list.
+set -euo pipefail
+
+# The extraction program. Given the database path, it prints one TAB-separated
+# `<folderUri>\t<label>` line per dev-container entry, newest first (recents
+# order). Exit codes are the failure vocabulary the shell turns into messages:
+# 3 = database unreadable, 4 = no recents key, 5 = recents value is not JSON.
+PY_EXTRACT=$(
+    cat <<'PY'
+import json
+import sqlite3
+import sys
+import urllib.parse
+
+KEY = "history.recentlyOpenedPathsList"
+PREFIXES = ("vscode-remote://dev-container+", "vscode-remote://dev-container%2b")
+
+try:
+    # mode=ro never creates and never writes. quote() is what makes a path with
+    # spaces ("Application Support") a legal URI.
+    uri = "file:" + urllib.parse.quote(sys.argv[1])
+    con = sqlite3.connect(uri + "?mode=ro", uri=True)
+    row = con.execute("SELECT value FROM ItemTable WHERE key = ?", (KEY,)).fetchone()
+except sqlite3.Error:
+    sys.exit(3)
+
+if row is None or row[0] is None or row[0] == "":
+    sys.exit(4)
+
+value = row[0]
+if isinstance(value, (bytes, bytearray)):
+    value = value.decode("utf-8", "replace")
+
+try:
+    data = json.loads(value)
+except ValueError:
+    sys.exit(5)
+
+
+def label_for(folder_uri):
+    """A human-readable one-liner: container path, host path, remote host."""
+    decoded = urllib.parse.unquote(folder_uri)
+    rest = decoded.split("://", 1)[1] if "://" in decoded else decoded
+    authority, _, path = rest.partition("/")
+    blob, _, remote = authority.partition("@")
+    host_path = ""
+    hex_blob = blob.split("+", 1)[1] if "+" in blob else ""
+    try:
+        # The blob is hex-encoded JSON; hostPath is the checkout on the remote
+        # host. Any shape we do not recognize simply costs us the extra detail.
+        info = json.loads(bytes.fromhex(hex_blob).decode("utf-8"))
+        if isinstance(info, dict) and isinstance(info.get("hostPath"), str):
+            host_path = info["hostPath"]
+    except Exception:
+        host_path = ""
+    label = "/" + path if path else decoded
+    extra = []
+    if host_path:
+        extra.append("host " + host_path)
+    if remote:
+        extra.append(remote)
+    if extra:
+        label += "  (" + ", ".join(extra) + ")"
+    # The output is line- and TAB-delimited; never let a label break it.
+    return label.replace("\t", " ").replace("\n", " ").replace("\r", " ")
+
+
+entries = data.get("entries") if isinstance(data, dict) else None
+for entry in entries if isinstance(entries, list) else []:
+    if not isinstance(entry, dict):
+        continue
+    folder_uri = entry.get("folderUri")
+    if not isinstance(folder_uri, str) or not folder_uri:
+        continue
+    if not folder_uri.lower().startswith(PREFIXES):
+        continue
+    sys.stdout.write(folder_uri + "\t" + label_for(folder_uri) + "\n")
+PY
+)
+
+usage() {
+    cat <<'EOF'
+Usage: open-devcontainer.sh [<repo-match>]
+
+  (no argument)  list the dev-container entries VS Code remembers
+  <repo-match>   case-insensitive substring; a unique match is launched with
+                 `code --folder-uri`, several are listed so you can narrow it
+
+Environment:
+  VSCODE_STATE_DB            path to VS Code's state.vscdb (default: per-platform)
+  CODE_BIN                   the VS Code CLI to launch (default: code)
+  PYTHON_BIN                 the Python 3 interpreter to use (default: python3)
+  OPEN_DEVCONTAINER_DRY_RUN  1 = print the launch command instead of running it
+EOF
+}
+
+die() {
+    echo "open-devcontainer: $*" >&2
+    exit 1
+}
+
+manual_flow_hint="open it once via the manual flow — see docs/guides/devcontainers.md (attach paths) — then this launcher can reopen it"
+
+case "${1-}" in
+-h | --help)
+    usage
+    exit 0
+    ;;
+esac
+if [ "$#" -gt 1 ]; then
+    usage >&2
+    exit 2
+fi
+match="${1-}"
+
+# ---- locate the state database -------------------------------------------
+
+db="${VSCODE_STATE_DB-}"
+if [ -z "$db" ]; then
+    case "$(uname -s)" in
+    Darwin) db="${HOME}/Library/Application Support/Code/User/globalStorage/state.vscdb" ;;
+    Linux) db="${HOME}/.config/Code/User/globalStorage/state.vscdb" ;;
+    *) die "unsupported platform '$(uname -s)' — set VSCODE_STATE_DB to VS Code's state.vscdb" ;;
+    esac
+fi
+[ -f "$db" ] || die "no VS Code state database at ${db} — run VS Code on this machine once, or set VSCODE_STATE_DB"
+
+# ---- read it --------------------------------------------------------------
+
+python_bin="${PYTHON_BIN:-python3}"
+# One probe covers both "not installed" and macOS's python3 shim, which exists
+# on PATH but only prints an install prompt until the command line tools are.
+if ! command -v "$python_bin" >/dev/null 2>&1 || ! "$python_bin" -c 'import json, sqlite3' >/dev/null 2>&1; then
+    die "no working python3 (tried '${python_bin}') — install it (macOS: xcode-select --install; Debian/Ubuntu: apt-get install python3) or set PYTHON_BIN"
+fi
+
+set +e
+extracted="$("$python_bin" -c "$PY_EXTRACT" "$db" 2>/dev/null)"
+rc=$?
+set -e
+case "$rc" in
+0) ;;
+3) die "could not read ${db} — is it VS Code's state.vscdb?" ;;
+4) die "no recently-opened list in ${db} — open a folder in VS Code first" ;;
+5) die "VS Code's recently-opened list in ${db} is not valid JSON" ;;
+*) die "failed to read ${db} (extractor exit ${rc})" ;;
+esac
+
+uris=()
+labels=()
+while IFS=$'\t' read -r uri label; do
+    [ -n "$uri" ] || continue
+    uris+=("$uri")
+    labels+=("$label")
+done <<<"$extracted"
+
+if [ "${#uris[@]}" -eq 0 ]; then
+    die "no dev-container entries in VS Code's recents — ${manual_flow_hint}"
+fi
+
+# ---- list, or match and launch --------------------------------------------
+
+if [ -z "$match" ]; then
+    echo "dev containers VS Code remembers (pass a substring to open one):" >&2
+    for label in "${labels[@]}"; do
+        printf '%s\n' "$label"
+    done
+    exit 0
+fi
+
+needle="$(printf '%s' "$match" | tr '[:upper:]' '[:lower:]')"
+hits=()
+for ((i = 0; i < ${#uris[@]}; i++)); do
+    # Matched against the LABEL, not the raw URI: the URI's hex blob is a long
+    # run of [0-9a-f] in which a short all-hex needle ("added", "cafe") would
+    # match nothing meaningful.
+    haystack="$(printf '%s' "${labels[i]}" | tr '[:upper:]' '[:lower:]')"
+    case "$haystack" in
+    *"$needle"*) hits+=("$i") ;;
+    esac
+done
+
+if [ "${#hits[@]}" -eq 0 ]; then
+    die "no dev-container entry matching '${match}' — ${manual_flow_hint}"
+fi
+
+if [ "${#hits[@]}" -gt 1 ]; then
+    echo "open-devcontainer: '${match}' matches ${#hits[@]} entries — narrow it:" >&2
+    for i in "${hits[@]}"; do
+        printf '%s\n' "${labels[i]}" >&2
+    done
+    exit 1
+fi
+
+target="${uris[${hits[0]}]}"
+code_bin="${CODE_BIN:-code}"
+
+if [ "${OPEN_DEVCONTAINER_DRY_RUN-}" = "1" ]; then
+    printf '%s --folder-uri %s\n' "$code_bin" "$target"
+    exit 0
+fi
+
+command -v "$code_bin" >/dev/null 2>&1 ||
+    die "'${code_bin}' not found on PATH — in VS Code run the command palette's \"Shell Command: Install 'code' command in PATH\" (or set CODE_BIN)"
+
+exec "$code_bin" --folder-uri "$target"

--- a/template/scripts/[% if devcontainer %]open-devcontainer.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]open-devcontainer.sh[% endif %]
@@ -24,6 +24,11 @@
 # dependency instead of three: python3 ships with the macOS command line tools,
 # whereas the sqlite3 CLI and jq are each absent often enough on a client to be
 # worth not requiring. `code` is needed only to launch, never to list.
+#
+# Self-contained on purpose: no `cd` to a repo root, no sibling files, nothing
+# read out of a checkout. The repo it ships from lives on the workspace HOST,
+# while VS Code's recents and the `code` CLI live on the client — so this is a
+# file you copy to the client once and run there, not one you run over SSH.
 set -euo pipefail
 
 # The extraction program. Given the database path, it prints one TAB-separated
@@ -32,6 +37,7 @@ set -euo pipefail
 # 3 = database unreadable, 4 = no recents key, 5 = recents value is not JSON.
 PY_EXTRACT=$(
     cat <<'PY'
+import hashlib
 import json
 import sqlite3
 import sys
@@ -62,30 +68,76 @@ except ValueError:
     sys.exit(5)
 
 
+def config_tail(info):
+    """The devcontainer.json this entry was built from, trimmed to its tail.
+
+    This is what tells one PROFILE of a checkout from another: the bot config
+    at `.devcontainer/devcontainer.json` and the dev config at
+    `.devcontainer/dev/devcontainer.json` produce two recents entries whose
+    container path, host path, and remote authority are all identical. Without
+    this, they are two indistinguishable lines.
+    """
+    config = info.get("configFile")
+    path = ""
+    if isinstance(config, str):
+        path = config
+    elif isinstance(config, dict) and isinstance(config.get("path"), str):
+        # VS Code serializes a URI as {"$mid":…,"path":…,"scheme":…}.
+        path = config["path"]
+    if not path:
+        return ""
+    path = urllib.parse.unquote(path)
+    marker = "/.devcontainer/"
+    at = path.find(marker)
+    if at >= 0:
+        return path[at + 1:]
+    parts = [p for p in path.split("/") if p]
+    return "/".join(parts[-2:])
+
+
+def token_for(folder_uri):
+    """A short, stable handle for an entry.
+
+    The discriminator of last resort. Everything else shown on a line is
+    decoded out of a blob the extension owns, so two entries CAN come back
+    with identical labels — and an ambiguous listing nothing can select is a
+    dead end. This is derived from the whole URI, so it always exists, always
+    differs between different entries, and does not move between runs.
+    """
+    return hashlib.sha256(folder_uri.encode("utf-8")).hexdigest()[:8]
+
+
 def label_for(folder_uri):
-    """A human-readable one-liner: container path, host path, remote host."""
+    """A human-readable one-liner ending in the entry's selection token."""
     decoded = urllib.parse.unquote(folder_uri)
     rest = decoded.split("://", 1)[1] if "://" in decoded else decoded
     authority, _, path = rest.partition("/")
     blob, _, remote = authority.partition("@")
-    host_path = ""
     hex_blob = blob.split("+", 1)[1] if "+" in blob else ""
+    info = {}
     try:
-        # The blob is hex-encoded JSON; hostPath is the checkout on the remote
-        # host. Any shape we do not recognize simply costs us the extra detail.
-        info = json.loads(bytes.fromhex(hex_blob).decode("utf-8"))
-        if isinstance(info, dict) and isinstance(info.get("hostPath"), str):
-            host_path = info["hostPath"]
+        # The blob is hex-encoded JSON. Any shape we do not recognize simply
+        # costs us the extra detail, never the line itself.
+        parsed = json.loads(bytes.fromhex(hex_blob).decode("utf-8"))
+        if isinstance(parsed, dict):
+            info = parsed
     except Exception:
+        info = {}
+    host_path = info.get("hostPath")
+    if not isinstance(host_path, str):
         host_path = ""
     label = "/" + path if path else decoded
     extra = []
     if host_path:
         extra.append("host " + host_path)
+    config = config_tail(info)
+    if config:
+        extra.append("config " + config)
     if remote:
         extra.append(remote)
     if extra:
         label += "  (" + ", ".join(extra) + ")"
+    label += "  [" + token_for(folder_uri) + "]"
     # The output is line- and TAB-delimited; never let a label break it.
     return label.replace("\t", " ").replace("\n", " ").replace("\r", " ")
 
@@ -109,7 +161,11 @@ Usage: open-devcontainer.sh [<repo-match>]
 
   (no argument)  list the dev-container entries VS Code remembers
   <repo-match>   case-insensitive substring; a unique match is launched with
-                 `code --folder-uri`, several are listed so you can narrow it
+                 `code --folder-uri`, several are listed so you can narrow it.
+                 Every listed line ends in a short [token] that is also a
+                 match target — the way to pick between two entries whose
+                 details are identical (the bot and dev profiles of one
+                 checkout, say)
 
 Environment:
   VSCODE_STATE_DB            path to VS Code's state.vscdb (default: per-platform)
@@ -186,7 +242,7 @@ fi
 # ---- list, or match and launch --------------------------------------------
 
 if [ -z "$match" ]; then
-    echo "dev containers VS Code remembers (pass a substring to open one):" >&2
+    echo "dev containers VS Code remembers (pass a substring or a [token] to open one):" >&2
     for label in "${labels[@]}"; do
         printf '%s\n' "$label"
     done
@@ -198,7 +254,8 @@ hits=()
 for ((i = 0; i < ${#uris[@]}; i++)); do
     # Matched against the LABEL, not the raw URI: the URI's hex blob is a long
     # run of [0-9a-f] in which a short all-hex needle ("added", "cafe") would
-    # match nothing meaningful.
+    # match nothing meaningful. The label carries the entry's token, so a
+    # token is matched by this same pass and needs no special case.
     haystack="$(printf '%s' "${labels[i]}" | tr '[:upper:]' '[:lower:]')"
     case "$haystack" in
     *"$needle"*) hits+=("$i") ;;
@@ -210,7 +267,7 @@ if [ "${#hits[@]}" -eq 0 ]; then
 fi
 
 if [ "${#hits[@]}" -gt 1 ]; then
-    echo "open-devcontainer: '${match}' matches ${#hits[@]} entries — narrow it:" >&2
+    echo "open-devcontainer: '${match}' matches ${#hits[@]} entries — narrow by name, or use the [token] at the end of a line:" >&2
     for i in "${hits[@]}"; do
         printf '%s\n' "${labels[i]}" >&2
     done

--- a/template/scripts/[% if devcontainer %]test-open-devcontainer.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]test-open-devcontainer.sh[% endif %]
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# test-open-devcontainer.sh — unit-test the client-side dev container launcher.
+#
+# The launcher's whole job is reading someone else's data format: VS Code's
+# recents list, a JSON blob inside a SQLite row, holding URIs whose authority
+# is hex-encoded JSON. Everything that can go wrong is in that parse, and none
+# of it needs VS Code — so each case here builds a throwaway state.vscdb with
+# a known recents payload and asserts what the launcher makes of it.
+#
+# Launching is asserted without opening anything: OPEN_DEVCONTAINER_DRY_RUN=1
+# prints the command, and CODE_BIN points at a stub that records its arguments.
+# Run via `task test:open-devcontainer`.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+launcher="scripts/open-devcontainer.sh"
+
+[ -r "$launcher" ] || {
+    echo "TEST FAIL: $launcher not found" >&2
+    exit 1
+}
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+tmp_root="$(mktemp -d -t harmon-open-devcontainer-XXXXXX)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+# hex <string> — hex-encode ASCII in pure bash, so building a fixture URI needs
+# no xxd (absent on stock macOS) and no second language.
+hex() {
+    local s="$1" i out=""
+    for ((i = 0; i < ${#s}; i++)); do
+        out="${out}$(printf '%02x' "'${s:i:1}")"
+    done
+    printf '%s' "$out"
+}
+
+# dc_uri <hostPath> <remote> <container path> [plus] — a dev-container folder
+# URI shaped exactly like the ones VS Code stores. The 4th argument chooses how
+# the `+` after `dev-container` is written: VS Code emits both forms, and the
+# launcher has to accept either.
+dc_uri() {
+    local blob plus="${4-+}"
+    blob="$(hex "{\"hostPath\":\"$1\",\"localDocker\":false}")"
+    printf 'vscode-remote://dev-container%s%s@%s%s' "$plus" "$blob" "$2" "$3"
+}
+
+# make_db <name> <json> — a state.vscdb holding <json> under the recents key.
+# Written with python3's stdlib sqlite3 for the same reason the launcher reads
+# it that way: the sqlite3 CLI is not present on every machine that runs this.
+make_db() {
+    local path="${tmp_root}/$1.vscdb"
+    python3 - "$path" "$2" <<'PY'
+import sqlite3, sys
+con = sqlite3.connect(sys.argv[1])
+con.execute("CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)")
+con.execute("INSERT INTO ItemTable VALUES (?, ?)", ("history.recentlyOpenedPathsList", sys.argv[2]))
+con.commit()
+con.close()
+PY
+    printf '%s' "$path"
+}
+
+# run_launcher <db> [arg…] — capture stdout+stderr and the exit code. Captured
+# explicitly: `set -e` would otherwise abort the suite on the very nonzero exit
+# a case exists to assert.
+out=""
+rc=0
+run_launcher() {
+    local db="$1"
+    shift
+    set +e
+    out="$(VSCODE_STATE_DB="$db" OPEN_DEVCONTAINER_DRY_RUN=1 bash "$launcher" "$@" 2>&1)"
+    rc=$?
+    set -e
+}
+
+uri_init="$(dc_uri /srv/coder/harmon-init ssh-remote+devbox /workspaces/harmon-init)"
+uri_site="$(dc_uri /srv/coder/evanharmon-site ssh-remote+devbox /workspaces/evanharmon-site %2B)"
+recents="{\"entries\":[{\"folderUri\":\"${uri_init}\"},{\"folderUri\":\"file:///srv/coder/notes\"},{\"folderUri\":\"${uri_site}\"}]}"
+db_ok="$(make_db recents "$recents")"
+
+# ---- 1. no argument lists the dev-container entries, and only those ----
+# The ordinary folder entry is the control: a launcher that lists it would send
+# `code --folder-uri` at a path with no container behind it.
+
+echo "==> no argument lists exactly the dev-container entries"
+run_launcher "$db_ok"
+[ "$rc" -eq 0 ] || fail "listing exited ${rc}, not 0"
+listed="$(VSCODE_STATE_DB="$db_ok" bash "$launcher" 2>/dev/null)"
+[ "$(printf '%s\n' "$listed" | grep -c .)" -eq 2 ] ||
+    fail "expected 2 listed entries on stdout, got: ${listed}"
+printf '%s\n' "$listed" | grep -q '/workspaces/harmon-init' ||
+    fail "the harmon-init entry is missing: ${listed}"
+printf '%s\n' "$listed" | grep -q '/workspaces/evanharmon-site' ||
+    fail "the percent-encoded '+' entry is missing: ${listed}"
+if printf '%s\n' "$listed" | grep -q 'notes'; then
+    fail "an ordinary (non-dev-container) folder was listed: ${listed}"
+fi
+# The hex blob is decoded far enough to name the checkout on the host.
+printf '%s\n' "$listed" | grep -q 'host /srv/coder/harmon-init' ||
+    fail "the hostPath was not decoded out of the hex authority: ${listed}"
+
+# ---- 2. a unique match launches that entry, matched case-insensitively ----
+
+echo "==> a unique match launches the right URI"
+run_launcher "$db_ok" HARMON-Init
+[ "$rc" -eq 0 ] || fail "a unique match exited ${rc}, not 0"
+printf '%s\n' "$out" | grep -qF -- "--folder-uri ${uri_init}" ||
+    fail "did not launch the harmon-init URI: ${out}"
+if printf '%s\n' "$out" | grep -qF -- "$uri_site"; then
+    fail "the launch command names the wrong entry too: ${out}"
+fi
+
+echo "==> the launch really execs the code CLI with the URI"
+stub="${tmp_root}/code-stub"
+cat >"$stub" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" >"${tmp_root}/stub-args"
+EOF
+chmod +x "$stub"
+VSCODE_STATE_DB="$db_ok" CODE_BIN="$stub" bash "$launcher" evanharmon-site >/dev/null 2>&1 ||
+    fail "launching through a CODE_BIN stub exited nonzero"
+[ -f "${tmp_root}/stub-args" ] || fail "the code stub was never invoked"
+grep -qxF -- "--folder-uri" "${tmp_root}/stub-args" ||
+    fail "the stub was not passed --folder-uri: $(cat "${tmp_root}/stub-args")"
+grep -qxF -- "$uri_site" "${tmp_root}/stub-args" ||
+    fail "the stub was passed the wrong URI: $(cat "${tmp_root}/stub-args")"
+
+# ---- 3. an ambiguous match refuses, and shows what to choose between ----
+# Silently opening the first of several is the failure mode worth designing
+# against: it is indistinguishable from success until the wrong window opens.
+
+echo "==> an ambiguous match exits 1 and lists the candidates"
+run_launcher "$db_ok" workspaces
+[ "$rc" -eq 1 ] || fail "an ambiguous match exited ${rc}, not 1"
+printf '%s\n' "$out" | grep -q '/workspaces/harmon-init' ||
+    fail "the ambiguous listing omits harmon-init: ${out}"
+printf '%s\n' "$out" | grep -q '/workspaces/evanharmon-site' ||
+    fail "the ambiguous listing omits evanharmon-site: ${out}"
+if printf '%s\n' "$out" | grep -qF -- "--folder-uri"; then
+    fail "an ambiguous match launched something anyway: ${out}"
+fi
+
+# ---- 4. no match points at the flow that would create the entry ----
+# The launcher cannot compose a dev-container URI it has never seen, so this
+# message is the whole remedy — it has to name the manual flow.
+
+echo "==> no match exits 1 with the manual-flow pointer"
+run_launcher "$db_ok" nonesuch
+[ "$rc" -eq 1 ] || fail "an unmatched name exited ${rc}, not 1"
+printf '%s\n' "$out" | grep -q 'docs/guides/devcontainers.md' ||
+    fail "the no-match message does not point at the guide: ${out}"
+
+echo "==> a recents list with no dev-container entries says the same thing"
+db_plain="$(make_db plain '{"entries":[{"folderUri":"file:///srv/coder/notes"}]}')"
+run_launcher "$db_plain" harmon-init
+[ "$rc" -ne 0 ] || fail "a recents list with no dev containers exited 0"
+printf '%s\n' "$out" | grep -q 'docs/guides/devcontainers.md' ||
+    fail "the empty-list message does not point at the guide: ${out}"
+
+# ---- 5. every missing precondition is one specific line, never a trace ----
+
+echo "==> a missing database exits nonzero naming the path"
+run_launcher "${tmp_root}/absent.vscdb"
+[ "$rc" -ne 0 ] || fail "a missing database exited 0"
+printf '%s\n' "$out" | grep -q 'no VS Code state database' ||
+    fail "a missing database did not say so: ${out}"
+if printf '%s\n' "$out" | grep -qi 'line [0-9]\|command not found'; then
+    fail "a missing database produced a bash trace: ${out}"
+fi
+
+echo "==> a database without the recents key exits nonzero"
+db_nokey="${tmp_root}/nokey.vscdb"
+python3 - "$db_nokey" <<'PY'
+import sqlite3, sys
+con = sqlite3.connect(sys.argv[1])
+con.execute("CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)")
+con.commit()
+con.close()
+PY
+run_launcher "$db_nokey"
+[ "$rc" -ne 0 ] || fail "a database without the recents key exited 0"
+printf '%s\n' "$out" | grep -q 'no recently-opened list' ||
+    fail "a database without the recents key did not say so: ${out}"
+
+echo "==> a database that is not a state.vscdb exits nonzero"
+db_junk="${tmp_root}/junk.vscdb"
+printf 'not a database\n' >"$db_junk"
+run_launcher "$db_junk"
+[ "$rc" -ne 0 ] || fail "a non-database file exited 0"
+printf '%s\n' "$out" | grep -q 'could not read' ||
+    fail "a non-database file did not say so: ${out}"
+
+echo "==> a missing python3 exits nonzero saying how to get one"
+set +e
+out="$(VSCODE_STATE_DB="$db_ok" PYTHON_BIN="${tmp_root}/no-such-python" bash "$launcher" 2>&1)"
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "a missing python3 exited 0"
+printf '%s\n' "$out" | grep -q 'no working python3' ||
+    fail "a missing python3 did not say so: ${out}"
+
+echo "open-devcontainer: all cases passed"

--- a/template/scripts/[% if devcontainer %]test-open-devcontainer.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]test-open-devcontainer.sh[% endif %]
@@ -27,14 +27,16 @@ fail() {
 tmp_root="$(mktemp -d -t harmon-open-devcontainer-XXXXXX)"
 trap 'rm -rf "$tmp_root"' EXIT
 
-# hex <string> — hex-encode ASCII in pure bash, so building a fixture URI needs
-# no xxd (absent on stock macOS) and no second language.
+# hex <string> — hex-encode a fixture blob in one python3 call. The launcher
+# under test already requires python3, so the test may too. What this replaced
+# looped in bash and forked a subshell PER CHARACTER — about 600 of them for
+# the fixtures below. Measured honestly in this Linux devcontainer that is
+# 1.36s before against 1.29s after: noise, because bash forks a subshell for
+# `$(printf …)` without an exec. It is kept for the process count itself,
+# which is real, and because fork is markedly dearer on the macOS client this
+# suite also runs on — not on a promise that `task verify` got faster.
 hex() {
-    local s="$1" i out=""
-    for ((i = 0; i < ${#s}; i++)); do
-        out="${out}$(printf '%02x' "'${s:i:1}")"
-    done
-    printf '%s' "$out"
+    python3 -c 'import sys; sys.stdout.write(sys.argv[1].encode("utf-8").hex())' "$1"
 }
 
 # dc_uri <hostPath> <remote> <container path> [plus] — a dev-container folder
@@ -224,6 +226,59 @@ run_launcher "$db_plain" harmon-init
 [ "$rc" -ne 0 ] || fail "a recents list with no dev containers exited 0"
 printf '%s\n' "$out" | grep -q 'docs/guides/devcontainers.md' ||
     fail "the empty-list message does not point at the guide: ${out}"
+
+echo "==> the no-entries path survives an explicit -u, and lists nothing"
+# Both of the paths above reach their message with EMPTY arrays. On bash 3.2 —
+# the /bin/bash of the macOS client this script targets — `arr=()` creates no
+# variable, so under `set -u` any expansion of a still-empty array (`${arr[@]}`
+# and `${#arr[@]}` alike) aborts with "unbound variable" BEFORE the message is
+# printed. That is the bug this pair of cases guards.
+#
+# Honest limit: bash 3.2 is not installed in this container, and `bash -u` on a
+# modern bash does NOT reproduce the 3.2 semantics — the run below only proves
+# the paths are clean under -u on the bash we have. The structural assertion
+# after it is what actually holds the line, because the 3.2 trap is reachable
+# only through `[@]`-style expansion: the launcher must not contain one.
+set +e
+out="$(VSCODE_STATE_DB="$db_plain" bash -u "$launcher" 2>&1)"
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "the no-entries listing exited 0 under -u"
+printf '%s\n' "$out" | grep -q 'no dev-container entries' ||
+    fail "the no-entries listing did not print its message under -u: ${out}"
+if printf '%s\n' "$out" | grep -q 'unbound variable'; then
+    fail "an empty array was expanded on the no-entries path: ${out}"
+fi
+
+echo "==> the launcher expands no array with [@] or [*]"
+# Comment lines are filtered out: the launcher's own explanation of this rule
+# necessarily spells the forbidden form.
+offenders="$(grep -nE '\$\{#?[A-Za-z_][A-Za-z0-9_]*\[[@*]\]' "$launcher" |
+    grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+[ -z "$offenders" ] ||
+    fail "array expansions unsafe on bash 3.2 + set -u (index them instead): ${offenders}"
+
+# ---- 4b. the Linux default path follows XDG ----
+# VS Code writes its state under XDG_CONFIG_HOME when that is set, so a client
+# that sets it would otherwise get "no VS Code state database" pointing at a
+# ~/.config path nothing ever wrote to.
+
+echo "==> the Linux default path honours XDG_CONFIG_HOME"
+if [ "$(uname -s)" = "Linux" ]; then
+    xdg_root="${tmp_root}/xdg"
+    mkdir -p "${xdg_root}/Code/User/globalStorage"
+    cp "$db_ok" "${xdg_root}/Code/User/globalStorage/state.vscdb"
+    # No VSCODE_STATE_DB here on purpose: the point is the DEFAULT path.
+    set +e
+    out="$(XDG_CONFIG_HOME="$xdg_root" OPEN_DEVCONTAINER_DRY_RUN=1 bash "$launcher" harmon-init 2>&1)"
+    rc=$?
+    set -e
+    [ "$rc" -eq 0 ] || fail "the XDG default path was not consulted (exit ${rc}): ${out}"
+    printf '%s\n' "$out" | grep -qF -- "--folder-uri ${uri_init}" ||
+        fail "the XDG default path found the wrong entry: ${out}"
+else
+    echo "    (skipped: XDG is the Linux branch, and this host is $(uname -s))"
+fi
 
 # ---- 5. every missing precondition is one specific line, never a trace ----
 

--- a/template/scripts/[% if devcontainer %]test-open-devcontainer.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]test-open-devcontainer.sh[% endif %]
@@ -41,10 +41,23 @@ hex() {
 # URI shaped exactly like the ones VS Code stores. The 4th argument chooses how
 # the `+` after `dev-container` is written: VS Code emits both forms, and the
 # launcher has to accept either.
+# A 5th argument gives the blob a configFile, serialized the way VS Code
+# serializes a URI ({"$mid":…,"path":…,"scheme":…}) — that is the only field
+# that differs between the dev and bot profiles of one checkout.
 dc_uri() {
-    local blob plus="${4-+}"
-    blob="$(hex "{\"hostPath\":\"$1\",\"localDocker\":false}")"
+    local blob json plus="${4-+}"
+    json="{\"hostPath\":\"$1\",\"localDocker\":false"
+    if [ -n "${5-}" ]; then
+        json="${json},\"configFile\":{\"\$mid\":1,\"path\":\"$5\",\"scheme\":\"vscode-fileHost\"}"
+    fi
+    blob="$(hex "${json}}")"
     printf 'vscode-remote://dev-container%s%s@%s%s' "$plus" "$blob" "$2" "$3"
+}
+
+# token_of <line> — the [xxxxxxxx] handle the launcher prints at the end of a
+# listed line.
+token_of() {
+    printf '%s\n' "$1" | sed -n 's/.*\[\([0-9a-f]\{8\}\)\]$/\1/p'
 }
 
 # make_db <name> <json> — a state.vscdb holding <json> under the recents key.
@@ -128,6 +141,57 @@ grep -qxF -- "--folder-uri" "${tmp_root}/stub-args" ||
     fail "the stub was not passed --folder-uri: $(cat "${tmp_root}/stub-args")"
 grep -qxF -- "$uri_site" "${tmp_root}/stub-args" ||
     fail "the stub was passed the wrong URI: $(cat "${tmp_root}/stub-args")"
+
+# ---- 2b. the two profiles of ONE checkout stay distinguishable ----
+# The dev and bot configs of a repo produce two recents entries with the same
+# container path, the same hostPath and the same remote authority — they differ
+# only inside the hex blob. If the listing renders them identically, ambiguity
+# is a dead end: no argument can ever select either one. Two things prevent
+# that, and both are asserted here — the decoded config path, and the token,
+# which exists even when the blob decodes to nothing at all.
+
+echo "==> the dev and bot profiles of one checkout list distinctly"
+uri_dev="$(dc_uri /srv/coder/harmon-init ssh-remote+devbox /workspaces/harmon-init \
+    + /srv/coder/harmon-init/.devcontainer/dev/devcontainer.json)"
+uri_bot="$(dc_uri /srv/coder/harmon-init ssh-remote+devbox /workspaces/harmon-init \
+    + /srv/coder/harmon-init/.devcontainer/devcontainer.json)"
+db_prof="$(make_db profiles "{\"entries\":[{\"folderUri\":\"${uri_dev}\"},{\"folderUri\":\"${uri_bot}\"}]}")"
+profiles="$(VSCODE_STATE_DB="$db_prof" bash "$launcher" 2>/dev/null)"
+[ "$(printf '%s\n' "$profiles" | grep -c .)" -eq 2 ] ||
+    fail "expected both profiles listed, got: ${profiles}"
+line_dev="$(printf '%s\n' "$profiles" | grep 'dev/devcontainer.json' || true)"
+line_bot="$(printf '%s\n' "$profiles" | grep -v 'dev/devcontainer.json' || true)"
+[ -n "$line_dev" ] || fail "the dev profile's config path was not decoded: ${profiles}"
+printf '%s\n' "$line_bot" | grep -q 'config .devcontainer/devcontainer.json' ||
+    fail "the bot profile's config path was not decoded: ${profiles}"
+[ "$line_dev" != "$line_bot" ] || fail "the two profiles rendered identically: ${profiles}"
+
+echo "==> each profile is selectable by its config path"
+run_launcher "$db_prof" dev/devcontainer.json
+[ "$rc" -eq 0 ] || fail "selecting the dev profile by config path exited ${rc}: ${out}"
+printf '%s\n' "$out" | grep -qF -- "--folder-uri ${uri_dev}" ||
+    fail "the config-path match launched the wrong profile: ${out}"
+
+echo "==> each profile is selectable by its token"
+tok_dev="$(token_of "$line_dev")"
+tok_bot="$(token_of "$line_bot")"
+[ -n "$tok_dev" ] || fail "the dev profile's line carries no token: ${profiles}"
+[ -n "$tok_bot" ] || fail "the bot profile's line carries no token: ${profiles}"
+[ "$tok_dev" != "$tok_bot" ] || fail "both profiles carry the same token: ${profiles}"
+# Stable and derived from the URI, not from listing order — a token a human
+# copied out of yesterday's listing has to still mean the same entry.
+[ "$tok_bot" = "$(python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest()[:8])' "$uri_bot")" ] ||
+    fail "the token is not the first 8 hex of sha256(uri): ${tok_bot}"
+run_launcher "$db_prof" "$tok_bot"
+[ "$rc" -eq 0 ] || fail "selecting the bot profile by token exited ${rc}: ${out}"
+printf '%s\n' "$out" | grep -qF -- "--folder-uri ${uri_bot}" ||
+    fail "the token match launched the wrong profile: ${out}"
+
+echo "==> an ambiguity between the profiles points at the token"
+run_launcher "$db_prof" harmon-init
+[ "$rc" -eq 1 ] || fail "the two profiles were not reported as ambiguous (exit ${rc}): ${out}"
+printf '%s\n' "$out" | grep -q 'token' ||
+    fail "the ambiguous message does not mention the token: ${out}"
 
 # ---- 3. an ambiguous match refuses, and shows what to choose between ----
 # Silently opening the first of several is the failure mode worth designing


### PR DESCRIPTION
## What / why

Reattaching to a repo's dev container through the recommended path (Dev Containers extension — builds from the checkout, applies `customizations.vscode`) was N clicks, so the convenient-but-stale Coder-direct hop kept winning on muscle memory. This ships the script surface of the attach-path recommendation:

- **`scripts/open-devcontainer.sh`** (client-side: Mac/Linux; python3 stdlib + `code` CLI, no other deps): extracts the `dev-container+` folder URIs the extension records in VS Code's recents (`state.vscdb`, opened read-only) and execs `code --folder-uri` on the match. No-arg form lists entries with decoded container path, host path, **config profile** (`.devcontainer/dev/devcontainer.json` vs root — so bot/dev profiles of one checkout are distinguishable), remote authority, and a stable `[sha256(uri)[:8]]` token that is always selectable even when the hex blob is opaque. Deliberately recents-based — the `dev-container+<hex>` encoding is an extension implementation detail, so the script replays entries the manual flow created rather than composing URIs blind.
- Every missing dependency fails with its own actionable one-line message; the script is verified location-independent, and the docs install it **from your own checkout** (`scp`, not a curl of a moving branch — the reviewed copy is what lands in `~/bin`), then wrap it in an alias/Raycast/Shortcuts launcher.
- 14-case fixture-SQLite test suite wired into `verify`; dogfood + template twins in parity throughout.

Closes #823

Sibling surfaces of the same recommendation: harmonops/harmon-infra#495 (Coder dashboard button), #824 (README badge).

## Verification

- `task ci` green on the final tree; `test:open-devcontainer` (14 cases) and dogfood parity (121 twins) inside it.
- Rigor: standard (`default_rigor`) → challenge ≤3, review ≤3, shepherd ≤4. Challenge converged in 3 rounds (round-1 P1s: profile-ambiguity dead end + docs assuming a client-side checkout, both fixed; round-2/3 P2s fixed in place: install-from-checkout supply-chain hardening and its template mirror); review converged in 1 round (no findings).
- All four acceptance criteria on #823 ticked as verified; the python3-instead-of-sqlite3-CLI dependency adjudication is recorded on the issue.
- Note: `task verify` flaked 5× today on the pre-existing #792 worktree timeout (unrelated suite); diagnosis evidence posted there.

## Deferred findings

None — every challenge/review finding was fixed in place or is recorded above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEFrEtVL8idUWCVLuuabWN