### PR TITLE
feat: route the challenge/review stage through the gauntlet skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -621,9 +621,11 @@ on Codex. Setup and mechanics: `docs/guides/codex-review.md`.
   past a BLOCK** — adjudicate the finding or escalate to Evan instead.
 
 These tasks slot into the **Dev Loop** above: after `task verify` goes green,
-before `task ci` — and the procedure for running them to convergence is the
-vendored `/gauntlet` skill, entered by reading
-`.claude/skills/gauntlet/SKILL.md`. What follows here is the policy that skill
+before `task ci` — and, where the skill's supported topology holds (`origin`
+is the repository the PR will target), the procedure for running them to
+convergence is the vendored `/gauntlet` skill, entered by reading
+`.claude/skills/gauntlet/SKILL.md`; otherwise the Dev Loop's fallback above
+is the procedure. What follows here is the policy that skill
 runs under; where the two disagree, this file wins. Codex cloud review is also connected to this repo's PRs —
 it posts inline comments only for high-priority findings. During shepherding,
 accept its clean comments, reviews, or reactions only under the current-head

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,7 +352,8 @@ allowed.
   the loop feeding on itself before the cap does, and round 2 is where that
   check is owed rather than optional.
 - **`task review`** — verification-checkpoint review, run out of the same
-  skill; same adjudication, the
+  procedure — the skill where its topology holds, the fallback otherwise;
+  same adjudication, the
   same exit condition counted over its own
   rounds, the same self-referential shape and so the
   same reason for a cap, under

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,10 +304,15 @@ allowed.
 - **`task verify`** — when the change feels done, loop edit → verify until
   green; verify is the definition-of-done gate (includes the render matrix).
 - **`task challenge`** — adversarial second-model review, under the resolved
-  **challenge cap**. `/gauntlet` is the procedure, and it is **user-invocable
-  only** (`disable-model-invocation: true`): an agent enters the stage by
-  reading `.claude/skills/gauntlet/SKILL.md` and following it, not by calling
-  a slash command it cannot call. The skill carries the mechanics this file
+  **challenge cap**. `/gauntlet` is the procedure **where its supported
+  topology holds — `origin` is the repository the PR will target** — and it
+  is **user-invocable only** (`disable-model-invocation: true`): an agent
+  enters the stage by reading `.claude/skills/gauntlet/SKILL.md` and
+  following it, not by calling a slash command it cannot call. In a fork
+  checkout where `origin` is the writable fork, the skill's entry gate stops
+  by design and this file's policy plus
+  [docs/guides/codex-review.md](docs/guides/codex-review.md) are the
+  procedure, exactly as when the skill is not vendored. The skill carries the mechanics this file
   deliberately does not restate — backgrounding the long reviewer runs, the
   adjudication table and its ledger, the deferred-findings sidecar, and the
   PR-open ritual. What stays here is the policy those mechanics run under, and
@@ -652,8 +657,10 @@ run, and nothing waits on it.
    appropriate.
 4. Explain why any rejected finding is incorrect or irrelevant.
 5. Re-run `task verify` (and the other relevant gates) after fixes.
-6. Finish the round with an adjudication table and record it; the skill
-   defines the columns and the per-branch ledger they are written to.
+6. Finish the round with an adjudication table — at minimum finding →
+   reviewer priority → **adjudicated** priority → classification → evidence →
+   action, plus the round-2 provenance column — and record it; the skill
+   adds the per-branch ledger the rows are written to.
 
 **Between rounds, check what the findings are about.** Those six steps are all
 *per-finding*, so a reviewer can be right every round while the loop as a whole

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,9 +303,18 @@ allowed.
   change.)
 - **`task verify`** — when the change feels done, loop edit → verify until
   green; verify is the definition-of-done gate (includes the render matrix).
