### PR TITLE
fix(template): state the Auto-review knobs as settled fact across both template layers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -615,12 +615,16 @@ workbench, and the second is actively harmful here — `gh pr ready` would kick
 off a fresh asynchronous review *after* the gate that was supposed to complete
 the automated work, so non-draft would stop meaning "ready for a human". The
 lifecycle therefore uses explicit `@codex review` requests while the PR is
-draft, per the current-head cycle above. Evan has set personal Auto review off
-and the repository preference to **Follow personal**; that state is a
-**human-configured prerequisite**, not something any API confirms, so never
-report it as mechanically verified. If it changes, the readiness gate stops
-being valid until it is restored. Mechanical enforcement is tracked separately
-in [#486](https://github.com/evanharmon1/harmon-init/issues/486).
+draft, per the current-head cycle above. They are disabled, platform-wide:
+personal Auto review is off, and the repository's Auto code review preference
+and its review **Trigger** are both on **Follow personal** — confirmed by the
+maintainer 2026-08-13 and recorded under docs/CHECKLIST.md's [human-only]
+item. Nothing in the lifecycle gates on it. One thing is worth telling the
+maintainer: if a Codex cloud review ever fires **unsolicited** — after a push
+or a promotion that no `@codex review` comment triggered — say so; that is
+the signature of the knobs drifting back on (observed and corrected
+2026-08-10). Reporting an anomaly you happened to observe is not a check to
+run, and nothing waits on it.
 
 **Treat Codex findings as hypotheses, not authority.** For every finding:
 

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -100,13 +100,17 @@ this comment. -->
       (`chatgpt-codex-connector[bot]`, type `Bot`).
 - [ ] **[human-only] Disable Codex Automatic reviews** — turn **personal Auto
       review** off and set this repository's **Auto code review** preference to
-      **Follow personal**. The draft-workbench lifecycle drives Codex with
+      **Follow personal** — and its review **Trigger** to Follow personal too,
+      since an "On every push" trigger sits dormant while Auto review is off
+      and arms across every Follow-personal repo at once the moment the
+      personal toggle changes. The draft-workbench lifecycle drives Codex with
       explicit `@codex review` requests while the PR is draft; left on,
       `gh pr ready` starts a *new* asynchronous review after the readiness gate,
-      and non-draft stops truthfully meaning "ready for a human". No API exposes
-      this setting, so it is a human-configured prerequisite the gate trusts on
-      the strength of this record — never report it as mechanically verified,
-      and re-check it here if Codex's settings change.
+      and non-draft stops truthfully meaning "ready for a human". Ticking this
+      item records that all three knobs are set; once recorded it is settled
+      configuration — nothing in the lifecycle gates on it — and the one thing
+      worth reporting later is an unsolicited Codex review, the signature of
+      the knobs drifting back on.
 - [ ] **[human-only] Any other automatic reviewer must review drafts** — if you
       enable one (GitHub Copilot code review, for example — foreman trusts its
       findings via `trusted_actors`), turn on its draft-review option.

--- a/docs/copier-options.md
+++ b/docs/copier-options.md
@@ -290,11 +290,11 @@ on `skill_categories`).
 
 ### Human-configured prerequisites (no API confirms these)
 
