### PR TITLE
fix(setup): mark setup:gh-scopes interactive so its TTY guard can pass

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -713,6 +713,13 @@ tasks:
       carries every scope this repo needs (refuses against a GH_TOKEN env
       credential and without a TTY; verifies the grant landed). Bot containers
       must reissue GH_TOKEN instead.
+    # Load-bearing, not cosmetic. This Taskfile sets `output: group` globally,
+    # which pipes every task's stdout — so the script's own `[ -t 1 ]` guard saw
+    # a pipe and refused with "no TTY" even in a real terminal, making the
+    # documented entry point impossible to use. `interactive: true` tells Task
+    # to skip output grouping and attach the task to the terminal, which is what
+    # both the guard and the browser device-code flow it protects require.
+    interactive: true
     cmds:
       - ./scripts/setup-gh-scopes.sh
 

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -267,6 +267,58 @@ for category in SSH_KEY SSHKEY; do
     fi
 done
 
+echo "==> tasks whose script demands a TTY are marked interactive, in both twins"
+# A run-time-only regression, and a total one: this Taskfile sets `output:
+# group` GLOBALLY, so Task pipes each task's stdout. A script guarding on
+# `[ -t 1 ]` then sees a pipe and refuses even in a real terminal, which made
+# `task setup:gh-scopes` impossible to use through its own documented entry
+# point (the smoke tests called the script directly and never saw the wiring).
+# `interactive: true` makes Task skip grouping and attach the task to the
+# terminal.
+#
+# Pinned for BOTH twins, because a generated repo inherits the same global
+# grouping and would inherit the same defect. Asserted against the file rather
+# than by running the task: running it would open a real browser device-code
+# flow against the operator's own credential.
+#
+# Keyed to a fatal `-t 1` check specifically. A `-t 0` guard (secret:set:*,
+# codex:gate:disable) is untouched by output grouping, which redirects stdout
+# only, and status.sh's `-t 1` merely selects colour and never refuses.
+# Both layers where they exist. A GENERATED repo has only the first — it is the
+# rendered output, with no template/ of its own — so a missing file is skipped
+# rather than failed, and the counter below keeps "skipped everything" from
+# passing silently.
+tty_gated_tasks="setup:gh-scopes"
+checked_taskfiles=0
+for taskfile in Taskfile.yml template/Taskfile.yml.jinja; do
+    [ -f "$taskfile" ] || continue
+    checked_taskfiles=$((checked_taskfiles + 1))
+    for t in $tty_gated_tasks; do
+        block="$(awk -v name="  ${t}:" '
+            $0 == name { inblock = 1; next }
+            inblock && /^  [a-zA-Z0-9]/ { inblock = 0 }
+            inblock { print }
+        ' "$taskfile")"
+        [ -n "$block" ] || fail "${taskfile}: task ${t} not found — did it get renamed?"
+        # A whole-line DIRECTIVE, never a substring: the task carries a comment
+        # explaining why the key is there, and that comment names the key — so a
+        # substring match passes on the prose alone and the assertion silently
+        # stops asserting. (It did, until a mutation test caught it.)
+        printf '%s\n' "$block" |
+            grep -vE '^[[:space:]]*#' |
+            grep -qE '^[[:space:]]*interactive:[[:space:]]*true[[:space:]]*$' ||
+            fail "${taskfile}: ${t} lacks 'interactive: true' — global 'output: group' pipes its stdout, so its TTY guard refuses in a real terminal"
+    done
+done
+
+[ "$checked_taskfiles" -gt 0 ] ||
+    fail "no Taskfile was checked for the interactive: true requirement — the assertion above proved nothing"
+
+# The guard above is worth nothing if the grouping it defends against is gone;
+# in that case the requirement should be re-derived rather than silently kept.
+grep -q '^output:' Taskfile.yml ||
+    fail "Taskfile.yml no longer sets a global 'output:' — re-derive whether the interactive: true assertion above still describes a real hazard"
+
 if [ -x ./scripts/test-terraform-provider-locks.sh ]; then
     echo "==> Terraform provider locks cover developer and CI platforms"
     ./scripts/test-terraform-provider-locks.sh

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -316,8 +316,17 @@ done
 
 # The guard above is worth nothing if the grouping it defends against is gone;
 # in that case the requirement should be re-derived rather than silently kept.
