### PR TITLE
fix(template): stop task status hanging on a terminal

### DIFF
--- a/.claude/hooks/session-start-context.sh
+++ b/.claude/hooks/session-start-context.sh
@@ -18,17 +18,24 @@ strip_ansi() { sed -E 's/\x1B\[''[0-9;]*[A-Za-z]//g'; }
 
 # The outer deadlines must exceed what the sections themselves allow, or the
 # inner bounds are pointless: whatever the section was about to report is lost
-# wholesale, because status.sh buffers each section before printing it. status:gh
-# spends up to NETWORK_TIMEOUT (5s) on the auth probe and then up to another 5s
-# on the PR/run probes it launches in parallel — 10s worst case, so 12 here.
-# status:git makes no network calls at all.
+# wholesale, because status.sh buffers each section before printing it.
+#
+# Each probe's worst case is its deadline PLUS status.sh's kill grace — the
+# second run_timeout waits between SIGTERM and SIGKILL for a probe that ignores
+# the first. Budgeting from the deadline alone understates every probe by that
+# second, which was the whole of the margin these numbers used to carry.
+#
+# status:gh spends up to NETWORK_TIMEOUT (5s) on the auth probe and then up to
+# another 5s on the PR/run probes it launches in parallel — 12s worst case with
+# the grace, so 14 here. status:git makes no network calls at all.
 #
 # status:creds is budgeted from its own probes rather than by copying a
 # neighbour's number: it makes NO network call (that is why it can be here at
 # all — status:gh already spends this startup's only auth round trip), and runs
-# three LOCAL probes back to back, each bounded at 3s inside status.sh — 9s
-# worst case, so 11 here for the `task` and shell startup around them. The three run in
-# parallel, so it adds nothing to the wall clock the gh deadline already allows.
+# three LOCAL probes back to back, each bounded at 3s inside status.sh — 12s
+# worst case with the grace, so 14 here for the `task` and shell startup around
+# them. The three run in parallel, so it adds nothing to the wall clock the gh
+# deadline already allows.
 remote_url="$(git config --get remote.origin.url 2>/dev/null || echo '')"
 host_owner="$(echo "$remote_url" | sed -E 's/^(https?:\/\/|git@)([^:\/]+)[:\/]([^\/]+)\/[^\/]+(\.git)?$/\2 \3/')"
 host="${host_owner% *}"
@@ -46,9 +53,9 @@ if [ "$host" = "github.com" ]; then
         fi
         "$timeout_cmd" 5 task status:git >"$git_out" 2>/dev/null &
         git_pid=$!
-        "$timeout_cmd" 12 task status:gh >"$gh_out" 2>/dev/null &
+        "$timeout_cmd" 14 task status:gh >"$gh_out" 2>/dev/null &
         gh_pid=$!
-        "$timeout_cmd" 11 task status:creds >"$creds_out" 2>/dev/null &
+        "$timeout_cmd" 14 task status:creds >"$creds_out" 2>/dev/null &
         creds_pid=$!
 
         git_rc=0

--- a/.devcontainer/config/claude-hooks/session-start-context.sh
+++ b/.devcontainer/config/claude-hooks/session-start-context.sh
@@ -18,24 +18,31 @@ strip_ansi() { sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'; }
 
 # The outer deadlines must exceed what the sections themselves allow, or the
 # inner bounds are pointless: whatever the section was about to report is lost
-# wholesale, because status.sh buffers each section before printing it. status:gh
-# spends up to NETWORK_TIMEOUT (5s) on the auth probe and then up to another 5s
-# on the PR/run probes it launches in parallel — 10s worst case, so 12 here.
-# status:git makes no network calls at all.
+# wholesale, because status.sh buffers each section before printing it.
+#
+# Each probe's worst case is its deadline PLUS status.sh's kill grace — the
+# second run_timeout waits between SIGTERM and SIGKILL for a probe that ignores
+# the first. Budgeting from the deadline alone understates every probe by that
+# second, which was the whole of the margin these numbers used to carry.
+#
+# status:gh spends up to NETWORK_TIMEOUT (5s) on the auth probe and then up to
+# another 5s on the PR/run probes it launches in parallel — 12s worst case with
+# the grace, so 14 here. status:git makes no network calls at all.
 #
 # status:creds is budgeted from its own probes rather than by copying a
 # neighbour's number: it makes NO network call (that is why it can be here at
 # all — status:gh already spends this startup's only auth round trip), and runs
-# three LOCAL probes back to back, each bounded at 3s inside status.sh — 9s
-# worst case, so 11 here for the `task` and shell startup around them.
+# three LOCAL probes back to back, each bounded at 3s inside status.sh — 12s
+# worst case with the grace, so 14 here for the `task` and shell startup around
+# them.
 #
 # There is a SECOND deadline above all of these: the `timeout` on the
 # SessionStart entries in claude-settings.json, which Claude Code applies to this
 # whole script. Overrunning it is worse than any single section overrunning its
 # own bound — the hook is killed before `jq` emits anything, so the entire
 # payload is lost rather than one section of it. The sections are therefore run
-# in PARALLEL: the hook's wall clock is then the LONGEST deadline (12s), which
-# fits inside that outer timeout, where the sum (25s) would not.
+# in PARALLEL: the hook's wall clock is then the LONGEST deadline (14s), which
+# fits inside that outer timeout, where the sum (33s) would not.
 git_out="$(mktemp)"
 gh_out="$(mktemp)"
 creds_out="$(mktemp)"
@@ -43,9 +50,9 @@ trap 'rm -f "${git_out}" "${gh_out}" "${creds_out}"' EXIT
 
 timeout 5 task status:git >"$git_out" 2>/dev/null &
 git_pid=$!
-timeout 12 task status:gh >"$gh_out" 2>/dev/null &
+timeout 14 task status:gh >"$gh_out" 2>/dev/null &
 gh_pid=$!
-timeout 11 task status:creds >"$creds_out" 2>/dev/null &
+timeout 14 task status:creds >"$creds_out" 2>/dev/null &
 creds_pid=$!
 
 # `wait` on each, with the failure recorded rather than propagated: `set -e`

--- a/.devcontainer/config/claude-settings.json
+++ b/.devcontainer/config/claude-settings.json
@@ -55,7 +55,7 @@
           {
             "type": "command",
             "command": "/etc/claude-code/hooks/session-start-context.sh",
-            "timeout": 15
+            "timeout": 18
           }
         ]
       },
@@ -65,7 +65,7 @@
           {
             "type": "command",
             "command": "/etc/claude-code/hooks/session-start-context.sh",
-            "timeout": 15
+            "timeout": 18
           }
         ]
       }

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -315,6 +315,11 @@ if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
     # a real failure because bounding this probe made a slow network
     # indistinguishable from a missing login, and reporting "not authenticated"
     # for a timeout sends the reader to fix the wrong thing.
+    #
+    # 137 is not proof the deadline fired: `timeout` also returns it for a probe
+    # killed by anything else (OOM, an operator, a supervisor). Both roads lead
+    # to the same verdict — UNKNOWN, never "logged out" — so they share a branch,
+    # and only the wording below stays agnostic about which one it was.
     case "${gh_auth_rc}" in
     0) GH_AUTHED=true ;;
     124 | 137) GH_AUTH_TIMEDOUT=true ;;
@@ -433,7 +438,7 @@ if should_show "gh"; then
     section_header "GitHub Status"
 
     if [[ "${GH_AUTH_TIMEDOUT}" == true ]]; then
-        echo "  (gh auth status timed out after ${NETWORK_TIMEOUT}s -- skipping)" | section_box
+        echo "  (gh auth status timed out after ${NETWORK_TIMEOUT}s, or was killed -- skipping)" | section_box
     elif [[ "${GH_AUTHED}" != true ]]; then
         echo "  (gh not authenticated -- skipping)" | section_box
     else
@@ -666,7 +671,7 @@ render_local_credentials() {
         # absence of everything after it, which this line does not.
         if [[ "${GH_AUTH_TIMEDOUT}" == true ]]; then
             checkline unknown "GitHub CLI (gh)" \
-                "auth probe timed out after ${NETWORK_TIMEOUT}s"
+                "auth probe timed out after ${NETWORK_TIMEOUT}s, or was killed"
         elif [[ "${GH_AUTHED}" == true ]]; then
             checkline ok "GitHub CLI (gh)" "authenticated to $(gh_target_host)"
         else
@@ -699,7 +704,7 @@ render_local_credentials() {
             checkline ok "GitHub CLI (gh)" \
                 "credential stored for $(gh_target_host) (not validated)"
             ;;
-        124 | 137) checkline unknown "GitHub CLI (gh)" "credential probe timed out" ;;
+        124 | 137) checkline unknown "GitHub CLI (gh)" "credential probe timed out or was killed" ;;
         *)
             case "$(printf '%s' "${gh_token_err}" | tr '[:upper:]' '[:lower:]')" in
             *"no oauth token"* | *"not logged in"*)
@@ -745,7 +750,7 @@ render_local_credentials() {
             codex_out="$(run_timeout 3 codex login status 2>&1)" || codex_rc=$?
             case "${codex_rc}" in
             0) checkline ok "Codex CLI" "logged in" ;;
-            124 | 137) checkline unknown "Codex CLI" "login status timed out" ;;
+            124 | 137) checkline unknown "Codex CLI" "login status timed out or was killed" ;;
             *)
                 case "${codex_out}" in
                 *"Not logged in"*) checkline no "Codex CLI" "codex login" ;;
@@ -794,7 +799,7 @@ render_local_credentials() {
         *'"loggedIn":false'*) checkline no "Claude Code CLI" "claude auth login" ;;
         *)
             case "${claude_rc}" in
-            124 | 137) checkline unknown "Claude Code CLI" "auth status timed out" ;;
+            124 | 137) checkline unknown "Claude Code CLI" "auth status timed out or was killed" ;;
             *) checkline unknown "Claude Code CLI" \
                 "auth status reported nothing readable (exit ${claude_rc})" ;;
             esac
@@ -871,7 +876,7 @@ if [[ "${SECTION}" == "setup" ]]; then
     # exactly like a missing login, and telling an authenticated user to run
     # `gh auth login` because GitHub was slow sends them to fix the wrong thing.
     if [[ "${GH_AUTH_TIMEDOUT}" == true ]]; then
-        echo "  (gh auth status timed out after ${NETWORK_TIMEOUT}s -- skipping)" | section_box
+        echo "  (gh auth status timed out after ${NETWORK_TIMEOUT}s, or was killed -- skipping)" | section_box
     elif [[ "${GH_AUTHED}" != true ]]; then
         echo "  (gh not authenticated -- run 'gh auth login')" | section_box
     else

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -39,22 +39,65 @@ else
     echo "status: no 'timeout' found (brew install coreutils) — network probes are unbounded." >&2
 fi
 