-- **Codex Auto review left off**, with the repository preference set to *Follow
-  personal* — a prerequisite of the readiness gate in `AGENTS.md`. Explicitly
-  **not** mechanically verifiable; never report it as verified. Mechanical
-  enforcement is tracked in
-  [#486](https://github.com/evanharmon1/harmon-init/issues/486).
+- **Codex Auto review left off**, with the repository preference *and* its
+  review Trigger set to *Follow personal* — settled configuration once
+  recorded under docs/CHECKLIST.md's [human-only] item (`AGENTS.md`, "Codex
+  Automatic reviews must stay disabled"). Nothing in the lifecycle gates on
+  it; an unsolicited Codex review is the drift signature worth reporting.
 - Codex cloud-review connector installed on the repository
   (`use_codex_cloud_review` is inert without it).
 - CodeRabbit GitHub App installation.

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -45,16 +45,20 @@ primary agent to adjudicate — the protocol and the loop caps live in AGENTS.md
    request itself and promotes a draft only on a current-head result from the
    configured login — fail-closed, with bounded attempts.
 
-6. **Then disable Codex Automatic reviews** — personal Auto review off, and the
-   repository's Auto code review preference set to **Follow personal**. Codex
-   triggers a cloud review on three events: opening a PR for review, marking a
-   draft ready, and an explicit `@codex review`. Only the third is usable here:
-   the PR is a draft for the whole automated lifecycle, so the first never
-   fires, and the second fires *after* the readiness gate — starting a new
-   asynchronous review at the exact moment "non-draft" is supposed to mean the
-   automated work is done. No API reports this setting, so it is a
-   human-configured prerequisite recorded in docs/CHECKLIST.md; the readiness
-   gate trusts that record and must never claim it was mechanically verified.
+6. **Then disable Codex Automatic reviews** — personal Auto review off, the
+   repository's Auto code review preference set to **Follow personal**, and its
+   review **Trigger** set to Follow personal too (an "On every push" trigger
+   sits dormant while Auto review is off and arms the moment the personal
+   toggle changes). Codex triggers a cloud review on three events: opening a
+   PR for review, marking a draft ready, and an explicit `@codex review`. Only
+   the third is usable here: the PR is a draft for the whole automated
+   lifecycle, so the first never fires, and the second fires *after* the
+   readiness gate — starting a new asynchronous review at the exact moment
+   "non-draft" is supposed to mean the automated work is done. Record the
+   three knobs under docs/CHECKLIST.md's [human-only] item; once recorded it
+   is settled configuration — nothing in the lifecycle gates on it, and the
+   one thing worth reporting later is an unsolicited Codex review, the
+   signature of the knobs drifting back on.
 
 ## Manual reviews
 

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -509,10 +509,15 @@ off a fresh asynchronous review *after* the gate that was supposed to complete
 the automated work, so non-draft would stop meaning "ready for a human". The
 lifecycle therefore uses explicit `@codex review` requests while the PR is
 draft, per the current-head cycle above. Turn personal Auto review off and set
-the repository's Auto code review preference to **Follow personal** (see
-docs/CHECKLIST.md). That state is a **human-configured prerequisite**, not
-something any API confirms, so never report it as mechanically verified; if it
-changes, the readiness gate stops being valid until it is restored.
+the repository's Auto code review preference — and its review **Trigger** —
+to **Follow personal** (see docs/CHECKLIST.md, whose [human-only] item is
+where the maintainer records that this was done). Once recorded there it is
+settled configuration: nothing in the lifecycle gates on it. One thing is
+worth telling the maintainer: if a Codex cloud review ever fires
+**unsolicited** — after a push or a promotion that no `@codex review` comment
+triggered — say so; that is the signature of the knobs drifting back on.
+Reporting an anomaly you happened to observe is not a check to run, and
+nothing waits on it.
 [% else %]
 These local tasks do not imply that Codex cloud review is installed or required.
 [% endif %]

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -96,13 +96,17 @@ environment — against the items below
       (`chatgpt-codex-connector[bot]`, type `Bot`).
 - [ ] **[human-only] Disable Codex Automatic reviews** — turn **personal Auto
       review** off and set this repository's **Auto code review** preference to
-      **Follow personal**. The draft-workbench lifecycle drives Codex with
+      **Follow personal** — and its review **Trigger** to Follow personal too,
+      since an "On every push" trigger sits dormant while Auto review is off
+      and arms across every Follow-personal repo at once the moment the
+      personal toggle changes. The draft-workbench lifecycle drives Codex with
       explicit `@codex review` requests while the PR is draft; left on,
       `gh pr ready` starts a *new* asynchronous review after the readiness gate,
