### PR TITLE
docs: add the issue-strategy spec

### DIFF
--- a/specs/issue-strategy.md
+++ b/specs/issue-strategy.md
@@ -63,7 +63,11 @@ Issues become cheap to classify and route, for humans and agents alike:
 ## Requirements
 
 - [ ] `label-registry.json` + schema + validator + `task test:label-registry`, template twins;
-      per family: prefix/names, color, purpose, axis, `writers` (`human | agent | tool:<name>`),
+      per family: prefix/names, color, purpose, axis, `writers`
+      (`human | trusted-human | agent | tool:<name>` — `trusted-human` marks values an
+      actor-verifying consumer additionally authenticates, e.g. foreman arming inputs; the
+      label itself still carries no permission, the class names which consumer-side check
+      applies),
       lifecycle, exclusivity, values, `source: inline | agent-registry | tool-owned` — with
       **per-value overrides** of `writers`, `lifecycle`, and `color`, because mixed
       namespaces exist (`foreman:*`: arming selectors and `approved` are trusted-human
@@ -234,6 +238,13 @@ Issues become cheap to classify and route, for humans and agents alike:
 - **Then** its title carries no `[Bug]:` prefix and it already carries `bug` + `needs-triage`
   — while on an organization repo the same form sets native issue Type `Bug` plus
   `needs-triage`, and no work-type label
+
+### Scenario: a blank form cannot dispatch
+
+- **Given** a Feature or Task form submitted with its Acceptance-criteria field left empty
+- **When** foreman evaluates the unit spec contract
+- **Then** the body carries no criteria list items (GitHub renders `_No response_` under the
+  heading) and foreman refuses the unit on its no-items check
 
 ### Scenario: a standard-authored issue is foreman-dispatchable
 

--- a/specs/issue-strategy.md
+++ b/specs/issue-strategy.md
@@ -100,9 +100,10 @@ Issues become cheap to classify and route, for humans and agents alike:
       sections), both axes are advisory-informational only — the labels still classify, and
       nothing resolves them to a model or workflow. `adaptive` is never a terminal answer:
       the consumer's preflight resolves it to a concrete ladder tier, and a consumer with no
