### PR TITLE
feat(devflow): add min_rounds floor and restructure-to-invariants damper

### DIFF
--- a/.devflow.toml
+++ b/.devflow.toml
@@ -14,9 +14,10 @@
 # PR body, so the budget a change was reviewed under is on the record rather
 # than recalled.
 #
-# When the change under review edits THIS FILE, resolve its caps from the
-# merge-base copy rather than the branch copy — otherwise a branch can lower
-# the very gate it is changing. An explicit human instruction still overrides.
+# When the change under review edits THIS FILE, resolve its caps AND floor
+# from the merge-base copy rather than the branch copy — otherwise a branch
+# can lower the very gate it is changing, a self-lowered min_rounds buying an
+# earlier empty-round exit. An explicit human instruction still overrides.
 #
 # These are ceilings, not quotas. A stage exits the moment any of its exit
 # conditions in AGENTS.md is met: two consecutive rounds adjudicated to zero

--- a/.devflow.toml
+++ b/.devflow.toml
@@ -20,16 +20,25 @@
 #
 # These are ceilings, not quotas. A stage exits the moment any of its exit
 # conditions in AGENTS.md is met: two consecutive rounds adjudicated to zero
-# P0/P1, any single round with no findings at all, or a round that hits the cap
-# below having adjudicated to zero P0/P1 — the confirming round it would
-# otherwise owe is one the cap forbids, so a clean last round is convergence,
-# not grounds to escalate. Nothing here obliges a round to be run.
+# P0/P1, any single round with no findings at all (once `min_rounds` rounds
+# have run), or a round that hits the cap below having adjudicated to zero
+# P0/P1 — the confirming round it would otherwise owe is one the cap forbids,
+# so a clean last round is convergence, not grounds to escalate.
 #
-# Retuning these is expected. The Dev Loop assumes four invariants, and nothing
+# `min_rounds` is the one number here that is a floor rather than a ceiling: it
+# is the minimum number of rounds a stage must actually run before the
+# empty-round instant exit is available. The other two exits already run two
+# rounds and one capped round respectively, so any floor of 2 or less is
+# satisfied by construction and `min_rounds` binds only the empty-round path.
+#
+# Retuning these is expected. The Dev Loop assumes five invariants, and nothing
 # at runtime will tell you if an edit breaks one:
-#   - every tier defines challenge, review and shepherd, all integers
+#   - every tier defines challenge, review, shepherd and min_rounds, all
+#     integers
 #   - challenge and review are >= 2, because the exit condition needs two
 #     consecutive adjudicated-clean rounds; at 1, one finding is an escalation
+#   - min_rounds is >= 1 and no greater than that tier's challenge or review
+#     cap — a floor above the ceiling makes the stage impossible to exit
 #   - shepherd is the same in every tier (see below)
 #   - default_rigor names a tier that exists here
 #
@@ -51,18 +60,21 @@ default_rigor = "standard"
 
 # Trivial, low-blast-radius work: doc touch-ups, mechanical bumps, typo fixes.
 [rigor.light]
-challenge = 2 # 2 is the floor, never 1: the exit condition needs two
-review    = 2 # consecutive adjudicated-clean rounds, so a cap of 1 turns any
-shepherd  = 4 # single finding into an immediate escalation.
+challenge  = 2 # 2 is the floor, never 1: the exit condition needs two
+review     = 2 # consecutive adjudicated-clean rounds, so a cap of 1 turns any
+shepherd   = 4 # single finding into an immediate escalation.
+min_rounds = 1
 
 # The default for ordinary changes.
 [rigor.standard]
-challenge = 3
-review    = 3
-shepherd  = 4
+challenge  = 3
+review     = 3
+shepherd   = 4
+min_rounds = 1
 
 # Security, migrations, data paths — anything with an irreversible failure mode.
 [rigor.deep]
-challenge = 5
-review    = 5
-shepherd  = 4
+challenge  = 5
+review     = 5
+shepherd   = 4
+min_rounds = 1

--- a/.devflow.toml
+++ b/.devflow.toml
@@ -37,8 +37,9 @@
 #     integers
 #   - challenge and review are >= 2, because the exit condition needs two
 #     consecutive adjudicated-clean rounds; at 1, one finding is an escalation
-#   - min_rounds is >= 1 and no greater than that tier's challenge or review
-#     cap — a floor above the ceiling makes the stage impossible to exit
+#   - min_rounds is 1 or 2, never more: two consecutive adjudicated-clean
+#     rounds — empty rounds included — exit a stage at round 2 whatever the
+#     floor says, so a value above 2 is a budget no stage ever spends
 #   - shepherd is the same in every tier (see below)
 #   - default_rigor names a tier that exists here
 #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,8 +249,10 @@ live in [`.devflow.toml`](.devflow.toml) as `rigor` tiers, so there is one
 place to change them and a parity gate that catches a change made on only one
 side. Resolve in this order — an explicit instruction in this session, then a
 `rigor:*` label on the issue, then `default_rigor`, then a built-in 4 / 4 / 4
-if the file is absent — with a `min_rounds` floor of 1 in that same absent-file
-case, which is the floor every shipped tier states anyway. When the change under review **edits `.devflow.toml`
+if the file is absent — with a `min_rounds` floor of 1 wherever no tier
+defines one — the absent-file case and any older or customized config whose
+tiers predate the key alike — which is also the floor every shipped tier
+states explicitly. When the change under review **edits `.devflow.toml`
 itself**, resolve its caps from the **merge-base** copy rather than the branch
 copy: otherwise a branch can lower the very gate it is changing — dropping every
 tier and `default_rigor` together passes the validator and evades the
@@ -260,7 +262,9 @@ decision rather than the branch deciding for itself. GitHub labels are
 multi-select and nothing stops an
 issue carrying two, so resolution is **per stage, taking the highest cap
 present**: a conflict can then only ever buy more review, never less, and no
-ranking of the tier names has to be agreed on anywhere. Because that is per
+ranking of the tier names has to be agreed on anywhere. `min_rounds` resolves
+under the same principle — the highest floor present wins — so a label
+conflict cannot quietly select the lower floor either. Because that is per
 stage, two retuned tiers can yield caps belonging to no single tier — so what
 you announce is the **caps**, naming a tier only when one supplied all of them,
 and the disclosure below compares caps rather than tier names. A `rigor:` value