-grep -q '^output:' Taskfile.yml ||
-    fail "Taskfile.yml no longer sets a global 'output:' — re-derive whether the interactive: true assertion above still describes a real hazard"
+# GROUP specifically, not merely the presence of an `output:` key: `interleaved`
+# and `prefixed` keep the key while dropping the stdout pipe that makes
+# `interactive: true` necessary, and a check on the key alone would keep
+# demanding it long after the reason had evaporated.
+awk '
+    /^output:/ { inout = 1; next }
+    inout && /^[^[:space:]]/ { inout = 0 }
+    inout && /^[[:space:]]+group:[[:space:]]*$/ { found = 1 }
+    END { exit(found ? 0 : 1) }
+' Taskfile.yml ||
+    fail "Taskfile.yml no longer selects 'output: group' — re-derive whether the interactive: true assertion above still describes a real hazard"
 
 if [ -x ./scripts/test-terraform-provider-locks.sh ]; then
     echo "==> Terraform provider locks cover developer and CI platforms"

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -1059,6 +1059,13 @@ tasks:
       carries every scope this repo needs (refuses against a GH_TOKEN env
       credential and without a TTY; verifies the grant landed). Bot containers
       must reissue GH_TOKEN instead.
+    # Load-bearing, not cosmetic. This Taskfile sets `output: group` globally,
+    # which pipes every task's stdout — so the script's own `[ -t 1 ]` guard saw
+    # a pipe and refused with "no TTY" even in a real terminal, making the
+    # documented entry point impossible to use. `interactive: true` tells Task
+    # to skip output grouping and attach the task to the terminal, which is what
+    # both the guard and the browser device-code flow it protects require.
+    interactive: true
     cmds:
       - ./scripts/setup-gh-scopes.sh
 [% if project_management == 'github' or use_foreman %]

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -267,6 +267,58 @@ for category in SSH_KEY SSHKEY; do
     fi
 done
 
+echo "==> tasks whose script demands a TTY are marked interactive, in both twins"
+# A run-time-only regression, and a total one: this Taskfile sets `output:
+# group` GLOBALLY, so Task pipes each task's stdout. A script guarding on
+# `[ -t 1 ]` then sees a pipe and refuses even in a real terminal, which made
+# `task setup:gh-scopes` impossible to use through its own documented entry
+# point (the smoke tests called the script directly and never saw the wiring).
+# `interactive: true` makes Task skip grouping and attach the task to the
+# terminal.
+#
+# Pinned for BOTH twins, because a generated repo inherits the same global
+# grouping and would inherit the same defect. Asserted against the file rather
+# than by running the task: running it would open a real browser device-code
+# flow against the operator's own credential.
+#
+# Keyed to a fatal `-t 1` check specifically. A `-t 0` guard (secret:set:*,
+# codex:gate:disable) is untouched by output grouping, which redirects stdout
+# only, and status.sh's `-t 1` merely selects colour and never refuses.
+# Both layers where they exist. A GENERATED repo has only the first — it is the
+# rendered output, with no template/ of its own — so a missing file is skipped
+# rather than failed, and the counter below keeps "skipped everything" from
+# passing silently.
+tty_gated_tasks="setup:gh-scopes"
+checked_taskfiles=0
+for taskfile in Taskfile.yml template/Taskfile.yml.jinja; do
+    [ -f "$taskfile" ] || continue
+    checked_taskfiles=$((checked_taskfiles + 1))
+    for t in $tty_gated_tasks; do
+        block="$(awk -v name="  ${t}:" '
+            $0 == name { inblock = 1; next }
+            inblock && /^  [a-zA-Z0-9]/ { inblock = 0 }
+            inblock { print }
+        ' "$taskfile")"
+        [ -n "$block" ] || fail "${taskfile}: task ${t} not found — did it get renamed?"
+        # A whole-line DIRECTIVE, never a substring: the task carries a comment
+        # explaining why the key is there, and that comment names the key — so a
+        # substring match passes on the prose alone and the assertion silently
+        # stops asserting. (It did, until a mutation test caught it.)
+        printf '%s\n' "$block" |
+            grep -vE '^[[:space:]]*#' |
+            grep -qE '^[[:space:]]*interactive:[[:space:]]*true[[:space:]]*$' ||
+            fail "${taskfile}: ${t} lacks 'interactive: true' — global 'output: group' pipes its stdout, so its TTY guard refuses in a real terminal"
+    done
+done
+
+[ "$checked_taskfiles" -gt 0 ] ||
+    fail "no Taskfile was checked for the interactive: true requirement — the assertion above proved nothing"
+
+# The guard above is worth nothing if the grouping it defends against is gone;
+# in that case the requirement should be re-derived rather than silently kept.
+grep -q '^output:' Taskfile.yml ||
+    fail "Taskfile.yml no longer sets a global 'output:' — re-derive whether the interactive: true assertion above still describes a real hazard"
+
 if [ -x ./scripts/test-terraform-provider-locks.sh ]; then
     echo "==> Terraform provider locks cover developer and CI platforms"
     ./scripts/test-terraform-provider-locks.sh

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -316,8 +316,17 @@ done
 
 # The guard above is worth nothing if the grouping it defends against is gone;
 # in that case the requirement should be re-derived rather than silently kept.
