### PR TITLE
fix(template): delete the Domain and Layer issue/project fields

### DIFF
--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -220,6 +220,12 @@ this comment. -->
       single-select field is missing (so a value added by a later harmon-init
       release lands on the next run) and never touch, reorder, or delete the
       options you added.
+- [ ] **Upgrading from a release before #875?** If this repo's board still
+      carries `Domain`/`Layer` fields from an earlier harmon-init release, they
+      are not deleted automatically — retiring them is a deliberate,
+      irreversible operator step. See
+      [project-management.md](project-management.md), "Migrating a board that
+      still has one."
 - [ ] Labels: run `task setup:github-labels` to seed this repo's starter label
       families (concerns/source/workflow/layer/domain — see
       [project-management.md](project-management.md)). `domain:` is seeded with

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -212,20 +212,22 @@ this comment. -->
       `evanharmon1 Project`) and idempotently sync its `Status` pipeline and
       `Size` number field — see
       [project-management.md](project-management.md).
-      On a personal account it also creates Priority/Product/Domain/Layer/
-      Size as project fields (issue fields are org-only); status automation is a
-      separate follow-up — the board is set up, but issue/PR status isn't
-      auto-synced yet. `Domain` is seeded with `auth`/`billing`/`platform` only —
-      add this product's real domains in the Project UI, and matching `domain:`
-      labels in `scripts/setup-github-labels.sh`. Re-runs **append** any starter
-      option a single-select field is missing (so a value added by a later
-      harmon-init release lands on the next run) and never touch, reorder, or
-      delete the options you added.
+      On a personal account it also creates Priority/Product/Size as project
+      fields (issue fields are org-only; there is deliberately no Domain or
+      Layer field — see project-management.md, "Label or field?"); status
+      automation is a separate follow-up — the board is set up, but issue/PR
+      status isn't auto-synced yet. Re-runs **append** any starter option a
+      single-select field is missing (so a value added by a later harmon-init
+      release lands on the next run) and never touch, reorder, or delete the
+      options you added.
 - [ ] Labels: run `task setup:github-labels` to seed this repo's starter label
       families (concerns/source/workflow/layer/domain — see
-      [project-management.md](project-management.md)). Labels are per-repo, so run
-      it in each repo; org default labels (org Settings → Repository, UI-only) only
-      seed new repos.
+      [project-management.md](project-management.md)). `domain:` is seeded with
+      `auth`/`billing`/`platform` only — add this product's real domains (from
+      your ERD entities) in `scripts/setup-github-labels.sh`; `layer:`
+      (`ui`/`logic`/`data`/`integration`) is product-independent and normally
+      needs no edits. Labels are per-repo, so run it in each repo; org default
+      labels (org Settings → Repository, UI-only) only seed new repos.
 - [ ] **[human-only] Retire any legacy `agent:*` claim labels** — needed only
       where `gh label list --limit 200` still shows the harness-named family
       (`agent:claude-code`, `agent:gemini-cli`, …) a pre-registry harmon-init

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -359,9 +359,15 @@ destroys every value on it, unrecoverably.
      labels are not — a repo that never ran the script has neither label
      family yet.
   2. List every issue or board item with `Domain`/`Layer` set, including
-     **draft items** (label-only, so a draft loses the value outright once the
-     field is gone). For each, add the matching `domain:*`/`layer:*` label if
-     it isn't already there — nothing kept the two in sync, so do not assume it is.
+     **draft items**, which can carry the project field but can never carry a
+     label. Convert any draft whose value you want to keep into an issue
+     first — a draft left as-is loses the value outright once the field is
+     gone. For each item, add the matching `domain:*`/`layer:*` label —
+     **creating it first** if the field carries a custom option (e.g.
+     `Domain: crm`) that has no label counterpart yet, since the starter set
+     `setup:github-labels` provisioned is only a floor. Nothing kept the two
+     in sync, so do not assume the label already exists just because the
+     field option does.
   3. Re-point any saved view that **groups, filters, or sorts** by the
      `Domain`/`Layer` field. A label can still filter a view (`domain:auth`,
      say), but — unlike a field — a project view cannot **group or sort** by a

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -306,36 +306,6 @@ The work-metadata fields:
 - **Size** — estimation points on the Fibonacci ladder (1 / 2 / 3 / 5 / 8 / 13 / 21),
   a project **number** field so a view can sum it per group
 - **Product** — which product/area it belongs to (free text)
-- **Domain** — which part of the *product* it belongs to. Ships as a starter
-  single-select (`auth`, `billing`, `platform`); the real vocabulary comes from
-  your ERD entities — add options as the product grows
-- **Layer** — which slice of the *stack* it changes: `ui` (components, styling,
-  interaction, tokens, a11y — no data change), `logic` (business rules,
-  handlers, calculation), `data` (schema, indexes, validators, migrations),
-  `integration` (external boundary: webhooks, API clients, credentials)
-
-Domain and Layer are orthogonal to each other and to `Type`/`Status`: an issue
-normally carries one of each — *what part of the product* × *what slice of the
-stack*. They ship with the same option lists as the `domain:` / `layer:` label
-families below, so both surfaces start from one vocabulary — but nothing keeps
-them in step afterwards. Two things to know before you extend either:
-
-- **Nothing syncs an individual issue's label to its field value**, so an issue
-  can carry `domain:auth` and `Domain=billing` at once. **Pick one surface as the
-  source of truth** — the fields if you work the board, the labels if you live in
-  `gh issue list` — and treat the other as optional. Dual-entering both by hand is
-  how they end up contradicting each other.
-- **A new starter value lands on a re-run.** `task setup:github-labels` creates
-  *or updates*, and both field scripts **append** any starter option an existing
-  single-select is missing — `task setup:github-project` for project fields,
-  `task setup:github-issue-fields` for org issue fields. So a value added by a
-  later harmon-init release reaches every surface the next time you run them.
-  Appending is purely additive: the options you added are kept *with their
-  identity*, so issues and board items already assigned to one keep their value,
-  and nothing is renamed, reordered, or deleted. A re-run against an
-  already-synced project writes nothing at all. One caveat: the issue-fields API
-  is in public preview, so if its update endpoint rejects the change, the script
-  names the missing options to add by hand rather than failing the run.
 
 There is deliberately **no `Agent` field**. Which agent *should* take an issue
 is the `suggest:*` label family plus the `Status: Agent Queue` lane; which agent