@@ -269,11 +273,12 @@ label as advisory: it is applied by people and verified by nothing, and
 GitHub's **triage** role can label an issue with no push access at all — so a
 budget can be retuned by someone who could not edit `.devflow.toml`. An agent
 never applies one to itself, and **says so in the announcement and in the PR
-body whenever any resolved cap is below what `default_rigor` would give**, so a
+body whenever any resolved cap or floor is below what `default_rigor` would give**, so a
 reduced budget is visible to the human reviewer instead of silent.
 **Announce the resolved caps on entering
 the loop** — "rigor: `<tier>` (`<source>`) → challenge ≤`<n>`, review ≤`<n>`,
-shepherd `<n>`", filled in by reading the file rather than from memory — and
+shepherd `<n>`, min_rounds `<n>`", filled in by reading the file rather than
+from memory — and
 carry it into the PR body, so a later round or a different session can see
 which budget it is spending instead of inferring one. Everything else about
 these stages is policy rather than a parameter and does not vary by tier: the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,8 @@ live in [`.devflow.toml`](.devflow.toml) as `rigor` tiers, so there is one
 place to change them and a parity gate that catches a change made on only one
 side. Resolve in this order — an explicit instruction in this session, then a
 `rigor:*` label on the issue, then `default_rigor`, then a built-in 4 / 4 / 4
-if the file is absent. When the change under review **edits `.devflow.toml`
+if the file is absent — with a `min_rounds` floor of 1 in that same absent-file
+case, which is the floor every shipped tier states anyway. When the change under review **edits `.devflow.toml`
 itself**, resolve its caps from the **merge-base** copy rather than the branch
 copy: otherwise a branch can lower the very gate it is changing — dropping every
 tier and `default_rigor` together passes the validator and evades the
@@ -303,9 +304,14 @@ allowed.
   table, not off the reviewer's label, and nothing further is owed after the
   second such round: the second round *is* the confirmation, so there is no
   extra clean run to buy. A round that returns **no findings at all** ends
-  the stage on its own, whenever it comes — an empty round is the old rule's
-  clean re-run, so neither a trivial change nor a clean post-fix re-run pays
-  for a confirmation pass. Fixing the findings is still not the exit
+  the stage on its own **once at least `min_rounds` rounds have run** — an
+  empty round is the old rule's clean re-run, so neither a trivial change nor
+  a clean post-fix re-run pays for a confirmation pass, but a tier that sets a
+  floor buys the rounds it asked for before that shortcut opens. The other two
+  exits satisfy any floor of 2 or less by construction — two consecutive clean
+  rounds *are* two rounds, and a capped final round is at least the cap, which
+  is never below 2 — so `min_rounds` binds the empty-round path and nothing
+  else. Fixing the findings is still not the exit
   condition; adjudicated-clean rounds are. The exit carries one
   precondition: every P2 you deferred during the stage must already be in the
   deferred-findings sidecar (see "Deferring P2s" below) — an exit that drops
@@ -653,8 +659,9 @@ exit the cap is no longer the only thing standing between you and a loop that
 feeds on itself, so the check has to happen where it first can. At round 2,
 for every finding, say on the adjudication table whether its subject exists
 only because an **earlier round of this same stage** added it. A finding that
-does gets adjudicated with one of two dispositions written out: **delete** the
-scaffolding (which moots the finding — see below), or state that it is in
+does gets adjudicated with one of three dispositions written out: **delete**
+the scaffolding (which moots the finding — see below), **restructure it to
+invariants** (deletion by abstraction — see below), or state that it is in
 scope and why the change genuinely needs it. What is not allowed is hardening
 round-1's scaffolding by reflex and letting round 3 attack the result.
 
@@ -674,6 +681,17 @@ re-raise. Name the mooted findings
 in the adjudication table *and* in the message of the commit that removes the
 code — the table is scrollback, but the commit is why the code is gone, and it
 is the record a later round or a different session can still find.
+
+**Restructuring to invariants is the same move where deletion is unavailable**
+— deletion by abstraction. When the artifact is a spec or a document whose
+accreted procedure-prose *cannot* simply be dropped because earlier rounds
+legitimately demanded it, replace the attackable procedure with the
+universally-quantified property it was approximating, delegate the mechanism to
+the implementation surface that can be tested, and carry the review's attack
+scenarios over as required test cases. The next round finds no wording seam to
+attack, and the obligation is preserved rather than dropped — which is what
+separates this from quietly deleting a requirement. Name it on the table and in
+the commit message exactly as a deletion is named.
 
 One endpoint is worth knowing: if the deletion empties the change *entirely*,
 there is no round to converge on — `codex-review.sh` refuses an empty scope
@@ -755,9 +773,16 @@ all-P2 as labeled, or P1-labeled and adjudicated down to P2; what counts is
 the **adjudicated** column of the table, not the reviewer's label, and the
 second such round is itself the confirmation, so no further run is owed. Two
 exits are faster still. A round with **no findings at all** ends the stage by
-itself, whenever it comes — an empty round is exactly the old rule's clean
-re-run, so neither a trivial change nor a clean post-fix re-run pays for a
-confirmation pass. And a **capped final round** that adjudicates to zero
+itself **once the stage has run at least `min_rounds` rounds** (the per-tier
+floor in `.devflow.toml`; 1 if the file is absent) — an empty round is exactly
+the old rule's clean re-run, so neither a trivial change nor a clean post-fix
+re-run pays for a confirmation pass, and the floor only stops that shortcut
+being taken before the tier's minimum work has happened. Say plainly what
+follows: the other two exits satisfy any floor of 2 or less **by
+construction** — the two-consecutive exit runs two rounds by definition, and
+the capped-clean exit runs the cap, which is never below 2 — so `min_rounds`
+constrains the empty-round exit alone and needs no separate check on the
+other two. And a **capped final round** that adjudicates to zero
 P0/P1 also ends the stage by itself: the confirmation it would otherwise owe
 is a run the cap forbids, and a rule that strands a stage holding a clean
 last round and no valid exit would be wrong — the cap bounds work, it does

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,10 +249,10 @@ live in [`.devflow.toml`](.devflow.toml) as `rigor` tiers, so there is one
 place to change them and a parity gate that catches a change made on only one
 side. Resolve in this order — an explicit instruction in this session, then a
 `rigor:*` label on the issue, then `default_rigor`, then a built-in 4 / 4 / 4
