### PR TITLE
feat(status): check gh token scopes at session start and add setup:gh-scopes

### DIFF
--- a/.claude/hooks/session-start-context.sh
+++ b/.claude/hooks/session-start-context.sh
@@ -24,10 +24,11 @@ strip_ansi() { sed -E 's/\x1B\[''[0-9;]*[A-Za-z]//g'; }
 # status:git makes no network calls at all.
 #
 # status:creds is budgeted from its own probes rather than by copying a
-# neighbour's number: it makes NO network call (that is why it can be here at
-# all — status:gh already spends this startup's only auth round trip), and runs
-# three LOCAL probes back to back, each bounded at 3s inside status.sh — 9s
-# worst case, so 11 here for the `task` and shell startup around them. The three run in
+# neighbour's number: it runs three LOCAL probes back to back, each bounded at
+# 3s inside status.sh, plus ONE bounded 3s call to read the gh token's SCOPES
+# (a server-side property no local file records — issue #827), which is why it
+# is capped at the local bound rather than NETWORK_TIMEOUT. 12s worst case, so
+# 13 here for the `task` and shell startup around them. The three run in
 # parallel, so it adds nothing to the wall clock the gh deadline already allows.
 remote_url="$(git config --get remote.origin.url 2>/dev/null || echo '')"
 host_owner="$(echo "$remote_url" | sed -E 's/^(https?:\/\/|git@)([^:\/]+)[:\/]([^\/]+)\/[^\/]+(\.git)?$/\2 \3/')"
@@ -48,7 +49,7 @@ if [ "$host" = "github.com" ]; then
         git_pid=$!
         "$timeout_cmd" 12 task status:gh >"$gh_out" 2>/dev/null &
         gh_pid=$!
-        "$timeout_cmd" 11 task status:creds >"$creds_out" 2>/dev/null &
+        "$timeout_cmd" 13 task status:creds >"$creds_out" 2>/dev/null &
         creds_pid=$!
 
         git_rc=0

--- a/.devcontainer/config/claude-hooks/session-start-context.sh
+++ b/.devcontainer/config/claude-hooks/session-start-context.sh
@@ -24,17 +24,18 @@ strip_ansi() { sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'; }
 # status:git makes no network calls at all.
 #
 # status:creds is budgeted from its own probes rather than by copying a
-# neighbour's number: it makes NO network call (that is why it can be here at
-# all — status:gh already spends this startup's only auth round trip), and runs
-# three LOCAL probes back to back, each bounded at 3s inside status.sh — 9s
-# worst case, so 11 here for the `task` and shell startup around them.
+# neighbour's number: it runs three LOCAL probes back to back, each bounded at
+# 3s inside status.sh, plus ONE bounded 3s call to read the gh token's SCOPES
+# (a server-side property no local file records — issue #827), which is why it
+# is capped at the local bound rather than NETWORK_TIMEOUT. 12s worst case, so
+# 13 here for the `task` and shell startup around them.
 #
 # There is a SECOND deadline above all of these: the `timeout` on the
 # SessionStart entries in claude-settings.json, which Claude Code applies to this
 # whole script. Overrunning it is worse than any single section overrunning its
 # own bound — the hook is killed before `jq` emits anything, so the entire
 # payload is lost rather than one section of it. The sections are therefore run
-# in PARALLEL: the hook's wall clock is then the LONGEST deadline (12s), which
+# in PARALLEL: the hook's wall clock is then the LONGEST deadline (13s), which
 # fits inside that outer timeout, where the sum (25s) would not.
 git_out="$(mktemp)"
 gh_out="$(mktemp)"
@@ -45,7 +46,7 @@ timeout 5 task status:git >"$git_out" 2>/dev/null &
 git_pid=$!
 timeout 12 task status:gh >"$gh_out" 2>/dev/null &
 gh_pid=$!
-timeout 11 task status:creds >"$creds_out" 2>/dev/null &
+timeout 13 task status:creds >"$creds_out" 2>/dev/null &
 creds_pid=$!
 
 # `wait` on each, with the failure recorded rather than propagated: `set -e`

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -56,6 +56,19 @@ git config --file "$ENV_GITCONFIG" user.email "${DEVCONTAINER_GIT_EMAIL}"
 #
 # $1 is an extra command for the login path (the git bridge), omitted where
 # VS Code already manages git's credential.
+# The scope list the login line below asks for comes from scripts/gh-scopes.sh,
+# the same file status.sh and setup-gh-scopes.sh read, so the banner cannot
+# drift from what the session-start check demands (issue #827). Sourced
+# defensively: this script also runs in trees where the workspace folder is not
+# yet the repo root, and a missing helper must not fail the whole post-create.
+GH_SCOPES_LIB="${GH_SCOPES_LIB:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)/scripts/gh-scopes.sh}"
+if [ -r "${GH_SCOPES_LIB}" ]; then
+    # shellcheck source=scripts/gh-scopes.sh
+    . "${GH_SCOPES_LIB}"
+else
+    gh_scopes_request_list() { printf '%s' "repo,workflow,project,read:project"; }
+fi
+
 gh_auth_help() {
     echo "=============================================================="
     echo "  GitHub CLI is NOT authenticated — gh pr / gh api and the"
@@ -65,7 +78,10 @@ gh_auth_help() {
         echo "  This profile authenticates as you. Log in:"
         echo ""
         echo "    gh auth login --hostname github.com --git-protocol https \\"
-        echo "      --web --scopes \"workflow,project\""
+        echo "      --web --scopes \"$(gh_scopes_request_list)\""
+        echo ""
+        echo "  In an existing checkout, 'task setup:gh-scopes' does the same"
+        echo "  from the repo and verifies the scopes landed."
         if [ -n "${1:-}" ]; then
             echo "    $1"
         fi

--- a/.devcontainer/scripts/post-create-common.sh
+++ b/.devcontainer/scripts/post-create-common.sh
@@ -80,8 +80,9 @@ gh_auth_help() {
         echo "    gh auth login --hostname github.com --git-protocol https \\"
         echo "      --web --scopes \"$(gh_scopes_request_list)\""
         echo ""
-        echo "  In an existing checkout, 'task setup:gh-scopes' does the same"
-        echo "  from the repo and verifies the scopes landed."
+        echo "  Then, in the checkout, 'task setup:gh-scopes' verifies the"
+        echo "  scopes landed and adds any this repo needs. (It refreshes an"
+        echo "  EXISTING login — it cannot replace the command above.)"
         if [ -n "${1:-}" ]; then
             echo "    $1"
         fi

--- a/README.md
+++ b/README.md
@@ -189,5 +189,5 @@ and canonical AGENTS.md. Projects generated from v2 should be re-templated
 | `task install` | Brewfile deps + lefthook hooks |
 | `task release:patch` | Tag + GitHub release (also `:minor`/`:major`) |
 | `task status` | Project dashboard (also `status:git`/`:gh`/`:creds`/`:code`/`:env`) |
-| `task status:creds` | Local credential logins (gh, Codex, Claude Code) — local probes, no network; also run at session start |
+| `task status:creds` | Credential logins (gh, Codex, Claude Code) + the gh token's scopes — local probes plus one bounded 3s scope check (`STATUS_NO_NETWORK=1` skips it); also run at session start |
 | `task status:setup` | Setup audit: local credentials, GitHub config, toolchain, devcontainer, dev env |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -691,9 +691,18 @@ tasks:
           echo "Skipping private vulnerability reporting ({{.REPO}} is private; public-repo-only feature)."
         fi
   setup:github-project:
-    desc: Idempotently create/sync the owner's GitHub Project V2 board + Status pipeline (on a personal account also its metadata fields). Requires `gh auth refresh -s project`.
+    desc: Idempotently create/sync the owner's GitHub Project V2 board + Status pipeline (on a personal account also its metadata fields). Requires the Projects scopes — `task setup:gh-scopes`.
     cmds:
       - ./scripts/setup-github-project.sh --owner "evanharmon1" --title "evanharmon1 Project"
+
+  setup:gh-scopes:
+    desc: >-
+      OPERATOR / DEV PROFILE ONLY: refresh your interactive gh login so it
+      carries every scope this repo needs (refuses against a GH_TOKEN env
+      credential and without a TTY; verifies the grant landed). Bot containers
+      must reissue GH_TOKEN instead.
+    cmds:
+      - ./scripts/setup-gh-scopes.sh
 
   setup:github-labels:
     desc: Idempotently create/update this repo's starter labels (see docs/project-management.md). Requires `gh` with repo write.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -817,7 +817,7 @@ tasks:
       - ./scripts/status.sh gh
 
   status:creds:
-    desc: Local credential section (gh, Codex, Claude Code logins — local probes, no network)
+    desc: Credential section (gh, Codex, Claude Code logins + gh token scopes — local probes plus one bounded scope check; STATUS_NO_NETWORK=1 skips it)
     cmds:
       - ./scripts/status.sh creds
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -84,6 +84,7 @@ tasks:
       - task: test:tasks
       - task: test:ci-results
       - task: test:status
+      - task: test:gh-scopes
       - task: test:meta-install
       - task: test:copier-validators
       - task: test:renovate-pins
@@ -394,6 +395,11 @@ tasks:
     desc: Unit-test the status board-writes + local-credential checks (stubbed CLIs, no network)
     cmds:
       - ./scripts/test-status.sh
+
+  test:gh-scopes:
+    desc: Unit-test the gh scope refresh task's refusals and post-refresh verification (stubbed gh, no network)
+    cmds:
+      - ./scripts/test-setup-gh-scopes.sh
 
   test:meta-install:
     desc: Unit-test the .meta sidecar installer's ~-expansion and refusals

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -322,9 +322,16 @@ you log in as yourself:
 
 ```sh
 gh auth login --hostname github.com --git-protocol https \
-  --web --scopes "workflow,project"
+  --web --scopes "$(. scripts/gh-scopes.sh && gh_scopes_request_list)"
 gh auth setup-git
 ```
+
+The scope list is **derived**, not typed: `scripts/gh-scopes.sh` is the single
+source this repo's session-start check and `task setup:gh-scopes` read, so the
+login above asks for exactly what the check demands — including profile-specific
+additions such as `admin:org` in an organization repo. Outside a checkout, use
+the literal `--scopes "workflow,project"` and then run `task setup:gh-scopes`
+once you have cloned, which adds anything missing and verifies it landed.
 
 `--scopes` is *additive* to gh's defaults (`repo`, `read:org`, `gist`). `project`
 is what Projects V2 writes need — without it `task status:gh` reports the board

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -322,7 +322,7 @@ you log in as yourself:
 
 ```sh
 gh auth login --hostname github.com --git-protocol https \
-  --web --scopes "$(. scripts/gh-scopes.sh && gh_scopes_request_list)"
+  --web --scopes "$(bash -c '. scripts/gh-scopes.sh && gh_scopes_request_list')"
 gh auth setup-git
 ```
 

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -77,6 +77,12 @@ Whitespace separates requirements; `|` joins alternatives that each satisfy one
 requirement. `gh auth refresh` is asked for *every* alternative, which is why
 the raw command above lists both Projects scopes.
 
+The Projects requirement is itself conditional: it applies only where
+`scripts/setup-github-project.sh` exists — the same marker the board-write
+check uses, and the same reason. `project_management` defaults to `none`, and a
+repo generated that way has no board, so demanding Projects access there would
+warn every session about a grant the repo never uses.
+
 ### Where it surfaces
 
 `task status:creds` — which the session-start hook runs every session — warns

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -53,14 +53,19 @@ a hardcoded copy silently goes stale the moment the list changes (an org repo,
 for instance, also needs `admin:org`):
 
 ```sh
-gh auth refresh -s "$(. scripts/gh-scopes.sh && gh_scopes_request_list)"
+gh auth refresh -s "$(bash -c '. scripts/gh-scopes.sh && gh_scopes_request_list')"
 ```
 
 To just see what this repo asks for:
 
 ```sh
-. scripts/gh-scopes.sh && gh_scopes_request_list
+bash -c '. scripts/gh-scopes.sh && gh_scopes_request_list'
 ```
+
+(Through `bash` on purpose: the helper resolves its own location via
+`BASH_SOURCE`, and the devcontainer's default shell is zsh, where sourcing it
+directly would resolve the repo root to the wrong directory and silently shrink
+the list.)
 
 Check what a token actually carries:
 
@@ -73,13 +78,19 @@ gh auth status | grep 'Token scopes'
 One file: [`scripts/gh-scopes.sh`](../scripts/gh-scopes.sh). `status.sh`'s
 session-start check, `setup-gh-scopes.sh`, and the devcontainer's
 `gh_auth_help` banner all read it, so the remedy a warning prints and the
-scopes the task requests cannot drift apart. A repo that needs more extends the
-list **without editing the file** by exporting `GH_REQUIRED_SCOPES` (e.g. from
+scopes the task requests cannot drift apart. A repo that needs more adds to the
+list **without editing the file** by exporting `GH_EXTRA_SCOPES` (e.g. from
 `.envrc`):
 
 ```sh
-export GH_REQUIRED_SCOPES="repo workflow project|read:project admin:org"
+export GH_EXTRA_SCOPES="delete_repo"
 ```
+
+That is **additive**: everything this repo's profile already requires keeps
+applying, including anything a later template update introduces.
+`GH_REQUIRED_SCOPES` also exists and **replaces** the computed list outright —
+an escape hatch, and one that freezes today's defaults, so a requirement added
+upstream silently stops being checked. Prefer `GH_EXTRA_SCOPES`.
 
 Whitespace separates requirements; `|` joins alternatives that each satisfy one
 requirement. `gh auth refresh` is asked for *every* alternative, which is why

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -48,10 +48,18 @@ A bot container is the one place this task is the wrong answer: there the
 credential is `GH_TOKEN`, reissued at its source. See
 [bot-account.md](guides/bot-account.md).
 
-The raw equivalent, for a shell that is not in a checkout yet:
+The raw equivalent, derived from the same list rather than copied out of it —
+a hardcoded copy silently goes stale the moment the list changes (an org repo,
+for instance, also needs `admin:org`):
 
 ```sh
-gh auth refresh -s repo,workflow,project,read:project
+gh auth refresh -s "$(. scripts/gh-scopes.sh && gh_scopes_request_list)"
+```
+
+To just see what this repo asks for:
+
+```sh
+. scripts/gh-scopes.sh && gh_scopes_request_list
 ```
 
 Check what a token actually carries:

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -27,11 +27,31 @@ board writes that do nothing.
 | `read:project` | read Projects | reading a card's current `Status`; **no writes** |
 | `project` | read **and write** Projects | everything on this page |
 
-Ask for the full scope. It is a superset, so there is no reason to request
-`read:project` alongside it:
+### Getting them: `task setup:gh-scopes`
 
 ```sh
-gh auth refresh -s project
+task setup:gh-scopes
+```
+
+**Operator / dev profile only.** It refreshes *your* interactive `gh` login —
+so it refuses when a `GH_TOKEN`/`GITHUB_TOKEN` env credential is set (an env
+token overrides the stored one, so a refresh would repair something this shell
+never uses — reissue that token at its source instead) and refuses without a
+TTY, because the flow is an interactive browser device-code exchange and no
+agent or CI job should re-mint a human credential. It prints the current
+scopes, requests the missing ones, and then **verifies they actually landed** —
+`gh auth refresh` can exit 0 having granted less than was asked for, and a
+remedy that reports success without checking puts the session straight back
+into the failure it was run to end.
+
+A bot container is the one place this task is the wrong answer: there the
+credential is `GH_TOKEN`, reissued at its source. See
+[bot-account.md](guides/bot-account.md).
+
+The raw equivalent, for a shell that is not in a checkout yet:
+
+```sh
+gh auth refresh -s repo,workflow,project,read:project
 ```
 
 Check what a token actually carries:
@@ -40,15 +60,40 @@ Check what a token actually carries:
 gh auth status | grep 'Token scopes'
 ```
 
-`task status:gh` reports this as **Project board writes**, so a missing scope
-surfaces at session start — before a claim is made against a board that cannot
-receive it. `task setup:github-project` refuses to run without it rather than
-failing partway through its writes.
+### Where the required list lives
+
+One file: [`scripts/gh-scopes.sh`](../scripts/gh-scopes.sh). `status.sh`'s
+session-start check, `setup-gh-scopes.sh`, and the devcontainer's
+`gh_auth_help` banner all read it, so the remedy a warning prints and the
+scopes the task requests cannot drift apart. A repo that needs more extends the
+list **without editing the file** by exporting `GH_REQUIRED_SCOPES` (e.g. from
+`.envrc`):
+
+```sh
+export GH_REQUIRED_SCOPES="repo workflow project|read:project admin:org"
+```
+
+Whitespace separates requirements; `|` joins alternatives that each satisfy one
+requirement. `gh auth refresh` is asked for *every* alternative, which is why
+the raw command above lists both Projects scopes.
+
+### Where it surfaces
+
+`task status:creds` — which the session-start hook runs every session — warns
+when the token is missing anything on that list, names the missing scopes, and
+prints the remedy. It is silent when the list is satisfied, read-only,
+non-fatal, and bounded (one 3s probe; `STATUS_NO_NETWORK=1` skips it). A probe
+that cannot answer reports nothing rather than accusing a working credential.
+
+`task status:gh` additionally reports **Project board writes**, which is a
+narrower question: `read:project` satisfies the session-start check but is
+read-only, so it fails that one. `task setup:github-project` refuses to run
+without `project` rather than failing partway through its writes.
 
 Two adjacent scopes, for completeness: an organization's **issue types** need
 `admin:org` (reported by `task status:setup`), and the vendored claim skills
-hint at `gh auth refresh -s read:project,project` — equivalent for this purpose,
-since `project` alone already covers it.
+hint at `gh auth refresh -s read:project,project` — a subset of what
+`setup:gh-scopes` requests, so a credential minted by the task satisfies it.
 
 ### Scopes are only half the story
 

--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -525,6 +525,14 @@ assert_unit() {
     sed -n '/^gh_auth_help()/,/^}/p' "$post_create_common" >"$helper_src"
     [ -s "$helper_src" ] || fail "could not extract gh_auth_help() from ${post_create_common}"
 
+    # The banner asks scripts/gh-scopes.sh for the scope list (the single
+    # source shared with status.sh and setup:gh-scopes), and the extraction
+    # above takes the function body ALONE. Without the library, the call
+    # resolves to nothing, the banner renders `--scopes ""`, and a check that
+    # only looked for a login command would pass on a broken banner.
+    local scopes_lib="${repo_root}/scripts/gh-scopes.sh"
+    [ -f "$scopes_lib" ] || fail "scripts/gh-scopes.sh not found at ${scopes_lib}"
+
     # Match a pasteable COMMAND line — `gh` as the first token — not the bare
     # phrase. The token message names `gh auth login` on purpose, in a "do NOT
     # run this here" warning; a substring test would read that warning as the
@@ -533,15 +541,28 @@ assert_unit() {
         printf '%s\n' "$1" | grep -qE '^[[:space:]]*gh[[:space:]]+auth[[:space:]]+login'
     }
 
-    help_out="$(unset DEVCONTAINER_GH_AUTH && "$bash_bin" -c '. "$1"; gh_auth_help "gh auth setup-git"' _ "$helper_src")"
+    help_out="$(unset DEVCONTAINER_GH_AUTH && "$bash_bin" -c '. "$2"; . "$1"; gh_auth_help "gh auth setup-git"' _ "$helper_src" "$scopes_lib")"
     if offers_login "$help_out"; then
         fail "post-create gh guidance offers an operator login by default — a bot container must never be told to run one"
     fi
 
-    help_out="$(DEVCONTAINER_GH_AUTH=login "$bash_bin" -c '. "$1"; gh_auth_help "gh auth setup-git"' _ "$helper_src")"
+    help_out="$(DEVCONTAINER_GH_AUTH=login "$bash_bin" -c '. "$2"; . "$1"; gh_auth_help "gh auth setup-git"' _ "$helper_src" "$scopes_lib")"
     if ! offers_login "$help_out"; then
         fail "post-create gh guidance omits the operator login where the profile declares one"
     fi
+
+    # The login it offers must carry the DERIVED scopes, not an empty or
+    # hardcoded list — that agreement between the banner and the scope check is
+    # the acceptance criterion the single source exists to satisfy (#827).
+    case "$help_out" in
+    *'--scopes ""'*) fail "post-create login line renders an empty scope list — gh-scopes.sh was not in scope" ;;
+    esac
+    for required_scope in repo workflow; do
+        case "$help_out" in
+        *"${required_scope}"*) ;;
+        *) fail "post-create login line omits the '${required_scope}' scope: ${help_out}" ;;
+        esac
+    done
 
     # 10. Static devcontainer.json invariants via the devcontainers CLI.
     assert_config_invariants "$repo_root" "$bot_config" bot

--- a/scripts/gh-scopes.sh
+++ b/scripts/gh-scopes.sh
@@ -146,6 +146,39 @@ gh_scopes_missing() {
     printf '%s' "${out}"
 }
 
+# gh_scopes_missing_requested SCOPE_LINE — the scopes that were REQUESTED but
+# are not present, whitespace-separated.
+#
+# Distinct from gh_scopes_missing, and both are needed. The status check asks
+# "was this credential minted with the right access in mind", and there the
+# `project|read:project` alternation is right — either proves it. A refresh
+# cannot use that question: `gh auth refresh` was handed every alternative, so
+# a grant that came back with only `read:project` satisfies the alternation
+# while board WRITES still fail, and reporting "all required scopes present"
+# there would leave the operator in exactly the failure the task exists to end.
+#
+# One implication is honoured, because GitHub's own scopes nest: `project`
+# (read and write) subsumes `read:project`, so a credential reported with only
+# `project` is not missing the read grant. Kept as a single named pair rather
+# than a general lattice — it is the only nesting this list contains, and an
+# implication table nobody can enumerate would be worse than none.
+gh_scopes_missing_requested() {
+    local line="$1" scope out=""
+    for scope in $(gh_scopes__alternatives "$(gh_scopes_request_list | tr ',' ' ')"); do
+        case "${line}" in
+        *"'${scope}'"*) continue ;;
+        esac
+        # `project` implies `read:project`.
+        if [ "${scope}" = "read:project" ]; then
+            case "${line}" in
+            *"'project'"*) continue ;;
+            esac
+        fi
+        out="${out:+${out} }${scope}"
+    done
+    printf '%s' "${out}"
+}
+
 # gh_scopes_human "req req…" — render requirements for a human: the `|`
 # alternation becomes " or ", and requirements are comma-separated.
 gh_scopes_human() {

--- a/scripts/gh-scopes.sh
+++ b/scripts/gh-scopes.sh
@@ -25,15 +25,77 @@
 # Why these four:
 #   repo      — the PR/issue surface the Dev Loop runs on
 #   workflow  — pushing branches that touch .github/workflows/
-#   project   — the claim lifecycle's board writes (read:project alone is
-#               read-only; status.sh reports that distinction separately)
+#   project   — the claim lifecycle's board writes, and ONLY in a repo that has
+#               board tooling (read:project alone is read-only; status.sh
+#               reports that distinction separately) — see gh_scopes_default
 #
 # Deliberately NOT a check of what the token can do — scopes are a server-side
 # property of the credential and this file only names what to compare against.
 
 # shellcheck shell=bash
 
-GH_REQUIRED_SCOPES="${GH_REQUIRED_SCOPES:-repo workflow project|read:project}"
+# The repo root these helpers answer for. Resolved from this file's own
+# location, not the caller's cwd, because the devcontainer banner sources it
+# from a lifecycle script whose working directory is not guaranteed.
+GH_SCOPES_ROOT="${GH_SCOPES_ROOT:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+# gh_target_host — the host gh will actually use for THIS repository.
+#
+# Lives here rather than in status.sh because scopes are a property of a
+# credential ON A HOST: "which scopes" is only answerable once "whose token" is,
+# and two copies of this resolution would let the check and the remedy disagree
+# about which credential they mean.
+#
+# Narrowing to github.com would disown a valid Enterprise login (`gh auth login
+# --hostname ghe.example.com`, no GH_HOST exported). So resolve it the way gh
+# documents: GH_HOST is the override for when a host "cannot be determined from
+# repository context", which means repository context comes first when GH_HOST
+# is unset. Local and network-free — the remote URL is the context.
+gh_target_host() {
+    local url host=""
+    if [ -n "${GH_HOST:-}" ]; then
+        printf '%s' "${GH_HOST}"
+        return 0
+    fi
+    url="$(git config --get remote.origin.url 2>/dev/null || true)"
+    case "${url}" in
+    *://*)                 # scheme://[user@]host[:port]/path
+        host="${url#*://}" # drop the scheme
+        host="${host#*@}"  # drop any userinfo
+        host="${host%%/*}" # drop the path
+        host="${host%%:*}" # drop any port
+        ;;
+    *@*:*) # scp-like: user@host:owner/repo
+        host="${url#*@}"
+        host="${host%%:*}"
+        ;;
+    esac
+    printf '%s' "${host:-github.com}"
+}
+
+# gh_scopes_default — the required list for THIS repo's actual feature set.
+#
+# `repo` and `workflow` are unconditional: every generated repo opens PRs and
+# has a .github/workflows/ a push may touch.
+#
+# The Projects scopes are NOT. `project_management` defaults to `none`, and a
+# repo generated that way has no board to write to — demanding Projects access
+# there would warn every session, in the majority profile, about a grant the
+# repo never uses, and train the reader to ignore the line where it matters.
+# So it is gated on the same marker the board-write check in status.sh uses:
+# setup-github-project.sh is rendered only for `project_management: github`,
+# which makes its presence the proxy for "this repo is configured to have a
+# board". Same accepted cost, recorded there: a repo on `none` whose issues
+# someone adds to a board by hand learns from the claim's own exit 2 instead.
+gh_scopes_default() {
+    local list="repo workflow"
+    if [ -f "${GH_SCOPES_ROOT}/scripts/setup-github-project.sh" ]; then
+        list="${list} project|read:project"
+    fi
+    printf '%s' "${list}"
+}
+
+GH_REQUIRED_SCOPES="${GH_REQUIRED_SCOPES:-$(gh_scopes_default)}"
 
 # gh_scopes_request_list — the comma-separated list to hand
 # `gh auth login --scopes` / `gh auth refresh -s`.

--- a/scripts/gh-scopes.sh
+++ b/scripts/gh-scopes.sh
@@ -87,10 +87,21 @@ gh_target_host() {
 # which makes its presence the proxy for "this repo is configured to have a
 # board". Same accepted cost, recorded there: a repo on `none` whose issues
 # someone adds to a board by hand learns from the claim's own exit 2 instead.
+#
+# `admin:org` rides on the same rule. The template renders
+# setup-github-issue-types.sh (and setup-github-issue-fields.sh) only when the
+# repo belongs to an ORG rather than the author's own account, and those tasks
+# state they need `admin:org` — so a generated org repo could otherwise pass
+# every scope check here and still fail those setups. A personal-account repo
+# renders neither script and is never asked for it.
 gh_scopes_default() {
     local list="repo workflow"
     if [ -f "${GH_SCOPES_ROOT}/scripts/setup-github-project.sh" ]; then
         list="${list} project|read:project"
+    fi
+    if [ -f "${GH_SCOPES_ROOT}/scripts/setup-github-issue-types.sh" ] ||
+        [ -f "${GH_SCOPES_ROOT}/scripts/setup-github-issue-fields.sh" ]; then
+        list="${list} admin:org"
     fi
     printf '%s' "${list}"
 }

--- a/scripts/gh-scopes.sh
+++ b/scripts/gh-scopes.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# gh-scopes.sh — the single source of truth for the GitHub token scopes this
+# repository's tooling needs.
+#
+# SOURCED, never executed. Three consumers read it so the required list is
+# stated once instead of drifting into three near-copies:
+#
+#   * scripts/status.sh          — warns at session start when a scope is missing
+#   * scripts/setup-gh-scopes.sh — mints/refreshes a credential that has them all
+#   * .devcontainer/scripts/post-create-common.sh — the gh_auth_help banner's
+#     `gh auth login --scopes` line
+#
+# A consumer repo extends the list WITHOUT editing this file by exporting
+# GH_REQUIRED_SCOPES before invoking any of the above (e.g. in .envrc):
+#
+#     export GH_REQUIRED_SCOPES="repo workflow project|read:project admin:org"
+#
+# Syntax: whitespace-separated requirements. A requirement is one scope name,
+# or several joined by `|` meaning "any one of these satisfies it". The
+# alternation exists because `project` and `read:project` are separate grants
+# that GitHub reports separately, and either one proves the token was minted
+# with Projects access in mind — while `gh auth refresh` is asked for BOTH, so
+# that the credential this repo mints can also write the board.
+#
+# Why these four:
+#   repo      — the PR/issue surface the Dev Loop runs on
+#   workflow  — pushing branches that touch .github/workflows/
+#   project   — the claim lifecycle's board writes (read:project alone is
+#               read-only; status.sh reports that distinction separately)
+#
+# Deliberately NOT a check of what the token can do — scopes are a server-side
+# property of the credential and this file only names what to compare against.
+
+# shellcheck shell=bash
+
+GH_REQUIRED_SCOPES="${GH_REQUIRED_SCOPES:-repo workflow project|read:project}"
+
+# gh_scopes_request_list — the comma-separated list to hand
+# `gh auth login --scopes` / `gh auth refresh -s`.
+#
+# Every alternative of every requirement is requested, not just one: asking for
+# `project` alone would satisfy the check while leaving the vendored track-work
+# skill's `read:project` hint unmet, and the two remedy strings that used to
+# disagree (issue #596) are exactly what one derived list removes.
+gh_scopes_request_list() {
+    local req alt out=""
+    for req in $(gh_scopes__words "${GH_REQUIRED_SCOPES}"); do
+        for alt in $(gh_scopes__alternatives "${req}"); do
+            case ",${out}," in *",${alt},"*) continue ;; esac
+            out="${out:+${out},}${alt}"
+        done
+    done
+    printf '%s' "${out}"
+}
+
+# gh_scopes_missing SCOPE_LINE — print the requirements SCOPE_LINE does not
+# satisfy, whitespace-separated; print nothing when it satisfies them all.
+#
+# SCOPE_LINE is the `Token scopes:` line of `gh auth status`, whose scopes are
+# quoted (`… 'gist', 'project', 'repo'`). Matching on the quotes is what keeps
+# `project` from also matching `read:project` and vice versa — they are
+# different grants, and the alternation above is how a caller says either will
+# do.
+#
+# A line with no quoted scopes at all is a fine-grained PAT or an App
+# installation token, which carries permissions rather than OAuth scopes. That
+# is NOT a missing-scope condition and callers must classify it as unknown —
+# this function reports every requirement as missing for such a line, so guard
+# the call, as status.sh does.
+gh_scopes_missing() {
+    local line="$1" req alt satisfied out=""
+    for req in $(gh_scopes__words "${GH_REQUIRED_SCOPES}"); do
+        satisfied=false
+        for alt in $(gh_scopes__alternatives "${req}"); do
+            case "${line}" in
+            *"'${alt}'"*)
+                satisfied=true
+                break
+                ;;
+            esac
+        done
+        [ "${satisfied}" = true ] || out="${out:+${out} }${req}"
+    done
+    printf '%s' "${out}"
+}
+
+# gh_scopes_human "req req…" — render requirements for a human: the `|`
+# alternation becomes " or ", and requirements are comma-separated.
+gh_scopes_human() {
+    local req out=""
+    for req in $(gh_scopes__words "$1"); do
+        out="${out:+${out}, }$(printf '%s' "${req}" | sed 's/|/ or /g')"
+    done
+    printf '%s' "${out}"
+}
+
+# Internal splitters. Word-splitting is the intent here, so it happens in one
+# named place with the shellcheck waiver attached to it rather than at four
+# call sites.
+gh_scopes__words() {
+    # shellcheck disable=SC2086 # deliberate: the list is whitespace-separated
+    printf '%s\n' $1
+}
+
+gh_scopes__alternatives() {
+    printf '%s' "$1" | tr '|' ' '
+}

--- a/scripts/gh-scopes.sh
+++ b/scripts/gh-scopes.sh
@@ -10,10 +10,15 @@
 #   * .devcontainer/scripts/post-create-common.sh — the gh_auth_help banner's
 #     `gh auth login --scopes` line
 #
-# A consumer repo extends the list WITHOUT editing this file by exporting
-# GH_REQUIRED_SCOPES before invoking any of the above (e.g. in .envrc):
+# A consumer repo adds its own requirements WITHOUT editing this file by
+# exporting GH_EXTRA_SCOPES before invoking any of the above (e.g. in .envrc):
 #
-#     export GH_REQUIRED_SCOPES="repo workflow project|read:project admin:org"
+#     export GH_EXTRA_SCOPES="delete_repo"
+#
+# That is ADDITIVE — the repo's own requirements keep applying, including any a
+# later template update introduces. GH_REQUIRED_SCOPES also exists and REPLACES
+# the computed list outright; it is the escape hatch, and it freezes today's
+# defaults.
 #
 # Syntax: whitespace-separated requirements. A requirement is one scope name,
 # or several joined by `|` meaning "any one of these satisfies it". The
@@ -106,7 +111,17 @@ gh_scopes_default() {
     printf '%s' "${list}"
 }
 
-GH_REQUIRED_SCOPES="${GH_REQUIRED_SCOPES:-$(gh_scopes_default)}"
+# Two knobs, because "extend" and "replace" are different intentions and only
+# one of them is safe to reach for by default:
+#
+#   GH_EXTRA_SCOPES     — ADDED to whatever this repo's profile already
+#                         requires. The one to use: a later template update
+#                         that adds a requirement still reaches you.
+#   GH_REQUIRED_SCOPES  — REPLACES the computed list outright. An escape
+#                         hatch. Setting it freezes today's defaults, so a
+#                         requirement added upstream will silently stop being
+#                         checked.
+GH_REQUIRED_SCOPES="${GH_REQUIRED_SCOPES:-$(gh_scopes_default)${GH_EXTRA_SCOPES:+ ${GH_EXTRA_SCOPES}}}"
 
 # gh_scopes_request_list — the comma-separated list to hand
 # `gh auth login --scopes` / `gh auth refresh -s`.

--- a/scripts/setup-gh-scopes.sh
+++ b/scripts/setup-gh-scopes.sh
@@ -55,15 +55,43 @@ if [ ! -t 0 ] || [ ! -t 1 ]; then
   re-mint the operator's credential."
 fi
 
-HOSTNAME_ARG="${GH_HOST:-github.com}"
+# The host comes from the repository, exactly as status.sh derives it — not a
+# github.com assumption. In an Enterprise checkout with no GH_HOST, status.sh
+# warns about the ghe.example.com credential and names this task; refreshing
+# github.com here would edit an unrelated credential and leave the one the
+# warning was about still under-scoped.
+HOSTNAME_ARG="$(gh_target_host)"
 REQUEST_LIST="$(gh_scopes_request_list)"
+
+# gh_auth_status_active — `gh auth status` narrowed to the ONE credential this
+# task refreshes. `gh auth refresh` updates only the ACTIVE account, while a
+# bare `--hostname` read reports every account on that host: concatenating
+# those scope lines lets one account's grants satisfy a requirement the
+# refreshed account still lacks, and the verification below would report a
+# success that did not happen. Same narrowing, and the same pre-2.40 fallback,
+# that status.sh uses.
+gh_auth_status_active() {
+    local out rc=0
+    out="$(gh auth status --active --hostname "${HOSTNAME_ARG}" 2>&1)" || rc=$?
+    case "${out}" in
+    *"unknown flag"*)
+        # gh predates --active (2.40). Multi-account per host arrived WITH
+        # 2.40, so on a gh this old one host means one account and the
+        # narrowing is already complete.
+        rc=0
+        out="$(gh auth status --hostname "${HOSTNAME_ARG}" 2>&1)" || rc=$?
+        ;;
+    esac
+    printf '%s\n' "${out}"
+    return "${rc}"
+}
 
 # `gh auth status` is the only place scopes are readable — they are a
 # server-side property of the token, not something stored locally. Captured
 # with 2>&1 because gh has moved this report between stdout and stderr across
 # versions; only the scope LINE is ever printed back.
 scopes_before=""
-if status_out="$(gh auth status --hostname "${HOSTNAME_ARG}" 2>&1)"; then
+if status_out="$(gh_auth_status_active)"; then
     scopes_before="$(printf '%s\n' "${status_out}" |
         grep -i 'token scopes:' || true)"
 else
@@ -83,7 +111,7 @@ gh auth refresh --hostname "${HOSTNAME_ARG}" -s "${REQUEST_LIST}"
 #    than was asked for — a browser flow the operator edited, an org that
 #    restricts the scope. Reporting success off the exit code alone would put
 #    the session right back into the failure this task exists to end.
-verify_out="$(gh auth status --hostname "${HOSTNAME_ARG}" 2>&1)" ||
+verify_out="$(gh_auth_status_active)" ||
     die "post-refresh 'gh auth status' failed — the credential may be broken."
 scopes_after="$(printf '%s\n' "${verify_out}" | grep -i 'token scopes:' || true)"
 

--- a/scripts/setup-gh-scopes.sh
+++ b/scripts/setup-gh-scopes.sh
@@ -119,6 +119,29 @@ else
   gh auth login --hostname ${HOSTNAME_ARG} --git-protocol https --web --scopes \"${REQUEST_LIST}\""
 fi
 
+# 3. Refuse a stored NON-OAuth credential before touching it. A fine-grained
+#    PAT or a GitHub App installation token carries permissions, not OAuth
+#    scopes, and gh reports its scope line with nothing quoted in it. Running
+#    `gh auth refresh` against one completes a device flow and STORES A NEW
+#    CLASSIC TOKEN — silently replacing a deliberately narrow credential with a
+#    broad one, and then reporting success. That is the opposite of the
+#    source-side remedy documented in docs/project-management.md.
+#
+#    Only the definite case is refused: a scope line that is present and has no
+#    quoted scopes in it. A missing line entirely is unknown (an older gh, a
+#    changed output format), and refusing on unknown would block a legitimate
+#    OAuth user from the one command that fixes their token.
+case "${scopes_before}" in
+"") ;;    # no scope line at all — unknown, not proof of a non-OAuth token
+*"'"*) ;; # quoted scopes present — a classic OAuth credential, proceed
+*)
+    die "the stored credential for ${HOSTNAME_ARG} reports no OAuth scopes — it is a
+  fine-grained PAT or a GitHub App token, which carries permissions rather than
+  scopes. 'gh auth refresh' would replace it with a broad classic token instead
+  of fixing it. Grant the matching permission where that token was issued."
+    ;;
+esac
+
 echo "==> Host:            ${HOSTNAME_ARG}"
 echo "==> Current scopes:  ${scopes_before:-<none reported>}"
 echo "==> Required:        $(gh_scopes_human "${GH_REQUIRED_SCOPES}")"