@@ -345,34 +315,59 @@ the Projects V2 API could not even write it — see
 [Label or field?](#label-or-field) and
 [ADR 0005](decisions/0005-unified-agent-vocabulary.md).
 
-**Migrating a board that still has one** (set up before the field was retired):
-the setup scripts are additive-only by design, so deleting the live field is an
+There is likewise deliberately **no `Domain` or `Layer` field** (#875). Both
+used to exist as a field *and* a label — `domain:` / `layer:` below — with
+nothing syncing an issue's field value to its label, which is exactly the
+[Label or field?](#label-or-field) trade-off: a label is readable without
+project scope, writable with plain repo scope, and available on personal
+repos, none of which the field bought back. Since one surface has to be the
+source of truth and the label already was for anyone living in `gh issue list`,
+the field was the redundant one.
+
+**Migrating a board that still has one** (set up before a field was retired):
+the setup scripts are additive-only by design, so deleting a live field is an
 explicit operator step, and reviewing its values comes first — deleting a field
 destroys every value on it, unrecoverably.
 
-1. Provision the replacement vocabulary first: run `task setup:github-labels`
-   in every repository whose issues carry the field — a `suggest:*` label must
-   exist in a repo before an assignment can be copied onto its issues.
-2. List what the field holds: every issue or board item with `Agent` set —
-   including **draft items**, which can carry the project field but can never
-   carry a label. Convert any draft whose assignment you want to keep into an
-   issue first; a draft you leave as-is loses its assignment with the field.
-3. Carry each assignment you still want over as the matching `suggest:*` label
-   on the issue (e.g. `Agent: Claude Code` → `suggest:claude`).
-4. Re-point the saved **Agent queue** view (below) at the new predicate —
-   filter on the `suggest:*` labels instead of the `Agent` field. A view still
-   filtered on the field loses its routing predicate the moment the field is
-   deleted.
-5. Only then delete the field — Project settings → the field → *Delete field*
-   on a personal project. On an organization the field is **org-wide**:
-   deleting it under **Settings → Planning → Issue fields** removes the value
-   from every issue in every repository and project the org owns, not just
-   this board — repeat steps 2–4 across the whole organization before
-   deleting, including step 4 for **every** Project whose saved views filter
-   on the field, not just the board being migrated.
+- **Agent** (retired earlier):
+  1. Provision the replacement vocabulary first: run `task setup:github-labels`
+     in every repository whose issues carry the field — a `suggest:*` label must
+     exist in a repo before an assignment can be copied onto its issues.
+  2. List what the field holds: every issue or board item with `Agent` set —
+     including **draft items**, which can carry the project field but can never
+     carry a label. Convert any draft whose assignment you want to keep into an
+     issue first; a draft you leave as-is loses its assignment with the field.
+  3. Carry each assignment you still want over as the matching `suggest:*` label
+     on the issue (e.g. `Agent: Claude Code` → `suggest:claude`).
+  4. Re-point the saved **Agent queue** view (below) at the new predicate —
+     filter on the `suggest:*` labels instead of the `Agent` field. A view still
+     filtered on the field loses its routing predicate the moment the field is
+     deleted.
+  5. Only then delete the field — Project settings → the field → *Delete field*
+     on a personal project. On an organization the field is **org-wide**:
+     deleting it under **Settings → Planning → Issue fields** removes the value
+     from every issue in every repository and project the org owns, not just
+     this board — repeat steps 2–4 across the whole organization before
+     deleting, including step 4 for **every** Project whose saved views filter
+     on the field, not just the board being migrated.
+- **Domain / Layer** (retired by #875): the replacement vocabulary is already
+  there — `task setup:github-labels` has provisioned `domain:*` / `layer:*`
+  since before the fields existed — so skip straight to reconciling values.
+  1. List every issue or board item with `Domain`/`Layer` set, including
+     **draft items** (label-only, so a draft loses the value outright once the
+     field is gone). For each, add the matching `domain:*`/`layer:*` label if
+     it isn't already there — nothing kept the two in sync, so do not assume it is.
+  2. Re-point any saved view that **groups or filters** by the `Domain`/`Layer`
+     field. A label can still filter a view (`domain:auth`, say), but — unlike a
+     field — a project view cannot **group** by a label, so a view built for the
+     per-domain/per-layer rollup loses that rollup; keep the grouping on
+     `Product` (still a field) and reach for a label filter instead.
+  3. Only then delete the field(s) — Project settings → the field → *Delete
+     field* on a personal project; **Settings → Planning → Issue fields** on an
+     organization, org-wide as above.
 
 On a personal account there are no issue fields, so `task setup:github-project`
-creates **Priority, Product, Domain, Layer, and Size** as project fields.
+creates **Priority, Product, and Size** as project fields.
 
 ### The provisioned field values
 
@@ -387,8 +382,6 @@ release lands on the next run.
 | **Size** | project number | free numeric entry; the Fibonacci ladder (1, 2, 3, 5, 8, 13, 21) is a convention, not an option list | `setup:github-project` |
 | **Priority** | single-select | Urgent, High, Medium, Low | `setup:github-project`, personal accounts only |
 | **Product** | text | free text | `setup:github-project` (personal) / `setup:github-issue-fields` (org) |
-| **Domain** | single-select | `auth`, `billing`, `platform` | `setup:github-project` (personal) / `setup:github-issue-fields` (org) |
-| **Layer** | single-select | `ui`, `logic`, `data`, `integration` | `setup:github-project` (personal) / `setup:github-issue-fields` (org) |
 
 Two org-only notes. GitHub ships **Priority** and **Effort** (plus **Start
 date** and **Target date**) as built-in *issue* fields, and both setup scripts
@@ -449,11 +442,9 @@ so provisioning and documentation cannot fork from each other.
 > carries. Do not seed `agent:*` into new repos; a repo carrying neither
 > family tracks a claim by assignee and claim comment alone.
 
-The `layer:` and `domain:` families offer the same options as the **Layer** and
-**Domain** fields above — same names, same meanings, but no per-issue sync (see
-Fields). Use the label when you want it on the issue list and in
-`gh issue list --label`, the field when you want to group a board view by it,
-and extend both together so the option sets stay identical.
+The `layer:` and `domain:` families are the *only* surface for this
+taxonomy (see Fields) — there is no more paired project/issue field to keep
+in step with, so extend the label lists alone as the product grows.
 
 The `claim:` and `suggest:` families share a vocabulary and *nothing else*.
 `suggest:` is the planned implementer, `claim:` is the active one — see
@@ -511,7 +502,7 @@ mechanics, not taste. Use a **label** when the datum must be any of:
 - **available on personal repos** — org issue fields do not exist there.
 
 Use a **field** when it is **single-valued planning metadata you slice the
-board by**: `Status`, `Priority`, `Size`, `Product`, `Domain`, `Layer`.
+board by**: `Status`, `Priority`, `Size`, `Product`.
 
 The consequences are not stylistic. Foreman arming is labels because only the
 label timeline names an arming actor. Claims are labels because a claim must be
@@ -519,7 +510,9 @@ writable and visible to an agent holding nothing but repo scope, on personal
 and org repos alike. And there is deliberately no `Agent` field: advisory
 routing and live ownership are two different facts, a single-select could carry
 neither without duplicating the label vocabulary, and on an organization the
-Projects V2 API could not write it at all.
+Projects V2 API could not write it at all. `Domain` and `Layer` were fields once
+too, and were retired for the same reason: a label already covered every one of
+the bullets above and nothing kept the two surfaces in sync (#875).
 
 ### The complete label taxonomy
 
@@ -532,8 +525,8 @@ it creates it on demand, and provisioning deliberately leaves it alone.
 | `sec`, `a11y`, `perf`, `tech-debt`, `i18n`, `l10n` | humans, at triage | humans, saved views | provisioned; inert | applied when true, removed when not |
 | `customer-request`, `ai-generated` | whoever files or authors the work, human or agent | humans, saved views | provisioned; inert | durable provenance — never removed |
 | `needs-triage`, `needs-requirements`, `blocked`, `waiting`, `needs-decision`, `needs-response`, `needs-communication` | humans, at triage | humans, the Triage view | provisioned; inert | transient — removed as soon as the state clears |
-| `layer:{ui,logic,data,integration}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; mirrors the `Layer` field, with no sync between them |
-| `domain:{auth,billing,platform,…}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; mirrors the `Domain` field, with no sync between them |
+| `layer:{ui,logic,data,integration}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; the only surface for this taxonomy (#875) |
+| `domain:{auth,billing,platform,…}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; the only surface for this taxonomy (#875) |
 | `rigor:{light,standard,deep}` | humans, at triage — **never an agent on itself** | agents, when entering the Dev Loop | provisioned; **read by agents** — selects a round-cap tier, arms nothing | set when the default budget is wrong for the change; survives the work |
 | `suggest:<family>` | humans, at planning | humans, the Agent queue view | provisioned from the registry (family level only); advisory — arms nothing | set at planning; survives the work and is never rewritten by a claim |
 | `suggest:<family>:<model>` | humans | humans | **tool-owned, created on demand** — seeding every model would be an unbounded roster | refines the family label; apply both |
@@ -1012,13 +1005,14 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   otherwise reach for an Epic type to get — the payoff of choosing **sub-issues
   over Epics**: structure without the "Feature or Epic?" tax. Still preview, so
   expect rough edges.
-- **Slice the board** — rather than separate per-product / per-layer saved
-  views, slice the one board: by **`Product`** when you go multi-product, by
-  **`Domain`** to focus a product area, by **`Layer`** to focus a slice of the
-  stack. One board, many lenses — and how multiple products stay legible in one
-  aggregating project instead of fragmenting into project-per-product. (The
-  agent split is a label question — `suggest:*`/`claim:*` — filter, don't
-  slice.)
+- **Slice the board** — rather than a separate saved view per product, slice
+  the one board by **`Product`** (still a field, so a view can group by it).
+  One board, many lenses — how multiple products stay legible in one
+  aggregating project instead of fragmenting into project-per-product. Domain
+  and Layer are labels only (#875): a view can still **filter** on
+  `domain:*`/`layer:*` (add the label to the view's filter), it just cannot
+  **group** by them the way a field allows — same as the agent split, which is
+  a label question too (`suggest:*`/`claim:*` — filter, don't slice).
 
 ## Notes
 

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -350,19 +350,25 @@ destroys every value on it, unrecoverably.
      this board — repeat steps 2–4 across the whole organization before
      deleting, including step 4 for **every** Project whose saved views filter
      on the field, not just the board being migrated.
-- **Domain / Layer** (retired by #875): the replacement vocabulary is already
-  there — `task setup:github-labels` has provisioned `domain:*` / `layer:*`
-  since before the fields existed — so skip straight to reconciling values.
-  1. List every issue or board item with `Domain`/`Layer` set, including
+- **Domain / Layer** (retired by #875): `domain:*`/`layer:*` are provisioned
+  by default, so most repos already carry them — but don't skip the
+  provisioning step on that assumption; confirm it.
+  1. Provision the replacement vocabulary first, the same as Agent: run
+     `task setup:github-labels` in every repository whose issues carry the
+     field. An org-wide issue field is shared by every repo in the org, and
+     labels are not — a repo that never ran the script has neither label
+     family yet.
+  2. List every issue or board item with `Domain`/`Layer` set, including
      **draft items** (label-only, so a draft loses the value outright once the
      field is gone). For each, add the matching `domain:*`/`layer:*` label if
      it isn't already there — nothing kept the two in sync, so do not assume it is.
-  2. Re-point any saved view that **groups or filters** by the `Domain`/`Layer`
-     field. A label can still filter a view (`domain:auth`, say), but — unlike a
-     field — a project view cannot **group** by a label, so a view built for the
-     per-domain/per-layer rollup loses that rollup; keep the grouping on
-     `Product` (still a field) and reach for a label filter instead.
-  3. Only then delete the field(s) — Project settings → the field → *Delete
+  3. Re-point any saved view that **groups, filters, or sorts** by the
+     `Domain`/`Layer` field. A label can still filter a view (`domain:auth`,
+     say), but — unlike a field — a project view cannot **group or sort** by a
+     label, so a view built for the per-domain/per-layer rollup or ordering
+     loses that; keep the grouping on `Product` (still a field) and reach for
+     a label filter instead.
+  4. Only then delete the field(s) — Project settings → the field → *Delete
      field* on a personal project; **Settings → Planning → Issue fields** on an
      organization, org-wide as above.
 

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -333,10 +333,14 @@ destroys every value on it, unrecoverably.
   1. Provision the replacement vocabulary first: run `task setup:github-labels`
      in every repository whose issues carry the field — a `suggest:*` label must
      exist in a repo before an assignment can be copied onto its issues.
-  2. List what the field holds: every issue or board item with `Agent` set —
-     including **draft items**, which can carry the project field but can never
-     carry a label. Convert any draft whose assignment you want to keep into an
-     issue first; a draft you leave as-is loses its assignment with the field.
+  2. List what the field holds — filter the Project's own board/table view by
+     the field, not a capped CLI listing (`gh project item-list` defaults to a
+     page size well under a typical board, and `gh issue list` won't show
+     draft items at all): every issue or board item with `Agent` set,
+     including **draft items**, which can carry the project field but can
+     never carry a label. Convert any draft whose assignment you want to keep
+     into an issue first; a draft you leave as-is loses its assignment with
+     the field.
   3. Carry each assignment you still want over as the matching `suggest:*` label
      on the issue (e.g. `Agent: Claude Code` → `suggest:claude`).
   4. Re-point the saved **Agent queue** view (below) at the new predicate —
@@ -358,7 +362,10 @@ destroys every value on it, unrecoverably.
      field. An org-wide issue field is shared by every repo in the org, and
      labels are not — a repo that never ran the script has neither label
      family yet.
-  2. List every issue or board item with `Domain`/`Layer` set, including
+  2. List every issue or board item with `Domain`/`Layer` set — filter the
+     Project's own board/table view by the field, not a capped CLI listing
+     (`gh project item-list` defaults to a page size well under a typical
+     board, and `gh issue list` won't show draft items at all) — including
      **draft items**, which can carry the project field but can never carry a
      label. Convert any draft whose value you want to keep into an issue
      first — a draft left as-is loses the value outright once the field is

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -3,10 +3,10 @@
 # set (docs/project-management.md). Colors are grouped by family (concerns=purple,
 # source=pink, workflow=orange, layer=blue, domain=yellow).
 #
-# The `layer:` and `domain:` families deliberately mirror the Layer and Domain
-# single-select fields created by setup-github-issue-fields.sh (org) /
-# setup-github-project.sh (personal account) — same vocabulary, so a label and a
-# field value never disagree. Keep the three lists in step when you extend them.
+# The `layer:` and `domain:` families are the only surface for that taxonomy —
+# there is deliberately no paired Layer/Domain project or issue field (#875;
+# see docs/project-management.md, "Label or field?"). Keep the two lists in
+# step with product growth.
 #
 # Labels are REPO-level in GitHub — there's no shared org label pool. Run this in
 # each repo; org "default labels" (Settings → Repository, UI-only, no API) only

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -6,9 +6,11 @@
 # because only project number fields sum in view group headers (issue-field
 # columns can group/filter/sort, not sum). The other metadata on an ORGANIZATION
 # are org-level ISSUE fields (Priority/Effort are GitHub built-ins, left at
-# their defaults; setup-github-issue-fields.sh adds Product, Domain, and
-# Layer); on a personal account (no org issue fields) this script creates
-# Priority/Product/Domain/Layer as project fields too.
+# their defaults; setup-github-issue-fields.sh adds Product); on a personal
+# account (no org issue fields) this script creates Priority/Product as
+# project fields too. Domain and Layer are deliberately NOT fields — the
+# `domain:`/`layer:` labels (setup-github-labels.sh) are their only surface
+# (#875).
 #
 # Safe to re-run and safe to run from every repo the owner controls: it looks the
 # project up by title, so the first run creates it and later runs just reconcile
@@ -478,11 +480,10 @@ create_number "Size"
 # Other metadata: on an ORGANIZATION these are org-level ISSUE fields (durable —
 # the value is on the issue, shared across every project; see
 # docs/project-management.md). Priority is a GitHub built-in;
-# setup-github-issue-fields.sh adds Product, Domain, and Layer. A personal
-# account has no org issue fields, so fall back to creating them as project
-# fields here.
+# setup-github-issue-fields.sh adds Product. A personal account has no org
+# issue fields, so fall back to creating them as project fields here.
 if [ "$owner_type" = "Organization" ]; then
-    echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product/Domain/Layer)"
+    echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product)"
     report_incompatible
     echo "==> Done — project #$project_number: $title"
     exit 0
@@ -501,24 +502,9 @@ create_text "Product"
 # the `Status: Agent Queue` lane; the live claim is a `claim:*` label written
 # by the agent itself. A single-select field could carry neither answer without
 # duplicating the label vocabulary (docs/project-management.md, ADR 0005 D4).
-# Domain (what part of the product) and Layer (which slice of the stack) mirror
-# the `domain:` / `layer:` label families in setup-github-labels.sh — keep the
-# lists in step. Domain is a starter set; real domains come from your product's
-# entities. create_single_select only ever ADDS to an existing field, so options
-# you add in the Project UI survive every re-run — and a starter value added by a
-# later harmon-init release lands on the next one, the same way a new
-# `domain:`/`layer:` label does.
-create_single_select "Domain" '[
-  {"name":"auth","color":"PURPLE","description":"Authentication and authorization"},
-  {"name":"billing","color":"GREEN","description":"Billing and payments"},
-  {"name":"platform","color":"GRAY","description":"CI, build, test infra, and tooling in this repo"}
-]'
-create_single_select "Layer" '[
-  {"name":"ui","color":"BLUE","description":"Components, styling, interaction, tokens, a11y. No data change"},
-  {"name":"logic","color":"GREEN","description":"Business rules, handlers, calculation"},
-  {"name":"data","color":"YELLOW","description":"Schema, indexes, validators, migrations"},
-  {"name":"integration","color":"ORANGE","description":"External boundary: webhooks, API clients, credentials"}
-]'
+# There is likewise deliberately no Domain or Layer field (#875) — same
+# reasoning as Agent: the `domain:`/`layer:` labels in setup-github-labels.sh
+# are the only surface now. See docs/project-management.md, "Label or field?".
 
 report_incompatible
 echo "==> Done — project #$project_number: $title"

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -1175,19 +1175,18 @@ if [[ "${SECTION}" == "setup" ]]; then
                     # runs per page and any single-line delimiter trick breaks at a
                     # page boundary.
                     field_rows="$(jq -r '(if type == "object" then (.issue_fields // []) elif type == "array" then . else [] end) | .[] | "\(.name)\t\(.data_type // "")"' "${d}/issue-fields.json" 2>/dev/null || echo "")"
-                    # Every non-built-in field setup-github-issue-fields.sh creates
-                    # must be present AND of the right type: an org set up before
-                    # Domain and Layer joined the set already has Product, and one
-                    # that happens to own a text field named `Domain` can never get
-                    # the taxonomy options (GitHub cannot change a field's data
-                    # type in place). Reporting either as done would hide exactly
-                    # what the setup script warns about. The retired Agent field is
-                    # deliberately NOT wanted here: the setup script no longer
-                    # creates it, so requiring it would report a permanent false
-                    # failure on every fresh org (#662).
+                    # Product must be present AND of the right type: an org that
+                    # happens to own a text-incompatible field named `Product`
+                    # can never get it created (GitHub cannot change a field's
+                    # data type in place). Reporting it done would hide exactly
+                    # what the setup script warns about. The retired Agent,
+                    # Domain, and Layer fields are deliberately NOT wanted here:
+                    # the setup script no longer creates any of them, so
+                    # requiring one would report a permanent false failure on
+                    # every fresh org (#662, #875).
                     missing_fields=""
                     wrong_fields=""
-                    for want in Product:text Domain:single_select Layer:single_select; do
+                    for want in Product:text; do
                         wname="${want%%:*}"
                         wtype="${want##*:}"
                         htype="$(printf '%s\n' "${field_rows}" | awk -F'\t' -v n="${wname}" '$1 == n { print $2; exit }')"
@@ -1202,7 +1201,7 @@ if [[ "${SECTION}" == "setup" ]]; then
                     elif [ -n "${wrong_fields}" ]; then
                         checkline no "Org issue fields" "wrong type: ${wrong_fields} — rename/delete, then re-run task setup:github-issue-fields"
                     elif [ -z "${missing_fields}" ]; then
-                        checkline ok "Org issue fields" "Product + Domain + Layer"
+                        checkline ok "Org issue fields" "Product"
                     else
                         checkline no "Org issue fields" "missing ${missing_fields} — run task setup:github-issue-fields"
                     fi

--- a/scripts/test-setup-github-project.sh
+++ b/scripts/test-setup-github-project.sh
@@ -100,16 +100,7 @@ complete='{"data":{"node":{"fields":{"nodes":[
    {"id":"p1","name":"Urgent","color":"RED","description":""},
    {"id":"p2","name":"High","color":"ORANGE","description":""},
    {"id":"p3","name":"Medium","color":"YELLOW","description":""},
-   {"id":"p4","name":"Low","color":"GRAY","description":""}]},
- {"id":"F_dom","name":"Domain","dataType":"SINGLE_SELECT","options":[
-   {"id":"d1","name":"auth","color":"PURPLE","description":"Authentication and authorization"},
-   {"id":"d2","name":"billing","color":"GREEN","description":"Billing and payments"},
-   {"id":"d3","name":"platform","color":"GRAY","description":"CI, build, test infra, and tooling in this repo"}]},
- {"id":"F_lay","name":"Layer","dataType":"SINGLE_SELECT","options":[
-   {"id":"l1","name":"ui","color":"BLUE","description":"Components, styling, interaction, tokens, a11y. No data change"},
-   {"id":"l2","name":"logic","color":"GREEN","description":"Business rules, handlers, calculation"},
-   {"id":"l3","name":"data","color":"YELLOW","description":"Schema, indexes, validators, migrations"},
-   {"id":"l4","name":"integration","color":"ORANGE","description":"External boundary: webhooks, API clients, credentials"}]}
+   {"id":"p4","name":"Low","color":"GRAY","description":""}]}
 ]}}}}'
 
 echo "==> a re-run against an already-synced project writes nothing"
