### PR TITLE
fix(foreman): bump pinned foreman to 2.5.0 and reconcile the adapter registry

### DIFF
--- a/agent-registry.json
+++ b/agent-registry.json
@@ -293,6 +293,33 @@
       "provision_label": false
     },
     {
+      "slug": "claude-code-glm",
+      "display_name": "Claude Code with GLM",
+      "source_file": "claude-code-glm.sh",
+      "harness": "claude-code-glm",
+      "classification": "production",
+      "production_dispatchable": false,
+      "provision_label": false
+    },
+    {
+      "slug": "claude-code-kimi",
+      "display_name": "Claude Code with Kimi",
+      "source_file": "claude-code-kimi.sh",
+      "harness": "claude-code-kimi",
+      "classification": "production",
+      "production_dispatchable": false,
+      "provision_label": false
+    },
+    {
+      "slug": "codex-cli",
+      "display_name": "OpenAI Codex CLI",
+      "source_file": "codex-cli.sh",
+      "harness": "codex-cli",
+      "classification": "production",
+      "production_dispatchable": false,
+      "provision_label": false
+    },
+    {
       "slug": "mock",
       "display_name": "Mock (tests only)",
       "source_file": "mock.sh",

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -608,12 +608,12 @@ with no adapter behind it is a false capability that can strand armed work.
 | `claude-code` | Claude Code CLI | `claude` | `foreman:claude` — production, dispatchable | `runner-config` |
 | `claude-code-action` | claude-code-action | `claude` | — | `workflow-config` |
 | `claude-code-deepseek` | Claude Code provider wrapper | `deepseek` | `claude-code-deepseek` — production, not dispatchable, no label | `provider-wrapper` |
-| `claude-code-glm` | Claude Code provider wrapper | `glm` | — | `provider-wrapper` |
-| `claude-code-kimi` | Claude Code provider wrapper | `kimi` | — | `provider-wrapper` |
+| `claude-code-glm` | Claude Code provider wrapper | `glm` | `claude-code-glm` — production, not dispatchable, no label | `provider-wrapper` |
+| `claude-code-kimi` | Claude Code provider wrapper | `kimi` | `claude-code-kimi` — production, not dispatchable, no label | `provider-wrapper` |
 | `claude-code-minimax` | Claude Code provider wrapper | `minimax` | — | `provider-wrapper` |
 | `claude-code-qwen` | Claude Code provider wrapper | `qwen` | — | `provider-wrapper` |
 | `claude-code-qwen-local` | Claude Code provider wrapper | `qwen` | — | `provider-wrapper` |
-| `codex-cli` | OpenAI Codex CLI | `gpt` | — | `runner-config` |
+| `codex-cli` | OpenAI Codex CLI | `gpt` | `codex-cli` — production, not dispatchable, no label | `runner-config` |
 | `copilot-cli` | GitHub Copilot CLI | any (multi-provider; default `mai`) | — | `harness-runtime` |
 | `qwen-code` | Qwen Code CLI | `qwen` | — | `runner-config` |
 | `antigravity` | Google Antigravity | `gemini` | — | `harness-runtime` |

--- a/taskfiles/foreman.yml
+++ b/taskfiles/foreman.yml
@@ -11,7 +11,7 @@ version: "3"
 
 vars:
   # renovate: datasource=github-tags depName=ponderousdev/foreman extractVersion=^v(?<version>.*)$
-  FOREMAN_VERSION: 2.3.0
+  FOREMAN_VERSION: 2.5.0
   FOREMAN: uvx --from git+https://github.com/ponderousdev/foreman@v{{.FOREMAN_VERSION}} foreman
 
 tasks:

--- a/template/[% if use_foreman %]taskfiles[% endif %]/foreman.yml
+++ b/template/[% if use_foreman %]taskfiles[% endif %]/foreman.yml
@@ -11,7 +11,7 @@ version: "3"
 
 vars:
   # renovate: datasource=github-tags depName=ponderousdev/foreman extractVersion=^v(?<version>.*)$
-  FOREMAN_VERSION: 2.3.0
+  FOREMAN_VERSION: 2.5.0
   FOREMAN: uvx --from git+https://github.com/ponderousdev/foreman@v{{.FOREMAN_VERSION}} foreman
 
 tasks:

--- a/template/agent-registry.json
+++ b/template/agent-registry.json
@@ -293,6 +293,33 @@
       "provision_label": false
     },
     {
+      "slug": "claude-code-glm",
+      "display_name": "Claude Code with GLM",
+      "source_file": "claude-code-glm.sh",
+      "harness": "claude-code-glm",
+      "classification": "production",
+      "production_dispatchable": false,
+      "provision_label": false
+    },
+    {
+      "slug": "claude-code-kimi",
+      "display_name": "Claude Code with Kimi",
+      "source_file": "claude-code-kimi.sh",
+      "harness": "claude-code-kimi",
+      "classification": "production",
+      "production_dispatchable": false,
+      "provision_label": false
+    },
+    {
+      "slug": "codex-cli",
+      "display_name": "OpenAI Codex CLI",
+      "source_file": "codex-cli.sh",
+      "harness": "codex-cli",
+      "classification": "production",
+      "production_dispatchable": false,
+      "provision_label": false
+    },
+    {
       "slug": "mock",
       "display_name": "Mock (tests only)",
       "source_file": "mock.sh",

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -701,12 +701,12 @@ dispatch".
 | `claude-code` | Claude Code CLI | `claude` | `foreman:claude` — production, dispatchable | `runner-config` |
 | `claude-code-action` | claude-code-action | `claude` | — | `workflow-config` |
 | `claude-code-deepseek` | Claude Code provider wrapper | `deepseek` | `claude-code-deepseek` — production, not dispatchable, no label | `provider-wrapper` |
-| `claude-code-glm` | Claude Code provider wrapper | `glm` | — | `provider-wrapper` |
-| `claude-code-kimi` | Claude Code provider wrapper | `kimi` | — | `provider-wrapper` |
+| `claude-code-glm` | Claude Code provider wrapper | `glm` | `claude-code-glm` — production, not dispatchable, no label | `provider-wrapper` |
+| `claude-code-kimi` | Claude Code provider wrapper | `kimi` | `claude-code-kimi` — production, not dispatchable, no label | `provider-wrapper` |
 | `claude-code-minimax` | Claude Code provider wrapper | `minimax` | — | `provider-wrapper` |
 | `claude-code-qwen` | Claude Code provider wrapper | `qwen` | — | `provider-wrapper` |
 | `claude-code-qwen-local` | Claude Code provider wrapper | `qwen` | — | `provider-wrapper` |
-| `codex-cli` | OpenAI Codex CLI | `gpt` | — | `runner-config` |
+| `codex-cli` | OpenAI Codex CLI | `gpt` | `codex-cli` — production, not dispatchable, no label | `runner-config` |
 | `copilot-cli` | GitHub Copilot CLI | any (multi-provider; default `mai`) | — | `harness-runtime` |
 | `qwen-code` | Qwen Code CLI | `qwen` | — | `runner-config` |
 | `antigravity` | Google Antigravity | `gemini` | — | `harness-runtime` |


### PR DESCRIPTION
## What

Bumps the pinned foreman from 2.3.0 to 2.5.0 and reconciles `agent-registry.json`'s
`foreman_adapters` roster (root and template twins in lockstep) with the 2.5.0 release:
adds `claude-code-glm`, `claude-code-kimi`, and `codex-cli`, each `classification:
production` with `production_dispatchable: false` / `provision_label: false` per the
`claude-code-deepseek` precedent (PR #689) — all three are gated behind default-off
opt-ins (`use_alternative_claude_providers`, manual Codex CLI install), so none should
publish a public `foreman:<slug>` arming label by default. Registry docs tables
regenerated in both layers.

Refs #849 (the issue's remaining box is the [HUMAN] verification below — deliberately
not a closing keyword so the close stays Evan's call after ticking it).

## Why

Foreman 2.4.0 added the three adapters (2.5.0 is liveness-only); the pinned roster and
the registry must move together or the adapter audit drifts — which it had:
`harnesses[]` already listed all three, `foreman_adapters` did not.

## Verification

- `task verify` green — full 7-profile template matrix; each rendered profile's own
  registry-drift check independently reports 6 adapters
- `task test:registry-drift` green (both layers)
- `task foreman:audit-adapters` (network, the issue's [HUMAN] criterion): **exit 0** —
  registry's 6 adapters match the 6 backend scripts foreman v2.5.0 ships
- `task ci` green (verify + skills drift + devcontainer assert + security; semgrep 0
  findings)
- Second-model rounds under rigor: standard (`default_rigor`) → challenge ≤3, review ≤3,
  shepherd 4: **challenge round 1 — no findings** (empty round ends the stage);
  **review round 1 — no findings** (same). Zero P2s raised in either stage.

## Notes for review

- The `[HUMAN]` acceptance box (audit exit 0) was executed with the evidence above but is
  left unticked for @evanharmon1.
- Upstream recon: `task foreman:plan -- --milestone 2` crashes identically under 2.3.0 and
  2.5.0 — foreman queries this repo's issue #382 (transferred away, so GraphQL cannot
  resolve it) and aborts. Reproduced 3×. Candidate report for ponderousdev/foreman;
  not filed yet.
- Merge-order note: `docs/project-management.md` is also touched by the in-flight #852
  branch (different table sections; expect a clean rebase either order).

## Deferred findings

None — both Codex stages returned empty rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZfmG4osB77DLhJc12p3ks