--- a/scripts/setup-gh-scopes.sh
+++ b/scripts/setup-gh-scopes.sh
@@ -147,7 +147,10 @@ case "${scopes_after}" in
     ;;
 esac
 
-missing="$(gh_scopes_missing "${scopes_after}")"
+# Every REQUESTED scope, not merely the required alternation: the refresh was
+# handed both Projects scopes, and coming back with only the read one leaves
+# board writes broken while satisfying `project|read:project`.
+missing="$(gh_scopes_missing_requested "${scopes_after}")"
 if [ -n "${missing}" ]; then
     die "the refresh did not grant: $(gh_scopes_human "${missing}").
   Re-run and approve every scope, or check whether the organization restricts
@@ -155,4 +158,4 @@ if [ -n "${missing}" ]; then
 fi
 
 echo ""
-echo "All required scopes present: $(gh_scopes_human "${GH_REQUIRED_SCOPES}")"
+echo "All requested scopes present: $(gh_scopes_request_list)"

--- a/scripts/setup-gh-scopes.sh
+++ b/scripts/setup-gh-scopes.sh
@@ -35,14 +35,35 @@ die() {
 
 command -v gh >/dev/null 2>&1 || die "gh is not installed (brew install gh)"
 
-# 1. Env-token refusal. Checked before anything else and named individually,
-#    because the fix differs per variable and a generic message sends the
-#    reader looking for the wrong one.
-for var in GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN; do
+# 1. Env-token refusal, for the token family gh actually uses on THIS host.
+#
+#    The four variables are not interchangeable: gh reads GH_TOKEN /
+#    GITHUB_TOKEN for github.com (and ghe.com), and GH_ENTERPRISE_TOKEN /
+#    GITHUB_ENTERPRISE_TOKEN for a GitHub Enterprise Server host. Refusing on
+#    any of the four blocked a legitimate dual-host workflow — an exported
+#    GH_ENTERPRISE_TOKEN for a GHES account stopped a github.com refresh that
+#    it does not override, and vice versa.
+#
+#    Where the variable DOES apply, the refusal stands: an env token overrides
+#    the stored credential, so `gh auth refresh` would repair something this
+#    shell never uses — and in a bot container it is the credential escalation
+#    ADR 0004 exists to prevent.
+#
+#    Resolved before the TTY check because the host is needed either way, and
+#    named individually because the fix differs per variable.
+HOSTNAME_ARG="$(gh_target_host)"
+
+case "${HOSTNAME_ARG}" in
+github.com | *.ghe.com) env_token_vars="GH_TOKEN GITHUB_TOKEN" ;;
+*) env_token_vars="GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN" ;;
+esac
+
+for var in ${env_token_vars}; do
     if [ -n "${!var:-}" ]; then
-        die "${var} is set. An env token overrides the stored credential, so
-  'gh auth refresh' would fix something this shell never uses. Reissue ${var}
-  at its source with: $(gh_scopes_request_list)
+        die "${var} is set, and gh uses it for ${HOSTNAME_ARG}. An env token
+  overrides the stored credential, so 'gh auth refresh' would fix something
+  this shell never uses. Reissue ${var} at its source with the scopes:
+  $(gh_scopes_request_list)
   (In a bot container this is the intended state — see docs/guides/bot-account.md.)"
     fi
 done
@@ -55,12 +76,11 @@ if [ ! -t 0 ] || [ ! -t 1 ]; then
   re-mint the operator's credential."
 fi
 
-# The host comes from the repository, exactly as status.sh derives it — not a
-# github.com assumption. In an Enterprise checkout with no GH_HOST, status.sh
-# warns about the ghe.example.com credential and names this task; refreshing
-# github.com here would edit an unrelated credential and leave the one the
-# warning was about still under-scoped.
-HOSTNAME_ARG="$(gh_target_host)"
+# HOSTNAME_ARG is resolved above, from the repository exactly as status.sh
+# derives it — not a github.com assumption. In an Enterprise checkout with no
+# GH_HOST, status.sh warns about the ghe.example.com credential and names this
+# task; refreshing github.com here would edit an unrelated credential and leave
+# the one the warning was about still under-scoped.
 REQUEST_LIST="$(gh_scopes_request_list)"
 
 # gh_auth_status_active — `gh auth status` narrowed to the ONE credential this

--- a/scripts/setup-gh-scopes.sh
+++ b/scripts/setup-gh-scopes.sh
@@ -148,6 +148,17 @@ echo "==> Required:        $(gh_scopes_human "${GH_REQUIRED_SCOPES}")"
 echo "==> Requesting:      ${REQUEST_LIST}"
 echo ""
 
+# Nothing to do? Say so and stop, WITHOUT opening a browser. `gh auth refresh`
+# is an interactive OAuth flow even when it would change nothing, so an
+# unconditional run makes the documented sequence (log in with the derived
+# scopes, then run this to verify) authenticate twice, and every idempotent
+# re-run repeats it. The docs promise this requests the MISSING scopes; this is
+# that promise kept.
+if [ -z "$(gh_scopes_missing_requested "${scopes_before}")" ]; then
+    echo "Already complete — no refresh needed."
+    exit 0
+fi
+
 gh auth refresh --hostname "${HOSTNAME_ARG}" -s "${REQUEST_LIST}"
 
 # 3. Verify the grant LANDED. `gh auth refresh` can exit 0 having granted less

--- a/scripts/setup-gh-scopes.sh
+++ b/scripts/setup-gh-scopes.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# setup-gh-scopes.sh — give the OPERATOR's interactive gh credential every scope
+# this repo's tooling needs, and prove the grant actually landed.
+#
+# Run via `task setup:gh-scopes`. The required list is not stated here — it
+# comes from scripts/gh-scopes.sh, the one place status.sh, the devcontainer's
+# gh_auth_help banner, and this script all read (issues #827, #596).
+#
+# OPERATOR / DEV PROFILE ONLY. This mints a human credential, so it refuses in
+# the two contexts where doing that would be wrong:
+#
+#   1. An env token (GH_TOKEN / GITHUB_TOKEN and the enterprise variants) is
+#      set. That token OVERRIDES the stored one, so `gh auth refresh` would
+#      quietly repair a credential the current shell will never use — and in a
+#      bot container it is the credential-escalation ADR 0004 exists to
+#      prevent. The remedy there is to reissue the token at its source.
+#   2. There is no TTY. The refresh is a browser device-code flow; an agent or
+#      a CI job cannot complete it, and neither should re-mint the operator's
+#      credential unattended.
+#
+# Read-only until the refresh: it prints the current scopes, then asks gh for
+# the missing ones. Token VALUES are never printed or captured.
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# shellcheck source=scripts/gh-scopes.sh
+. "${REPO_ROOT}/scripts/gh-scopes.sh"
+
+die() {
+    echo "setup:gh-scopes: $*" >&2
+    exit 1
+}
+
+command -v gh >/dev/null 2>&1 || die "gh is not installed (brew install gh)"
+
+# 1. Env-token refusal. Checked before anything else and named individually,
+#    because the fix differs per variable and a generic message sends the
+#    reader looking for the wrong one.
+for var in GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN; do
+    if [ -n "${!var:-}" ]; then
+        die "${var} is set. An env token overrides the stored credential, so
+  'gh auth refresh' would fix something this shell never uses. Reissue ${var}
+  at its source with: $(gh_scopes_request_list)
+  (In a bot container this is the intended state — see docs/guides/bot-account.md.)"
+    fi
+done
+
+# 2. TTY refusal. Both directions are required: the device-code flow prints a
+#    code to be read (stdout) and waits on a keypress (stdin).
+if [ ! -t 0 ] || [ ! -t 1 ]; then
+    die "no TTY. The scope refresh is an interactive browser device-code flow —
+  run 'task setup:gh-scopes' yourself in a terminal. Agents and CI must not
+  re-mint the operator's credential."
+fi
+
+HOSTNAME_ARG="${GH_HOST:-github.com}"
+REQUEST_LIST="$(gh_scopes_request_list)"
+
+# `gh auth status` is the only place scopes are readable — they are a
+# server-side property of the token, not something stored locally. Captured
+# with 2>&1 because gh has moved this report between stdout and stderr across
+# versions; only the scope LINE is ever printed back.
+scopes_before=""
+if status_out="$(gh auth status --hostname "${HOSTNAME_ARG}" 2>&1)"; then
+    scopes_before="$(printf '%s\n' "${status_out}" |
+        grep -i 'token scopes:' || true)"
+else
+    die "not logged in to ${HOSTNAME_ARG}. Run:
+  gh auth login --hostname ${HOSTNAME_ARG} --git-protocol https --web --scopes \"${REQUEST_LIST}\""
+fi
+
+echo "==> Host:            ${HOSTNAME_ARG}"
+echo "==> Current scopes:  ${scopes_before:-<none reported>}"
+echo "==> Required:        $(gh_scopes_human "${GH_REQUIRED_SCOPES}")"
+echo "==> Requesting:      ${REQUEST_LIST}"
+echo ""
+
+gh auth refresh --hostname "${HOSTNAME_ARG}" -s "${REQUEST_LIST}"
+
+# 3. Verify the grant LANDED. `gh auth refresh` can exit 0 having granted less
+#    than was asked for — a browser flow the operator edited, an org that
+#    restricts the scope. Reporting success off the exit code alone would put
+#    the session right back into the failure this task exists to end.
+verify_out="$(gh auth status --hostname "${HOSTNAME_ARG}" 2>&1)" ||
+    die "post-refresh 'gh auth status' failed — the credential may be broken."
+scopes_after="$(printf '%s\n' "${verify_out}" | grep -i 'token scopes:' || true)"
+
+echo ""
+echo "==> New scopes:      ${scopes_after:-<none reported>}"
+
+case "${scopes_after}" in
+*"'"*) ;;
+*)
+    die "no OAuth scopes reported after the refresh. A fine-grained PAT or an
+  App token carries permissions rather than scopes — grant Projects access
+  where that token was issued instead."
+    ;;
+esac
+
+missing="$(gh_scopes_missing "${scopes_after}")"
+if [ -n "${missing}" ]; then
+    die "the refresh did not grant: $(gh_scopes_human "${missing}").
+  Re-run and approve every scope, or check whether the organization restricts
+  them (Settings → Third-party access)."
+fi
+
+echo ""
+echo "All required scopes present: $(gh_scopes_human "${GH_REQUIRED_SCOPES}")"

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -184,40 +184,10 @@ has_scope() {
     esac
 }
 
-# gh_target_host — the host gh will actually use for THIS repository.
-#
-# Narrowing `gh auth status --hostname` is only safe against the same host the
-# repo-aware calls use. Forcing github.com disowns a valid Enterprise login
-# (`gh auth login --hostname ghe.example.com`, no GH_HOST exported): the probe
-# exits non-zero, which this script reads as "not authenticated" and skips the
-# whole GitHub section — while `gh pr list` and `gh run list` would have worked
-# fine against that remote. So resolve it the way gh documents: GH_HOST is the
-# override for when a host "cannot be determined from repository context", which
-# means repository context comes first when GH_HOST is unset.
-#
-# Local and network-free — the remote URL is the context. github.com only as a
-# last resort, when there is no remote to read.
-gh_target_host() {
-    local url host=""
-    if [[ -n "${GH_HOST:-}" ]]; then
-        printf '%s' "${GH_HOST}"
-        return 0
-    fi
-    url="$(git config --get remote.origin.url 2>/dev/null || true)"
-    case "${url}" in
-    *://*)                 # scheme://[user@]host[:port]/path
-        host="${url#*://}" # drop the scheme
-        host="${host#*@}"  # drop any userinfo
-        host="${host%%/*}" # drop the path
-        host="${host%%:*}" # drop any port
-        ;;
-    *@*:*) # scp-like: user@host:owner/repo
-        host="${url#*@}"
-        host="${host%%:*}"
-        ;;
-    esac
-    printf '%s' "${host:-github.com}"
-}
+# gh_target_host is defined in scripts/gh-scopes.sh, sourced above: the host and
+# the required scopes are one question (whose token, carrying what), and two
+# copies of the resolution would let the check and its remedy disagree about
+# which credential they mean.
 
 # ── Parallel data collection ────────────────────────────────────────────────
 
@@ -284,7 +254,11 @@ if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
     esac
 fi
 
-# The token's scope line, and how to give THIS credential Projects write access.
+# The token's scope line, and how to give THIS credential more access. The
+# remedy names the credential SOURCE, never a particular scope: the call sites
+# already say which requirement is unmet, and a remedy that hardcoded "Projects"
+# mis-instructed a reader whose missing scope was `workflow` — or one of a
+# consumer's own GH_REQUIRED_SCOPES additions.
 # Derived once, because every call site below would otherwise guess — and a
 # remedy that cannot work is worse than none. `gh auth refresh` edits only the
 # STORED classic credential: it cannot touch an env-provided token (which
@@ -313,22 +287,22 @@ derive_gh_scope_state() {
     GH_SCOPES_LINE="$(grep -i 'token scopes:' "${file}" 2>/dev/null || true)"
     case "$(<"${file}")" in
     *"(GH_TOKEN)"*)
-        GH_REMEDY="reissue GH_TOKEN with Projects write — an env token overrides gh auth refresh"
+        GH_REMEDY="reissue GH_TOKEN with the missing scopes — an env token overrides gh auth refresh"
         ;;
     *"(GITHUB_TOKEN)"*)
-        GH_REMEDY="reissue GITHUB_TOKEN with Projects write — an env token overrides gh auth refresh"
+        GH_REMEDY="reissue GITHUB_TOKEN with the missing scopes — an env token overrides gh auth refresh"
         ;;
     *"(GH_ENTERPRISE_TOKEN)"*)
-        GH_REMEDY="reissue GH_ENTERPRISE_TOKEN with Projects write — an env token overrides gh auth refresh"
+        GH_REMEDY="reissue GH_ENTERPRISE_TOKEN with the missing scopes — an env token overrides gh auth refresh"
         ;;
     *"(GITHUB_ENTERPRISE_TOKEN)"*)
-        GH_REMEDY="reissue GITHUB_ENTERPRISE_TOKEN with Projects write — an env token overrides gh auth refresh"
+        GH_REMEDY="reissue GITHUB_ENTERPRISE_TOKEN with the missing scopes — an env token overrides gh auth refresh"
         ;;
     *)
         # Not an env token. A scope line with no scopes in it is a fine-grained
         # PAT or an App installation token — a permission, granted at the source.
         if [[ -n "${GH_SCOPES_LINE}" && "${GH_SCOPES_LINE}" != *"'"* ]]; then
-            GH_REMEDY="set its Projects permission where the token was issued"
+            GH_REMEDY="grant the matching permission where the token was issued"
         fi
         ;;
     esac

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -15,6 +15,12 @@ trap 'rm -rf "${TMPDIR_STATUS}"' EXIT
 # Overridable so a test can drive the deadline path without waiting on it.
 NETWORK_TIMEOUT="${NETWORK_TIMEOUT:-5}"
 
+# The required-scope list and its comparison helpers, stated once for this
+# script, setup-gh-scopes.sh, and the devcontainer's gh_auth_help banner.
+# A consumer repo extends it by exporting GH_REQUIRED_SCOPES — see that file.
+# shellcheck source=scripts/gh-scopes.sh
+. "${REPO_ROOT}/scripts/gh-scopes.sh"
+
 # ── Tool detection ──────────────────────────────────────────────────────────
 
 # NO_COLOR (https://no-color.org/) turns off gum styling as well as ANSI, which
@@ -240,10 +246,11 @@ GH_AUTH_PROBED=false
 # read the board, and used to run its own `gh auth status` to decide whether to
 # render at all. One probe, two consumers.
 #
-# Deliberately NOT extended to `SECTION == creds`: that section is invoked on its
-# own from the session-start hook, which already runs `status:gh` in the same
-# startup, and a second `gh auth status` there would be a net-new network call in
-# the one path whose whole budget argument is that it makes none.
+# Deliberately NOT extended to `SECTION == creds`: that section's gh line is a
+# LOCAL read (see render_local_credentials), and turning it into the full
+# validating probe would change what that line is entitled to claim. The scope
+# check issue #827 asks for is added there as its own narrowly-scoped call
+# instead — see render_gh_scope_check.
 if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
     GH_AUTH_PROBED=true
     gh_auth_rc=0
@@ -284,10 +291,27 @@ fi
 # overrides the stored one, on github.com and Enterprise alike) and cannot add a
 # fine-grained or App token's permissions, which are not OAuth scopes at all.
 GH_SCOPES_LINE=""
-GH_REMEDY="run: gh auth refresh -s project"
-if [[ -s "${GH_AUTH_FILE}" ]]; then
-    GH_SCOPES_LINE="$(grep -i 'token scopes:' "${GH_AUTH_FILE}" 2>/dev/null || true)"
-    case "$(<"${GH_AUTH_FILE}")" in
+# The stored-credential remedy names the TASK rather than a raw command: the
+# task refuses against an env token and without a TTY, and verifies the grant
+# actually landed, which a pasted `gh auth refresh` does none of (issue #596).
+# The raw command rides along for a reader who is not in a checkout yet, and is
+# derived from the same required-scope list — the two divergent remedy strings
+# #596 reported were exactly this string drifting from the skills' hint.
+GH_REMEDY_DEFAULT="run: task setup:gh-scopes (or: gh auth refresh -s $(gh_scopes_request_list))"
+GH_REMEDY="${GH_REMEDY_DEFAULT}"
+
+# derive_gh_scope_state FILE — set GH_SCOPES_LINE and GH_REMEDY from a captured
+# `gh auth status` report. A function rather than a straight-line block because
+# there are two probes that can produce one: the shared one below, and the
+# credentials section's own narrow one (render_gh_scope_check). Deriving it
+# twice by hand is how the two remedy strings issue #596 reported came to exist.
+derive_gh_scope_state() {
+    local file="$1"
+    GH_SCOPES_LINE=""
+    GH_REMEDY="${GH_REMEDY_DEFAULT}"
+    [[ -s "${file}" ]] || return 0
+    GH_SCOPES_LINE="$(grep -i 'token scopes:' "${file}" 2>/dev/null || true)"
+    case "$(<"${file}")" in
     *"(GH_TOKEN)"*)
         GH_REMEDY="reissue GH_TOKEN with Projects write — an env token overrides gh auth refresh"
         ;;