-      and non-draft stops truthfully meaning "ready for a human". No API exposes
-      this setting, so it is a human-configured prerequisite the gate trusts on
-      the strength of this record — never report it as mechanically verified,
-      and re-check it here if Codex's settings change.
+      and non-draft stops truthfully meaning "ready for a human". Ticking this
+      item records that all three knobs are set; once recorded it is settled
+      configuration — nothing in the lifecycle gates on it — and the one thing
+      worth reporting later is an unsolicited Codex review, the signature of
+      the knobs drifting back on.
 [% endif %]
 - [ ] **[human-only] Any other automatic reviewer must review drafts** — if you
       enable one (GitHub Copilot code review, for example[% if use_foreman %] — foreman trusts its

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -45,16 +45,20 @@ primary agent to adjudicate — the protocol and the loop caps live in AGENTS.md
    request itself and promotes a draft only on a current-head result from the
    configured login — fail-closed, with bounded attempts.
 
-6. **Then disable Codex Automatic reviews** — personal Auto review off, and the
-   repository's Auto code review preference set to **Follow personal**. Codex
-   triggers a cloud review on three events: opening a PR for review, marking a
-   draft ready, and an explicit `@codex review`. Only the third is usable here:
-   the PR is a draft for the whole automated lifecycle, so the first never
-   fires, and the second fires *after* the readiness gate — starting a new
-   asynchronous review at the exact moment "non-draft" is supposed to mean the
-   automated work is done. No API reports this setting, so it is a
-   human-configured prerequisite recorded in docs/CHECKLIST.md; the readiness
-   gate trusts that record and must never claim it was mechanically verified.
+6. **Then disable Codex Automatic reviews** — personal Auto review off, the
+   repository's Auto code review preference set to **Follow personal**, and its
+   review **Trigger** set to Follow personal too (an "On every push" trigger
+   sits dormant while Auto review is off and arms the moment the personal
+   toggle changes). Codex triggers a cloud review on three events: opening a
+   PR for review, marking a draft ready, and an explicit `@codex review`. Only
+   the third is usable here: the PR is a draft for the whole automated
+   lifecycle, so the first never fires, and the second fires *after* the
+   readiness gate — starting a new asynchronous review at the exact moment
+   "non-draft" is supposed to mean the automated work is done. Record the
+   three knobs under docs/CHECKLIST.md's [human-only] item; once recorded it
+   is settled configuration — nothing in the lifecycle gates on it, and the
+   one thing worth reporting later is an unsolicited Codex review, the
+   signature of the knobs drifting back on.
 
 ## Manual reviews
 


### PR DESCRIPTION
## What / why

The harmon-init mirror of evanharmon1/harmon-devkit#445's maintainer-directed policy — the final criterion of evanharmon1/harmon-devkit#444. The Codex Auto-review knobs are settled configuration: nothing in the lifecycle checks, gates on, or reports about them; the only guidance left is passive (an unsolicited Codex review — the 2026-08-10 drift signature — is worth telling the maintainer about, and nothing waits on it).

- **AGENTS.md**: flat statement with the maintainer's dated confirmation (2026-08-13); the human-configured-prerequisite / never-mechanically-verified / gate-stops-being-valid framing removed, along with the knob-slice citation of the mechanical-enforcement epic #486 (superseded for this knob by the maintainer's decision; the epic itself stands and gets a note).
- **template/AGENTS.md.jinja**: keeps the knob-flipping setup instruction for freshly generated repos — settling the moment their checklist records it — with the same passive anomaly note.
- **Both CHECKLIST copies** (challenge finding): the [human-only] item now names all three knobs including the review **Trigger** (previously unrecorded — a maintainer could complete the item with an "On every push" trigger still armed) and speaks the settled-once-recorded language. Item text only; checkbox state untouched.
- **codex-review guide (root + jinja twin) and copier-options** (review finding): aligned to the three-knob, settled-once-recorded contract; a full-tree sweep for the retired framing phrases comes back empty.

Refs evanharmon1/harmon-devkit#444.

## Verification

- `task ci` green on the final tree. (Process note: an earlier compound command pushed this branch before its CI mirror had gone green — the gap between that push and this PR was closed by a fresh green `task ci` on the identical tree, and no PR existed in between. The recurring #802 worktree flake cost four gate runs on this branch; evidence updated there.)
- Rigor: standard. Challenge: 2 rounds (round-1 P1 — the checklist couldn't record the Trigger the text trusts it to record — fixed; round 2 no findings at all, with the reviewer noting the design is "intentional maintainer policy"). Review: 2 rounds (round-1 P1 — guide/copier-options still on the old contract — fixed; round 2 zero P0/P1).

## Deferred findings

- [x] `docs/CHECKLIST.md:101` — the [human-only] "Disable Codex Automatic reviews" checkbox is unticked while AGENTS.md states the confirmation is recorded there; the checklist's agent guard reserves the tick for the maintainer. Same situation as harmon-devkit#445's deferred item (also still unticked). Maintainer: two one-character ticks, one per repo. — declined: the checklist's agent guard reserves checkbox state for the maintainer; also answered in the matching inline thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEFrEtVL8idUWCVLuuabWN