+# A deadline alone does NOT bound a probe, because every probe below is read
+# through `$(...)`: a command substitution returns when the write end of its
+# pipe closes, not when `timeout` exits. A probe that survives SIGTERM keeps
+# that pipe open and the board hangs FOREVER while `timeout` has already
+# reported 124 (harmon-init#865 — `claude auth status --json` blocks reading a
+# terminal stdin, and `timeout 3` around it wedged the whole board with no
+# deadline left to fire). Two guards, because they fail differently:
+#
+#   * `</dev/null` — no probe here reads stdin, and a CLI that waits on one
+#     never starts blocking. This is the fix for the observed hang.
+#   * `-k` — a hard kill after the deadline, so the pipe closes even for a
+#     probe that ignores or traps SIGTERM. This is the guard for the next one.
+#
+# `-k` is probed rather than assumed: where `timeout` is BusyBox's, rejecting
+# the flag would fail every probe and report a wholly broken board. Note the
+# deadline exit code is then 137 (SIGKILL) rather than 124 — both mean "the
+# deadline fired", and every reader of these codes treats them alike.
+TIMEOUT_KILL_AFTER=no
+if [ -n "${TIMEOUT_BIN}" ] && "${TIMEOUT_BIN}" -k 1 1 true 2>/dev/null; then
+    TIMEOUT_KILL_AFTER=yes
+fi
+
 run_timeout() {
     local secs="$1"
     shift
-    if [ -n "${TIMEOUT_BIN}" ]; then
-        "${TIMEOUT_BIN}" "${secs}" "$@"
+    if [ -z "${TIMEOUT_BIN}" ]; then
+        "$@" </dev/null
+    elif [ "${TIMEOUT_KILL_AFTER}" = yes ]; then
+        "${TIMEOUT_BIN}" -k 1 "${secs}" "$@" </dev/null
     else
-        "$@"
+        "${TIMEOUT_BIN}" "${secs}" "$@" </dev/null
     fi
 }
 
 # ── Formatting helpers ──────────────────────────────────────────────────────
 
+# Every `gum` call goes through here, because gum asks the TERMINAL for its
+# background colour (OSC 11) whenever its own stdout is one — and waits 5s for
+# an answer. A terminal that replies to neither that nor the cursor-position
+# probe gum falls back on pays the full 5s, EVERY invocation; a board renders
+# a dozen of them, which is the minutes-long hang of harmon-init#865 on a
+# devcontainer terminal. (Terminals that answer either probe were always fast,
+# which is why this never reproduced on a Mac.)
+#
+# Piping stdout removes the terminal from gum's view, so it does not ask.
+# `CLICOLOR_FORCE` then restores the colour gum drops for a non-terminal
+# stdout: with stderr still on the terminal the output is BYTE-IDENTICAL to
+# what an answering terminal produced before this change, 256-colour included.
+# Where stderr is redirected too, gum cannot read the depth and falls back to
+# 16 colours — not a regression, since gum emitted no colour at all into that
+# case before.
+gum_style() {
+    CLICOLOR_FORCE=1 gum style "$@" | cat
+}
+
 section_header() {
     local title="$1"
     if $HAS_GUM; then
-        gum style --bold --foreground 212 --border-foreground 240 \
+        gum_style --bold --foreground 212 --border-foreground 240 \
             --border rounded --padding "0 1" -- "$title"
     else
         echo ""
@@ -67,7 +110,7 @@ section_box() {
     local content
     content="$(cat)"
     if $HAS_GUM; then
-        echo "$content" | gum style --border rounded \
+        echo "$content" | gum_style --border rounded \
             --border-foreground 240 --padding "0 1" --margin "0 0"
     else
         echo "$content"
@@ -78,7 +121,7 @@ section_box() {
 kv() {
     local key="$1" val="$2"
     if $HAS_GUM; then
-        printf "  %s  %s\n" "$(gum style --bold --foreground 39 "$key:")" "$val"
+        printf "  %s  %s\n" "$(gum_style --bold --foreground 39 "$key:")" "$val"
     else
         printf "  %-20s %s\n" "$key:" "$val"
     fi
@@ -267,13 +310,14 @@ if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
             --hostname "${gh_host}" >"${GH_AUTH_FILE}" 2>&1 ||
             gh_auth_rc=$?
     fi
-    # 124 is `timeout`'s own "deadline hit" code. Distinguished from a real
-    # failure because bounding this probe made a slow network indistinguishable
-    # from a missing login, and reporting "not authenticated" for a timeout
-    # sends the reader to fix the wrong thing.
+    # 124 is `timeout`'s own "deadline hit" code, and 137 the same deadline
+    # reached through run_timeout's `-k` hard kill. Both are distinguished from
+    # a real failure because bounding this probe made a slow network
+    # indistinguishable from a missing login, and reporting "not authenticated"
+    # for a timeout sends the reader to fix the wrong thing.
     case "${gh_auth_rc}" in
     0) GH_AUTHED=true ;;
-    124) GH_AUTH_TIMEDOUT=true ;;
+    124 | 137) GH_AUTH_TIMEDOUT=true ;;
     esac
 fi
 
@@ -345,7 +389,7 @@ done
 
 if [[ -z "${SECTION}" ]]; then
     if $HAS_GUM; then
-        gum style --bold --foreground 212 --border double \
+        gum_style --bold --foreground 212 --border double \
             --border-foreground 99 --padding "0 2" --margin "1 0" \
             -- "${PROJECT_NAME}"
     else
@@ -655,7 +699,7 @@ render_local_credentials() {
             checkline ok "GitHub CLI (gh)" \
                 "credential stored for $(gh_target_host) (not validated)"
             ;;
-        124) checkline unknown "GitHub CLI (gh)" "credential probe timed out" ;;
+        124 | 137) checkline unknown "GitHub CLI (gh)" "credential probe timed out" ;;
         *)
             case "$(printf '%s' "${gh_token_err}" | tr '[:upper:]' '[:lower:]')" in
             *"no oauth token"* | *"not logged in"*)
@@ -701,7 +745,7 @@ render_local_credentials() {
             codex_out="$(run_timeout 3 codex login status 2>&1)" || codex_rc=$?
             case "${codex_rc}" in
             0) checkline ok "Codex CLI" "logged in" ;;
-            124) checkline unknown "Codex CLI" "login status timed out" ;;
+            124 | 137) checkline unknown "Codex CLI" "login status timed out" ;;
             *)
                 case "${codex_out}" in
                 *"Not logged in"*) checkline no "Codex CLI" "codex login" ;;
@@ -750,7 +794,7 @@ render_local_credentials() {
         *'"loggedIn":false'*) checkline no "Claude Code CLI" "claude auth login" ;;
         *)
             case "${claude_rc}" in
-            124) checkline unknown "Claude Code CLI" "auth status timed out" ;;
+            124 | 137) checkline unknown "Claude Code CLI" "auth status timed out" ;;
             *) checkline unknown "Claude Code CLI" \
                 "auth status reported nothing readable (exit ${claude_rc})" ;;
             esac

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -632,8 +632,25 @@ echo "==> the session-start hook allows more time than this section can spend"
 # the section was about to report — including the board-writes line. The section
 # spends up to NETWORK_TIMEOUT on the auth probe and then up to NETWORK_TIMEOUT
 # again on the PR/run probes, so the hook must allow more than twice the probe
-# budget. Skipped where the hook is not generated (no devcontainer).
+# budget. Skipped where a hook is not generated (no devcontainer).
 hook=".devcontainer/config/claude-hooks/session-start-context.sh"
+
+# EVERY session-start hook that launches status sections under a deadline, not
+# just the devcontainer one. Both ship and both are live — that one through
+# claude-settings.json, the repo-local one through .agents/hooks.json — so a
+# budget corrected in one of them is corrected nowhere for whoever runs the
+# other. Checking only the first is how the repo-local copy kept a stale
+# deadline through a change that existed to fix exactly that.
+STATUS_HOOKS=".devcontainer/config/claude-hooks/session-start-context.sh .claude/hooks/session-start-context.sh"
+
+# hook_deadline HOOK SECTION — the seconds HOOK allows `task status:SECTION`.
+# Anchored on `task status:` rather than on the command, because the two hooks
+# spell the deadline differently (`timeout 14` vs `"$timeout_cmd" 14`) and a
+# pattern keyed to one of them silently reads nothing from the other — which is
+# not a failure, just an assertion that stops asserting.
+hook_deadline() {
+    sed -n -E "s/.*[[:space:]]([0-9]+) task status:$2([[:space:]].*)?\$/\1/p" "$1" | head -1
+}
 
 # The seconds run_timeout waits between SIGTERM and SIGKILL. A probe that
 # ignores the first spends its deadline PLUS this before the pipe it holds
@@ -644,17 +661,21 @@ hook=".devcontainer/config/claude-hooks/session-start-context.sh"
 kill_grace="$(sed -n -E 's/.*"\$\{TIMEOUT_BIN\}" -k ([0-9]+) "\$\{secs\}".*/\1/p' "${status}" | head -1)"
 : "${kill_grace:=0}"
 
-if [ -f "$hook" ]; then
-    budget="$(sed -n -E 's/.*timeout ([0-9]+) task status:gh.*/\1/p' "$hook")"
-    probe="$(sed -n -E 's/^NETWORK_TIMEOUT="\$\{NETWORK_TIMEOUT:-([0-9]+)\}"$/\1/p' "${status}")"
-    [ -n "$budget" ] || fail "could not read the status:gh timeout out of ${hook}"
-    [ -n "$probe" ] || fail "could not read NETWORK_TIMEOUT out of ${status}"
-    gh_worst="$(((probe + kill_grace) * 2))"
+probe="$(sed -n -E 's/^NETWORK_TIMEOUT="\$\{NETWORK_TIMEOUT:-([0-9]+)\}"$/\1/p' "${status}")"
+[ -n "$probe" ] || fail "could not read NETWORK_TIMEOUT out of ${status}"
+gh_worst="$(((probe + kill_grace) * 2))"
+checked_hooks=0
+for h in ${STATUS_HOOKS}; do
+    [ -f "$h" ] || continue
+    checked_hooks=$((checked_hooks + 1))
+    budget="$(hook_deadline "$h" gh)"
+    [ -n "$budget" ] || fail "could not read the status:gh timeout out of ${h}"
     [ "$budget" -gt "$gh_worst" ] ||
-        fail "hook allows ${budget}s but the section can spend ${gh_worst}s on probes alone (${probe}s deadline + ${kill_grace}s kill grace, twice) — the board-writes line is lost first"
-else
-    echo "    (skipped: no devcontainer hook in this profile)"
-fi
+        fail "${h} allows ${budget}s but the section can spend ${gh_worst}s on probes alone (${probe}s deadline + ${kill_grace}s kill grace, twice) — the board-writes line is lost first"
+done
+[ "$checked_hooks" -gt 0 ] &&
+    echo "    (checked ${checked_hooks} hook(s))" ||
+    echo "    (skipped: no session-start hook in this profile)"
 
 echo "==> the check never runs the setup section's Projects query"
 # The line is fed by the auth probe the section already makes. If it ever grows a