-      preflight capability treats it as `default_tier` where that key is configured — absent
-      the config, `adaptive` resolves to nothing, like every tier value under the
-      axes-inert fallback above. (#855)
+      preflight capability treats it as `default_tier` where that key is configured —
+      validation rejects `adaptive` as a `default_tier`, so that fallback is always
+      concrete — and absent the config, `adaptive` resolves to nothing, like every tier
+      value under the axes-inert fallback above. (#855)
 - [ ] `method:*` values `oneshot | plan | plan-approved | orchestrate | council | human-led`;
       `default_method` in `.devflow.toml`. Method conflicts resolve by a **config-backed
       rank** (shipped order, most human oversight first:
@@ -121,11 +122,14 @@ Issues become cheap to classify and route, for humans and agents alike:
       trust list cannot be assumed everywhere: an **interactive session** treats these labels
       exactly as it treats `rigor:*` — advisory and unauthenticated, with below-default
       disclosure as the mitigation (#809's accepted posture; works on every render, foreman
-      or not) — while **unattended automation** (foreman-class) honors a value only when the
-      actor of the **most recent apply of the current label state** is in that automation's
-      own trusted-actor configuration, re-read immediately before acting: a removal, or an
-      untrusted re-add after one, resolves to the config default rather than inheriting
-      stale trust. Advisory families fail open to the default; arming stays fail-closed.
+      or not), plus one hardening beyond it: before honoring a label that resolves **below**
+      the configured default, the session confirms with its operator, so the disclosure
+      records a human decision rather than a label's — while **unattended automation**
+      (foreman-class) honors a value only when the actor of the **latest mutation of the
+      whole axis** — any apply or removal of any label in that family — is in that
+      automation's own trusted-actor configuration, re-read immediately before acting: one
+      untrusted mutation anywhere on the axis resolves it to the config default, so neither
+      a removal nor a re-add can resurrect or launder an older value. Advisory families fail open to the default; arming stays fail-closed.
       Rigor's values are called **levels** in all prose from here on; "tier" belongs to the
       model axis. (#855)
 - [ ] ADR 0005 D6 amendment: suggestions become human- **or agent-**authored; `suggest:*` stays
@@ -151,7 +155,9 @@ Issues become cheap to classify and route, for humans and agents alike:
       quick capture stays legal, and the authoring standard supplies criteria at triage
       before any dispatch. (#852)
 - [ ] Triage skill v1 (#856): write-allowlist = the manifest's `writers` field; v1 writes only
-      area/layer/domain, unambiguous missing work-type, and `needs-triage` add/remove; never
+      area/layer/domain, an unambiguous missing work-type **on personal-account repos** (org
+      classification is native Type, which v1 cannot write — a missing org Type is reported,
+      never labeled), and `needs-triage` add/remove; never
       `foreman:*`/`rigor:*`/`tier:*`/`method:*`/`claim:*`/`suggest:*`, milestones, closes,
       assignees, or body/title edits; everything else lands in one rolling report issue.
 - [ ] Foreman alignment: pin bump to 2.5.0 (#849), AdmiralFraggle in `trusted_actors` (#850),
@@ -182,9 +188,10 @@ Issues become cheap to classify and route, for humans and agents alike:
 - **Given** `tier:apex` applied by a login not in the automation's trusted-actor configuration
 - **When** unattended automation resolves the tier from the label timeline immediately before
   acting
-- **Then** the label is ignored with a warning and the config default applies — and a
-  previously trusted value that was removed, or re-added by an untrusted login, resolves to
-  the default too, because trust binds to the most recent apply of the current state
+- **Then** the label is ignored with a warning and the config default applies — and any
+  untrusted apply **or removal** anywhere on the axis resolves it to the default too,
+  because trust binds to the latest mutation of the whole axis, never to a surviving older
+  value
 
 ### Scenario: incomparable methods still resolve deterministically
 

--- a/specs/issue-strategy.md
+++ b/specs/issue-strategy.md
@@ -73,19 +73,46 @@ Issues become cheap to classify and route, for humans and agents alike:
 - [ ] `tier:*` ladder `local → economy → standard → frontier → apex` plus `adaptive`; `apex` =
       mythos-class (fable, sol), `frontier` = opus-class. `.devflow.toml` gains `default_tier`
       and `[tier.<value>]` tables mapping families to `agent-registry.json` model slugs
-      (validated), `escalate_to` chains, and `endpoint = "local"` on the self-hosted tier
-      (endpoint is a harness property per ADR 0005 D9). `tier:local` escalates to economy;
-      privacy-pinning is a future separate concern label, not a tier semantic. (#855)
+      (validated), `escalate_to` chains, and `endpoint = "local"` on the self-hosted tier.
+      `tier:local` escalates to economy; privacy-pinning is a future separate concern label,
+      not a tier semantic. (#855)
+- [ ] Tier tables are **inert routing preferences, never dependencies**: nothing in a
+      generated repo invokes any model because the config exists, and an acting consumer may
+      select only among vendors/harnesses the operator has already configured and
+      authenticated — the shipped defaults therefore create no account, trial, or paid-SaaS
+      dependency (Hard Rule preserved), and escalation can never switch a repo to a vendor it
+      does not already use. The `local` tier's machinery binding is explicit: its entries
+      resolve to the registry's `-local` endpoint-variant harnesses (ADR 0005 D9), and
+      validation fails a local entry whose family has no registered `-local` harness.
+      `escalate_to` chains validate as referential, acyclic, and monotonic toward `apex`;
+      *when* escalation fires (failure, refusal, operator policy — never cost alone) is
+      defined in ADR 0006. (#855)
+- [ ] Built-in fallbacks are defined: absent `.devflow.toml` (or its `[tier]`/`[method]`
+      sections), both axes are advisory-informational only — the labels still classify, and
+      nothing resolves them to a model or workflow. `adaptive` is never a terminal answer:
+      the consumer's preflight resolves it to a concrete ladder tier, and a consumer with no
+      preflight capability treats it as `default_tier`. (#855)
 - [ ] `method:*` values `oneshot | plan | plan-approved | orchestrate | council | human-led`;
-      `default_method` in `.devflow.toml`. (#855)
-- [ ] Resolution and trust (ADR 0006): explicit instruction > trusted label > config default >
+      `default_method` in `.devflow.toml`. Method conflicts resolve by a **config-backed
+      rank** (shipped order, most human oversight first:
+      `human-led > plan-approved > council > orchestrate > plan > oneshot`), so topologies
+      with no inherent ordering still resolve deterministically and identically for every
+      consumer. (#855)
+- [ ] Resolution and trust (ADR 0006): explicit instruction > label > config default >
       built-in; merge-base copy when the change edits `.devflow.toml`; conflicts resolve
-      strongest-wins (a label only ever buys more capability or oversight); a concrete tier
-      beats `adaptive`; below-default resolutions are disclosed in the PR body (#809 doctrine
-      extended). Acting consumers read the label timeline and honor values only from
-      `trusted_actors` logins — advisory families fail open to the default, arming stays
-      fail-closed. Rigor's values are called **levels** in all prose from here on; "tier"
-      belongs to the model axis. (#855)
+      strongest-wins on tier and by the method rank above (a label only ever buys more
+      capability or oversight); a concrete tier beats `adaptive`; below-default resolutions
+      are disclosed in the PR body (#809 doctrine extended). Two consumer classes, because a
+      trust list cannot be assumed everywhere: an **interactive session** treats these labels
+      exactly as it treats `rigor:*` — advisory and unauthenticated, with below-default
+      disclosure as the mitigation (#809's accepted posture; works on every render, foreman
+      or not) — while **unattended automation** (foreman-class) honors a value only when the
+      actor of the **most recent apply of the current label state** is in that automation's
+      own trusted-actor configuration, re-read immediately before acting: a removal, or an
+      untrusted re-add after one, resolves to the config default rather than inheriting
+      stale trust. Advisory families fail open to the default; arming stays fail-closed.
+      Rigor's values are called **levels** in all prose from here on; "tier" belongs to the
+      model axis. (#855)
 - [ ] ADR 0005 D6 amendment: suggestions become human- **or agent-**authored; `suggest:*` stays
       family[:model] (vendor preference), `tier:*` is the human-decided policy layer;
       `suggest:tier:<value>` is reserved, not built. `claim:*` stays on the family axis; the
@@ -97,8 +124,13 @@ Issues become cheap to classify and route, for humans and agents alike:
       perishable facts are cited → optional `## Out of scope` / `## Provenance`; metadata
       checklist enforced by `check-issue-metadata.sh`; vocabulary read from the manifest with
       `gh label list` fallback.
-- [ ] Issue forms drop `title:` prefixes, apply `labels:` (work-type + `needs-triage`), and
-      match the skeleton's field names; org twins keep native `type:`. (#852)
+- [ ] Issue forms drop `title:` prefixes and match the skeleton's field names. Work-type
+      labels are applied by forms **only where native issue Type is unavailable** (personal
+      accounts); org twins set native `type:` and no work-type label, so each owner type has
+      exactly one writable source for the classification. Every form applies `needs-triage`.
+      Forms reference only labels the manifest provisions; provisioning order is the existing
+      CHECKLIST guarantee (`task setup:github-labels`), and an unprovisioned repo degrades to
+      unlabeled creation, which triage then catches. (#852)
 - [ ] Triage skill v1 (#856): write-allowlist = the manifest's `writers` field; v1 writes only
       area/layer/domain, unambiguous missing work-type, and `needs-triage` add/remove; never
       `foreman:*`/`rigor:*`/`tier:*`/`method:*`/`claim:*`/`suggest:*`, milestones, closes,
@@ -126,11 +158,21 @@ Issues become cheap to classify and route, for humans and agents alike:
 - **Then** the resolution is `standard`, and any resolution below `default_tier` is disclosed in
   the PR body
 
-### Scenario: untrusted strategy labels are inert
+### Scenario: untrusted strategy labels are inert to automation
 
-- **Given** `tier:apex` applied by a login not in `trusted_actors`
-- **When** an acting consumer resolves the tier from the label timeline
-- **Then** the label is ignored with a warning and the config default applies
+- **Given** `tier:apex` applied by a login not in the automation's trusted-actor configuration
+- **When** unattended automation resolves the tier from the label timeline immediately before
+  acting
+- **Then** the label is ignored with a warning and the config default applies — and a
+  previously trusted value that was removed, or re-added by an untrusted login, resolves to
+  the default too, because trust binds to the most recent apply of the current state
+
+### Scenario: incomparable methods still resolve deterministically
+
+- **Given** an issue carrying both `method:orchestrate` and `method:council`
+- **When** any consumer resolves the method
+- **Then** the config-backed rank decides (`council`, under the shipped order) and every
+  consumer reaches the same answer
 
 ### Scenario: triage stays inside its allowlist
 
@@ -141,9 +183,11 @@ Issues become cheap to classify and route, for humans and agents alike:
 
 ### Scenario: a form-filed bug arrives classified
 
-- **Given** a user files through the Bug form
-- **When** the issue is created
+- **Given** a personal-account repo whose labels are provisioned (`task setup:github-labels`)
+- **When** a user files through the Bug form
 - **Then** its title carries no `[Bug]:` prefix and it already carries `bug` + `needs-triage`
+  — while on an organization repo the same form sets native issue Type `Bug` plus
+  `needs-triage`, and no work-type label
 
 ### Scenario: a standard-authored issue is foreman-dispatchable
 

--- a/specs/issue-strategy.md
+++ b/specs/issue-strategy.md
@@ -1,0 +1,177 @@
+# Spec: GitHub issue strategy — taxonomy manifest, strategy axes, authoring standard, triage
+
+- **Status:** Approved
+- **Owner:** Evan Harmon
+- **Date:** 2026-08-13
+- **Related:** milestone [Issue strategy overhaul](https://github.com/evanharmon1/harmon-init/milestone/2)
+  (#849–#858) · [ADR 0005](../docs/decisions/0005-unified-agent-vocabulary.md) · #754 · #809 · #620 ·
+  [ponderousdev/foreman#139](https://github.com/ponderousdev/foreman/issues/139) ·
+  [ponderousdev/foreman#169](https://github.com/ponderousdev/foreman/issues/169) ·
+  harmon-devkit [#449](https://github.com/evanharmon1/harmon-devkit/issues/449),
+  [#450](https://github.com/evanharmon1/harmon-devkit/issues/450),
+  [#451](https://github.com/evanharmon1/harmon-devkit/issues/451),
+  [#382](https://github.com/evanharmon1/harmon-devkit/issues/382)
+
+## Problem / Why
+
+The label taxonomy is well-designed and near-unused. At audit (2026-08-13): 230 open issues,
+104 (45%) with no labels, 4 carrying `needs-triage`, 14 carrying any `domain:*`/`layer:*`, and
+zero open issues carrying the `suggest:*`/`claim:*`/`foreman:*`/`rigor:*` machinery. Titles follow
+four dialects; the issue forms prefix titles and apply no labels; native issue Types do not exist
+on personal accounts. Classification depends on humans remembering at filing time, and every
+filing surface skips it.
+
+Three gaps cause this, and they are the ones this spec closes:
+
+1. **No machine-readable taxonomy.** The vocabulary is split across a script heredoc, the
+   agent-registry renderer, and a prose table whose Writer/Trust/Lifecycle columns automation
+   cannot read.
+2. **No writers.** Nothing applies classification automatically — not the forms, not the agents,
+   not a scheduled groomer.
+3. **No authoring standard.** track-work governs closing/linking, not titles, body shape, or
+   at-create metadata — and there is no per-issue vocabulary for AI execution strategy (how to
+   work an issue, what model class to route it to).
+
+## Goal
+
+Issues become cheap to classify and route, for humans and agents alike:
+
+- One manifest (`label-registry.json`) is the source of truth for every label family — including
+  who may write each family — rendered into provisioning, docs, and skill behavior.
+- Three classification axes: `area:*` (codebase subsystem), `domain:*` (product capability),
+  `layer:*` (stack slice); at most one of each per issue.
+- Two advisory strategy axes with config-backed semantics: `method:*` (execution topology) and
+  `tier:*` (model routing), resolved like rigor and consumable by foreman under its trust model.
+- One authoring standard (title rule, body skeleton, metadata checklist) enforced by a checker
+  and mirrored by the issue forms.
+- A manifest-governed triage skill that classifies the backlog and reports what it cannot decide.
+
+## Non-goals
+
+- **No auto-merge label, ever.** Merging stays a human decision (AGENTS.md hard rule; foreman
+  permanent non-goal). A triage-writable label authorizing an unreviewed merge is the
+  label-as-permission anti-pattern the taxonomy doc forbids. The attributable native mechanism —
+  a human enabling GitHub auto-merge on a PR with required checks — already exists.
+- **No new arming surface.** `foreman:*` remains the only arming namespace; upstream parses any
+  unrecognized `foreman:*` value as a backend selector, so no metadata may ever live there.
+- **No `type:*` work-type family.** That prefix is foreman's conventional-commit override. Work
+  type is native issue Type on org repos and the informal labels
+  (`bug`/`enhancement`/`documentation`/`question`/`task`/`research`) on personal repos.
+- **No board/field mirrors for the new families** until a view needs one; labels only.
+- **No unattended triage in v1.** Scheduling is a separate, explicit later decision.
+
+## Requirements
+
+- [ ] `label-registry.json` + schema + validator + `task test:label-registry`, template twins;
+      per family: prefix/names, color, purpose, axis, `writers` (`human | agent | tool:<name>`),
+      lifecycle, exclusivity, values, `source: inline | agent-registry | tool-owned`.
+      `setup-github-labels.sh` renders from it; the docs taxonomy table is generated between
+      markers; descriptions ≤ 100 chars in both this schema and agent-registry's (#680). (#851)
+- [ ] `area:*` family — harmon-init values (template, devcontainer, ci, tasks, skills, foreman,
+      codex, worktree, release, security, pm, docs); generic template starter (ci, docs, deps,
+      build). Rule: area = solution space, domain = problem space, layer = stack slice. (#854)
+- [ ] `tier:*` ladder `local → economy → standard → frontier → apex` plus `adaptive`; `apex` =
+      mythos-class (fable, sol), `frontier` = opus-class. `.devflow.toml` gains `default_tier`
+      and `[tier.<value>]` tables mapping families to `agent-registry.json` model slugs
+      (validated), `escalate_to` chains, and `endpoint = "local"` on the self-hosted tier
+      (endpoint is a harness property per ADR 0005 D9). `tier:local` escalates to economy;
+      privacy-pinning is a future separate concern label, not a tier semantic. (#855)
+- [ ] `method:*` values `oneshot | plan | plan-approved | orchestrate | council | human-led`;
+      `default_method` in `.devflow.toml`. (#855)
+- [ ] Resolution and trust (ADR 0006): explicit instruction > trusted label > config default >
+      built-in; merge-base copy when the change edits `.devflow.toml`; conflicts resolve
+      strongest-wins (a label only ever buys more capability or oversight); a concrete tier
+      beats `adaptive`; below-default resolutions are disclosed in the PR body (#809 doctrine
+      extended). Acting consumers read the label timeline and honor values only from
+      `trusted_actors` logins — advisory families fail open to the default, arming stays
+      fail-closed. Rigor's values are called **levels** in all prose from here on; "tier"
+      belongs to the model axis. (#855)
+- [ ] ADR 0005 D6 amendment: suggestions become human- **or agent-**authored; `suggest:*` stays
+      family[:model] (vendor preference), `tier:*` is the human-decided policy layer;
+      `suggest:tier:<value>` is reserved, not built. `claim:*` stays on the family axis; the
+      claim record gains `harness:`/`model:`/`session:` fields (harmon-devkit#450). (#855)
+- [ ] Authoring standard (canonical in harmon-devkit#449): titles are imperative
+      problem/outcome statements, ≤ ~70 chars, no prefixes; body skeleton `## Problem` →
+      optional `## Current violation (observed YYYY-MM-DD)` → `## Acceptance criteria` with
+      `[CI]`/`[HUMAN]` tags (foreman's dispatch contract, case-insensitive) → `## Verify` when
+      perishable facts are cited → optional `## Out of scope` / `## Provenance`; metadata
+      checklist enforced by `check-issue-metadata.sh`; vocabulary read from the manifest with
+      `gh label list` fallback.
+- [ ] Issue forms drop `title:` prefixes, apply `labels:` (work-type + `needs-triage`), and
+      match the skeleton's field names; org twins keep native `type:`. (#852)
+- [ ] Triage skill v1 (#856): write-allowlist = the manifest's `writers` field; v1 writes only
+      area/layer/domain, unambiguous missing work-type, and `needs-triage` add/remove; never
+      `foreman:*`/`rigor:*`/`tier:*`/`method:*`/`claim:*`/`suggest:*`, milestones, closes,
+      assignees, or body/title edits; everything else lands in one rolling report issue.
+- [ ] Foreman alignment: pin bump to 2.5.0 (#849), AdmiralFraggle in `trusted_actors` (#850),
+      claim contract at dispatch proposed upstream (foreman#169, engaging foreman#82), tier
+      vocabulary contributed to foreman#139. Foreman consumption of `tier:*`/`method:*` follows
+      #139's rails; nothing here arms anything.
+- [ ] Docs reconciliation (#857): manifest named as source; scope-batch milestones legitimized
+      for rolling-release repos; #683/#702/#703 absorbed.
+
+## Acceptance criteria (Given / When / Then)
+
+### Scenario: the manifest is the single source
+
+- **Given** `label-registry.json` exists with the full taxonomy
+- **When** `task setup:github-labels` and the docs generation run
+- **Then** the provisioned label set and the docs table both derive from the manifest, and a
+  hand-edit to either is caught by a drift test in `task verify`
+
+### Scenario: tier conflict can only buy more
+
+- **Given** an issue carrying both `tier:economy` and `tier:standard`
+- **When** an agent (or foreman, later) resolves the tier
+- **Then** the resolution is `standard`, and any resolution below `default_tier` is disclosed in
+  the PR body
+
+### Scenario: untrusted strategy labels are inert
+
+- **Given** `tier:apex` applied by a login not in `trusted_actors`
+- **When** an acting consumer resolves the tier from the label timeline
+- **Then** the label is ignored with a warning and the config default applies
+
+### Scenario: triage stays inside its allowlist
+
+- **Given** the triage skill running over the live backlog
+- **When** it classifies an issue it is confident about
+- **Then** it writes only labels whose manifest `writers` include `agent`, and everything else —
+  including every tier/method/suggest proposal — appears only in the rolling report
+
+### Scenario: a form-filed bug arrives classified
+
+- **Given** a user files through the Bug form
+- **When** the issue is created
+- **Then** its title carries no `[Bug]:` prefix and it already carries `bug` + `needs-triage`
+
+### Scenario: a standard-authored issue is foreman-dispatchable
+
+- **Given** an issue written to the authoring skeleton with tagged acceptance criteria
+- **When** foreman evaluates the unit spec contract
+- **Then** the `## Acceptance criteria` section parses with its `[CI]`/`[HUMAN]` items and the
+  unit is not refused for spec shape
+
+## Open questions
+
+- Triage Phase B: whether/where to schedule (Actions cron vs devcontainer cron) — decided after
+  v1 precision is observed on the live backlog.
+- Whether a `premium` stratum between `standard` and `frontier` ever becomes necessary, or
+  `suggest:<family>:<model>` covers within-family precision indefinitely.
+- `suggest:tier:<value>` stays reserved until a board view needs labeled tier proposals.
+
+## Notes
+
+- Rollout is the milestone's dependency graph: #849/#850/#851/#852 and the devkit children are
+  the ready set; #854/#855/#856 unblock on #851; #857 closes the loop; #858 lands the vendored
+  skills after the devkit release.
+- The `tier:*`/`method:*`/`area:*`/`task`/`research` labels were hand-seeded on 2026-08-13 across
+  harmon-init, harmon-devkit, and ponderousdev/foreman (colors: area `0E8A16`, tier `7057FF`,
+  method `BF3989`, task `6E7781`, research `0E7C86`); #851 formalizes them — the manifest must
+  adopt these exact names/colors so provisioning reconciles instead of fighting.
+- Design rails inherited from upstream foreman (v2.5.0 source, verified): unrecognized
+  `foreman:*` labels arm as backend selectors; `type:<commit-type>` is parsed (two = error);
+  dispatchability requires an `## Acceptance Criteria` section (case-insensitive) with ≥ 1
+  bullet; adapters hold read-only tokens, so any issue-side write is foreman-core's.
+- Labels carry no permissions (project-management.md): every consumer that acts on one verifies
+  who applied it; these new families are advisory and trigger nothing by existence.

--- a/specs/issue-strategy.md
+++ b/specs/issue-strategy.md
@@ -64,7 +64,10 @@ Issues become cheap to classify and route, for humans and agents alike:
 
 - [ ] `label-registry.json` + schema + validator + `task test:label-registry`, template twins;
       per family: prefix/names, color, purpose, axis, `writers` (`human | agent | tool:<name>`),
-      lifecycle, exclusivity, values, `source: inline | agent-registry | tool-owned`.
+      lifecycle, exclusivity, values, `source: inline | agent-registry | tool-owned` — with
+      **per-value overrides** of `writers`/`lifecycle`, because mixed namespaces exist
+      (`foreman:*`: arming selectors and `approved` are trusted-human inputs, `hold` is
+      human, `dispatched`/`ready-for-review` are tool-owned outputs).
       `setup-github-labels.sh` renders from it; the docs taxonomy table is generated between
       markers; descriptions ≤ 100 chars in both this schema and agent-registry's (#680).
       Every existing consumer of the inline rows migrates in the same change — in particular
@@ -92,7 +95,9 @@ Issues become cheap to classify and route, for humans and agents alike:
       *when* escalation fires (failure, refusal, operator policy — never cost alone) is
       defined in ADR 0006. Candidate selection is deterministic, also in ADR 0006: the
       resolved tier names the stratum; a `suggest:<family>[:<model>]` narrows within it only
-      when that family is configured and eligible (otherwise it is ignored with a note);
+      when that family is configured and eligible (otherwise it is ignored with a note) —
+      and unattended consumption of a suggestion is subject to the same provenance
+      invariant as the strategy axes below;
       absent a suggestion, the consumer's own configured backend or harness picks; a tier
       with no eligible configured candidate escalates along the chain, and an exhausted
       chain **stops with a report** — never a silent vendor switch or downgrade. (#855)
@@ -118,18 +123,22 @@ Issues become cheap to classify and route, for humans and agents alike:
       the change edits `.devflow.toml`; conflicts resolve
       strongest-wins on tier and by the method rank above (a label only ever buys more
       capability or oversight); a concrete tier beats `adaptive`; below-default resolutions
-      are disclosed in the PR body (#809 doctrine extended). Two consumer classes, because a
-      trust list cannot be assumed everywhere: an **interactive session** treats these labels
-      exactly as it treats `rigor:*` — advisory and unauthenticated, with below-default
-      disclosure as the mitigation (#809's accepted posture; works on every render, foreman
-      or not), plus one hardening beyond it: before honoring a label that resolves **below**
-      the configured default, the session confirms with its operator, so the disclosure
-      records a human decision rather than a label's — while **unattended automation**
-      (foreman-class) honors a value only when the actor of the **latest mutation of the
-      whole axis** — any apply or removal of any label in that family — is in that
-      automation's own trusted-actor configuration, re-read immediately before acting: one
-      untrusted mutation anywhere on the axis resolves it to the config default, so neither
-      a removal nor a re-add can resurrect or launder an older value. Advisory families fail open to the default; arming stays fail-closed.
+      are disclosed in the PR body (#809 doctrine extended). Consumer trust is stated as
+      **invariants**; the concrete timeline-validation algorithm is deliberately not
+      specified here — it is ADR 0006 / foreman#139 design work under #855, and the
+      adversarial scenarios raised in this spec's review are carried there as required test
+      cases:
+      1. **Unattended automation** acts on a strategy or suggestion label only after
+         verifying its provenance end-to-end from its own trusted-actor configuration,
+         re-read immediately before acting — and no sequence of untrusted mutations,
+         applies **or removals**, on any label of the axis, may move the resolved outcome
+         away from what trusted actors' surviving actions alone would produce. Anything
+         short of that resolves to the config default with a warning.
+      2. An **interactive session** treats these labels as advisory (the #809 rigor
+         posture), and requires operator confirmation for **any off-default resolution** —
+         above or below, since one direction skips oversight and the other spends money —
+         arising from a label the session cannot attribute.
+      3. Advisory families fail open to the config default; arming stays fail-closed.
       Rigor's values are called **levels** in all prose from here on; "tier" belongs to the
       model axis. (#855)
 - [ ] ADR 0005 D6 amendment: suggestions become human- **or agent-**authored; `suggest:*` stays
@@ -150,14 +159,20 @@ Issues become cheap to classify and route, for humans and agents alike:
       Forms reference only labels the manifest provisions; provisioning order is the existing
       CHECKLIST guarantee (`task setup:github-labels`), and an unprovisioned repo degrades to
       unlabeled creation, which triage then catches. Forms whose type implies implementable
-      work (Feature, Task) ship an Acceptance-criteria field; a form-filed issue with no
-      tagged criteria is non-dispatchable under foreman's spec contract **by design** —
-      quick capture stays legal, and the authoring standard supplies criteria at triage
+      work (Feature, Task) ship an Acceptance-criteria field that is **empty — no prefilled
+      `- [ ]` placeholder**: foreman's parser accepts any nonempty section (untagged bullets
+      become `[CI]` with a warning), so a placeholder would make placeholder issues
+      dispatchable; an unfilled empty field omits the section entirely, and a form-filed
+      issue with no acceptance-criteria section is genuinely non-dispatchable **by design**
+      — quick capture stays legal, and the authoring standard supplies criteria at triage
       before any dispatch. (#852)
 - [ ] Triage skill v1 (#856): write-allowlist = the manifest's `writers` field; v1 writes only
       area/layer/domain, an unambiguous missing work-type **on personal-account repos** (org
       classification is native Type, which v1 cannot write — a missing org Type is reported,
-      never labeled), and `needs-triage` add/remove; never
+      never labeled), and `needs-triage` — added freely, removed **only when classification
+      is complete** (work type present in the owner-appropriate form, and each of
+      area/layer/domain either applied or genuinely inapplicable); a partially classified
+      issue keeps the label and appears in the report; never
       `foreman:*`/`rigor:*`/`tier:*`/`method:*`/`claim:*`/`suggest:*`, milestones, closes,
       assignees, or body/title edits; everything else lands in one rolling report issue.
 - [ ] Foreman alignment: pin bump to 2.5.0 (#849), AdmiralFraggle in `trusted_actors` (#850),
@@ -188,10 +203,10 @@ Issues become cheap to classify and route, for humans and agents alike:
 - **Given** `tier:apex` applied by a login not in the automation's trusted-actor configuration
 - **When** unattended automation resolves the tier from the label timeline immediately before
   acting
-- **Then** the label is ignored with a warning and the config default applies — and any
-  untrusted apply **or removal** anywhere on the axis resolves it to the default too,
-  because trust binds to the latest mutation of the whole axis, never to a surviving older
-  value
+- **Then** the label is ignored with a warning and the config default applies — and no
+  sequence of untrusted applies **or removals** anywhere on the axis can move the outcome
+  away from what trusted actors' surviving actions alone would produce (the provenance
+  invariant; the concrete algorithm lives with ADR 0006 / foreman#139)
 
 ### Scenario: incomparable methods still resolve deterministically
 

--- a/specs/issue-strategy.md
+++ b/specs/issue-strategy.md
@@ -65,9 +65,11 @@ Issues become cheap to classify and route, for humans and agents alike:
 - [ ] `label-registry.json` + schema + validator + `task test:label-registry`, template twins;
       per family: prefix/names, color, purpose, axis, `writers` (`human | agent | tool:<name>`),
       lifecycle, exclusivity, values, `source: inline | agent-registry | tool-owned` — with
-      **per-value overrides** of `writers`/`lifecycle`, because mixed namespaces exist
-      (`foreman:*`: arming selectors and `approved` are trusted-human inputs, `hold` is
-      human, `dispatched`/`ready-for-review` are tool-owned outputs).
+      **per-value overrides** of `writers`, `lifecycle`, and `color`, because mixed
+      namespaces exist (`foreman:*`: arming selectors and `approved` are trusted-human
+      inputs, `hold` is human, `dispatched`/`ready-for-review` are tool-owned outputs — and
+      the four protocol labels ship four different colors today, which family-level color
+      alone cannot reproduce).
       `setup-github-labels.sh` renders from it; the docs taxonomy table is generated between
       markers; descriptions ≤ 100 chars in both this schema and agent-registry's (#680).
       Every existing consumer of the inline rows migrates in the same change — in particular
@@ -137,7 +139,9 @@ Issues become cheap to classify and route, for humans and agents alike:
       2. An **interactive session** treats these labels as advisory (the #809 rigor
          posture), and requires operator confirmation for **any off-default resolution** —
          above or below, since one direction skips oversight and the other spends money —
-         arising from a label the session cannot attribute.
+         arising from a label that was not applied by an actor the operator has
+         **authorized** (the operator themselves, or a login their configuration trusts);
+         attribution to *some* identifiable actor is not authorization.
       3. Advisory families fail open to the config default; arming stays fail-closed.
       Rigor's values are called **levels** in all prose from here on; "tier" belongs to the
       model axis. (#855)
@@ -162,8 +166,9 @@ Issues become cheap to classify and route, for humans and agents alike:
       work (Feature, Task) ship an Acceptance-criteria field that is **empty — no prefilled
       `- [ ]` placeholder**: foreman's parser accepts any nonempty section (untagged bullets
       become `[CI]` with a warning), so a placeholder would make placeholder issues
-      dispatchable; an unfilled empty field omits the section entirely, and a form-filed
-      issue with no acceptance-criteria section is genuinely non-dispatchable **by design**
+      dispatchable; an unfilled optional field renders as the heading plus `_No response_`
+      — no checkbox items — so foreman's no-items check refuses it, and a form-filed issue
+      with no acceptance-criteria **items** is genuinely non-dispatchable **by design**
       — quick capture stays legal, and the authoring standard supplies criteria at triage
       before any dispatch. (#852)
 - [ ] Triage skill v1 (#856): write-allowlist = the manifest's `writers` field; v1 writes only
@@ -259,7 +264,8 @@ Issues become cheap to classify and route, for humans and agents alike:
   dispatchability requires an `## Acceptance Criteria` section (case-insensitive) with ≥ 1
   bullet; adapters hold read-only tokens, so any issue-side write is foreman-core's.
 - Labels carry no permissions (project-management.md): the new families trigger nothing by
-  existence. The verification obligation is consumer-specific — unattended automation that
-  acts on one verifies the actor (latest-apply timeline trust), while interactive sessions
-  treat them as advisory with the below-default disclosure, the same accepted posture #809
-  records for `rigor:*`.
+  existence. The verification obligation is consumer-specific — unattended automation
+  verifies provenance under the Requirements invariants (no sequence of untrusted
+  mutations may influence the outcome), while interactive sessions treat the labels as
+  advisory with off-default operator confirmation plus disclosure — the #809 posture,
+  extended.

--- a/specs/issue-strategy.md
+++ b/specs/issue-strategy.md
@@ -175,7 +175,9 @@ Issues become cheap to classify and route, for humans and agents alike:
       with no acceptance-criteria **items** is genuinely non-dispatchable **by design**
       — quick capture stays legal, and the authoring standard supplies criteria at triage
       before any dispatch. (#852)
-- [ ] Triage skill v1 (#856): write-allowlist = the manifest's `writers` field; v1 writes only
+- [ ] Triage skill v1 (canonical in harmon-devkit#455 — skills live in harmon-devkit;
+      vendored and supervised here via #864): write-allowlist = the manifest's `writers`
+      field; v1 writes only
       area/layer/domain, an unambiguous missing work-type **on personal-account repos** (org
       classification is native Type, which v1 cannot write — a missing org Type is reported,
       never labeled), and `needs-triage` — added freely, removed **only when classification
@@ -264,7 +266,7 @@ Issues become cheap to classify and route, for humans and agents alike:
 ## Notes
 
 - Rollout is the milestone's dependency graph: #849/#850/#851/#852 and the devkit children are
-  the ready set; #854/#855/#856 unblock on #851; #857 closes the loop; #858 lands the vendored
+  the ready set; #854/#855/#864 unblock on #851; #857 closes the loop; #858 lands the vendored
   skills after the devkit release.
 - The `tier:*`/`method:*`/`area:*`/`task`/`research` labels were hand-seeded on 2026-08-13 across
   harmon-init, harmon-devkit, and ponderousdev/foreman (colors: area `0E8A16`, tier `7057FF`,

--- a/specs/issue-strategy.md
+++ b/specs/issue-strategy.md
@@ -66,7 +66,11 @@ Issues become cheap to classify and route, for humans and agents alike:
       per family: prefix/names, color, purpose, axis, `writers` (`human | agent | tool:<name>`),
       lifecycle, exclusivity, values, `source: inline | agent-registry | tool-owned`.
       `setup-github-labels.sh` renders from it; the docs taxonomy table is generated between
-      markers; descriptions ≤ 100 chars in both this schema and agent-registry's (#680). (#851)
+      markers; descriptions ≤ 100 chars in both this schema and agent-registry's (#680).
+      Every existing consumer of the inline rows migrates in the same change — in particular
+      `scripts/status.sh` (and its template twin) reads its expected-label inventory from the
+      manifest renderer, covered by the drift test, so `task status` cannot report an
+      incompletely seeded repo as complete. (#851)
 - [ ] `area:*` family — harmon-init values (template, devcontainer, ci, tasks, skills, foreman,
       codex, worktree, release, security, pm, docs); generic template starter (ci, docs, deps,
       build). Rule: area = solution space, domain = problem space, layer = stack slice. (#854)
@@ -86,12 +90,19 @@ Issues become cheap to classify and route, for humans and agents alike:
       validation fails a local entry whose family has no registered `-local` harness.
       `escalate_to` chains validate as referential, acyclic, and monotonic toward `apex`;
       *when* escalation fires (failure, refusal, operator policy — never cost alone) is
-      defined in ADR 0006. (#855)
+      defined in ADR 0006. Candidate selection is deterministic, also in ADR 0006: the
+      resolved tier names the stratum; a `suggest:<family>[:<model>]` narrows within it only
+      when that family is configured and eligible (otherwise it is ignored with a note);
+      absent a suggestion, the consumer's own configured backend or harness picks; a tier
+      with no eligible configured candidate escalates along the chain, and an exhausted
+      chain **stops with a report** — never a silent vendor switch or downgrade. (#855)
 - [ ] Built-in fallbacks are defined: absent `.devflow.toml` (or its `[tier]`/`[method]`
       sections), both axes are advisory-informational only — the labels still classify, and
       nothing resolves them to a model or workflow. `adaptive` is never a terminal answer:
       the consumer's preflight resolves it to a concrete ladder tier, and a consumer with no
-      preflight capability treats it as `default_tier`. (#855)
+      preflight capability treats it as `default_tier` where that key is configured — absent
+      the config, `adaptive` resolves to nothing, like every tier value under the
+      axes-inert fallback above. (#855)
 - [ ] `method:*` values `oneshot | plan | plan-approved | orchestrate | council | human-led`;
       `default_method` in `.devflow.toml`. Method conflicts resolve by a **config-backed
       rank** (shipped order, most human oversight first:
@@ -99,7 +110,11 @@ Issues become cheap to classify and route, for humans and agents alike:
       with no inherent ordering still resolve deterministically and identically for every
       consumer. (#855)
 - [ ] Resolution and trust (ADR 0006): explicit instruction > label > config default >
-      built-in; merge-base copy when the change edits `.devflow.toml`; conflicts resolve
+      built-in — where an **explicit instruction** is one arriving on the operator's
+      attributable channel (the interactive session's human input, or the automation's own
+      configuration) and never repository content: issue bodies, comments, and PR text are
+      untrusted input and can never outrank labels or config. Merge-base copy applies when
+      the change edits `.devflow.toml`; conflicts resolve
       strongest-wins on tier and by the method rank above (a label only ever buys more
       capability or oversight); a concrete tier beats `adaptive`; below-default resolutions
       are disclosed in the PR body (#809 doctrine extended). Two consumer classes, because a
@@ -130,7 +145,11 @@ Issues become cheap to classify and route, for humans and agents alike:
       exactly one writable source for the classification. Every form applies `needs-triage`.
       Forms reference only labels the manifest provisions; provisioning order is the existing
       CHECKLIST guarantee (`task setup:github-labels`), and an unprovisioned repo degrades to
-      unlabeled creation, which triage then catches. (#852)
+      unlabeled creation, which triage then catches. Forms whose type implies implementable
+      work (Feature, Task) ship an Acceptance-criteria field; a form-filed issue with no
+      tagged criteria is non-dispatchable under foreman's spec contract **by design** —
+      quick capture stays legal, and the authoring standard supplies criteria at triage
+      before any dispatch. (#852)
 - [ ] Triage skill v1 (#856): write-allowlist = the manifest's `writers` field; v1 writes only
       area/layer/domain, unambiguous missing work-type, and `needs-triage` add/remove; never
       `foreman:*`/`rigor:*`/`tier:*`/`method:*`/`claim:*`/`suggest:*`, milestones, closes,
@@ -217,5 +236,8 @@ Issues become cheap to classify and route, for humans and agents alike:
   `foreman:*` labels arm as backend selectors; `type:<commit-type>` is parsed (two = error);
   dispatchability requires an `## Acceptance Criteria` section (case-insensitive) with ≥ 1
   bullet; adapters hold read-only tokens, so any issue-side write is foreman-core's.
-- Labels carry no permissions (project-management.md): every consumer that acts on one verifies
-  who applied it; these new families are advisory and trigger nothing by existence.
+- Labels carry no permissions (project-management.md): the new families trigger nothing by
+  existence. The verification obligation is consumer-specific — unattended automation that
+  acts on one verifies the actor (latest-apply timeline trust), while interactive sessions
+  treat them as advisory with the below-default disclosure, the same accepted posture #809
+  records for `rigor:*`.


### PR DESCRIPTION
## What

Adds `specs/issue-strategy.md` — the approved spec for the GitHub issue-strategy overhaul: the `label-registry.json` taxonomy manifest (with per-value writer/lifecycle/color overrides and the `trusted-human` writer class), the `area:*` classification axis, the `tier:*` ladder (`local → economy → standard → frontier → apex`, + `adaptive`) and `method:*` strategy axes with `.devflow.toml`-backed resolution and consumer-trust invariants, the rigor "levels" prose rename, the issue authoring standard (canonical in harmon-devkit), the manifest-governed triage skill, and the foreman alignment items.

## Why

The audit (2026-08-13, in the spec) found 45% of open issues unlabeled and the agent-routing vocabulary at zero adoption: the taxonomy needs a machine-readable source, automated writers, and an authoring standard. The spec records the settled decisions so the milestone's issues implement against one reviewed document instead of session scrollback.

Implementation is tracked in milestone [Issue strategy overhaul](https://github.com/evanharmon1/harmon-init/milestone/2): Refs evanharmon1/harmon-init#849, evanharmon1/harmon-init#850, evanharmon1/harmon-init#851, evanharmon1/harmon-init#852, evanharmon1/harmon-init#853, evanharmon1/harmon-init#854, evanharmon1/harmon-init#855, evanharmon1/harmon-devkit#455 (triage canonical home; vendor + supervised run: evanharmon1/harmon-init#864), evanharmon1/harmon-init#857, evanharmon1/harmon-init#858; upstream ponderousdev/foreman#169 and the tier-vocabulary comment on ponderousdev/foreman#139; skill follow-ups evanharmon1/harmon-devkit#454 and evanharmon1/harmon-init#862.

## Verification

- `task verify` green; `task ci` (full mirror incl. render matrix, skills drift, devcontainer assert, security) green.
- Challenge stage: 4 rounds (3 = cap, +1 explicitly authorized by @evanharmon1), 21 P1-class findings adjudicated; converged by restructuring accreted trust prose into invariants with the algorithm delegated to ADR 0006 / foreman#139.
- Review stage: 3 rounds (cap), trajectory 4 P1 → 1 P1 → 0; capped-clean exit with the reviewer's explicit pass.
- Rigor: standard (`default_rigor`) → challenge ≤3 (+1 authorized), review ≤3, shepherd 4.

## Deferred findings

- [x] specs/issue-strategy.md (label-manifest requirement, evanharmon1/harmon-init#851/#854) — additive-only provisioning has no story for renamed/removed manifest values: no tombstones, no association-preserving migration, so the live taxonomy can diverge permanently from the claimed source of truth. Define removal/rename/deprecation policy in the manifest design (consumers ignore manifest-absent labels, or a documented migration). (Codex challenge r1 P2, restated r2) — **filed as evanharmon1/harmon-init#851** (Deferred design considerations, 2026-08-14)
- [x] specs/issue-strategy.md (area requirement, evanharmon1/harmon-init#851/#854) — root manifest carries harmon-init area values while the template twin carries the generic starter; neither a jinja render rule nor an allowlisted divergence is specified, so a verbatim twin would fail dogfood parity. Decide the twin mechanism (render input vs documented divergence) in evanharmon1/harmon-init#851. (Codex challenge r1, P2) — **filed as evanharmon1/harmon-init#851** (Deferred design considerations, 2026-08-14)
- [x] specs/issue-strategy.md (tier validation, evanharmon1/harmon-init#855) — validation covers slug existence and escalation-chain shape but not capability monotonicity of per-family model maps: a schema-valid config can map a higher tier to a weaker model, breaking the "a label only buys more" guarantee. Consider encoding tier membership/capability in the registry and validating maps monotonically. (Codex challenge r2, P2) — **filed as evanharmon1/harmon-init#855** (Deferred design consideration, 2026-08-14)
- [x] specs/issue-strategy.md (triage requirement, evanharmon1/harmon-devkit#455) — the rolling triage report has no idempotency contract: no stable report identity, per-issue keys, update/removal behavior, or self-exclusion from the scan; reruns can duplicate findings or report the report. Require an upsert-by-issue contract in the skill design. (Codex challenge r2, P2) — **filed as evanharmon1/harmon-devkit#455** — its synced body already carries the upsert/self-exclusion contract and a matching acceptance criterion (2026-08-14 sync)
- [x] specs/issue-strategy.md (label-manifest requirement, evanharmon1/harmon-init#851) — `source` is family-level while only writers/lifecycle/color are per-value overridable; the mixed foreman:* namespace (registry selectors + inline protocol labels + tool-owned outputs) leaves the renderer without an unambiguous per-value source. Make `source` per-value overridable or split the namespace into separately modeled groups. (Codex review r3, P2) — **filed as evanharmon1/harmon-init#851** (Deferred design considerations, 2026-08-14)
- [x] specs/issue-strategy.md (triage requirement, evanharmon1/harmon-devkit#455) — the classification-completeness test can read a conflicted axis (two area:/domain:/layer: labels) as "applied" and remove needs-triage; conflicts must retain needs-triage and enter the report unless the correct value is unambiguous. (Codex review r3, P2) — **filed as evanharmon1/harmon-devkit#455** (Deferred design consideration, 2026-08-14)




