### PR TITLE
fix(template): register the session-end transcript archive hook in the devcontainer

### DIFF
--- a/.devcontainer/config/claude-settings.json
+++ b/.devcontainer/config/claude-settings.json
@@ -69,6 +69,18 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/local/share/devcontainer-config/claude-hooks/session-end-archive.sh",
+            "async": true,
+            "timeout": 120
+          }
+        ]
+      }
     ]
   }
 }

--- a/.github/workflows/publish-harmon-devcontainer.yml
+++ b/.github/workflows/publish-harmon-devcontainer.yml
@@ -16,6 +16,12 @@ on:
       # reach them. PR-side only, deliberately: this file is repository config,
       # not image content, so it must never trigger a publish on main.
       - ".devcontainer/config/ghostty.terminfo"
+      # Same reason, same PR-side-only caveat: those assertions are also the
+      # only place the managed settings are checked for registering every hook
+      # they name — and specifically for keeping the optional archive hook on
+      # its rollback-safe staged path. A settings-only PR is exactly the change
+      # that would regress it, so it has to reach them.
+      - ".devcontainer/config/claude-settings.json"
   push:
     branches: [main]
     paths:

--- a/docs/architecture/devcontainer-image.md
+++ b/docs/architecture/devcontainer-image.md
@@ -81,6 +81,29 @@ bridge from "image bytes exist" to "harmon-init recommends those bytes".
 Source-commit tags are immutable, so a rollback cannot silently resolve to
 different bytes.
 
+That one-line guarantee constrains how managed settings may reference hooks.
+A `claude-settings.json` entry pointing at `/etc/claude-code/hooks/…` is only
+valid for images whose installer places that hook there, so rolling the pin
+back past the image that introduced one would leave the setting invoking a
+command that does not exist — silently, for a hook that is deliberately
+`async` and quiet. Optional hooks are therefore referenced at their **staged**
+path, `/usr/local/share/devcontainer-config/claude-hooks/…`: the consumer's own
+`COPY .devcontainer/config/` puts them there regardless of which image is
+pinned, so the setting and the script it names ship as one artifact and roll
+back together. Mandatory hooks keep the `/etc/claude-code/…` path — the
+installer's `required_files` check guarantees them in every image, so no
+version coupling exists to break.
+
+The staged path is chosen for rollback safety, **not** as a security boundary,
+and it should not be described as one. The staged directory is root-owned while
+the container runs as `vscode`, so an *unprivileged* write cannot modify it —
+but that is the whole of the property. `vscode` has passwordless `sudo` (the
+Microsoft devcontainer base grants it, and the lifecycle scripts rely on it
+non-interactively), and the bot profile runs Claude in `bypassPermissions`, so
+an agent can overwrite the staged hook. `/etc/claude-code/` is no better:
+`enable-claude-bypass.sh` already writes the managed settings there with
+`sudo`. Neither location is protected from an agent that wants to change it.
+
 **Outage behavior:** pulls need no GHCR credential; if GHCR is unavailable,
 existing local/runner caches keep working and clean builders fail closed
 rather than falling back to an unpinned image.

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -72,9 +72,24 @@ status line:
 | What | Lives at | Source | Overridable |
 |---|---|---|---|
 | Managed settings | `/etc/claude-code/managed-settings.json` (image) | `config/claude-settings.json` | no (policy) |
-| Hook scripts | `/etc/claude-code/hooks/` (image) | `config/claude-hooks/` | no |
+| Hook scripts (mandatory) | `/etc/claude-code/hooks/` (image) | `config/claude-hooks/` | no |
+| Hook scripts (optional) | `/usr/local/share/devcontainer-config/claude-hooks/` (**staged**) | `config/claude-hooks/` | no |
 | Status line | `/etc/claude-code/statusline.sh` (image) | `config/claude-statusline.sh` | yes |
 | User defaults | `~/.claude/settings.json` (**volume**) | `config/claude-user-defaults.json` | yes |
+
+Two rows for hooks, because they are not installed the same way. A **mandatory**
+hook is listed in the image installer's `required_files`, so every image is
+guaranteed to place it under `/etc/claude-code/hooks/`. An **optional** hook —
+currently `session-end-archive.sh` — is installed only when the repository
+ships it, so a settings entry naming the `/etc` copy would break the moment the
+image pin were rolled back past the release that added it. Those are registered
+at their **staged** path instead, where the repository's own
+`COPY .devcontainer/config/` puts them regardless of which image is pinned.
+
+The practical consequence when troubleshooting: for an optional hook, the copy
+under `/etc/claude-code/hooks/` is **not** the one that runs. Inspect or replace
+the staged copy, and check `managed-settings.json` for the path actually
+registered rather than assuming it.
 
 The last row is the one exception, and deliberately so: `~/.claude/settings.json`
 is volume-backed because Claude Code writes your in-app changes there. Every