@@ -1133,33 +1154,37 @@ echo "==> the session-start hook allows more time than status:creds can spend"
 # mode — but budgeted from THIS section's own probes rather than inherited from
 # its neighbour's. Both bounds are read out of the files, so adding a probe to
 # the credentials group without widening the hook fails here.
-if [ -f "$hook" ]; then
-    creds_budget="$(sed -n -E 's/.*timeout ([0-9]+) task status:creds.*/\1/p' "$hook" | head -1)"
-    # Deadlines and probe COUNT, because each probe carries the kill grace too.
-    creds_probes="$(awk '
-        /^render_local_credentials\(\) \{/ { inf = 1 }
-        inf && /^\}/ { inf = 0 }
-        inf {
-            line = $0
-            while (match(line, /run_timeout [0-9]+ /)) {
-                total += substr(line, RSTART + 12, RLENGTH - 13) + 0
-                n += 1
-                line = substr(line, RSTART + RLENGTH)
-            }
+# Deadlines and probe COUNT, because each probe carries the kill grace too.
+creds_probes="$(awk '
+    /^render_local_credentials\(\) \{/ { inf = 1 }
+    inf && /^\}/ { inf = 0 }
+    inf {
+        line = $0
+        while (match(line, /run_timeout [0-9]+ /)) {
+            total += substr(line, RSTART + 12, RLENGTH - 13) + 0
+            n += 1
+            line = substr(line, RSTART + RLENGTH)
         }
-        END { print total + 0, n + 0 }
-    ' "${status}")"
-    creds_deadlines="${creds_probes% *}"
-    creds_count="${creds_probes#* }"
-    creds_worst="$((creds_deadlines + creds_count * kill_grace))"
-    [ -n "$creds_budget" ] || fail "could not read the status:creds timeout out of ${hook}"
-    [ "$creds_count" -gt 0 ] ||
-        fail "found no bounded probes in render_local_credentials — the budget below would assert nothing"
+    }
+    END { print total + 0, n + 0 }
+' "${status}")"
+creds_deadlines="${creds_probes% *}"
+creds_count="${creds_probes#* }"
+creds_worst="$((creds_deadlines + creds_count * kill_grace))"
+[ "$creds_count" -gt 0 ] ||
+    fail "found no bounded probes in render_local_credentials — the budget below would assert nothing"
+checked_hooks=0
+for h in ${STATUS_HOOKS}; do
+    [ -f "$h" ] || continue
+    checked_hooks=$((checked_hooks + 1))
+    creds_budget="$(hook_deadline "$h" creds)"
+    [ -n "$creds_budget" ] || fail "could not read the status:creds timeout out of ${h}"
     [ "$creds_budget" -gt "$creds_worst" ] ||
-        fail "hook allows ${creds_budget}s but the credentials section can spend ${creds_worst}s on probes alone (${creds_deadlines}s of deadlines + ${creds_count} probes x ${kill_grace}s kill grace) — the whole group is lost first"
-else
-    echo "    (skipped: no devcontainer hook in this profile)"
-fi
+        fail "${h} allows ${creds_budget}s but the credentials section can spend ${creds_worst}s on probes alone (${creds_deadlines}s of deadlines + ${creds_count} probes x ${kill_grace}s kill grace) — the whole group is lost first"
+done
+[ "$checked_hooks" -gt 0 ] &&
+    echo "    (checked ${checked_hooks} hook(s))" ||
+    echo "    (skipped: no session-start hook in this profile)"
 
 echo "==> the session-start hook fits inside its managed SessionStart deadline"
 # The deadline ABOVE the per-section ones: Claude Code applies the `timeout` on

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -634,13 +634,24 @@ echo "==> the session-start hook allows more time than this section can spend"
 # again on the PR/run probes, so the hook must allow more than twice the probe
 # budget. Skipped where the hook is not generated (no devcontainer).
 hook=".devcontainer/config/claude-hooks/session-start-context.sh"
+
+# The seconds run_timeout waits between SIGTERM and SIGKILL. A probe that
+# ignores the first spends its deadline PLUS this before the pipe it holds
+# closes, so every budget below is modelled from the sum, not the deadline
+# alone. Read out of status.sh rather than restated, because a grace changed
+# in one place and remembered in the other is exactly how these budgets rot.
+# Absent (no `-k` in run_timeout) it is zero and the sums are unchanged.
+kill_grace="$(sed -n -E 's/.*"\$\{TIMEOUT_BIN\}" -k ([0-9]+) "\$\{secs\}".*/\1/p' "${status}" | head -1)"
+: "${kill_grace:=0}"
+
 if [ -f "$hook" ]; then
     budget="$(sed -n -E 's/.*timeout ([0-9]+) task status:gh.*/\1/p' "$hook")"
     probe="$(sed -n -E 's/^NETWORK_TIMEOUT="\$\{NETWORK_TIMEOUT:-([0-9]+)\}"$/\1/p' "${status}")"
     [ -n "$budget" ] || fail "could not read the status:gh timeout out of ${hook}"
     [ -n "$probe" ] || fail "could not read NETWORK_TIMEOUT out of ${status}"
-    [ "$budget" -gt "$((probe * 2))" ] ||
-        fail "hook allows ${budget}s but the section can spend $((probe * 2))s on probes alone — the board-writes line is lost first"
+    gh_worst="$(((probe + kill_grace) * 2))"
+    [ "$budget" -gt "$gh_worst" ] ||
+        fail "hook allows ${budget}s but the section can spend ${gh_worst}s on probes alone (${probe}s deadline + ${kill_grace}s kill grace, twice) — the board-writes line is lost first"
 else
     echo "    (skipped: no devcontainer hook in this profile)"
 fi
@@ -1009,7 +1020,12 @@ run_creds_wedged() {
     rm -f "${fifo}"
     mkfifo "${fifo}"
     exec 9<>"${fifo}"
-    "${TIMEOUT_FOR_TESTS}" 60 env PATH="${TMP}/bin:${PATH}" NO_COLOR=1 \
+    # `-k` on the safety net for the same reason status.sh needs one: the stub
+    # under test ignores SIGTERM, and a net that can only ask nicely is not a
+    # net. Harmless where the shape already terminates — status.sh dies on the
+    # TERM and the stub holds only status.sh's own capture pipe, not this one.
+    # shellcheck disable=SC2086 # deliberate: empty or the two words `-k 5`
+    "${TIMEOUT_FOR_TESTS}" ${TEST_KILL_AFTER} 60 env PATH="${TMP}/bin:${PATH}" NO_COLOR=1 \
         "${WITH_CODEX}" creds <&9 2>&1 || rc=$?
     exec 9>&-
     rm -f "${fifo}"
@@ -1017,6 +1033,12 @@ run_creds_wedged() {
 }
 
 TIMEOUT_FOR_TESTS="$(command -v timeout || command -v gtimeout || true)"
+# Either empty or the two words `-k 5`; expanded unquoted at the call site
+# because a quoted "" would be passed as a zero-length duration argument.
+TEST_KILL_AFTER=""
+if [ -n "${TIMEOUT_FOR_TESTS}" ] && "${TIMEOUT_FOR_TESTS}" -k 1 1 true 2>/dev/null; then
+    TEST_KILL_AFTER="-k 5"
+fi
 if [ -n "${TIMEOUT_FOR_TESTS}" ]; then
     echo "==> a probe that blocks on stdin cannot wedge the board"
     # Passes only if run_timeout handed the probe its own empty stdin: the stub
@@ -1078,23 +1100,28 @@ echo "==> the session-start hook allows more time than status:creds can spend"
 # the credentials group without widening the hook fails here.
 if [ -f "$hook" ]; then
     creds_budget="$(sed -n -E 's/.*timeout ([0-9]+) task status:creds.*/\1/p' "$hook" | head -1)"
-    creds_worst="$(awk '
+    # Deadlines and probe COUNT, because each probe carries the kill grace too.
+    creds_probes="$(awk '
         /^render_local_credentials\(\) \{/ { inf = 1 }
         inf && /^\}/ { inf = 0 }
         inf {
             line = $0
             while (match(line, /run_timeout [0-9]+ /)) {
                 total += substr(line, RSTART + 12, RLENGTH - 13) + 0
+                n += 1
                 line = substr(line, RSTART + RLENGTH)
             }
         }
-        END { print total + 0 }
+        END { print total + 0, n + 0 }
     ' "${status}")"
+    creds_deadlines="${creds_probes% *}"
+    creds_count="${creds_probes#* }"
+    creds_worst="$((creds_deadlines + creds_count * kill_grace))"
     [ -n "$creds_budget" ] || fail "could not read the status:creds timeout out of ${hook}"
-    [ "$creds_worst" -gt 0 ] ||
+    [ "$creds_count" -gt 0 ] ||
         fail "found no bounded probes in render_local_credentials — the budget below would assert nothing"
     [ "$creds_budget" -gt "$creds_worst" ] ||
-        fail "hook allows ${creds_budget}s but the credentials section can spend ${creds_worst}s on probes alone — the whole group is lost first"
+        fail "hook allows ${creds_budget}s but the credentials section can spend ${creds_worst}s on probes alone (${creds_deadlines}s of deadlines + ${creds_count} probes x ${kill_grace}s kill grace) — the whole group is lost first"
 else
     echo "    (skipped: no devcontainer hook in this profile)"
 fi

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -1093,6 +1093,32 @@ stray="$(grep -nE '(^|[^_[:alnum:]])gum[[:space:]]+style' "${status}" |
     fail "gum is invoked outside gum_style, so its stdout is a terminal and it will stall there:
 ${stray}"
 
+# The half of gum_style the grep above cannot see: that piping stdout does not
+# cost the colour. gum drops ANSI for a stdout it does not consider a terminal,
+# and CLICOLOR_FORCE is the whole of what puts it back — so assert the mechanism
+# rather than trusting it. Run against the same shape gum_style uses, which needs
+# no terminal and therefore works in CI.
+#
+# What this canNOT see is the colour DEPTH: with no terminal on stdout or stderr
+# gum reads 16 colours here, where an interactive board keeps the full 256. That
+# distinction needs a pty, and a pty harness portable to macOS bash 3.2 would
+# cost either divergent `script` invocations or a new dependency in a file that
+# ships to generated repos. Total colour loss is the regression worth catching;
+# the depth was verified by hand against a terminal that answers.
+if command -v gum >/dev/null 2>&1; then
+    gum_plain="$(gum style --bold --foreground 212 -- probe | cat)"
+    gum_forced="$(CLICOLOR_FORCE=1 gum style --bold --foreground 212 -- probe | cat)"
+    case "$gum_plain" in
+    *$'\033['*) fail "gum coloured a piped stdout unprompted — CLICOLOR_FORCE is asserting nothing below" ;;
+    esac
+    case "$gum_forced" in
+    *$'\033['*) ;;
+    *) fail "CLICOLOR_FORCE did not restore gum's colour through a pipe, so gum_style renders the board plain" ;;
+    esac
+else
+    echo "    (skipped: gum not installed — the board renders its plain fallback)"
+fi
+
 echo "==> the session-start hook allows more time than status:creds can spend"
 # The same coupling as the status:gh assertion above, and the same total failure
 # mode — but budgeted from THIS section's own probes rather than inherited from

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -967,6 +967,110 @@ case "$out" in
 *) fail "expected an install remedy for a missing gh, got: ${out}" ;;
 esac
 