@@ -308,7 +332,9 @@ if [[ -s "${GH_AUTH_FILE}" ]]; then
         fi
         ;;
     esac
-fi
+}
+
+derive_gh_scope_state "${GH_AUTH_FILE}"
 
 # `should_show "gh"` as well as the auth flag: the auth probe above now also runs
 # for the setup section, and these two lists are read only by the GitHub section.
@@ -604,6 +630,76 @@ fi
 # Every probe here is bounded by the short LOCAL bound (3s), never by
 # NETWORK_TIMEOUT — nothing in it may reach the network, or the session-start
 # path inherits a cost its budget was not derived for.
+# render_gh_scope_check — one ⚠/unknown line when the authenticated token is
+# missing a scope this repo's tooling needs, and NOTHING when it has them all.
+#
+# Silent-on-success is a deliberate exception to this script's usual
+# report-both-directions rule (issue #827's acceptance criterion). The rule
+# exists so a check that never runs cannot masquerade as a passing one — and
+# here the caller has already printed a ✓ line for the same credential from the
+# same probe, so the evidence that this ran is on screen either way. A second
+# green line on every session start, in every repo, would be pure noise.
+#
+# Read-only and non-fatal: it only compares the scope line the shared probe
+# already captured.
+render_gh_scope_check() {
+    local missing rc=0 file
+    if [[ "${GH_AUTH_PROBED}" != true ]]; then
+        # Standalone `task status:creds` — the session-start path, and the one
+        # #827 is about. Scopes are a SERVER-side property of the token: no
+        # local file records them, so the one fact this check needs cannot be
+        # had without asking. The rest of the section stays local-only; this is
+        # a single bounded, read-only, non-fatal call, and
+        # `STATUS_NO_NETWORK=1` removes even that for offline shells.
+        if [[ "${STATUS_NO_NETWORK:-}" == 1 ]]; then
+            return 0
+        fi
+        file="${TMPDIR_STATUS}/auth-creds.txt"
+        : >"${file}"
+        # ONE call, bounded at the section's short local bound rather than
+        # NETWORK_TIMEOUT. Not because it is local — it is not — but because
+        # the session-start hook budgets this section from the sum of its
+        # probes, and a section that overruns loses ALL of its output
+        # (status.sh buffers before printing). A scope warning that costs the
+        # reader their credential lines is worse than no scope warning. For
+        # the same reason there is no `--active`-unsupported retry here: on a
+        # gh older than 2.40 the check simply does not run.
+        run_timeout 3 gh auth status --active \
+            --hostname "$(gh_target_host)" >"${file}" 2>&1 || rc=$?
+        if [[ "${rc}" -ne 0 ]] || grep -qi 'unknown flag' "${file}" 2>/dev/null; then
+            # A failed probe is NOT a missing login (issues #774, #478) and is
+            # not a missing scope either — say nothing rather than send a
+            # correctly-scoped operator to re-mint a working credential. The
+            # gh line above has already reported the credential itself.
+            return 0
+        fi
+        derive_gh_scope_state "${file}"
+    fi
+    if [[ -z "${GH_SCOPES_LINE}" ]]; then
+        # The probe ran and authenticated, but reported no scope line — an
+        # older gh, or an output change. Unknown, never "missing": telling
+        # someone to re-mint a working credential is the worse error.
+        checkline unknown "gh token scopes" \
+            "could not read token scopes from gh auth status"
+        return
+    fi
+    if [[ "${GH_SCOPES_LINE}" != *"'"* ]]; then
+        # A fine-grained PAT or an App installation token: permissions, not
+        # OAuth scopes. gh reports the line with nothing quoted in it. Such a
+        # token may well carry everything needed, so this is unknown — and the
+        # bot profile's credential is exactly this case, which is why the
+        # remedy here never says "log in" (see GH_REMEDY).
+        checkline unknown "gh token scopes" \
+            "no OAuth scopes reported (fine-grained or App token) — ${GH_REMEDY}"
+        return
+    fi
+    missing="$(gh_scopes_missing "${GH_SCOPES_LINE}")"
+    if [[ -n "${missing}" ]]; then
+        checkline no "gh token scopes" \
+            "missing $(gh_scopes_human "${missing}") — ${GH_REMEDY}"
+    fi
+}
+
 render_local_credentials() {
     # Not-installed is tested FIRST because it makes every other branch
     # meaningless: with no gh on PATH the shared probe above exits 127, which
@@ -625,6 +721,7 @@ render_local_credentials() {
                 "auth probe timed out after ${NETWORK_TIMEOUT}s"
         elif [[ "${GH_AUTHED}" == true ]]; then
             checkline ok "GitHub CLI (gh)" "authenticated to $(gh_target_host)"
+            render_gh_scope_check
         else
             checkline no "GitHub CLI (gh)" "gh auth login"
         fi
@@ -654,6 +751,10 @@ render_local_credentials() {
         0)
             checkline ok "GitHub CLI (gh)" \
                 "credential stored for $(gh_target_host) (not validated)"
+            # Only once a credential is known to exist: asking GitHub about the
+            # scopes of a token that is not there would spend a round trip to
+            # learn what the line above already said.
+            render_gh_scope_check
             ;;
         124) checkline unknown "GitHub CLI (gh)" "credential probe timed out" ;;
         *)

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -602,8 +602,18 @@ fi
 # network-heavy; this group is not, so the reason to exclude it does not apply.
 #
 # Every probe here is bounded by the short LOCAL bound (3s), never by
-# NETWORK_TIMEOUT — nothing in it may reach the network, or the session-start
-# path inherits a cost its budget was not derived for.
+# NETWORK_TIMEOUT — the session-start path must not inherit a cost its budget
+# was not derived for.
+#
+# ONE of them reaches the network: the gh token's SCOPES (render_gh_scope_check
+# below). That is not a local fact — no file on disk records it — and issue
+# #827 needs it at session start, so the section spends exactly one bounded 3s
+# call for it and nothing else. It is capped at the LOCAL bound rather than
+# NETWORK_TIMEOUT for the same budget reason as everything else here: the hook
+# budgets this section from the sum of these bounds (13s, both hook copies),
+# and a section that overruns loses ALL of its buffered output. Set
+# `STATUS_NO_NETWORK=1` to drop that one probe and make the section local-only
+# again. Anything else added here must stay local.
 # render_gh_scope_check — one ⚠/unknown line when the authenticated token is
 # missing a scope this repo's tooling needs, and NOTHING when it has them all.
 #
@@ -614,8 +624,9 @@ fi
 # same probe, so the evidence that this ran is on screen either way. A second
 # green line on every session start, in every repo, would be pure noise.
 #
-# Read-only and non-fatal: it only compares the scope line the shared probe
-# already captured.
+# Read-only and non-fatal. It compares the scope line the shared probe already
+# captured where there is one; standalone (`status:creds`) it makes the single
+# bounded probe described above.
 render_gh_scope_check() {
     local missing rc=0 file
     if [[ "${GH_AUTH_PROBED}" != true ]]; then

--- a/scripts/test-setup-gh-scopes.sh
+++ b/scripts/test-setup-gh-scopes.sh
@@ -21,6 +21,14 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# Scrub every GitHub token variable from this test's own environment before
+# anything runs. The BOT devcontainer profile supplies GH_TOKEN by design, and
+# `task verify` runs there — so an inherited token would trip the env-token
+# refusal in the baseline cases below and fail the suite for a reason that has
+# nothing to do with the code. The explicit env-token cases set what they need,
+# one variable at a time.
+unset GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN GH_HOST
+
 script="./scripts/setup-gh-scopes.sh"
 scopes_lib="./scripts/gh-scopes.sh"
 
@@ -75,6 +83,18 @@ make_stub() {
             echo "        echo \"  - Token scopes: 'repo', 'workflow'\""
             echo "        echo \"  - Token scopes: 'project', 'read:project'\""
             echo '    fi'
+            echo '    exit 0'
+            ;;
+        read-only-grant)
+            # GitHub granted only the READ scope — an org restriction, or an
+            # operator who unticked the write box in the browser.
+            echo "    echo \"  - Token scopes: 'repo', 'workflow', 'read:project'\""
+            echo '    exit 0'
+            ;;
+        write-only-grant)
+            # Only 'project' reported. It subsumes 'read:project', so this must
+            # NOT be reported as a missing scope.
+            echo "    echo \"  - Token scopes: 'repo', 'workflow', 'project'\""
             echo '    exit 0'
             ;;
         logged-out)
@@ -224,7 +244,7 @@ if [ "${PTY_OK}" = true ]; then
     echo "==> succeeds when the refresh lands, naming the scopes"
     out="$(run_sut_pty lands GH_HOST=github.com)"
     case "$out" in
-    *"All required scopes present"*) ;;
+    *"All requested scopes present"*) ;;
     *) fail "expected success after a landed refresh, got: ${out}" ;;
     esac
 
@@ -243,9 +263,28 @@ if [ "${PTY_OK}" = true ]; then
     # host would let an unrelated login satisfy the requirement.
     out="$(run_sut_pty inactive-has-scope GH_HOST=github.com)"
     case "$out" in
-    *"All required scopes present"*) fail "an inactive account's scopes verified the active one: ${out}" ;;
+    *"All requested scopes present"*) fail "an inactive account's scopes verified the active one: ${out}" ;;
     *"did not grant"*) ;;
     *) fail "expected the active account's missing scopes to be reported, got: ${out}" ;;
+    esac
+
+    echo "==> a refresh that grants only read:project FAILS"
+    # The alternation `project|read:project` is right for the status check —
+    # either proves the credential was minted with Projects in mind. It is
+    # wrong here: the refresh asked for both, and coming back with only the
+    # read grant leaves board writes broken while satisfying the alternation.
+    out="$(run_sut_pty read-only-grant GH_HOST=github.com)"
+    case "$out" in
+    *"All requested scopes present"*) fail "a read-only grant was reported as success: ${out}" ;;
+    *"did not grant"*"project"*) ;;
+    *) fail "expected the missing write scope to be reported, got: ${out}" ;;
+    esac
+
+    echo "==> a write-only grant is accepted (project implies read:project)"
+    out="$(run_sut_pty write-only-grant GH_HOST=github.com)"
+    case "$out" in
+    *"All requested scopes present"*) ;;
+    *) fail "'project' subsumes 'read:project' and must not fail: ${out}" ;;
     esac
 
     echo "==> a fine-grained token is rejected with a source-side remedy"

--- a/scripts/test-setup-gh-scopes.sh
+++ b/scripts/test-setup-gh-scopes.sh
@@ -125,7 +125,7 @@ make_stub() {
 # (macOS) and util-linux (CI) argument orders differ.
 pty_exec() {
     if command -v python3 >/dev/null 2>&1; then
-        python3 -c 'import pty,sys; sys.exit(pty.spawn(sys.argv[1:]))' "$@" 2>&1
+        python3 -c 'import os,pty,sys; sys.exit(os.waitstatus_to_exitcode(pty.spawn(sys.argv[1:])))' "$@" 2>&1
     elif [ "$(uname -s)" = "Darwin" ]; then
         script -q /dev/null "$@" 2>&1
     else
@@ -157,6 +157,25 @@ run_sut_pty() {
         for kv in "$@"; do export "${kv?}"; done
         pty_exec "${SUT}"
     ) || true
+}
+
+# rc_pty_of SCENARIO [ENV...] — the exit code from a run that got a TTY, so a
+# case can assert on the code the POST-REFRESH path returned. rc_of cannot:
+# it runs without a TTY, so its non-zero comes from the TTY guard long before
+# the verification under test, and a missing-scope branch that printed the
+# right message but exited 0 would still look green.
+rc_pty_of() {
+    local scenario="$1"
+    shift
+    make_stub "${scenario}"
+    local rc=0
+    (
+        export PATH="${TMP}/bin:${PATH}"
+        local kv
+        for kv in "$@"; do export "${kv?}"; done
+        pty_exec "${SUT}" >/dev/null 2>&1
+    ) || rc=$?
+    printf '%s' "${rc}"
 }
 
 # run_sut_notty SCENARIO [ENV...] — capture output with NO tty. Valid for every
@@ -255,8 +274,10 @@ if [ "${PTY_OK}" = true ]; then
     *"did not grant"*) ;;
     *) fail "a refresh that did not land must fail loudly, got: ${out}" ;;
     esac
-    [ "$(rc_of does-not-land GH_HOST=github.com)" != 0 ] ||
-        fail "an unlanded refresh must exit non-zero"
+    [ "$(rc_pty_of does-not-land GH_HOST=github.com)" != 0 ] ||
+        fail "an unlanded refresh must exit non-zero from the verification path"
+    [ "$(rc_pty_of lands GH_HOST=github.com)" = 0 ] ||
+        fail "a landed refresh must exit zero (else the case above proves nothing)"
 
     echo "==> another account's scopes cannot verify the refreshed one"
     # gh auth refresh updates only the ACTIVE account; reading every account on the
@@ -287,12 +308,25 @@ if [ "${PTY_OK}" = true ]; then
     *) fail "'project' subsumes 'read:project' and must not fail: ${out}" ;;
     esac
 
-    echo "==> a fine-grained token is rejected with a source-side remedy"
+    echo "==> a stored fine-grained token is refused BEFORE any refresh"
+    # `gh auth refresh` against a fine-grained PAT completes a device flow and
+    # stores a new CLASSIC token — silently replacing a deliberately narrow
+    # credential with a broad one. The refusal has to precede the mutation, so
+    # this asserts on the call log, not just the message.
+    STUB_CALLS="${TMP}/fg-calls.txt"
+    export STUB_CALLS
+    : >"${STUB_CALLS}"
     out="$(run_sut_pty fine-grained GH_HOST=github.com)"
+    if grep -q 'auth refresh' "${STUB_CALLS}"; then
+        fail "refreshed a fine-grained credential: $(tr '\n' ' ' <"${STUB_CALLS}")"
+    fi
+    unset STUB_CALLS
     case "$out" in
-    *"no OAuth scopes reported"*) ;;
-    *) fail "expected the fine-grained-token notice, got: ${out}" ;;
+    *"reports no OAuth scopes"*"where that token was issued"*) ;;
+    *) fail "expected the source-side remedy for a fine-grained token, got: ${out}" ;;
     esac
+    [ "$(rc_pty_of fine-grained GH_HOST=github.com)" != 0 ] ||
+        fail "the fine-grained refusal must exit non-zero"
 
     echo "==> the token value is never printed"
     # The script prints scope LINES; nothing it captures may contain a credential,

--- a/scripts/test-setup-gh-scopes.sh
+++ b/scripts/test-setup-gh-scopes.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# test-setup-gh-scopes.sh — unit-test setup-gh-scopes.sh, the one script here
+# that MUTATES the operator's stored credential.
+#
+# Run via `task test:gh-scopes`.
+#
+# Its refusals are the safety story (an env token it cannot fix, a shell that
+# cannot complete a browser flow) and its post-refresh verification is the
+# reason it exists at all — `gh auth refresh` can exit 0 having granted less
+# than was asked for. None of that is exercised by test-status.sh, which only
+# covers the status consumer.
+#
+# Hermetic in two directions, as test-status.sh is:
+#
+#   * every `gh` call is answered by a stub on PATH, so this never reaches
+#     GitHub and never touches the developer's own credential — which is the
+#     whole point: the bug it guards (reporting a refresh that did not land)
+#     is INVISIBLE when tested against a token that already has the scopes.
+#   * the script runs from a fixture root this test builds, never the repo it
+#     lives in, so the required-scope list under test is the fixture's.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+script="./scripts/setup-gh-scopes.sh"
+scopes_lib="./scripts/gh-scopes.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+# A board-carrying fixture, so the required list includes the Projects scopes.
+mkdir -p "${TMP}/repo/scripts"
+cp "${script}" "${TMP}/repo/scripts/setup-gh-scopes.sh"
+cp "${scopes_lib}" "${TMP}/repo/scripts/gh-scopes.sh"
+: >"${TMP}/repo/scripts/setup-github-project.sh"
+SUT="${TMP}/repo/scripts/setup-gh-scopes.sh"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+# make_stub SCENARIO — write $TMP/bin/gh. The refresh is RECORDED, never real:
+# a stub that silently succeeded would let a broken verification pass.
+make_stub() {
+    local scenario="$1"
+    mkdir -p "${TMP}/bin"
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'if [ -n "${STUB_CALLS:-}" ]; then echo "$*" >>"$STUB_CALLS"; fi'
+        echo 'if [ "$1" = "auth" ] && [ "$2" = "refresh" ]; then exit 0; fi'
+        echo 'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then'
+        echo '    seen_active=false'
+        echo '    for a in "$@"; do [ "$a" = "--active" ] && seen_active=true; done'
+        case "$scenario" in
+        lands)
+            # The happy path: after the refresh every requirement is present.
+            echo "    echo \"  - Token scopes: 'repo', 'workflow', 'project', 'read:project'\""
+            echo '    exit 0'
+            ;;
+        does-not-land)
+            # `gh auth refresh` exits 0 but the grant did not happen — an org
+            # that restricts the scope, or an operator who unticked it in the
+            # browser. The reason this script verifies instead of trusting.
+            echo "    echo \"  - Token scopes: 'repo', 'workflow'\""
+            echo '    exit 0'
+            ;;
+        inactive-has-scope)
+            # Two accounts on one host; only the INACTIVE one is fully scoped.
+            # `gh auth refresh` only ever updates the active account, so a
+            # verification that read every account would report a success that
+            # did not happen.
+            echo '    if [ "$seen_active" = true ]; then'
+            echo "        echo \"  - Token scopes: 'repo', 'workflow'\""
+            echo '    else'
+            echo "        echo \"  - Token scopes: 'repo', 'workflow'\""
+            echo "        echo \"  - Token scopes: 'project', 'read:project'\""
+            echo '    fi'
+            echo '    exit 0'
+            ;;
+        logged-out)
+            echo '    echo "You are not logged into any GitHub hosts." >&2'
+            echo '    exit 1'
+            ;;
+        fine-grained)
+            # Permissions, not OAuth scopes: gh reports the line with nothing
+            # quoted. `gh auth refresh` cannot add to such a token.
+            echo '    echo "  - Token scopes: none"'
+            echo '    exit 0'
+            ;;
+        esac
+        echo 'fi'
+        echo 'echo "stub: unexpected gh call: $*" >&2; exit 1'
+    } >"${TMP}/bin/gh"
+    chmod +x "${TMP}/bin/gh"
+}
+
+# pty_exec CMD... — run CMD under a pseudo-terminal, so the script sees a TTY
+# on stdin and stdout.
+#
+# Two allocators, in preference order. `python3 -c 'pty.spawn(...)'` calls
+# openpty directly and therefore works in a sandbox or CI shell with no
+# CONTROLLING terminal — where `script` fails with tcgetattr/ioctl before ever
+# running the command, failing every case for a reason unrelated to the code
+# under test. `script` is the fallback for a host without python3; its BSD
+# (macOS) and util-linux (CI) argument orders differ.
+pty_exec() {
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c 'import pty,sys; sys.exit(pty.spawn(sys.argv[1:]))' "$@" 2>&1
+    elif [ "$(uname -s)" = "Darwin" ]; then
+        script -q /dev/null "$@" 2>&1
+    else
+        script -qec "$*" /dev/null 2>&1
+    fi
+}
+
+# Whether a pty can be allocated AT ALL. The cases that need one are skipped
+# with a note rather than silently dropped (the same treatment test-status.sh
+# gives a missing `timeout` binary). Everything BEFORE the TTY gate — the
+# env-token refusals — is tested without a pty either way, because that
+# refusal deliberately runs first.
+PTY_OK=false
+if [ "$(pty_exec printf PTYPROBE 2>/dev/null | tr -dc 'A-Z')" = "PTYPROBE" ]; then
+    PTY_OK=true
+fi
+
+# run_sut_pty SCENARIO [ENV...] — the same, under a pseudo-terminal, capturing
+# output. Only call when PTY_OK.
+run_sut_pty() {
+    local scenario="$1"
+    shift
+    make_stub "${scenario}"
+    # A subshell with explicit exports rather than `env`: pty_exec is a shell
+    # function, and `env` can only exec a real binary.
+    (
+        export PATH="${TMP}/bin:${PATH}"
+        local kv
+        for kv in "$@"; do export "${kv?}"; done
+        pty_exec "${SUT}"
+    ) || true
+}
+
+# run_sut_notty SCENARIO [ENV...] — capture output with NO tty. Valid for every
+# assertion about a refusal that precedes the TTY gate.
+run_sut_notty() {
+    local scenario="$1"
+    shift
+    make_stub "${scenario}"
+    env "$@" PATH="${TMP}/bin:${PATH}" "${SUT}" </dev/null 2>&1 || true
+}
+
+# rc_of SCENARIO [ENV...] — the exit code, which the refusals must make
+# non-zero: a refusal that exited 0 would tell a caller the scopes are fine.
+rc_of() {
+    local scenario="$1"
+    shift
+    make_stub "${scenario}"
+    local rc=0
+    env "$@" PATH="${TMP}/bin:${PATH}" "${SUT}" </dev/null >/dev/null 2>&1 || rc=$?
+    printf '%s' "${rc}"
+}
+
+echo "==> refuses without a TTY, and says why"
+make_stub lands
+out="$(PATH="${TMP}/bin:${PATH}" "${SUT}" </dev/null 2>&1 || true)"
+case "$out" in
+*"no TTY"*) ;;
+*) fail "expected a TTY refusal, got: ${out}" ;;
+esac
+[ "$(rc_of lands)" != 0 ] || fail "the TTY refusal must exit non-zero"
+
+echo "==> a no-TTY refusal never reaches gh auth refresh"
+# The safety property behind the refusal: agents and CI must not re-mint the
+# operator's credential, so the refusal has to come BEFORE the mutation.
+STUB_CALLS="${TMP}/calls.txt"
+export STUB_CALLS
+: >"${STUB_CALLS}"
+make_stub lands
+PATH="${TMP}/bin:${PATH}" "${SUT}" </dev/null >/dev/null 2>&1 || true
+if grep -q 'auth refresh' "${STUB_CALLS}"; then
+    fail "a non-interactive run mutated the credential: $(tr '\n' ' ' <"${STUB_CALLS}")"
+fi
+unset STUB_CALLS
+
+echo "==> refuses the env-token family gh uses for THIS host"
+out="$(run_sut_notty lands GH_HOST=github.com GH_TOKEN=x)"
+case "$out" in
+*"GH_TOKEN is set"*"github.com"*) ;;
+*) fail "expected a GH_TOKEN refusal on github.com, got: ${out}" ;;
+esac
+[ "$(rc_of lands GH_HOST=github.com GH_TOKEN=x)" != 0 ] ||
+    fail "the env-token refusal must exit non-zero"
+
+echo "==> does NOT refuse an env token gh ignores on this host"
+# The dual-host case: gh reads GH_ENTERPRISE_TOKEN for a GHES host, not for
+# github.com, so it does not override the credential being refreshed here.
+out="$(run_sut_notty lands GH_HOST=github.com GH_ENTERPRISE_TOKEN=x)"
+case "$out" in
+*"GH_ENTERPRISE_TOKEN is set"*) fail "refused a token gh ignores on this host: ${out}" ;;
+*"no TTY"*) ;; # fell through to the NEXT gate, which is the point
+*) fail "expected the run to reach the TTY gate, got: ${out}" ;;
+esac
+out="$(run_sut_notty lands GH_HOST=ghe.example.com GH_TOKEN=x)"
+case "$out" in
+*"GH_TOKEN is set"*) fail "refused a github.com token in a GHES checkout: ${out}" ;;
+*"no TTY"*) ;;
+*) fail "expected the run to reach the TTY gate, got: ${out}" ;;
+esac
+
+echo "==> refuses the enterprise env token on an enterprise host"
+out="$(run_sut_notty lands GH_HOST=ghe.example.com GH_ENTERPRISE_TOKEN=x)"
+case "$out" in
+*"GH_ENTERPRISE_TOKEN is set"*"ghe.example.com"*) ;;
+*) fail "expected an enterprise env-token refusal, got: ${out}" ;;
+esac
+
+if [ "${PTY_OK}" = true ]; then
+    echo "==> a logged-out host is told to log in, not refreshed"
+    out="$(run_sut_pty logged-out GH_HOST=github.com)"
+    case "$out" in
+    *"not logged in"*"gh auth login"*) ;;
+    *) fail "expected a login remedy, got: ${out}" ;;
+    esac
+
+    echo "==> succeeds when the refresh lands, naming the scopes"
+    out="$(run_sut_pty lands GH_HOST=github.com)"
+    case "$out" in
+    *"All required scopes present"*) ;;
+    *) fail "expected success after a landed refresh, got: ${out}" ;;
+    esac
+
+    echo "==> FAILS when the refresh silently did not land"
+    # The whole reason this script verifies rather than trusting the exit code.
+    out="$(run_sut_pty does-not-land GH_HOST=github.com)"
+    case "$out" in
+    *"did not grant"*) ;;
+    *) fail "a refresh that did not land must fail loudly, got: ${out}" ;;
+    esac
+    [ "$(rc_of does-not-land GH_HOST=github.com)" != 0 ] ||
+        fail "an unlanded refresh must exit non-zero"
+
+    echo "==> another account's scopes cannot verify the refreshed one"
+    # gh auth refresh updates only the ACTIVE account; reading every account on the
+    # host would let an unrelated login satisfy the requirement.
+    out="$(run_sut_pty inactive-has-scope GH_HOST=github.com)"
+    case "$out" in
+    *"All required scopes present"*) fail "an inactive account's scopes verified the active one: ${out}" ;;
+    *"did not grant"*) ;;
+    *) fail "expected the active account's missing scopes to be reported, got: ${out}" ;;
+    esac
+
+    echo "==> a fine-grained token is rejected with a source-side remedy"
+    out="$(run_sut_pty fine-grained GH_HOST=github.com)"
+    case "$out" in
+    *"no OAuth scopes reported"*) ;;
+    *) fail "expected the fine-grained-token notice, got: ${out}" ;;
+    esac
+
+    echo "==> the token value is never printed"
+    # The script prints scope LINES; nothing it captures may contain a credential,
+    # and the stub's scope lines are the only thing it is allowed to echo back.
+    out="$(run_sut_pty lands GH_HOST=github.com)"
+    case "$out" in
+    *ghp_* | *gho_*) fail "something token-shaped reached the output: ${out}" ;;
+    esac
+else
+    echo "    (skipped: no controlling terminal — cannot allocate a pty for the"
+    echo "     interactive path; the refusals above are covered without one)"
+fi
+
+echo "setup-gh-scopes.sh tests passed"

