### PR TITLE
fix: stop lefthook post-checkout deadlocking test:worktree on a never-EOF stdin

### DIFF
--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -94,6 +94,10 @@ rm -f "$WORKTREE_TIMEOUT_SENTINEL"
 # as the refusal it was asserting. A hang would be accepted as a pass. The
 # sentinel escapes every subshell — it is a file, not an exit status — so
 # however the status is swallowed, the suite still ends non-zero and says why.
+# Initialized empty BEFORE the trap is armed: an exported variable of this
+# name would otherwise flow in from the environment and the cleanup below
+# would kill a PID this suite never owned.
+WORKTREE_STDIN_HOLDER=""
 worktree_exit() {
     exit_status=$?
     # Reap the hostile-stdin writer if a case aborted before its explicit kill

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -11,6 +11,15 @@
 # hook assertion runs everywhere — including CI runners that carry no lefthook.
 set -euo pipefail
 
+# The suite reads nothing from stdin, and its children must not inherit one
+# that never ends: lefthook blocks `run post-checkout` until stdin reaches EOF
+# (observed on v2.1.10), so an invocation context holding stdin open — an
+# agent harness socket, a task runner pipe — deadlocks the fixture's hooks
+# (harmon-init#802). /dev/null hands every child an immediate EOF. One case
+# below deliberately re-introduces a never-ending stdin to prove the
+# entrypoint itself is immune.
+exec </dev/null
+
 repo="$(git rev-parse --show-toplevel)"
 
 # Hooks export GIT_DIR/GIT_WORK_TREE; left set, every `git` below would retarget
@@ -903,7 +912,20 @@ rm -f "$shared_hooks/post-checkout"
 
 echo "==> --no-install skips the dependency install"
 : >"$pnpm_marker"
-new no-install-tree --no-install >/dev/null || fail "worktree-new.sh --no-install failed"
+# This case runs real lefthook's post-checkout (the custom shim above is gone,
+# so worktree-new.sh reinstalled lefthook's own shims), and it runs under a
+# stdin that never reaches EOF — the agent-session condition the suite's own
+# `exec </dev/null` shields everything else from. lefthook blocks
+# `run post-checkout` until stdin EOF (harmon-init#802), so a worktree-new.sh
+# that ties the deferred hook to the caller's stdin hangs here into the #792
+# bound and fails the suite instead of passing by accident.
+mkfifo "$test_tmp/hostile-stdin"
+sleep 300 >"$test_tmp/hostile-stdin" &
+hostile_stdin_pid=$!
+new no-install-tree --no-install <"$test_tmp/hostile-stdin" >/dev/null ||
+    fail "worktree-new.sh --no-install failed under a non-EOF stdin"
+kill "$hostile_stdin_pid" 2>/dev/null || true
+wait "$hostile_stdin_pid" 2>/dev/null || true
 if [ -s "$pnpm_marker" ]; then
     fail "worktree-new.sh ran the installer despite --no-install"
 fi

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -96,6 +96,12 @@ rm -f "$WORKTREE_TIMEOUT_SENTINEL"
 # however the status is swallowed, the suite still ends non-zero and says why.
 worktree_exit() {
     exit_status=$?
+    # Reap the hostile-stdin writer if a case aborted before its explicit kill
+    # — it is backgrounded outside the timeout's process group, so nothing
+    # else collects it on a failing run (harmon-init#802).
+    if [ -n "${WORKTREE_STDIN_HOLDER:-}" ]; then
+        kill "$WORKTREE_STDIN_HOLDER" 2>/dev/null || true
+    fi
     if [ -e "$WORKTREE_TIMEOUT_SENTINEL" ]; then
         # Print what the sentinel HOLDS, not where it lives: it is removed
         # immediately below, so a path would point at nothing by the time
@@ -912,20 +918,42 @@ rm -f "$shared_hooks/post-checkout"
 
 echo "==> --no-install skips the dependency install"
 : >"$pnpm_marker"
-# This case runs real lefthook's post-checkout (the custom shim above is gone,
-# so worktree-new.sh reinstalled lefthook's own shims), and it runs under a
-# stdin that never reaches EOF — the agent-session condition the suite's own
-# `exec </dev/null` shields everything else from. lefthook blocks
-# `run post-checkout` until stdin EOF (harmon-init#802), so a worktree-new.sh
-# that ties the deferred hook to the caller's stdin hangs here into the #792
-# bound and fails the suite instead of passing by accident.
+# This case runs under a stdin that never reaches EOF — the agent-session
+# condition the suite's own `exec </dev/null` shields everything else from.
+# lefthook blocks `run post-checkout` until stdin EOF (harmon-init#802), so
+# worktree-new.sh must hand the deferred hook an already-EOF stdin. The shim
+# below asserts that invariant ITSELF (`cat` drains to EOF before logging):
+# relying on the real lefthook to do the blocking would make this case
+# vacuous under the stub (whose `run` reads nothing) and hostage to whichever
+# stdin behavior a future lefthook ships. A worktree-new.sh that ties the
+# hook to the caller's stdin blocks in `cat` and hangs into the #792 bound.
+cat >"$shared_hooks/post-checkout" <<EOF
+#!/bin/sh
+if [ "\$LEFTHOOK" = "0" ]; then
+  exit 0
+fi
+if [ -n "\$LEFTHOOK_BIN" ]; then
+  exec "\$LEFTHOOK_BIN" run "post-checkout" "\$@"
+fi
+cat >/dev/null
+printf 'post-checkout-eof %s\n' "\$PWD" >>"$test_tmp/post-checkout.log"
+EOF
+chmod +x "$shared_hooks/post-checkout"
+: >"$test_tmp/post-checkout.log"
 mkfifo "$test_tmp/hostile-stdin"
 sleep 300 >"$test_tmp/hostile-stdin" &
-hostile_stdin_pid=$!
+WORKTREE_STDIN_HOLDER=$!
 new no-install-tree --no-install <"$test_tmp/hostile-stdin" >/dev/null ||
     fail "worktree-new.sh --no-install failed under a non-EOF stdin"
-kill "$hostile_stdin_pid" 2>/dev/null || true
-wait "$hostile_stdin_pid" 2>/dev/null || true
+grep -qx "post-checkout-eof $fixture/.worktrees/no-install-tree" "$test_tmp/post-checkout.log" 2>/dev/null ||
+    fail "the deferred post-checkout never reached EOF on its stdin — is it still tied to the caller's stdin? (harmon-init#802)"
+kill "$WORKTREE_STDIN_HOLDER" 2>/dev/null || true
+wait "$WORKTREE_STDIN_HOLDER" 2>/dev/null || true
+WORKTREE_STDIN_HOLDER=""
+# The shim deliberately stays installed: the missing-pnpm case below runs
+# under a PATH mask that hides lefthook, so a configured-but-absent
+# post-checkout hook would fail it at the hook stage instead of the pnpm
+# gate it exists to assert.
 if [ -s "$pnpm_marker" ]; then
     fail "worktree-new.sh ran the installer despite --no-install"
 fi

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -945,7 +945,12 @@ EOF
 chmod +x "$shared_hooks/post-checkout"
 : >"$test_tmp/post-checkout.log"
 mkfifo "$test_tmp/hostile-stdin"
-sleep 300 >"$test_tmp/hostile-stdin" &
+# The writer is UNBOUNDED (`tail -f /dev/null` never exits, on macOS and
+# Linux alike): a `sleep <n>` writer would close the fifo at n seconds, and a
+# WORKTREE_OP_TIMEOUT configured above n would then hand a regressed hook its
+# EOF and pass this case instead of failing it. The explicit kill below and
+# the EXIT trap are what end this process.
+tail -f /dev/null >"$test_tmp/hostile-stdin" &
 WORKTREE_STDIN_HOLDER=$!
 new no-install-tree --no-install <"$test_tmp/hostile-stdin" >/dev/null ||
     fail "worktree-new.sh --no-install failed under a non-EOF stdin"

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -465,7 +465,12 @@ if [ "$run_post_checkout" -eq 1 ] && [ -x "$hooks_dir/post-checkout" ]; then
     new_head="$(git -C "$tree" rev-parse HEAD)"
     null_oid="$(printf '%s' "$new_head" | tr '[:alnum:]' '0')"
     echo "==> Running post-checkout now that the tree is provisioned"
-    (cd "$tree" && "$hooks_dir/post-checkout" "$null_oid" "$new_head" 1) ||
+    # </dev/null is load-bearing: lefthook blocks `run post-checkout` until its
+    # stdin reaches EOF (observed on v2.1.10), so inheriting a stdin the caller
+    # holds open — an agent harness socket, a task runner pipe — deadlocks the
+    # hook here indefinitely (harmon-init#802). Git hands post-checkout no
+    # stdin payload, so an immediate EOF loses nothing.
+    (cd "$tree" && "$hooks_dir/post-checkout" "$null_oid" "$new_head" 1 </dev/null) ||
         die "the repository's post-checkout hook failed in $tree"
 fi
 

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -94,6 +94,10 @@ rm -f "$WORKTREE_TIMEOUT_SENTINEL"
 # as the refusal it was asserting. A hang would be accepted as a pass. The
 # sentinel escapes every subshell — it is a file, not an exit status — so
 # however the status is swallowed, the suite still ends non-zero and says why.
+# Initialized empty BEFORE the trap is armed: an exported variable of this
+# name would otherwise flow in from the environment and the cleanup below
+# would kill a PID this suite never owned.
+WORKTREE_STDIN_HOLDER=""
 worktree_exit() {
     exit_status=$?
     # Reap the hostile-stdin writer if a case aborted before its explicit kill

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -11,6 +11,15 @@
 # hook assertion runs everywhere — including CI runners that carry no lefthook.
 set -euo pipefail
 
+# The suite reads nothing from stdin, and its children must not inherit one
+# that never ends: lefthook blocks `run post-checkout` until stdin reaches EOF
+# (observed on v2.1.10), so an invocation context holding stdin open — an
+# agent harness socket, a task runner pipe — deadlocks the fixture's hooks
+# (harmon-init#802). /dev/null hands every child an immediate EOF. One case
+# below deliberately re-introduces a never-ending stdin to prove the
+# entrypoint itself is immune.
+exec </dev/null
+
 repo="$(git rev-parse --show-toplevel)"
 
 # Hooks export GIT_DIR/GIT_WORK_TREE; left set, every `git` below would retarget
@@ -903,7 +912,20 @@ rm -f "$shared_hooks/post-checkout"
 
 echo "==> --no-install skips the dependency install"
 : >"$pnpm_marker"
-new no-install-tree --no-install >/dev/null || fail "worktree-new.sh --no-install failed"
+# This case runs real lefthook's post-checkout (the custom shim above is gone,
+# so worktree-new.sh reinstalled lefthook's own shims), and it runs under a
+# stdin that never reaches EOF — the agent-session condition the suite's own
+# `exec </dev/null` shields everything else from. lefthook blocks
+# `run post-checkout` until stdin EOF (harmon-init#802), so a worktree-new.sh
+# that ties the deferred hook to the caller's stdin hangs here into the #792
+# bound and fails the suite instead of passing by accident.
+mkfifo "$test_tmp/hostile-stdin"
+sleep 300 >"$test_tmp/hostile-stdin" &
+hostile_stdin_pid=$!
+new no-install-tree --no-install <"$test_tmp/hostile-stdin" >/dev/null ||
+    fail "worktree-new.sh --no-install failed under a non-EOF stdin"
+kill "$hostile_stdin_pid" 2>/dev/null || true
+wait "$hostile_stdin_pid" 2>/dev/null || true
 if [ -s "$pnpm_marker" ]; then
     fail "worktree-new.sh ran the installer despite --no-install"
 fi

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -96,6 +96,12 @@ rm -f "$WORKTREE_TIMEOUT_SENTINEL"
 # however the status is swallowed, the suite still ends non-zero and says why.
 worktree_exit() {
     exit_status=$?
+    # Reap the hostile-stdin writer if a case aborted before its explicit kill
+    # — it is backgrounded outside the timeout's process group, so nothing
+    # else collects it on a failing run (harmon-init#802).
+    if [ -n "${WORKTREE_STDIN_HOLDER:-}" ]; then
+        kill "$WORKTREE_STDIN_HOLDER" 2>/dev/null || true
+    fi
     if [ -e "$WORKTREE_TIMEOUT_SENTINEL" ]; then
         # Print what the sentinel HOLDS, not where it lives: it is removed
         # immediately below, so a path would point at nothing by the time
@@ -912,20 +918,42 @@ rm -f "$shared_hooks/post-checkout"
 
 echo "==> --no-install skips the dependency install"
 : >"$pnpm_marker"
-# This case runs real lefthook's post-checkout (the custom shim above is gone,
-# so worktree-new.sh reinstalled lefthook's own shims), and it runs under a
-# stdin that never reaches EOF — the agent-session condition the suite's own
-# `exec </dev/null` shields everything else from. lefthook blocks
-# `run post-checkout` until stdin EOF (harmon-init#802), so a worktree-new.sh
-# that ties the deferred hook to the caller's stdin hangs here into the #792
-# bound and fails the suite instead of passing by accident.
+# This case runs under a stdin that never reaches EOF — the agent-session
+# condition the suite's own `exec </dev/null` shields everything else from.
+# lefthook blocks `run post-checkout` until stdin EOF (harmon-init#802), so
+# worktree-new.sh must hand the deferred hook an already-EOF stdin. The shim
+# below asserts that invariant ITSELF (`cat` drains to EOF before logging):
+# relying on the real lefthook to do the blocking would make this case
+# vacuous under the stub (whose `run` reads nothing) and hostage to whichever
+# stdin behavior a future lefthook ships. A worktree-new.sh that ties the
+# hook to the caller's stdin blocks in `cat` and hangs into the #792 bound.
+cat >"$shared_hooks/post-checkout" <<EOF
+#!/bin/sh
+if [ "\$LEFTHOOK" = "0" ]; then
+  exit 0
+fi
+if [ -n "\$LEFTHOOK_BIN" ]; then
+  exec "\$LEFTHOOK_BIN" run "post-checkout" "\$@"
+fi
+cat >/dev/null
+printf 'post-checkout-eof %s\n' "\$PWD" >>"$test_tmp/post-checkout.log"
+EOF
+chmod +x "$shared_hooks/post-checkout"
+: >"$test_tmp/post-checkout.log"
 mkfifo "$test_tmp/hostile-stdin"
 sleep 300 >"$test_tmp/hostile-stdin" &
-hostile_stdin_pid=$!
+WORKTREE_STDIN_HOLDER=$!
 new no-install-tree --no-install <"$test_tmp/hostile-stdin" >/dev/null ||
     fail "worktree-new.sh --no-install failed under a non-EOF stdin"
-kill "$hostile_stdin_pid" 2>/dev/null || true
-wait "$hostile_stdin_pid" 2>/dev/null || true
+grep -qx "post-checkout-eof $fixture/.worktrees/no-install-tree" "$test_tmp/post-checkout.log" 2>/dev/null ||
+    fail "the deferred post-checkout never reached EOF on its stdin — is it still tied to the caller's stdin? (harmon-init#802)"
+kill "$WORKTREE_STDIN_HOLDER" 2>/dev/null || true
+wait "$WORKTREE_STDIN_HOLDER" 2>/dev/null || true
+WORKTREE_STDIN_HOLDER=""
+# The shim deliberately stays installed: the missing-pnpm case below runs
+# under a PATH mask that hides lefthook, so a configured-but-absent
+# post-checkout hook would fail it at the hook stage instead of the pnpm
+# gate it exists to assert.
 if [ -s "$pnpm_marker" ]; then
     fail "worktree-new.sh ran the installer despite --no-install"
 fi

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -945,7 +945,12 @@ EOF
 chmod +x "$shared_hooks/post-checkout"
 : >"$test_tmp/post-checkout.log"
 mkfifo "$test_tmp/hostile-stdin"
-sleep 300 >"$test_tmp/hostile-stdin" &
+# The writer is UNBOUNDED (`tail -f /dev/null` never exits, on macOS and
+# Linux alike): a `sleep <n>` writer would close the fifo at n seconds, and a
+# WORKTREE_OP_TIMEOUT configured above n would then hand a regressed hook its
+# EOF and pass this case instead of failing it. The explicit kill below and
+# the EXIT trap are what end this process.
+tail -f /dev/null >"$test_tmp/hostile-stdin" &
 WORKTREE_STDIN_HOLDER=$!
 new no-install-tree --no-install <"$test_tmp/hostile-stdin" >/dev/null ||
     fail "worktree-new.sh --no-install failed under a non-EOF stdin"

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -465,7 +465,12 @@ if [ "$run_post_checkout" -eq 1 ] && [ -x "$hooks_dir/post-checkout" ]; then
     new_head="$(git -C "$tree" rev-parse HEAD)"
     null_oid="$(printf '%s' "$new_head" | tr '[:alnum:]' '0')"
     echo "==> Running post-checkout now that the tree is provisioned"
-    (cd "$tree" && "$hooks_dir/post-checkout" "$null_oid" "$new_head" 1) ||
+    # </dev/null is load-bearing: lefthook blocks `run post-checkout` until its
+    # stdin reaches EOF (observed on v2.1.10), so inheriting a stdin the caller
+    # holds open — an agent harness socket, a task runner pipe — deadlocks the
+    # hook here indefinitely (harmon-init#802). Git hands post-checkout no
+    # stdin payload, so an immediate EOF loses nothing.
+    (cd "$tree" && "$hooks_dir/post-checkout" "$null_oid" "$new_head" 1 </dev/null) ||
         die "the repository's post-checkout hook failed in $tree"
 fi
 


### PR DESCRIPTION
## What

Root-causes and fixes the intermittent `test:worktree` deadlock (#802).
lefthook v2.1.10 blocks `run post-checkout` — that hook alone — until its
stdin reaches EOF. `worktree-new.sh`'s deferred post-checkout run inherited
the caller's stdin, so any invocation context holding stdin open (an agent
harness socket, a task runner pipe) deadlocked: futex/psynch wait, no
children, exactly as observed on Linux **and** macOS (see the issue's
2026-08-15 downstream reports). The "intermittency" was never a race — it
tracked what stdin the invoking context held: TTYs and `/dev/null` EOF
immediately, sockets and pipes never do. That also explains why a bare
`docker run` repro loop stayed green (no `-i` → `/dev/null` stdin) and why
half of interactive-session runs hung.

Changes, all in byte-identical root/template twins:

- `worktree-new.sh`: run the deferred post-checkout with `</dev/null` — git
  hands post-checkout no stdin payload, so an immediate EOF loses nothing.
- `test-worktree.sh`: `exec </dev/null` so no child ever inherits a non-EOF
  stdin; a regression case runs `--no-install` under a deliberately
  never-closing fifo with a controlled shim that drains stdin itself
  (version-independent, non-vacuous on the stub-lefthook path); the fifo
  writer is unbounded (`tail -f /dev/null`) and reaped by the EXIT trap.

## Verification

- Pre-fix: deterministic reproduction on macOS — the suite fails at
  `--no-install` with the exact #792 timeout signature under hostile stdin;
  the bare construct fails 200/200… reproduced at will.
- Post-fix: 5 consecutive local runs green under hostile stdin across Bash
  3.2.57 and 5.3.15; 3 container runs green on the pinned devcontainer image
  with piped stdin; stub-path (masked lefthook) run green.
- Mutation-verified: un-fixing `worktree-new.sh` fails the suite on both the
  real-lefthook and stub paths with the observed signature.
- Gates: `task check`, `task verify`, challenge (converged r2), review
  (converged r2), `task ci` — all green.

Closes #802

rigor: standard (default_rigor) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1

## Deferred findings

None — every adjudicated P2 was fixed in place during the stages.

## Adjudication record

<details>
<summary>Per-branch ledger (challenge/review rounds)</summary>

```text
challenge r1 | zero P0/P1, two P2
scripts/test-worktree.sh:~920 | orphaned fifo writer survives failing case | fixed: WORKTREE_STDIN_HOLDER reaped in worktree_exit | challenge r1
scripts/test-worktree.sh:~915 | regression vacuous on stub path, coupled to lefthook internals | fixed: shim drains stdin itself (cat), version-independent | challenge r1
challenge r2 | zero P0/P1, one P2
scripts/test-worktree.sh:~102 | inherited WORKTREE_STDIN_HOLDER env var could kill foreign pid | fixed: initialized empty before trap armed; provenance: subject added by r1 fix, in scope | challenge r2
challenge stage EXIT | two consecutive rounds adjudicated zero P0/P1 (r1, r2)
review r1 | zero P0/P1, one P2
scripts/test-worktree.sh:~948 | sleep-300 writer EOFs before a >300s WORKTREE_OP_TIMEOUT, regression could false-pass | fixed: unbounded tail -f /dev/null writer, killed explicitly + EXIT trap | review r1
review r2 | no findings
review stage EXIT | two consecutive rounds adjudicated zero P0/P1 (r1, r2)
```

</details>

## Follow-up

The underlying defect is lefthook's: `run post-checkout` should not block on
stdin (git sends that hook no stdin payload). Reported upstream with the
minimal repro, at the maintainer's request, as
[evilmartians/lefthook#1493](https://github.com/evilmartians/lefthook/issues/1493).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