+# ── run_timeout actually bounds a probe (harmon-init#865) ───────────────────
+#
+# A deadline is NOT a bound here. status.sh reads every probe through `$(...)`,
+# and a command substitution returns when the write end of its pipe closes, not
+# when `timeout` exits — so a probe that blocks on stdin, or that survives the
+# SIGTERM the deadline sends, hangs the board FOREVER while `timeout` has long
+# since reported 124. That is what `task status` did in a devcontainer terminal:
+# `claude auth status --json` waits on a terminal stdin, and nothing downstream
+# was left to fire.
+#
+# Both cases are driven from a stdin that is open and silent, the way a terminal
+# with nobody typing at it is. The outer deadline is the test's own safety net:
+# a regression must FAIL here, not wedge CI.
+
+# make_claude_stub_wedged MODE — a `claude` that reproduces one half of the hang.
+#   stdin — reads stdin to EOF before answering. Answers only if it was given
+#           an empty stdin of its own; otherwise it blocks on the caller's.
+#   term  — ignores SIGTERM and never exits, so only a hard kill closes the
+#           pipe the capture is waiting on.
+make_claude_stub_wedged() {
+    mkdir -p "${TMP}/bin"
+    {
+        echo '#!/usr/bin/env bash'
+        echo "trap '' TERM"
+        case "$1" in
+        stdin) echo 'cat >/dev/null' ;;
+        term) echo 'while :; do sleep 1; done' ;;
+        *) fail "unknown wedged claude stub mode: $1" ;;
+        esac
+        echo 'echo "{ \"loggedIn\": true }"'
+    } >"${TMP}/bin/claude"
+    chmod +x "${TMP}/bin/claude"
+}
+
+# run_creds_wedged — the credentials section with stdin bound to a pipe that
+# stays open and never delivers a byte. Read-write is how the fifo is opened
+# without blocking on a writer that will never come.
+run_creds_wedged() {
+    local fifo="${TMP}/wedge.fifo" rc=0
+    rm -f "${fifo}"
+    mkfifo "${fifo}"
+    exec 9<>"${fifo}"
+    "${TIMEOUT_FOR_TESTS}" 60 env PATH="${TMP}/bin:${PATH}" NO_COLOR=1 \
+        "${WITH_CODEX}" creds <&9 2>&1 || rc=$?
+    exec 9>&-
+    rm -f "${fifo}"
+    return "${rc}"
+}
+
+TIMEOUT_FOR_TESTS="$(command -v timeout || command -v gtimeout || true)"
+if [ -n "${TIMEOUT_FOR_TESTS}" ]; then
+    echo "==> a probe that blocks on stdin cannot wedge the board"
+    # Passes only if run_timeout handed the probe its own empty stdin: the stub
+    # answers after EOF, and EOF is what it never gets from the caller's.
+    make_stub project
+    make_codex_stub in
+    make_claude_stub_wedged stdin
+    out="$(run_creds_wedged)" ||
+        fail "status:creds never returned with a probe blocked on stdin — the deadline does not bound the capture"
+    case "$out" in
+    *"Claude Code CLI"*"logged in"*) ;;
+    *) fail "expected the stdin-blocked probe to be answered from an empty stdin, got: ${out}" ;;
+    esac
+
+    echo "==> a probe that ignores SIGTERM cannot wedge the board either"
+    # Nothing can make this one answer, so the contract is weaker but the point
+    # is the same: report the deadline and move on, rather than hang holding a
+    # pipe open. Skipped where `timeout` has no `-k`, which is the one build
+    # where status.sh cannot promise this.
+    if "${TIMEOUT_FOR_TESTS}" -k 1 1 true 2>/dev/null; then
+        make_claude_stub_wedged term
+        out="$(run_creds_wedged)" ||
+            fail "status:creds never returned with a probe that ignores SIGTERM — the capture outlives its deadline"
+        case "$out" in
+        *"[?] Claude Code CLI"*"timed out"*) ;;
+        *) fail "expected a timeout notice for a probe that ignores SIGTERM, got: ${out}" ;;
+        esac
+    else
+        echo "    (skipped: this timeout has no -k, so the hard kill is unavailable)"
+    fi
+    make_claude_stub in
+else
+    echo "    (skipped: no timeout binary — the probes are unbounded here)"
+fi
+
+echo "==> every gum call keeps its stdout off the terminal"
+# gum asks the TERMINAL for its background colour (OSC 11) whenever its own
+# stdout is one, and waits 5s when nothing answers — per invocation, and a board
+# renders a dozen. That is the other half of harmon-init#865, and it is invisible
+# in every test above because they all run under NO_COLOR with no terminal at
+# all. gum_style is the single place that keeps stdout off the terminal; a call
+# site that bypasses it reintroduces the stall on exactly the terminals that
+# cannot answer, which are the ones nobody develops on.
+grep -qF 'CLICOLOR_FORCE=1 gum style "$@" | cat' "${status}" ||
+    fail "gum_style no longer pipes gum's stdout with CLICOLOR_FORCE — the terminal probe and the colour both depend on it"
+grep -q 'gum_style ' "${status}" ||
+    fail "nothing calls gum_style — the check below would pass vacuously"
+stray="$(grep -nE '(^|[^_[:alnum:]])gum[[:space:]]+style' "${status}" |
+    grep -vF 'CLICOLOR_FORCE=1 gum style' |
+    grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+[ -z "${stray}" ] ||
+    fail "gum is invoked outside gum_style, so its stdout is a terminal and it will stall there:
+${stray}"
+
 echo "==> the session-start hook allows more time than status:creds can spend"
 # The same coupling as the status:gh assertion above, and the same total failure
 # mode — but budgeted from THIS section's own probes rather than inherited from

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -1105,9 +1105,18 @@ ${stray}"
 # cost either divergent `script` invocations or a new dependency in a file that
 # ships to generated repos. Total colour loss is the regression worth catching;
 # the depth was verified by hand against a terminal that answers.
+#
+# Both probes run with the caller's colour environment CLEARED, so that
+# CLICOLOR_FORCE is the only difference between them. Either variable leaking in
+# breaks the assertion in a different direction: an inherited NO_COLOR (which gum
+# honours over CLICOLOR_FORCE) renders the forced probe plain, and an inherited
+# CLICOLOR_FORCE colours the plain one. Both would fail this gate purely on the
+# environment it was run in — `NO_COLOR=1 task verify` is an ordinary thing to
+# type — while status.sh stays correct in both, since NO_COLOR turns gum off
+# there entirely.
 if command -v gum >/dev/null 2>&1; then
-    gum_plain="$(gum style --bold --foreground 212 -- probe | cat)"
-    gum_forced="$(CLICOLOR_FORCE=1 gum style --bold --foreground 212 -- probe | cat)"
+    gum_plain="$(env -u NO_COLOR -u CLICOLOR_FORCE gum style --bold --foreground 212 -- probe | cat)"
+    gum_forced="$(env -u NO_COLOR CLICOLOR_FORCE=1 gum style --bold --foreground 212 -- probe | cat)"
     case "$gum_plain" in
     *$'\033['*) fail "gum coloured a piped stdout unprompted — CLICOLOR_FORCE is asserting nothing below" ;;
     esac

--- a/template/.claude/hooks/session-start-context.sh.jinja
+++ b/template/.claude/hooks/session-start-context.sh.jinja
@@ -18,17 +18,24 @@ strip_ansi() { sed -E 's/\x1B\[''[0-9;]*[A-Za-z]//g'; }
 
 # The outer deadlines must exceed what the sections themselves allow, or the
 # inner bounds are pointless: whatever the section was about to report is lost
-# wholesale, because status.sh buffers each section before printing it. status:gh
-# spends up to NETWORK_TIMEOUT (5s) on the auth probe and then up to another 5s
-# on the PR/run probes it launches in parallel — 10s worst case, so 12 here.
-# status:git makes no network calls at all.
+# wholesale, because status.sh buffers each section before printing it.
+#
+# Each probe's worst case is its deadline PLUS status.sh's kill grace — the
+# second run_timeout waits between SIGTERM and SIGKILL for a probe that ignores
+# the first. Budgeting from the deadline alone understates every probe by that
+# second, which was the whole of the margin these numbers used to carry.
+#
+# status:gh spends up to NETWORK_TIMEOUT (5s) on the auth probe and then up to
+# another 5s on the PR/run probes it launches in parallel — 12s worst case with
+# the grace, so 14 here. status:git makes no network calls at all.
 #
 # status:creds is budgeted from its own probes rather than by copying a
 # neighbour's number: it makes NO network call (that is why it can be here at
 # all — status:gh already spends this startup's only auth round trip), and runs
-# three LOCAL probes back to back, each bounded at 3s inside status.sh — 9s
-# worst case, so 11 here for the `task` and shell startup around them. The three run in
-# parallel, so it adds nothing to the wall clock the gh deadline already allows.
+# three LOCAL probes back to back, each bounded at 3s inside status.sh — 12s
+# worst case with the grace, so 14 here for the `task` and shell startup around
+# them. The three run in parallel, so it adds nothing to the wall clock the gh
+# deadline already allows.
 remote_url="$(git config --get remote.origin.url 2>/dev/null || echo '')"
 host_owner="$(echo "$remote_url" | sed -E 's/^(https?:\/\/|git@)([^:\/]+)[:\/]([^\/]+)\/[^\/]+(\.git)?$/\2 \3/')"
 host="${host_owner% *}"
@@ -46,9 +53,9 @@ if [ "$host" = "github.com" ]; then
     fi
     "$timeout_cmd" 5 task status:git >"$git_out" 2>/dev/null &
     git_pid=$!
-    "$timeout_cmd" 12 task status:gh >"$gh_out" 2>/dev/null &
+    "$timeout_cmd" 14 task status:gh >"$gh_out" 2>/dev/null &
     gh_pid=$!