--- a/scripts/test-setup-gh-scopes.sh
+++ b/scripts/test-setup-gh-scopes.sh
@@ -55,7 +55,10 @@ make_stub() {
     {
         echo '#!/usr/bin/env bash'
         echo 'if [ -n "${STUB_CALLS:-}" ]; then echo "$*" >>"$STUB_CALLS"; fi'
-        echo 'if [ "$1" = "auth" ] && [ "$2" = "refresh" ]; then exit 0; fi'
+        echo 'if [ "$1" = "auth" ] && [ "$2" = "refresh" ]; then'
+        echo '    [ -n "${TMP_PHASE:-}" ] && : >"$TMP_PHASE"'
+        echo '    exit 0'
+        echo 'fi'
         echo 'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then'
         echo '    seen_active=false'
         echo '    for a in "$@"; do [ "$a" = "--active" ] && seen_active=true; done'
@@ -82,6 +85,17 @@ make_stub() {
             echo '    else'
             echo "        echo \"  - Token scopes: 'repo', 'workflow'\""
             echo "        echo \"  - Token scopes: 'project', 'read:project'\""
+            echo '    fi'
+            echo '    exit 0'
+            ;;
+        lands-after-refresh)
+            # The genuine success path: incomplete BEFORE the refresh, complete
+            # after it. A single-phase stub cannot test this any more, now that
+            # an already-complete credential short-circuits without refreshing.
+            echo '    if [ -f "${TMP_PHASE:-/nonexistent}" ]; then'
+            echo "        echo \"  - Token scopes: 'repo', 'workflow', 'project', 'read:project'\""
+            echo '    else'
+            echo "        echo \"  - Token scopes: 'repo', 'workflow'\""
             echo '    fi'
             echo '    exit 0'
             ;;
@@ -153,6 +167,8 @@ run_sut_pty() {
     # function, and `env` can only exec a real binary.
     (
         export PATH="${TMP}/bin:${PATH}"
+        export TMP_PHASE="${TMP}/phase-marker"
+        rm -f "${TMP_PHASE}"
         local kv
         for kv in "$@"; do export "${kv?}"; done
         pty_exec "${SUT}"
@@ -171,6 +187,8 @@ rc_pty_of() {
     local rc=0
     (
         export PATH="${TMP}/bin:${PATH}"
+        export TMP_PHASE="${TMP}/phase-marker"
+        rm -f "${TMP_PHASE}"
         local kv
         for kv in "$@"; do export "${kv?}"; done
         pty_exec "${SUT}" >/dev/null 2>&1
@@ -261,7 +279,7 @@ if [ "${PTY_OK}" = true ]; then
     esac
 
     echo "==> succeeds when the refresh lands, naming the scopes"
-    out="$(run_sut_pty lands GH_HOST=github.com)"
+    out="$(run_sut_pty lands-after-refresh GH_HOST=github.com)"
     case "$out" in
     *"All requested scopes present"*) ;;
     *) fail "expected success after a landed refresh, got: ${out}" ;;
@@ -276,7 +294,7 @@ if [ "${PTY_OK}" = true ]; then
     esac
     [ "$(rc_pty_of does-not-land GH_HOST=github.com)" != 0 ] ||
         fail "an unlanded refresh must exit non-zero from the verification path"
-    [ "$(rc_pty_of lands GH_HOST=github.com)" = 0 ] ||
+    [ "$(rc_pty_of lands-after-refresh GH_HOST=github.com)" = 0 ] ||
         fail "a landed refresh must exit zero (else the case above proves nothing)"
 
     echo "==> another account's scopes cannot verify the refreshed one"
@@ -302,11 +320,33 @@ if [ "${PTY_OK}" = true ]; then
     esac
 
     echo "==> a write-only grant is accepted (project implies read:project)"
+    # Reported with only 'project', which subsumes 'read:project' — so nothing
+    # is missing, and the run must succeed rather than report a missing scope.
     out="$(run_sut_pty write-only-grant GH_HOST=github.com)"
     case "$out" in
-    *"All requested scopes present"*) ;;
-    *) fail "'project' subsumes 'read:project' and must not fail: ${out}" ;;
+    *"did not grant"*) fail "'project' subsumes 'read:project' and must not fail: ${out}" ;;
     esac
+    [ "$(rc_pty_of write-only-grant GH_HOST=github.com)" = 0 ] ||
+        fail "a write-only grant must exit zero: ${out}"
+
+    echo "==> an already-complete credential is NOT refreshed"
+    # `gh auth refresh` opens a browser even when it would change nothing, so
+    # the documented sequence (log in with the derived scopes, then run this to
+    # verify) would authenticate twice, and every re-run would repeat it.
+    STUB_CALLS="${TMP}/complete-calls.txt"
+    export STUB_CALLS
+    : >"${STUB_CALLS}"
+    out="$(run_sut_pty lands GH_HOST=github.com)"
+    if grep -q 'auth refresh' "${STUB_CALLS}"; then
+        fail "refreshed a credential that needed nothing: $(tr '\n' ' ' <"${STUB_CALLS}")"
+    fi
+    unset STUB_CALLS
+    case "$out" in
+    *"Already complete"*) ;;
+    *) fail "expected the no-op path to say so, got: ${out}" ;;
+    esac
+    [ "$(rc_pty_of lands GH_HOST=github.com)" = 0 ] ||
+        fail "the already-complete path must exit zero"
 
     echo "==> a stored fine-grained token is refused BEFORE any refresh"
     # `gh auth refresh` against a fine-grained PAT completes a device flow and

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -995,6 +995,23 @@ case "$scope_out" in
 *"admin:org"*) fail "a personal-account repo must not demand admin:org: ${scope_out}" ;;
 esac
 
+echo "==> GH_EXTRA_SCOPES adds to the profile's list rather than replacing it"
+# The documented extension point. Additive is the whole contract: a consumer
+# that names only its own requirement must still be held to this repo's, and to
+# any a later template update introduces.
+make_codex_stub in
+scope_out="$(GH_EXTRA_SCOPES=delete_repo run_creds_section fully-scoped "${CREDS_BOARD}")"
+case "$scope_out" in
+*"gh token scopes"*"missing delete_repo"*) ;;
+*) fail "GH_EXTRA_SCOPES was not required, got: ${scope_out}" ;;
+esac
+make_codex_stub in
+scope_out="$(GH_EXTRA_SCOPES=delete_repo run_creds_section none "${CREDS_BOARD}")"
+case "$scope_out" in
+*"project"*) ;;
+*) fail "GH_EXTRA_SCOPES replaced the built-in requirements: ${scope_out}" ;;
+esac
+
 echo "==> status:creds never prints the token it reads"
 # `gh auth token` writes the credential to stdout — the value is the output. The
 # probe reads its exit code only, so the stub's placeholder must not reach the

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -44,7 +44,10 @@ trap 'rm -rf "${TMP}"' EXIT
 #   with-codex  — opted into second-model review, so the Codex login is a gate.
 #                 The other three have no codex-review.sh, which is what makes
 #                 them the not-opted-in case for that check.
-for fixture in with-board no-board skills-only with-codex; do
+#   creds-board — codex opted in AND board tooling present, so the session-start
+#                 scope check demands the Projects scopes. Its twin below
+#                 (with-codex, no board) is what proves that demand is gated.
+for fixture in with-board no-board skills-only with-codex creds-board; do
     mkdir -p "${TMP}/${fixture}/scripts"
     cp "${status}" "${TMP}/${fixture}/scripts/status.sh"
     cp "${scopes_lib}" "${TMP}/${fixture}/scripts/gh-scopes.sh"
@@ -52,6 +55,8 @@ done
 # The markers status.sh feature-detects on. Contents are never read.
 : >"${TMP}/with-board/scripts/setup-github-project.sh"
 : >"${TMP}/with-codex/scripts/codex-review.sh"
+: >"${TMP}/creds-board/scripts/codex-review.sh"
+: >"${TMP}/creds-board/scripts/setup-github-project.sh"
 mkdir -p "${TMP}/skills-only/.claude/skills/track-work/assets"
 : >"${TMP}/skills-only/.claude/skills/track-work/assets/set-issue-status.sh"
 
@@ -69,6 +74,7 @@ NO_BOARD="${TMP}/no-board/scripts/status.sh"
 SKILLS_ONLY="${TMP}/skills-only/scripts/status.sh"
 ENTERPRISE="${TMP}/enterprise/scripts/status.sh"
 WITH_CODEX="${TMP}/with-codex/scripts/status.sh"
+CREDS_BOARD="${TMP}/creds-board/scripts/status.sh"
 
 fail() {
     echo "TEST FAIL: $*" >&2
@@ -221,6 +227,12 @@ make_stub() {
             # silence, never an accusation.
             echo '    echo "error connecting to github.com" >&2'
             echo '    exit 1'
+            ;;
+        no-workflow)
+            # A credential that satisfies the Projects half but not the
+            # unconditional half of the list.
+            echo "    echo \"  - Token scopes: 'repo', 'project', 'read:project'\""
+            echo '    exit 0'
             ;;
         *) fail "unknown stub scenario: ${scenario}" ;;
         esac
@@ -879,7 +891,7 @@ export STUB_CALLS
 make_codex_stub in
 make_stub none
 offline_out="$(PATH="${TMP}/bin:${PATH}" NO_COLOR=1 STATUS_NO_NETWORK=1 \
-    "${WITH_CODEX}" creds 2>&1)"
+    "${CREDS_BOARD}" creds 2>&1)"
 if grep -q 'auth status' "${STUB_CALLS}"; then
     fail "STATUS_NO_NETWORK=1 still probed the network: $(tr '\n' ' ' <"${STUB_CALLS}")"
 fi
@@ -896,7 +908,7 @@ echo "==> status:creds warns when the token is missing a required scope"
 # The whole point of #827: an under-scoped login is caught at session start
 # rather than days later, when a board write fails mid-shepherd.
 make_codex_stub in
-scope_out="$(run_creds_section none)"
+scope_out="$(run_creds_section none "${CREDS_BOARD}")"
 case "$scope_out" in
 *"gh token scopes"*"missing"*"project"*) ;;
 *) fail "expected a missing-scope warning from status:creds, got: ${scope_out}" ;;
@@ -910,7 +922,7 @@ echo "==> a fully-scoped token produces NO scope line"
 # Silent on success, deliberately: the ✓ credential line above already proves
 # the check ran, and a second green line every session in every repo is noise.
 make_codex_stub in
-scope_out="$(run_creds_section fully-scoped)"
+scope_out="$(run_creds_section fully-scoped "${CREDS_BOARD}")"
 case "$scope_out" in
 *"gh token scopes"*) fail "a complete token must not produce a scope line: ${scope_out}" ;;
 esac
@@ -920,7 +932,7 @@ echo "==> 'read:project' alone satisfies the session-start scope check"
 # not: these are different questions about the same token. This one asks
 # whether the credential was minted with Projects in mind at all.
 make_codex_stub in
-scope_out="$(run_creds_section creds-read-project)"
+scope_out="$(run_creds_section creds-read-project "${CREDS_BOARD}")"
 case "$scope_out" in
 *"gh token scopes"*) fail "read:project must satisfy the session-start check: ${scope_out}" ;;
 esac
@@ -930,13 +942,35 @@ echo "==> a failed scope probe is not reported as a missing scope"
 # verdict. Sending a correctly-scoped operator to re-mint a working credential
 # is the error this guards.
 make_codex_stub in
-scope_out="$(run_creds_section scope-probe-fails)"
+scope_out="$(run_creds_section scope-probe-fails "${CREDS_BOARD}")"
 case "$scope_out" in
 *"missing"*"project"*) fail "a failed probe must not accuse the token: ${scope_out}" ;;
 esac
 case "$scope_out" in
 *"credential stored"*) ;;
 *) fail "the credential line must survive a failed scope probe: ${scope_out}" ;;
+esac
+
+echo "==> a repo with no board tooling is never asked for Projects scopes"
+# `project_management: none` is the DEFAULT generated profile, and such a repo
+# has no board to write to. Demanding Projects access there would warn every
+# session, in the majority profile, about a grant the repo never uses — and
+# train the reader to ignore the line in the repos where it matters. Same
+# marker, and the same accepted cost, as the board-writes check in status:gh.
+make_codex_stub in
+scope_out="$(run_creds_section none)"
+case "$scope_out" in
+*"gh token scopes"*) fail "a boardless repo must not demand Projects scopes: ${scope_out}" ;;
+esac
+
+echo "==> a boardless repo IS still warned about repo/workflow"
+# The gate is on the Projects requirement alone — the unconditional part of the
+# list must keep working, or the case above would pass for the wrong reason.
+make_codex_stub in
+scope_out="$(run_creds_section no-workflow)"
+case "$scope_out" in
+*"gh token scopes"*"missing workflow"*) ;;
+*) fail "expected an unconditional-scope warning in a boardless repo: ${scope_out}" ;;
 esac
 
 echo "==> status:creds never prints the token it reads"

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -8,8 +8,8 @@
 #     and Codex logins the Dev Loop gates on, in every state including
 #     not-installed, rendered as its own section for the session-start hook AND
 #     inside the setup audit BEFORE the gate that skips the rest of it, counted
-#     by the summary at the end of that audit, and — standalone — making no
-#     network call at all.
+#     by the summary at the end of that audit, and — standalone — spending
+#     exactly one bounded network call, for the token scopes alone (#827).
 #
 # Run via `task test:status`.
 #
@@ -28,6 +28,9 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 status="./scripts/status.sh"
+# status.sh sources the required-scope list from its sibling; every fixture root
+# below therefore needs both files, not just the script under test.
+scopes_lib="./scripts/gh-scopes.sh"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "${TMP}"' EXIT
@@ -44,6 +47,7 @@ trap 'rm -rf "${TMP}"' EXIT
 for fixture in with-board no-board skills-only with-codex; do
     mkdir -p "${TMP}/${fixture}/scripts"
     cp "${status}" "${TMP}/${fixture}/scripts/status.sh"
+    cp "${scopes_lib}" "${TMP}/${fixture}/scripts/gh-scopes.sh"
 done
 # The markers status.sh feature-detects on. Contents are never read.
 : >"${TMP}/with-board/scripts/setup-github-project.sh"
@@ -55,6 +59,7 @@ mkdir -p "${TMP}/skills-only/.claude/skills/track-work/assets"
 # GH_HOST — the case where forcing github.com disowns a valid login.
 mkdir -p "${TMP}/enterprise/scripts"
 cp "${status}" "${TMP}/enterprise/scripts/status.sh"
+cp "${scopes_lib}" "${TMP}/enterprise/scripts/gh-scopes.sh"
 : >"${TMP}/enterprise/scripts/setup-github-project.sh"
 git -C "${TMP}/enterprise" init -q
 git -C "${TMP}/enterprise" remote add origin git@ghe.example.com:owner/repo.git
@@ -195,6 +200,27 @@ make_stub() {
             # carry gh's no-credential wording: that is the whole distinction.
             echo "    echo \"  - Token scopes: 'gist', 'project', 'repo'\""
             echo '    exit 0'
+            ;;
+        fully-scoped)
+            # Every required scope. The session-start check must then say
+            # nothing at all.
+            echo "    echo \"  - Token scopes: 'read:project', 'project', 'repo', 'workflow'\""
+            echo '    exit 0'
+            ;;
+        creds-read-project)
+            # Projects READ only. Satisfies the session-start "was this
+            # credential minted with Projects in mind" check via the
+            # `project|read:project` alternation, while still failing the
+            # board-WRITE check in the GitHub section.
+            echo "    echo \"  - Token scopes: 'read:project', 'repo', 'workflow'\""
+            echo '    exit 0'
+            ;;
+        scope-probe-fails)
+            # The LOCAL credential read succeeds (see `auth token` below) but
+            # the scope probe cannot answer — a network blip, a proxy. Must be
+            # silence, never an accusation.
+            echo '    echo "error connecting to github.com" >&2'
+            echo '    exit 1'
             ;;
         *) fail "unknown stub scenario: ${scenario}" ;;
         esac
@@ -439,14 +465,14 @@ echo "==> read-only 'read:project' is NOT reported as satisfied"
 out="$(run_gh_section read-only)"
 case "$out" in
 *"token has 'project'"*) fail "read:project must not satisfy a WRITE check: ${out}" ;;
-*"read-only"*"gh auth refresh -s project"*) ;;
+*"read-only"*"task setup:gh-scopes"*) ;;
 *) fail "expected a read-only warning naming the remedy, got: ${out}" ;;
 esac
 
 echo "==> a token with neither scope warns and names the remedy"
 out="$(run_gh_section none)"
 case "$out" in
-*"lacks 'project'"*"gh auth refresh -s project"*) ;;
+*"lacks 'project'"*"task setup:gh-scopes"*) ;;
 *) fail "expected a missing-scope warning naming the remedy, got: ${out}" ;;
 esac
 
@@ -514,7 +540,7 @@ echo "==> an env-provided token gets a remedy that can actually work"
 # advice that silently changes nothing.
 out="$(run_gh_section env-token-no-scope)"
 case "$out" in
-*"gh auth refresh -s project"*) fail "gh auth refresh cannot change an env token: ${out}" ;;
+*"gh auth refresh -s"* | *"task setup:gh-scopes"*) fail "neither a refresh nor the setup task can change an env token: ${out}" ;;
 *"reissue GH_TOKEN"*) ;;
 *) fail "expected an env-token remedy, got: ${out}" ;;
 esac
@@ -523,7 +549,7 @@ echo "==> an Enterprise env token gets the same treatment as GH_TOKEN"
 # The override problem is a property of environment tokens, not of github.com.
 out="$(run_gh_section enterprise-env-token)"
 case "$out" in
-*"gh auth refresh -s project"*) fail "gh auth refresh cannot change an env token: ${out}" ;;
+*"gh auth refresh -s"* | *"task setup:gh-scopes"*) fail "neither a refresh nor the setup task can change an env token: ${out}" ;;
 *"reissue GH_ENTERPRISE_TOKEN"*) ;;
 *) fail "expected the Enterprise env-token remedy, got: ${out}" ;;
 esac
@@ -618,7 +644,7 @@ while IFS= read -r line; do
     [ -n "$line" ] || continue
     case "$line" in
     *"#"*"gh auth refresh"*) continue ;; # a comment explaining the rule
-    *GH_REMEDY=*) continue ;;            # the derivation itself
+    *GH_REMEDY*=*) continue ;;           # the derivation itself
     *) fail "hardcoded refresh remedy — use \${GH_REMEDY}: ${line}" ;;
     esac
 done <<EOF
@@ -825,23 +851,93 @@ case "$out" in
 *) fail "expected a Codex credential line from status:creds, got: ${out}" ;;
 esac
 
-echo "==> status:creds makes no network call"
-# The acceptance criterion the session-start budget rests on. `gh auth status`
-# validates the token against the API; `gh auth token` reads local config and
-# the environment. The hook already spends this startup's one auth round trip in
-# status:gh, so this section must add none — and a stub that answers `auth
-# status` perfectly well would hide a second one from every output assertion.
+echo "==> status:creds spends exactly ONE network call, and only for scopes"
+# The session-start budget rests on this count. `gh auth status` asks GitHub;
+# `gh auth token` reads local config and the environment. The section was
+# network-free until issue #827 — scopes are a server-side property of the
+# token that no local file records, so the check it asks for cannot be had
+# without exactly one round trip. One, not two: a stub that answers `auth
+# status` happily would hide a second from every output assertion.
 STUB_CALLS="${TMP}/creds-calls.txt"
 export STUB_CALLS
 : >"${STUB_CALLS}"
 make_codex_stub in
 out="$(run_creds_section project)"
-if grep -q 'auth status' "${STUB_CALLS}"; then
-    fail "status:creds called 'gh auth status' — that is a network probe: $(tr '\n' ' ' <"${STUB_CALLS}")"
-fi
 grep -q 'auth token' "${STUB_CALLS}" ||
     fail "status:creds made no local credential read at all: $(tr '\n' ' ' <"${STUB_CALLS}")"
+calls="$(grep -c 'auth status' "${STUB_CALLS}" || true)"
+[ "${calls}" = 1 ] ||
+    fail "status:creds made ${calls} 'gh auth status' calls, expected exactly 1: $(tr '\n' ' ' <"${STUB_CALLS}")"
 unset STUB_CALLS
+
+echo "==> STATUS_NO_NETWORK=1 returns status:creds to a local-only read"
+# The opt-out for an offline or latency-sensitive shell. The credential lines
+# must still render — only the scope probe is given up.
+STUB_CALLS="${TMP}/creds-calls-offline.txt"
+export STUB_CALLS
+: >"${STUB_CALLS}"
+make_codex_stub in
+make_stub none
+offline_out="$(PATH="${TMP}/bin:${PATH}" NO_COLOR=1 STATUS_NO_NETWORK=1 \
+    "${WITH_CODEX}" creds 2>&1)"
+if grep -q 'auth status' "${STUB_CALLS}"; then
+    fail "STATUS_NO_NETWORK=1 still probed the network: $(tr '\n' ' ' <"${STUB_CALLS}")"
+fi
+case "$offline_out" in
+*"gh token scopes"*) fail "a scope verdict without a probe to back it: ${offline_out}" ;;
+esac
+case "$offline_out" in
+*"GitHub CLI (gh)"*) ;;
+*) fail "the credential lines must still render offline: ${offline_out}" ;;
+esac
+unset STUB_CALLS
+
+echo "==> status:creds warns when the token is missing a required scope"
+# The whole point of #827: an under-scoped login is caught at session start
+# rather than days later, when a board write fails mid-shepherd.
+make_codex_stub in
+scope_out="$(run_creds_section none)"
+case "$scope_out" in
+*"gh token scopes"*"missing"*"project"*) ;;
+*) fail "expected a missing-scope warning from status:creds, got: ${scope_out}" ;;
+esac
+case "$scope_out" in
+*"task setup:gh-scopes"*) ;;
+*) fail "the warning must name the runnable remedy, got: ${scope_out}" ;;
+esac
+
+echo "==> a fully-scoped token produces NO scope line"
+# Silent on success, deliberately: the ✓ credential line above already proves
+# the check ran, and a second green line every session in every repo is noise.
+make_codex_stub in
+scope_out="$(run_creds_section fully-scoped)"
+case "$scope_out" in
+*"gh token scopes"*) fail "a complete token must not produce a scope line: ${scope_out}" ;;
+esac
+
+echo "==> 'read:project' alone satisfies the session-start scope check"
+# It does not satisfy the board-WRITE check in the GitHub section, and must
+# not: these are different questions about the same token. This one asks
+# whether the credential was minted with Projects in mind at all.
+make_codex_stub in
+scope_out="$(run_creds_section creds-read-project)"
+case "$scope_out" in
+*"gh token scopes"*) fail "read:project must satisfy the session-start check: ${scope_out}" ;;
+esac
+
+echo "==> a failed scope probe is not reported as a missing scope"
+# Issues #774 and #478: a probe that could not answer is unknown, never a
+# verdict. Sending a correctly-scoped operator to re-mint a working credential
+# is the error this guards.
+make_codex_stub in
+scope_out="$(run_creds_section scope-probe-fails)"
+case "$scope_out" in
+*"missing"*"project"*) fail "a failed probe must not accuse the token: ${scope_out}" ;;
+esac
+case "$scope_out" in
+*"credential stored"*) ;;
+*) fail "the credential line must survive a failed scope probe: ${scope_out}" ;;
+esac
 
 echo "==> status:creds never prints the token it reads"
 # `gh auth token` writes the credential to stdout — the value is the output. The
@@ -976,6 +1072,7 @@ if [ -f "$hook" ]; then
     creds_budget="$(sed -n -E 's/.*timeout ([0-9]+) task status:creds.*/\1/p' "$hook" | head -1)"
     creds_worst="$(awk '
         /^render_local_credentials\(\) \{/ { inf = 1 }
+        /^render_gh_scope_check\(\) \{/ { inf = 1 }
         inf && /^\}/ { inf = 0 }
         inf {
             line = $0

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -47,7 +47,9 @@ trap 'rm -rf "${TMP}"' EXIT
 #   creds-board — codex opted in AND board tooling present, so the session-start
 #                 scope check demands the Projects scopes. Its twin below
 #                 (with-codex, no board) is what proves that demand is gated.
-for fixture in with-board no-board skills-only with-codex creds-board; do
+#   org-repo    — an ORG repo (github_org != the author's account), which
+#                 renders the issue-types setup and therefore needs admin:org.
+for fixture in with-board no-board skills-only with-codex creds-board org-repo; do
     mkdir -p "${TMP}/${fixture}/scripts"
     cp "${status}" "${TMP}/${fixture}/scripts/status.sh"
     cp "${scopes_lib}" "${TMP}/${fixture}/scripts/gh-scopes.sh"
@@ -57,6 +59,8 @@ done
 : >"${TMP}/with-codex/scripts/codex-review.sh"
 : >"${TMP}/creds-board/scripts/codex-review.sh"
 : >"${TMP}/creds-board/scripts/setup-github-project.sh"
+: >"${TMP}/org-repo/scripts/codex-review.sh"
+: >"${TMP}/org-repo/scripts/setup-github-issue-types.sh"
 mkdir -p "${TMP}/skills-only/.claude/skills/track-work/assets"
 : >"${TMP}/skills-only/.claude/skills/track-work/assets/set-issue-status.sh"
 
@@ -75,6 +79,7 @@ SKILLS_ONLY="${TMP}/skills-only/scripts/status.sh"
 ENTERPRISE="${TMP}/enterprise/scripts/status.sh"
 WITH_CODEX="${TMP}/with-codex/scripts/status.sh"
 CREDS_BOARD="${TMP}/creds-board/scripts/status.sh"
+ORG_REPO="${TMP}/org-repo/scripts/status.sh"
 
 fail() {
     echo "TEST FAIL: $*" >&2
@@ -971,6 +976,23 @@ scope_out="$(run_creds_section no-workflow)"
 case "$scope_out" in
 *"gh token scopes"*"missing workflow"*) ;;
 *) fail "expected an unconditional-scope warning in a boardless repo: ${scope_out}" ;;
+esac
+
+echo "==> an org repo is asked for admin:org, a personal one is not"
+# The org-only setup tasks (issue types, issue fields) state they need
+# admin:org, and the template renders them only when the repo belongs to an
+# org. Same marker rule as the Projects scopes: a personal-account repo renders
+# neither script and must never be warned about a grant it cannot use.
+make_codex_stub in
+scope_out="$(run_creds_section fully-scoped "${ORG_REPO}")"
+case "$scope_out" in
+*"gh token scopes"*"missing admin:org"*) ;;
+*) fail "expected an admin:org warning in an org repo, got: ${scope_out}" ;;
+esac
+make_codex_stub in
+scope_out="$(run_creds_section fully-scoped "${CREDS_BOARD}")"
+case "$scope_out" in
+*"admin:org"*) fail "a personal-account repo must not demand admin:org: ${scope_out}" ;;
 esac
 
 echo "==> status:creds never prints the token it reads"

--- a/template/.claude/hooks/session-start-context.sh.jinja
+++ b/template/.claude/hooks/session-start-context.sh.jinja
@@ -24,10 +24,11 @@ strip_ansi() { sed -E 's/\x1B\[''[0-9;]*[A-Za-z]//g'; }
 # status:git makes no network calls at all.
 #
 # status:creds is budgeted from its own probes rather than by copying a
-# neighbour's number: it makes NO network call (that is why it can be here at
-# all — status:gh already spends this startup's only auth round trip), and runs
-# three LOCAL probes back to back, each bounded at 3s inside status.sh — 9s
-# worst case, so 11 here for the `task` and shell startup around them. The three run in
+# neighbour's number: it runs three LOCAL probes back to back, each bounded at
+# 3s inside status.sh, plus ONE bounded 3s call to read the gh token's SCOPES
+# (a server-side property no local file records — issue #827), which is why it
+# is capped at the local bound rather than NETWORK_TIMEOUT. 12s worst case, so
+# 13 here for the `task` and shell startup around them. The three run in
 # parallel, so it adds nothing to the wall clock the gh deadline already allows.
 remote_url="$(git config --get remote.origin.url 2>/dev/null || echo '')"
 host_owner="$(echo "$remote_url" | sed -E 's/^(https?:\/\/|git@)([^:\/]+)[:\/]([^\/]+)\/[^\/]+(\.git)?$/\2 \3/')"
@@ -48,7 +49,7 @@ if [ "$host" = "github.com" ]; then
     git_pid=$!
     "$timeout_cmd" 12 task status:gh >"$gh_out" 2>/dev/null &
     gh_pid=$!
-    "$timeout_cmd" 11 task status:creds >"$creds_out" 2>/dev/null &
+    "$timeout_cmd" 13 task status:creds >"$creds_out" 2>/dev/null &
     creds_pid=$!
 
     git_rc=0

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -124,7 +124,7 @@ See [DESIGN.md](DESIGN.md) for visual/UX direction.
 [% endif %]
 | `task release:patch` | Tag + GitHub release (also `:minor` / `:major`) |
 | `task status` | Project status dashboard (also `status:git`/`:gh`/`:creds`/`:code`/`:env`) |
-| `task status:creds` | Local credential logins (gh, Codex, Claude Code) — local probes, no network; also run at session start |
+| `task status:creds` | Credential logins (gh, Codex, Claude Code) + the gh token's scopes — local probes plus one bounded 3s scope check (`STATUS_NO_NETWORK=1` skips it); also run at session start |
 | `task status:setup` | Setup audit: local credentials, GitHub config, toolchain, devcontainer, dev env |
 
 ## Testing

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -112,6 +112,7 @@ tasks:
       - task: test:tasks
       - task: test:ci-results
       - task: test:status
+      - task: test:gh-scopes
       - task: test:meta-install
 [% if use_codex_review %]
       - task: test:codex-review
@@ -706,6 +707,11 @@ tasks:
     desc: Unit-test the status board-writes + local-credential checks (stubbed CLIs, no network)
     cmds:
       - ./scripts/test-status.sh
+
+  test:gh-scopes:
+    desc: Unit-test the gh scope refresh task's refusals and post-refresh verification (stubbed gh, no network)
+    cmds:
+      - ./scripts/test-setup-gh-scopes.sh
 
   test:meta-install:
     desc: Unit-test the .meta sidecar installer's ~-expansion and refusals

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -1030,10 +1030,19 @@ tasks:
     desc: >-
       Idempotently create/sync the owner's GitHub Project V2 board + Status
       pipeline + Size number field (on a personal account also the other
-      metadata fields). Requires `gh auth refresh -s project`.
+      metadata fields). Requires the Projects scopes — `task setup:gh-scopes`.
     cmds:
       - ./scripts/setup-github-project.sh --owner "[[ github_org ]]" --title "[[ github_org ]] Project"
 [% endif %]