--- a/scripts/test-devcontainer-image.sh
+++ b/scripts/test-devcontainer-image.sh
@@ -81,6 +81,38 @@ docker run --rm "$overlay" sh -eu -c '
     [ -f /etc/claude-code/managed-settings.json ]
     [ -x /etc/claude-code/hooks/protect-files.sh ]
     [ -x /etc/claude-code/hooks/session-end-archive.sh ]
+    # Every hook the managed settings REGISTER must resolve to an executable.
+    # Reading the config rather than a hardcoded path is the point: a settings
+    # entry naming a file the image never creates is inert, and silently so,
+    # because these hooks are deliberately async and quiet (harmon-init#829 —
+    # the hook was installed for a whole release without ever running). The
+    # line above proves the installer placed a file; this proves the settings
+    # point at one. The two are independent, and the second is what a session
+    # actually executes.
+    for cmd in $(jq -r ".hooks[][].hooks[].command" \
+        /etc/claude-code/managed-settings.json | grep "^/" | sort -u); do
+        [ -x "$cmd" ] || {
+            echo "registered hook is not executable: $cmd" >&2
+            exit 1
+        }
+    done
+    # …and SessionEnd must be registered at its STAGED path specifically.
+    # Checking for non-null is not enough: pointing it back at
+    # /etc/claude-code/hooks/… would still pass here, because this candidate
+    # image does install that copy — and would silently break the documented
+    # one-line rollback the moment a consumer reverted to a pre-hook image.
+    # Asserting the exact path is what guards that contract; the loop above
+    # only proves whatever is registered resolves against THIS image.
+    # Says why it failed — a bare test exits silently under `sh -eu`, leaving
+    # the next reader to infer the cause from an exit code.
+    [ "$(jq -r ".hooks.SessionEnd[0].hooks[0].command" \
+        /etc/claude-code/managed-settings.json)" \
+        = /usr/local/share/devcontainer-config/claude-hooks/session-end-archive.sh ] || {
+        echo "SessionEnd must be registered at the staged hook path" >&2
+        echo "  expected: /usr/local/share/devcontainer-config/claude-hooks/session-end-archive.sh" >&2
+        echo "  an /etc/claude-code/… path breaks the one-line image rollback" >&2
+        exit 1
+    }
     [ -f /etc/codex/managed_config.toml ]
     [ -x /etc/codex/hooks/claude-compat.sh ]
     [ "$(yq ".model" /etc/codex/managed_config.toml)" = "gpt-5.6-sol" ]

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-settings.json
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-settings.json
@@ -69,6 +69,18 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/local/share/devcontainer-config/claude-hooks/session-end-archive.sh",
+            "async": true,
+            "timeout": 120
+          }
+        ]
+      }
     ]
   }
 }

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -79,9 +79,24 @@ status line:
 | What | Lives at | Source | Overridable |
 |---|---|---|---|
 | Managed settings | `/etc/claude-code/managed-settings.json` (image) | `config/claude-settings.json` | no (policy) |
-| Hook scripts | `/etc/claude-code/hooks/` (image) | `config/claude-hooks/` | no |
+| Hook scripts (mandatory) | `/etc/claude-code/hooks/` (image) | `config/claude-hooks/` | no |
+| Hook scripts (optional) | `/usr/local/share/devcontainer-config/claude-hooks/` (**staged**) | `config/claude-hooks/` | no |
 | Status line | `/etc/claude-code/statusline.sh` (image) | `config/claude-statusline.sh` | yes |
 | User defaults | `~/.claude/settings.json` (**volume**) | `config/claude-user-defaults.json` | yes |