@@ -126,24 +117,24 @@ case "$(cat "$MUTATIONS")" in
 esac
 
 echo "==> a field missing a starter option gains ONLY that option"
-# Domain lacks `billing` and carries an owner-added `crm`.
+# Priority lacks `Low` and carries an owner-added `Critical`.
 partial=$(printf '%s' "$complete" | jq -c '
     .data.node.fields.nodes |= map(
-        if .name == "Domain" then
-            .options = [ .options[] | if .name == "billing"
-                then {id: "d9", name: "crm", color: "PINK", description: "owner added"}
+        if .name == "Priority" then
+            .options = [ .options[] | if .name == "Low"
+                then {id: "p9", name: "Critical", color: "PINK", description: "owner added"}
                 else . end ]
         else . end)')
 run_with "$partial"
 [ "$(updates)" = 1 ] || fail "expected exactly 1 update mutation, got $(updates)"
 mut=$(cat "$MUTATIONS")
 case "$mut" in
-*'{name:"billing"'*) : ;;
+*'{name:"Low"'*) : ;;
 *) fail "the appended option should be sent WITHOUT an id" ;;
 esac
 
 echo "==> every pre-existing option is re-sent WITH its id (identity preserved)"
-for pair in 'd1:auth' 'd9:crm' 'd3:platform'; do
+for pair in 'p1:Urgent' 'p9:Critical' 'p3:Medium'; do
     case "$mut" in
     *"{id:\"${pair%%:*}\",name:\"${pair##*:}\""*) : ;;
     *) fail "existing option '${pair##*:}' lost its id '${pair%%:*}' — item values would be cleared" ;;
@@ -152,17 +143,17 @@ done
 
 echo "==> an owner-added option survives the append"
 case "$mut" in
-*'name:"crm"'*) : ;;
-*) fail "owner-added option 'crm' was dropped from the replacement list" ;;
+*'name:"Critical"'*) : ;;
+*) fail "owner-added option 'Critical' was dropped from the replacement list" ;;
 esac
 
 echo "==> a field of the wrong data type is warned about, never appended to"
 wrong=$(printf '%s' "$complete" | jq -c '
     .data.node.fields.nodes |= map(
-        if .name == "Domain" then {id: .id, name: .name, dataType: "TEXT"} else . end)')
+        if .name == "Priority" then {id: .id, name: .name, dataType: "TEXT"} else . end)')
 run_with "$wrong"
 [ "$(updates)" = 0 ] || fail "a wrong-typed field must not receive an option update"
-grep -q "already exists as TEXT" "$tmp/out" || fail "expected a data-type warning for Domain"
+grep -q "already exists as TEXT" "$tmp/out" || fail "expected a data-type warning for Priority"
 
 echo "==> a non-single-select Status warns and is skipped, never aborting the run"
 # Status is reconciled by its own call site rather than create_single_select, so
@@ -184,21 +175,21 @@ grep -q "Status (is TEXT, wanted SINGLE_SELECT)" "$tmp/out" ||
 echo "==> a field at the option cap warns instead of attempting an oversized write"
 capped=$(printf '%s' "$complete" | jq -c '
     .data.node.fields.nodes |= map(
-        if .name == "Domain" then
-            .options = ([ .options[] | select(.name != "billing") ]
-                + [ range(0; 48) | {id: "x\(.)", name: "custom\(.)", color: "GRAY", description: ""} ])
+        if .name == "Priority" then
+            .options = ([ .options[] | select(.name != "Low") ]
+                + [ range(0; 47) | {id: "x\(.)", name: "custom\(.)", color: "GRAY", description: ""} ])
         else . end)')
 run_with "$capped"
 [ "$(updates)" = 0 ] || fail "an over-capacity append must be skipped, not attempted"
-grep -q "cannot fit billing" "$tmp/out" || fail "expected a capacity warning naming the missing option"
+grep -q "cannot fit Low" "$tmp/out" || fail "expected a capacity warning naming the missing option"
 
 echo "==> an option added after the startup snapshot survives the append"
 # The re-read immediately before the write is what saves it: the replacement is
 # built from the fresh list, not the stale one.
 concurrent=$(printf '%s' "$partial" | jq -c '
     .data.node.fields.nodes |= map(
-        if .name == "Domain" then
-            .options += [{id: "d42", name: "raced-in", color: "BLUE", description: "added concurrently"}]
+        if .name == "Priority" then
+            .options += [{id: "p42", name: "raced-in", color: "BLUE", description: "added concurrently"}]
         else . end)')
 run_with "$partial" "$concurrent"
 mut=$(cat "$MUTATIONS")

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -85,26 +85,6 @@ err() {
     fail=1
 }
 
-# opt_names FILE START_REGEX — the `"name":"…"` values of one single-select
-# option block, sorted and deduped. The block opens on the line matching
-# START_REGEX and closes on the next line starting with `]`, so options are read
-# from the field they actually belong to rather than from anywhere in the file.
-# Any non-quote name matches: a name this misses would be silently absent from
-# the set comparison below, turning a drift failure into a false pass.
-opt_names() {
-    awk -v start="$2" '
-        $0 ~ start { inblock = 1; next }
-        inblock && /^\]/ { inblock = 0 }
-        inblock {
-            line = $0
-            while (match(line, /"name":"[^"]+"/)) {
-                print substr(line, RSTART + 8, RLENGTH - 9)
-                line = substr(line, RSTART + RLENGTH)
-            }
-        }
-    ' "$1" | sort -u
-}
-
 # Answers shared by every profile. Side-effectful answers are forced off so
 # this is safe to run anywhere (no gh repo create, no iCloud moves). The meta
 # profile re-enables bunch/obsidian but renders with --skip-tasks.
@@ -920,45 +900,25 @@ full) # project_management=github; github_org=test-org (an org repo)
     ./scripts/test-setup-github-issue-fields.sh >/dev/null ||
         err "rendered org issue-field reconciliation tests failed"
     [ -f scripts/setup-github-issue-types.sh ] || err "org-gated scripts/setup-github-issue-types.sh did not render"
-    # The Layer/Domain taxonomy is seeded in three places — the `layer:`/`domain:`
-    # label families, the org issue fields, and the personal-account project
-    # fields. They are meant to be one vocabulary per family, so compare each
-    # family's option SET across all three, exactly (not just membership
-    # somewhere in the file: `auth` living under Domain must not satisfy a
-    # `layer:auth` label) and in both directions (a field option with no label is
-    # drift too).
-    # The agent vocabulary is no longer a label/field pair here: it moved to
+    # The agent vocabulary is not a label/field pair here: it moved to
     # registry-driven suggest:/claim: labels (checked by test:registry-drift),
-    # and the Agent field is retired (#662) — the rendered scripts must not
-    # recreate it. Only the Layer/Domain taxonomy is cross-checked across
-    # labels + fields now.
+    # and the Agent field is retired (#662). The Layer/Domain taxonomy is
+    # likewise label-only now (#875) — both fields are retired, and the
+    # `layer:`/`domain:` label families in setup-github-labels.sh are their
+    # only surface, with no paired field vocabulary left to drift against.
+    # The rendered scripts must not recreate any of the three.
     ! grep -q 'create_field "Agent"' scripts/setup-github-issue-fields.sh ||
         err "rendered setup-github-issue-fields.sh recreates the retired Agent field (#662)"
     ! grep -q 'create_single_select "Agent"' scripts/setup-github-project.sh ||
         err "rendered setup-github-project.sh recreates the retired Agent field (#662)"
-    for pair in layer:Layer domain:Domain; do
-        fam="${pair%%:*}"
-        field="${pair##*:}"
-        # Each source's option set for this family, one name per line, sorted.
-        # Name charset is deliberately permissive: a domain like `oauth2` or
-        # `saas_billing` must land in the compared set, not be silently dropped
-        # (which would make an "exact set" comparison quietly pass on drift).
-        lbl_set="$(sed -n -E "s/^${fam}:([^|]+)\|.*/\1/p" scripts/setup-github-labels.sh | sort -u)"
-        # `<fam>_opts='[ … ]'` in the org script; `create_single_select "<Field>" '[ … ]'`
-        # in the project script. Both blocks end on a line starting with `]`.
-        # Layer and Domain are compared EXACTLY: their option names and label
-        # suffixes are meant to be character-identical, and normalizing would
-        # let `Domain: Auth` pass against `domain:auth` — drift this guard has
-        # always caught.
-        normalize=cat
-        fld_set="$(opt_names scripts/setup-github-issue-fields.sh "^${fam}_opts='" | "$normalize")"
-        prj_set="$(opt_names scripts/setup-github-project.sh "^create_single_select \"${field}\" '" | "$normalize")"
-        [ -n "$lbl_set" ] || err "no ${fam}: labels found in setup-github-labels.sh"
-        [ "$lbl_set" = "$fld_set" ] ||
-            err "${fam} vocabulary drift: labels [$(echo "$lbl_set" | tr '\n' ' ')] != issue-field options [$(echo "$fld_set" | tr '\n' ' ')]"
-        [ "$lbl_set" = "$prj_set" ] ||
-            err "${fam} vocabulary drift: labels [$(echo "$lbl_set" | tr '\n' ' ')] != project-field options [$(echo "$prj_set" | tr '\n' ' ')]"
-    done
+    ! grep -q 'create_field "Domain"' scripts/setup-github-issue-fields.sh ||
+        err "rendered setup-github-issue-fields.sh recreates the retired Domain field (#875)"
+    ! grep -q 'create_field "Layer"' scripts/setup-github-issue-fields.sh ||
+        err "rendered setup-github-issue-fields.sh recreates the retired Layer field (#875)"
+    ! grep -q 'create_single_select "Domain"' scripts/setup-github-project.sh ||
+        err "rendered setup-github-project.sh recreates the retired Domain field (#875)"
+    ! grep -q 'create_single_select "Layer"' scripts/setup-github-project.sh ||
+        err "rendered setup-github-project.sh recreates the retired Layer field (#875)"
     ;;
 minimal) # project_management=github on a PERSONAL account, use_foreman=false
     [ -f docs/project-management.md ] || err "GitHub project-management.md missing from docs/"

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -1048,12 +1048,12 @@ tasks:
 
   setup:github-issue-fields:
     desc: >-
-      Idempotently add the org's Product + Domain + Layer issue fields
-      (Priority/Effort are GitHub built-ins, left at defaults; the numeric Size
-      estimate is a project field via setup:github-project). Additive, org-wide:
-      creates what is missing and appends starter options an existing
-      single-select lacks, never renaming or deleting. Requires `gh` with the
-      admin:org scope.
+      Idempotently add the org's Product issue field (Priority/Effort are
+      GitHub built-ins, left at defaults; the numeric Size estimate is a
+      project field via setup:github-project; there is deliberately no Domain
+      or Layer field, #875 — see docs/project-management.md, "Label or
+      field?"). Creates the field if missing, never renaming or deleting.
+      Requires `gh` with the admin:org scope.
     cmds:
       - ./scripts/setup-github-issue-fields.sh --org "[[ github_org ]]"
 [% endif %]

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -262,6 +262,12 @@ environment — against the items below
       later harmon-init release lands on the next run) and never touch,
       reorder, or delete the options you added.
 [% endif %]
+- [ ] **Upgrading from a release before #875?** If this repo's board still
+      carries `Domain`/`Layer` fields from an earlier harmon-init release, they
+      are not deleted automatically — retiring them is a deliberate,
+      irreversible operator step. See
+      [project-management.md](project-management.md), "Migrating a board that
+      still has one."
 - [ ] Labels: run `task setup:github-labels` to seed this repo's starter label
       families (concerns/source/workflow/layer/domain — see
       [project-management.md](project-management.md)). `domain:` is seeded with

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -243,40 +243,33 @@ environment — against the items below
       project-automation.yml and the claude-* workflows read (they fall back to
       the project title).
 - [ ] Org issue fields: run `task setup:github-issue-fields` (needs `gh` with the
-      `admin:org` scope) to add the org's **Product**, **Domain**, and
-      **Layer** issue fields.
+      `admin:org` scope) to add the org's **Product** issue field. There is
+      deliberately no Domain or Layer issue field — see
+      [project-management.md](project-management.md), "Label or field?".
       Priority/Effort (and the date fields) are GitHub built-in issue fields, left
       at their defaults — tune options in the org's issue-field settings if you
       like. **The numeric estimate is the `Size` project number field** (created
       by `task setup:github-project`; only project number fields sum in view
-      group headers). Idempotent and additive: it creates fields that are missing
-      and **appends** any starter option an existing single-select lacks, keeping
-      your own options (and the values already assigned to them) intact. The
-      issue-fields API is in public preview, so if that update is rejected the
-      script names the options to add by hand instead of failing — read its
-      output after a harmon-init upgrade.
-- [ ] `Domain` options: the script seeds `auth`/`billing`/`platform` only — add
-      this product's real domains (from your ERD entities) in the org's
-      issue-field settings, and add matching `domain:` labels in
-      `scripts/setup-github-labels.sh`. `Layer` (`ui`/`logic`/`data`/
-      `integration`) is product-independent and normally needs no edits. See
-      [project-management.md](project-management.md).
+      group headers). Idempotent: it creates the field if missing and leaves it
+      alone if already present.
 [% else %]