+
+  setup:gh-scopes:
+    desc: >-
+      OPERATOR / DEV PROFILE ONLY: refresh your interactive gh login so it
+      carries every scope this repo needs (refuses against a GH_TOKEN env
+      credential and without a TTY; verifies the grant landed). Bot containers
+      must reissue GH_TOKEN instead.
+    cmds:
+      - ./scripts/setup-gh-scopes.sh
 [% if project_management == 'github' or use_foreman %]
 
   setup:github-labels:

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -1196,7 +1196,7 @@ tasks:
       - ./scripts/status.sh gh
 
   status:creds:
-    desc: Local credential section (gh, Codex, Claude Code logins — local probes, no network)
+    desc: Credential section (gh, Codex, Claude Code logins + gh token scopes — local probes plus one bounded scope check; STATUS_NO_NETWORK=1 skips it)
     cmds:
       - ./scripts/status.sh creds
 

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-hooks/session-start-context.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-hooks/session-start-context.sh
@@ -24,17 +24,18 @@ strip_ansi() { sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'; }
 # status:git makes no network calls at all.
 #
 # status:creds is budgeted from its own probes rather than by copying a
-# neighbour's number: it makes NO network call (that is why it can be here at
-# all — status:gh already spends this startup's only auth round trip), and runs
-# three LOCAL probes back to back, each bounded at 3s inside status.sh — 9s
-# worst case, so 11 here for the `task` and shell startup around them.
+# neighbour's number: it runs three LOCAL probes back to back, each bounded at
+# 3s inside status.sh, plus ONE bounded 3s call to read the gh token's SCOPES
+# (a server-side property no local file records — issue #827), which is why it
+# is capped at the local bound rather than NETWORK_TIMEOUT. 12s worst case, so
+# 13 here for the `task` and shell startup around them.
 #
 # There is a SECOND deadline above all of these: the `timeout` on the
 # SessionStart entries in claude-settings.json, which Claude Code applies to this
 # whole script. Overrunning it is worse than any single section overrunning its
 # own bound — the hook is killed before `jq` emits anything, so the entire
 # payload is lost rather than one section of it. The sections are therefore run
-# in PARALLEL: the hook's wall clock is then the LONGEST deadline (12s), which
+# in PARALLEL: the hook's wall clock is then the LONGEST deadline (13s), which
 # fits inside that outer timeout, where the sum (25s) would not.
 git_out="$(mktemp)"
 gh_out="$(mktemp)"
@@ -45,7 +46,7 @@ timeout 5 task status:git >"$git_out" 2>/dev/null &
 git_pid=$!
 timeout 12 task status:gh >"$gh_out" 2>/dev/null &
 gh_pid=$!
-timeout 11 task status:creds >"$creds_out" 2>/dev/null &
+timeout 13 task status:creds >"$creds_out" 2>/dev/null &
 creds_pid=$!
 
 # `wait` on each, with the failure recorded rather than propagated: `set -e`

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -56,6 +56,19 @@ git config --file "$ENV_GITCONFIG" user.email "${DEVCONTAINER_GIT_EMAIL}"
 #
 # $1 is an extra command for the login path (the git bridge), omitted where
 # VS Code already manages git's credential.
+# The scope list the login line below asks for comes from scripts/gh-scopes.sh,
+# the same file status.sh and setup-gh-scopes.sh read, so the banner cannot
+# drift from what the session-start check demands (issue #827). Sourced
+# defensively: this script also runs in trees where the workspace folder is not
+# yet the repo root, and a missing helper must not fail the whole post-create.
+GH_SCOPES_LIB="${GH_SCOPES_LIB:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)/scripts/gh-scopes.sh}"
+if [ -r "${GH_SCOPES_LIB}" ]; then
+    # shellcheck source=scripts/gh-scopes.sh
+    . "${GH_SCOPES_LIB}"
+else
+    gh_scopes_request_list() { printf '%s' "repo,workflow,project,read:project"; }
+fi
+
 gh_auth_help() {
     echo "=============================================================="
     echo "  GitHub CLI is NOT authenticated — gh pr / gh api and the"
@@ -65,7 +78,10 @@ gh_auth_help() {
         echo "  This profile authenticates as you. Log in:"
         echo ""
         echo "    gh auth login --hostname github.com --git-protocol https \\"
-        echo "      --web --scopes \"workflow,project\""
+        echo "      --web --scopes \"$(gh_scopes_request_list)\""
+        echo ""
+        echo "  In an existing checkout, 'task setup:gh-scopes' does the same"
+        echo "  from the repo and verifies the scopes landed."
         if [ -n "${1:-}" ]; then
             echo "    $1"
         fi

--- a/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/scripts/post-create-common.sh
@@ -80,8 +80,9 @@ gh_auth_help() {
         echo "    gh auth login --hostname github.com --git-protocol https \\"
         echo "      --web --scopes \"$(gh_scopes_request_list)\""
         echo ""
-        echo "  In an existing checkout, 'task setup:gh-scopes' does the same"
-        echo "  from the repo and verifies the scopes landed."
+        echo "  Then, in the checkout, 'task setup:gh-scopes' verifies the"
+        echo "  scopes landed and adds any this repo needs. (It refreshes an"
+        echo "  EXISTING login — it cannot replace the command above.)"
         if [ -n "${1:-}" ]; then
             echo "    $1"
         fi

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -27,11 +27,25 @@ board writes that do nothing.
 | `read:project` | read Projects | reading a card's current `Status`; **no writes** |
 | `project` | read **and write** Projects | everything on this page |
 
-Ask for the full scope. It is a superset, so there is no reason to request
-`read:project` alongside it:
+### Getting them: `task setup:gh-scopes`
 
 ```sh
-gh auth refresh -s project
+task setup:gh-scopes
+```
+
+**Operator / dev profile only.** It refreshes *your* interactive `gh` login —
+so it refuses when a `GH_TOKEN`/`GITHUB_TOKEN` env credential is set (an env
+token overrides the stored one, so a refresh would repair something this shell
+never uses — reissue that token at its source instead) and refuses without a
+TTY, because the flow is an interactive browser device-code exchange and no
+agent or CI job should re-mint a human credential. It prints the current
+scopes, requests the missing ones, and then **verifies they actually landed** —
+`gh auth refresh` can exit 0 having granted less than was asked for.
+
+The raw equivalent, for a shell that is not in a checkout yet:
+
+```sh
+gh auth refresh -s repo,workflow,project,read:project
 ```
 
 Check what a token actually carries:
@@ -40,10 +54,35 @@ Check what a token actually carries:
 gh auth status | grep 'Token scopes'
 ```
 
-`task status:gh` reports this as **Project board writes**, so a missing scope
-surfaces at session start — before a claim is made against a board that cannot
-receive it. `task setup:github-project` refuses to run without it rather than
-failing partway through its writes.
+### Where the required list lives
+
+One file: `scripts/gh-scopes.sh`. The session-start check in `status.sh`,
+`setup-gh-scopes.sh`, and the devcontainer's `gh_auth_help` banner all read it,
+so the remedy a warning prints and the scopes the task requests cannot drift
+apart. Extend it **without editing the file** by exporting
+`GH_REQUIRED_SCOPES` (e.g. from `.envrc`):
+
+```sh
+export GH_REQUIRED_SCOPES="repo workflow project|read:project admin:org"
+```
+
+Whitespace separates requirements; `|` joins alternatives that each satisfy
+one. The Projects requirement is present only because this repo has board
+tooling — a repo generated without it requires `repo workflow` alone, and is
+never warned about a grant it does not use.
+
+### Where it surfaces
+
+`task status:creds` — which the session-start hook runs every session — warns
+when the token is missing anything on that list, names the missing scopes, and
+prints the remedy. It is silent when the list is satisfied, read-only,
+non-fatal, and bounded (one 3s probe; `STATUS_NO_NETWORK=1` skips it). A probe
+that cannot answer reports nothing rather than accusing a working credential.
+
+`task status:gh` additionally reports **Project board writes**, a narrower
+question: `read:project` satisfies the session-start check but is read-only, so
+it fails that one. `task setup:github-project` refuses to run without `project`
+rather than failing partway through its writes.
 
 Two adjacent scopes, for completeness: an organization's **issue types** need
 `admin:org` (reported by `task status:setup`), and the vendored claim skills

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -42,10 +42,18 @@ agent or CI job should re-mint a human credential. It prints the current
 scopes, requests the missing ones, and then **verifies they actually landed** —
 `gh auth refresh` can exit 0 having granted less than was asked for.
 
-The raw equivalent, for a shell that is not in a checkout yet:
+The raw equivalent, derived from the same list rather than copied out of it —
+a hardcoded copy silently goes stale the moment the list changes (an org repo,
+for instance, also needs `admin:org`):
 
 ```sh
-gh auth refresh -s repo,workflow,project,read:project
+gh auth refresh -s "$(. scripts/gh-scopes.sh && gh_scopes_request_list)"
+```
+
+To just see what this repo asks for:
+
+```sh
+. scripts/gh-scopes.sh && gh_scopes_request_list
 ```
 
 Check what a token actually carries:

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -47,14 +47,19 @@ a hardcoded copy silently goes stale the moment the list changes (an org repo,
 for instance, also needs `admin:org`):
 
 ```sh
-gh auth refresh -s "$(. scripts/gh-scopes.sh && gh_scopes_request_list)"
+gh auth refresh -s "$(bash -c '. scripts/gh-scopes.sh && gh_scopes_request_list')"
 ```
 
 To just see what this repo asks for:
 
 ```sh
-. scripts/gh-scopes.sh && gh_scopes_request_list
+bash -c '. scripts/gh-scopes.sh && gh_scopes_request_list'
 ```
+
+(Through `bash` on purpose: the helper resolves its own location via
+`BASH_SOURCE`, and the devcontainer's default shell is zsh, where sourcing it
+directly would resolve the repo root to the wrong directory and silently shrink
+the list.)
 
 Check what a token actually carries:
 
@@ -67,12 +72,17 @@ gh auth status | grep 'Token scopes'
 One file: `scripts/gh-scopes.sh`. The session-start check in `status.sh`,
 `setup-gh-scopes.sh`, and the devcontainer's `gh_auth_help` banner all read it,
 so the remedy a warning prints and the scopes the task requests cannot drift
-apart. Extend it **without editing the file** by exporting
-`GH_REQUIRED_SCOPES` (e.g. from `.envrc`):
+apart. Add your own **without editing the file** by exporting
+`GH_EXTRA_SCOPES` (e.g. from `.envrc`):
 
 ```sh
-export GH_REQUIRED_SCOPES="repo workflow project|read:project admin:org"
+export GH_EXTRA_SCOPES="delete_repo"
 ```
+
+That is **additive**: everything this repo's profile already requires keeps
+applying, including anything a later template update introduces.
+`GH_REQUIRED_SCOPES` also exists and **replaces** the computed list outright —
+an escape hatch that freezes today's defaults. Prefer `GH_EXTRA_SCOPES`.
 
 Whitespace separates requirements; `|` joins alternatives that each satisfy
 one. The Projects requirement is present only because this repo has board

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -329,7 +329,7 @@ you log in as yourself:
 
 ```sh
 gh auth login --hostname github.com --git-protocol https \
-  --web --scopes "$(. scripts/gh-scopes.sh && gh_scopes_request_list)"
+  --web --scopes "$(bash -c '. scripts/gh-scopes.sh && gh_scopes_request_list')"
 gh auth setup-git
 ```
 

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -329,9 +329,16 @@ you log in as yourself:
 
 ```sh
 gh auth login --hostname github.com --git-protocol https \
-  --web --scopes "workflow,project"
+  --web --scopes "$(. scripts/gh-scopes.sh && gh_scopes_request_list)"
 gh auth setup-git
 ```
+
+The scope list is **derived**, not typed: `scripts/gh-scopes.sh` is the single
+source this repo's session-start check and `task setup:gh-scopes` read, so the
+login above asks for exactly what the check demands — including profile-specific
+additions such as `admin:org` in an organization repo. Outside a checkout, use
+the literal `--scopes "workflow,project"` and then run `task setup:gh-scopes`
+once you have cloned, which adds anything missing and verifies it landed.
 
 `--scopes` is *additive* to gh's defaults (`repo`, `read:org`, `gist`). `project`
 is what Projects V2 writes need — without it `task status:gh` reports the board

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -525,6 +525,14 @@ assert_unit() {
     sed -n '/^gh_auth_help()/,/^}/p' "$post_create_common" >"$helper_src"
     [ -s "$helper_src" ] || fail "could not extract gh_auth_help() from ${post_create_common}"
 
+    # The banner asks scripts/gh-scopes.sh for the scope list (the single
+    # source shared with status.sh and setup:gh-scopes), and the extraction
+    # above takes the function body ALONE. Without the library, the call
+    # resolves to nothing, the banner renders `--scopes ""`, and a check that
+    # only looked for a login command would pass on a broken banner.
+    local scopes_lib="${repo_root}/scripts/gh-scopes.sh"
+    [ -f "$scopes_lib" ] || fail "scripts/gh-scopes.sh not found at ${scopes_lib}"
+
     # Match a pasteable COMMAND line — `gh` as the first token — not the bare
     # phrase. The token message names `gh auth login` on purpose, in a "do NOT
     # run this here" warning; a substring test would read that warning as the
@@ -533,15 +541,28 @@ assert_unit() {
         printf '%s\n' "$1" | grep -qE '^[[:space:]]*gh[[:space:]]+auth[[:space:]]+login'
     }
 
-    help_out="$(unset DEVCONTAINER_GH_AUTH && "$bash_bin" -c '. "$1"; gh_auth_help "gh auth setup-git"' _ "$helper_src")"
+    help_out="$(unset DEVCONTAINER_GH_AUTH && "$bash_bin" -c '. "$2"; . "$1"; gh_auth_help "gh auth setup-git"' _ "$helper_src" "$scopes_lib")"
     if offers_login "$help_out"; then
         fail "post-create gh guidance offers an operator login by default — a bot container must never be told to run one"
     fi
 
-    help_out="$(DEVCONTAINER_GH_AUTH=login "$bash_bin" -c '. "$1"; gh_auth_help "gh auth setup-git"' _ "$helper_src")"
+    help_out="$(DEVCONTAINER_GH_AUTH=login "$bash_bin" -c '. "$2"; . "$1"; gh_auth_help "gh auth setup-git"' _ "$helper_src" "$scopes_lib")"
     if ! offers_login "$help_out"; then
         fail "post-create gh guidance omits the operator login where the profile declares one"
     fi
+
+    # The login it offers must carry the DERIVED scopes, not an empty or
+    # hardcoded list — that agreement between the banner and the scope check is
+    # the acceptance criterion the single source exists to satisfy (#827).
+    case "$help_out" in
+    *'--scopes ""'*) fail "post-create login line renders an empty scope list — gh-scopes.sh was not in scope" ;;
+    esac
+    for required_scope in repo workflow; do
+        case "$help_out" in
+        *"${required_scope}"*) ;;
+        *) fail "post-create login line omits the '${required_scope}' scope: ${help_out}" ;;
+        esac
+    done
 
     # 10. Static devcontainer.json invariants via the devcontainers CLI.
     assert_config_invariants "$repo_root" "$bot_config" bot

--- a/template/scripts/gh-scopes.sh
+++ b/template/scripts/gh-scopes.sh
@@ -146,6 +146,39 @@ gh_scopes_missing() {
     printf '%s' "${out}"
 }
 
+# gh_scopes_missing_requested SCOPE_LINE — the scopes that were REQUESTED but
+# are not present, whitespace-separated.
+#
+# Distinct from gh_scopes_missing, and both are needed. The status check asks
+# "was this credential minted with the right access in mind", and there the
+# `project|read:project` alternation is right — either proves it. A refresh
+# cannot use that question: `gh auth refresh` was handed every alternative, so
+# a grant that came back with only `read:project` satisfies the alternation
+# while board WRITES still fail, and reporting "all required scopes present"
+# there would leave the operator in exactly the failure the task exists to end.
+#
+# One implication is honoured, because GitHub's own scopes nest: `project`
+# (read and write) subsumes `read:project`, so a credential reported with only
+# `project` is not missing the read grant. Kept as a single named pair rather
+# than a general lattice — it is the only nesting this list contains, and an
+# implication table nobody can enumerate would be worse than none.
+gh_scopes_missing_requested() {
+    local line="$1" scope out=""
+    for scope in $(gh_scopes__alternatives "$(gh_scopes_request_list | tr ',' ' ')"); do
+        case "${line}" in
+        *"'${scope}'"*) continue ;;
+        esac
+        # `project` implies `read:project`.
+        if [ "${scope}" = "read:project" ]; then
+            case "${line}" in
+            *"'project'"*) continue ;;
+            esac
+        fi
+        out="${out:+${out} }${scope}"
+    done
+    printf '%s' "${out}"
+}
+
 # gh_scopes_human "req req…" — render requirements for a human: the `|`
 # alternation becomes " or ", and requirements are comma-separated.
 gh_scopes_human() {

--- a/template/scripts/gh-scopes.sh
+++ b/template/scripts/gh-scopes.sh
@@ -25,15 +25,77 @@
 # Why these four:
 #   repo      — the PR/issue surface the Dev Loop runs on
 #   workflow  — pushing branches that touch .github/workflows/
-#   project   — the claim lifecycle's board writes (read:project alone is
-#               read-only; status.sh reports that distinction separately)
+#   project   — the claim lifecycle's board writes, and ONLY in a repo that has
+#               board tooling (read:project alone is read-only; status.sh
+#               reports that distinction separately) — see gh_scopes_default
 #
 # Deliberately NOT a check of what the token can do — scopes are a server-side
 # property of the credential and this file only names what to compare against.
 
 # shellcheck shell=bash
 
-GH_REQUIRED_SCOPES="${GH_REQUIRED_SCOPES:-repo workflow project|read:project}"
+# The repo root these helpers answer for. Resolved from this file's own
+# location, not the caller's cwd, because the devcontainer banner sources it
+# from a lifecycle script whose working directory is not guaranteed.
+GH_SCOPES_ROOT="${GH_SCOPES_ROOT:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+# gh_target_host — the host gh will actually use for THIS repository.
+#
+# Lives here rather than in status.sh because scopes are a property of a
+# credential ON A HOST: "which scopes" is only answerable once "whose token" is,
+# and two copies of this resolution would let the check and the remedy disagree
+# about which credential they mean.
+#
+# Narrowing to github.com would disown a valid Enterprise login (`gh auth login
+# --hostname ghe.example.com`, no GH_HOST exported). So resolve it the way gh
+# documents: GH_HOST is the override for when a host "cannot be determined from
+# repository context", which means repository context comes first when GH_HOST
+# is unset. Local and network-free — the remote URL is the context.
+gh_target_host() {
+    local url host=""
+    if [ -n "${GH_HOST:-}" ]; then
+        printf '%s' "${GH_HOST}"
+        return 0
+    fi
+    url="$(git config --get remote.origin.url 2>/dev/null || true)"
+    case "${url}" in
+    *://*)                 # scheme://[user@]host[:port]/path
+        host="${url#*://}" # drop the scheme
+        host="${host#*@}"  # drop any userinfo
+        host="${host%%/*}" # drop the path
+        host="${host%%:*}" # drop any port
+        ;;
+    *@*:*) # scp-like: user@host:owner/repo
+        host="${url#*@}"
+        host="${host%%:*}"
+        ;;
+    esac
+    printf '%s' "${host:-github.com}"
+}
+
+# gh_scopes_default — the required list for THIS repo's actual feature set.
+#
+# `repo` and `workflow` are unconditional: every generated repo opens PRs and
+# has a .github/workflows/ a push may touch.
+#
+# The Projects scopes are NOT. `project_management` defaults to `none`, and a
+# repo generated that way has no board to write to — demanding Projects access
+# there would warn every session, in the majority profile, about a grant the
+# repo never uses, and train the reader to ignore the line where it matters.
+# So it is gated on the same marker the board-write check in status.sh uses:
+# setup-github-project.sh is rendered only for `project_management: github`,
+# which makes its presence the proxy for "this repo is configured to have a
+# board". Same accepted cost, recorded there: a repo on `none` whose issues
+# someone adds to a board by hand learns from the claim's own exit 2 instead.
+gh_scopes_default() {
+    local list="repo workflow"
+    if [ -f "${GH_SCOPES_ROOT}/scripts/setup-github-project.sh" ]; then
+        list="${list} project|read:project"
+    fi
+    printf '%s' "${list}"
+}
+
+GH_REQUIRED_SCOPES="${GH_REQUIRED_SCOPES:-$(gh_scopes_default)}"
 
 # gh_scopes_request_list — the comma-separated list to hand
 # `gh auth login --scopes` / `gh auth refresh -s`.

--- a/template/scripts/gh-scopes.sh
+++ b/template/scripts/gh-scopes.sh
@@ -87,10 +87,21 @@ gh_target_host() {
 # which makes its presence the proxy for "this repo is configured to have a
 # board". Same accepted cost, recorded there: a repo on `none` whose issues
 # someone adds to a board by hand learns from the claim's own exit 2 instead.
+#
+# `admin:org` rides on the same rule. The template renders
+# setup-github-issue-types.sh (and setup-github-issue-fields.sh) only when the
+# repo belongs to an ORG rather than the author's own account, and those tasks
+# state they need `admin:org` — so a generated org repo could otherwise pass
+# every scope check here and still fail those setups. A personal-account repo
+# renders neither script and is never asked for it.
 gh_scopes_default() {
     local list="repo workflow"
     if [ -f "${GH_SCOPES_ROOT}/scripts/setup-github-project.sh" ]; then
         list="${list} project|read:project"
+    fi
+    if [ -f "${GH_SCOPES_ROOT}/scripts/setup-github-issue-types.sh" ] ||
+        [ -f "${GH_SCOPES_ROOT}/scripts/setup-github-issue-fields.sh" ]; then
+        list="${list} admin:org"
     fi
     printf '%s' "${list}"
 }

--- a/template/scripts/gh-scopes.sh
+++ b/template/scripts/gh-scopes.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# gh-scopes.sh — the single source of truth for the GitHub token scopes this
+# repository's tooling needs.
+#
+# SOURCED, never executed. Three consumers read it so the required list is
+# stated once instead of drifting into three near-copies:
+#
+#   * scripts/status.sh          — warns at session start when a scope is missing
+#   * scripts/setup-gh-scopes.sh — mints/refreshes a credential that has them all
+#   * .devcontainer/scripts/post-create-common.sh — the gh_auth_help banner's
+#     `gh auth login --scopes` line
+#
+# A consumer repo extends the list WITHOUT editing this file by exporting
+# GH_REQUIRED_SCOPES before invoking any of the above (e.g. in .envrc):
+#
+#     export GH_REQUIRED_SCOPES="repo workflow project|read:project admin:org"
+#
+# Syntax: whitespace-separated requirements. A requirement is one scope name,
+# or several joined by `|` meaning "any one of these satisfies it". The
+# alternation exists because `project` and `read:project` are separate grants
+# that GitHub reports separately, and either one proves the token was minted
+# with Projects access in mind — while `gh auth refresh` is asked for BOTH, so
+# that the credential this repo mints can also write the board.
+#
+# Why these four:
+#   repo      — the PR/issue surface the Dev Loop runs on
+#   workflow  — pushing branches that touch .github/workflows/
+#   project   — the claim lifecycle's board writes (read:project alone is
+#               read-only; status.sh reports that distinction separately)
+#
+# Deliberately NOT a check of what the token can do — scopes are a server-side
+# property of the credential and this file only names what to compare against.
+
+# shellcheck shell=bash
+
+GH_REQUIRED_SCOPES="${GH_REQUIRED_SCOPES:-repo workflow project|read:project}"
+
+# gh_scopes_request_list — the comma-separated list to hand
+# `gh auth login --scopes` / `gh auth refresh -s`.
+#
+# Every alternative of every requirement is requested, not just one: asking for
+# `project` alone would satisfy the check while leaving the vendored track-work
+# skill's `read:project` hint unmet, and the two remedy strings that used to
+# disagree (issue #596) are exactly what one derived list removes.
+gh_scopes_request_list() {
+    local req alt out=""
+    for req in $(gh_scopes__words "${GH_REQUIRED_SCOPES}"); do
+        for alt in $(gh_scopes__alternatives "${req}"); do
+            case ",${out}," in *",${alt},"*) continue ;; esac
+            out="${out:+${out},}${alt}"
+        done
+    done
+    printf '%s' "${out}"
+}
+
+# gh_scopes_missing SCOPE_LINE — print the requirements SCOPE_LINE does not
+# satisfy, whitespace-separated; print nothing when it satisfies them all.
+#
+# SCOPE_LINE is the `Token scopes:` line of `gh auth status`, whose scopes are
+# quoted (`… 'gist', 'project', 'repo'`). Matching on the quotes is what keeps
+# `project` from also matching `read:project` and vice versa — they are
+# different grants, and the alternation above is how a caller says either will
+# do.
+#
+# A line with no quoted scopes at all is a fine-grained PAT or an App
+# installation token, which carries permissions rather than OAuth scopes. That
+# is NOT a missing-scope condition and callers must classify it as unknown —
+# this function reports every requirement as missing for such a line, so guard
+# the call, as status.sh does.
+gh_scopes_missing() {
+    local line="$1" req alt satisfied out=""
+    for req in $(gh_scopes__words "${GH_REQUIRED_SCOPES}"); do
+        satisfied=false
+        for alt in $(gh_scopes__alternatives "${req}"); do
+            case "${line}" in
+            *"'${alt}'"*)
+                satisfied=true
+                break
+                ;;
+            esac
+        done
+        [ "${satisfied}" = true ] || out="${out:+${out} }${req}"
+    done
+    printf '%s' "${out}"
+}
+
+# gh_scopes_human "req req…" — render requirements for a human: the `|`
+# alternation becomes " or ", and requirements are comma-separated.
+gh_scopes_human() {
+    local req out=""
+    for req in $(gh_scopes__words "$1"); do
+        out="${out:+${out}, }$(printf '%s' "${req}" | sed 's/|/ or /g')"
+    done
+    printf '%s' "${out}"
+}
+
+# Internal splitters. Word-splitting is the intent here, so it happens in one
+# named place with the shellcheck waiver attached to it rather than at four
+# call sites.
+gh_scopes__words() {
+    # shellcheck disable=SC2086 # deliberate: the list is whitespace-separated
+    printf '%s\n' $1
+}
+
+gh_scopes__alternatives() {
+    printf '%s' "$1" | tr '|' ' '
+}

--- a/template/scripts/gh-scopes.sh
+++ b/template/scripts/gh-scopes.sh
@@ -10,10 +10,15 @@
 #   * .devcontainer/scripts/post-create-common.sh — the gh_auth_help banner's
 #     `gh auth login --scopes` line
 #
-# A consumer repo extends the list WITHOUT editing this file by exporting
-# GH_REQUIRED_SCOPES before invoking any of the above (e.g. in .envrc):
+# A consumer repo adds its own requirements WITHOUT editing this file by
+# exporting GH_EXTRA_SCOPES before invoking any of the above (e.g. in .envrc):
 #
-#     export GH_REQUIRED_SCOPES="repo workflow project|read:project admin:org"
+#     export GH_EXTRA_SCOPES="delete_repo"
+#
+# That is ADDITIVE — the repo's own requirements keep applying, including any a
+# later template update introduces. GH_REQUIRED_SCOPES also exists and REPLACES
+# the computed list outright; it is the escape hatch, and it freezes today's
+# defaults.
 #
 # Syntax: whitespace-separated requirements. A requirement is one scope name,
 # or several joined by `|` meaning "any one of these satisfies it". The
@@ -106,7 +111,17 @@ gh_scopes_default() {
     printf '%s' "${list}"
 }
 
-GH_REQUIRED_SCOPES="${GH_REQUIRED_SCOPES:-$(gh_scopes_default)}"
+# Two knobs, because "extend" and "replace" are different intentions and only
+# one of them is safe to reach for by default:
+#
+#   GH_EXTRA_SCOPES     — ADDED to whatever this repo's profile already
+#                         requires. The one to use: a later template update
+#                         that adds a requirement still reaches you.
+#   GH_REQUIRED_SCOPES  — REPLACES the computed list outright. An escape
+#                         hatch. Setting it freezes today's defaults, so a
+#                         requirement added upstream will silently stop being
+#                         checked.
+GH_REQUIRED_SCOPES="${GH_REQUIRED_SCOPES:-$(gh_scopes_default)${GH_EXTRA_SCOPES:+ ${GH_EXTRA_SCOPES}}}"
 
 # gh_scopes_request_list — the comma-separated list to hand
 # `gh auth login --scopes` / `gh auth refresh -s`.

--- a/template/scripts/setup-gh-scopes.sh
+++ b/template/scripts/setup-gh-scopes.sh
@@ -55,15 +55,43 @@ if [ ! -t 0 ] || [ ! -t 1 ]; then
   re-mint the operator's credential."
 fi
 
-HOSTNAME_ARG="${GH_HOST:-github.com}"
+# The host comes from the repository, exactly as status.sh derives it — not a
+# github.com assumption. In an Enterprise checkout with no GH_HOST, status.sh
+# warns about the ghe.example.com credential and names this task; refreshing
+# github.com here would edit an unrelated credential and leave the one the
+# warning was about still under-scoped.
+HOSTNAME_ARG="$(gh_target_host)"
 REQUEST_LIST="$(gh_scopes_request_list)"
+
+# gh_auth_status_active — `gh auth status` narrowed to the ONE credential this
+# task refreshes. `gh auth refresh` updates only the ACTIVE account, while a
+# bare `--hostname` read reports every account on that host: concatenating
+# those scope lines lets one account's grants satisfy a requirement the
+# refreshed account still lacks, and the verification below would report a
+# success that did not happen. Same narrowing, and the same pre-2.40 fallback,
+# that status.sh uses.
+gh_auth_status_active() {
+    local out rc=0
+    out="$(gh auth status --active --hostname "${HOSTNAME_ARG}" 2>&1)" || rc=$?
+    case "${out}" in
+    *"unknown flag"*)
+        # gh predates --active (2.40). Multi-account per host arrived WITH
+        # 2.40, so on a gh this old one host means one account and the
+        # narrowing is already complete.
+        rc=0
+        out="$(gh auth status --hostname "${HOSTNAME_ARG}" 2>&1)" || rc=$?
+        ;;
+    esac
+    printf '%s\n' "${out}"
+    return "${rc}"
+}
 
 # `gh auth status` is the only place scopes are readable — they are a
 # server-side property of the token, not something stored locally. Captured
 # with 2>&1 because gh has moved this report between stdout and stderr across
 # versions; only the scope LINE is ever printed back.
 scopes_before=""
-if status_out="$(gh auth status --hostname "${HOSTNAME_ARG}" 2>&1)"; then
+if status_out="$(gh_auth_status_active)"; then
     scopes_before="$(printf '%s\n' "${status_out}" |
         grep -i 'token scopes:' || true)"
 else