-if the file is absent — with a `min_rounds` floor of 1 wherever no tier
-defines one — the absent-file case and any older or customized config whose
-tiers predate the key alike — which is also the floor every shipped tier
-states explicitly. When the change under review **edits `.devflow.toml`
+if the file is absent — with a `min_rounds` floor of 1 for any tier that
+does not define it — the absent-file case, a legacy config predating the key,
+and a partially migrated one where only some tiers state it alike — which is
+also the floor every shipped tier states explicitly. When the change under review **edits `.devflow.toml`
 itself**, resolve its caps **and floor** from the **merge-base** copy rather
 than the branch copy: otherwise a branch can lower the very gate it is
 changing — the floor included, since a self-lowered `min_rounds` buys an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,8 +253,10 @@ if the file is absent — with a `min_rounds` floor of 1 wherever no tier
 defines one — the absent-file case and any older or customized config whose
 tiers predate the key alike — which is also the floor every shipped tier
 states explicitly. When the change under review **edits `.devflow.toml`
-itself**, resolve its caps from the **merge-base** copy rather than the branch
-copy: otherwise a branch can lower the very gate it is changing — dropping every
+itself**, resolve its caps **and floor** from the **merge-base** copy rather
+than the branch copy: otherwise a branch can lower the very gate it is
+changing — the floor included, since a self-lowered `min_rounds` buys an
+earlier empty-round exit — dropping every
 tier and `default_rigor` together passes the validator and evades the
 below-default disclosure, because nothing is left to be below. An explicit
 instruction from Evan still overrides, since that is an attributable human

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,7 +268,8 @@ ranking of the tier names has to be agreed on anywhere. `min_rounds` resolves
 under the same principle — the highest floor present wins — so a label
 conflict cannot quietly select the lower floor either. Because that is per
 stage, two retuned tiers can yield caps belonging to no single tier — so what
-you announce is the **caps**, naming a tier only when one supplied all of them,
+you announce is the **caps**, naming a tier only when one supplied all of
+them — the floor included,
 and the disclosure below compares caps rather than tier names. A `rigor:` value
 that names no tier in the file is ignored rather than guessed at. Treat the
 label as advisory: it is applied by people and verified by nothing, and

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -235,8 +235,9 @@ task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
                 # until TWO CONSECUTIVE rounds adjudicate to zero P0/P1
-                # (any round with no findings at all ends it), under the
-                # challenge cap resolved from .devflow.toml
+                # (a round with no findings ends it once the tier's
+                # min_rounds floor is met), under the challenge cap
+                # resolved from .devflow.toml
 task review     # verification checkpoint — same convergence rule, under its
                 # own resolved review cap
 task ci         # full CI mirror
@@ -278,9 +279,12 @@ down to
 P2; what counts is the **adjudicated** column of your adjudication table, not
 the label Codex attached. The second such round *is* the confirmation, so no
 extra run is owed after it. Two cases exit faster still. A round with **no
-findings at all** ends the stage on the spot, whenever it comes — an empty
-round is exactly the older "clean re-run" exit, so neither a trivial change
-nor a clean post-fix re-run pays for a confirmation pass. And a **capped
+findings at all** ends the stage on the spot **once the tier's `min_rounds`
+floor is met** (1 wherever a tier does not set it) — an empty round is exactly
+the older "clean re-run" exit, so neither a trivial change nor a clean
+post-fix re-run pays for a confirmation pass, and a floor of 2 only delays
+that shortcut, never the other two exits, which run at least two rounds by
+construction. And a **capped
 final round** that adjudicates to zero P0/P1 ends the stage by itself: the
 confirmation it would otherwise owe is a run the cap forbids, and escalation
 at the cap is reserved for P0/P1 findings that persist — a clean last round

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -257,9 +257,10 @@ The caps are not written down here, or in AGENTS.md. They live in
 [`.devflow.toml`](../../.devflow.toml) as `rigor` tiers, and **AGENTS.md alone
 defines how a change resolves one** — restating that chain here would only give
 it a second place to drift from, and which inputs are even available depends on
-how the repository is set up. Only `challenge` and `review` vary by tier; the
+how the repository is set up. `challenge`, `review`, and the `min_rounds` floor vary by tier; the
 shepherd cap is fixed, because it bounds other people's findings rather than
-self-generated work. Announce the resolved caps when you enter the loop.
+self-generated work. Announce the resolved caps — the floor included — when
+you enter the loop.
 
 If Codex cloud review is connected to the repo, PRs
 get a cloud pass too: inline comments only for high-priority findings, a

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -298,9 +298,27 @@ along the way was individually defensible.
 The **scaffolding damper** is what replaces the cap as the first line of
 defense. At round 2 — the earliest round that can show the pattern — say on
 the table, for each finding, whether its subject exists only because an earlier
-round of the same stage added it. Where it does, adjudicate it with one of two
-dispositions written down: delete the scaffolding, or state that the code is
-in scope and why the change needs it. A deletion does not re-score the round
+round of the same stage added it. Where it does, adjudicate it with one of
+three dispositions written down: delete the scaffolding, restructure it to
+invariants, or state that the code is in scope and why the change needs it.
+
+**Restructuring to invariants** is deletion by abstraction, and it is the
+disposition to reach for when plain deletion is unavailable. Some artifacts —
+specs, policy documents, AGENTS.md itself — accrete procedure-prose that
+earlier rounds legitimately demanded, so it cannot just be dropped without
+dropping the obligation with it. Instead, replace the attackable procedure with
+the universally-quantified property it was approximating, delegate the
+mechanism to the implementation surface that can actually be tested, and carry
+the round's attack scenarios across as required test cases. The wording seam
+the next round would have attacked is gone, and the obligation survives as a
+property plus its tests rather than as prose. Three rounds of trust-rule
+whack-a-mole in the 2026-08-13/14 spec session ended in exactly one such
+restructure. It shares deletion's accounting: it does not re-score the round
+that raised the findings, and it must be named on the table and in the commit
+message, because "the procedure is gone" and "the requirement is gone" look
+identical in a diff and are not the same thing.
+
+A deletion does not re-score the round
 that flagged the code — the finding keeps its adjudicated priority there, and
 it is the **next** round, reviewing the tree without it, that finds nothing
 left to re-raise and counts toward convergence. Reflexively hardening the

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -420,8 +420,9 @@ families, color-coded by family; the starter set is created by
   gate: nothing verifies who applied it, and the **triage** role can label an
   issue with no push access — so AGENTS.md requires any cap resolving below
   `default_rigor` to be stated in the PR body, keeping a reduced budget visible