-    "$timeout_cmd" 11 task status:creds >"$creds_out" 2>/dev/null &
+    "$timeout_cmd" 14 task status:creds >"$creds_out" 2>/dev/null &
     creds_pid=$!
 
     git_rc=0

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-hooks/session-start-context.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-hooks/session-start-context.sh
@@ -18,24 +18,31 @@ strip_ansi() { sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'; }
 
 # The outer deadlines must exceed what the sections themselves allow, or the
 # inner bounds are pointless: whatever the section was about to report is lost
-# wholesale, because status.sh buffers each section before printing it. status:gh
-# spends up to NETWORK_TIMEOUT (5s) on the auth probe and then up to another 5s
-# on the PR/run probes it launches in parallel — 10s worst case, so 12 here.
-# status:git makes no network calls at all.
+# wholesale, because status.sh buffers each section before printing it.
+#
+# Each probe's worst case is its deadline PLUS status.sh's kill grace — the
+# second run_timeout waits between SIGTERM and SIGKILL for a probe that ignores
+# the first. Budgeting from the deadline alone understates every probe by that
+# second, which was the whole of the margin these numbers used to carry.
+#
+# status:gh spends up to NETWORK_TIMEOUT (5s) on the auth probe and then up to
+# another 5s on the PR/run probes it launches in parallel — 12s worst case with
+# the grace, so 14 here. status:git makes no network calls at all.
 #
 # status:creds is budgeted from its own probes rather than by copying a
 # neighbour's number: it makes NO network call (that is why it can be here at
 # all — status:gh already spends this startup's only auth round trip), and runs
-# three LOCAL probes back to back, each bounded at 3s inside status.sh — 9s
-# worst case, so 11 here for the `task` and shell startup around them.
+# three LOCAL probes back to back, each bounded at 3s inside status.sh — 12s
+# worst case with the grace, so 14 here for the `task` and shell startup around
+# them.
 #
 # There is a SECOND deadline above all of these: the `timeout` on the
 # SessionStart entries in claude-settings.json, which Claude Code applies to this
 # whole script. Overrunning it is worse than any single section overrunning its
 # own bound — the hook is killed before `jq` emits anything, so the entire
 # payload is lost rather than one section of it. The sections are therefore run
-# in PARALLEL: the hook's wall clock is then the LONGEST deadline (12s), which
-# fits inside that outer timeout, where the sum (25s) would not.
+# in PARALLEL: the hook's wall clock is then the LONGEST deadline (14s), which
+# fits inside that outer timeout, where the sum (33s) would not.
 git_out="$(mktemp)"
 gh_out="$(mktemp)"
 creds_out="$(mktemp)"
@@ -43,9 +50,9 @@ trap 'rm -f "${git_out}" "${gh_out}" "${creds_out}"' EXIT
 
 timeout 5 task status:git >"$git_out" 2>/dev/null &
 git_pid=$!
-timeout 12 task status:gh >"$gh_out" 2>/dev/null &
+timeout 14 task status:gh >"$gh_out" 2>/dev/null &
 gh_pid=$!
-timeout 11 task status:creds >"$creds_out" 2>/dev/null &
+timeout 14 task status:creds >"$creds_out" 2>/dev/null &
 creds_pid=$!
 
 # `wait` on each, with the failure recorded rather than propagated: `set -e`

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-settings.json
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-settings.json
@@ -55,7 +55,7 @@
           {
             "type": "command",
             "command": "/etc/claude-code/hooks/session-start-context.sh",
-            "timeout": 15
+            "timeout": 18
           }
         ]
       },
@@ -65,7 +65,7 @@
           {
             "type": "command",
             "command": "/etc/claude-code/hooks/session-start-context.sh",
-            "timeout": 15
+            "timeout": 18
           }
         ]
       }

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -315,6 +315,11 @@ if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
     # a real failure because bounding this probe made a slow network
     # indistinguishable from a missing login, and reporting "not authenticated"
     # for a timeout sends the reader to fix the wrong thing.
+    #
+    # 137 is not proof the deadline fired: `timeout` also returns it for a probe
+    # killed by anything else (OOM, an operator, a supervisor). Both roads lead
+    # to the same verdict — UNKNOWN, never "logged out" — so they share a branch,
+    # and only the wording below stays agnostic about which one it was.
     case "${gh_auth_rc}" in
     0) GH_AUTHED=true ;;
     124 | 137) GH_AUTH_TIMEDOUT=true ;;
@@ -433,7 +438,7 @@ if should_show "gh"; then
     section_header "GitHub Status"
 
     if [[ "${GH_AUTH_TIMEDOUT}" == true ]]; then
-        echo "  (gh auth status timed out after ${NETWORK_TIMEOUT}s -- skipping)" | section_box
+        echo "  (gh auth status timed out after ${NETWORK_TIMEOUT}s, or was killed -- skipping)" | section_box
     elif [[ "${GH_AUTHED}" != true ]]; then
         echo "  (gh not authenticated -- skipping)" | section_box
     else
@@ -666,7 +671,7 @@ render_local_credentials() {
         # absence of everything after it, which this line does not.
         if [[ "${GH_AUTH_TIMEDOUT}" == true ]]; then
             checkline unknown "GitHub CLI (gh)" \
-                "auth probe timed out after ${NETWORK_TIMEOUT}s"
+                "auth probe timed out after ${NETWORK_TIMEOUT}s, or was killed"
         elif [[ "${GH_AUTHED}" == true ]]; then
             checkline ok "GitHub CLI (gh)" "authenticated to $(gh_target_host)"
         else
@@ -699,7 +704,7 @@ render_local_credentials() {
             checkline ok "GitHub CLI (gh)" \
                 "credential stored for $(gh_target_host) (not validated)"
             ;;
-        124 | 137) checkline unknown "GitHub CLI (gh)" "credential probe timed out" ;;
+        124 | 137) checkline unknown "GitHub CLI (gh)" "credential probe timed out or was killed" ;;
         *)
             case "$(printf '%s' "${gh_token_err}" | tr '[:upper:]' '[:lower:]')" in
             *"no oauth token"* | *"not logged in"*)
@@ -745,7 +750,7 @@ render_local_credentials() {
             codex_out="$(run_timeout 3 codex login status 2>&1)" || codex_rc=$?
             case "${codex_rc}" in
             0) checkline ok "Codex CLI" "logged in" ;;
-            124 | 137) checkline unknown "Codex CLI" "login status timed out" ;;
+            124 | 137) checkline unknown "Codex CLI" "login status timed out or was killed" ;;
             *)
                 case "${codex_out}" in
                 *"Not logged in"*) checkline no "Codex CLI" "codex login" ;;
@@ -794,7 +799,7 @@ render_local_credentials() {
         *'"loggedIn":false'*) checkline no "Claude Code CLI" "claude auth login" ;;
         *)
             case "${claude_rc}" in
-            124 | 137) checkline unknown "Claude Code CLI" "auth status timed out" ;;
+            124 | 137) checkline unknown "Claude Code CLI" "auth status timed out or was killed" ;;
             *) checkline unknown "Claude Code CLI" \
                 "auth status reported nothing readable (exit ${claude_rc})" ;;
             esac
@@ -871,7 +876,7 @@ if [[ "${SECTION}" == "setup" ]]; then
     # exactly like a missing login, and telling an authenticated user to run
     # `gh auth login` because GitHub was slow sends them to fix the wrong thing.
     if [[ "${GH_AUTH_TIMEDOUT}" == true ]]; then
-        echo "  (gh auth status timed out after ${NETWORK_TIMEOUT}s -- skipping)" | section_box
+        echo "  (gh auth status timed out after ${NETWORK_TIMEOUT}s, or was killed -- skipping)" | section_box
     elif [[ "${GH_AUTHED}" != true ]]; then
         echo "  (gh not authenticated -- run 'gh auth login')" | section_box
     else

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -39,22 +39,65 @@ else
     echo "status: no 'timeout' found (brew install coreutils) — network probes are unbounded." >&2
 fi
 
+# A deadline alone does NOT bound a probe, because every probe below is read
+# through `$(...)`: a command substitution returns when the write end of its
+# pipe closes, not when `timeout` exits. A probe that survives SIGTERM keeps
+# that pipe open and the board hangs FOREVER while `timeout` has already
+# reported 124 (harmon-init#865 — `claude auth status --json` blocks reading a
+# terminal stdin, and `timeout 3` around it wedged the whole board with no
+# deadline left to fire). Two guards, because they fail differently:
+#
+#   * `</dev/null` — no probe here reads stdin, and a CLI that waits on one
+#     never starts blocking. This is the fix for the observed hang.
+#   * `-k` — a hard kill after the deadline, so the pipe closes even for a
+#     probe that ignores or traps SIGTERM. This is the guard for the next one.
+#
+# `-k` is probed rather than assumed: where `timeout` is BusyBox's, rejecting
+# the flag would fail every probe and report a wholly broken board. Note the
+# deadline exit code is then 137 (SIGKILL) rather than 124 — both mean "the
+# deadline fired", and every reader of these codes treats them alike.
+TIMEOUT_KILL_AFTER=no
+if [ -n "${TIMEOUT_BIN}" ] && "${TIMEOUT_BIN}" -k 1 1 true 2>/dev/null; then
+    TIMEOUT_KILL_AFTER=yes
+fi
+
 run_timeout() {
     local secs="$1"
     shift
-    if [ -n "${TIMEOUT_BIN}" ]; then
-        "${TIMEOUT_BIN}" "${secs}" "$@"
+    if [ -z "${TIMEOUT_BIN}" ]; then
+        "$@" </dev/null
+    elif [ "${TIMEOUT_KILL_AFTER}" = yes ]; then
+        "${TIMEOUT_BIN}" -k 1 "${secs}" "$@" </dev/null
     else
-        "$@"
+        "${TIMEOUT_BIN}" "${secs}" "$@" </dev/null
     fi
 }
 
 # ── Formatting helpers ──────────────────────────────────────────────────────
 