-- **`task challenge`** — adversarial second-model review. Adjudicate per
-  "Second-Model Review" below, fix confirmed findings, re-run `task verify`,
-  then **re-run `task challenge`**. The stage ends when **two consecutive
+- **`task challenge`** — adversarial second-model review, under the resolved
+  **challenge cap**. `/gauntlet` is the procedure, and it is **user-invocable
+  only** (`disable-model-invocation: true`): an agent enters the stage by
+  reading `.claude/skills/gauntlet/SKILL.md` and following it, not by calling
+  a slash command it cannot call. The skill carries the mechanics this file
+  deliberately does not restate — backgrounding the long reviewer runs, the
+  adjudication table and its ledger, the deferred-findings sidecar, and the
+  PR-open ritual. What stays here is the policy those mechanics run under, and
+  where a **vendored** skill (`/gauntlet`) states a different cap, floor, or
+  exit condition, **this file wins** — the skills are synced from harmon-devkit
+  on its own release cadence and can lag a policy change made here.
+  The stage ends when **two consecutive
   rounds adjudicate to zero P0 and zero P1 findings** — whether those rounds
   came back empty, all-P2 as labeled, or P1-labeled and adjudicated down to
   P2. Severity is read off the **adjudicated** column of your adjudication
@@ -325,7 +334,7 @@ allowed.
   deferred-findings sidecar (see "Deferring P2s" below) — an exit that drops
   a P2 is not an exit, because nothing downstream will ever see it again.
   **P2s do not gate this stage**: carry
-  them to the PR (see "Deferring P2s" below). This loop is
+  them to the PR. This loop is
   **self-referential** — the fixes you make in response to a round become the
   next round's input, so it can generate its own work indefinitely — and that
   is what the cap defends against: the resolved **challenge cap** bounds the
@@ -337,20 +346,11 @@ allowed.
   "Between rounds, check what the findings are about" below is how you catch
   the loop feeding on itself before the cap does, and round 2 is where that
   check is owed rather than optional.