-  to the reviewer. Two present resolve per stage to the highest cap, so a
-  conflict can only ever buy more review.
+  to the reviewer — the `min_rounds` floor included. Two present resolve per
+  stage to the highest cap, and the floor likewise to the highest present, so
+  a conflict can only ever buy more review.
 
 Two more families name **model intelligence** rather than a facet of the work,
 and their vocabulary is not hand-listed anywhere: it is rendered from

--- a/scripts/test-devflow-config.sh
+++ b/scripts/test-devflow-config.sh
@@ -42,6 +42,11 @@ import tomllib
 
 labels_script, agents_root, agents_template, *config_paths = sys.argv[1:]
 STAGES = ("challenge", "review", "shepherd")
+# `min_rounds` is a floor on rounds actually run, not a cap — it gates only the
+# empty-round instant exit (AGENTS.md, "Loop cap and exit"). It is required in
+# every tier, so both dogfood copies state it rather than relying on a default.
+MIN_ROUNDS = "min_rounds"
+KNOWN_KEYS = STAGES + (MIN_ROUNDS,)
 # The floor is 2, not 1: a stage exits on two consecutive adjudicated-clean
 # rounds, so a cap of 1 makes any single finding an instant escalation.
 FLOOR = {"challenge": 2, "review": 2, "shepherd": 1}
@@ -77,10 +82,10 @@ for path in config_paths:
         if not isinstance(caps, dict):
             failures.append(f"{path}: [rigor.{name}] is not a table")
             continue
-        missing = [s for s in STAGES if s not in caps]
+        missing = [s for s in KNOWN_KEYS if s not in caps]
         if missing:
             failures.append(f"{path}: [rigor.{name}] missing {', '.join(missing)}")
-        extra = [k for k in caps if k not in STAGES]
+        extra = [k for k in caps if k not in KNOWN_KEYS]
         if extra:
             failures.append(f"{path}: [rigor.{name}] has unknown key(s) {', '.join(extra)}")
         for stage in STAGES:
@@ -94,6 +99,30 @@ for path in config_paths:
                 failures.append(
                     f"{path}: rigor.{name}.{stage}={value} is below the floor of {FLOOR[stage]}"
                 )
+        floor_value = caps.get(MIN_ROUNDS)
+        if floor_value is not None:
+            # bool is an int subclass in Python; `min_rounds = true` must fail.
+            if not isinstance(floor_value, int) or isinstance(floor_value, bool):
+                failures.append(
+                    f"{path}: rigor.{name}.{MIN_ROUNDS}={floor_value!r} is not an integer"
+                )
+            elif floor_value < 1:
+                failures.append(
+                    f"{path}: rigor.{name}.{MIN_ROUNDS}={floor_value} is below 1 — a stage "
+                    "always runs at least one round"
+                )
+            else:
+                # A floor above the ceiling makes the stage impossible to exit:
+                # the empty-round path is unreachable and the cap forces an
+                # escalation that no amount of reviewing could avoid.
+                for stage in ("challenge", "review"):
+                    cap = caps.get(stage)
+                    if isinstance(cap, int) and not isinstance(cap, bool) and floor_value > cap:
+                        failures.append(
+                            f"{path}: rigor.{name}.{MIN_ROUNDS}={floor_value} exceeds the "
+                            f"{stage} cap of {cap} — the floor cannot be above the ceiling"
+                        )
+
         if isinstance(caps.get("shepherd"), int) and not isinstance(caps.get("shepherd"), bool):
             shepherd_values.add(caps["shepherd"])
 
@@ -138,8 +167,9 @@ with open(config_paths[0], "rb") as fh:
     cfg = tomllib.load(fh)
 tiers = cfg["rigor"]
 summary = "; ".join(
-    f"{n}={t['challenge']}/{t['review']}/{t['shepherd']}" for n, t in sorted(tiers.items())
+    f"{n}={t['challenge']}/{t['review']}/{t['shepherd']} (min {t['min_rounds']})"
+    for n, t in sorted(tiers.items())
 )
 print(f"devflow config OK: default={cfg['default_rigor']} — {summary}")
-print("  (challenge/review/shepherd; both copies valid, every tier has a rigor:* label)")
+print("  (challenge/review/shepherd + min_rounds; both copies valid, every tier has a label)")
 PY

--- a/scripts/test-devflow-config.sh
+++ b/scripts/test-devflow-config.sh
@@ -111,17 +111,17 @@ for path in config_paths:
                     f"{path}: rigor.{name}.{MIN_ROUNDS}={floor_value} is below 1 — a stage "
                     "always runs at least one round"
                 )
-            else:
-                # A floor above the ceiling makes the stage impossible to exit:
-                # the empty-round path is unreachable and the cap forces an
-                # escalation that no amount of reviewing could avoid.
-                for stage in ("challenge", "review"):
-                    cap = caps.get(stage)
-                    if isinstance(cap, int) and not isinstance(cap, bool) and floor_value > cap:
-                        failures.append(
-                            f"{path}: rigor.{name}.{MIN_ROUNDS}={floor_value} exceeds the "
-                            f"{stage} cap of {cap} — the floor cannot be above the ceiling"
-                        )
+            elif floor_value > 2:
+                # A floor above 2 is unenforceable, not merely aggressive: two
+                # consecutive adjudicated-clean rounds — including two empty
+                # ones — exit the stage at round 2 whatever the floor says, so
+                # accepting 3+ would document a budget no stage ever spends.
+                # (2 <= every cap, so the floor can never exceed a cap either.)
+                failures.append(
+                    f"{path}: rigor.{name}.{MIN_ROUNDS}={floor_value} is above 2 — the "
+                    "two-consecutive-clean exit ends a stage at round 2 whatever the "
+                    "floor, so values above 2 cannot bind"
+                )
 
         if isinstance(caps.get("shepherd"), int) and not isinstance(caps.get("shepherd"), bool):
             shepherd_values.add(caps["shepherd"])

--- a/scripts/test-devflow-config.sh
+++ b/scripts/test-devflow-config.sh
@@ -143,7 +143,7 @@ for path in config_paths:
 FALLBACK_RE = re.compile(r"built-in (\d+ / \d+ / \d+)")
 # The missing-key floor exists only in prose, so its parity is checked the
 # same way as the caps: exactly one statement per layer, equal across layers.