-grep -q '^output:' Taskfile.yml ||
-    fail "Taskfile.yml no longer sets a global 'output:' — re-derive whether the interactive: true assertion above still describes a real hazard"
+# GROUP specifically, not merely the presence of an `output:` key: `interleaved`
+# and `prefixed` keep the key while dropping the stdout pipe that makes
+# `interactive: true` necessary, and a check on the key alone would keep
+# demanding it long after the reason had evaporated.
+awk '
+    /^output:/ { inout = 1; next }
+    inout && /^[^[:space:]]/ { inout = 0 }
+    inout && /^[[:space:]]+group:[[:space:]]*$/ { found = 1 }
+    END { exit(found ? 0 : 1) }
+' Taskfile.yml ||
+    fail "Taskfile.yml no longer selects 'output: group' — re-derive whether the interactive: true assertion above still describes a real hazard"
 
 if [ -x ./scripts/test-terraform-provider-locks.sh ]; then
     echo "==> Terraform provider locks cover developer and CI platforms"


### PR DESCRIPTION
## What

`task setup:gh-scopes` refused with **"no TTY" in a real terminal**, so the task
could never succeed through its own documented entry point. Adds
`interactive: true` to the task in both twins.

## Why

This Taskfile sets `output: group` **globally**, so Task pipes every task's
stdout. `scripts/setup-gh-scopes.sh` guards with `[ ! -t 0 ] || [ ! -t 1 ]`
before starting the browser device-code flow — and the stdout half of that guard
saw a pipe, so it refused. Always, and only under `task`.

`interactive: true` tells Task to skip output grouping and attach the task to
the terminal, which is what both the guard and the flow it protects require.
It is an established pattern here (`menu`, `menu-tv` already use it).

Applied to **both** twins: a generated repo inherits the same global grouping,
so it would inherit the same defect.

## Why the smoke tests missed it

They invoked `scripts/setup-gh-scopes.sh` directly, under a pty. That exercises
the script but never the *task-level wiring*, which is where the defect lived —
the script's guard was correct all along.

## Verification

Reproduced and fixed against a real pty (no pipes, since a pipe would itself
defeat the guard under test):

- **before:** `setup:gh-scopes: no TTY. The scope refresh is an interactive
  browser device-code flow — …`
- **after:** reaches the flow proper — `==> Host: github.com` /
  `==> Current scopes: …` / `==> Requesting: repo,workflow,project,read:project`

The after-run was aborted at the device-code prompt rather than completed:
finishing it would have re-minted the maintainer's live credential. `gh auth
refresh` only writes on completion, and `gh auth status` confirms the token's
scopes are unchanged.

## Regression test

`task test:tasks` now pins `interactive: true` for TTY-gated tasks in **both**
Taskfiles, so a grouped-output regression cannot silently re-break it. Three
things worth noting, because each one is a way the assertion could have quietly
stopped asserting:

- It matches a whole-line **directive**, not a substring. The task carries a
  comment explaining the key, and that comment names the key — so a substring
  match passed on the prose alone. A mutation test caught exactly that: the
  first version of this guard went green with `interactive: true` deleted.
- It **skips** a Taskfile that does not exist (a generated repo has no
  `template/`) but counts what it checked, so "skipped everything" cannot pass.
- Its escape hatch asserts `output:` actually selects **`group`** — `interleaved`
  and `prefixed` keep the key while dropping the stdout pipe, and a check on the
  key alone would keep demanding `interactive: true` after the hazard was gone.

Each assertion was mutation-tested: removing the key from either twin, and
switching the output mode, both fail the suite.

## Scope: is anything else affected?

Checked every script in `scripts/` with a TTY guard. **`setup:gh-scopes` is the
only task with the failing shape**, and the guard is keyed to that shape rather
than to the task name:

| Script | Guard | Affected? |
|---|---|---|
| `setup-gh-scopes.sh` | fatal `-t 1` | **yes — fixed** |
| `secret-set-1p.sh`, `secret-set-gh.sh` | `-t 0` | no — grouping redirects stdout only |
| `codex-gate.sh` | `-t 0` | no — same reason |
| `status.sh` | `-t 1` | no — selects colour, never refuses |

## Considered and declined: a `/dev/tty` fallback

It would also make the task work, but it answers *"does a controlling terminal
exist anywhere"* rather than *"are this process's streams a terminal"*. That
would let an agent running inside a terminal session re-mint the operator's
credential — weakening an intentional safety property (the dev-credential
boundary ADR 0004 exists to protect) to buy convenience under a pipe. The
`interactive: true` pair is the load-bearing change; the guard is left strict.

## Rigor

rigor: `standard` (`default_rigor`) → challenge ≤3, review ≤3, shepherd 4.
No `rigor:` label; not applied by an agent.

- **Challenge — converged in 2.** r1: zero P0/P1, one P2 (the `output:` escape
  hatch checked for any output block rather than `group`) — confirmed and fixed.
  r2: **no findings**.
- **Review — converged in 1.** r1: **no findings at all**.

`task verify` and `task ci` both green.

## Deferred findings

None. The single P2 raised was fixed in `37707e9`; the sidecar is empty.

Refs #885