+
+Two rows for hooks, because they are not installed the same way. A **mandatory**
+hook is listed in the image installer's `required_files`, so every image is
+guaranteed to place it under `/etc/claude-code/hooks/`. An **optional** hook —
+currently `session-end-archive.sh` — is installed only when the repository
+ships it, so a settings entry naming the `/etc` copy would break the moment the
+image pin were rolled back past the release that added it. Those are registered
+at their **staged** path instead, where the repository's own
+`COPY .devcontainer/config/` puts them regardless of which image is pinned.
+
+The practical consequence when troubleshooting: for an optional hook, the copy
+under `/etc/claude-code/hooks/` is **not** the one that runs. Inspect or replace
+the staged copy, and check `managed-settings.json` for the path actually
+registered rather than assuming it.
 
 The last row is the one exception, and deliberately so: `~/.claude/settings.json`
 is volume-backed because Claude Code writes your in-app changes there. Every


### PR DESCRIPTION
Closes #829.

## What

Registers the `session-end-archive.sh` hook so Claude Code actually runs it in
devcontainers. **This is the change that makes container transcript archiving
live** — the hook has shipped in the image and never executed, because Claude
Code runs only what a settings `hooks` block names, and nothing named it.

## Why the staged path, not `/etc/claude-code/`

Registering `/etc/claude-code/hooks/session-end-archive.sh` would break the
one-line image rollback that `docs/architecture/devcontainer-image.md`
guarantees. Revert the `FROM` pin to an image whose installer predates the hook
and the setting names a file that image never creates — silently, for a hook
that is deliberately `async` and quiet.

The staged path has no such coupling: `COPY .devcontainer/config/` lives in the
**consumer's** Dockerfile, so the hook is present whatever image is pinned. The
settings entry and the script it names ship as one artifact and roll back
together. Mandatory hooks keep `/etc/…` — `required_files` guarantees them in
every image, so there is no coupling to break.

**This reverses the path choice argued in #816**, and that reversal is the
point rather than a detail. Neither original reason survives:

- *"consistency with the other seven registrations"* — those are **mandatory**
  hooks, guaranteed in `/etc` by `required_files`. They cannot have this
  problem. An optional hook is genuinely a different case.
- *"`protect-files.sh` guards `/etc/claude-code/`"* — not a real boundary.
  `vscode` has passwordless `sudo`, and `enable-claude-bypass.sh` already
  writes the managed settings there with it.

The documentation now states the staged path is chosen for **rollback safety
and explicitly not as a security boundary** — the earlier claim that root
ownership made it agent-write-protected was simply false.

## Regression coverage

Nothing could catch this bug class. Dogfood parity only compares the twins to
each other, and #816's assertion checks the `/etc` copy this change does not
use — so the hook could be unregistered, or pointed anywhere, with every gate
green.

The image test now reads the **installed managed settings** and requires every
hook command they name to resolve to an executable, and asserts `SessionEnd` is
registered at the staged path *specifically*. A non-null check is not enough: an
`/etc` path would still pass, because this candidate image does install that
copy.

That assertion also has to **run**. It lives in the image test, which fires on
image inputs — so a settings-only PR, which is exactly how this regresses, would
have missed it. `claude-settings.json` is now in the PR-side paths filter beside
`ghostty.terminfo`, which is there for the identical reason. The push-side list
is untouched, so repository config still never triggers a publish on `main`.

Negative-controlled, each against the shipping code:

| Simulated regression | Caught by |
|---|---|
| `SessionEnd` deleted | presence check |
| Bad path | executable loop |
| Reverted to `/etc/…` | staged-path assertion |

## Shipped docs

`docs/guides/devcontainers.md` said hook scripts live at
`/etc/claude-code/hooks/`, which would send someone troubleshooting to a real
file that is **not** the one running. It now distinguishes mandatory from
optional hooks and says so plainly. Both twins updated in lockstep.

## Rigor

**standard (default) → challenge ≤3, review ≤3, shepherd 4.**

- **Challenge: converged at 3/3** — rounds 2 and 3 adjudicated clean.
- **Review: converged at 2/3** — rounds 1 and 2 adjudicated clean.

Six findings (one P1, five P2), **all fixed in place, none deferred** — every
one concerned this change's own correctness rather than the vendored script.

## Verification

`task verify`, `task ci`, and `task test:devcontainer:image` green; 120 dogfood
twins identical; `actionlint` and `yamllint` clean.

## Not in this PR

`evanharmon1/harmon-devkit#439`, `#440`, `#441` — defects in the vendored
archive script itself (corrupt archives never repaired, unbounded growth on the
volume, PID-reuse lock window). They become live once this merges and the hook
starts running. None blocks registration: archiving imperfectly beats a 30-day
deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