-FLOOR_FALLBACK_RE = re.compile(r"`min_rounds` floor of\s+(\d+) wherever no tier\s+defines one")
+FLOOR_FALLBACK_RE = re.compile(r"`min_rounds` floor of\s+(\d+) for any tier that\s+does not define it")
 fallbacks = {}
 floor_fallbacks = {}
 for path in (agents_root, agents_template):

--- a/scripts/test-devflow-config.sh
+++ b/scripts/test-devflow-config.sh
@@ -176,6 +176,14 @@ if len(set(floor_fallbacks.values())) > 1:
         + "; ".join(f"{p} says {v}" for p, v in sorted(floor_fallbacks.items()))
         + " — root and generated agents would use different exit rules"
     )
+for path, value in sorted(floor_fallbacks.items()):
+    # Same range as configured min_rounds: 1 or 2. A fallback outside it would
+    # hand absent-file/legacy repos an exit rule no shipped tier may state.
+    if not value.isdigit() or not 1 <= int(value) <= 2:
+        failures.append(
+            f"{path}: fallback min_rounds floor {value} is outside the supported "
+            "range 1-2"
+        )
 
 if failures:
     for line in failures:

--- a/scripts/test-devflow-config.sh
+++ b/scripts/test-devflow-config.sh
@@ -141,9 +141,14 @@ for path in config_paths:
         )
 
 FALLBACK_RE = re.compile(r"built-in (\d+ / \d+ / \d+)")
+# The missing-key floor exists only in prose, so its parity is checked the
+# same way as the caps: exactly one statement per layer, equal across layers.
+FLOOR_FALLBACK_RE = re.compile(r"`min_rounds` floor of\s+(\d+) wherever no tier\s+defines one")
 fallbacks = {}
+floor_fallbacks = {}
 for path in (agents_root, agents_template):
-    found = set(FALLBACK_RE.findall(open(path).read()))
+    text = open(path).read()
+    found = set(FALLBACK_RE.findall(text))
     if len(found) != 1:
         failures.append(
             f"{path}: expected exactly one 'built-in N / N / N' fallback, found "
@@ -151,11 +156,25 @@ for path in (agents_root, agents_template):
         )
     else:
         fallbacks[path] = found.pop()
+    floor_found = set(FLOOR_FALLBACK_RE.findall(text))
+    if len(floor_found) != 1:
+        failures.append(
+            f"{path}: expected exactly one 'min_rounds floor of N wherever no tier "
+            f"defines one' fallback, found {sorted(floor_found) if floor_found else 'none'}"
+        )
+    else:
+        floor_fallbacks[path] = floor_found.pop()
 if len(set(fallbacks.values())) > 1:
     failures.append(
         "the fallback caps disagree across the dogfood: "
         + "; ".join(f"{p} says {v}" for p, v in sorted(fallbacks.items()))
         + " — root and generated agents would use different caps"
+    )
+if len(set(floor_fallbacks.values())) > 1:
+    failures.append(
+        "the fallback min_rounds floor disagrees across the dogfood: "
+        + "; ".join(f"{p} says {v}" for p, v in sorted(floor_fallbacks.items()))
+        + " — root and generated agents would use different exit rules"
     )
 
 if failures:

--- a/template/.devflow.toml
+++ b/template/.devflow.toml
@@ -14,9 +14,10 @@
 # PR body, so the budget a change was reviewed under is on the record rather
 # than recalled.
 #
-# When the change under review edits THIS FILE, resolve its caps from the
-# merge-base copy rather than the branch copy — otherwise a branch can lower
-# the very gate it is changing. An explicit human instruction still overrides.
+# When the change under review edits THIS FILE, resolve its caps AND floor
+# from the merge-base copy rather than the branch copy — otherwise a branch
+# can lower the very gate it is changing, a self-lowered min_rounds buying an
+# earlier empty-round exit. An explicit human instruction still overrides.
 #
 # These are ceilings, not quotas. A stage exits the moment any of its exit
 # conditions in AGENTS.md is met: two consecutive rounds adjudicated to zero

--- a/template/.devflow.toml
+++ b/template/.devflow.toml
@@ -20,16 +20,25 @@
 #
 # These are ceilings, not quotas. A stage exits the moment any of its exit
 # conditions in AGENTS.md is met: two consecutive rounds adjudicated to zero
-# P0/P1, any single round with no findings at all, or a round that hits the cap
-# below having adjudicated to zero P0/P1 — the confirming round it would
-# otherwise owe is one the cap forbids, so a clean last round is convergence,
-# not grounds to escalate. Nothing here obliges a round to be run.
+# P0/P1, any single round with no findings at all (once `min_rounds` rounds
+# have run), or a round that hits the cap below having adjudicated to zero
+# P0/P1 — the confirming round it would otherwise owe is one the cap forbids,
+# so a clean last round is convergence, not grounds to escalate.
 #
-# Retuning these is expected. The Dev Loop assumes four invariants, and nothing
+# `min_rounds` is the one number here that is a floor rather than a ceiling: it
+# is the minimum number of rounds a stage must actually run before the
+# empty-round instant exit is available. The other two exits already run two
+# rounds and one capped round respectively, so any floor of 2 or less is
+# satisfied by construction and `min_rounds` binds only the empty-round path.
+#
+# Retuning these is expected. The Dev Loop assumes five invariants, and nothing
 # at runtime will tell you if an edit breaks one:
-#   - every tier defines challenge, review and shepherd, all integers
+#   - every tier defines challenge, review, shepherd and min_rounds, all
+#     integers
 #   - challenge and review are >= 2, because the exit condition needs two
 #     consecutive adjudicated-clean rounds; at 1, one finding is an escalation
+#   - min_rounds is >= 1 and no greater than that tier's challenge or review
+#     cap — a floor above the ceiling makes the stage impossible to exit
 #   - shepherd is the same in every tier (see below)
 #   - default_rigor names a tier that exists here
 #
@@ -51,18 +60,21 @@ default_rigor = "standard"
 
 # Trivial, low-blast-radius work: doc touch-ups, mechanical bumps, typo fixes.
 [rigor.light]
-challenge = 2 # 2 is the floor, never 1: the exit condition needs two
-review    = 2 # consecutive adjudicated-clean rounds, so a cap of 1 turns any
-shepherd  = 4 # single finding into an immediate escalation.
+challenge  = 2 # 2 is the floor, never 1: the exit condition needs two
+review     = 2 # consecutive adjudicated-clean rounds, so a cap of 1 turns any
+shepherd   = 4 # single finding into an immediate escalation.
+min_rounds = 1
 
 # The default for ordinary changes.
 [rigor.standard]