@@ -83,7 +111,7 @@ gh auth refresh --hostname "${HOSTNAME_ARG}" -s "${REQUEST_LIST}"
 #    than was asked for — a browser flow the operator edited, an org that
 #    restricts the scope. Reporting success off the exit code alone would put
 #    the session right back into the failure this task exists to end.
-verify_out="$(gh auth status --hostname "${HOSTNAME_ARG}" 2>&1)" ||
+verify_out="$(gh_auth_status_active)" ||
     die "post-refresh 'gh auth status' failed — the credential may be broken."
 scopes_after="$(printf '%s\n' "${verify_out}" | grep -i 'token scopes:' || true)"
 

--- a/template/scripts/setup-gh-scopes.sh
+++ b/template/scripts/setup-gh-scopes.sh
@@ -119,6 +119,29 @@ else
   gh auth login --hostname ${HOSTNAME_ARG} --git-protocol https --web --scopes \"${REQUEST_LIST}\""
 fi
 
+# 3. Refuse a stored NON-OAuth credential before touching it. A fine-grained
+#    PAT or a GitHub App installation token carries permissions, not OAuth
+#    scopes, and gh reports its scope line with nothing quoted in it. Running
+#    `gh auth refresh` against one completes a device flow and STORES A NEW
+#    CLASSIC TOKEN — silently replacing a deliberately narrow credential with a
+#    broad one, and then reporting success. That is the opposite of the
+#    source-side remedy documented in docs/project-management.md.
+#
+#    Only the definite case is refused: a scope line that is present and has no
+#    quoted scopes in it. A missing line entirely is unknown (an older gh, a
+#    changed output format), and refusing on unknown would block a legitimate
+#    OAuth user from the one command that fixes their token.
+case "${scopes_before}" in
+"") ;;    # no scope line at all — unknown, not proof of a non-OAuth token
+*"'"*) ;; # quoted scopes present — a classic OAuth credential, proceed
+*)
+    die "the stored credential for ${HOSTNAME_ARG} reports no OAuth scopes — it is a
+  fine-grained PAT or a GitHub App token, which carries permissions rather than
+  scopes. 'gh auth refresh' would replace it with a broad classic token instead
+  of fixing it. Grant the matching permission where that token was issued."
+    ;;
+esac
+
 echo "==> Host:            ${HOSTNAME_ARG}"
 echo "==> Current scopes:  ${scopes_before:-<none reported>}"
 echo "==> Required:        $(gh_scopes_human "${GH_REQUIRED_SCOPES}")"

--- a/template/scripts/setup-gh-scopes.sh
+++ b/template/scripts/setup-gh-scopes.sh
@@ -147,7 +147,10 @@ case "${scopes_after}" in
     ;;
 esac
 
-missing="$(gh_scopes_missing "${scopes_after}")"
+# Every REQUESTED scope, not merely the required alternation: the refresh was
+# handed both Projects scopes, and coming back with only the read one leaves
+# board writes broken while satisfying `project|read:project`.
+missing="$(gh_scopes_missing_requested "${scopes_after}")"
 if [ -n "${missing}" ]; then
     die "the refresh did not grant: $(gh_scopes_human "${missing}").
   Re-run and approve every scope, or check whether the organization restricts
@@ -155,4 +158,4 @@ if [ -n "${missing}" ]; then
 fi
 
 echo ""
-echo "All required scopes present: $(gh_scopes_human "${GH_REQUIRED_SCOPES}")"
+echo "All requested scopes present: $(gh_scopes_request_list)"

--- a/template/scripts/setup-gh-scopes.sh
+++ b/template/scripts/setup-gh-scopes.sh
@@ -35,14 +35,35 @@ die() {
 
 command -v gh >/dev/null 2>&1 || die "gh is not installed (brew install gh)"
 
-# 1. Env-token refusal. Checked before anything else and named individually,
-#    because the fix differs per variable and a generic message sends the
-#    reader looking for the wrong one.
-for var in GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN; do
+# 1. Env-token refusal, for the token family gh actually uses on THIS host.
+#
+#    The four variables are not interchangeable: gh reads GH_TOKEN /
+#    GITHUB_TOKEN for github.com (and ghe.com), and GH_ENTERPRISE_TOKEN /
+#    GITHUB_ENTERPRISE_TOKEN for a GitHub Enterprise Server host. Refusing on
+#    any of the four blocked a legitimate dual-host workflow — an exported
+#    GH_ENTERPRISE_TOKEN for a GHES account stopped a github.com refresh that
+#    it does not override, and vice versa.
+#
+#    Where the variable DOES apply, the refusal stands: an env token overrides
+#    the stored credential, so `gh auth refresh` would repair something this
+#    shell never uses — and in a bot container it is the credential escalation
+#    ADR 0004 exists to prevent.
+#
+#    Resolved before the TTY check because the host is needed either way, and
+#    named individually because the fix differs per variable.
+HOSTNAME_ARG="$(gh_target_host)"
+
+case "${HOSTNAME_ARG}" in
+github.com | *.ghe.com) env_token_vars="GH_TOKEN GITHUB_TOKEN" ;;
+*) env_token_vars="GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN" ;;
+esac
+
+for var in ${env_token_vars}; do
     if [ -n "${!var:-}" ]; then
-        die "${var} is set. An env token overrides the stored credential, so
-  'gh auth refresh' would fix something this shell never uses. Reissue ${var}
-  at its source with: $(gh_scopes_request_list)
+        die "${var} is set, and gh uses it for ${HOSTNAME_ARG}. An env token
+  overrides the stored credential, so 'gh auth refresh' would fix something
+  this shell never uses. Reissue ${var} at its source with the scopes:
+  $(gh_scopes_request_list)
   (In a bot container this is the intended state — see docs/guides/bot-account.md.)"
     fi
 done
@@ -55,12 +76,11 @@ if [ ! -t 0 ] || [ ! -t 1 ]; then
   re-mint the operator's credential."
 fi
 
-# The host comes from the repository, exactly as status.sh derives it — not a
-# github.com assumption. In an Enterprise checkout with no GH_HOST, status.sh
-# warns about the ghe.example.com credential and names this task; refreshing
-# github.com here would edit an unrelated credential and leave the one the
-# warning was about still under-scoped.
-HOSTNAME_ARG="$(gh_target_host)"
+# HOSTNAME_ARG is resolved above, from the repository exactly as status.sh
+# derives it — not a github.com assumption. In an Enterprise checkout with no
+# GH_HOST, status.sh warns about the ghe.example.com credential and names this
+# task; refreshing github.com here would edit an unrelated credential and leave
+# the one the warning was about still under-scoped.
 REQUEST_LIST="$(gh_scopes_request_list)"
 
 # gh_auth_status_active — `gh auth status` narrowed to the ONE credential this

--- a/template/scripts/setup-gh-scopes.sh
+++ b/template/scripts/setup-gh-scopes.sh
@@ -148,6 +148,17 @@ echo "==> Required:        $(gh_scopes_human "${GH_REQUIRED_SCOPES}")"
 echo "==> Requesting:      ${REQUEST_LIST}"
 echo ""
 
+# Nothing to do? Say so and stop, WITHOUT opening a browser. `gh auth refresh`
+# is an interactive OAuth flow even when it would change nothing, so an
+# unconditional run makes the documented sequence (log in with the derived
+# scopes, then run this to verify) authenticate twice, and every idempotent
+# re-run repeats it. The docs promise this requests the MISSING scopes; this is
+# that promise kept.
+if [ -z "$(gh_scopes_missing_requested "${scopes_before}")" ]; then
+    echo "Already complete — no refresh needed."
+    exit 0
+fi
+
 gh auth refresh --hostname "${HOSTNAME_ARG}" -s "${REQUEST_LIST}"
 
 # 3. Verify the grant LANDED. `gh auth refresh` can exit 0 having granted less

--- a/template/scripts/setup-gh-scopes.sh
+++ b/template/scripts/setup-gh-scopes.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# setup-gh-scopes.sh — give the OPERATOR's interactive gh credential every scope
+# this repo's tooling needs, and prove the grant actually landed.
+#
+# Run via `task setup:gh-scopes`. The required list is not stated here — it
+# comes from scripts/gh-scopes.sh, the one place status.sh, the devcontainer's
+# gh_auth_help banner, and this script all read (issues #827, #596).
+#
+# OPERATOR / DEV PROFILE ONLY. This mints a human credential, so it refuses in
+# the two contexts where doing that would be wrong:
+#
+#   1. An env token (GH_TOKEN / GITHUB_TOKEN and the enterprise variants) is
+#      set. That token OVERRIDES the stored one, so `gh auth refresh` would
+#      quietly repair a credential the current shell will never use — and in a
+#      bot container it is the credential-escalation ADR 0004 exists to
+#      prevent. The remedy there is to reissue the token at its source.
+#   2. There is no TTY. The refresh is a browser device-code flow; an agent or
+#      a CI job cannot complete it, and neither should re-mint the operator's
+#      credential unattended.
+#
+# Read-only until the refresh: it prints the current scopes, then asks gh for
+# the missing ones. Token VALUES are never printed or captured.
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# shellcheck source=scripts/gh-scopes.sh
+. "${REPO_ROOT}/scripts/gh-scopes.sh"
+
+die() {
+    echo "setup:gh-scopes: $*" >&2
+    exit 1
+}
+
+command -v gh >/dev/null 2>&1 || die "gh is not installed (brew install gh)"
+
+# 1. Env-token refusal. Checked before anything else and named individually,
+#    because the fix differs per variable and a generic message sends the
+#    reader looking for the wrong one.
+for var in GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN; do
+    if [ -n "${!var:-}" ]; then
+        die "${var} is set. An env token overrides the stored credential, so
+  'gh auth refresh' would fix something this shell never uses. Reissue ${var}
+  at its source with: $(gh_scopes_request_list)
+  (In a bot container this is the intended state — see docs/guides/bot-account.md.)"
+    fi
+done
+
+# 2. TTY refusal. Both directions are required: the device-code flow prints a
+#    code to be read (stdout) and waits on a keypress (stdin).
+if [ ! -t 0 ] || [ ! -t 1 ]; then
+    die "no TTY. The scope refresh is an interactive browser device-code flow —
+  run 'task setup:gh-scopes' yourself in a terminal. Agents and CI must not
+  re-mint the operator's credential."
+fi
+
+HOSTNAME_ARG="${GH_HOST:-github.com}"
+REQUEST_LIST="$(gh_scopes_request_list)"
+
+# `gh auth status` is the only place scopes are readable — they are a
+# server-side property of the token, not something stored locally. Captured
+# with 2>&1 because gh has moved this report between stdout and stderr across
+# versions; only the scope LINE is ever printed back.
+scopes_before=""
+if status_out="$(gh auth status --hostname "${HOSTNAME_ARG}" 2>&1)"; then
+    scopes_before="$(printf '%s\n' "${status_out}" |
+        grep -i 'token scopes:' || true)"
+else
+    die "not logged in to ${HOSTNAME_ARG}. Run:
+  gh auth login --hostname ${HOSTNAME_ARG} --git-protocol https --web --scopes \"${REQUEST_LIST}\""
+fi
+
+echo "==> Host:            ${HOSTNAME_ARG}"
+echo "==> Current scopes:  ${scopes_before:-<none reported>}"
+echo "==> Required:        $(gh_scopes_human "${GH_REQUIRED_SCOPES}")"
+echo "==> Requesting:      ${REQUEST_LIST}"
+echo ""
+
+gh auth refresh --hostname "${HOSTNAME_ARG}" -s "${REQUEST_LIST}"
+
+# 3. Verify the grant LANDED. `gh auth refresh` can exit 0 having granted less
+#    than was asked for — a browser flow the operator edited, an org that
+#    restricts the scope. Reporting success off the exit code alone would put
+#    the session right back into the failure this task exists to end.
+verify_out="$(gh auth status --hostname "${HOSTNAME_ARG}" 2>&1)" ||
+    die "post-refresh 'gh auth status' failed — the credential may be broken."
+scopes_after="$(printf '%s\n' "${verify_out}" | grep -i 'token scopes:' || true)"
+
+echo ""
+echo "==> New scopes:      ${scopes_after:-<none reported>}"
+
+case "${scopes_after}" in
+*"'"*) ;;
+*)
+    die "no OAuth scopes reported after the refresh. A fine-grained PAT or an
+  App token carries permissions rather than scopes — grant Projects access
+  where that token was issued instead."
+    ;;
+esac
+
+missing="$(gh_scopes_missing "${scopes_after}")"
+if [ -n "${missing}" ]; then
+    die "the refresh did not grant: $(gh_scopes_human "${missing}").
+  Re-run and approve every scope, or check whether the organization restricts
+  them (Settings → Third-party access)."
+fi
+
+echo ""
+echo "All required scopes present: $(gh_scopes_human "${GH_REQUIRED_SCOPES}")"

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -184,40 +184,10 @@ has_scope() {
     esac
 }
 
-# gh_target_host — the host gh will actually use for THIS repository.
-#
-# Narrowing `gh auth status --hostname` is only safe against the same host the
-# repo-aware calls use. Forcing github.com disowns a valid Enterprise login
-# (`gh auth login --hostname ghe.example.com`, no GH_HOST exported): the probe
-# exits non-zero, which this script reads as "not authenticated" and skips the
-# whole GitHub section — while `gh pr list` and `gh run list` would have worked
-# fine against that remote. So resolve it the way gh documents: GH_HOST is the
-# override for when a host "cannot be determined from repository context", which
-# means repository context comes first when GH_HOST is unset.
-#
-# Local and network-free — the remote URL is the context. github.com only as a
-# last resort, when there is no remote to read.
-gh_target_host() {
-    local url host=""
-    if [[ -n "${GH_HOST:-}" ]]; then
-        printf '%s' "${GH_HOST}"
-        return 0
-    fi
-    url="$(git config --get remote.origin.url 2>/dev/null || true)"
-    case "${url}" in
-    *://*)                 # scheme://[user@]host[:port]/path
-        host="${url#*://}" # drop the scheme
-        host="${host#*@}"  # drop any userinfo
-        host="${host%%/*}" # drop the path
-        host="${host%%:*}" # drop any port
-        ;;
-    *@*:*) # scp-like: user@host:owner/repo
-        host="${url#*@}"
-        host="${host%%:*}"
-        ;;
-    esac
-    printf '%s' "${host:-github.com}"
-}
+# gh_target_host is defined in scripts/gh-scopes.sh, sourced above: the host and
+# the required scopes are one question (whose token, carrying what), and two
+# copies of the resolution would let the check and its remedy disagree about
+# which credential they mean.
 
 # ── Parallel data collection ────────────────────────────────────────────────
 
@@ -284,7 +254,11 @@ if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
     esac
 fi
 
-# The token's scope line, and how to give THIS credential Projects write access.
+# The token's scope line, and how to give THIS credential more access. The
+# remedy names the credential SOURCE, never a particular scope: the call sites
+# already say which requirement is unmet, and a remedy that hardcoded "Projects"
+# mis-instructed a reader whose missing scope was `workflow` — or one of a
+# consumer's own GH_REQUIRED_SCOPES additions.
 # Derived once, because every call site below would otherwise guess — and a
 # remedy that cannot work is worse than none. `gh auth refresh` edits only the
 # STORED classic credential: it cannot touch an env-provided token (which
@@ -313,22 +287,22 @@ derive_gh_scope_state() {
     GH_SCOPES_LINE="$(grep -i 'token scopes:' "${file}" 2>/dev/null || true)"
     case "$(<"${file}")" in
     *"(GH_TOKEN)"*)
-        GH_REMEDY="reissue GH_TOKEN with Projects write — an env token overrides gh auth refresh"
+        GH_REMEDY="reissue GH_TOKEN with the missing scopes — an env token overrides gh auth refresh"
         ;;
     *"(GITHUB_TOKEN)"*)
-        GH_REMEDY="reissue GITHUB_TOKEN with Projects write — an env token overrides gh auth refresh"
+        GH_REMEDY="reissue GITHUB_TOKEN with the missing scopes — an env token overrides gh auth refresh"
         ;;
     *"(GH_ENTERPRISE_TOKEN)"*)
-        GH_REMEDY="reissue GH_ENTERPRISE_TOKEN with Projects write — an env token overrides gh auth refresh"
+        GH_REMEDY="reissue GH_ENTERPRISE_TOKEN with the missing scopes — an env token overrides gh auth refresh"
         ;;
     *"(GITHUB_ENTERPRISE_TOKEN)"*)
-        GH_REMEDY="reissue GITHUB_ENTERPRISE_TOKEN with Projects write — an env token overrides gh auth refresh"
+        GH_REMEDY="reissue GITHUB_ENTERPRISE_TOKEN with the missing scopes — an env token overrides gh auth refresh"
         ;;
     *)
         # Not an env token. A scope line with no scopes in it is a fine-grained
         # PAT or an App installation token — a permission, granted at the source.
         if [[ -n "${GH_SCOPES_LINE}" && "${GH_SCOPES_LINE}" != *"'"* ]]; then
-            GH_REMEDY="set its Projects permission where the token was issued"
+            GH_REMEDY="grant the matching permission where the token was issued"
         fi
         ;;
     esac

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -15,6 +15,12 @@ trap 'rm -rf "${TMPDIR_STATUS}"' EXIT
 # Overridable so a test can drive the deadline path without waiting on it.
 NETWORK_TIMEOUT="${NETWORK_TIMEOUT:-5}"
 
+# The required-scope list and its comparison helpers, stated once for this
+# script, setup-gh-scopes.sh, and the devcontainer's gh_auth_help banner.
+# A consumer repo extends it by exporting GH_REQUIRED_SCOPES — see that file.
+# shellcheck source=scripts/gh-scopes.sh
+. "${REPO_ROOT}/scripts/gh-scopes.sh"
+
 # ── Tool detection ──────────────────────────────────────────────────────────
 
 # NO_COLOR (https://no-color.org/) turns off gum styling as well as ANSI, which
@@ -240,10 +246,11 @@ GH_AUTH_PROBED=false
 # read the board, and used to run its own `gh auth status` to decide whether to
 # render at all. One probe, two consumers.
 #
-# Deliberately NOT extended to `SECTION == creds`: that section is invoked on its
-# own from the session-start hook, which already runs `status:gh` in the same
-# startup, and a second `gh auth status` there would be a net-new network call in
-# the one path whose whole budget argument is that it makes none.
+# Deliberately NOT extended to `SECTION == creds`: that section's gh line is a
+# LOCAL read (see render_local_credentials), and turning it into the full
+# validating probe would change what that line is entitled to claim. The scope
+# check issue #827 asks for is added there as its own narrowly-scoped call
+# instead — see render_gh_scope_check.
 if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
     GH_AUTH_PROBED=true
     gh_auth_rc=0
@@ -284,10 +291,27 @@ fi
 # overrides the stored one, on github.com and Enterprise alike) and cannot add a
 # fine-grained or App token's permissions, which are not OAuth scopes at all.
 GH_SCOPES_LINE=""
-GH_REMEDY="run: gh auth refresh -s project"
-if [[ -s "${GH_AUTH_FILE}" ]]; then
-    GH_SCOPES_LINE="$(grep -i 'token scopes:' "${GH_AUTH_FILE}" 2>/dev/null || true)"
-    case "$(<"${GH_AUTH_FILE}")" in
+# The stored-credential remedy names the TASK rather than a raw command: the
+# task refuses against an env token and without a TTY, and verifies the grant
+# actually landed, which a pasted `gh auth refresh` does none of (issue #596).
+# The raw command rides along for a reader who is not in a checkout yet, and is
+# derived from the same required-scope list — the two divergent remedy strings
+# #596 reported were exactly this string drifting from the skills' hint.
+GH_REMEDY_DEFAULT="run: task setup:gh-scopes (or: gh auth refresh -s $(gh_scopes_request_list))"
+GH_REMEDY="${GH_REMEDY_DEFAULT}"
+
+# derive_gh_scope_state FILE — set GH_SCOPES_LINE and GH_REMEDY from a captured
+# `gh auth status` report. A function rather than a straight-line block because
+# there are two probes that can produce one: the shared one below, and the
+# credentials section's own narrow one (render_gh_scope_check). Deriving it
+# twice by hand is how the two remedy strings issue #596 reported came to exist.
+derive_gh_scope_state() {
+    local file="$1"
+    GH_SCOPES_LINE=""
+    GH_REMEDY="${GH_REMEDY_DEFAULT}"
+    [[ -s "${file}" ]] || return 0
+    GH_SCOPES_LINE="$(grep -i 'token scopes:' "${file}" 2>/dev/null || true)"
+    case "$(<"${file}")" in
     *"(GH_TOKEN)"*)
         GH_REMEDY="reissue GH_TOKEN with Projects write — an env token overrides gh auth refresh"
         ;;
@@ -308,7 +332,9 @@ if [[ -s "${GH_AUTH_FILE}" ]]; then
         fi
         ;;
     esac
-fi
+}
+
+derive_gh_scope_state "${GH_AUTH_FILE}"
 
 # `should_show "gh"` as well as the auth flag: the auth probe above now also runs
 # for the setup section, and these two lists are read only by the GitHub section.
@@ -604,6 +630,76 @@ fi
 # Every probe here is bounded by the short LOCAL bound (3s), never by
 # NETWORK_TIMEOUT — nothing in it may reach the network, or the session-start
 # path inherits a cost its budget was not derived for.
+# render_gh_scope_check — one ⚠/unknown line when the authenticated token is
+# missing a scope this repo's tooling needs, and NOTHING when it has them all.
+#
+# Silent-on-success is a deliberate exception to this script's usual
+# report-both-directions rule (issue #827's acceptance criterion). The rule
+# exists so a check that never runs cannot masquerade as a passing one — and
+# here the caller has already printed a ✓ line for the same credential from the
+# same probe, so the evidence that this ran is on screen either way. A second
+# green line on every session start, in every repo, would be pure noise.
+#
+# Read-only and non-fatal: it only compares the scope line the shared probe
+# already captured.
+render_gh_scope_check() {
+    local missing rc=0 file
+    if [[ "${GH_AUTH_PROBED}" != true ]]; then
+        # Standalone `task status:creds` — the session-start path, and the one
+        # #827 is about. Scopes are a SERVER-side property of the token: no
+        # local file records them, so the one fact this check needs cannot be
+        # had without asking. The rest of the section stays local-only; this is
+        # a single bounded, read-only, non-fatal call, and
+        # `STATUS_NO_NETWORK=1` removes even that for offline shells.
+        if [[ "${STATUS_NO_NETWORK:-}" == 1 ]]; then
+            return 0
+        fi
+        file="${TMPDIR_STATUS}/auth-creds.txt"
+        : >"${file}"
+        # ONE call, bounded at the section's short local bound rather than
+        # NETWORK_TIMEOUT. Not because it is local — it is not — but because
+        # the session-start hook budgets this section from the sum of its
+        # probes, and a section that overruns loses ALL of its output
+        # (status.sh buffers before printing). A scope warning that costs the
+        # reader their credential lines is worse than no scope warning. For
+        # the same reason there is no `--active`-unsupported retry here: on a
+        # gh older than 2.40 the check simply does not run.
+        run_timeout 3 gh auth status --active \
+            --hostname "$(gh_target_host)" >"${file}" 2>&1 || rc=$?
+        if [[ "${rc}" -ne 0 ]] || grep -qi 'unknown flag' "${file}" 2>/dev/null; then
+            # A failed probe is NOT a missing login (issues #774, #478) and is
+            # not a missing scope either — say nothing rather than send a
+            # correctly-scoped operator to re-mint a working credential. The
+            # gh line above has already reported the credential itself.
+            return 0
+        fi
+        derive_gh_scope_state "${file}"
+    fi
+    if [[ -z "${GH_SCOPES_LINE}" ]]; then
+        # The probe ran and authenticated, but reported no scope line — an
+        # older gh, or an output change. Unknown, never "missing": telling
+        # someone to re-mint a working credential is the worse error.
+        checkline unknown "gh token scopes" \
+            "could not read token scopes from gh auth status"
+        return
+    fi
+    if [[ "${GH_SCOPES_LINE}" != *"'"* ]]; then
+        # A fine-grained PAT or an App installation token: permissions, not
+        # OAuth scopes. gh reports the line with nothing quoted in it. Such a
+        # token may well carry everything needed, so this is unknown — and the
+        # bot profile's credential is exactly this case, which is why the
+        # remedy here never says "log in" (see GH_REMEDY).
+        checkline unknown "gh token scopes" \
+            "no OAuth scopes reported (fine-grained or App token) — ${GH_REMEDY}"
+        return
+    fi
+    missing="$(gh_scopes_missing "${GH_SCOPES_LINE}")"
+    if [[ -n "${missing}" ]]; then
+        checkline no "gh token scopes" \
+            "missing $(gh_scopes_human "${missing}") — ${GH_REMEDY}"
+    fi
+}
+
 render_local_credentials() {
     # Not-installed is tested FIRST because it makes every other branch
     # meaningless: with no gh on PATH the shared probe above exits 127, which
@@ -625,6 +721,7 @@ render_local_credentials() {
                 "auth probe timed out after ${NETWORK_TIMEOUT}s"
         elif [[ "${GH_AUTHED}" == true ]]; then
             checkline ok "GitHub CLI (gh)" "authenticated to $(gh_target_host)"
+            render_gh_scope_check
         else
             checkline no "GitHub CLI (gh)" "gh auth login"
         fi
@@ -654,6 +751,10 @@ render_local_credentials() {
         0)
             checkline ok "GitHub CLI (gh)" \
                 "credential stored for $(gh_target_host) (not validated)"
+            # Only once a credential is known to exist: asking GitHub about the
+            # scopes of a token that is not there would spend a round trip to
+            # learn what the line above already said.
+            render_gh_scope_check
             ;;
         124) checkline unknown "GitHub CLI (gh)" "credential probe timed out" ;;
         *)

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -602,8 +602,18 @@ fi
 # network-heavy; this group is not, so the reason to exclude it does not apply.
 #
 # Every probe here is bounded by the short LOCAL bound (3s), never by