-      On a personal account it also creates Priority/Product/Domain/Layer/
-      Size as project fields (issue fields are org-only); status automation is a
-      separate follow-up — the board is set up, but issue/PR status isn't
-      auto-synced yet. `Domain` is seeded with `auth`/`billing`/`platform` only —
-      add this product's real domains in the Project UI, and matching `domain:`
-      labels in `scripts/setup-github-labels.sh`. Re-runs **append** any starter
-      option a single-select field is missing (so a value added by a later
-      harmon-init release lands on the next run) and never touch, reorder, or
-      delete the options you added.
+      On a personal account it also creates Priority/Product/Size as project
+      fields (issue fields are org-only; there is deliberately no Domain or
+      Layer field — see [project-management.md](project-management.md), "Label
+      or field?"); status automation is a separate follow-up — the board is set
+      up, but issue/PR status isn't auto-synced yet. Re-runs **append** any
+      starter option a single-select field is missing (so a value added by a
+      later harmon-init release lands on the next run) and never touch,
+      reorder, or delete the options you added.
 [% endif %]
 - [ ] Labels: run `task setup:github-labels` to seed this repo's starter label
       families (concerns/source/workflow/layer/domain — see
-      [project-management.md](project-management.md)). Labels are per-repo, so run
-      it in each repo; org default labels (org Settings → Repository, UI-only) only
-      seed new repos.
+      [project-management.md](project-management.md)). `domain:` is seeded with
+      `auth`/`billing`/`platform` only — add this product's real domains (from
+      your ERD entities) in `scripts/setup-github-labels.sh`; `layer:`
+      (`ui`/`logic`/`data`/`integration`) is product-independent and normally
+      needs no edits. Labels are per-repo, so run it in each repo; org default
+      labels (org Settings → Repository, UI-only) only seed new repos.
 - [ ] **[human-only] Retire any legacy `agent:*` claim labels** — needed only
       where `gh label list --limit 200` still shows the harness-named family
       (`agent:claude-code`, `agent:gemini-cli`, …) a pre-registry harmon-init

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -262,7 +262,7 @@ environment — against the items below
       later harmon-init release lands on the next run) and never touch,
       reorder, or delete the options you added.
 [% endif %]
-- [ ] **Upgrading from a release before #875?** If this repo's board still
+- [ ] **Upgrading from a release before harmon-init#875?** If this repo's board still
       carries `Domain`/`Layer` fields from an earlier harmon-init release, they
       are not deleted automatically — retiring them is a deliberate,
       irreversible operator step. See

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -262,10 +262,17 @@ environment — against the items below
       later harmon-init release lands on the next run) and never touch,
       reorder, or delete the options you added.
 [% endif %]
-- [ ] **Upgrading from a release before harmon-init#875?** If this repo's board still
-      carries `Domain`/`Layer` fields from an earlier harmon-init release, they
-      are not deleted automatically — retiring them is a deliberate,
-      irreversible operator step. See
+- [ ] **Upgrading from a release before harmon-init#875?**
+[% if github_org != author_git_provider_username %]
+      Check the org's issue-field settings (**Settings → Planning → Issue
+      fields**), not just this repo's board — `Domain`/`Layer` from an
+      earlier release are org issue fields, so they can survive on issues
+      outside this Project even after the board itself looks clean.
+[% else %]
+      If this repo's board still carries `Domain`/`Layer` fields from an
+      earlier release, they are not deleted automatically.
+[% endif %]
+      Retiring them is a deliberate, irreversible operator step — see
       [project-management.md](project-management.md), "Migrating a board that
       still has one."
 - [ ] Labels: run `task setup:github-labels` to seed this repo's starter label

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -356,10 +356,14 @@ destroys every value on it, unrecoverably.
   1. Provision the replacement vocabulary first: run `task setup:github-labels`
      in every repository whose issues carry the field — a `suggest:*` label must
      exist in a repo before an assignment can be copied onto its issues.
-  2. List what the field holds: every issue or board item with `Agent` set —
-     including **draft items**, which can carry the project field but can never
-     carry a label. Convert any draft whose assignment you want to keep into an
-     issue first; a draft you leave as-is loses its assignment with the field.
+  2. List what the field holds — filter the Project's own board/table view by
+     the field, not a capped CLI listing (`gh project item-list` defaults to a
+     page size well under a typical board, and `gh issue list` won't show
+     draft items at all): every issue or board item with `Agent` set,
+     including **draft items**, which can carry the project field but can
+     never carry a label. Convert any draft whose assignment you want to keep
+     into an issue first; a draft you leave as-is loses its assignment with
+     the field.
   3. Carry each assignment you still want over as the matching `suggest:*` label
      on the issue (e.g. `Agent: Claude Code` → `suggest:claude`).
   4. Re-point the saved **Agent queue** view (below) at the new predicate —
@@ -381,7 +385,10 @@ destroys every value on it, unrecoverably.
      field. An org-wide issue field is shared by every repo in the org, and
      labels are not — a repo that never ran the script has neither label
      family yet.