-challenge = 3
-review    = 3
-shepherd  = 4
+challenge  = 3
+review     = 3
+shepherd   = 4
+min_rounds = 1
 
 # Security, migrations, data paths — anything with an irreversible failure mode.
 [rigor.deep]
-challenge = 5
-review    = 5
-shepherd  = 4
+challenge  = 5
+review     = 5
+shepherd   = 4
+min_rounds = 1

--- a/template/.devflow.toml
+++ b/template/.devflow.toml
@@ -37,8 +37,9 @@
 #     integers
 #   - challenge and review are >= 2, because the exit condition needs two
 #     consecutive adjudicated-clean rounds; at 1, one finding is an escalation
-#   - min_rounds is >= 1 and no greater than that tier's challenge or review
-#     cap — a floor above the ceiling makes the stage impossible to exit
+#   - min_rounds is 1 or 2, never more: two consecutive adjudicated-clean
+#     rounds — empty rounds included — exit a stage at round 2 whatever the
+#     floor says, so a value above 2 is a budget no stage ever spends
 #   - shepherd is the same in every tier (see below)
 #   - default_rigor names a tier that exists here
 #

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -158,7 +158,8 @@ on anywhere. `min_rounds` resolves under the same principle — the highest
 floor present wins — so a label conflict cannot quietly select the lower floor
 either. Because that is per stage, two retuned tiers can yield caps
 belonging to no single tier — so what you announce is the **caps**, naming a
-tier only when one supplied all of them, and the disclosure below compares caps
+tier only when one supplied all of them — the floor included — and the
+disclosure below compares caps
 rather than tier names. A `rigor:` value naming no tier in the file is ignored
 rather than guessed at. Treat the label as advisory: it is applied by people and
 verified by nothing, and GitHub's **triage** role can label an issue with no

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -142,8 +142,9 @@ capped, but this file names no numbers: the caps live in
 change them and one place to read them. Resolve in this order — an explicit
 instruction in this session, then [% if project_management == 'github' or use_foreman %]a `rigor:*` label on the issue, then [% endif %]`default_rigor`,
 then a built-in 4 / 4 / 4 if the file is absent — with a `min_rounds` floor of
-1 in that same absent-file case, which is the floor every shipped tier states
-anyway. When the change under review
+1 wherever no tier defines one — the absent-file case and any older or
+customized config whose tiers predate the key alike — which is also the floor
+every shipped tier states explicitly. When the change under review
 **edits `.devflow.toml` itself**, resolve its caps from the **merge-base** copy
 rather than the branch copy: otherwise a branch can lower the very gate it is
 changing, and dropping every tier together evades the below-default disclosure
@@ -152,7 +153,9 @@ overrides.
 [% if project_management == 'github' or use_foreman %]Labels are multi-select and nothing stops an issue carrying two, so resolution
 is **per stage, taking the highest cap present**: a conflict can then only ever
 buy more review, never less, and no ranking of the tier names has to be agreed
-on anywhere. Because that is per stage, two retuned tiers can yield caps
+on anywhere. `min_rounds` resolves under the same principle — the highest
+floor present wins — so a label conflict cannot quietly select the lower floor
+either. Because that is per stage, two retuned tiers can yield caps
 belonging to no single tier — so what you announce is the **caps**, naming a
 tier only when one supplied all of them, and the disclosure below compares caps
 rather than tier names. A `rigor:` value naming no tier in the file is ignored
@@ -160,11 +163,11 @@ rather than guessed at. Treat the label as advisory: it is applied by people and
 verified by nothing, and GitHub's **triage** role can label an issue with no
 push access at all — so a budget can be retuned by someone who could not edit
 `.devflow.toml`. An agent never applies one to itself, and **says so in the
-announcement and in the PR body whenever any resolved cap is below what
+announcement and in the PR body whenever any resolved cap or floor is below what
 `default_rigor` would give**, so a reduced budget is visible to the human
 reviewer instead of silent.
 [% endif %]**Announce the resolved caps on entering the loop** — "rigor:
-`<tier>` (`<source>`) → [% if use_codex_review %]challenge ≤`<n>`, review ≤`<n>`, [% endif %]shepherd `<n>`", filled in
+`<tier>` (`<source>`) → [% if use_codex_review %]challenge ≤`<n>`, review ≤`<n>`, [% endif %]shepherd `<n>`, min_rounds `<n>`", filled in
 by reading the file rather than from memory — and carry it into the PR body, so
 a later round or a different session can see which budget it is spending
 instead of inferring one. Everything else about these stages is policy rather

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -145,9 +145,10 @@ then a built-in 4 / 4 / 4 if the file is absent — with a `min_rounds` floor of
 1 wherever no tier defines one — the absent-file case and any older or
 customized config whose tiers predate the key alike — which is also the floor
 every shipped tier states explicitly. When the change under review
-**edits `.devflow.toml` itself**, resolve its caps from the **merge-base** copy
-rather than the branch copy: otherwise a branch can lower the very gate it is
-changing, and dropping every tier together evades the below-default disclosure
+**edits `.devflow.toml` itself**, resolve its caps **and floor** from the
+**merge-base** copy rather than the branch copy: otherwise a branch can lower
+the very gate it is changing — the floor included, since a self-lowered
+`min_rounds` buys an earlier empty-round exit, and dropping every tier together evades the below-default disclosure
 because nothing is left to be below. An explicit human instruction still
 overrides.
 [% if project_management == 'github' or use_foreman %]Labels are multi-select and nothing stops an issue carrying two, so resolution
@@ -167,7 +168,7 @@ announcement and in the PR body whenever any resolved cap or floor is below what
 `default_rigor` would give**, so a reduced budget is visible to the human
 reviewer instead of silent.
 [% endif %]**Announce the resolved caps on entering the loop** — "rigor:
-`<tier>` (`<source>`) → [% if use_codex_review %]challenge ≤`<n>`, review ≤`<n>`, [% endif %]shepherd `<n>`, min_rounds `<n>`", filled in
+`<tier>` (`<source>`) → [% if use_codex_review %]challenge ≤`<n>`, review ≤`<n>`, [% endif %]shepherd `<n>`[% if use_codex_review %], min_rounds `<n>`[% endif %]", filled in
 by reading the file rather than from memory — and carry it into the PR body, so
 a later round or a different session can see which budget it is spending
 instead of inferring one. Everything else about these stages is policy rather

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -142,9 +142,9 @@ capped, but this file names no numbers: the caps live in
 change them and one place to read them. Resolve in this order — an explicit
 instruction in this session, then [% if project_management == 'github' or use_foreman %]a `rigor:*` label on the issue, then [% endif %]`default_rigor`,
 then a built-in 4 / 4 / 4 if the file is absent — with a `min_rounds` floor of
-1 wherever no tier defines one — the absent-file case and any older or
-customized config whose tiers predate the key alike — which is also the floor
-every shipped tier states explicitly. When the change under review
+1 for any tier that does not define it — the absent-file case, a legacy config
+predating the key, and a partially migrated one where only some tiers state it
+alike — which is also the floor every shipped tier states explicitly. When the change under review
 **edits `.devflow.toml` itself**, resolve its caps **and floor** from the
 **merge-base** copy rather than the branch copy: otherwise a branch can lower
 the very gate it is changing — the floor included, since a self-lowered

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -141,7 +141,9 @@ capped, but this file names no numbers: the caps live in
 [`.devflow.toml`](.devflow.toml) as `rigor` tiers, so there is one place to
 change them and one place to read them. Resolve in this order — an explicit
 instruction in this session, then [% if project_management == 'github' or use_foreman %]a `rigor:*` label on the issue, then [% endif %]`default_rigor`,
-then a built-in 4 / 4 / 4 if the file is absent. When the change under review
+then a built-in 4 / 4 / 4 if the file is absent — with a `min_rounds` floor of
+1 in that same absent-file case, which is the floor every shipped tier states
+anyway. When the change under review
 **edits `.devflow.toml` itself**, resolve its caps from the **merge-base** copy
 rather than the branch copy: otherwise a branch can lower the very gate it is
 changing, and dropping every tier together evades the below-default disclosure
@@ -193,9 +195,14 @@ tier allowed.
   table, not off the reviewer's label, and nothing further is owed after the
   second such round: the second round *is* the confirmation, so there is no
   extra clean run to buy. A round that returns **no findings at all** ends
-  the stage on its own, whenever it comes — an empty round is the old rule's
-  clean re-run, so neither a trivial change nor a clean post-fix re-run pays
-  for a confirmation pass. Fixing the findings is still not the exit
+  the stage on its own **once at least `min_rounds` rounds have run** — an
+  empty round is the old rule's clean re-run, so neither a trivial change nor
+  a clean post-fix re-run pays for a confirmation pass, but a tier that sets a
+  floor buys the rounds it asked for before that shortcut opens. The other two
+  exits satisfy any floor of 2 or less by construction — two consecutive clean
+  rounds *are* two rounds, and a capped final round is at least the cap, which
+  is never below 2 — so `min_rounds` binds the empty-round path and nothing
+  else. Fixing the findings is still not the exit
   condition; adjudicated-clean rounds are. The exit carries one
   precondition: every P2 you deferred during the stage must already be in the
   deferred-findings sidecar (see "Deferring P2s" below) — an exit that drops
@@ -549,8 +556,9 @@ exit the cap is no longer the only thing standing between you and a loop that
 feeds on itself, so the check has to happen where it first can. At round 2,
 for every finding, say on the adjudication table whether its subject exists
 only because an **earlier round of this same stage** added it. A finding that
-does gets adjudicated with one of two dispositions written out: **delete** the
-scaffolding (which moots the finding — see below), or state that it is in
+does gets adjudicated with one of three dispositions written out: **delete**
+the scaffolding (which moots the finding — see below), **restructure it to
+invariants** (deletion by abstraction — see below), or state that it is in
 scope and why the change genuinely needs it. What is not allowed is hardening
 round-1's scaffolding by reflex and letting round 3 attack the result.
 
@@ -570,6 +578,17 @@ re-raise. Name the mooted findings
 in the adjudication table *and* in the message of the commit that removes the
 code — the table is scrollback, but the commit is why the code is gone, and it
 is the record a later round or a different session can still find.
+
+**Restructuring to invariants is the same move where deletion is unavailable**
+— deletion by abstraction. When the artifact is a spec or a document whose
+accreted procedure-prose *cannot* simply be dropped because earlier rounds
+legitimately demanded it, replace the attackable procedure with the
+universally-quantified property it was approximating, delegate the mechanism to
+the implementation surface that can be tested, and carry the review's attack
+scenarios over as required test cases. The next round finds no wording seam to
+attack, and the obligation is preserved rather than dropped — which is what
+separates this from quietly deleting a requirement. Name it on the table and in
+the commit message exactly as a deletion is named.
 
 One endpoint is worth knowing: if the deletion empties the change *entirely*,
 there is no round to converge on — `codex-review.sh` refuses an empty scope
@@ -651,9 +670,16 @@ all-P2 as labeled, or P1-labeled and adjudicated down to P2; what counts is
 the **adjudicated** column of the table, not the reviewer's label, and the
 second such round is itself the confirmation, so no further run is owed. Two
 exits are faster still. A round with **no findings at all** ends the stage by
-itself, whenever it comes — an empty round is exactly the old rule's clean
-re-run, so neither a trivial change nor a clean post-fix re-run pays for a
-confirmation pass. And a **capped final round** that adjudicates to zero
+itself **once the stage has run at least `min_rounds` rounds** (the per-tier
+floor in `.devflow.toml`; 1 if the file is absent) — an empty round is exactly
+the old rule's clean re-run, so neither a trivial change nor a clean post-fix
+re-run pays for a confirmation pass, and the floor only stops that shortcut
+being taken before the tier's minimum work has happened. Say plainly what
+follows: the other two exits satisfy any floor of 2 or less **by
+construction** — the two-consecutive exit runs two rounds by definition, and
+the capped-clean exit runs the cap, which is never below 2 — so `min_rounds`
+constrains the empty-round exit alone and needs no separate check on the
+other two. And a **capped final round** that adjudicates to zero
 P0/P1 also ends the stage by itself: the confirmation it would otherwise owe
 is a run the cap forbids, and a rule that strands a stage holding a clean
 last round and no valid exit would be wrong — the cap bounds work, it does

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -491,8 +491,9 @@ families, color-coded by family; the starter set is created by
   gate: nothing verifies who applied it, and the **triage** role can label an
   issue with no push access — so AGENTS.md requires any cap resolving below
   `default_rigor` to be stated in the PR body, keeping a reduced budget visible