+# Every `gum` call goes through here, because gum asks the TERMINAL for its
+# background colour (OSC 11) whenever its own stdout is one — and waits 5s for
+# an answer. A terminal that replies to neither that nor the cursor-position
+# probe gum falls back on pays the full 5s, EVERY invocation; a board renders
+# a dozen of them, which is the minutes-long hang of harmon-init#865 on a
+# devcontainer terminal. (Terminals that answer either probe were always fast,
+# which is why this never reproduced on a Mac.)
+#
+# Piping stdout removes the terminal from gum's view, so it does not ask.
+# `CLICOLOR_FORCE` then restores the colour gum drops for a non-terminal
+# stdout: with stderr still on the terminal the output is BYTE-IDENTICAL to
+# what an answering terminal produced before this change, 256-colour included.
+# Where stderr is redirected too, gum cannot read the depth and falls back to
+# 16 colours — not a regression, since gum emitted no colour at all into that
+# case before.
+gum_style() {
+    CLICOLOR_FORCE=1 gum style "$@" | cat
+}
+
 section_header() {
     local title="$1"
     if $HAS_GUM; then
-        gum style --bold --foreground 212 --border-foreground 240 \
+        gum_style --bold --foreground 212 --border-foreground 240 \
             --border rounded --padding "0 1" -- "$title"
     else
         echo ""
@@ -67,7 +110,7 @@ section_box() {
     local content
     content="$(cat)"
     if $HAS_GUM; then
-        echo "$content" | gum style --border rounded \
+        echo "$content" | gum_style --border rounded \
             --border-foreground 240 --padding "0 1" --margin "0 0"
     else
         echo "$content"
@@ -78,7 +121,7 @@ section_box() {
 kv() {
     local key="$1" val="$2"
     if $HAS_GUM; then
-        printf "  %s  %s\n" "$(gum style --bold --foreground 39 "$key:")" "$val"
+        printf "  %s  %s\n" "$(gum_style --bold --foreground 39 "$key:")" "$val"
     else
         printf "  %-20s %s\n" "$key:" "$val"
     fi
@@ -267,13 +310,14 @@ if should_show "gh" || [[ "${SECTION}" == "setup" ]]; then
             --hostname "${gh_host}" >"${GH_AUTH_FILE}" 2>&1 ||
             gh_auth_rc=$?
     fi
-    # 124 is `timeout`'s own "deadline hit" code. Distinguished from a real
-    # failure because bounding this probe made a slow network indistinguishable
-    # from a missing login, and reporting "not authenticated" for a timeout
-    # sends the reader to fix the wrong thing.
+    # 124 is `timeout`'s own "deadline hit" code, and 137 the same deadline
+    # reached through run_timeout's `-k` hard kill. Both are distinguished from
+    # a real failure because bounding this probe made a slow network
+    # indistinguishable from a missing login, and reporting "not authenticated"
+    # for a timeout sends the reader to fix the wrong thing.
     case "${gh_auth_rc}" in
     0) GH_AUTHED=true ;;
-    124) GH_AUTH_TIMEDOUT=true ;;
+    124 | 137) GH_AUTH_TIMEDOUT=true ;;
     esac
 fi
 
@@ -345,7 +389,7 @@ done
 
 if [[ -z "${SECTION}" ]]; then
     if $HAS_GUM; then
-        gum style --bold --foreground 212 --border double \
+        gum_style --bold --foreground 212 --border double \
             --border-foreground 99 --padding "0 2" --margin "1 0" \
             -- "${PROJECT_NAME}"
     else
@@ -655,7 +699,7 @@ render_local_credentials() {
             checkline ok "GitHub CLI (gh)" \
                 "credential stored for $(gh_target_host) (not validated)"
             ;;
-        124) checkline unknown "GitHub CLI (gh)" "credential probe timed out" ;;
+        124 | 137) checkline unknown "GitHub CLI (gh)" "credential probe timed out" ;;
         *)
             case "$(printf '%s' "${gh_token_err}" | tr '[:upper:]' '[:lower:]')" in
             *"no oauth token"* | *"not logged in"*)
@@ -701,7 +745,7 @@ render_local_credentials() {
             codex_out="$(run_timeout 3 codex login status 2>&1)" || codex_rc=$?
             case "${codex_rc}" in
             0) checkline ok "Codex CLI" "logged in" ;;
-            124) checkline unknown "Codex CLI" "login status timed out" ;;
+            124 | 137) checkline unknown "Codex CLI" "login status timed out" ;;
             *)
                 case "${codex_out}" in
                 *"Not logged in"*) checkline no "Codex CLI" "codex login" ;;
@@ -750,7 +794,7 @@ render_local_credentials() {
         *'"loggedIn":false'*) checkline no "Claude Code CLI" "claude auth login" ;;
         *)
             case "${claude_rc}" in
-            124) checkline unknown "Claude Code CLI" "auth status timed out" ;;
+            124 | 137) checkline unknown "Claude Code CLI" "auth status timed out" ;;
             *) checkline unknown "Claude Code CLI" \
                 "auth status reported nothing readable (exit ${claude_rc})" ;;
             esac

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -632,8 +632,25 @@ echo "==> the session-start hook allows more time than this section can spend"
 # the section was about to report — including the board-writes line. The section
 # spends up to NETWORK_TIMEOUT on the auth probe and then up to NETWORK_TIMEOUT
 # again on the PR/run probes, so the hook must allow more than twice the probe
-# budget. Skipped where the hook is not generated (no devcontainer).
+# budget. Skipped where a hook is not generated (no devcontainer).
 hook=".devcontainer/config/claude-hooks/session-start-context.sh"
+
+# EVERY session-start hook that launches status sections under a deadline, not
+# just the devcontainer one. Both ship and both are live — that one through
+# claude-settings.json, the repo-local one through .agents/hooks.json — so a
+# budget corrected in one of them is corrected nowhere for whoever runs the
+# other. Checking only the first is how the repo-local copy kept a stale
+# deadline through a change that existed to fix exactly that.
+STATUS_HOOKS=".devcontainer/config/claude-hooks/session-start-context.sh .claude/hooks/session-start-context.sh"
+
+# hook_deadline HOOK SECTION — the seconds HOOK allows `task status:SECTION`.
+# Anchored on `task status:` rather than on the command, because the two hooks
+# spell the deadline differently (`timeout 14` vs `"$timeout_cmd" 14`) and a
+# pattern keyed to one of them silently reads nothing from the other — which is
+# not a failure, just an assertion that stops asserting.
+hook_deadline() {
+    sed -n -E "s/.*[[:space:]]([0-9]+) task status:$2([[:space:]].*)?\$/\1/p" "$1" | head -1
+}
 
 # The seconds run_timeout waits between SIGTERM and SIGKILL. A probe that
 # ignores the first spends its deadline PLUS this before the pipe it holds
@@ -644,17 +661,21 @@ hook=".devcontainer/config/claude-hooks/session-start-context.sh"
 kill_grace="$(sed -n -E 's/.*"\$\{TIMEOUT_BIN\}" -k ([0-9]+) "\$\{secs\}".*/\1/p' "${status}" | head -1)"
 : "${kill_grace:=0}"
 
-if [ -f "$hook" ]; then
-    budget="$(sed -n -E 's/.*timeout ([0-9]+) task status:gh.*/\1/p' "$hook")"
-    probe="$(sed -n -E 's/^NETWORK_TIMEOUT="\$\{NETWORK_TIMEOUT:-([0-9]+)\}"$/\1/p' "${status}")"
-    [ -n "$budget" ] || fail "could not read the status:gh timeout out of ${hook}"
-    [ -n "$probe" ] || fail "could not read NETWORK_TIMEOUT out of ${status}"
-    gh_worst="$(((probe + kill_grace) * 2))"
+probe="$(sed -n -E 's/^NETWORK_TIMEOUT="\$\{NETWORK_TIMEOUT:-([0-9]+)\}"$/\1/p' "${status}")"
+[ -n "$probe" ] || fail "could not read NETWORK_TIMEOUT out of ${status}"
+gh_worst="$(((probe + kill_grace) * 2))"
+checked_hooks=0
+for h in ${STATUS_HOOKS}; do
+    [ -f "$h" ] || continue
+    checked_hooks=$((checked_hooks + 1))
+    budget="$(hook_deadline "$h" gh)"
+    [ -n "$budget" ] || fail "could not read the status:gh timeout out of ${h}"
     [ "$budget" -gt "$gh_worst" ] ||
-        fail "hook allows ${budget}s but the section can spend ${gh_worst}s on probes alone (${probe}s deadline + ${kill_grace}s kill grace, twice) — the board-writes line is lost first"
-else
-    echo "    (skipped: no devcontainer hook in this profile)"
-fi
+        fail "${h} allows ${budget}s but the section can spend ${gh_worst}s on probes alone (${probe}s deadline + ${kill_grace}s kill grace, twice) — the board-writes line is lost first"
+done
+[ "$checked_hooks" -gt 0 ] &&
+    echo "    (checked ${checked_hooks} hook(s))" ||
+    echo "    (skipped: no session-start hook in this profile)"
 
 echo "==> the check never runs the setup section's Projects query"
 # The line is fed by the auth probe the section already makes. If it ever grows a
@@ -1133,33 +1154,37 @@ echo "==> the session-start hook allows more time than status:creds can spend"
 # mode — but budgeted from THIS section's own probes rather than inherited from
 # its neighbour's. Both bounds are read out of the files, so adding a probe to
 # the credentials group without widening the hook fails here.