-# NETWORK_TIMEOUT — nothing in it may reach the network, or the session-start
-# path inherits a cost its budget was not derived for.
+# NETWORK_TIMEOUT — the session-start path must not inherit a cost its budget
+# was not derived for.
+#
+# ONE of them reaches the network: the gh token's SCOPES (render_gh_scope_check
+# below). That is not a local fact — no file on disk records it — and issue
+# #827 needs it at session start, so the section spends exactly one bounded 3s
+# call for it and nothing else. It is capped at the LOCAL bound rather than
+# NETWORK_TIMEOUT for the same budget reason as everything else here: the hook
+# budgets this section from the sum of these bounds (13s, both hook copies),
+# and a section that overruns loses ALL of its buffered output. Set
+# `STATUS_NO_NETWORK=1` to drop that one probe and make the section local-only
+# again. Anything else added here must stay local.
 # render_gh_scope_check — one ⚠/unknown line when the authenticated token is
 # missing a scope this repo's tooling needs, and NOTHING when it has them all.
 #
@@ -614,8 +624,9 @@ fi
 # same probe, so the evidence that this ran is on screen either way. A second
 # green line on every session start, in every repo, would be pure noise.
 #
-# Read-only and non-fatal: it only compares the scope line the shared probe
-# already captured.
+# Read-only and non-fatal. It compares the scope line the shared probe already
+# captured where there is one; standalone (`status:creds`) it makes the single
+# bounded probe described above.
 render_gh_scope_check() {
     local missing rc=0 file
     if [[ "${GH_AUTH_PROBED}" != true ]]; then

--- a/template/scripts/test-setup-gh-scopes.sh
+++ b/template/scripts/test-setup-gh-scopes.sh
@@ -21,6 +21,14 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# Scrub every GitHub token variable from this test's own environment before
+# anything runs. The BOT devcontainer profile supplies GH_TOKEN by design, and
+# `task verify` runs there — so an inherited token would trip the env-token
+# refusal in the baseline cases below and fail the suite for a reason that has
+# nothing to do with the code. The explicit env-token cases set what they need,
+# one variable at a time.
+unset GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN GH_HOST
+
 script="./scripts/setup-gh-scopes.sh"
 scopes_lib="./scripts/gh-scopes.sh"
 
@@ -75,6 +83,18 @@ make_stub() {
             echo "        echo \"  - Token scopes: 'repo', 'workflow'\""
             echo "        echo \"  - Token scopes: 'project', 'read:project'\""
             echo '    fi'
+            echo '    exit 0'
+            ;;
+        read-only-grant)
+            # GitHub granted only the READ scope — an org restriction, or an
+            # operator who unticked the write box in the browser.
+            echo "    echo \"  - Token scopes: 'repo', 'workflow', 'read:project'\""
+            echo '    exit 0'
+            ;;
+        write-only-grant)
+            # Only 'project' reported. It subsumes 'read:project', so this must
+            # NOT be reported as a missing scope.
+            echo "    echo \"  - Token scopes: 'repo', 'workflow', 'project'\""
             echo '    exit 0'
             ;;
         logged-out)
@@ -224,7 +244,7 @@ if [ "${PTY_OK}" = true ]; then
     echo "==> succeeds when the refresh lands, naming the scopes"
     out="$(run_sut_pty lands GH_HOST=github.com)"
     case "$out" in
-    *"All required scopes present"*) ;;
+    *"All requested scopes present"*) ;;
     *) fail "expected success after a landed refresh, got: ${out}" ;;
     esac
 
@@ -243,9 +263,28 @@ if [ "${PTY_OK}" = true ]; then
     # host would let an unrelated login satisfy the requirement.
     out="$(run_sut_pty inactive-has-scope GH_HOST=github.com)"
     case "$out" in
-    *"All required scopes present"*) fail "an inactive account's scopes verified the active one: ${out}" ;;
+    *"All requested scopes present"*) fail "an inactive account's scopes verified the active one: ${out}" ;;
     *"did not grant"*) ;;
     *) fail "expected the active account's missing scopes to be reported, got: ${out}" ;;
+    esac
+
+    echo "==> a refresh that grants only read:project FAILS"
+    # The alternation `project|read:project` is right for the status check —
+    # either proves the credential was minted with Projects in mind. It is
+    # wrong here: the refresh asked for both, and coming back with only the
+    # read grant leaves board writes broken while satisfying the alternation.
+    out="$(run_sut_pty read-only-grant GH_HOST=github.com)"
+    case "$out" in
+    *"All requested scopes present"*) fail "a read-only grant was reported as success: ${out}" ;;
+    *"did not grant"*"project"*) ;;
+    *) fail "expected the missing write scope to be reported, got: ${out}" ;;
+    esac
+
+    echo "==> a write-only grant is accepted (project implies read:project)"
+    out="$(run_sut_pty write-only-grant GH_HOST=github.com)"
+    case "$out" in
+    *"All requested scopes present"*) ;;
+    *) fail "'project' subsumes 'read:project' and must not fail: ${out}" ;;
     esac
 
     echo "==> a fine-grained token is rejected with a source-side remedy"

--- a/template/scripts/test-setup-gh-scopes.sh
+++ b/template/scripts/test-setup-gh-scopes.sh
@@ -125,7 +125,7 @@ make_stub() {
 # (macOS) and util-linux (CI) argument orders differ.
 pty_exec() {
     if command -v python3 >/dev/null 2>&1; then
-        python3 -c 'import pty,sys; sys.exit(pty.spawn(sys.argv[1:]))' "$@" 2>&1
+        python3 -c 'import os,pty,sys; sys.exit(os.waitstatus_to_exitcode(pty.spawn(sys.argv[1:])))' "$@" 2>&1
     elif [ "$(uname -s)" = "Darwin" ]; then
         script -q /dev/null "$@" 2>&1
     else
@@ -157,6 +157,25 @@ run_sut_pty() {
         for kv in "$@"; do export "${kv?}"; done
         pty_exec "${SUT}"
     ) || true
+}
+
+# rc_pty_of SCENARIO [ENV...] — the exit code from a run that got a TTY, so a
+# case can assert on the code the POST-REFRESH path returned. rc_of cannot:
+# it runs without a TTY, so its non-zero comes from the TTY guard long before
+# the verification under test, and a missing-scope branch that printed the
+# right message but exited 0 would still look green.
+rc_pty_of() {
+    local scenario="$1"
+    shift
+    make_stub "${scenario}"
+    local rc=0
+    (
+        export PATH="${TMP}/bin:${PATH}"
+        local kv
+        for kv in "$@"; do export "${kv?}"; done
+        pty_exec "${SUT}" >/dev/null 2>&1
+    ) || rc=$?
+    printf '%s' "${rc}"
 }
 
 # run_sut_notty SCENARIO [ENV...] — capture output with NO tty. Valid for every
@@ -255,8 +274,10 @@ if [ "${PTY_OK}" = true ]; then
     *"did not grant"*) ;;
     *) fail "a refresh that did not land must fail loudly, got: ${out}" ;;
     esac
-    [ "$(rc_of does-not-land GH_HOST=github.com)" != 0 ] ||
-        fail "an unlanded refresh must exit non-zero"
+    [ "$(rc_pty_of does-not-land GH_HOST=github.com)" != 0 ] ||
+        fail "an unlanded refresh must exit non-zero from the verification path"
+    [ "$(rc_pty_of lands GH_HOST=github.com)" = 0 ] ||
+        fail "a landed refresh must exit zero (else the case above proves nothing)"
 
     echo "==> another account's scopes cannot verify the refreshed one"
     # gh auth refresh updates only the ACTIVE account; reading every account on the
@@ -287,12 +308,25 @@ if [ "${PTY_OK}" = true ]; then
     *) fail "'project' subsumes 'read:project' and must not fail: ${out}" ;;
     esac
 
-    echo "==> a fine-grained token is rejected with a source-side remedy"
+    echo "==> a stored fine-grained token is refused BEFORE any refresh"
+    # `gh auth refresh` against a fine-grained PAT completes a device flow and
+    # stores a new CLASSIC token — silently replacing a deliberately narrow
+    # credential with a broad one. The refusal has to precede the mutation, so
+    # this asserts on the call log, not just the message.
+    STUB_CALLS="${TMP}/fg-calls.txt"
+    export STUB_CALLS
+    : >"${STUB_CALLS}"
     out="$(run_sut_pty fine-grained GH_HOST=github.com)"
+    if grep -q 'auth refresh' "${STUB_CALLS}"; then
+        fail "refreshed a fine-grained credential: $(tr '\n' ' ' <"${STUB_CALLS}")"
+    fi
+    unset STUB_CALLS
     case "$out" in
-    *"no OAuth scopes reported"*) ;;
-    *) fail "expected the fine-grained-token notice, got: ${out}" ;;
+    *"reports no OAuth scopes"*"where that token was issued"*) ;;
+    *) fail "expected the source-side remedy for a fine-grained token, got: ${out}" ;;
     esac
+    [ "$(rc_pty_of fine-grained GH_HOST=github.com)" != 0 ] ||
+        fail "the fine-grained refusal must exit non-zero"
 
     echo "==> the token value is never printed"
     # The script prints scope LINES; nothing it captures may contain a credential,

--- a/template/scripts/test-setup-gh-scopes.sh
+++ b/template/scripts/test-setup-gh-scopes.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# test-setup-gh-scopes.sh — unit-test setup-gh-scopes.sh, the one script here
+# that MUTATES the operator's stored credential.
+#
+# Run via `task test:gh-scopes`.
+#
+# Its refusals are the safety story (an env token it cannot fix, a shell that
+# cannot complete a browser flow) and its post-refresh verification is the
+# reason it exists at all — `gh auth refresh` can exit 0 having granted less
+# than was asked for. None of that is exercised by test-status.sh, which only
+# covers the status consumer.
+#
+# Hermetic in two directions, as test-status.sh is:
+#
+#   * every `gh` call is answered by a stub on PATH, so this never reaches
+#     GitHub and never touches the developer's own credential — which is the
+#     whole point: the bug it guards (reporting a refresh that did not land)
+#     is INVISIBLE when tested against a token that already has the scopes.
+#   * the script runs from a fixture root this test builds, never the repo it
+#     lives in, so the required-scope list under test is the fixture's.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+script="./scripts/setup-gh-scopes.sh"
+scopes_lib="./scripts/gh-scopes.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+# A board-carrying fixture, so the required list includes the Projects scopes.
+mkdir -p "${TMP}/repo/scripts"
+cp "${script}" "${TMP}/repo/scripts/setup-gh-scopes.sh"
+cp "${scopes_lib}" "${TMP}/repo/scripts/gh-scopes.sh"
+: >"${TMP}/repo/scripts/setup-github-project.sh"
+SUT="${TMP}/repo/scripts/setup-gh-scopes.sh"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+# make_stub SCENARIO — write $TMP/bin/gh. The refresh is RECORDED, never real:
+# a stub that silently succeeded would let a broken verification pass.
+make_stub() {
+    local scenario="$1"
+    mkdir -p "${TMP}/bin"
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'if [ -n "${STUB_CALLS:-}" ]; then echo "$*" >>"$STUB_CALLS"; fi'
+        echo 'if [ "$1" = "auth" ] && [ "$2" = "refresh" ]; then exit 0; fi'
+        echo 'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then'
+        echo '    seen_active=false'
+        echo '    for a in "$@"; do [ "$a" = "--active" ] && seen_active=true; done'
+        case "$scenario" in
+        lands)
+            # The happy path: after the refresh every requirement is present.
+            echo "    echo \"  - Token scopes: 'repo', 'workflow', 'project', 'read:project'\""
+            echo '    exit 0'
+            ;;
+        does-not-land)
+            # `gh auth refresh` exits 0 but the grant did not happen — an org
+            # that restricts the scope, or an operator who unticked it in the
+            # browser. The reason this script verifies instead of trusting.
+            echo "    echo \"  - Token scopes: 'repo', 'workflow'\""
+            echo '    exit 0'
+            ;;
+        inactive-has-scope)
+            # Two accounts on one host; only the INACTIVE one is fully scoped.
+            # `gh auth refresh` only ever updates the active account, so a
+            # verification that read every account would report a success that
+            # did not happen.
+            echo '    if [ "$seen_active" = true ]; then'
+            echo "        echo \"  - Token scopes: 'repo', 'workflow'\""
+            echo '    else'
+            echo "        echo \"  - Token scopes: 'repo', 'workflow'\""
+            echo "        echo \"  - Token scopes: 'project', 'read:project'\""
+            echo '    fi'
+            echo '    exit 0'
+            ;;
+        logged-out)
+            echo '    echo "You are not logged into any GitHub hosts." >&2'
+            echo '    exit 1'
+            ;;
+        fine-grained)
+            # Permissions, not OAuth scopes: gh reports the line with nothing
+            # quoted. `gh auth refresh` cannot add to such a token.
+            echo '    echo "  - Token scopes: none"'
+            echo '    exit 0'
+            ;;
+        esac
+        echo 'fi'
+        echo 'echo "stub: unexpected gh call: $*" >&2; exit 1'
+    } >"${TMP}/bin/gh"
+    chmod +x "${TMP}/bin/gh"
+}
+
+# pty_exec CMD... — run CMD under a pseudo-terminal, so the script sees a TTY
+# on stdin and stdout.
+#
+# Two allocators, in preference order. `python3 -c 'pty.spawn(...)'` calls
+# openpty directly and therefore works in a sandbox or CI shell with no
+# CONTROLLING terminal — where `script` fails with tcgetattr/ioctl before ever
+# running the command, failing every case for a reason unrelated to the code
+# under test. `script` is the fallback for a host without python3; its BSD
+# (macOS) and util-linux (CI) argument orders differ.
+pty_exec() {
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c 'import pty,sys; sys.exit(pty.spawn(sys.argv[1:]))' "$@" 2>&1
+    elif [ "$(uname -s)" = "Darwin" ]; then
+        script -q /dev/null "$@" 2>&1
+    else
+        script -qec "$*" /dev/null 2>&1
+    fi
+}
+
+# Whether a pty can be allocated AT ALL. The cases that need one are skipped
+# with a note rather than silently dropped (the same treatment test-status.sh
+# gives a missing `timeout` binary). Everything BEFORE the TTY gate — the
+# env-token refusals — is tested without a pty either way, because that
+# refusal deliberately runs first.
+PTY_OK=false
+if [ "$(pty_exec printf PTYPROBE 2>/dev/null | tr -dc 'A-Z')" = "PTYPROBE" ]; then
+    PTY_OK=true
+fi
+
+# run_sut_pty SCENARIO [ENV...] — the same, under a pseudo-terminal, capturing
+# output. Only call when PTY_OK.
+run_sut_pty() {
+    local scenario="$1"
+    shift
+    make_stub "${scenario}"
+    # A subshell with explicit exports rather than `env`: pty_exec is a shell
+    # function, and `env` can only exec a real binary.
+    (
+        export PATH="${TMP}/bin:${PATH}"
+        local kv
+        for kv in "$@"; do export "${kv?}"; done
+        pty_exec "${SUT}"
+    ) || true
+}
+
+# run_sut_notty SCENARIO [ENV...] — capture output with NO tty. Valid for every
+# assertion about a refusal that precedes the TTY gate.
+run_sut_notty() {
+    local scenario="$1"
+    shift
+    make_stub "${scenario}"
+    env "$@" PATH="${TMP}/bin:${PATH}" "${SUT}" </dev/null 2>&1 || true
+}
+
+# rc_of SCENARIO [ENV...] — the exit code, which the refusals must make
+# non-zero: a refusal that exited 0 would tell a caller the scopes are fine.
+rc_of() {
+    local scenario="$1"
+    shift
+    make_stub "${scenario}"
+    local rc=0
+    env "$@" PATH="${TMP}/bin:${PATH}" "${SUT}" </dev/null >/dev/null 2>&1 || rc=$?
+    printf '%s' "${rc}"
+}
+
+echo "==> refuses without a TTY, and says why"
+make_stub lands
+out="$(PATH="${TMP}/bin:${PATH}" "${SUT}" </dev/null 2>&1 || true)"
+case "$out" in
+*"no TTY"*) ;;
+*) fail "expected a TTY refusal, got: ${out}" ;;
+esac
+[ "$(rc_of lands)" != 0 ] || fail "the TTY refusal must exit non-zero"
+
+echo "==> a no-TTY refusal never reaches gh auth refresh"
+# The safety property behind the refusal: agents and CI must not re-mint the
+# operator's credential, so the refusal has to come BEFORE the mutation.
+STUB_CALLS="${TMP}/calls.txt"
+export STUB_CALLS
+: >"${STUB_CALLS}"
+make_stub lands
+PATH="${TMP}/bin:${PATH}" "${SUT}" </dev/null >/dev/null 2>&1 || true
+if grep -q 'auth refresh' "${STUB_CALLS}"; then
+    fail "a non-interactive run mutated the credential: $(tr '\n' ' ' <"${STUB_CALLS}")"
+fi
+unset STUB_CALLS
+
+echo "==> refuses the env-token family gh uses for THIS host"
+out="$(run_sut_notty lands GH_HOST=github.com GH_TOKEN=x)"
+case "$out" in
+*"GH_TOKEN is set"*"github.com"*) ;;
+*) fail "expected a GH_TOKEN refusal on github.com, got: ${out}" ;;
+esac
+[ "$(rc_of lands GH_HOST=github.com GH_TOKEN=x)" != 0 ] ||
+    fail "the env-token refusal must exit non-zero"
+
+echo "==> does NOT refuse an env token gh ignores on this host"
+# The dual-host case: gh reads GH_ENTERPRISE_TOKEN for a GHES host, not for
+# github.com, so it does not override the credential being refreshed here.
+out="$(run_sut_notty lands GH_HOST=github.com GH_ENTERPRISE_TOKEN=x)"
+case "$out" in
+*"GH_ENTERPRISE_TOKEN is set"*) fail "refused a token gh ignores on this host: ${out}" ;;
+*"no TTY"*) ;; # fell through to the NEXT gate, which is the point
+*) fail "expected the run to reach the TTY gate, got: ${out}" ;;
+esac
+out="$(run_sut_notty lands GH_HOST=ghe.example.com GH_TOKEN=x)"
+case "$out" in
+*"GH_TOKEN is set"*) fail "refused a github.com token in a GHES checkout: ${out}" ;;
+*"no TTY"*) ;;
+*) fail "expected the run to reach the TTY gate, got: ${out}" ;;
+esac
+
+echo "==> refuses the enterprise env token on an enterprise host"
+out="$(run_sut_notty lands GH_HOST=ghe.example.com GH_ENTERPRISE_TOKEN=x)"
+case "$out" in
+*"GH_ENTERPRISE_TOKEN is set"*"ghe.example.com"*) ;;
+*) fail "expected an enterprise env-token refusal, got: ${out}" ;;
+esac
+
+if [ "${PTY_OK}" = true ]; then
+    echo "==> a logged-out host is told to log in, not refreshed"
+    out="$(run_sut_pty logged-out GH_HOST=github.com)"
+    case "$out" in
+    *"not logged in"*"gh auth login"*) ;;
+    *) fail "expected a login remedy, got: ${out}" ;;
+    esac
+
+    echo "==> succeeds when the refresh lands, naming the scopes"
+    out="$(run_sut_pty lands GH_HOST=github.com)"
+    case "$out" in
+    *"All required scopes present"*) ;;
+    *) fail "expected success after a landed refresh, got: ${out}" ;;
+    esac
+
+    echo "==> FAILS when the refresh silently did not land"
+    # The whole reason this script verifies rather than trusting the exit code.
+    out="$(run_sut_pty does-not-land GH_HOST=github.com)"
+    case "$out" in
+    *"did not grant"*) ;;
+    *) fail "a refresh that did not land must fail loudly, got: ${out}" ;;
+    esac
+    [ "$(rc_of does-not-land GH_HOST=github.com)" != 0 ] ||
+        fail "an unlanded refresh must exit non-zero"
+
+    echo "==> another account's scopes cannot verify the refreshed one"
+    # gh auth refresh updates only the ACTIVE account; reading every account on the
+    # host would let an unrelated login satisfy the requirement.
+    out="$(run_sut_pty inactive-has-scope GH_HOST=github.com)"
+    case "$out" in
+    *"All required scopes present"*) fail "an inactive account's scopes verified the active one: ${out}" ;;
+    *"did not grant"*) ;;
+    *) fail "expected the active account's missing scopes to be reported, got: ${out}" ;;
+    esac
+
+    echo "==> a fine-grained token is rejected with a source-side remedy"
+    out="$(run_sut_pty fine-grained GH_HOST=github.com)"
+    case "$out" in
+    *"no OAuth scopes reported"*) ;;
+    *) fail "expected the fine-grained-token notice, got: ${out}" ;;
+    esac
+
+    echo "==> the token value is never printed"
+    # The script prints scope LINES; nothing it captures may contain a credential,
+    # and the stub's scope lines are the only thing it is allowed to echo back.
+    out="$(run_sut_pty lands GH_HOST=github.com)"
+    case "$out" in
+    *ghp_* | *gho_*) fail "something token-shaped reached the output: ${out}" ;;
+    esac
+else
+    echo "    (skipped: no controlling terminal — cannot allocate a pty for the"
+    echo "     interactive path; the refusals above are covered without one)"
+fi
+
+echo "setup-gh-scopes.sh tests passed"

--- a/template/scripts/test-setup-gh-scopes.sh
+++ b/template/scripts/test-setup-gh-scopes.sh
@@ -55,7 +55,10 @@ make_stub() {
     {
         echo '#!/usr/bin/env bash'
         echo 'if [ -n "${STUB_CALLS:-}" ]; then echo "$*" >>"$STUB_CALLS"; fi'
-        echo 'if [ "$1" = "auth" ] && [ "$2" = "refresh" ]; then exit 0; fi'
+        echo 'if [ "$1" = "auth" ] && [ "$2" = "refresh" ]; then'
+        echo '    [ -n "${TMP_PHASE:-}" ] && : >"$TMP_PHASE"'
+        echo '    exit 0'
+        echo 'fi'
         echo 'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then'
         echo '    seen_active=false'
         echo '    for a in "$@"; do [ "$a" = "--active" ] && seen_active=true; done'
@@ -82,6 +85,17 @@ make_stub() {
             echo '    else'
             echo "        echo \"  - Token scopes: 'repo', 'workflow'\""
             echo "        echo \"  - Token scopes: 'project', 'read:project'\""
+            echo '    fi'
+            echo '    exit 0'
+            ;;
+        lands-after-refresh)
+            # The genuine success path: incomplete BEFORE the refresh, complete
+            # after it. A single-phase stub cannot test this any more, now that
+            # an already-complete credential short-circuits without refreshing.
+            echo '    if [ -f "${TMP_PHASE:-/nonexistent}" ]; then'
+            echo "        echo \"  - Token scopes: 'repo', 'workflow', 'project', 'read:project'\""
+            echo '    else'
+            echo "        echo \"  - Token scopes: 'repo', 'workflow'\""
             echo '    fi'
             echo '    exit 0'
             ;;
@@ -153,6 +167,8 @@ run_sut_pty() {
     # function, and `env` can only exec a real binary.
     (
         export PATH="${TMP}/bin:${PATH}"
+        export TMP_PHASE="${TMP}/phase-marker"
+        rm -f "${TMP_PHASE}"
         local kv
         for kv in "$@"; do export "${kv?}"; done
         pty_exec "${SUT}"
@@ -171,6 +187,8 @@ rc_pty_of() {
     local rc=0
     (
         export PATH="${TMP}/bin:${PATH}"
+        export TMP_PHASE="${TMP}/phase-marker"
+        rm -f "${TMP_PHASE}"
         local kv
         for kv in "$@"; do export "${kv?}"; done
         pty_exec "${SUT}" >/dev/null 2>&1
@@ -261,7 +279,7 @@ if [ "${PTY_OK}" = true ]; then
     esac
 
     echo "==> succeeds when the refresh lands, naming the scopes"
-    out="$(run_sut_pty lands GH_HOST=github.com)"
+    out="$(run_sut_pty lands-after-refresh GH_HOST=github.com)"
     case "$out" in
     *"All requested scopes present"*) ;;
     *) fail "expected success after a landed refresh, got: ${out}" ;;
@@ -276,7 +294,7 @@ if [ "${PTY_OK}" = true ]; then
     esac
     [ "$(rc_pty_of does-not-land GH_HOST=github.com)" != 0 ] ||
         fail "an unlanded refresh must exit non-zero from the verification path"
-    [ "$(rc_pty_of lands GH_HOST=github.com)" = 0 ] ||
+    [ "$(rc_pty_of lands-after-refresh GH_HOST=github.com)" = 0 ] ||
         fail "a landed refresh must exit zero (else the case above proves nothing)"
 
     echo "==> another account's scopes cannot verify the refreshed one"
@@ -302,11 +320,33 @@ if [ "${PTY_OK}" = true ]; then
     esac
 
     echo "==> a write-only grant is accepted (project implies read:project)"
+    # Reported with only 'project', which subsumes 'read:project' — so nothing
+    # is missing, and the run must succeed rather than report a missing scope.
     out="$(run_sut_pty write-only-grant GH_HOST=github.com)"
     case "$out" in
-    *"All requested scopes present"*) ;;
-    *) fail "'project' subsumes 'read:project' and must not fail: ${out}" ;;
+    *"did not grant"*) fail "'project' subsumes 'read:project' and must not fail: ${out}" ;;
     esac
+    [ "$(rc_pty_of write-only-grant GH_HOST=github.com)" = 0 ] ||
+        fail "a write-only grant must exit zero: ${out}"
+
+    echo "==> an already-complete credential is NOT refreshed"
+    # `gh auth refresh` opens a browser even when it would change nothing, so
+    # the documented sequence (log in with the derived scopes, then run this to
+    # verify) would authenticate twice, and every re-run would repeat it.
+    STUB_CALLS="${TMP}/complete-calls.txt"
+    export STUB_CALLS
+    : >"${STUB_CALLS}"
+    out="$(run_sut_pty lands GH_HOST=github.com)"
+    if grep -q 'auth refresh' "${STUB_CALLS}"; then
+        fail "refreshed a credential that needed nothing: $(tr '\n' ' ' <"${STUB_CALLS}")"
+    fi
+    unset STUB_CALLS
+    case "$out" in
+    *"Already complete"*) ;;
+    *) fail "expected the no-op path to say so, got: ${out}" ;;
+    esac
+    [ "$(rc_pty_of lands GH_HOST=github.com)" = 0 ] ||
+        fail "the already-complete path must exit zero"
 
     echo "==> a stored fine-grained token is refused BEFORE any refresh"
     # `gh auth refresh` against a fine-grained PAT completes a device flow and

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -995,6 +995,23 @@ case "$scope_out" in
 *"admin:org"*) fail "a personal-account repo must not demand admin:org: ${scope_out}" ;;
 esac
 
+echo "==> GH_EXTRA_SCOPES adds to the profile's list rather than replacing it"
+# The documented extension point. Additive is the whole contract: a consumer
+# that names only its own requirement must still be held to this repo's, and to
+# any a later template update introduces.
+make_codex_stub in
+scope_out="$(GH_EXTRA_SCOPES=delete_repo run_creds_section fully-scoped "${CREDS_BOARD}")"
+case "$scope_out" in
+*"gh token scopes"*"missing delete_repo"*) ;;
+*) fail "GH_EXTRA_SCOPES was not required, got: ${scope_out}" ;;
+esac
+make_codex_stub in
+scope_out="$(GH_EXTRA_SCOPES=delete_repo run_creds_section none "${CREDS_BOARD}")"
+case "$scope_out" in
+*"project"*) ;;
+*) fail "GH_EXTRA_SCOPES replaced the built-in requirements: ${scope_out}" ;;
+esac
+
 echo "==> status:creds never prints the token it reads"
 # `gh auth token` writes the credential to stdout — the value is the output. The
 # probe reads its exit code only, so the stub's placeholder must not reach the

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -44,7 +44,10 @@ trap 'rm -rf "${TMP}"' EXIT
 #   with-codex  — opted into second-model review, so the Codex login is a gate.
 #                 The other three have no codex-review.sh, which is what makes
 #                 them the not-opted-in case for that check.
-for fixture in with-board no-board skills-only with-codex; do
+#   creds-board — codex opted in AND board tooling present, so the session-start
+#                 scope check demands the Projects scopes. Its twin below
+#                 (with-codex, no board) is what proves that demand is gated.
+for fixture in with-board no-board skills-only with-codex creds-board; do
     mkdir -p "${TMP}/${fixture}/scripts"
     cp "${status}" "${TMP}/${fixture}/scripts/status.sh"
     cp "${scopes_lib}" "${TMP}/${fixture}/scripts/gh-scopes.sh"