-  to the reviewer. Two present resolve per stage to the highest cap, so a
-  conflict can only ever buy more review.
+  to the reviewer — the `min_rounds` floor included. Two present resolve per
+  stage to the highest cap, and the floor likewise to the highest present, so
+  a conflict can only ever buy more review.
 
 Two more families name **model intelligence** rather than a facet of the work,
 and their vocabulary is not hand-listed anywhere: it is rendered from

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -235,8 +235,9 @@ task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
                 # until TWO CONSECUTIVE rounds adjudicate to zero P0/P1
-                # (any round with no findings at all ends it), under the
-                # challenge cap resolved from .devflow.toml
+                # (a round with no findings ends it once the tier's
+                # min_rounds floor is met), under the challenge cap
+                # resolved from .devflow.toml
 task review     # verification checkpoint — same convergence rule, under its
                 # own resolved review cap
 task ci         # full CI mirror
@@ -278,9 +279,12 @@ down to
 P2; what counts is the **adjudicated** column of your adjudication table, not
 the label Codex attached. The second such round *is* the confirmation, so no
 extra run is owed after it. Two cases exit faster still. A round with **no
-findings at all** ends the stage on the spot, whenever it comes — an empty
-round is exactly the older "clean re-run" exit, so neither a trivial change
-nor a clean post-fix re-run pays for a confirmation pass. And a **capped
+findings at all** ends the stage on the spot **once the tier's `min_rounds`
+floor is met** (1 wherever a tier does not set it) — an empty round is exactly
+the older "clean re-run" exit, so neither a trivial change nor a clean
+post-fix re-run pays for a confirmation pass, and a floor of 2 only delays
+that shortcut, never the other two exits, which run at least two rounds by
+construction. And a **capped
 final round** that adjudicates to zero P0/P1 ends the stage by itself: the
 confirmation it would otherwise owe is a run the cap forbids, and escalation
 at the cap is reserved for P0/P1 findings that persist — a clean last round

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -257,9 +257,10 @@ The caps are not written down here, or in AGENTS.md. They live in
 [`.devflow.toml`](../../.devflow.toml) as `rigor` tiers, and **AGENTS.md alone
 defines how a change resolves one** — restating that chain here would only give
 it a second place to drift from, and which inputs are even available depends on
-how the repository is set up. Only `challenge` and `review` vary by tier; the
+how the repository is set up. `challenge`, `review`, and the `min_rounds` floor vary by tier; the
 shepherd cap is fixed, because it bounds other people's findings rather than
-self-generated work. Announce the resolved caps when you enter the loop.
+self-generated work. Announce the resolved caps — the floor included — when
+you enter the loop.
 
 If Codex cloud review is connected to the repo, PRs
 get a cloud pass too: inline comments only for high-priority findings, a

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -298,9 +298,27 @@ along the way was individually defensible.
 The **scaffolding damper** is what replaces the cap as the first line of
 defense. At round 2 — the earliest round that can show the pattern — say on
 the table, for each finding, whether its subject exists only because an earlier
-round of the same stage added it. Where it does, adjudicate it with one of two
-dispositions written down: delete the scaffolding, or state that the code is
-in scope and why the change needs it. A deletion does not re-score the round
+round of the same stage added it. Where it does, adjudicate it with one of
+three dispositions written down: delete the scaffolding, restructure it to
+invariants, or state that the code is in scope and why the change needs it.
+
+**Restructuring to invariants** is deletion by abstraction, and it is the
+disposition to reach for when plain deletion is unavailable. Some artifacts —
+specs, policy documents, AGENTS.md itself — accrete procedure-prose that
+earlier rounds legitimately demanded, so it cannot just be dropped without
+dropping the obligation with it. Instead, replace the attackable procedure with
+the universally-quantified property it was approximating, delegate the
+mechanism to the implementation surface that can actually be tested, and carry
+the round's attack scenarios across as required test cases. The wording seam
+the next round would have attacked is gone, and the obligation survives as a
+property plus its tests rather than as prose. Three rounds of trust-rule
+whack-a-mole in the 2026-08-13/14 spec session ended in exactly one such
+restructure. It shares deletion's accounting: it does not re-score the round
+that raised the findings, and it must be named on the table and in the commit
+message, because "the procedure is gone" and "the requirement is gone" look
+identical in a diff and are not the same thing.
+
+A deletion does not re-score the round
 that flagged the code — the finding keeps its adjudicated priority there, and
 it is the **next** round, reviewing the tree without it, that finds nothing
 left to re-raise and counts toward convergence. Reflexively hardening the


### PR DESCRIPTION
## What

Adds a per-tier `min_rounds` floor to `.devflow.toml` (both dogfood layers) gating the empty-round instant exit, with validation in `test-devflow-config.sh` (integer, 1 or 2 — values above 2 cannot bind under the two-consecutive-clean exit); amends both AGENTS.md layers' exit-condition, resolution (missing-key default 1, highest-floor-wins under label conflicts, merge-base for self-edits, announcement/disclosure), and adds the **restructure-to-invariants** damper (deletion by abstraction) as a third scaffolding disposition in `codex-review.md` (both copies), AGENTS.md, and the rigor-label guide.

This is the no-dependency half of the issue; the routing half (challenge/review stage → gauntlet skill) waits on the harmon-devkit release and pin bump. Refs evanharmon1/harmon-init#862.

## Verification

- `task test:devflow-config`, `task test:dogfood-parity`, `task test:dogfood-structure`, `task verify`, `task ci` — all green.
- Challenge stage: 5 rounds (cap 3, rounds 4–5 maintainer-authorized) — R1 3×P1 fixed, R2 1×P1 fixed, R3 1×P1 fixed, R4 1×P1 fixed + floor-unaware-prose sweep, R5 clean (empty round, converged).
- Review stage: round 1 clean (empty round, converged).
- rigor: standard (default_rigor, merge-base copy) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1.

## Deferred findings

- [x] fixed in fb120a1 — scripts/test-devflow-config.sh:45-49 — the AGENTS.md fallback cross-check parses only the `N / N / N` caps; the absent-file/missing-key `min_rounds` floor of 1 stated in prose is not extracted or compared across layers, so a one-sided edit to it would pass. Consider extending the extraction to the floor sentence.