-if [ -f "$hook" ]; then
-    creds_budget="$(sed -n -E 's/.*timeout ([0-9]+) task status:creds.*/\1/p' "$hook" | head -1)"
-    # Deadlines and probe COUNT, because each probe carries the kill grace too.
-    creds_probes="$(awk '
-        /^render_local_credentials\(\) \{/ { inf = 1 }
-        inf && /^\}/ { inf = 0 }
-        inf {
-            line = $0
-            while (match(line, /run_timeout [0-9]+ /)) {
-                total += substr(line, RSTART + 12, RLENGTH - 13) + 0
-                n += 1
-                line = substr(line, RSTART + RLENGTH)
-            }
+# Deadlines and probe COUNT, because each probe carries the kill grace too.
+creds_probes="$(awk '
+    /^render_local_credentials\(\) \{/ { inf = 1 }
+    inf && /^\}/ { inf = 0 }
+    inf {
+        line = $0
+        while (match(line, /run_timeout [0-9]+ /)) {
+            total += substr(line, RSTART + 12, RLENGTH - 13) + 0
+            n += 1
+            line = substr(line, RSTART + RLENGTH)
         }
-        END { print total + 0, n + 0 }
-    ' "${status}")"
-    creds_deadlines="${creds_probes% *}"
-    creds_count="${creds_probes#* }"
-    creds_worst="$((creds_deadlines + creds_count * kill_grace))"
-    [ -n "$creds_budget" ] || fail "could not read the status:creds timeout out of ${hook}"
-    [ "$creds_count" -gt 0 ] ||
-        fail "found no bounded probes in render_local_credentials — the budget below would assert nothing"
+    }
+    END { print total + 0, n + 0 }
+' "${status}")"
+creds_deadlines="${creds_probes% *}"
+creds_count="${creds_probes#* }"
+creds_worst="$((creds_deadlines + creds_count * kill_grace))"
+[ "$creds_count" -gt 0 ] ||
+    fail "found no bounded probes in render_local_credentials — the budget below would assert nothing"
+checked_hooks=0
+for h in ${STATUS_HOOKS}; do
+    [ -f "$h" ] || continue
+    checked_hooks=$((checked_hooks + 1))
+    creds_budget="$(hook_deadline "$h" creds)"
+    [ -n "$creds_budget" ] || fail "could not read the status:creds timeout out of ${h}"
     [ "$creds_budget" -gt "$creds_worst" ] ||
-        fail "hook allows ${creds_budget}s but the credentials section can spend ${creds_worst}s on probes alone (${creds_deadlines}s of deadlines + ${creds_count} probes x ${kill_grace}s kill grace) — the whole group is lost first"
-else
-    echo "    (skipped: no devcontainer hook in this profile)"
-fi
+        fail "${h} allows ${creds_budget}s but the credentials section can spend ${creds_worst}s on probes alone (${creds_deadlines}s of deadlines + ${creds_count} probes x ${kill_grace}s kill grace) — the whole group is lost first"
+done
+[ "$checked_hooks" -gt 0 ] &&
+    echo "    (checked ${checked_hooks} hook(s))" ||
+    echo "    (skipped: no session-start hook in this profile)"
 
 echo "==> the session-start hook fits inside its managed SessionStart deadline"
 # The deadline ABOVE the per-section ones: Claude Code applies the `timeout` on

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -634,13 +634,24 @@ echo "==> the session-start hook allows more time than this section can spend"
 # again on the PR/run probes, so the hook must allow more than twice the probe
 # budget. Skipped where the hook is not generated (no devcontainer).
 hook=".devcontainer/config/claude-hooks/session-start-context.sh"
+
+# The seconds run_timeout waits between SIGTERM and SIGKILL. A probe that
+# ignores the first spends its deadline PLUS this before the pipe it holds
+# closes, so every budget below is modelled from the sum, not the deadline
+# alone. Read out of status.sh rather than restated, because a grace changed
+# in one place and remembered in the other is exactly how these budgets rot.
+# Absent (no `-k` in run_timeout) it is zero and the sums are unchanged.
+kill_grace="$(sed -n -E 's/.*"\$\{TIMEOUT_BIN\}" -k ([0-9]+) "\$\{secs\}".*/\1/p' "${status}" | head -1)"
+: "${kill_grace:=0}"
+
 if [ -f "$hook" ]; then
     budget="$(sed -n -E 's/.*timeout ([0-9]+) task status:gh.*/\1/p' "$hook")"
     probe="$(sed -n -E 's/^NETWORK_TIMEOUT="\$\{NETWORK_TIMEOUT:-([0-9]+)\}"$/\1/p' "${status}")"
     [ -n "$budget" ] || fail "could not read the status:gh timeout out of ${hook}"
     [ -n "$probe" ] || fail "could not read NETWORK_TIMEOUT out of ${status}"
-    [ "$budget" -gt "$((probe * 2))" ] ||
-        fail "hook allows ${budget}s but the section can spend $((probe * 2))s on probes alone — the board-writes line is lost first"
+    gh_worst="$(((probe + kill_grace) * 2))"
+    [ "$budget" -gt "$gh_worst" ] ||
+        fail "hook allows ${budget}s but the section can spend ${gh_worst}s on probes alone (${probe}s deadline + ${kill_grace}s kill grace, twice) — the board-writes line is lost first"
 else
     echo "    (skipped: no devcontainer hook in this profile)"
 fi
@@ -1009,7 +1020,12 @@ run_creds_wedged() {
     rm -f "${fifo}"
     mkfifo "${fifo}"
     exec 9<>"${fifo}"
-    "${TIMEOUT_FOR_TESTS}" 60 env PATH="${TMP}/bin:${PATH}" NO_COLOR=1 \
+    # `-k` on the safety net for the same reason status.sh needs one: the stub
+    # under test ignores SIGTERM, and a net that can only ask nicely is not a
+    # net. Harmless where the shape already terminates — status.sh dies on the
+    # TERM and the stub holds only status.sh's own capture pipe, not this one.
+    # shellcheck disable=SC2086 # deliberate: empty or the two words `-k 5`
+    "${TIMEOUT_FOR_TESTS}" ${TEST_KILL_AFTER} 60 env PATH="${TMP}/bin:${PATH}" NO_COLOR=1 \
         "${WITH_CODEX}" creds <&9 2>&1 || rc=$?
     exec 9>&-
     rm -f "${fifo}"
@@ -1017,6 +1033,12 @@ run_creds_wedged() {
 }
 
 TIMEOUT_FOR_TESTS="$(command -v timeout || command -v gtimeout || true)"
+# Either empty or the two words `-k 5`; expanded unquoted at the call site
+# because a quoted "" would be passed as a zero-length duration argument.
+TEST_KILL_AFTER=""
+if [ -n "${TIMEOUT_FOR_TESTS}" ] && "${TIMEOUT_FOR_TESTS}" -k 1 1 true 2>/dev/null; then
+    TEST_KILL_AFTER="-k 5"
+fi
 if [ -n "${TIMEOUT_FOR_TESTS}" ]; then
     echo "==> a probe that blocks on stdin cannot wedge the board"
     # Passes only if run_timeout handed the probe its own empty stdin: the stub
@@ -1078,23 +1100,28 @@ echo "==> the session-start hook allows more time than status:creds can spend"
 # the credentials group without widening the hook fails here.
 if [ -f "$hook" ]; then
     creds_budget="$(sed -n -E 's/.*timeout ([0-9]+) task status:creds.*/\1/p' "$hook" | head -1)"
-    creds_worst="$(awk '
+    # Deadlines and probe COUNT, because each probe carries the kill grace too.
+    creds_probes="$(awk '
         /^render_local_credentials\(\) \{/ { inf = 1 }
         inf && /^\}/ { inf = 0 }
         inf {
             line = $0
             while (match(line, /run_timeout [0-9]+ /)) {
                 total += substr(line, RSTART + 12, RLENGTH - 13) + 0
+                n += 1
                 line = substr(line, RSTART + RLENGTH)
             }
         }
-        END { print total + 0 }
+        END { print total + 0, n + 0 }
     ' "${status}")"
+    creds_deadlines="${creds_probes% *}"
+    creds_count="${creds_probes#* }"
+    creds_worst="$((creds_deadlines + creds_count * kill_grace))"
     [ -n "$creds_budget" ] || fail "could not read the status:creds timeout out of ${hook}"
-    [ "$creds_worst" -gt 0 ] ||
+    [ "$creds_count" -gt 0 ] ||
         fail "found no bounded probes in render_local_credentials — the budget below would assert nothing"
     [ "$creds_budget" -gt "$creds_worst" ] ||
-        fail "hook allows ${creds_budget}s but the credentials section can spend ${creds_worst}s on probes alone — the whole group is lost first"
+        fail "hook allows ${creds_budget}s but the credentials section can spend ${creds_worst}s on probes alone (${creds_deadlines}s of deadlines + ${creds_count} probes x ${kill_grace}s kill grace) — the whole group is lost first"
 else
     echo "    (skipped: no devcontainer hook in this profile)"
 fi

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -1093,6 +1093,32 @@ stray="$(grep -nE '(^|[^_[:alnum:]])gum[[:space:]]+style' "${status}" |
     fail "gum is invoked outside gum_style, so its stdout is a terminal and it will stall there:
 ${stray}"
 
+# The half of gum_style the grep above cannot see: that piping stdout does not
+# cost the colour. gum drops ANSI for a stdout it does not consider a terminal,
+# and CLICOLOR_FORCE is the whole of what puts it back — so assert the mechanism
+# rather than trusting it. Run against the same shape gum_style uses, which needs
+# no terminal and therefore works in CI.
+#
+# What this canNOT see is the colour DEPTH: with no terminal on stdout or stderr
+# gum reads 16 colours here, where an interactive board keeps the full 256. That
+# distinction needs a pty, and a pty harness portable to macOS bash 3.2 would
+# cost either divergent `script` invocations or a new dependency in a file that
+# ships to generated repos. Total colour loss is the regression worth catching;
+# the depth was verified by hand against a terminal that answers.
+if command -v gum >/dev/null 2>&1; then
+    gum_plain="$(gum style --bold --foreground 212 -- probe | cat)"
+    gum_forced="$(CLICOLOR_FORCE=1 gum style --bold --foreground 212 -- probe | cat)"
+    case "$gum_plain" in
+    *$'\033['*) fail "gum coloured a piped stdout unprompted — CLICOLOR_FORCE is asserting nothing below" ;;
+    esac
+    case "$gum_forced" in
+    *$'\033['*) ;;
+    *) fail "CLICOLOR_FORCE did not restore gum's colour through a pipe, so gum_style renders the board plain" ;;
+    esac
+else
+    echo "    (skipped: gum not installed — the board renders its plain fallback)"
+fi
+
 echo "==> the session-start hook allows more time than status:creds can spend"
 # The same coupling as the status:gh assertion above, and the same total failure
 # mode — but budgeted from THIS section's own probes rather than inherited from

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -967,6 +967,110 @@ case "$out" in
 *) fail "expected an install remedy for a missing gh, got: ${out}" ;;
 esac
 
+# ── run_timeout actually bounds a probe (harmon-init#865) ───────────────────
+#
+# A deadline is NOT a bound here. status.sh reads every probe through `$(...)`,
+# and a command substitution returns when the write end of its pipe closes, not
+# when `timeout` exits — so a probe that blocks on stdin, or that survives the
+# SIGTERM the deadline sends, hangs the board FOREVER while `timeout` has long
+# since reported 124. That is what `task status` did in a devcontainer terminal:
+# `claude auth status --json` waits on a terminal stdin, and nothing downstream
+# was left to fire.
+#
+# Both cases are driven from a stdin that is open and silent, the way a terminal
+# with nobody typing at it is. The outer deadline is the test's own safety net:
+# a regression must FAIL here, not wedge CI.
+
+# make_claude_stub_wedged MODE — a `claude` that reproduces one half of the hang.
+#   stdin — reads stdin to EOF before answering. Answers only if it was given
+#           an empty stdin of its own; otherwise it blocks on the caller's.
+#   term  — ignores SIGTERM and never exits, so only a hard kill closes the
+#           pipe the capture is waiting on.
+make_claude_stub_wedged() {
+    mkdir -p "${TMP}/bin"
+    {
+        echo '#!/usr/bin/env bash'
+        echo "trap '' TERM"
+        case "$1" in
+        stdin) echo 'cat >/dev/null' ;;
+        term) echo 'while :; do sleep 1; done' ;;
+        *) fail "unknown wedged claude stub mode: $1" ;;
+        esac
+        echo 'echo "{ \"loggedIn\": true }"'
+    } >"${TMP}/bin/claude"
+    chmod +x "${TMP}/bin/claude"
+}
+
+# run_creds_wedged — the credentials section with stdin bound to a pipe that
+# stays open and never delivers a byte. Read-write is how the fifo is opened
+# without blocking on a writer that will never come.
+run_creds_wedged() {
+    local fifo="${TMP}/wedge.fifo" rc=0
+    rm -f "${fifo}"
+    mkfifo "${fifo}"
+    exec 9<>"${fifo}"
+    "${TIMEOUT_FOR_TESTS}" 60 env PATH="${TMP}/bin:${PATH}" NO_COLOR=1 \
+        "${WITH_CODEX}" creds <&9 2>&1 || rc=$?
+    exec 9>&-
+    rm -f "${fifo}"
+    return "${rc}"
+}
+
+TIMEOUT_FOR_TESTS="$(command -v timeout || command -v gtimeout || true)"
+if [ -n "${TIMEOUT_FOR_TESTS}" ]; then
+    echo "==> a probe that blocks on stdin cannot wedge the board"
+    # Passes only if run_timeout handed the probe its own empty stdin: the stub
+    # answers after EOF, and EOF is what it never gets from the caller's.
+    make_stub project
+    make_codex_stub in
+    make_claude_stub_wedged stdin
+    out="$(run_creds_wedged)" ||
+        fail "status:creds never returned with a probe blocked on stdin — the deadline does not bound the capture"
+    case "$out" in
+    *"Claude Code CLI"*"logged in"*) ;;
+    *) fail "expected the stdin-blocked probe to be answered from an empty stdin, got: ${out}" ;;
+    esac
+
+    echo "==> a probe that ignores SIGTERM cannot wedge the board either"
+    # Nothing can make this one answer, so the contract is weaker but the point
+    # is the same: report the deadline and move on, rather than hang holding a
+    # pipe open. Skipped where `timeout` has no `-k`, which is the one build
+    # where status.sh cannot promise this.
+    if "${TIMEOUT_FOR_TESTS}" -k 1 1 true 2>/dev/null; then
+        make_claude_stub_wedged term
+        out="$(run_creds_wedged)" ||
+            fail "status:creds never returned with a probe that ignores SIGTERM — the capture outlives its deadline"
+        case "$out" in
+        *"[?] Claude Code CLI"*"timed out"*) ;;
+        *) fail "expected a timeout notice for a probe that ignores SIGTERM, got: ${out}" ;;
+        esac
+    else
+        echo "    (skipped: this timeout has no -k, so the hard kill is unavailable)"
+    fi
+    make_claude_stub in
+else
+    echo "    (skipped: no timeout binary — the probes are unbounded here)"
+fi
+
+echo "==> every gum call keeps its stdout off the terminal"
+# gum asks the TERMINAL for its background colour (OSC 11) whenever its own
+# stdout is one, and waits 5s when nothing answers — per invocation, and a board
+# renders a dozen. That is the other half of harmon-init#865, and it is invisible
+# in every test above because they all run under NO_COLOR with no terminal at
+# all. gum_style is the single place that keeps stdout off the terminal; a call
+# site that bypasses it reintroduces the stall on exactly the terminals that
+# cannot answer, which are the ones nobody develops on.
+grep -qF 'CLICOLOR_FORCE=1 gum style "$@" | cat' "${status}" ||
+    fail "gum_style no longer pipes gum's stdout with CLICOLOR_FORCE — the terminal probe and the colour both depend on it"
+grep -q 'gum_style ' "${status}" ||
+    fail "nothing calls gum_style — the check below would pass vacuously"
+stray="$(grep -nE '(^|[^_[:alnum:]])gum[[:space:]]+style' "${status}" |
+    grep -vF 'CLICOLOR_FORCE=1 gum style' |
+    grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+[ -z "${stray}" ] ||
+    fail "gum is invoked outside gum_style, so its stdout is a terminal and it will stall there:
+${stray}"
+
 echo "==> the session-start hook allows more time than status:creds can spend"
 # The same coupling as the status:gh assertion above, and the same total failure
 # mode — but budgeted from THIS section's own probes rather than inherited from

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -1105,9 +1105,18 @@ ${stray}"
 # cost either divergent `script` invocations or a new dependency in a file that
 # ships to generated repos. Total colour loss is the regression worth catching;
 # the depth was verified by hand against a terminal that answers.