-  2. List every issue or board item with `Domain`/`Layer` set, including
+  2. List every issue or board item with `Domain`/`Layer` set — filter the
+     Project's own board/table view by the field, not a capped CLI listing
+     (`gh project item-list` defaults to a page size well under a typical
+     board, and `gh issue list` won't show draft items at all) — including
      **draft items**, which can carry the project field but can never carry a
      label. Convert any draft whose value you want to keep into an issue
      first — a draft left as-is loses the value outright once the field is

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -330,36 +330,6 @@ The work-metadata fields:
 - **Size** — estimation points on the Fibonacci ladder (1 / 2 / 3 / 5 / 8 / 13 / 21),
   a project **number** field so a view can sum it per group
 - **Product** — which product/area it belongs to (free text)
-- **Domain** — which part of the *product* it belongs to. Ships as a starter
-  single-select (`auth`, `billing`, `platform`); the real vocabulary comes from
-  your ERD entities — add options as the product grows
-- **Layer** — which slice of the *stack* it changes: `ui` (components, styling,
-  interaction, tokens, a11y — no data change), `logic` (business rules,
-  handlers, calculation), `data` (schema, indexes, validators, migrations),
-  `integration` (external boundary: webhooks, API clients, credentials)
-
-Domain and Layer are orthogonal to each other and to `Type`/`Status`: an issue
-normally carries one of each — *what part of the product* × *what slice of the
-stack*. They ship with the same option lists as the `domain:` / `layer:` label
-families below, so both surfaces start from one vocabulary — but nothing keeps
-them in step afterwards. Two things to know before you extend either:
-
-- **Nothing syncs an individual issue's label to its field value**, so an issue
-  can carry `domain:auth` and `Domain=billing` at once. **Pick one surface as the
-  source of truth** — the fields if you work the board, the labels if you live in
-  `gh issue list` — and treat the other as optional. Dual-entering both by hand is
-  how they end up contradicting each other.
-- **A new starter value lands on a re-run.** `task setup:github-labels` creates
-  *or updates*, and both field scripts **append** any starter option an existing
-  single-select is missing — `task setup:github-project` for project fields,
-  `task setup:github-issue-fields` for org issue fields. So a value added by a
-  later harmon-init release reaches every surface the next time you run them.
-  Appending is purely additive: the options you added are kept *with their
-  identity*, so issues and board items already assigned to one keep their value,
-  and nothing is renamed, reordered, or deleted. A re-run against an
-  already-synced project writes nothing at all. One caveat: the issue-fields API
-  is in public preview, so if its update endpoint rejects the change, the script
-  names the missing options to add by hand rather than failing the run.
 
 There is deliberately **no `Agent` field**. Which agent *should* take an issue
 is the `suggest:*` label family plus the `Status: Agent Queue` lane; which agent
@@ -368,44 +338,64 @@ neither answer without duplicating the label vocabulary, and on an organization
 the Projects V2 API could not even write it — see
 [Label or field?](#label-or-field).
 
-**Migrating a board that still has one** (set up before the field was retired):
-the setup scripts are additive-only by design, so deleting the live field is an
+There is likewise deliberately **no `Domain` or `Layer` field** (#875). Both
+used to exist as a field *and* a label — `domain:` / `layer:` below — with
+nothing syncing an issue's field value to its label, which is exactly the
+[Label or field?](#label-or-field) trade-off: a label is readable without
+project scope, writable with plain repo scope, and available on personal
+repos, none of which the field bought back. Since one surface has to be the
+source of truth and the label already was for anyone living in `gh issue list`,
+the field was the redundant one.
+
+**Migrating a board that still has one** (set up before a field was retired):
+the setup scripts are additive-only by design, so deleting a live field is an
 explicit operator step, and reviewing its values comes first — deleting a field
 destroys every value on it, unrecoverably.
 
-1. Provision the replacement vocabulary first: run `task setup:github-labels`
-   in every repository whose issues carry the field — a `suggest:*` label must
-   exist in a repo before an assignment can be copied onto its issues.
-2. List what the field holds: every issue or board item with `Agent` set —
-   including **draft items**, which can carry the project field but can never
-   carry a label. Convert any draft whose assignment you want to keep into an
-   issue first; a draft you leave as-is loses its assignment with the field.
-3. Carry each assignment you still want over as the matching `suggest:*` label
-   on the issue (e.g. `Agent: Claude Code` → `suggest:claude`).
-4. Re-point the saved **Agent queue** view (below) at the new predicate —
-   filter on the `suggest:*` labels instead of the `Agent` field. A view still
-   filtered on the field loses its routing predicate the moment the field is
-   deleted.
-5. Only then delete the field — Project settings → the field → *Delete field*
-   on a personal project. On an organization the field is **org-wide**:
-   deleting it under **Settings → Planning → Issue fields** removes the value
-   from every issue in every repository and project the org owns, not just
-   this board — repeat steps 2–4 across the whole organization before
-   deleting, including step 4 for **every** Project whose saved views filter
-   on the field, not just the board being migrated.
+- **Agent** (retired earlier):
+  1. Provision the replacement vocabulary first: run `task setup:github-labels`
+     in every repository whose issues carry the field — a `suggest:*` label must
+     exist in a repo before an assignment can be copied onto its issues.
+  2. List what the field holds: every issue or board item with `Agent` set —
+     including **draft items**, which can carry the project field but can never
+     carry a label. Convert any draft whose assignment you want to keep into an
+     issue first; a draft you leave as-is loses its assignment with the field.
+  3. Carry each assignment you still want over as the matching `suggest:*` label
+     on the issue (e.g. `Agent: Claude Code` → `suggest:claude`).
+  4. Re-point the saved **Agent queue** view (below) at the new predicate —
+     filter on the `suggest:*` labels instead of the `Agent` field. A view still
+     filtered on the field loses its routing predicate the moment the field is
+     deleted.
+  5. Only then delete the field — Project settings → the field → *Delete field*
+     on a personal project. On an organization the field is **org-wide**:
+     deleting it under **Settings → Planning → Issue fields** removes the value
+     from every issue in every repository and project the org owns, not just
+     this board — repeat steps 2–4 across the whole organization before
+     deleting, including step 4 for **every** Project whose saved views filter
+     on the field, not just the board being migrated.
+- **Domain / Layer** (retired by #875): the replacement vocabulary is already
+  there — `task setup:github-labels` has provisioned `domain:*` / `layer:*`
+  since before the fields existed — so skip straight to reconciling values.
+  1. List every issue or board item with `Domain`/`Layer` set, including
+     **draft items** (label-only, so a draft loses the value outright once the
+     field is gone). For each, add the matching `domain:*`/`layer:*` label if
+     it isn't already there — nothing kept the two in sync, so do not assume it is.
+  2. Re-point any saved view that **groups or filters** by the `Domain`/`Layer`
+     field. A label can still filter a view (`domain:auth`, say), but — unlike a
+     field — a project view cannot **group** by a label, so a view built for the
+     per-domain/per-layer rollup loses that rollup; keep the grouping on
+     `Product` (still a field) and reach for a label filter instead.
+  3. Only then delete the field(s) — Project settings → the field → *Delete
+     field* on a personal project; **Settings → Planning → Issue fields** on an
+     organization, org-wide as above.
 
 [% if github_org != author_git_provider_username %]
-**Priority, Product, Domain, and Layer are org issue fields**: org-level,
-defined once, and — unlike a project field — the value lives on the **issue**,
-stays consistent across every project the issue belongs to, and shows in the issue
-timeline. GitHub ships **Priority** and **Effort** (plus **Start date** /
-**Target date**) built in, left at their defaults, so
-`task setup:github-issue-fields` only adds **Product**, **Domain**, and
-**Layer**.
-
-Because issue fields are org-level, `Domain`'s option list is shared by every
-repo in the org — expect it to accumulate the union of your products' domains.
-`Product` is what disambiguates them; scope a board view by filtering on both.
+**Priority and Product are org issue fields**: org-level, defined once, and —
+unlike a project field — the value lives on the **issue**, stays consistent
+across every project the issue belongs to, and shows in the issue timeline.
+GitHub ships **Priority** and **Effort** (plus **Start date** / **Target
+date**) built in, left at their defaults, so `task setup:github-issue-fields`
+only adds **Product**.
 
 **Size is the exception — a project number field** (created by
 `task setup:github-project`): project views can group, filter, and sort by
@@ -417,7 +407,7 @@ its default (a coarse gut-check) and put points in `Size`.
 
 [% else %]
 On a personal account there are no issue fields, so `task setup:github-project`
-creates **Priority, Product, Domain, Layer, and Size** as project fields.
+creates **Priority, Product, and Size** as project fields.
 
 [% endif %]
 ### The provisioned field values
@@ -434,8 +424,6 @@ lands on the next run.
 [% if github_org != author_git_provider_username %]
 | **Priority** | org issue field | GitHub's built-in field, left at its defaults | GitHub |
 | **Product** | org issue field, text | free text | `setup:github-issue-fields` |
-| **Domain** | org issue field, single-select | `auth`, `billing`, `platform` | `setup:github-issue-fields` |
-| **Layer** | org issue field, single-select | `ui`, `logic`, `data`, `integration` | `setup:github-issue-fields` |
 
 GitHub also ships **Effort**, **Start date**, and **Target date** as built-in
 issue fields, left at their defaults. `Effort` cannot hold the estimate: an
@@ -444,8 +432,6 @@ be summed in a view's group header, which is `Size`'s whole job.
 [% else %]
 | **Priority** | project single-select | Urgent, High, Medium, Low | `setup:github-project` |
 | **Product** | project text | free text | `setup:github-project` |
-| **Domain** | project single-select | `auth`, `billing`, `platform` | `setup:github-project` |
-| **Layer** | project single-select | `ui`, `logic`, `data`, `integration` | `setup:github-project` |
 [% endif %]
 
 [% if github_org != author_git_provider_username %]
@@ -519,11 +505,9 @@ so provisioning and documentation cannot fork from each other.
 > into new repos; a repo carrying neither family tracks a claim by assignee
 > and claim comment alone.
 
-The `layer:` and `domain:` families offer the same options as the **Layer** and
-**Domain** fields above — same names, same meanings, but no per-issue sync (see
-Fields). Use the label when you want it on the issue list and in
-`gh issue list --label`, the field when you want to group a board view by it,
-and extend both together so the option sets stay identical.
+The `layer:` and `domain:` families are the *only* surface for this
+taxonomy (see Fields) — there is no more paired project/issue field to keep
+in step with, so extend the label lists alone as the product grows.
 
 The `claim:` and `suggest:` families share a vocabulary and *nothing else*.
 `suggest:` is the planned implementer, `claim:` is the active one — see
@@ -592,7 +576,7 @@ mechanics, not taste. Use a **label** when the datum must be any of:
 - **available on personal repos** — org issue fields do not exist there.
 
 Use a **field** when it is **single-valued planning metadata you slice the
-board by**: `Status`, `Priority`, `Size`, `Product`, `Domain`, `Layer`.
+board by**: `Status`, `Priority`, `Size`, `Product`.
 
 The consequences are not stylistic.[% if use_foreman %] Foreman arming is labels because only
 the label timeline names an arming actor.[% endif %] Claims are labels because a claim
@@ -600,7 +584,9 @@ must be writable and visible to an agent holding nothing but repo scope, on
 personal and org repos alike. And there is deliberately no `Agent` field:
 advisory routing and live ownership are two different facts, a single-select
 could carry neither without duplicating the label vocabulary, and on an
-organization the Projects V2 API could not write it at all.
+organization the Projects V2 API could not write it at all. `Domain` and `Layer` were fields once
+too, and were retired for the same reason: a label already covered every one of
+the bullets above and nothing kept the two surfaces in sync (#875).
 
 ### The complete label taxonomy
 
@@ -613,8 +599,8 @@ it creates it on demand, and provisioning deliberately leaves it alone.
 | `sec`, `a11y`, `perf`, `tech-debt`, `i18n`, `l10n` | humans, at triage | humans, saved views | provisioned; inert | applied when true, removed when not |
 | `customer-request`, `ai-generated` | whoever files or authors the work, human or agent | humans, saved views | provisioned; inert | durable provenance — never removed |
 | `needs-triage`, `needs-requirements`, `blocked`, `waiting`, `needs-decision`, `needs-response`, `needs-communication` | humans, at triage | humans, the Triage view | provisioned; inert | transient — removed as soon as the state clears |
-| `layer:{ui,logic,data,integration}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; mirrors the `Layer` field, with no sync between them |
-| `domain:{auth,billing,platform,…}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; mirrors the `Domain` field, with no sync between them |
+| `layer:{ui,logic,data,integration}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; the only surface for this taxonomy (#875) |
+| `domain:{auth,billing,platform,…}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; the only surface for this taxonomy (#875) |
 | `rigor:{light,standard,deep}` | humans, at triage — **never an agent on itself** | agents, when entering the Dev Loop | provisioned; **read by agents** — selects a round-cap tier, arms nothing | set when the default budget is wrong for the change; survives the work |
 | `suggest:<family>` | humans, at planning | humans, the Agent queue view | provisioned from the registry (family level only); advisory — arms nothing | set at planning; survives the work and is never rewritten by a claim |
 | `suggest:<family>:<model>` | humans | humans | **tool-owned, created on demand** — seeding every model would be an unbounded roster | refines the family label; apply both |
@@ -1117,13 +1103,14 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   otherwise reach for an Epic type to get — the payoff of choosing **sub-issues
   over Epics**: structure without the "Feature or Epic?" tax. Still preview, so
   expect rough edges.
-- **Slice the board** — rather than separate per-product / per-layer saved
-  views, slice the one board: by **`Product`** when you go multi-product, by
-  **`Domain`** to focus a product area, by **`Layer`** to focus a slice of the
-  stack. One board, many lenses — and how multiple products stay legible in one
-  aggregating project instead of fragmenting into project-per-product. (The
-  agent split is a label question — `suggest:*`/`claim:*` — filter, don't
-  slice.)
+- **Slice the board** — rather than a separate saved view per product, slice
+  the one board by **`Product`** (still a field, so a view can group by it).
+  One board, many lenses — how multiple products stay legible in one
+  aggregating project instead of fragmenting into project-per-product. Domain
+  and Layer are labels only (#875): a view can still **filter** on
+  `domain:*`/`layer:*` (add the label to the view's filter), it just cannot
+  **group** by them the way a field allows — same as the agent split, which is
+  a label question too (`suggest:*`/`claim:*` — filter, don't slice).
 
 ## Notes
 

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -373,19 +373,25 @@ destroys every value on it, unrecoverably.
      this board — repeat steps 2–4 across the whole organization before
      deleting, including step 4 for **every** Project whose saved views filter
      on the field, not just the board being migrated.
-- **Domain / Layer** (retired by #875): the replacement vocabulary is already
-  there — `task setup:github-labels` has provisioned `domain:*` / `layer:*`
-  since before the fields existed — so skip straight to reconciling values.
-  1. List every issue or board item with `Domain`/`Layer` set, including
+- **Domain / Layer** (retired by #875): `domain:*`/`layer:*` are provisioned
+  by default, so most repos already carry them — but don't skip the
+  provisioning step on that assumption; confirm it.
+  1. Provision the replacement vocabulary first, the same as Agent: run
+     `task setup:github-labels` in every repository whose issues carry the
+     field. An org-wide issue field is shared by every repo in the org, and
+     labels are not — a repo that never ran the script has neither label
+     family yet.
+  2. List every issue or board item with `Domain`/`Layer` set, including
      **draft items** (label-only, so a draft loses the value outright once the
      field is gone). For each, add the matching `domain:*`/`layer:*` label if
      it isn't already there — nothing kept the two in sync, so do not assume it is.
-  2. Re-point any saved view that **groups or filters** by the `Domain`/`Layer`
-     field. A label can still filter a view (`domain:auth`, say), but — unlike a
-     field — a project view cannot **group** by a label, so a view built for the
-     per-domain/per-layer rollup loses that rollup; keep the grouping on
-     `Product` (still a field) and reach for a label filter instead.
-  3. Only then delete the field(s) — Project settings → the field → *Delete
+  3. Re-point any saved view that **groups, filters, or sorts** by the
+     `Domain`/`Layer` field. A label can still filter a view (`domain:auth`,
+     say), but — unlike a field — a project view cannot **group or sort** by a
+     label, so a view built for the per-domain/per-layer rollup or ordering
+     loses that; keep the grouping on `Product` (still a field) and reach for
+     a label filter instead.
+  4. Only then delete the field(s) — Project settings → the field → *Delete
      field* on a personal project; **Settings → Planning → Issue fields** on an
      organization, org-wide as above.
 

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -338,7 +338,7 @@ neither answer without duplicating the label vocabulary, and on an organization
 the Projects V2 API could not even write it — see
 [Label or field?](#label-or-field).
 
-There is likewise deliberately **no `Domain` or `Layer` field** (#875). Both
+There is likewise deliberately **no `Domain` or `Layer` field** (harmon-init#875). Both
 used to exist as a field *and* a label — `domain:` / `layer:` below — with
 nothing syncing an issue's field value to its label, which is exactly the
 [Label or field?](#label-or-field) trade-off: a label is readable without
@@ -377,7 +377,7 @@ destroys every value on it, unrecoverably.
      this board — repeat steps 2–4 across the whole organization before
      deleting, including step 4 for **every** Project whose saved views filter
      on the field, not just the board being migrated.
-- **Domain / Layer** (retired by #875): `domain:*`/`layer:*` are provisioned
+- **Domain / Layer** (retired by harmon-init#875): `domain:*`/`layer:*` are provisioned
   by default, so most repos already carry them — but don't skip the
   provisioning step on that assumption; confirm it.
   1. Provision the replacement vocabulary first, the same as Agent: run
@@ -385,16 +385,30 @@ destroys every value on it, unrecoverably.
      field. An org-wide issue field is shared by every repo in the org, and
      labels are not — a repo that never ran the script has neither label
      family yet.
-  2. List every issue or board item with `Domain`/`Layer` set — filter the
-     Project's own board/table view by the field, not a capped CLI listing
-     (`gh project item-list` defaults to a page size well under a typical
-     board, and `gh issue list` won't show draft items at all) — including
-     **draft items**, which can carry the project field but can never carry a
-     label. Convert any draft whose value you want to keep into an issue
-     first — a draft left as-is loses the value outright once the field is
-     gone. For each item, add the matching `domain:*`/`layer:*` label —
-     **creating it first** if the field carries a custom option (e.g.
-     `Domain: crm`) that has no label counterpart yet, since the starter set
+  2. List every issue with `Domain`/`Layer` set.
+[% if github_org != author_git_provider_username %]
+     This is an **org issue field** — the value lives on the issue
+     independent of project membership, so an issue can carry it without
+     belonging to the Project you're migrating from. A single Project's
+     filtered view is therefore NOT a complete inventory: check the org's
+     issue-field settings (**Settings → Planning → Issue fields** → the
+     field) and sweep every repository/project in the org, not just the one
+     board. There are no draft items to convert here — a draft project item
+     isn't a real issue, so it can never carry an org issue field in the
+     first place.
+[% else %]
+     Filter the Project's own board/table view by the field — every value is
+     necessarily an item of that one project on a personal account — not a
+     capped CLI listing (`gh project item-list` defaults to a page size well
+     under a typical board, and `gh issue list` won't show draft items at
+     all). Include **draft items**, which can carry the project field but can
+     never carry a label: convert any draft whose value you want to keep into
+     an issue first, since a draft left as-is loses the value outright once
+     the field is gone.
+[% endif %]
+     For each item, add the matching `domain:*`/`layer:*` label — **creating
+     it first** if the field carries a custom option (e.g. `Domain: crm`)
+     that has no label counterpart yet, since the starter set
      `setup:github-labels` provisioned is only a floor. Nothing kept the two
      in sync, so do not assume the label already exists just because the
      field option does.
@@ -605,7 +619,7 @@ advisory routing and live ownership are two different facts, a single-select
 could carry neither without duplicating the label vocabulary, and on an
 organization the Projects V2 API could not write it at all. `Domain` and `Layer` were fields once
 too, and were retired for the same reason: a label already covered every one of
-the bullets above and nothing kept the two surfaces in sync (#875).
+the bullets above and nothing kept the two surfaces in sync (harmon-init#875).
 
 ### The complete label taxonomy
 
@@ -618,8 +632,8 @@ it creates it on demand, and provisioning deliberately leaves it alone.
 | `sec`, `a11y`, `perf`, `tech-debt`, `i18n`, `l10n` | humans, at triage | humans, saved views | provisioned; inert | applied when true, removed when not |
 | `customer-request`, `ai-generated` | whoever files or authors the work, human or agent | humans, saved views | provisioned; inert | durable provenance — never removed |
 | `needs-triage`, `needs-requirements`, `blocked`, `waiting`, `needs-decision`, `needs-response`, `needs-communication` | humans, at triage | humans, the Triage view | provisioned; inert | transient — removed as soon as the state clears |
-| `layer:{ui,logic,data,integration}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; the only surface for this taxonomy (#875) |
-| `domain:{auth,billing,platform,…}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; the only surface for this taxonomy (#875) |
+| `layer:{ui,logic,data,integration}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; the only surface for this taxonomy (harmon-init#875) |
+| `domain:{auth,billing,platform,…}` | humans, at triage | humans, `gh issue list --label` | provisioned; inert | durable classification; the only surface for this taxonomy (harmon-init#875) |
 | `rigor:{light,standard,deep}` | humans, at triage — **never an agent on itself** | agents, when entering the Dev Loop | provisioned; **read by agents** — selects a round-cap tier, arms nothing | set when the default budget is wrong for the change; survives the work |
 | `suggest:<family>` | humans, at planning | humans, the Agent queue view | provisioned from the registry (family level only); advisory — arms nothing | set at planning; survives the work and is never rewritten by a claim |
 | `suggest:<family>:<model>` | humans | humans | **tool-owned, created on demand** — seeding every model would be an unbounded roster | refines the family label; apply both |
@@ -1126,7 +1140,7 @@ view**). Keep the saved set small; **slice the one board** (below) for the rest.
   the one board by **`Product`** (still a field, so a view can group by it).
   One board, many lenses — how multiple products stay legible in one
   aggregating project instead of fragmenting into project-per-product. Domain
-  and Layer are labels only (#875): a view can still **filter** on
+  and Layer are labels only (harmon-init#875): a view can still **filter** on
   `domain:*`/`layer:*` (add the label to the view's filter), it just cannot
   **group** by them the way a field allows — same as the agent split, which is
   a label question too (`suggest:*`/`claim:*` — filter, don't slice).

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -382,9 +382,15 @@ destroys every value on it, unrecoverably.
      labels are not — a repo that never ran the script has neither label
      family yet.
   2. List every issue or board item with `Domain`/`Layer` set, including
-     **draft items** (label-only, so a draft loses the value outright once the
-     field is gone). For each, add the matching `domain:*`/`layer:*` label if
-     it isn't already there — nothing kept the two in sync, so do not assume it is.
+     **draft items**, which can carry the project field but can never carry a
+     label. Convert any draft whose value you want to keep into an issue
+     first — a draft left as-is loses the value outright once the field is
+     gone. For each item, add the matching `domain:*`/`layer:*` label —
+     **creating it first** if the field carries a custom option (e.g.
+     `Domain: crm`) that has no label counterpart yet, since the starter set
+     `setup:github-labels` provisioned is only a floor. Nothing kept the two
+     in sync, so do not assume the label already exists just because the
+     field option does.
   3. Re-point any saved view that **groups, filters, or sorts** by the
      `Domain`/`Layer` field. A label can still filter a view (`domain:auth`,
      say), but — unlike a field — a project view cannot **group or sort** by a

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -6,9 +6,11 @@
 # because only project number fields sum in view group headers (issue-field
 # columns can group/filter/sort, not sum). The other metadata on an ORGANIZATION
 # are org-level ISSUE fields (Priority/Effort are GitHub built-ins, left at
-# their defaults; setup-github-issue-fields.sh adds Product, Domain, and
-# Layer); on a personal account (no org issue fields) this script creates
-# Priority/Product/Domain/Layer as project fields too.
+# their defaults; setup-github-issue-fields.sh adds Product); on a personal
+# account (no org issue fields) this script creates Priority/Product as
+# project fields too. Domain and Layer are deliberately NOT fields — the
+# `domain:`/`layer:` labels (setup-github-labels.sh) are their only surface
+# (#875).
 #
 # Safe to re-run and safe to run from every repo the owner controls: it looks the
 # project up by title, so the first run creates it and later runs just reconcile
@@ -478,11 +480,10 @@ create_number "Size"
 # Other metadata: on an ORGANIZATION these are org-level ISSUE fields (durable —
 # the value is on the issue, shared across every project; see
 # docs/project-management.md). Priority is a GitHub built-in;
-# setup-github-issue-fields.sh adds Product, Domain, and Layer. A personal
-# account has no org issue fields, so fall back to creating them as project
-# fields here.
+# setup-github-issue-fields.sh adds Product. A personal account has no org
+# issue fields, so fall back to creating them as project fields here.
 if [ "$owner_type" = "Organization" ]; then
-    echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product/Domain/Layer)"
+    echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product)"
     report_incompatible
     echo "==> Done — project #$project_number: $title"
     exit 0
@@ -501,24 +502,9 @@ create_text "Product"
 # the `Status: Agent Queue` lane; the live claim is a `claim:*` label written
 # by the agent itself. A single-select field could carry neither answer without
 # duplicating the label vocabulary (docs/project-management.md, ADR 0005 D4).
-# Domain (what part of the product) and Layer (which slice of the stack) mirror
-# the `domain:` / `layer:` label families in setup-github-labels.sh — keep the
-# lists in step. Domain is a starter set; real domains come from your product's
-# entities. create_single_select only ever ADDS to an existing field, so options
-# you add in the Project UI survive every re-run — and a starter value added by a
-# later harmon-init release lands on the next one, the same way a new
-# `domain:`/`layer:` label does.
-create_single_select "Domain" '[
-  {"name":"auth","color":"PURPLE","description":"Authentication and authorization"},
-  {"name":"billing","color":"GREEN","description":"Billing and payments"},
-  {"name":"platform","color":"GRAY","description":"CI, build, test infra, and tooling in this repo"}
-]'
-create_single_select "Layer" '[
-  {"name":"ui","color":"BLUE","description":"Components, styling, interaction, tokens, a11y. No data change"},
-  {"name":"logic","color":"GREEN","description":"Business rules, handlers, calculation"},
-  {"name":"data","color":"YELLOW","description":"Schema, indexes, validators, migrations"},
-  {"name":"integration","color":"ORANGE","description":"External boundary: webhooks, API clients, credentials"}
-]'
+# There is likewise deliberately no Domain or Layer field (#875) — same
+# reasoning as Agent: the `domain:`/`layer:` labels in setup-github-labels.sh
+# are the only surface now. See docs/project-management.md, "Label or field?".
 
 report_incompatible
 echo "==> Done — project #$project_number: $title"

--- a/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
@@ -100,16 +100,7 @@ complete='{"data":{"node":{"fields":{"nodes":[
    {"id":"p1","name":"Urgent","color":"RED","description":""},
    {"id":"p2","name":"High","color":"ORANGE","description":""},
    {"id":"p3","name":"Medium","color":"YELLOW","description":""},
-   {"id":"p4","name":"Low","color":"GRAY","description":""}]},
- {"id":"F_dom","name":"Domain","dataType":"SINGLE_SELECT","options":[
-   {"id":"d1","name":"auth","color":"PURPLE","description":"Authentication and authorization"},
-   {"id":"d2","name":"billing","color":"GREEN","description":"Billing and payments"},
-   {"id":"d3","name":"platform","color":"GRAY","description":"CI, build, test infra, and tooling in this repo"}]},
- {"id":"F_lay","name":"Layer","dataType":"SINGLE_SELECT","options":[
-   {"id":"l1","name":"ui","color":"BLUE","description":"Components, styling, interaction, tokens, a11y. No data change"},
-   {"id":"l2","name":"logic","color":"GREEN","description":"Business rules, handlers, calculation"},
-   {"id":"l3","name":"data","color":"YELLOW","description":"Schema, indexes, validators, migrations"},
-   {"id":"l4","name":"integration","color":"ORANGE","description":"External boundary: webhooks, API clients, credentials"}]}
+   {"id":"p4","name":"Low","color":"GRAY","description":""}]}
 ]}}}}'
 
 echo "==> a re-run against an already-synced project writes nothing"
@@ -126,24 +117,24 @@ case "$(cat "$MUTATIONS")" in
 esac
 
 echo "==> a field missing a starter option gains ONLY that option"
-# Domain lacks `billing` and carries an owner-added `crm`.
+# Priority lacks `Low` and carries an owner-added `Critical`.
 partial=$(printf '%s' "$complete" | jq -c '
     .data.node.fields.nodes |= map(
-        if .name == "Domain" then
-            .options = [ .options[] | if .name == "billing"
-                then {id: "d9", name: "crm", color: "PINK", description: "owner added"}
+        if .name == "Priority" then
+            .options = [ .options[] | if .name == "Low"
+                then {id: "p9", name: "Critical", color: "PINK", description: "owner added"}
                 else . end ]
         else . end)')
 run_with "$partial"
 [ "$(updates)" = 1 ] || fail "expected exactly 1 update mutation, got $(updates)"
 mut=$(cat "$MUTATIONS")
 case "$mut" in
-*'{name:"billing"'*) : ;;
+*'{name:"Low"'*) : ;;
 *) fail "the appended option should be sent WITHOUT an id" ;;
 esac
 
 echo "==> every pre-existing option is re-sent WITH its id (identity preserved)"
-for pair in 'd1:auth' 'd9:crm' 'd3:platform'; do
+for pair in 'p1:Urgent' 'p9:Critical' 'p3:Medium'; do
     case "$mut" in
     *"{id:\"${pair%%:*}\",name:\"${pair##*:}\""*) : ;;
     *) fail "existing option '${pair##*:}' lost its id '${pair%%:*}' — item values would be cleared" ;;
@@ -152,17 +143,17 @@ done
 
 echo "==> an owner-added option survives the append"
 case "$mut" in
-*'name:"crm"'*) : ;;
-*) fail "owner-added option 'crm' was dropped from the replacement list" ;;
+*'name:"Critical"'*) : ;;
+*) fail "owner-added option 'Critical' was dropped from the replacement list" ;;
 esac
 
 echo "==> a field of the wrong data type is warned about, never appended to"
 wrong=$(printf '%s' "$complete" | jq -c '
     .data.node.fields.nodes |= map(
-        if .name == "Domain" then {id: .id, name: .name, dataType: "TEXT"} else . end)')
+        if .name == "Priority" then {id: .id, name: .name, dataType: "TEXT"} else . end)')
 run_with "$wrong"
 [ "$(updates)" = 0 ] || fail "a wrong-typed field must not receive an option update"
-grep -q "already exists as TEXT" "$tmp/out" || fail "expected a data-type warning for Domain"
+grep -q "already exists as TEXT" "$tmp/out" || fail "expected a data-type warning for Priority"
 
 echo "==> a non-single-select Status warns and is skipped, never aborting the run"
 # Status is reconciled by its own call site rather than create_single_select, so
@@ -184,21 +175,21 @@ grep -q "Status (is TEXT, wanted SINGLE_SELECT)" "$tmp/out" ||
 echo "==> a field at the option cap warns instead of attempting an oversized write"
 capped=$(printf '%s' "$complete" | jq -c '
     .data.node.fields.nodes |= map(
-        if .name == "Domain" then
-            .options = ([ .options[] | select(.name != "billing") ]
-                + [ range(0; 48) | {id: "x\(.)", name: "custom\(.)", color: "GRAY", description: ""} ])
+        if .name == "Priority" then
+            .options = ([ .options[] | select(.name != "Low") ]
+                + [ range(0; 47) | {id: "x\(.)", name: "custom\(.)", color: "GRAY", description: ""} ])
         else . end)')
 run_with "$capped"
 [ "$(updates)" = 0 ] || fail "an over-capacity append must be skipped, not attempted"
-grep -q "cannot fit billing" "$tmp/out" || fail "expected a capacity warning naming the missing option"
+grep -q "cannot fit Low" "$tmp/out" || fail "expected a capacity warning naming the missing option"
 
 echo "==> an option added after the startup snapshot survives the append"
 # The re-read immediately before the write is what saves it: the replacement is
 # built from the fresh list, not the stale one.
 concurrent=$(printf '%s' "$partial" | jq -c '
     .data.node.fields.nodes |= map(
-        if .name == "Domain" then
-            .options += [{id: "d42", name: "raced-in", color: "BLUE", description: "added concurrently"}]
+        if .name == "Priority" then
+            .options += [{id: "p42", name: "raced-in", color: "BLUE", description: "added concurrently"}]
         else . end)')
 run_with "$partial" "$concurrent"
 mut=$(cat "$MUTATIONS")

--- a/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
@@ -1,20 +1,15 @@
 #!/usr/bin/env bash
 # setup-github-issue-fields.sh — idempotently add the org ISSUE FIELDS that are
-# NOT GitHub built-ins: Product, Domain, and Layer. GitHub already ships
-# Priority, Effort, Start date, and Target date as built-in issue fields, and we
-# never recreate or modify those (leave them at their defaults).
-# Additive only; it never renames or deletes a field or an option — so the
-# starter Domain/Layer options below are a floor, and per-product options you add
-# later in the org's issue-field settings survive every re-run.
+# NOT GitHub built-ins: Product. GitHub already ships Priority, Effort, Start
+# date, and Target date as built-in issue fields, and we never recreate or
+# modify those (leave them at their defaults).
 #
-# One exception to "never edits": a single-select field that is MISSING a starter
-# option gains it, via PATCH /orgs/{org}/issue-fields/{id} — the same additive
-# reconciliation setup-github-project.sh does for project fields, so a value added
-# by a later harmon-init release lands on a re-run instead of drifting. Purely
-# additive: existing options are sent back with their ids (see append_options),
-# and nothing is renamed, reordered, or deleted. Because these endpoints are in
-# PUBLIC PREVIEW, a rejected PATCH degrades to a warning naming the missing
-# options rather than failing the run.
+# There is deliberately no Domain or Layer issue field (#875): they used to
+# mirror the `domain:`/`layer:` label families in setup-github-labels.sh with
+# nothing syncing an issue's field value to its label, and only the label
+# surface is readable without project scope, writable with plain repo scope,
+# and available on personal repos — so it is the one that stays (see
+# docs/project-management.md, "Label or field?").
 #
 # NB: the numeric, summable estimate is NOT an issue field — it is the Size
 # project NUMBER field (setup-github-project.sh), because only project number
@@ -70,31 +65,6 @@ api_version="2026-03-10"
 # There is deliberately no Agent field: advisory agent routing is the
 # `suggest:*` label family plus the `Status: Agent Queue` lane, and the live
 # claim is a `claim:*` label (docs/project-management.md, ADR 0005 D4).
-#
-# Colors are GitHub's palette: gray, blue, green, yellow, orange, red, pink,
-# purple. `priority` (1-based) is REQUIRED per option on this preview endpoint
-# and sets the display order (1 shows first).
-#
-# Domain (what part of the product) and Layer (which slice of the stack) are
-# orthogonal to each other and to Type/Status — an issue normally carries one of
-# each. Both mirror the `domain:` / `layer:` label families in
-# setup-github-labels.sh; keep the two lists in step.
-#
-# Domain is a STARTER set only: real domains come from your product's entities
-# (crm, invoicing, scheduling, …). Add them in the org's issue-field settings —
-# this script only ever appends what is missing, so they survive.
-domain_opts='[
-  {"name":"auth","color":"purple","description":"Authentication and authorization","priority":1},
-  {"name":"billing","color":"green","description":"Billing and payments","priority":2},
-  {"name":"platform","color":"gray","description":"CI, build, test infra, and tooling in this repo","priority":3}
-]'
-
-layer_opts='[
-  {"name":"ui","color":"blue","description":"Components, styling, interaction, tokens, a11y. No data change","priority":1},
-  {"name":"logic","color":"green","description":"Business rules, handlers, calculation","priority":2},
-  {"name":"data","color":"yellow","description":"Schema, indexes, validators, migrations","priority":3},
-  {"name":"integration","color":"orange","description":"External boundary: webhooks, API clients, credentials","priority":4}
-]'
 
 # refresh_fields — (re-)read the org's issue fields into existing_json. Returns
 # non-zero when the read or the parse fails, leaving any previous snapshot in
@@ -124,147 +94,44 @@ field_json() { printf '%s' "$existing_json" | jq -c --arg n "$1" '[ .[] | select
 field_present() { [ -n "$(field_json "$1")" ]; }
 field_type() { printf '%s' "$existing_json" | jq -r --arg n "$1" '[ .[] | select(.name==$n) ] | first | .data_type // ""'; }
 
-# Names like `Domain` and `Layer` are generic enough that an adopting org may
-# already have one — of the wrong data type. GitHub cannot change an issue
-# field's data type in place, so the intended options are simply unavailable
-# until that field is renamed or deleted. Warn (loudly, and again in the summary)
-# rather than exit non-zero: this script only ever creates or appends, and one
-# pre-existing field the org owns is not a reason to abort the fields that *can*
-# still be reconciled.
+# A field name generic enough that an adopting org may already have one — of
+# the wrong data type. GitHub cannot change an issue field's data type in
+# place, so the intended field is simply unavailable until it is renamed or
+# deleted. Warn (loudly, and again in the summary) rather than exit non-zero:
+# this script only ever creates, and one pre-existing field the org owns is
+# not a reason to abort.
 incompatible=""
 
-# Existing fields that are missing a starter option, collected for the summary.
-missing_options=""
-
-# append_options NAME OPTIONS_JSON — add any starter option the existing field is
-# missing, via PATCH /orgs/{org}/issue-fields/{id}.
-#
-# Two hazards, both handled in the jq below:
-#  1. `options` REPLACES the whole list, so every existing option must be sent
-#     back or it is deleted. They are read from the field and concatenated first.
-#  2. An existing option must be sent WITH its `id`, or it is destroyed and
-#     recreated — blanking the field on every issue already assigned to it. New
-#     options carry no id (GitHub assigns one).
-# `priority` is renumbered 1..N over the existing order followed by the appended
-# options: it encodes display order only, so this keeps the owner's order intact
-# while guaranteeing the contiguous, unique values the endpoint expects.
-#
-# The endpoint is PUBLIC PREVIEW and may change or vanish, so this fails safe in
-# both directions: an unreadable snapshot is never turned into replacement data
-# (see the `blocked` guard), and a rejected PATCH degrades to a warning rather
-# than aborting the run part-way. Either way the operator learns exactly which
-# options to add by hand.
-append_options() {
-    name="$1"
-    # Re-read immediately before building the replacement. The PATCH replaces the
-    # ENTIRE option list, so an option added between the startup read and this
-    # write — a parallel run, or someone in the org settings UI — would otherwise
-    # be deleted. This narrows the lost-update window to a single round-trip; it
-    # cannot close it, as the endpoint accepts no expected-version token.
-    if ! refresh_fields; then
-        echo "    WARNING: could not re-read issue field '$name' before updating it — leaving it untouched" >&2
-        missing_options="${missing_options}${missing_options:+; }${name}: (could not re-read the field)"
-        return 0
-    fi
-    fjson="$(field_json "$name")"
-    if [ -z "$fjson" ]; then
-        echo "    WARNING: issue field '$name' disappeared while this script was running — skipping" >&2
-        return 0
-    fi
-    merged=$(jq -cn --argjson f "$fjson" --argjson want "$2" '
-        (if ($f.options | type) == "array" then $f.options else [] end
-            | sort_by(.priority // 0)) as $ex
-        | (if ($f | has("options") | not) then "the response carried no options array for it"
-           elif ($f.options | type) != "array" then "its options came back as a \($f.options | type), not an array"
-           elif ([ $ex[] | select(.id == null) ] | length) > 0 then "an existing option came back without an id"
-           else "" end) as $blocked
-        | [ $ex[].name ] as $names
-        | [ $want[] | select( .name as $n | ($names | index($n)) == null ) ] as $new
-        | { blocked: $blocked,
-            new: [ $new[].name ],
-            body: { options: (
-                [ $ex[]  | {id, name, description: (.description // ""), color: (.color // "gray")} ]
-              + [ $new[] | {    name, description: (.description // ""), color: (.color // "gray")} ]
-              | to_entries | map(.value + {priority: (.key + 1)}) ) } }')
-    missing=$(printf '%s' "$merged" | jq -r '.new | join(", ")')
-    if [ -z "$missing" ]; then
-        echo "    Issue field '$name' already exists with every starter option — leaving it as-is"
-        return 0
-    fi
-    # Fail CLOSED on an unreadable snapshot. A preview response that omits
-    # `options` would otherwise look like a field with none, and the PATCH — which
-    # replaces the whole list — would delete every option the org owns. An option
-    # without an id is equally unusable: re-sending it would destroy and recreate
-    # it, blanking that field on every issue assigned to it. In both cases the
-    # promised warning is the correct outcome, not a best-effort write.
-    blocked=$(printf '%s' "$merged" | jq -r '.blocked')
-    if [ -n "$blocked" ]; then
-        echo "    WARNING: issue field '$name' is missing starter option(s) $missing, but $blocked —" >&2
-        echo "             not sending a replacement that could delete existing options." >&2
-        missing_options="${missing_options}${missing_options:+; }${name}: ${missing}"
-        return 0
-    fi
-    fid=$(printf '%s' "$fjson" | jq -r '.id')
-    if err=$(printf '%s' "$merged" | jq -c '.body' |
-        gh api --method PATCH "orgs/$org/issue-fields/$fid" \
-            -H "X-GitHub-Api-Version: $api_version" --input - 2>&1 >/dev/null); then
-        echo "    Issue field '$name' already exists — appended missing option(s): $missing"
-        return 0
-    fi
-    echo "    WARNING: issue field '$name' is missing starter option(s) $missing, and the update was rejected:" >&2
-    echo "             $(printf '%s' "$err" | tr '\n' ' ' | cut -c1-200)" >&2
-    missing_options="${missing_options}${missing_options:+; }${name}: ${missing}"
-}
-
-# create_field NAME DATA_TYPE DESCRIPTION [OPTIONS_JSON]
+# create_field NAME DATA_TYPE DESCRIPTION
 create_field() {
     name="$1"
     dtype="$2"
     desc="$3"
-    opts="${4:-}"
     if field_present "$name"; then
         etype="$(field_type "$name")"
         if [ -n "$etype" ] && [ "$etype" != "$dtype" ]; then
-            # A wrong-typed field cannot hold the intended options at all, so this
-            # takes precedence over the missing-option check below.
-            echo "    WARNING: issue field '$name' already exists as '$etype', not '$dtype' — its intended options are NOT available" >&2
+            echo "    WARNING: issue field '$name' already exists as '$etype', not '$dtype'" >&2
             incompatible="${incompatible}${incompatible:+, }${name} (is '$etype', wanted '$dtype')"
-        elif [ -n "$opts" ]; then
-            append_options "$name" "$opts"
         else
             echo "    Issue field '$name' already exists — leaving it as-is"
         fi
         return 0
     fi
     echo "    Creating $dtype issue field '$name'"
-    if [ -n "$opts" ]; then
-        body=$(jq -cn --arg n "$name" --arg d "$desc" --arg t "$dtype" --argjson o "$opts" \
-            '{name:$n,description:$d,data_type:$t,options:$o}')
-    else
-        body=$(jq -cn --arg n "$name" --arg d "$desc" --arg t "$dtype" \
-            '{name:$n,description:$d,data_type:$t}')
-    fi
+    body=$(jq -cn --arg n "$name" --arg d "$desc" --arg t "$dtype" \
+        '{name:$n,description:$d,data_type:$t}')
     printf '%s' "$body" |
         gh api --method POST "orgs/$org/issue-fields" \
             -H "X-GitHub-Api-Version: $api_version" --input - >/dev/null
 }
 
 create_field "Product" "text" "Which product/area it belongs to"
-create_field "Domain" "single_select" "Which part of the product it belongs to" "$domain_opts"
-create_field "Layer" "single_select" "Which slice of the stack it changes" "$layer_opts"
 
-if [ -n "$incompatible" ] || [ -n "$missing_options" ]; then
+if [ -n "$incompatible" ]; then
     echo "==> Done, WITH WARNINGS" >&2
-    if [ -n "$incompatible" ]; then
-        echo "    These fields already exist with a different data type: $incompatible" >&2
-        echo "    GitHub cannot change an issue field's data type in place. Rename or delete each one in the org's" >&2
-        echo "    issue-field settings and re-run this script to get the intended options." >&2
-    fi
-    if [ -n "$missing_options" ]; then
-        echo "    These existing fields are still missing a starter option — $missing_options" >&2
-        echo "    The update was rejected (the issue-fields API is in public preview and may have changed)." >&2
-        echo "    Add each one by hand in the org's issue-field settings (Settings -> Planning -> Issue fields)." >&2
-    fi
+    echo "    These fields already exist with a different data type: $incompatible" >&2
+    echo "    GitHub cannot change an issue field's data type in place. Rename or delete each one in the org's" >&2
+    echo "    issue-field settings and re-run this script to get the intended options." >&2
 else
-    echo "==> Done — added issue fields on '$org': Product, Domain, Layer (Priority/Effort/dates are GitHub built-ins)"
+    echo "==> Done — added issue fields on '$org': Product (Priority/Effort/dates are GitHub built-ins)"
 fi

--- a/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]test-setup-github-issue-fields.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]test-setup-github-issue-fields.sh[% endif %]
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
 # test-setup-github-issue-fields.sh — unit-test setup-github-issue-fields.sh's
-# option reconciliation against a stubbed `gh`; no live API calls, so it is safe
-# in CI. Run via `task test:setup-github-issue-fields`.
+# field creation against a stubbed `gh`; no live API calls, so it is safe in CI.
+# Run via `task test:setup-github-issue-fields`.
 #
-# What makes a test worth having here: the PATCH replaces an ORG-WIDE option list,
-# and existing assignments survive only while every existing option goes back with
-# its `id`. This path talks to a public-preview REST API, so nothing else can
-# exercise it — a regression that dropped the ids, or that turned a malformed
-# snapshot into replacement data, would clear field values across every repo in
-# the organization while still passing `verify`.
+# What makes a test worth having here: this hits a public-preview REST API, so
+# nothing else exercises it — a regression that recreated a retired field
+# (Agent, Domain, Layer — #662, #875) or warned on the wrong condition would
+# still pass `verify`.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 script="$PWD/scripts/setup-github-issue-fields.sh"
@@ -22,8 +20,7 @@ fail() {
     exit 1
 }
 
-# Fake `gh`: serves $STUB_FIELDS_FILE for reads, records write bodies, and can be
-# told to reject the PATCH so the warn-fallback path is exercised.
+# Fake `gh`: serves $STUB_FIELDS_FILE for reads, records write bodies.
 mkdir -p "$tmp/bin"
 cat >"$tmp/bin/gh" <<'STUB'
 #!/usr/bin/env bash
@@ -39,14 +36,6 @@ POST)
     cat >>"$POSTS"
     printf '\n' >>"$POSTS"
     ;;
-PATCH)
-    cat >>"$PATCHES"
-    printf '\n' >>"$PATCHES"
-    if [ -n "${GH_FAIL_PATCH:-}" ]; then
-        echo "gh: HTTP 422: option list rejected" >&2
-        exit 1
-    fi
-    ;;
 *)
     echo "fake gh: unexpected method $method" >&2
     exit 1
@@ -59,97 +48,51 @@ export PATH
 
 STUB_FIELDS_FILE="$tmp/fields.json"
 POSTS="$tmp/posts"
-PATCHES="$tmp/patches"
-export STUB_FIELDS_FILE POSTS PATCHES
+export STUB_FIELDS_FILE POSTS
 
 # run_with FIELDS_JSON — run the script against that org snapshot.
 run_with() {
     printf '%s' "$1" >"$STUB_FIELDS_FILE"
     : >"$POSTS"
-    : >"$PATCHES"
     "$script" --org testorg >"$tmp/out" 2>&1 || fail "script exited non-zero"
 }
 
-patches() { grep -c . "$PATCHES" || true; }
-
-# Every field present and complete. Deliberately no Agent field: it is retired
-# (advisory routing is suggest:* labels + Status: Agent Queue; ADR 0005 D4).
+# Every field present. Deliberately no Agent, Domain, or Layer field: all
+# three are retired (advisory routing is suggest:*/claim:* labels + Status:
+# Agent Queue for Agent, ADR 0005 D4; Domain/Layer's only surface is the
+# domain:/layer: labels, #875).
 complete='[
- {"id":1,"name":"Product","data_type":"text"},
- {"id":3,"name":"Domain","data_type":"single_select","options":[
-   {"id":20,"name":"auth","color":"purple","description":"","priority":1},
-   {"id":21,"name":"billing","color":"green","description":"","priority":2},
-   {"id":22,"name":"platform","color":"gray","description":"","priority":3}]},
- {"id":4,"name":"Layer","data_type":"single_select","options":[
-   {"id":30,"name":"ui","color":"blue","description":"","priority":1},
-   {"id":31,"name":"logic","color":"green","description":"","priority":2},
-   {"id":32,"name":"data","color":"yellow","description":"","priority":3},
-   {"id":33,"name":"integration","color":"orange","description":"","priority":4}]}
+ {"id":1,"name":"Product","data_type":"text"}
 ]'
 
 echo "==> a re-run against an already-synced org writes nothing"
 run_with "$complete"
-[ "$(patches)" = 0 ] || fail "expected no PATCH on an unchanged org, got $(patches)"
 [ ! -s "$POSTS" ] || fail "expected no field creation on an unchanged org"
+grep -q "already exists — leaving it as-is" "$tmp/out" || fail "expected 'leaving it as-is' output for Product"
 
 echo "==> the retired Agent field is never created"
-# The fixture has no Agent field, so a POST naming one is the script recreating
-# it. Also covered by the empty-POSTS check above, but this names the intent so
-# a reintroduction fails with the right message.
 grep -q '"name":"Agent"' "$POSTS" &&
     fail "the retired Agent field was created — routing lives in suggest:*/claim:* labels"
 
-echo "==> a field missing a starter option is PATCHed with the full merged list"
-# Domain lacks `billing` but carries an owner-added `crm`.
-partial=$(printf '%s' "$complete" | jq -c '
-    map(if .name == "Domain" then
-            .options = [ .options[] | if .name == "billing"
-                then {id: 99, name: "crm", color: "pink", description: "owner added", priority: 2}
-                else . end ]
-        else . end)')
-run_with "$partial"
-[ "$(patches)" = 1 ] || fail "expected exactly 1 PATCH, got $(patches)"
-body=$(cat "$PATCHES")
-[ "$(printf '%s' "$body" | jq -r '.options | length')" = 4 ] ||
-    fail "expected 4 options (3 existing + billing), got $(printf '%s' "$body" | jq -r '.options | length')"
+echo "==> Domain and Layer are never created"
+case "$(cat "$POSTS")" in
+*'"name":"Domain"'* | *'"name":"Layer"'*)
+    fail "a retired Domain/Layer issue field was created — their only surface is domain:/layer: labels (#875)"
+    ;;
+esac
 
-echo "==> every pre-existing option keeps its id (org-wide assignments preserved)"
-for id in 20 99 22; do
-    [ "$(printf '%s' "$body" | jq --argjson i "$id" '[.options[] | select(.id == $i)] | length')" = 1 ] ||
-        fail "existing option id $id was not sent back — its assigned values would be cleared"
-done
+echo "==> a missing Product field is created"
+run_with '[]'
+[ -s "$POSTS" ] || fail "expected a field creation when Product is missing"
+grep -q '"name":"Product"' "$POSTS" || fail "expected the POST body to name Product"
+grep -q '"data_type":"text"' "$POSTS" || fail "expected Product to be created as text"
 
-echo "==> the appended option is sent WITHOUT an id, and the owner's option survives"
-[ "$(printf '%s' "$body" | jq -r '[.options[] | select(.name == "billing")] | .[0] | has("id")')" = false ] ||
-    fail "the appended option must not carry an id"
-[ "$(printf '%s' "$body" | jq -r '[.options[] | select(.name == "crm")] | length')" = 1 ] ||
-    fail "owner-added option 'crm' was dropped from the replacement list"
+echo "==> a field of the wrong data type is warned about, never recreated"
+wrong='[{"id":1,"name":"Product","data_type":"single_select"}]'
+run_with "$wrong"
+[ ! -s "$POSTS" ] || fail "a wrong-typed field must not be recreated"
+grep -q "already exists as 'single_select', not 'text'" "$tmp/out" ||
+    fail "expected a data-type warning for Product"
+grep -q "Done, WITH WARNINGS" "$tmp/out" || fail "expected the run to end with warnings"
 
-echo "==> priorities come back contiguous and in order"
-[ "$(printf '%s' "$body" | jq -c '[.options[].priority]')" = "[1,2,3,4]" ] ||
-    fail "priorities must be renumbered 1..N in order, got $(printf '%s' "$body" | jq -c '[.options[].priority]')"
-
-echo "==> a snapshot with no options array is refused, not turned into a replacement"
-malformed=$(printf '%s' "$complete" | jq -c 'map(if .name == "Domain" then del(.options) else . end)')
-run_with "$malformed"
-[ "$(patches)" = 0 ] || fail "a field with no options array must not be PATCHed"
-grep -q "carried no options array" "$tmp/out" || fail "expected a fail-closed warning for the malformed snapshot"
-
-echo "==> an existing option with no id is refused"
-# The field must also be missing a starter, or there is no write to guard: when
-# nothing needs appending the script returns before validating the snapshot,
-# which is correct — an untouched field cannot lose anything.
-noid=$(printf '%s' "$complete" | jq -c '
-    map(if .name == "Domain"
-        then .options = [ .options[] | select(.name != "billing") | del(.id) ]
-        else . end)')
-run_with "$noid"
-[ "$(patches)" = 0 ] || fail "options without ids must not be PATCHed"
-grep -q "without an id" "$tmp/out" || fail "expected a fail-closed warning for the id-less option"
-
-echo "==> a rejected PATCH degrades to a warning naming the options"
-GH_FAIL_PATCH=1 run_with "$partial"
-grep -q "billing" "$tmp/out" || fail "a rejected PATCH must name the missing options"
-grep -q "still missing a starter option" "$tmp/out" || fail "expected the summary warning after a rejected PATCH"
-
-echo "PASS: setup-github-issue-fields.sh option reconciliation"
+echo "PASS: setup-github-issue-fields.sh field creation"

--- a/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
@@ -3,10 +3,10 @@
 # set (docs/project-management.md). Colors are grouped by family (concerns=purple,
 # source=pink, workflow=orange, layer=blue, domain=yellow).
 #
-# The `layer:` and `domain:` families deliberately mirror the Layer and Domain
-# single-select fields created by setup-github-issue-fields.sh (org) /
-# setup-github-project.sh (personal account) — same vocabulary, so a label and a
-# field value never disagree. Keep the three lists in step when you extend them.
+# The `layer:` and `domain:` families are the only surface for that taxonomy —
+# there is deliberately no paired Layer/Domain project or issue field (#875;
+# see docs/project-management.md, "Label or field?"). Keep the two lists in
+# step with product growth.
 #
 # Labels are REPO-level in GitHub — there's no shared org label pool. Run this in
 # each repo; org "default labels" (Settings → Repository, UI-only, no API) only

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -1175,19 +1175,18 @@ if [[ "${SECTION}" == "setup" ]]; then
                     # runs per page and any single-line delimiter trick breaks at a
                     # page boundary.
                     field_rows="$(jq -r '(if type == "object" then (.issue_fields // []) elif type == "array" then . else [] end) | .[] | "\(.name)\t\(.data_type // "")"' "${d}/issue-fields.json" 2>/dev/null || echo "")"
-                    # Every non-built-in field setup-github-issue-fields.sh creates
-                    # must be present AND of the right type: an org set up before
-                    # Domain and Layer joined the set already has Product, and one
-                    # that happens to own a text field named `Domain` can never get
-                    # the taxonomy options (GitHub cannot change a field's data
-                    # type in place). Reporting either as done would hide exactly
-                    # what the setup script warns about. The retired Agent field is
-                    # deliberately NOT wanted here: the setup script no longer
-                    # creates it, so requiring it would report a permanent false
-                    # failure on every fresh org (#662).
+                    # Product must be present AND of the right type: an org that
+                    # happens to own a text-incompatible field named `Product`
+                    # can never get it created (GitHub cannot change a field's
+                    # data type in place). Reporting it done would hide exactly
+                    # what the setup script warns about. The retired Agent,
+                    # Domain, and Layer fields are deliberately NOT wanted here:
+                    # the setup script no longer creates any of them, so
+                    # requiring one would report a permanent false failure on
+                    # every fresh org (#662, #875).
                     missing_fields=""
                     wrong_fields=""
-                    for want in Product:text Domain:single_select Layer:single_select; do
+                    for want in Product:text; do
                         wname="${want%%:*}"
                         wtype="${want##*:}"
                         htype="$(printf '%s\n' "${field_rows}" | awk -F'\t' -v n="${wname}" '$1 == n { print $2; exit }')"
@@ -1202,7 +1201,7 @@ if [[ "${SECTION}" == "setup" ]]; then
                     elif [ -n "${wrong_fields}" ]; then
                         checkline no "Org issue fields" "wrong type: ${wrong_fields} — rename/delete, then re-run task setup:github-issue-fields"
                     elif [ -z "${missing_fields}" ]; then
-                        checkline ok "Org issue fields" "Product + Domain + Layer"
+                        checkline ok "Org issue fields" "Product"
                     else
                         checkline no "Org issue fields" "missing ${missing_fields} — run task setup:github-issue-fields"
                     fi


### PR DESCRIPTION
## What

Deletes the `Domain` and `Layer` GitHub Projects/issue fields from `setup-github-project.sh` (personal accounts) and `setup-github-issue-fields.sh` (org accounts) — both scripts now only ever created these as a duplicate of the already-existing `domain:`/`layer:` labels, with nothing syncing an issue's field value to its label. Retargets both scripts' unit tests, retires the now-obsolete label↔field vocabulary cross-check in `scripts/test-template.sh` (there's no more field vocabulary to drift against), and documents the migration for boards/orgs that already have the fields from an earlier release.

Applied to root and `template/` in lockstep per AGENTS.md's two-layer architecture — every verbatim twin stays byte-identical (`test:dogfood-parity`), every jinja twin's structure matches (`test:dogfood-structure`).

Also deleted the live `Domain`/`Layer` fields from the **evanharmon1 Project** board directly (per Evan's explicit request), after confirming via a full paginated scan that none of the board's 103 items had either field set — nothing was lost.

## Why

Closes #875. Domain and Layer only ever offered what the `Label or field?` section of `docs/project-management.md` already lists as reasons to prefer a label: multi-valued, readable without project scope, writable with plain repo scope, timeline-attributable, and available on personal repos. The label was already the source of truth for anyone living in `gh issue list`; the field was the redundant surface.

## Second-model review

Rigor: `standard` (`default_rigor` in `.devflow.toml` — issue #875 carries no `rigor:*` label) → challenge ≤3, review ≤3, shepherd 4.

**`task challenge`** (3 rounds, converged at the cap):

| Round | Findings | Adjudication |
|---|---|---|
| 1 | P1: retargeted single-select test coverage was fine, but the vendored `standardize-repo` skill catalog (harmon-devkit) still requires/preserves Domain/Layer, contradicting these docs once applied | Confirmed. Not fixable here — AGENTS.md forbids hand-editing vendored skill content. Filed [harmon-devkit#459](https://github.com/evanharmon1/harmon-devkit/issues/459) to track the upstream fix + pin bump |
| 1 | P2 ×2: migration steps assumed `domain:`/`layer:` labels already exist org-wide (labels are repo-local); omitted saved-view **sorting** as a third view config a field deletion breaks | Confirmed, fixed |
| 2 | P1 ×2: no instruction to convert draft items to issues before labeling (drafts can't carry labels at all); no instruction to create a label first for a custom field option with no label counterpart | Confirmed, fixed |
| 3 (cap) | P1: migration steps had no pagination guidance and no quiescence/final-verification procedure | Partially confirmed — fixed the pagination gap (point at the Project's own filtered view or `--limit`, not a bare `gh issue list`/`gh project item-list`). Declined the quiescence/final-verification framing as disproportionate for a human-driven, one-time documentation migration: the pre-existing, unchanged Agent-field migration directly above it (already shipped) carries the identical rigor level, and the section already opens with "reviewing its values comes first" |
| 3 (cap) | P2: `CHECKLIST.md` (a fresh-generation doc) had no pointer for a repo upgrading from an older release with live fields | Confirmed, fixed with a one-line pointer to the existing migration procedure — not a duplicated procedure, matching this repo's "optimize for rolling updates, not every historical migration path" convention |

Round 3 (the cap) adjudicates to zero P0/P1 after the above reclassification — a capped final round that converges clean ends the stage by itself (AGENTS.md).

**`task review`** (3 rounds, converged normally):

| Round | Findings | Adjudication |
|---|---|---|
| 1 | P1: the org-issue-field migration step pointed at a single Project's filtered view, but an org issue field's value lives on the issue independent of project membership — an issue can carry it without ever being added to that Project | Confirmed, fixed — split the enumeration step by owner type (org: issue-field settings + org-wide sweep; personal: the Project's own view, which is complete for a project field) |
| 1 | P2: every `#875` in generated docs was a bare issue number that resolves to the *consumer* repo's own issue #875 once rendered, not harmon-init's | Confirmed, fixed — switched to `harmon-init#875`, matching this file's own existing convention (`harmon-init#427`, `#663`, `#725`, `#664`/`#666`) |
| 2 | P2: the `CHECKLIST.md` pointer said "this repo's board," insufficient for an org issue field that can survive on issues outside any one Project | Confirmed, fixed |
| 3 (cap) | none | Clean — 2nd consecutive zero-P0/P1 round, converges |

`task ci` is green (skills-drift, secrets, devcontainer permissions, Semgrep: 0 findings across 265 files).

## Verification

- `task verify`, `task ci` — green
- `task test:template:all` — all 6 profiles pass, including the new regression guards that the retired fields are never recreated
- `scripts/test-setup-github-project.sh`, and the rendered `test-setup-github-issue-fields.sh`, run directly — pass
- Manually rendered both the `full` (org) and `minimal` (personal) copier profiles and inspected the jinja-conditional migration text for clean markdown in both branches

Closes #875