-  A `task challenge` round is long — 5–15 minutes is ordinary, past most
-  agents' tool-call timeouts — so **run it in the background and poll**
-  instead of blocking one call on it. Growing output means running, not hung;
-  relaunching a live run only doubles the cost. Re-challenge with a bare
-  `task challenge` — it covers the branch's commits *and* the working tree,
-  so an uncommitted fix cannot narrow the re-run to itself; an explicit
-  `--base`/`--uncommitted` reviews one half only. Committing each round's
-  fixes first is still tidier, not load-bearing. Details:
-  [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
-  backgrounding").
-- **`task review`** — verification-checkpoint review; same adjudication, the
-  same two-consecutive-adjudicated-clean exit condition counted over its own
+- **`task review`** — verification-checkpoint review, run out of the same
+  skill; same adjudication, the
+  same exit condition counted over its own
   rounds, the same self-referential shape and so the
-  same reason for a cap, and the same background-and-poll handling, under
+  same reason for a cap, under
   its own resolved **review cap**. The two stages are counted separately — and
   capped separately, even where the tier gives them equal numbers: a converged
   challenge says nothing about review.
@@ -616,7 +616,10 @@ on Codex. Setup and mechanics: `docs/guides/codex-review.md`.
   past a BLOCK** — adjudicate the finding or escalate to Evan instead.
 
 These tasks slot into the **Dev Loop** above: after `task verify` goes green,
-before `task ci`. Codex cloud review is also connected to this repo's PRs —
+before `task ci` — and the procedure for running them to convergence is the
+vendored `/gauntlet` skill, entered by reading
+`.claude/skills/gauntlet/SKILL.md`. What follows here is the policy that skill
+runs under; where the two disagree, this file wins. Codex cloud review is also connected to this repo's PRs —
 it posts inline comments only for high-priority findings. During shepherding,
 accept its clean comments, reviews, or reactions only under the current-head
 cycle above: stale activity is not evidence for the current commit, and a lone
@@ -649,8 +652,8 @@ run, and nothing waits on it.
    appropriate.
 4. Explain why any rejected finding is incorrect or irrelevant.
 5. Re-run `task verify` (and the other relevant gates) after fixes.
-6. Finish with a concise adjudication table: finding → priority →
-   classification → evidence → action taken.
+6. Finish the round with an adjudication table and record it; the skill
+   defines the columns and the per-branch ledger they are written to.
 
 **Between rounds, check what the findings are about.** Those six steps are all
 *per-finding*, so a reviewer can be right every round while the loop as a whole
@@ -727,44 +730,16 @@ This is not bookkeeping: `task challenge` and `task review` run locally and
 their output is ephemeral, and the cloud reviewer reposts only high-priority
 findings, so a P2 that is not written into the PR body is simply lost.
 
-Record each one **the moment you defer it**. Challenge and review both run
-before `gh pr create`, so there is usually no PR body to write to yet: append
-it to the file
-`git rev-parse --git-path "deferred-findings/$(git branch --show-current)"`
-names (`mkdir -p` its directory first) — but only if that finding is not
-already listed. A P2 you leave open is reported again by design — it is
-unchanged code, so every remaining round of the stage and the next stage after
-it will raise it; appending blindly would hand the shepherd four copies
-of one finding to settle. Match on location plus substance, not exact
-wording — the same finding rarely comes back phrased identically. Then
-move the list into the description when you open the PR (then delete the
-file). Terminal scrollback is not a record — a context reset between
-`task challenge` and `gh pr create` would take the findings with it.
-
-**Sweep for orphans when you open the PR.** List the whole tree —
-`ls -R "$(git rev-parse --git-path deferred-findings)"` — and account for
-every file it holds, not just your branch's. Renaming a branch (`git branch
--m`) or deleting one strands its notes under the old name, where nothing will
-ever look for them again; a rename mid-change is exactly when that happens.
-Adopt an orphan into this PR if it belongs to this work, otherwise leave it
-and say it is there. Listing costs one command; migration logic would cost a
-mechanism that then needs its own correctness argument.
-
-That path is not arbitrary. It sits in the **git directory**, so it is
-deterministic (any later session in this checkout finds it the same way, and
-`git rev-parse` resolves it correctly inside a linked worktree) and invisible
-to `git status`. It is keyed by **branch** because an ordinary clone switches
-branches in place: with one shared file, opening branch B's PR would sweep up
-branch A's findings and then delete A's only copy of them. The branch name
-becomes a *path*, verbatim and without a suffix — folding `/` to `-` would
-collide `feat/x` with `feat-x` and reintroduce exactly that loss, and adding
-an extension would make `foo` (a file) block `foo.md/bar` (needing a
-directory). Used as-is, the mapping is git's own ref namespace, and git
-already forbids one live branch from being a path prefix of another. A note in the *worktree* would be worse than none:
-`codex-review.sh` puts uncommitted files in scope whenever the tree is dirty,
-so the note would be handed to the next bare `task challenge` as part of the
-change under review — a file of open findings, presented to the reviewer as
-work to adjudicate.
+Record each one **the moment you defer it**, and never twice. Challenge and
+review both run before `gh pr create`, so there is usually no PR body to write
+to yet: it goes to the per-branch sidecar in the git directory, and the sweep
+for stray notes happens when you open the PR. The path, the reason it is keyed
+by branch and lives outside the worktree, and the append-once matching rule
+are the skill's (`.claude/skills/gauntlet/SKILL.md`), with the recipe in
+[docs/guides/codex-review.md](docs/guides/codex-review.md) — this file states
+only the obligation, because terminal scrollback is not a record: a context
+reset between `task challenge` and `gh pr create` would take the findings with
+it.
 
 The shepherd stage settles every entry and **edits the PR body to tick it**
 (`- [x] … — fixed in <sha>` / `declined: <reason>` / `filed as #<n>`) in the

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -192,14 +192,17 @@ tier allowed.
   green; verify is the definition-of-done gate.
 [% if use_codex_review %]
 - **`task challenge`** — adversarial second-model review, under the resolved
-  **challenge cap**. Where the optional `/gauntlet` skill is vendored it is the
-  procedure, and it is **user-invocable only**
+  **challenge cap**. Where the optional `/gauntlet` skill is vendored **and its
+  supported topology holds — `origin` is the repository the PR will
+  target** — it is the procedure, and it is **user-invocable only**
   (`disable-model-invocation: true`): an agent enters the stage by reading
   `.claude/skills/gauntlet/SKILL.md` and following it, not by calling a slash
   command it cannot call. That skill carries the mechanics this file does not
   restate — backgrounding the long reviewer runs, the adjudication table and
   its ledger, the deferred-findings sidecar recipe, and the PR-open ritual.
-  Where it is not vendored, the stage still runs from what ships without it:
+  Where it is not vendored — or the checkout is the conventional fork layout
+  whose `origin` is the writable fork, which the skill's entry gate stops on
+  by design — the stage still runs from what ships without it:
   the backgrounding guidance in
   [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
   backgrounding"), the sidecar obligation in "Deferring P2s" below, and the
@@ -553,9 +556,11 @@ These local tasks do not imply that Codex cloud review is installed or required.
    appropriate.
 4. Explain why any rejected finding is incorrect or irrelevant.
 5. Re-run `task verify` (and the other relevant gates) after fixes.
-6. Finish the round with an adjudication table and record it; where the
-   `/gauntlet` skill is vendored it defines the columns and the per-branch
-   ledger they are written to.
+6. Finish the round with an adjudication table — at minimum finding →
+   reviewer priority → **adjudicated** priority → classification → evidence →
+   action, plus the round-2 provenance column — and record it; where the
+   `/gauntlet` skill is vendored it adds the per-branch ledger the rows are
+   written to.
 
 **Between rounds, check what the findings are about.** Those six steps are all
 *per-finding*, so a reviewer can be right every round while the loop as a whole

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -198,9 +198,13 @@ tier allowed.
   `.claude/skills/gauntlet/SKILL.md` and following it, not by calling a slash
   command it cannot call. That skill carries the mechanics this file does not
   restate — backgrounding the long reviewer runs, the adjudication table and
-  its ledger, the deferred-findings sidecar, and the PR-open ritual; where it
-  is not vendored, those live in
-  [docs/guides/codex-review.md](docs/guides/codex-review.md). What stays here
+  its ledger, the deferred-findings sidecar recipe, and the PR-open ritual.
+  Where it is not vendored, the stage still runs from what ships without it:
+  the backgrounding guidance in
+  [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
+  backgrounding"), the sidecar obligation in "Deferring P2s" below, and the
+  Dev Loop's draft-PR bullet — the ledger and the extended ritual are
+  gauntlet enhancements a no-skill repo simply does not owe. What stays here
   is the policy they run under, and where a **vendored** skill (`/gauntlet`)
   states a different cap, floor, or exit condition, **this file wins** —
   vendored skills are synced on their own release cadence and can lag a policy

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -191,9 +191,21 @@ tier allowed.
 - **`task verify`** — when the change feels done, loop edit → verify until
   green; verify is the definition-of-done gate.
 [% if use_codex_review %]
-- **`task challenge`** — adversarial second-model review. Adjudicate per
-  "Second-Model Review" below, fix confirmed findings, re-run `task verify`,
-  then **re-run `task challenge`**. The stage ends when **two consecutive
+- **`task challenge`** — adversarial second-model review, under the resolved
+  **challenge cap**. Where the optional `/gauntlet` skill is vendored it is the
+  procedure, and it is **user-invocable only**
+  (`disable-model-invocation: true`): an agent enters the stage by reading
+  `.claude/skills/gauntlet/SKILL.md` and following it, not by calling a slash
+  command it cannot call. That skill carries the mechanics this file does not
+  restate — backgrounding the long reviewer runs, the adjudication table and
+  its ledger, the deferred-findings sidecar, and the PR-open ritual; where it
+  is not vendored, those live in
+  [docs/guides/codex-review.md](docs/guides/codex-review.md). What stays here
+  is the policy they run under, and where a **vendored** skill (`/gauntlet`)
+  states a different cap, floor, or exit condition, **this file wins** —
+  vendored skills are synced on their own release cadence and can lag a policy
+  change made here.
+  The stage ends when **two consecutive
   rounds adjudicate to zero P0 and zero P1 findings** — whether those rounds
   came back empty, all-P2 as labeled, or P1-labeled and adjudicated down to
   P2. Severity is read off the **adjudicated** column of your adjudication
@@ -213,7 +225,7 @@ tier allowed.
   deferred-findings sidecar (see "Deferring P2s" below) — an exit that drops
   a P2 is not an exit, because nothing downstream will ever see it again.
   **P2s do not gate this stage**: carry
-  them to the PR (see "Deferring P2s" below). This loop is
+  them to the PR. This loop is
   **self-referential** — the fixes you make in response to a round become the
   next round's input, so it can generate its own work indefinitely — and that
   is what the cap defends against: the resolved **challenge cap** bounds the
@@ -225,20 +237,11 @@ tier allowed.
   "Between rounds, check what the findings are about" below is how you catch
   the loop feeding on itself before the cap does, and round 2 is where that
   check is owed rather than optional.
-  A `task challenge` round is long — 5–15 minutes is ordinary, past most
-  agents' tool-call timeouts — so **run it in the background and poll**
-  instead of blocking one call on it. Growing output means running, not hung;
-  relaunching a live run only doubles the cost. Re-challenge with a bare
-  `task challenge` — it covers the branch's commits *and* the working tree,
-  so an uncommitted fix cannot narrow the re-run to itself; an explicit
-  `--base`/`--uncommitted` reviews one half only. Committing each round's
-  fixes first is still tidier, not load-bearing. Details:
-  [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
-  backgrounding").
-- **`task review`** — verification-checkpoint review; same adjudication, the
-  same two-consecutive-adjudicated-clean exit condition counted over its own
+- **`task review`** — verification-checkpoint review, run out of the same
+  procedure; same adjudication, the
+  same exit condition counted over its own
   rounds, the same self-referential shape and so the
-  same reason for a cap, and the same background-and-poll handling, under
+  same reason for a cap, under
   its own resolved **review cap**. The two stages are counted separately — and
   capped separately, even where the tier gives them equal numbers: a converged
   challenge says nothing about review.
@@ -504,7 +507,10 @@ Setup and mechanics: [docs/guides/codex-review.md](docs/guides/codex-review.md).
   past a BLOCK** — adjudicate the finding or escalate to the maintainer instead.
 
 These tasks slot into the **Dev Loop** above: after `task verify` goes green,
-before `task ci`.
+before `task ci` — and where the optional `/gauntlet` skill is vendored, the
+procedure for running them to convergence is that skill, entered by reading
+`.claude/skills/gauntlet/SKILL.md`. What follows here is the policy it runs
+under; where the two disagree, this file wins.
 [% if use_codex_cloud_review %]
 Codex cloud review is also connected to the repo; it reviews PRs too and posts
 inline comments only for high-priority findings.
@@ -543,8 +549,9 @@ These local tasks do not imply that Codex cloud review is installed or required.
    appropriate.
 4. Explain why any rejected finding is incorrect or irrelevant.
 5. Re-run `task verify` (and the other relevant gates) after fixes.
-6. Finish with a concise adjudication table: finding → priority →
-   classification → evidence → action taken.
+6. Finish the round with an adjudication table and record it; where the
+   `/gauntlet` skill is vendored it defines the columns and the per-branch
+   ledger they are written to.
 
 **Between rounds, check what the findings are about.** Those six steps are all
 *per-finding*, so a reviewer can be right every round while the loop as a whole
@@ -621,44 +628,16 @@ This is not bookkeeping: `task challenge` and `task review` run locally and
 their output is ephemeral, and the cloud reviewer reposts only high-priority
 findings, so a P2 that is not written into the PR body is simply lost.
 
-Record each one **the moment you defer it**. Challenge and review both run
-before `gh pr create`, so there is usually no PR body to write to yet: append
-it to the file
-`git rev-parse --git-path "deferred-findings/$(git branch --show-current)"`
-names (`mkdir -p` its directory first) — but only if that finding is not
-already listed. A P2 you leave open is reported again by design — it is
-unchanged code, so every remaining round of the stage and the next stage after
-it will raise it; appending blindly would hand the shepherd four copies
-of one finding to settle. Match on location plus substance, not exact
-wording — the same finding rarely comes back phrased identically. Then
-move the list into the description when you open the PR (then delete the
-file). Terminal scrollback is not a record — a context reset between
-`task challenge` and `gh pr create` would take the findings with it.
-
-**Sweep for orphans when you open the PR.** List the whole tree —
-`ls -R "$(git rev-parse --git-path deferred-findings)"` — and account for
-every file it holds, not just your branch's. Renaming a branch (`git branch
--m`) or deleting one strands its notes under the old name, where nothing will
-ever look for them again; a rename mid-change is exactly when that happens.
-Adopt an orphan into this PR if it belongs to this work, otherwise leave it
-and say it is there. Listing costs one command; migration logic would cost a
-mechanism that then needs its own correctness argument.
-
-That path is not arbitrary. It sits in the **git directory**, so it is
-deterministic (any later session in this checkout finds it the same way, and
-`git rev-parse` resolves it correctly inside a linked worktree) and invisible
-to `git status`. It is keyed by **branch** because an ordinary clone switches
-branches in place: with one shared file, opening branch B's PR would sweep up
-branch A's findings and then delete A's only copy of them. The branch name
-becomes a *path*, verbatim and without a suffix — folding `/` to `-` would
-collide `feat/x` with `feat-x` and reintroduce exactly that loss, and adding
-an extension would make `foo` (a file) block `foo.md/bar` (needing a
-directory). Used as-is, the mapping is git's own ref namespace, and git
-already forbids one live branch from being a path prefix of another. A note in the *worktree* would be worse than none:
-`codex-review.sh` puts uncommitted files in scope whenever the tree is dirty,
-so the note would be handed to the next bare `task challenge` as part of the
-change under review — a file of open findings, presented to the reviewer as
-work to adjudicate.
+Record each one **the moment you defer it**, and never twice. Challenge and
+review both run before `gh pr create`, so there is usually no PR body to write
+to yet: it goes to the per-branch sidecar in the git directory, and the sweep
+for stray notes happens when you open the PR. The path, the reason it is keyed
+by branch and lives outside the worktree, and the append-once matching rule
+are the `/gauntlet` skill's where it is vendored, with the recipe in
+[docs/guides/codex-review.md](docs/guides/codex-review.md) either way — this
+file states only the obligation, because terminal scrollback is not a record:
+a context reset between `task challenge` and `gh pr create` would take the
+findings with it.
 
 The shepherd stage settles every entry and **edits the PR body to tick it**
 (`- [x] … — fixed in <sha>` / `declined: <reason>` / `filed as #<n>`) in the

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -514,9 +514,11 @@ Setup and mechanics: [docs/guides/codex-review.md](docs/guides/codex-review.md).
   past a BLOCK** — adjudicate the finding or escalate to the maintainer instead.
 
 These tasks slot into the **Dev Loop** above: after `task verify` goes green,
-before `task ci` — and where the optional `/gauntlet` skill is vendored, the
-procedure for running them to convergence is that skill, entered by reading
-`.claude/skills/gauntlet/SKILL.md`. What follows here is the policy it runs
+before `task ci` — and where the optional `/gauntlet` skill is vendored **and
+its supported topology holds (`origin` is the repository the PR will
+target)**, the procedure for running them to convergence is that skill,
+entered by reading `.claude/skills/gauntlet/SKILL.md`; otherwise the Dev
+Loop's fallback above is the procedure. What follows here is the policy it runs
 under; where the two disagree, this file wins.
 [% if use_codex_cloud_review %]
 Codex cloud review is also connected to the repo; it reviews PRs too and posts


### PR DESCRIPTION
## What

Routes AGENTS.md's challenge/review stage through the vendored gauntlet skill the way the shepherd stage already routes: the `task challenge`/`task review` bullets and the Second-Model Review lead-in now say an agent enters the stage by reading `.claude/skills/gauntlet/SKILL.md`, keep the normative layer inline (caps and min_rounds floor from `.devflow.toml`, the three-way exit rule, escalation at cap), and state the AGENTS.md-wins precedence for `/gauntlet`. Backgrounding recipes, adjudication-table/ledger mechanics, and sidecar detail move to the skill.

**Template twin deviation for the [HUMAN] criterion:** the root routes unconditionally (the skill is vendored here — strict sequencing satisfied), while `template/AGENTS.md.jinja` keeps the shepherd bullet's where-vendored phrasing because `use_codex_review` does not imply `use_skills_sync` — unconditional routing would hand such a render a dangling pointer; its no-skill fallback names only resources that actually ship.

Refs evanharmon1/harmon-init#862 (last CI criterion; the [HUMAN] confirmation remains yours).

## Verification

- `task verify`, `task test:dogfood-structure`, `task test:dogfood-parity`, `task test:devflow-config`, `task ci` — all green.
- Challenge: 2 rounds (R1 clean-of-blockers with one P2 fixed in place, R2 empty) — converged. Review: 2 rounds (R1 clean with one P2 deferred, R2 clean) — converged.
- rigor: standard (default_rigor) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1.

## Deferred findings

- [x] filed as evanharmon1/harmon-init#898 — template/AGENTS.md.jinja:202-207 — the render matrix has no profile with use_codex_review=true and skills sync off, so the new no-skill fallback path has no regression coverage; add a profile or focused render assertion for that combination.

