### PR TITLE
fix: make test:worktree's EXIT-trap assertion portable to Bash 3.2

### DIFF
--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -1016,8 +1016,12 @@ chmod +x "$fixture/scripts/worktree-new.sh"
 # paths — the subshell's assignments keep the live $test_tmp and sentinel out
 # of its `rm -rf`.
 echo "==> the EXIT trap turns a swallowed timeout into a failing suite"
-trap -p EXIT | grep -q 'worktree_exit' ||
-    fail "the EXIT trap is no longer wired to worktree_exit"
+# Captured, never piped: Bash 3.2 resets traps in a pipeline's subshell, so
+# `trap -p EXIT | grep -q …` reads an empty trap list and fails even when the
+# trap is wired (harmon-init#844). `$(trap -p EXIT)` reports the parent
+# shell's traps on every supported Bash.
+exit_trap="$(trap -p EXIT)"
+case "$exit_trap" in *worktree_exit*) : ;; *) fail "the EXIT trap is no longer wired to worktree_exit" ;; esac
 trap_log="$test_tmp/trap.log"
 if (
     test_tmp="$(mktemp -d -t harmon-init-worktree-trap-XXXXXX)"

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -1016,8 +1016,12 @@ chmod +x "$fixture/scripts/worktree-new.sh"
 # paths — the subshell's assignments keep the live $test_tmp and sentinel out
 # of its `rm -rf`.
 echo "==> the EXIT trap turns a swallowed timeout into a failing suite"
-trap -p EXIT | grep -q 'worktree_exit' ||
-    fail "the EXIT trap is no longer wired to worktree_exit"
+# Captured, never piped: Bash 3.2 resets traps in a pipeline's subshell, so
+# `trap -p EXIT | grep -q …` reads an empty trap list and fails even when the
+# trap is wired (harmon-init#844). `$(trap -p EXIT)` reports the parent
+# shell's traps on every supported Bash.
+exit_trap="$(trap -p EXIT)"
+case "$exit_trap" in *worktree_exit*) : ;; *) fail "the EXIT trap is no longer wired to worktree_exit" ;; esac
 trap_log="$test_tmp/trap.log"
 if (
     test_tmp="$(mktemp -d -t harmon-init-worktree-trap-XXXXXX)"


### PR DESCRIPTION
## What

`task test:worktree`'s EXIT-trap self-test asserted the trap wiring with
`trap -p EXIT | grep -q 'worktree_exit'`, which fails deterministically under
macOS Bash 3.2 even when the trap is correctly wired. Replaced with a
command-substitution capture matched by the script's existing one-line `case`
idiom, in both verbatim twins (`scripts/test-worktree.sh` and
`template/scripts/test-worktree.sh`).

## Why

Bash 3.2 resets traps inside a pipeline's subshell, so `trap -p EXIT` as the
first pipeline element prints an **empty** trap list — grep never matches and
the required gate fails spuriously on a supported platform (reproduced
200/200 under `/bin/bash` 3.2.57). Modern Bash special-cases trap reporting in
subshells, which is why Linux and Homebrew Bash never saw it. (The issue
hypothesized a `grep -q` closed-pipe race; the observed mechanism is the trap
reset, which also explains the determinism.) `$(trap -p EXIT)` reports the
parent shell's traps on every supported Bash — verified empirically on 3.2.57
and 5.3.15.

Closes #844

## Verification

- Old pipeline: fails 200/200 under `/bin/bash` 3.2.57 with the trap wired.
- New construct: detects wired, unwired, and no-trap correctly under both
  3.2.57 and 5.3.15 (mutation-checked).
- Full suite: `/bin/bash scripts/test-worktree.sh` (Bash 3.2) and
  `task test:worktree` (Bash 5.3) both pass; PR CI covers Linux Bash.
- Twins byte-identical (`cmp` clean; `test:dogfood-parity` in `verify`).
- Gates run: `task check`, `task verify`, `task challenge` (converged r1),
  `task review` (converged r1), `task ci` — all green.

rigor: standard (default_rigor) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1

## Deferred findings

None — both gauntlet stages returned no findings.

## Adjudication record

<details>
<summary>Per-branch ledger (challenge/review rounds)</summary>

```text
challenge r1 | no findings (reviewer verified both bashes, twin parity, suite green)
review r1 | no findings (assertion, tests, lint, twin parity all confirmed)
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