@@ -52,6 +55,8 @@ done
 # The markers status.sh feature-detects on. Contents are never read.
 : >"${TMP}/with-board/scripts/setup-github-project.sh"
 : >"${TMP}/with-codex/scripts/codex-review.sh"
+: >"${TMP}/creds-board/scripts/codex-review.sh"
+: >"${TMP}/creds-board/scripts/setup-github-project.sh"
 mkdir -p "${TMP}/skills-only/.claude/skills/track-work/assets"
 : >"${TMP}/skills-only/.claude/skills/track-work/assets/set-issue-status.sh"
 
@@ -69,6 +74,7 @@ NO_BOARD="${TMP}/no-board/scripts/status.sh"
 SKILLS_ONLY="${TMP}/skills-only/scripts/status.sh"
 ENTERPRISE="${TMP}/enterprise/scripts/status.sh"
 WITH_CODEX="${TMP}/with-codex/scripts/status.sh"
+CREDS_BOARD="${TMP}/creds-board/scripts/status.sh"
 
 fail() {
     echo "TEST FAIL: $*" >&2
@@ -221,6 +227,12 @@ make_stub() {
             # silence, never an accusation.
             echo '    echo "error connecting to github.com" >&2'
             echo '    exit 1'
+            ;;
+        no-workflow)
+            # A credential that satisfies the Projects half but not the
+            # unconditional half of the list.
+            echo "    echo \"  - Token scopes: 'repo', 'project', 'read:project'\""
+            echo '    exit 0'
             ;;
         *) fail "unknown stub scenario: ${scenario}" ;;
         esac
@@ -879,7 +891,7 @@ export STUB_CALLS
 make_codex_stub in
 make_stub none
 offline_out="$(PATH="${TMP}/bin:${PATH}" NO_COLOR=1 STATUS_NO_NETWORK=1 \
-    "${WITH_CODEX}" creds 2>&1)"
+    "${CREDS_BOARD}" creds 2>&1)"
 if grep -q 'auth status' "${STUB_CALLS}"; then
     fail "STATUS_NO_NETWORK=1 still probed the network: $(tr '\n' ' ' <"${STUB_CALLS}")"
 fi
@@ -896,7 +908,7 @@ echo "==> status:creds warns when the token is missing a required scope"
 # The whole point of #827: an under-scoped login is caught at session start
 # rather than days later, when a board write fails mid-shepherd.
 make_codex_stub in
-scope_out="$(run_creds_section none)"
+scope_out="$(run_creds_section none "${CREDS_BOARD}")"
 case "$scope_out" in
 *"gh token scopes"*"missing"*"project"*) ;;
 *) fail "expected a missing-scope warning from status:creds, got: ${scope_out}" ;;
@@ -910,7 +922,7 @@ echo "==> a fully-scoped token produces NO scope line"
 # Silent on success, deliberately: the ✓ credential line above already proves
 # the check ran, and a second green line every session in every repo is noise.
 make_codex_stub in
-scope_out="$(run_creds_section fully-scoped)"
+scope_out="$(run_creds_section fully-scoped "${CREDS_BOARD}")"
 case "$scope_out" in
 *"gh token scopes"*) fail "a complete token must not produce a scope line: ${scope_out}" ;;
 esac
@@ -920,7 +932,7 @@ echo "==> 'read:project' alone satisfies the session-start scope check"
 # not: these are different questions about the same token. This one asks
 # whether the credential was minted with Projects in mind at all.
 make_codex_stub in
-scope_out="$(run_creds_section creds-read-project)"
+scope_out="$(run_creds_section creds-read-project "${CREDS_BOARD}")"
 case "$scope_out" in
 *"gh token scopes"*) fail "read:project must satisfy the session-start check: ${scope_out}" ;;
 esac
@@ -930,13 +942,35 @@ echo "==> a failed scope probe is not reported as a missing scope"
 # verdict. Sending a correctly-scoped operator to re-mint a working credential
 # is the error this guards.
 make_codex_stub in
-scope_out="$(run_creds_section scope-probe-fails)"
+scope_out="$(run_creds_section scope-probe-fails "${CREDS_BOARD}")"
 case "$scope_out" in
 *"missing"*"project"*) fail "a failed probe must not accuse the token: ${scope_out}" ;;
 esac
 case "$scope_out" in
 *"credential stored"*) ;;
 *) fail "the credential line must survive a failed scope probe: ${scope_out}" ;;
+esac
+
+echo "==> a repo with no board tooling is never asked for Projects scopes"
+# `project_management: none` is the DEFAULT generated profile, and such a repo
+# has no board to write to. Demanding Projects access there would warn every
+# session, in the majority profile, about a grant the repo never uses — and
+# train the reader to ignore the line in the repos where it matters. Same
+# marker, and the same accepted cost, as the board-writes check in status:gh.
+make_codex_stub in
+scope_out="$(run_creds_section none)"
+case "$scope_out" in
+*"gh token scopes"*) fail "a boardless repo must not demand Projects scopes: ${scope_out}" ;;
+esac
+
+echo "==> a boardless repo IS still warned about repo/workflow"
+# The gate is on the Projects requirement alone — the unconditional part of the
+# list must keep working, or the case above would pass for the wrong reason.
+make_codex_stub in
+scope_out="$(run_creds_section no-workflow)"
+case "$scope_out" in
+*"gh token scopes"*"missing workflow"*) ;;
+*) fail "expected an unconditional-scope warning in a boardless repo: ${scope_out}" ;;
 esac
 
 echo "==> status:creds never prints the token it reads"

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -8,8 +8,8 @@
 #     and Codex logins the Dev Loop gates on, in every state including
 #     not-installed, rendered as its own section for the session-start hook AND
 #     inside the setup audit BEFORE the gate that skips the rest of it, counted
-#     by the summary at the end of that audit, and — standalone — making no
-#     network call at all.
+#     by the summary at the end of that audit, and — standalone — spending
+#     exactly one bounded network call, for the token scopes alone (#827).
 #
 # Run via `task test:status`.
 #
@@ -28,6 +28,9 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 status="./scripts/status.sh"
+# status.sh sources the required-scope list from its sibling; every fixture root
+# below therefore needs both files, not just the script under test.
+scopes_lib="./scripts/gh-scopes.sh"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "${TMP}"' EXIT
@@ -44,6 +47,7 @@ trap 'rm -rf "${TMP}"' EXIT
 for fixture in with-board no-board skills-only with-codex; do
     mkdir -p "${TMP}/${fixture}/scripts"
     cp "${status}" "${TMP}/${fixture}/scripts/status.sh"
+    cp "${scopes_lib}" "${TMP}/${fixture}/scripts/gh-scopes.sh"
 done
 # The markers status.sh feature-detects on. Contents are never read.
 : >"${TMP}/with-board/scripts/setup-github-project.sh"
@@ -55,6 +59,7 @@ mkdir -p "${TMP}/skills-only/.claude/skills/track-work/assets"
 # GH_HOST — the case where forcing github.com disowns a valid login.
 mkdir -p "${TMP}/enterprise/scripts"
 cp "${status}" "${TMP}/enterprise/scripts/status.sh"
+cp "${scopes_lib}" "${TMP}/enterprise/scripts/gh-scopes.sh"
 : >"${TMP}/enterprise/scripts/setup-github-project.sh"
 git -C "${TMP}/enterprise" init -q
 git -C "${TMP}/enterprise" remote add origin git@ghe.example.com:owner/repo.git
@@ -195,6 +200,27 @@ make_stub() {
             # carry gh's no-credential wording: that is the whole distinction.
             echo "    echo \"  - Token scopes: 'gist', 'project', 'repo'\""
             echo '    exit 0'
+            ;;
+        fully-scoped)
+            # Every required scope. The session-start check must then say
+            # nothing at all.
+            echo "    echo \"  - Token scopes: 'read:project', 'project', 'repo', 'workflow'\""
+            echo '    exit 0'
+            ;;
+        creds-read-project)
+            # Projects READ only. Satisfies the session-start "was this
+            # credential minted with Projects in mind" check via the
+            # `project|read:project` alternation, while still failing the
+            # board-WRITE check in the GitHub section.
+            echo "    echo \"  - Token scopes: 'read:project', 'repo', 'workflow'\""
+            echo '    exit 0'
+            ;;
+        scope-probe-fails)
+            # The LOCAL credential read succeeds (see `auth token` below) but
+            # the scope probe cannot answer — a network blip, a proxy. Must be
+            # silence, never an accusation.
+            echo '    echo "error connecting to github.com" >&2'
+            echo '    exit 1'
             ;;
         *) fail "unknown stub scenario: ${scenario}" ;;
         esac
@@ -439,14 +465,14 @@ echo "==> read-only 'read:project' is NOT reported as satisfied"
 out="$(run_gh_section read-only)"
 case "$out" in
 *"token has 'project'"*) fail "read:project must not satisfy a WRITE check: ${out}" ;;
-*"read-only"*"gh auth refresh -s project"*) ;;
+*"read-only"*"task setup:gh-scopes"*) ;;
 *) fail "expected a read-only warning naming the remedy, got: ${out}" ;;
 esac
 
 echo "==> a token with neither scope warns and names the remedy"
 out="$(run_gh_section none)"
 case "$out" in
-*"lacks 'project'"*"gh auth refresh -s project"*) ;;
+*"lacks 'project'"*"task setup:gh-scopes"*) ;;
 *) fail "expected a missing-scope warning naming the remedy, got: ${out}" ;;
 esac
 
@@ -514,7 +540,7 @@ echo "==> an env-provided token gets a remedy that can actually work"
 # advice that silently changes nothing.
 out="$(run_gh_section env-token-no-scope)"
 case "$out" in
-*"gh auth refresh -s project"*) fail "gh auth refresh cannot change an env token: ${out}" ;;
+*"gh auth refresh -s"* | *"task setup:gh-scopes"*) fail "neither a refresh nor the setup task can change an env token: ${out}" ;;
 *"reissue GH_TOKEN"*) ;;
 *) fail "expected an env-token remedy, got: ${out}" ;;
 esac
@@ -523,7 +549,7 @@ echo "==> an Enterprise env token gets the same treatment as GH_TOKEN"
 # The override problem is a property of environment tokens, not of github.com.
 out="$(run_gh_section enterprise-env-token)"
 case "$out" in
-*"gh auth refresh -s project"*) fail "gh auth refresh cannot change an env token: ${out}" ;;
+*"gh auth refresh -s"* | *"task setup:gh-scopes"*) fail "neither a refresh nor the setup task can change an env token: ${out}" ;;
 *"reissue GH_ENTERPRISE_TOKEN"*) ;;
 *) fail "expected the Enterprise env-token remedy, got: ${out}" ;;
 esac
@@ -618,7 +644,7 @@ while IFS= read -r line; do
     [ -n "$line" ] || continue
     case "$line" in
     *"#"*"gh auth refresh"*) continue ;; # a comment explaining the rule
-    *GH_REMEDY=*) continue ;;            # the derivation itself
+    *GH_REMEDY*=*) continue ;;           # the derivation itself
     *) fail "hardcoded refresh remedy — use \${GH_REMEDY}: ${line}" ;;
     esac
 done <<EOF
@@ -825,23 +851,93 @@ case "$out" in
 *) fail "expected a Codex credential line from status:creds, got: ${out}" ;;
 esac
 
-echo "==> status:creds makes no network call"
-# The acceptance criterion the session-start budget rests on. `gh auth status`
-# validates the token against the API; `gh auth token` reads local config and
-# the environment. The hook already spends this startup's one auth round trip in
-# status:gh, so this section must add none — and a stub that answers `auth
-# status` perfectly well would hide a second one from every output assertion.
+echo "==> status:creds spends exactly ONE network call, and only for scopes"
+# The session-start budget rests on this count. `gh auth status` asks GitHub;
+# `gh auth token` reads local config and the environment. The section was
+# network-free until issue #827 — scopes are a server-side property of the
+# token that no local file records, so the check it asks for cannot be had
+# without exactly one round trip. One, not two: a stub that answers `auth
+# status` happily would hide a second from every output assertion.
 STUB_CALLS="${TMP}/creds-calls.txt"
 export STUB_CALLS
 : >"${STUB_CALLS}"
 make_codex_stub in
 out="$(run_creds_section project)"
-if grep -q 'auth status' "${STUB_CALLS}"; then
-    fail "status:creds called 'gh auth status' — that is a network probe: $(tr '\n' ' ' <"${STUB_CALLS}")"
-fi
 grep -q 'auth token' "${STUB_CALLS}" ||
     fail "status:creds made no local credential read at all: $(tr '\n' ' ' <"${STUB_CALLS}")"
+calls="$(grep -c 'auth status' "${STUB_CALLS}" || true)"
+[ "${calls}" = 1 ] ||
+    fail "status:creds made ${calls} 'gh auth status' calls, expected exactly 1: $(tr '\n' ' ' <"${STUB_CALLS}")"
 unset STUB_CALLS
+
+echo "==> STATUS_NO_NETWORK=1 returns status:creds to a local-only read"
+# The opt-out for an offline or latency-sensitive shell. The credential lines
+# must still render — only the scope probe is given up.
+STUB_CALLS="${TMP}/creds-calls-offline.txt"
+export STUB_CALLS
+: >"${STUB_CALLS}"
+make_codex_stub in
+make_stub none
+offline_out="$(PATH="${TMP}/bin:${PATH}" NO_COLOR=1 STATUS_NO_NETWORK=1 \
+    "${WITH_CODEX}" creds 2>&1)"
+if grep -q 'auth status' "${STUB_CALLS}"; then
+    fail "STATUS_NO_NETWORK=1 still probed the network: $(tr '\n' ' ' <"${STUB_CALLS}")"
+fi
+case "$offline_out" in
+*"gh token scopes"*) fail "a scope verdict without a probe to back it: ${offline_out}" ;;
+esac
+case "$offline_out" in
+*"GitHub CLI (gh)"*) ;;
+*) fail "the credential lines must still render offline: ${offline_out}" ;;
+esac
+unset STUB_CALLS
+
+echo "==> status:creds warns when the token is missing a required scope"
+# The whole point of #827: an under-scoped login is caught at session start
+# rather than days later, when a board write fails mid-shepherd.
+make_codex_stub in
+scope_out="$(run_creds_section none)"
+case "$scope_out" in
+*"gh token scopes"*"missing"*"project"*) ;;
+*) fail "expected a missing-scope warning from status:creds, got: ${scope_out}" ;;
+esac
+case "$scope_out" in
+*"task setup:gh-scopes"*) ;;
+*) fail "the warning must name the runnable remedy, got: ${scope_out}" ;;
+esac
+
+echo "==> a fully-scoped token produces NO scope line"
+# Silent on success, deliberately: the ✓ credential line above already proves
+# the check ran, and a second green line every session in every repo is noise.
+make_codex_stub in
+scope_out="$(run_creds_section fully-scoped)"
+case "$scope_out" in
+*"gh token scopes"*) fail "a complete token must not produce a scope line: ${scope_out}" ;;
+esac
+
+echo "==> 'read:project' alone satisfies the session-start scope check"
+# It does not satisfy the board-WRITE check in the GitHub section, and must
+# not: these are different questions about the same token. This one asks
+# whether the credential was minted with Projects in mind at all.
+make_codex_stub in
+scope_out="$(run_creds_section creds-read-project)"
+case "$scope_out" in
+*"gh token scopes"*) fail "read:project must satisfy the session-start check: ${scope_out}" ;;
+esac
+
+echo "==> a failed scope probe is not reported as a missing scope"
+# Issues #774 and #478: a probe that could not answer is unknown, never a
+# verdict. Sending a correctly-scoped operator to re-mint a working credential
+# is the error this guards.
+make_codex_stub in
+scope_out="$(run_creds_section scope-probe-fails)"
+case "$scope_out" in
+*"missing"*"project"*) fail "a failed probe must not accuse the token: ${scope_out}" ;;
+esac
+case "$scope_out" in
+*"credential stored"*) ;;
+*) fail "the credential line must survive a failed scope probe: ${scope_out}" ;;
+esac
 
 echo "==> status:creds never prints the token it reads"
 # `gh auth token` writes the credential to stdout — the value is the output. The
@@ -976,6 +1072,7 @@ if [ -f "$hook" ]; then
     creds_budget="$(sed -n -E 's/.*timeout ([0-9]+) task status:creds.*/\1/p' "$hook" | head -1)"
     creds_worst="$(awk '
         /^render_local_credentials\(\) \{/ { inf = 1 }
+        /^render_gh_scope_check\(\) \{/ { inf = 1 }
         inf && /^\}/ { inf = 0 }
         inf {
             line = $0

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -47,7 +47,9 @@ trap 'rm -rf "${TMP}"' EXIT
 #   creds-board — codex opted in AND board tooling present, so the session-start
 #                 scope check demands the Projects scopes. Its twin below
 #                 (with-codex, no board) is what proves that demand is gated.
-for fixture in with-board no-board skills-only with-codex creds-board; do
+#   org-repo    — an ORG repo (github_org != the author's account), which
+#                 renders the issue-types setup and therefore needs admin:org.
+for fixture in with-board no-board skills-only with-codex creds-board org-repo; do
     mkdir -p "${TMP}/${fixture}/scripts"
     cp "${status}" "${TMP}/${fixture}/scripts/status.sh"
     cp "${scopes_lib}" "${TMP}/${fixture}/scripts/gh-scopes.sh"
@@ -57,6 +59,8 @@ done
 : >"${TMP}/with-codex/scripts/codex-review.sh"
 : >"${TMP}/creds-board/scripts/codex-review.sh"
 : >"${TMP}/creds-board/scripts/setup-github-project.sh"
+: >"${TMP}/org-repo/scripts/codex-review.sh"
+: >"${TMP}/org-repo/scripts/setup-github-issue-types.sh"
 mkdir -p "${TMP}/skills-only/.claude/skills/track-work/assets"
 : >"${TMP}/skills-only/.claude/skills/track-work/assets/set-issue-status.sh"
 
@@ -75,6 +79,7 @@ SKILLS_ONLY="${TMP}/skills-only/scripts/status.sh"
 ENTERPRISE="${TMP}/enterprise/scripts/status.sh"
 WITH_CODEX="${TMP}/with-codex/scripts/status.sh"
 CREDS_BOARD="${TMP}/creds-board/scripts/status.sh"
+ORG_REPO="${TMP}/org-repo/scripts/status.sh"
 
 fail() {
     echo "TEST FAIL: $*" >&2
@@ -971,6 +976,23 @@ scope_out="$(run_creds_section no-workflow)"
 case "$scope_out" in
 *"gh token scopes"*"missing workflow"*) ;;
 *) fail "expected an unconditional-scope warning in a boardless repo: ${scope_out}" ;;
+esac
+
+echo "==> an org repo is asked for admin:org, a personal one is not"
+# The org-only setup tasks (issue types, issue fields) state they need
+# admin:org, and the template renders them only when the repo belongs to an
+# org. Same marker rule as the Projects scopes: a personal-account repo renders
+# neither script and must never be warned about a grant it cannot use.
+make_codex_stub in
+scope_out="$(run_creds_section fully-scoped "${ORG_REPO}")"
+case "$scope_out" in
+*"gh token scopes"*"missing admin:org"*) ;;
+*) fail "expected an admin:org warning in an org repo, got: ${scope_out}" ;;
+esac
+make_codex_stub in
+scope_out="$(run_creds_section fully-scoped "${CREDS_BOARD}")"
+case "$scope_out" in
+*"admin:org"*) fail "a personal-account repo must not demand admin:org: ${scope_out}" ;;
 esac
 
 echo "==> status:creds never prints the token it reads"


### PR DESCRIPTION
## What

`status:creds` now verifies the `gh` token's **scopes**, and `task setup:gh-scopes`
performs the fully-scoped login — so the memorable path is the correct one.

- **`scripts/gh-scopes.sh`** — the single source of truth. It owns the required
  list *and* `gh_target_host`, because scopes are a property of a credential **on
  a host**: "which scopes" is only answerable once "whose token" is, and two
  copies of that resolution would let a warning and its remedy mean different
  credentials. Read by `status.sh`, `setup-gh-scopes.sh`, and the devcontainer's
  `gh_auth_help` banner.
- **`status:creds`** warns with the missing scope names and a runnable remedy;
  silent when complete; read-only, non-fatal, and bounded to one 3s probe
  (`STATUS_NO_NETWORK=1` opts out).
- **`task setup:gh-scopes`** — operator/dev-profile only: refuses the env-token
  family `gh` uses for the target host, refuses without a TTY, refuses a stored
  non-OAuth credential *before* touching it, and **verifies the grant actually
  landed** rather than trusting `gh auth refresh`'s exit code.

## Why

A plain `gh auth login` mints `gist, read:org, repo, workflow` — no Projects
scopes — and `status:creds` reported that token as a plain ✓. The gap surfaced
days later as `set-issue-status.sh` exiting 2 mid-shepherd. It also removes the
two-remedy-strings problem #596 reported: one derived list now feeds the warning,
the task, and the banner.

Verified live on this machine — the check catches the real under-scoped token:

```
[ ] gh token scopes — missing project or read:project — run: task setup:gh-scopes
```

## Design decisions

**Task name: `setup:gh-scopes`, not `gh:login`.** #827 suggested `gh:login` per
`group:action`; #596 specified `setup:gh-scopes`. I took the latter: it joins the
existing `setup:github-project` / `setup:github-labels` family, and `group:action`
is satisfied either way (`setup` is the group). The task also does more than log
in — it refreshes and verifies an existing credential.

**The Projects requirement is conditional.** `project_management` defaults to
`none`, and such a repo has no board. Demanding Projects access there would warn
every session, in the majority profile, about a grant the repo never uses — and
train the reader to ignore the line where it matters. It is gated on the same
`scripts/setup-github-project.sh` marker the existing board-write check uses,
with the same accepted cost recorded there.

**Two different scope questions, deliberately.** The status check asks "was this
credential minted with Projects in mind" — `project|read:project`, either will
do. The task's post-refresh check asks "did everything I requested land", where
that alternation would be wrong: a refresh handed both scopes that returns only
`read:project` leaves board writes broken. The one nesting GitHub's scopes
actually have is honoured (`project` subsumes `read:project`), so a write-only
grant is not reported as missing the read one.

**`status:creds` was network-free and now makes exactly one bounded call.** That
invariant existed for the session-start budget, and it was tested. Scopes are a
server-side property of the token that no local file records, so the check #827
asks for cannot be had without asking. The call is bounded at the section's short
3s local bound (not `NETWORK_TIMEOUT`) because the hooks budget the section from
the sum of its probes and a section that overruns loses *all* its buffered output.
The test now asserts *exactly one* call rather than none; the session-start hook
copies' creds budget moved 11s → **17s**; and the README/Taskfile descriptions
that promised "no network" were corrected.

> The 17s is the result of merging #886, which landed a kill-grace-aware budget
> model (worst case = sum of deadlines + one grace *per probe*) and raised the
> outer SessionStart deadline to 18s. Under that model this section's four
> probes cost 12s of deadlines + 4×1s grace = 16s, so the budget is 17 and the
> hook's wall clock (the longest section, run in parallel) stays under 18.

**One remedy string, partially.** `status.sh`, the task, and the banner share one
derived list. The vendored `track-work` skill's `read:project,project` hint is a
*subset* of what the task requests, so a credential minted here satisfies it —
fully unifying that string is a harmon-devkit-side change, not this repo's.

## Scope

Both issues are addressed by one task. Template parity throughout: `status.sh`,
`gh-scopes.sh`, `setup-gh-scopes.sh`, `test-setup-gh-scopes.sh`,
`test-status.sh`, `post-create-common.sh`, `devcontainer-assert.sh` and both
`session-start-context.sh` copies are edited in both layers, plus
`Taskfile.yml` / `Taskfile.yml.jinja`, both `README`s, and both
`project-management.md` copies (the template's lives behind a Jinja-conditional
filename).

## Verification

- `task verify` green; `task ci` green (including the devcontainer permission
  assert, gitleaks, and Semgrep).
- `task test:status` — 9 new cases, including both directions of the board
  gating (a boardless repo is never asked for Projects scopes, but is still
  warned about `repo`/`workflow`), the one-network-call bound, the
  `STATUS_NO_NETWORK` opt-out, and a failed probe not being reported as a
  missing scope.
- **New** `task test:gh-scopes` — 13 hermetic cases over the credential-mutating
  script: both env-token refusal directions (including the dual-host case that
  must *not* refuse), the no-TTY refusal and that it precedes any mutation, the
  stored fine-grained refusal asserted against the gh call log, active-account
  narrowing, a read-only grant failing, a write-only grant passing, and
  post-refresh exit codes asserted through a pty.
- `PR_TITLE=… BASE_SHA=main task guard:release-title` passes.

## Rigor

rigor: `standard` (`default_rigor`) → challenge ≤3, review ≤3, shepherd 4.
No `rigor:` label on either issue; not applied by an agent.

**Challenge — converged.** r1: 3×P1 confirmed and fixed (github.com hardcoded in
an Enterprise checkout; verification reading every account on the host; the
Projects requirement being unconditional) + 3×P2, two fixed and one deferred.
r2: 2×P1 confirmed and fixed (only the devcontainer hook's budget was raised;
the env-token refusal ignored which host each variable applies to) — the
round-2 scaffolding checkpoint found neither to be about r1's fixes. r3: **no
findings at all**, which ends the stage on an empty round.

**Review — hit its cap.** r1: 1×P1 + 3×P2. r2: 2×P1 + 2×P2. r3 (the cap):
1×P1 + 1×P2, both confirmed and fixed in `857f5f3`.

> ⚠️ **Disclosure for the reviewer:** the review stage reached its cap of 3 with
> round 3's findings *fixed but not confirmed by a further round*, because the
> cap forbids a fourth. Nothing is unresolved — every P0/P1 raised in this stage
> is fixed — but no review round has yet looked at `857f5f3`. The current-head
> Codex cloud review during shepherding covers exactly that commit, and is the
> second-model check standing in for the round the cap disallowed.

## Adjudicated but not fixed here

Review r1 raised a P1 that `gh_target_host` returns `GH_HOST` unconditionally,
while `gh` documents repository context as taking precedence. **Confirmed** —
but the behaviour predates this PR, which only relocated the function verbatim;
fixing it here would change separately-tested `status:gh` host resolution under
an issue about scopes, and the existing in-code comment argues the current order
deliberately. Adjudicated to P2 and filed as **#882** with the evidence.

## Shepherd (4 rounds, the cap — all findings settled)

Every round was a Codex cloud review on the current head; CI was green on each.
All findings were P2, each answered in its own thread.

1. **`admin:org` was never required** where the template renders the org-level
   issue-type/field setups — fixed, gated on the same marker rule.
   *(Also: `GH_HOST` precedence — declined with evidence, see below.)*
2. **The banner told a logged-out reader** that the task "does the same" as
   `gh auth login`, in the one context where the task refuses — reworded. And
   the docs' "raw equivalent" was a hardcoded copy of a derived list — derived.
3. **A third hardcoded scope list** in both devcontainer guides — derived, and
   I swept the tree rather than wait for a fourth.
4. **Three at once:** the derived command was broken under the devcontainer's
   zsh (`BASH_SOURCE` unset → the list silently shrank) — all six invocations
   now go through `bash -c`; `gh auth refresh` opened a browser with nothing to
   add, so the sequence this PR documents authenticated twice — it now
   short-circuits; and `GH_REQUIRED_SCOPES` was documented as extending while
   actually replacing — **`GH_EXTRA_SCOPES`** is additive and is what the docs
   now steer to.

Round 5's cycle came back **clean** on `61b1d82`.

Rounds 2–4 were largely my own previous round's ripples (three hardcoded copies
of one list, then a fix that was itself broken in the target shell). That is the
propagation-debt shape, which is why round 3 ended with a tree-wide sweep for
scope literals instead of another single-copy fix.

## Adjudicated but not fixed here

`gh_target_host` returns `GH_HOST` unconditionally, while `gh` documents
repository context as taking precedence (raised in local review, and again by
the cloud reviewer with a `gh help environment` citation). **Confirmed, and
declined in this PR:** the behaviour predates it — the function was moved
verbatim — and `scripts/test-status.sh:586` asserts *"GH_HOST still overrides
the repository's remote"*, so reversing it means deleting a deliberate, tested
invariant of `status:gh`. Filed as **#882**.

## Deferred findings

None. Nothing was deferred to a later stage: every P2 raised locally or on the
PR is fixed, or declined in-thread with evidence and tracked in #882.

Refs #827
Refs #596