+#
+# Both probes run with the caller's colour environment CLEARED, so that
+# CLICOLOR_FORCE is the only difference between them. Either variable leaking in
+# breaks the assertion in a different direction: an inherited NO_COLOR (which gum
+# honours over CLICOLOR_FORCE) renders the forced probe plain, and an inherited
+# CLICOLOR_FORCE colours the plain one. Both would fail this gate purely on the
+# environment it was run in — `NO_COLOR=1 task verify` is an ordinary thing to
+# type — while status.sh stays correct in both, since NO_COLOR turns gum off
+# there entirely.
 if command -v gum >/dev/null 2>&1; then
-    gum_plain="$(gum style --bold --foreground 212 -- probe | cat)"
-    gum_forced="$(CLICOLOR_FORCE=1 gum style --bold --foreground 212 -- probe | cat)"
+    gum_plain="$(env -u NO_COLOR -u CLICOLOR_FORCE gum style --bold --foreground 212 -- probe | cat)"
+    gum_forced="$(env -u NO_COLOR CLICOLOR_FORCE=1 gum style --bold --foreground 212 -- probe | cat)"
     case "$gum_plain" in
     *$'\033['*) fail "gum coloured a piped stdout unprompted — CLICOLOR_FORCE is asserting nothing below" ;;
     esac


### PR DESCRIPTION
## What

`task status` hung for minutes — often indefinitely — in a devcontainer terminal
while working fine on a Mac. Two independent TTY-only faults, fixed here.

Closes #865

## Why it only happened on a terminal

Every existing test runs the board with `NO_COLOR=1` and no terminal at all, so
both faults were invisible to the suite and to CI. Repro:
`script -qec "task status" /dev/null` — a pty nothing answers on.

### 1. A deadline did not bound a probe

`status.sh` reads every probe through `$(...)`, and a command substitution
returns when the write end of its pipe closes, not when `timeout` exits.
`claude auth status --json` blocks reading a terminal stdin *and* survives
SIGTERM, so the capture hung forever with `timeout` having already reported 124
and no deadline left to fire.

| | |
|---|---|
| no tty | 507 ms, rc=0 |
| pty, `timeout 3 claude … >/dev/null` | 3045 ms, rc=124 — the deadline works |
| pty, `x=$(timeout 3 claude …)` | **never returns** |
| pty, `x=$(timeout 3 claude … </dev/null)` | 507 ms, rc=0 |
| pty, `x=$(timeout -k 1 3 claude …)` | 4009 ms, rc=137 |

`run_timeout` now gives every probe its own empty stdin (the fix) and a hard
kill after the deadline (the guard for the next probe that ignores SIGTERM —
`claude` demonstrably does). `-k` is feature-probed, not assumed, so a BusyBox
`timeout` degrades to today's behaviour instead of failing every probe; its 137
now reads as a deadline everywhere 124 did.

### 2. gum probes the terminal, once per invocation

gum asks the terminal for its background colour (OSC 11) whenever its stdout is
one, falling back to a cursor-position probe, and waits 5 s when neither is
answered. A board renders a dozen such calls. Terminals that answer either probe
were always fast — which is why this never reproduced on a Mac.

All gum calls now route through `gum_style`, which keeps stdout off the terminal
so gum never asks; `CLICOLOR_FORCE` restores the colour it would otherwise drop.

Colour is unchanged — byte-identical to what an answering terminal produced
before, 256-colour included:

| | answering terminal (before) | this change | identical |
|---|---|---|---|
| `section_header` | `1;38;5;212`, `38;5;240` | same | yes |
| `section_box` | `38;5;240` | same | yes |
| `kv` | `1;38;5;39` | same | yes |

### Result

Real board, under a terminal that answers neither probe: **never completes →
2.8 s**.

## Verification

- `task verify` green; `task ci` green.
- Three regression guards in `test-status.sh`, each verified to fail against the
  unfixed script: a probe blocking on stdin, a probe ignoring SIGTERM (both
  driven from an open, silent stdin under the test's own hard-killed deadline),
  and a static call-site guard that fails if gum is invoked outside `gum_style`.
- Dogfood twins updated in lockstep (`template/scripts/status.sh`,
  `template/scripts/test-status.sh`, the devcontainer hook and claude-settings
  twins).

### Second-model review

rigor: challenge ≤3, review ≤5, shepherd 4. Challenge and shepherd come from
`default_rigor` (`standard`) in `.devflow.toml`; there is no `rigor:*` label on
#865 and the agent applied none. **Review was raised from 3 to 5 by an explicit
instruction from the maintainer**, after the stage hit its cap at 3 without a
valid exit and the agent stopped and escalated rather than opening the PR. It
exited at round 4 with the fifth round unspent.

| Stage | R1 | R2 | R3 | R4 | Exit |
|---|---|---|---|---|---|
| challenge | 1 P1, 1 P2 | clean | clean | — | two consecutive adjudicated-clean |
| review | clean | 1 P1 | 1 P1 | empty | a round with no findings |

Confirmed and fixed along the way:

- **P1 — the kill grace invalidated the session hooks' outer deadlines** and the
  budget tests asserting those deadlines exceed what a section can spend. Both
  tests now read the grace out of `status.sh` and model deadline+grace per probe.
- **P1 — the gum colour assertion depended on the caller's environment.** gum
  honours `NO_COLOR` over `CLICOLOR_FORCE`, so `NO_COLOR=1 task verify` failed
  the gate. Both probes now run with the colour environment cleared, which also
  covers the mirror case (an inherited `CLICOLOR_FORCE` breaking the plain probe)
  found while fixing it.
- **P1 — a second live session hook was missed.** `.claude/hooks/session-start-context.sh`
  (via `.agents/hooks.json`) kept the stale 12s/11s deadlines. The root cause was
  in the test: it checked one hardcoded path with a pattern anchored on
  `timeout N`, which matches nothing in a hook spelling it `"$timeout_cmd" N` —
  and an assertion that reads nothing does not fail, it just stops asserting.
  Both budget tests now iterate every shipped hook and anchor on `task status:`.
- **P2 — 137 read as proof of a timeout.** `timeout` also returns it for a probe
  killed by anything else. The verdict was already right either way (`unknown`,
  never "logged out"); the wording now says so.

One finding was **rejected with evidence**: that piping gum's stdout drops its
colour and `CLICOLOR_FORCE` does not restore it on gum v0.17.0. Measured
byte-for-byte — old code on a terminal that answers vs new code on one that does
not — identical 2468 bytes and 58 SGR sequences, 256-colour intact; and in
isolation `gum … | cat` emits `probe\n` where `CLICOLOR_FORCE=1 gum … | cat`
emits `\033[1;95mprobe\033[0m`. The finding's other half was right, though, and
was fixed: the guard only grepped the implementation, so it now asserts the
mechanism behaviourally too.

## Deferred findings

- [x] **filed as #887** — `scripts/status.sh:69-70` (`run_timeout`) — `timeout -k` kills only the
  DIRECT child. A probe that spawns a descendant which inherits the capture pipe,
  ignores SIGTERM, and outlives a parent that exits on it would still wedge the
  `$( )` capture indefinitely: GNU `timeout` exits with the parent and cancels
  its delayed SIGKILL. Not observed in any probe `status.sh` runs — `claude`
  ignores SIGTERM as the direct child, which `-k` does cover — and the regression
  test covers only the directly-wedged case. The remedy is process-group
  supervision (`setsid` + `kill -PID`), i.e. a hand-rolled supervisor: real added
  surface for an unobserved case, so it is deliberately left as the reviewer's
  call rather than taken unilaterally. (challenge round 3, P2)
  **Settled during shepherding:** confirmed reproducible in isolation — a probe
  that exits on SIGTERM while a SIGTERM-ignoring descendant inherits the pipe
  keeps the capture open past both the deadline and the grace (`rc=124` at the
  outer 20s bound, no `returned`). Still not reachable through any probe
  `status.sh` runs. Filed as #887 with that reproducer as its `Verify` block,
  rather than fixed here, on the maintainer's decision.

## Note for the reviewer

The gum stall is guarded **statically plus behaviourally, but not end-to-end**.
The call-site guard fails if gum is invoked outside `gum_style`, and a
behavioural assertion proves `CLICOLOR_FORCE` restores colour through the pipe.
Neither exercises the 5s stall itself, and neither can see colour *depth* — both
need a pty, and a pty harness portable to macOS bash 3.2 would cost either
divergent `script` invocations or a new dependency in a file that ships to
generated repos. The depth was verified by hand instead, and that limitation is
written down next to the assertion rather than implied away.

