### PR TITLE
fix: make worktree:new remote-aware for the default base and the requested branch

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -36,8 +36,16 @@ it points here.
   rather than recreating — installs **this tree's** dependencies, proves the
   git hooks fire inside it, prints the ready path, and rolls the tree back if
   any of that fails. A new branch is based on the **main worktree's HEAD**, not
-  the caller's, so running the task from inside a worktree does not silently
-  stack the new branch on that one; `--base HEAD` stacks deliberately.
+  the caller's — and when that branch has a configured upstream, the base is
+  first verified against it: behind means the fresh upstream tip is used
+  (announced), diverged refuses with a `--base` remedy, so a tree never
+  silently starts from stale history. Running the task from inside a worktree
+  does not silently stack the new branch on that one; `--base HEAD` stacks
+  deliberately. Creating a genuinely new branch also probes every configured
+  remote for a same-named branch first — a branch that exists remotely is
+  tracked, never recreated — so that path needs the remotes reachable: an
+  offline run fails closed with the fix in the message, and an explicit
+  `--base <ref>` skips the remote lookup entirely.
   `--branch` and `--no-install` cover the rest.
   One entrypoint means a second agent session, a terminal multiplexer, or a
   human all get the same tree instead of each rediscovering the setup.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -36,8 +36,8 @@ it points here.
   rather than recreating — installs **this tree's** dependencies, proves the
   git hooks fire inside it, prints the ready path, and rolls the tree back if
   any of that fails. A new branch is based on the **main worktree's HEAD**, not
-  the caller's — and when that branch has a configured upstream, the base is
-  first verified against it: behind means the fresh upstream tip is used
+  the caller's — and when that branch's configured upstream resolves, the base
+  is first verified against it: behind means the fresh upstream tip is used
   (announced), diverged refuses with a `--base` remedy, so a tree never
   silently starts from stale history. Running the task from inside a worktree
   does not silently stack the new branch on that one; `--base HEAD` stacks

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -830,6 +830,121 @@ rm_wt team-only >/dev/null || fail "cleanup of the slash-remote tree failed"
 git -C "$fixture" branch -D team-only >/dev/null 2>&1 || true
 git -C "$fixture" remote remove team/sub
 
+# ── stale remote state must not decide anything (#813 / #840) ────────
+echo "==> a branch pushed after the last fetch is still detected and tracked"
+# Push, then delete the tracking ref the push just wrote: the local
+# refs/remotes namespace now predates the branch, which is exactly the state
+# after a collaborator pushes and nothing fetches (harmon-init#840).
+git -C "$fixture" push -q origin HEAD:refs/heads/late-remote
+git -C "$fixture" update-ref -d refs/remotes/origin/late-remote
+late_tip="$(git -C "$fixture" ls-remote origin refs/heads/late-remote | awk '{print $1}')"
+# Advance main past the push, so a helper that misses the remote branch
+# creates 'late-remote' at a DIFFERENT commit — the divergence itself, not
+# only the missing tracking, is what the assertion below must catch.
+printf 'ahead of late-remote\n' >"$fixture/LATE.md"
+git -C "$fixture" add LATE.md
+LEFTHOOK=0 git -C "$fixture" commit -qm "chore: move main ahead of the late-pushed branch" >"$test_tmp/commit.log" 2>&1 ||
+    fail "committing ahead of the late-pushed branch failed"
+new late-remote >/dev/null || fail "worktree-new.sh failed for a branch with no local tracking ref"
+[ "$(git -C "$fixture/.worktrees/late-remote" rev-parse HEAD)" = "$late_tip" ] ||
+    fail "worktree-new.sh created 'late-remote' from the default base instead of the remote branch (harmon-init#840)"
+[ "$(git -C "$fixture" rev-parse --abbrev-ref late-remote@{upstream} 2>/dev/null)" = "origin/late-remote" ] ||
+    fail "worktree-new.sh did not set up tracking for the late-pushed branch"
+rm_wt late-remote >/dev/null || fail "cleanup of the late-remote tree failed"
+git -C "$fixture" branch -D late-remote >/dev/null 2>&1 || true
+
+echo "==> a stale tracking ref is refreshed to the remote's current tip"
+git -C "$fixture" push -q origin HEAD:refs/heads/moving-remote
+stale_tip="$(git -C "$fixture" rev-parse refs/remotes/origin/moving-remote)"
+printf 'advance\n' >"$fixture/MOVING.md"
+git -C "$fixture" add MOVING.md
+LEFTHOOK=0 git -C "$fixture" commit -qm "chore: advance the moving branch" >"$test_tmp/commit.log" 2>&1 ||
+    fail "committing the moving-branch advance failed"
+git -C "$fixture" push -q origin HEAD:refs/heads/moving-remote
+moving_tip="$(git -C "$fixture" rev-parse HEAD)"
+# Roll main back and force the tracking ref stale, so only a live probe plus
+# fetch can know where the remote actually is.
+git -C "$fixture" reset -q --hard HEAD~1
+git -C "$fixture" update-ref refs/remotes/origin/moving-remote "$stale_tip"
+new moving-remote >/dev/null || fail "worktree-new.sh failed for a branch with a stale tracking ref"
+[ "$(git -C "$fixture/.worktrees/moving-remote" rev-parse HEAD)" = "$moving_tip" ] ||
+    fail "worktree-new.sh attached 'moving-remote' at the stale tracking tip instead of the remote's current commit (harmon-init#840)"
+rm_wt moving-remote >/dev/null || fail "cleanup of the moving-remote tree failed"
+git -C "$fixture" branch -D moving-remote >/dev/null 2>&1 || true
+
+echo "==> an unqueryable remote fails closed, and an explicit --base opts out"
+git -C "$fixture" remote add badremote "$test_tmp/nonexistent-bare.git"
+if new probe-fail >/dev/null 2>&1; then
+    fail "worktree-new.sh invented a new branch although a remote could not be queried (harmon-init#840)"
+fi
+refute_exists "$fixture/.worktrees/probe-fail" "the fail-closed probe left a tree behind"
+if git -C "$fixture" show-ref --verify --quiet refs/heads/probe-fail; then
+    fail "the fail-closed probe left the branch behind"
+fi
+new probe-fail --base HEAD >/dev/null || fail "an explicit --base did not skip the remote probe"
+rm_wt probe-fail >/dev/null || fail "cleanup of the probe-fail tree failed"
+git -C "$fixture" branch -D probe-fail >/dev/null 2>&1 || true
+git -C "$fixture" remote remove badremote
+
+echo "==> a default base behind its upstream hands out the upstream tip"
+base_upstream="$test_tmp/base-upstream.git"
+git init -q --bare "$base_upstream"
+git -C "$fixture" remote add baseup "$base_upstream"
+fixture_head_branch="$(git -C "$fixture" symbolic-ref --short HEAD)"
+git -C "$fixture" push -q -u baseup "$fixture_head_branch" >/dev/null 2>&1 ||
+    fail "seeding the base upstream failed"
+anchor_sha="$(git -C "$fixture" rev-parse HEAD)"
+printf 'merged upstream\n' >"$fixture/UPSTREAM.md"
+git -C "$fixture" add UPSTREAM.md
+LEFTHOOK=0 git -C "$fixture" commit -qm "chore: land work on the upstream" >"$test_tmp/commit.log" 2>&1 ||
+    fail "committing the upstream advance failed"
+git -C "$fixture" push -q baseup "$fixture_head_branch"
+upstream_sha="$(git -C "$fixture" rev-parse HEAD)"
+# Roll local back AND stale the tracking ref: only the fetch inside
+# worktree-new.sh can now learn where the upstream is (harmon-init#813).
+git -C "$fixture" reset -q --hard "$anchor_sha"
+git -C "$fixture" update-ref "refs/remotes/baseup/$fixture_head_branch" "$anchor_sha"
+base_out="$(new fresh-base)" || fail "worktree-new.sh failed with a behind upstream"
+[ "$(git -C "$fixture/.worktrees/fresh-base" rev-parse HEAD)" = "$upstream_sha" ] ||
+    fail "worktree-new.sh based 'fresh-base' on the stale local HEAD instead of the upstream tip (harmon-init#813)"
+case "$base_out" in *"is behind baseup/$fixture_head_branch"*) : ;; *) fail "worktree-new.sh did not announce the behind-upstream base" ;; esac
+rm_wt fresh-base >/dev/null || fail "cleanup of the fresh-base tree failed"
+git -C "$fixture" branch -D fresh-base >/dev/null 2>&1 || true
+
+echo "==> a default base diverged from its upstream is refused"
+printf 'local divergence\n' >"$fixture/DIVERGED.md"
+git -C "$fixture" add DIVERGED.md
+LEFTHOOK=0 git -C "$fixture" commit -qm "chore: diverge from the upstream" >"$test_tmp/commit.log" 2>&1 ||
+    fail "committing the divergence failed"
+if new diverged-base >/dev/null 2>&1; then
+    fail "worktree-new.sh picked a base although local and upstream have diverged (harmon-init#813)"
+fi
+refute_exists "$fixture/.worktrees/diverged-base" "the diverged-base refusal left a tree behind"
+new diverged-base --base HEAD >/dev/null || fail "an explicit --base did not bypass the divergence refusal"
+rm_wt diverged-base >/dev/null || fail "cleanup of the diverged-base tree failed"
+git -C "$fixture" branch -D diverged-base >/dev/null 2>&1 || true
+
+echo "==> an unreachable upstream warns, and an existing branch still attaches"
+# For a NEW branch an unreachable remote already fails closed at the branch
+# probe (the case above) — the loud failure #813 allows. The warn-and-proceed
+# path is therefore the one the probe skips: attaching a branch that already
+# exists locally, where the base is not used but the staleness warning must
+# still be heard.
+git -C "$fixture" remote set-url baseup "$test_tmp/nonexistent-upstream.git"
+git -C "$fixture" branch warn-base
+local_tip="$(git -C "$fixture" rev-parse HEAD)"
+warn_out="$(new warn-base 2>&1)" || fail "worktree-new.sh failed outright on an unreachable upstream"
+[ "$(git -C "$fixture/.worktrees/warn-base" rev-parse HEAD)" = "$local_tip" ] ||
+    fail "the unreachable-upstream attach did not check out the local branch tip"
+case "$warn_out" in *"could not reach 'baseup'"*) : ;; *) fail "the unreachable upstream produced no warning (harmon-init#813)" ;; esac
+rm_wt warn-base >/dev/null || fail "cleanup of the warn-base tree failed"
+git -C "$fixture" branch -D warn-base >/dev/null 2>&1 || true
+# Teardown: restore the pre-case fixture state so later default-base cases
+# are decided by the local HEAD again, exactly as before this block.
+git -C "$fixture" branch --unset-upstream >/dev/null 2>&1 || true
+git -C "$fixture" remote remove baseup
+git -C "$fixture" reset -q --hard "$anchor_sha"
+
 echo "==> a dot-segment name cannot smuggle a worktree inside another"
 new dotparent >/dev/null || fail "worktree-new.sh failed creating the dot-parent tree"
 if new ./dotparent/child --branch dotchild >/dev/null 2>&1; then

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -911,6 +911,35 @@ case "$base_out" in *"is behind baseup/$fixture_head_branch"*) : ;; *) fail "wor
 rm_wt fresh-base >/dev/null || fail "cleanup of the fresh-base tree failed"
 git -C "$fixture" branch -D fresh-base >/dev/null 2>&1 || true
 
+echo "==> losing the upstream ref-lock race still reads the winner's update"
+# The loser of two parallel worktree:new runs fails its own fetch while the
+# tracking ref already holds the winner's fresher value. Deterministic
+# reconstruction of that instant: the REMOTE is one commit past the winner's
+# value (commit-tree, so the local checkout never moves), the tracking ref
+# holds the winner's value, and a held ref lock makes THIS fetch fail — it
+# has an update to attempt and cannot take the lock. The loser must base on
+# the winner's value, read after the failed fetch, never return early on its
+# stale pre-fetch snapshot (which would base the tree on the local anchor).
+race_tip="$(git -C "$fixture" commit-tree -m "race remote tip" -p "$upstream_sha" "$(git -C "$fixture" rev-parse "$upstream_sha^{tree}")")"
+git -C "$fixture" push -q baseup "$race_tip:refs/heads/$fixture_head_branch"
+git -C "$fixture" update-ref "refs/remotes/baseup/$fixture_head_branch" "$upstream_sha"
+race_lock="$fixture/.git/refs/remotes/baseup/$fixture_head_branch.lock"
+mkdir -p "$(dirname "$race_lock")"
+: >"$race_lock"
+race_out="$(new race-base 2>&1)" || {
+    rm -f "$race_lock"
+    fail "worktree-new.sh failed outright when the upstream fetch lost the ref lock"
+}
+rm -f "$race_lock"
+[ "$(git -C "$fixture/.worktrees/race-base" rev-parse HEAD)" = "$upstream_sha" ] ||
+    fail "the fetch-race loser based on its stale snapshot instead of the winner's ref (harmon-init#813)"
+case "$race_out" in *"could not fetch"*) : ;; *) fail "the lost ref-lock race produced no warning" ;; esac
+rm_wt race-base >/dev/null || fail "cleanup of the race-base tree failed"
+git -C "$fixture" branch -D race-base >/dev/null 2>&1 || true
+# Put the remote back at the winner's value for the cases that follow.
+git -C "$fixture" push -q -f baseup "$upstream_sha:refs/heads/$fixture_head_branch"
+git -C "$fixture" update-ref "refs/remotes/baseup/$fixture_head_branch" "$upstream_sha"
+
 echo "==> a non-identity fetch refspec still verifies against the true source branch"
 # The upstream's short name and its source branch deliberately differ
 # (+refs/heads/trunk-src:refs/remotes/niup/localname): a helper that derives
@@ -973,6 +1002,38 @@ git -C "$fixture" branch -D attach-diverged >/dev/null 2>&1 || true
 git -C "$fixture" branch --unset-upstream >/dev/null 2>&1 || true
 git -C "$fixture" remote remove baseup
 git -C "$fixture" reset -q --hard "$anchor_sha"
+
+echo "==> a remote-only branch under a custom refspec never clobbers foreign tracking refs"
+# The remote maps ONLY decoy into refs/remotes/cref/victim. Creating the
+# remote-only branch 'victim' must attach it at the remote's tip via the
+# probe — not via any ref this script writes — and the mapped tracking ref
+# that belongs to decoy must be exactly as it was afterwards.
+cref_up="$test_tmp/cref-up.git"
+git init -q --bare "$cref_up"
+git -C "$fixture" remote add cref "$cref_up"
+git -C "$fixture" config remote.cref.fetch "+refs/heads/decoy:refs/remotes/cref/victim"
+git -C "$fixture" push -q cref HEAD:refs/heads/decoy
+decoy_tip="$(git -C "$fixture" rev-parse HEAD)"
+printf 'victim work\n' >"$fixture/VICTIM.md"
+git -C "$fixture" add VICTIM.md
+LEFTHOOK=0 git -C "$fixture" commit -qm "chore: advance the victim branch" >"$test_tmp/commit.log" 2>&1 ||
+    fail "committing the victim advance failed"
+git -C "$fixture" push -q cref HEAD:refs/heads/victim
+victim_tip="$(git -C "$fixture" rev-parse HEAD)"
+git -C "$fixture" reset -q --hard "$decoy_tip"
+git -C "$fixture" update-ref refs/remotes/cref/victim "$decoy_tip"
+new victim >/dev/null || fail "worktree-new.sh failed for a remote-only branch under a custom refspec"
+[ "$(git -C "$fixture/.worktrees/victim" rev-parse HEAD)" = "$victim_tip" ] ||
+    fail "worktree-new.sh did not attach 'victim' at the remote tip under a custom refspec"
+[ "$(git -C "$fixture" rev-parse refs/remotes/cref/victim)" = "$decoy_tip" ] ||
+    fail "worktree-new.sh clobbered a tracking ref the custom refspec maps from another branch (harmon-init#840)"
+[ "$(git -C "$fixture" config branch.victim.remote)" = "cref" ] ||
+    fail "the custom-refspec branch is not configured to track its remote"
+[ "$(git -C "$fixture" config branch.victim.merge)" = "refs/heads/victim" ] ||
+    fail "the custom-refspec branch tracks the wrong merge ref"
+rm_wt victim >/dev/null || fail "cleanup of the victim tree failed"
+git -C "$fixture" branch -D victim >/dev/null 2>&1 || true
+git -C "$fixture" remote remove cref
 
 echo "==> a dot-segment name cannot smuggle a worktree inside another"
 new dotparent >/dev/null || fail "worktree-new.sh failed creating the dot-parent tree"

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -1022,7 +1022,7 @@ git -C "$fixture" push -q cref HEAD:refs/heads/victim
 victim_tip="$(git -C "$fixture" rev-parse HEAD)"
 git -C "$fixture" reset -q --hard "$decoy_tip"
 git -C "$fixture" update-ref refs/remotes/cref/victim "$decoy_tip"
-new victim >/dev/null || fail "worktree-new.sh failed for a remote-only branch under a custom refspec"
+victim_out="$(new victim)" || fail "worktree-new.sh failed for a remote-only branch under a custom refspec"
 [ "$(git -C "$fixture/.worktrees/victim" rev-parse HEAD)" = "$victim_tip" ] ||
     fail "worktree-new.sh did not attach 'victim' at the remote tip under a custom refspec"
 [ "$(git -C "$fixture" rev-parse refs/remotes/cref/victim)" = "$decoy_tip" ] ||
@@ -1031,6 +1031,12 @@ new victim >/dev/null || fail "worktree-new.sh failed for a remote-only branch u
     fail "the custom-refspec branch is not configured to track its remote"
 [ "$(git -C "$fixture" config branch.victim.merge)" = "refs/heads/victim" ] ||
     fail "the custom-refspec branch tracks the wrong merge ref"
+# The refspec maps only decoy, so @{upstream} for victim CANNOT resolve —
+# and the command must say so rather than claim full tracking.
+if git -C "$fixture" rev-parse --verify --quiet "victim@{upstream}" >/dev/null 2>&1; then
+    fail "victim@{upstream} resolved although the refspec maps no such branch — fixture assumption broken"
+fi
+case "$victim_out" in *"does not map refs/heads/victim"*) : ;; *) fail "the unmapped-refspec degradation was not announced" ;; esac
 rm_wt victim >/dev/null || fail "cleanup of the victim tree failed"
 git -C "$fixture" branch -D victim >/dev/null 2>&1 || true
 git -C "$fixture" remote remove cref

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -911,6 +911,37 @@ case "$base_out" in *"is behind baseup/$fixture_head_branch"*) : ;; *) fail "wor
 rm_wt fresh-base >/dev/null || fail "cleanup of the fresh-base tree failed"
 git -C "$fixture" branch -D fresh-base >/dev/null 2>&1 || true
 
+echo "==> a non-identity fetch refspec still verifies against the true source branch"
+# The upstream's short name and its source branch deliberately differ
+# (+refs/heads/trunk-src:refs/remotes/niup/localname): a helper that derives
+# the fetch source by splitting the abbreviated upstream name would fetch a
+# branch that does not exist and silently keep the stale base (challenge
+# round 2 of harmon-init#813/#840).
+ni_upstream="$test_tmp/ni-upstream.git"
+git init -q --bare "$ni_upstream"
+git -C "$fixture" remote add niup "$ni_upstream"
+git -C "$fixture" config remote.niup.fetch "+refs/heads/trunk-src:refs/remotes/niup/localname"
+git -C "$fixture" push -q niup HEAD:refs/heads/trunk-src
+ni_anchor="$(git -C "$fixture" rev-parse HEAD)"
+printf 'landed on trunk-src\n' >"$fixture/NI.md"
+git -C "$fixture" add NI.md
+LEFTHOOK=0 git -C "$fixture" commit -qm "chore: advance the non-identity upstream" >"$test_tmp/commit.log" 2>&1 ||
+    fail "committing the non-identity advance failed"
+git -C "$fixture" push -q niup HEAD:refs/heads/trunk-src
+ni_tip="$(git -C "$fixture" rev-parse HEAD)"
+git -C "$fixture" reset -q --hard "$ni_anchor"
+git -C "$fixture" config "branch.$fixture_head_branch.remote" niup
+git -C "$fixture" config "branch.$fixture_head_branch.merge" refs/heads/trunk-src
+git -C "$fixture" update-ref refs/remotes/niup/localname "$ni_anchor"
+new ni-base >/dev/null || fail "worktree-new.sh failed with a non-identity upstream refspec"
+[ "$(git -C "$fixture/.worktrees/ni-base" rev-parse HEAD)" = "$ni_tip" ] ||
+    fail "worktree-new.sh did not fetch the true source branch through the non-identity refspec (harmon-init#813)"
+rm_wt ni-base >/dev/null || fail "cleanup of the ni-base tree failed"
+git -C "$fixture" branch -D ni-base >/dev/null 2>&1 || true
+git -C "$fixture" config "branch.$fixture_head_branch.remote" baseup
+git -C "$fixture" config "branch.$fixture_head_branch.merge" "refs/heads/$fixture_head_branch"
+git -C "$fixture" remote remove niup
+
 echo "==> a default base diverged from its upstream is refused"
 printf 'local divergence\n' >"$fixture/DIVERGED.md"
 git -C "$fixture" add DIVERGED.md

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -924,21 +924,19 @@ new diverged-base --base HEAD >/dev/null || fail "an explicit --base did not byp
 rm_wt diverged-base >/dev/null || fail "cleanup of the diverged-base tree failed"
 git -C "$fixture" branch -D diverged-base >/dev/null 2>&1 || true
 
-echo "==> an unreachable upstream warns, and an existing branch still attaches"
-# For a NEW branch an unreachable remote already fails closed at the branch
-# probe (the case above) — the loud failure #813 allows. The warn-and-proceed
-# path is therefore the one the probe skips: attaching a branch that already
-# exists locally, where the base is not used but the staleness warning must
-# still be heard.
-git -C "$fixture" remote set-url baseup "$test_tmp/nonexistent-upstream.git"
-git -C "$fixture" branch warn-base
+echo "==> attaching an existing branch is never blocked by base staleness"
+# The default base is only consumed when a NEW branch is created from it, so
+# the diverged main that just refused 'diverged-base' must not block — or
+# even warn about — attaching a branch that already exists: the base plays
+# no part in that path (harmon-init#813, challenge round 1).
+git -C "$fixture" branch attach-diverged
 local_tip="$(git -C "$fixture" rev-parse HEAD)"
-warn_out="$(new warn-base 2>&1)" || fail "worktree-new.sh failed outright on an unreachable upstream"
-[ "$(git -C "$fixture/.worktrees/warn-base" rev-parse HEAD)" = "$local_tip" ] ||
-    fail "the unreachable-upstream attach did not check out the local branch tip"
-case "$warn_out" in *"could not reach 'baseup'"*) : ;; *) fail "the unreachable upstream produced no warning (harmon-init#813)" ;; esac
-rm_wt warn-base >/dev/null || fail "cleanup of the warn-base tree failed"
-git -C "$fixture" branch -D warn-base >/dev/null 2>&1 || true
+attach_out="$(new attach-diverged 2>&1)" || fail "worktree-new.sh refused to attach an existing branch while main is diverged from its upstream"
+[ "$(git -C "$fixture/.worktrees/attach-diverged" rev-parse HEAD)" = "$local_tip" ] ||
+    fail "the attach did not check out the existing branch tip"
+case "$attach_out" in *"has diverged from"*) fail "attaching an existing branch surfaced the base divergence it never uses" ;; esac
+rm_wt attach-diverged >/dev/null || fail "cleanup of the attach-diverged tree failed"
+git -C "$fixture" branch -D attach-diverged >/dev/null 2>&1 || true
 # Teardown: restore the pre-case fixture state so later default-base cases
 # are decided by the local HEAD again, exactly as before this block.
 git -C "$fixture" branch --unset-upstream >/dev/null 2>&1 || true

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -126,6 +126,11 @@ if [ -z "$base" ]; then
     base="$(git -C "$main_root" rev-parse --verify --quiet HEAD || true)"
     [ -n "$base" ] ||
         die "the main worktree has no commits yet — make an initial commit, or pass --base <ref>"
+    # Captured HERE, in the same breath as $base, and never re-read: the main
+    # worktree can switch branches while this script runs (parallel use is
+    # this entrypoint's design space), and a verify that re-resolved HEAD
+    # later would compare one branch's upstream against another branch's SHA.
+    default_base_branch="$(git -C "$main_root" symbolic-ref --quiet --short HEAD || true)"
     echo "==> Base: ${base_origin} (${base_label} @ $(git rev-parse --short "$base")) — pass --base <ref> to branch elsewhere"
 fi
 
@@ -133,11 +138,19 @@ fi
 # this entrypoint is run by agents with no terminal, where a credential
 # prompt is an indefinite hang (the same failure shape as harmon-init#802),
 # and a degraded remote that accepts the connection and then stalls would
-# hang it just as hard. GIT_TERMINAL_PROMPT=0 turns a would-be prompt into a
-# fast failure; the low-speed bounds turn an HTTP stall into one. SSH obeys
-# the user's own ssh config and is deliberately not overridden here.
+# hang it just as hard. GIT_TERMINAL_PROMPT=0 turns a would-be HTTP prompt
+# into a fast failure and the low-speed bounds turn an HTTP stall into one;
+# neither reaches an SSH transport, so the ssh command gets BatchMode (no
+# interactive auth) and a connect timeout too. The options are APPENDED to
+# the user's own ssh command — ssh takes the first value obtained for an
+# option, so anything they set explicitly still wins — and core.sshCommand
+# is honoured before falling back to plain ssh, so a configured proxy or
+# jump host keeps working.
 git_net() {
-    GIT_TERMINAL_PROMPT=0 git -C "$main_root" \
+    _ssh_base="${GIT_SSH_COMMAND:-$(git -C "$main_root" config --get core.sshCommand 2>/dev/null || echo ssh)}"
+    GIT_TERMINAL_PROMPT=0 \
+        GIT_SSH_COMMAND="$_ssh_base -o BatchMode=yes -o ConnectTimeout=30" \
+        git -C "$main_root" \
         -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=30 "$@"
 }
 
@@ -151,43 +164,52 @@ git_net() {
 # uses the base, so neither should be blocked (or even warned) by its
 # staleness. May rewrite $base/$base_label or die.
 verify_default_base() {
-    # The remote name comes from branch config, never from splitting the ref
-    # text (a remote name may itself contain '/'), and the fetch SOURCE comes
-    # from branch.<name>.merge, never from the abbreviated upstream name — a
-    # non-identity fetch refspec makes @{u}'s short name differ from the
-    # branch it mirrors on the remote.
-    head_branch="$(git -C "$main_root" symbolic-ref --quiet --short HEAD || true)"
-    [ -n "$head_branch" ] || return 0
-    upstream_remote="$(git -C "$main_root" config --get "branch.$head_branch.remote" 2>/dev/null || true)"
-    upstream_merge="$(git -C "$main_root" config --get "branch.$head_branch.merge" 2>/dev/null || true)"
-    upstream_ref="$(git -C "$main_root" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
-    { [ -n "$upstream_remote" ] && [ -n "$upstream_ref" ]; } || return 0
-    fetch_ok=1
+    # Everything resolves from $default_base_branch, captured with $base —
+    # never from a fresh HEAD read (the main worktree can have switched
+    # branches since). The remote name comes from branch config, never from
+    # splitting ref text (a remote name may itself contain '/'); the fetch
+    # SOURCE comes from branch.<name>.merge, never from the abbreviated
+    # upstream name (a non-identity fetch refspec makes them differ); and the
+    # fetch DESTINATION is the upstream's full symbolic ref, never a
+    # refs/remotes/ prefix guess (a custom refspec can map outside
+    # refs/remotes/, and an ambiguous short name would mislead a prefix).
+    [ -n "$default_base_branch" ] || return 0
+    upstream_remote="$(git -C "$main_root" config --get "branch.$default_base_branch.remote" 2>/dev/null || true)"
+    upstream_merge="$(git -C "$main_root" config --get "branch.$default_base_branch.merge" 2>/dev/null || true)"
+    upstream_full="$(git -C "$main_root" rev-parse --symbolic-full-name "$default_base_branch@{upstream}" 2>/dev/null || true)"
+    { [ -n "$upstream_remote" ] && [ -n "$upstream_full" ]; } || return 0
+    upstream_label="$(git -C "$main_root" rev-parse --abbrev-ref "$default_base_branch@{upstream}" 2>/dev/null || echo "$upstream_full")"
+    fetch_failed=0
     if [ "$upstream_remote" != "." ]; then
         [ -n "$upstream_merge" ] || return 0
         git_net fetch --quiet "$upstream_remote" \
-            "+$upstream_merge:refs/remotes/$upstream_ref" 2>/dev/null ||
-            fetch_ok=0
+            "+$upstream_merge:$upstream_full" 2>/dev/null ||
+            fetch_failed=1
     fi
-    if [ "$fetch_ok" -eq 0 ]; then
-        echo "worktree:new: warning: could not reach '$upstream_remote' to verify ${base_label} against ${upstream_ref} — the base may be missing recently merged work (harmon-init#813)" >&2
-        return 0
+    # The comparison reads the tracking ref AFTER the fetch attempt, success
+    # or not: a parallel worktree:new fetching the same upstream can win the
+    # ref lock and fail THIS fetch while leaving the ref freshly updated —
+    # returning early on failure would base the loser on the stale snapshot.
+    # Only a genuinely unreadable state keeps the base as captured, and a
+    # failed fetch still says so out loud.
+    if [ "$fetch_failed" -eq 1 ]; then
+        echo "worktree:new: warning: could not fetch '$upstream_remote' — verifying ${base_label} against the last-known ${upstream_label}, which may itself be stale (harmon-init#813)" >&2
     fi
-    upstream_tip="$(git -C "$main_root" rev-parse --verify --quiet "$upstream_ref^{commit}" || true)"
+    upstream_tip="$(git -C "$main_root" rev-parse --verify --quiet "$upstream_full^{commit}" || true)"
     { [ -n "$upstream_tip" ] && [ "$upstream_tip" != "$base" ]; } || return 0
     if git -C "$main_root" merge-base --is-ancestor "$base" "$upstream_tip"; then
         # Behind: hand out the current upstream tip, not the stale local one.
         # Resolved to a SHA so branch creation picks up no tracking side
         # effects.
-        echo "==> Base: ${base_label} is behind ${upstream_ref} — using ${upstream_ref} @ $(git rev-parse --short "$upstream_tip")"
+        echo "==> Base: ${base_label} is behind ${upstream_label} — using ${upstream_label} @ $(git rev-parse --short "$upstream_tip")"
         base="$upstream_tip"
-        base_label="$upstream_ref"
+        base_label="$upstream_label"
     elif git -C "$main_root" merge-base --is-ancestor "$upstream_tip" "$base"; then
         # Ahead: local has everything the upstream has, plus unpushed work
         # the caller presumably wants. Say so.
-        echo "==> Note: ${base_label} is ahead of ${upstream_ref}; basing on the local tip"
+        echo "==> Note: ${base_label} is ahead of ${upstream_label}; basing on the local tip"
     else
-        die "${base_label} has diverged from ${upstream_ref} — reconcile them, or pass --base <ref> to choose a start point explicitly"
+        die "${base_label} has diverged from ${upstream_label} — reconcile them, or pass --base <ref> to choose a start point explicitly"
     fi
 }
 

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -460,17 +460,23 @@ EOF
         # present after the fetch rather than read from any ref of ours.
         git_net fetch --quiet "$remote_match_remote" "refs/heads/$branch" ||
             die "found branch '$branch' on remote '$remote_match_remote' but could not fetch it — retry, or pass --base <ref>"
-        if ! git rev-parse --verify --quiet "$remote_probe_sha^{commit}" >/dev/null; then
-            # The remote moved (or force-moved) between the probe and the
-            # fetch, so the probed commit never arrived. Probe once more:
-            # a stable answer this time is usable, anything else is a
-            # remote in motion.
-            probe_out="$(git_net ls-remote --heads "$remote_match_remote" "refs/heads/$branch")" ||
-                die "remote '$remote_match_remote' became unqueryable while fetching '$branch' — retry, or pass --base <ref>"
-            remote_probe_sha="$(printf '%s\n' "$probe_out" | awk -v ref="refs/heads/$branch" -F'\t' '$2 == ref {print $1; exit}')"
-            { [ -n "$remote_probe_sha" ] && git rev-parse --verify --quiet "$remote_probe_sha^{commit}" >/dev/null; } ||
-                die "branch '$branch' on remote '$remote_match_remote' is moving — retry, or pass --base <ref>"
-        fi
+        # One UNCONDITIONAL post-fetch probe. The remote can advance between
+        # the first probe and the fetch, and the first probe's tip resolving
+        # locally is no evidence it stayed current — a stale tracking ref
+        # can make an outdated commit resolve just fine. The fetch already
+        # imported whatever the remote advanced to, so the fresh probe's
+        # answer normally resolves and the attach lands on it; a tip that
+        # arrives unresolvable means the remote moved again mid-operation,
+        # which no client-side sequence can chase — stop and say so. (The
+        # window between this probe and the attach is inherent; this keeps
+        # it one probe wide instead of pretending to close it.)
+        probe_out="$(git_net ls-remote --heads "$remote_match_remote" "refs/heads/$branch")" ||
+            die "remote '$remote_match_remote' became unqueryable while fetching '$branch' — retry, or pass --base <ref>"
+        remote_probe_sha="$(printf '%s\n' "$probe_out" | awk -v ref="refs/heads/$branch" -F'\t' '$2 == ref {print $1; exit}')"
+        [ -n "$remote_probe_sha" ] ||
+            die "branch '$branch' disappeared from remote '$remote_match_remote' while fetching — retry, or pass --base <ref>"
+        git rev-parse --verify --quiet "$remote_probe_sha^{commit}" >/dev/null ||
+            die "branch '$branch' on remote '$remote_match_remote' is moving — retry, or pass --base <ref>"
         remote_ref="$remote_matches"
     fi
 fi
@@ -492,6 +498,14 @@ elif [ -n "$remote_ref" ]; then
     LEFTHOOK=0 git worktree add "$tree" -b "$branch" "$remote_probe_sha"
     git config "branch.$branch.remote" "$remote_match_remote"
     git config "branch.$branch.merge" "refs/heads/$branch"
+    # Honesty check on the tracking claim: pull and push work off the branch
+    # config just written, but @{upstream}-based tooling (status ahead/behind,
+    # verify_default_base if this branch ever becomes the main HEAD) resolves
+    # through the remote's fetch refspec — which a custom refspec may simply
+    # not map for this branch. Say so instead of letting "tracking" imply
+    # more than it delivers.
+    git rev-parse --verify --quiet "$branch@{upstream}" >/dev/null 2>&1 ||
+        echo "==> Note: '$remote_match_remote's fetch refspec does not map refs/heads/$branch — pull/push work via branch config, but @{upstream} tooling will not see an upstream"
 else
     # The one path that consumes the default base — verify its freshness
     # here and nowhere earlier, so attaching an existing branch or tracking

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -168,9 +168,19 @@ fi
 # because closing it means a hand-rolled process watchdog whose own failure
 # modes (PID reuse, signal races, orphan supervision) outweigh the residual.
 git_net() {
-    _ssh_base="${GIT_SSH_COMMAND:-$(git -C "$main_root" config --get core.sshCommand 2>/dev/null || echo ssh)}"
+    _ssh_cmd="${GIT_SSH_COMMAND:-$(git -C "$main_root" config --get core.sshCommand 2>/dev/null || true)}"
+    if [ -z "$_ssh_cmd" ] && [ -n "${GIT_SSH:-}" ]; then
+        # GIT_SSH names a bare program that accepts no extra options —
+        # appending ours would break the wrapper, and exporting
+        # GIT_SSH_COMMAND would silently bypass it. Leave the SSH transport
+        # to it, unbounded; the HTTP bounds and prompt suppression still
+        # apply.
+        GIT_TERMINAL_PROMPT=0 git -C "$main_root" \
+            -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=30 "$@"
+        return
+    fi
     GIT_TERMINAL_PROMPT=0 \
-        GIT_SSH_COMMAND="$_ssh_base -o BatchMode=yes -o ConnectTimeout=30" \
+        GIT_SSH_COMMAND="${_ssh_cmd:-ssh} -o BatchMode=yes -o ConnectTimeout=30" \
         git -C "$main_root" \
         -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=30 "$@"
 }

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -122,15 +122,25 @@ main_root="$(git worktree list --porcelain | awk '/^worktree /{print substr($0, 
 base_origin="explicit"
 if [ -z "$base" ]; then
     base_origin="the main worktree's HEAD"
-    base_label="$(git -C "$main_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
-    base="$(git -C "$main_root" rev-parse --verify --quiet HEAD || true)"
+    # The branch NAME is captured first and the SHA resolved FROM that name,
+    # never from a second HEAD read: parallel use is this entrypoint's design
+    # space, and two separate HEAD reads can straddle a concurrent branch
+    # switch in the main worktree — the pair would then mix one branch's
+    # upstream with another branch's commit. Resolving refs/heads/<captured>
+    # yields a self-consistent pair even if HEAD has moved on; the
+    # verification below reuses the same captured name and never re-reads
+    # HEAD either. A detached HEAD has no branch: its SHA is read directly
+    # and the upstream verification stays off.
+    default_base_branch="$(git -C "$main_root" symbolic-ref --quiet --short HEAD || true)"
+    if [ -n "$default_base_branch" ]; then
+        base_label="$default_base_branch"
+        base="$(git -C "$main_root" rev-parse --verify --quiet "refs/heads/$default_base_branch" || true)"
+    else
+        base_label="HEAD"
+        base="$(git -C "$main_root" rev-parse --verify --quiet HEAD || true)"
+    fi
     [ -n "$base" ] ||
         die "the main worktree has no commits yet — make an initial commit, or pass --base <ref>"
-    # Captured HERE, in the same breath as $base, and never re-read: the main
-    # worktree can switch branches while this script runs (parallel use is
-    # this entrypoint's design space), and a verify that re-resolved HEAD
-    # later would compare one branch's upstream against another branch's SHA.
-    default_base_branch="$(git -C "$main_root" symbolic-ref --quiet --short HEAD || true)"
     echo "==> Base: ${base_origin} (${base_label} @ $(git rev-parse --short "$base")) — pass --base <ref> to branch elsewhere"
 fi
 
@@ -146,6 +156,15 @@ fi
 # option, so anything they set explicitly still wins — and core.sshCommand
 # is honoured before falling back to plain ssh, so a configured proxy or
 # jump host keeps working.
+#
+# Residual, stated so nobody rediscovers it as a surprise: a server that
+# ACCEPTS a connection and then stalls mid-protocol is bounded on HTTP (the
+# low-speed limits) but not on SSH past the handshake, nor on git:// or
+# custom remote helpers. This fleet's transport is HTTPS via gh (provisioned
+# hosts rewrite SSH remotes), so the exposure is an unprovisioned host on an
+# established-then-wedged non-HTTP connection — accepted rather than closed,
+# because closing it means a hand-rolled process watchdog whose own failure
+# modes (PID reuse, signal races, orphan supervision) outweigh the residual.
 git_net() {
     _ssh_base="${GIT_SSH_COMMAND:-$(git -C "$main_root" config --get core.sshCommand 2>/dev/null || echo ssh)}"
     GIT_TERMINAL_PROMPT=0 \
@@ -444,9 +463,21 @@ if git show-ref --verify --quiet "refs/heads/$branch"; then
     echo "==> Attaching existing branch '$branch'"
     LEFTHOOK=0 git worktree add "$tree" "$branch"
 elif [ -n "$remote_ref" ]; then
-    echo "==> Creating branch '$branch' tracking ${remote_ref#refs/remotes/}"
+    echo "==> Creating branch '$branch' tracking $remote_match_remote/$branch"
     branch_created=1
-    LEFTHOOK=0 git worktree add "$tree" --track -b "$branch" "${remote_ref#refs/remotes/}"
+    # Created from the fetched SHA with tracking written as plain branch
+    # config, never via `--track` DWIM: --track derives the upstream by
+    # reverse-mapping the start point through the remote's fetch refspec, and
+    # under a non-identity refspec our synthesized refs/remotes/<r>/<b> ref
+    # maps to nothing — git aborts with "starting point is not a branch".
+    # branch.<name>.remote + branch.<name>.merge are correct under EVERY
+    # refspec, and @{u} then resolves through whatever mapping the repo
+    # actually configures.
+    remote_tip="$(git rev-parse --verify --quiet "$remote_ref^{commit}")" ||
+        die "fetched '$branch' from '$remote_match_remote' but cannot resolve it"
+    LEFTHOOK=0 git worktree add "$tree" -b "$branch" "$remote_tip"
+    git config "branch.$branch.remote" "$remote_match_remote"
+    git config "branch.$branch.merge" "refs/heads/$branch"
 else
     # The one path that consumes the default base — verify its freshness
     # here and nowhere earlier, so attaching an existing branch or tracking

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -12,7 +12,9 @@
 #
 # Options:
 #   --branch <name>   branch to create/attach (default: the worktree name)
-#   --base <ref>      base for a NEW branch (default: HEAD)
+#   --base <ref>      base for a NEW branch (default: the main worktree's
+#                     HEAD, verified against its configured upstream; also
+#                     skips the live remote lookup for the branch name)
 #   --no-install      skip the per-tree dependency install
 #
 # Exits non-zero with the fix in the message when a precondition is missing, and
@@ -440,6 +442,7 @@ if [ "$base_origin" != "explicit" ] && ! git show-ref --verify --quiet "refs/hea
         if [ -n "$probe_sha" ]; then
             remote_matches="refs/remotes/$remote_name/$branch"
             remote_match_remote="$remote_name"
+            remote_probe_sha="$probe_sha"
             remote_count=$((remote_count + 1))
         fi
     done <<EOF
@@ -449,12 +452,25 @@ EOF
         die "branch '$branch' exists on more than one remote — pass --base <remote>/<branch> to choose one"
     fi
     if [ "$remote_count" -eq 1 ]; then
-        # Refresh the tracking ref to the tip the probe just saw, so the
-        # tracked checkout starts at the remote's current commit rather than
-        # a stale local mirror of it.
-        git_net fetch --quiet "$remote_match_remote" \
-            "+refs/heads/$branch:refs/remotes/$remote_match_remote/$branch" ||
+        # Fetched WITHOUT a destination refspec, so the only tracking refs
+        # updated are the ones the remote's OWN configured refspec maps —
+        # a synthesized identity destination could overwrite a tracking ref
+        # that a custom refspec maps a different branch into. The commit to
+        # attach is the one the probe saw ($remote_probe_sha), verified
+        # present after the fetch rather than read from any ref of ours.
+        git_net fetch --quiet "$remote_match_remote" "refs/heads/$branch" ||
             die "found branch '$branch' on remote '$remote_match_remote' but could not fetch it — retry, or pass --base <ref>"
+        if ! git rev-parse --verify --quiet "$remote_probe_sha^{commit}" >/dev/null; then
+            # The remote moved (or force-moved) between the probe and the
+            # fetch, so the probed commit never arrived. Probe once more:
+            # a stable answer this time is usable, anything else is a
+            # remote in motion.
+            probe_out="$(git_net ls-remote --heads "$remote_match_remote" "refs/heads/$branch")" ||
+                die "remote '$remote_match_remote' became unqueryable while fetching '$branch' — retry, or pass --base <ref>"
+            remote_probe_sha="$(printf '%s\n' "$probe_out" | awk -v ref="refs/heads/$branch" -F'\t' '$2 == ref {print $1; exit}')"
+            { [ -n "$remote_probe_sha" ] && git rev-parse --verify --quiet "$remote_probe_sha^{commit}" >/dev/null; } ||
+                die "branch '$branch' on remote '$remote_match_remote' is moving — retry, or pass --base <ref>"
+        fi
         remote_ref="$remote_matches"
     fi
 fi
@@ -465,17 +481,15 @@ if git show-ref --verify --quiet "refs/heads/$branch"; then
 elif [ -n "$remote_ref" ]; then
     echo "==> Creating branch '$branch' tracking $remote_match_remote/$branch"
     branch_created=1
-    # Created from the fetched SHA with tracking written as plain branch
-    # config, never via `--track` DWIM: --track derives the upstream by
-    # reverse-mapping the start point through the remote's fetch refspec, and
-    # under a non-identity refspec our synthesized refs/remotes/<r>/<b> ref
-    # maps to nothing — git aborts with "starting point is not a branch".
-    # branch.<name>.remote + branch.<name>.merge are correct under EVERY
-    # refspec, and @{u} then resolves through whatever mapping the repo
-    # actually configures.
-    remote_tip="$(git rev-parse --verify --quiet "$remote_ref^{commit}")" ||
-        die "fetched '$branch' from '$remote_match_remote' but cannot resolve it"
-    LEFTHOOK=0 git worktree add "$tree" -b "$branch" "$remote_tip"
+    # Created from the PROBED commit with tracking written as plain branch
+    # config, never via `--track` DWIM and never via a ref this script
+    # wrote: --track derives the upstream by reverse-mapping the start point
+    # through the remote's fetch refspec and aborts under a non-identity
+    # one, and any destination ref we synthesized could collide with what a
+    # custom refspec maps there. branch.<name>.remote + branch.<name>.merge
+    # are correct under EVERY refspec, and @{u} then resolves through
+    # whatever mapping the repo actually configures.
+    LEFTHOOK=0 git worktree add "$tree" -b "$branch" "$remote_probe_sha"
     git config "branch.$branch.remote" "$remote_match_remote"
     git config "branch.$branch.merge" "refs/heads/$branch"
 else

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -126,6 +126,50 @@ if [ -z "$base" ]; then
     base="$(git -C "$main_root" rev-parse --verify --quiet HEAD || true)"
     [ -n "$base" ] ||
         die "the main worktree has no commits yet — make an initial commit, or pass --base <ref>"
+    # A local HEAD goes stale: merges land on the forge and nothing pulls, so
+    # an agent handed a fresh tree can be missing recently merged work
+    # (harmon-init#813). When HEAD's branch has an upstream, verify against it
+    # — this is not a guessed branch name; the upstream of whatever HEAD
+    # points at is configuration, which is what keeps #757's no-guessing
+    # design intact. The remote name comes from branch config, never from
+    # splitting the ref text: a remote name may itself contain '/'.
+    head_branch="$(git -C "$main_root" symbolic-ref --quiet --short HEAD || true)"
+    upstream_remote=""
+    upstream_ref=""
+    if [ -n "$head_branch" ]; then
+        upstream_remote="$(git -C "$main_root" config --get "branch.$head_branch.remote" 2>/dev/null || true)"
+        upstream_ref="$(git -C "$main_root" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+    fi
+    if [ -n "$upstream_remote" ] && [ -n "$upstream_ref" ]; then
+        fetch_ok=1
+        if [ "$upstream_remote" != "." ]; then
+            upstream_branch="${upstream_ref#"$upstream_remote"/}"
+            git -C "$main_root" fetch --quiet "$upstream_remote" \
+                "+refs/heads/$upstream_branch:refs/remotes/$upstream_remote/$upstream_branch" 2>/dev/null ||
+                fetch_ok=0
+        fi
+        if [ "$fetch_ok" -eq 1 ]; then
+            upstream_tip="$(git -C "$main_root" rev-parse --verify --quiet "$upstream_ref^{commit}" || true)"
+            if [ -n "$upstream_tip" ] && [ "$upstream_tip" != "$base" ]; then
+                if git -C "$main_root" merge-base --is-ancestor "$base" "$upstream_tip"; then
+                    # Behind: hand out the current upstream tip, not the stale
+                    # local one. Resolved to a SHA so branch creation below
+                    # picks up no tracking side effects.
+                    echo "==> Base: ${base_label} is behind ${upstream_ref} — using ${upstream_ref} @ $(git rev-parse --short "$upstream_tip")"
+                    base="$upstream_tip"
+                    base_label="$upstream_ref"
+                elif git -C "$main_root" merge-base --is-ancestor "$upstream_tip" "$base"; then
+                    # Ahead: local has everything the upstream has, plus
+                    # unpushed work the caller presumably wants. Say so.
+                    echo "==> Note: ${base_label} is ahead of ${upstream_ref}; basing on the local tip"
+                else
+                    die "${base_label} has diverged from ${upstream_ref} — reconcile them, or pass --base <ref> to choose a start point explicitly"
+                fi
+            fi
+        else
+            echo "worktree:new: warning: could not reach '$upstream_remote' to verify ${base_label} against ${upstream_ref} — the base may be missing recently merged work (harmon-init#813)" >&2
+        fi
+    fi
     echo "==> Base: ${base_origin} (${base_label} @ $(git rev-parse --short "$base")) — pass --base <ref> to branch elsewhere"
 fi
 
@@ -319,12 +363,24 @@ trap cleanup EXIT
 remote_ref=""
 if [ "$base_origin" != "explicit" ] && ! git show-ref --verify --quiet "refs/heads/$branch"; then
     remote_matches=""
+    remote_match_remote=""
     remote_count=0
     while IFS= read -r remote_name; do
         [ -n "$remote_name" ] || continue
-        candidate="refs/remotes/$remote_name/$branch"
-        if git show-ref --verify --quiet "$candidate"; then
-            remote_matches="$candidate"
+        # Each remote is probed LIVE (harmon-init#840): the local
+        # refs/remotes/* namespace is only as fresh as the last fetch, so a
+        # branch pushed since then would read as absent and be silently
+        # recreated at the default base — diverging from the collaborator's
+        # branch. `ls-remote` patterns are tail-matched, so the answer is
+        # filtered to the exact ref before it counts. A probe that cannot
+        # answer fails CLOSED: "the remote is unreachable" is not evidence
+        # the branch is new, and guessing here is the data-loss path.
+        probe_out="$(git ls-remote --heads "$remote_name" "refs/heads/$branch")" ||
+            die "could not query remote '$remote_name' for branch '$branch' — offline or unreachable; retry with network, or pass --base <ref> to skip the remote lookup"
+        probe_sha="$(printf '%s\n' "$probe_out" | awk -v ref="refs/heads/$branch" -F'\t' '$2 == ref {print $1; exit}')"
+        if [ -n "$probe_sha" ]; then
+            remote_matches="refs/remotes/$remote_name/$branch"
+            remote_match_remote="$remote_name"
             remote_count=$((remote_count + 1))
         fi
     done <<EOF
@@ -333,7 +389,15 @@ EOF
     if [ "$remote_count" -gt 1 ]; then
         die "branch '$branch' exists on more than one remote — pass --base <remote>/<branch> to choose one"
     fi
-    [ "$remote_count" -eq 1 ] && remote_ref="$remote_matches"
+    if [ "$remote_count" -eq 1 ]; then
+        # Refresh the tracking ref to the tip the probe just saw, so the
+        # tracked checkout starts at the remote's current commit rather than
+        # a stale local mirror of it.
+        git fetch --quiet "$remote_match_remote" \
+            "+refs/heads/$branch:refs/remotes/$remote_match_remote/$branch" ||
+            die "found branch '$branch' on remote '$remote_match_remote' but could not fetch it — retry, or pass --base <ref>"
+        remote_ref="$remote_matches"
+    fi
 fi
 
 if git show-ref --verify --quiet "refs/heads/$branch"; then

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -126,52 +126,70 @@ if [ -z "$base" ]; then
     base="$(git -C "$main_root" rev-parse --verify --quiet HEAD || true)"
     [ -n "$base" ] ||
         die "the main worktree has no commits yet — make an initial commit, or pass --base <ref>"
-    # A local HEAD goes stale: merges land on the forge and nothing pulls, so
-    # an agent handed a fresh tree can be missing recently merged work
-    # (harmon-init#813). When HEAD's branch has an upstream, verify against it
-    # — this is not a guessed branch name; the upstream of whatever HEAD
-    # points at is configuration, which is what keeps #757's no-guessing
-    # design intact. The remote name comes from branch config, never from
-    # splitting the ref text: a remote name may itself contain '/'.
-    head_branch="$(git -C "$main_root" symbolic-ref --quiet --short HEAD || true)"
-    upstream_remote=""
-    upstream_ref=""
-    if [ -n "$head_branch" ]; then
-        upstream_remote="$(git -C "$main_root" config --get "branch.$head_branch.remote" 2>/dev/null || true)"
-        upstream_ref="$(git -C "$main_root" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
-    fi
-    if [ -n "$upstream_remote" ] && [ -n "$upstream_ref" ]; then
-        fetch_ok=1
-        if [ "$upstream_remote" != "." ]; then
-            upstream_branch="${upstream_ref#"$upstream_remote"/}"
-            git -C "$main_root" fetch --quiet "$upstream_remote" \
-                "+refs/heads/$upstream_branch:refs/remotes/$upstream_remote/$upstream_branch" 2>/dev/null ||
-                fetch_ok=0
-        fi
-        if [ "$fetch_ok" -eq 1 ]; then
-            upstream_tip="$(git -C "$main_root" rev-parse --verify --quiet "$upstream_ref^{commit}" || true)"
-            if [ -n "$upstream_tip" ] && [ "$upstream_tip" != "$base" ]; then
-                if git -C "$main_root" merge-base --is-ancestor "$base" "$upstream_tip"; then
-                    # Behind: hand out the current upstream tip, not the stale
-                    # local one. Resolved to a SHA so branch creation below
-                    # picks up no tracking side effects.
-                    echo "==> Base: ${base_label} is behind ${upstream_ref} — using ${upstream_ref} @ $(git rev-parse --short "$upstream_tip")"
-                    base="$upstream_tip"
-                    base_label="$upstream_ref"
-                elif git -C "$main_root" merge-base --is-ancestor "$upstream_tip" "$base"; then
-                    # Ahead: local has everything the upstream has, plus
-                    # unpushed work the caller presumably wants. Say so.
-                    echo "==> Note: ${base_label} is ahead of ${upstream_ref}; basing on the local tip"
-                else
-                    die "${base_label} has diverged from ${upstream_ref} — reconcile them, or pass --base <ref> to choose a start point explicitly"
-                fi
-            fi
-        else
-            echo "worktree:new: warning: could not reach '$upstream_remote' to verify ${base_label} against ${upstream_ref} — the base may be missing recently merged work (harmon-init#813)" >&2
-        fi
-    fi
     echo "==> Base: ${base_origin} (${base_label} @ $(git rev-parse --short "$base")) — pass --base <ref> to branch elsewhere"
 fi
+
+# Every network call this script makes must stay headless-safe and bounded:
+# this entrypoint is run by agents with no terminal, where a credential
+# prompt is an indefinite hang (the same failure shape as harmon-init#802),
+# and a degraded remote that accepts the connection and then stalls would
+# hang it just as hard. GIT_TERMINAL_PROMPT=0 turns a would-be prompt into a
+# fast failure; the low-speed bounds turn an HTTP stall into one. SSH obeys
+# the user's own ssh config and is deliberately not overridden here.
+git_net() {
+    GIT_TERMINAL_PROMPT=0 git -C "$main_root" \
+        -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=30 "$@"
+}
+
+# A local HEAD goes stale: merges land on the forge and nothing pulls, so an
+# agent handed a fresh tree can be missing recently merged work
+# (harmon-init#813). When HEAD's branch has an upstream, verify against it —
+# not a guessed branch name; the upstream of whatever HEAD points at is
+# configuration, which keeps #757's no-guessing design intact. Called ONLY
+# where the default base is actually consumed — creating a NEW branch from
+# it. Attaching an existing branch or tracking a remote-only branch never
+# uses the base, so neither should be blocked (or even warned) by its
+# staleness. May rewrite $base/$base_label or die.
+verify_default_base() {
+    # The remote name comes from branch config, never from splitting the ref
+    # text (a remote name may itself contain '/'), and the fetch SOURCE comes
+    # from branch.<name>.merge, never from the abbreviated upstream name — a
+    # non-identity fetch refspec makes @{u}'s short name differ from the
+    # branch it mirrors on the remote.
+    head_branch="$(git -C "$main_root" symbolic-ref --quiet --short HEAD || true)"
+    [ -n "$head_branch" ] || return 0
+    upstream_remote="$(git -C "$main_root" config --get "branch.$head_branch.remote" 2>/dev/null || true)"
+    upstream_merge="$(git -C "$main_root" config --get "branch.$head_branch.merge" 2>/dev/null || true)"
+    upstream_ref="$(git -C "$main_root" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+    { [ -n "$upstream_remote" ] && [ -n "$upstream_ref" ]; } || return 0
+    fetch_ok=1
+    if [ "$upstream_remote" != "." ]; then
+        [ -n "$upstream_merge" ] || return 0
+        git_net fetch --quiet "$upstream_remote" \
+            "+$upstream_merge:refs/remotes/$upstream_ref" 2>/dev/null ||
+            fetch_ok=0
+    fi
+    if [ "$fetch_ok" -eq 0 ]; then
+        echo "worktree:new: warning: could not reach '$upstream_remote' to verify ${base_label} against ${upstream_ref} — the base may be missing recently merged work (harmon-init#813)" >&2
+        return 0
+    fi
+    upstream_tip="$(git -C "$main_root" rev-parse --verify --quiet "$upstream_ref^{commit}" || true)"
+    { [ -n "$upstream_tip" ] && [ "$upstream_tip" != "$base" ]; } || return 0
+    if git -C "$main_root" merge-base --is-ancestor "$base" "$upstream_tip"; then
+        # Behind: hand out the current upstream tip, not the stale local one.
+        # Resolved to a SHA so branch creation picks up no tracking side
+        # effects.
+        echo "==> Base: ${base_label} is behind ${upstream_ref} — using ${upstream_ref} @ $(git rev-parse --short "$upstream_tip")"
+        base="$upstream_tip"
+        base_label="$upstream_ref"
+    elif git -C "$main_root" merge-base --is-ancestor "$upstream_tip" "$base"; then
+        # Ahead: local has everything the upstream has, plus unpushed work
+        # the caller presumably wants. Say so.
+        echo "==> Note: ${base_label} is ahead of ${upstream_ref}; basing on the local tip"
+    else
+        die "${base_label} has diverged from ${upstream_ref} — reconcile them, or pass --base <ref> to choose a start point explicitly"
+    fi
+}
 
 # Validated here, before anything is created, so a bad --base fails without a
 # rollback message about a tree that never existed.
@@ -375,8 +393,8 @@ if [ "$base_origin" != "explicit" ] && ! git show-ref --verify --quiet "refs/hea
         # filtered to the exact ref before it counts. A probe that cannot
         # answer fails CLOSED: "the remote is unreachable" is not evidence
         # the branch is new, and guessing here is the data-loss path.
-        probe_out="$(git ls-remote --heads "$remote_name" "refs/heads/$branch")" ||
-            die "could not query remote '$remote_name' for branch '$branch' — offline or unreachable; retry with network, or pass --base <ref> to skip the remote lookup"
+        probe_out="$(git_net ls-remote --heads "$remote_name" "refs/heads/$branch")" ||
+            die "could not query remote '$remote_name' for branch '$branch' — offline, unreachable, or needs interactive credentials; retry with network/auth, or pass --base <ref> to skip the remote lookup"
         probe_sha="$(printf '%s\n' "$probe_out" | awk -v ref="refs/heads/$branch" -F'\t' '$2 == ref {print $1; exit}')"
         if [ -n "$probe_sha" ]; then
             remote_matches="refs/remotes/$remote_name/$branch"
@@ -384,7 +402,7 @@ if [ "$base_origin" != "explicit" ] && ! git show-ref --verify --quiet "refs/hea
             remote_count=$((remote_count + 1))
         fi
     done <<EOF
-$(git remote)
+$(git -C "$main_root" remote)
 EOF
     if [ "$remote_count" -gt 1 ]; then
         die "branch '$branch' exists on more than one remote — pass --base <remote>/<branch> to choose one"
@@ -393,7 +411,7 @@ EOF
         # Refresh the tracking ref to the tip the probe just saw, so the
         # tracked checkout starts at the remote's current commit rather than
         # a stale local mirror of it.
-        git fetch --quiet "$remote_match_remote" \
+        git_net fetch --quiet "$remote_match_remote" \
             "+refs/heads/$branch:refs/remotes/$remote_match_remote/$branch" ||
             die "found branch '$branch' on remote '$remote_match_remote' but could not fetch it — retry, or pass --base <ref>"
         remote_ref="$remote_matches"
@@ -408,6 +426,11 @@ elif [ -n "$remote_ref" ]; then
     branch_created=1
     LEFTHOOK=0 git worktree add "$tree" --track -b "$branch" "${remote_ref#refs/remotes/}"
 else
+    # The one path that consumes the default base — verify its freshness
+    # here and nowhere earlier, so attaching an existing branch or tracking
+    # a remote-only one is never blocked by a stale or diverged main
+    # (harmon-init#813).
+    [ "$base_origin" = "explicit" ] || verify_default_base
     echo "==> Creating branch '$branch' from '$base'"
     branch_created=1
     LEFTHOOK=0 git worktree add "$tree" -b "$branch" "$base"

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -38,8 +38,8 @@ it points here.
   rather than recreating — installs **this tree's** dependencies, proves the
   git hooks fire inside it, prints the ready path, and rolls the tree back if
   any of that fails. A new branch is based on the **main worktree's HEAD**, not
-  the caller's — and when that branch has a configured upstream, the base is
-  first verified against it: behind means the fresh upstream tip is used
+  the caller's — and when that branch's configured upstream resolves, the base
+  is first verified against it: behind means the fresh upstream tip is used
   (announced), diverged refuses with a `--base` remedy, so a tree never
   silently starts from stale history. Running the task from inside a worktree
   does not silently stack the new branch on that one; `--base HEAD` stacks

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -38,8 +38,16 @@ it points here.
   rather than recreating — installs **this tree's** dependencies, proves the
   git hooks fire inside it, prints the ready path, and rolls the tree back if
   any of that fails. A new branch is based on the **main worktree's HEAD**, not
-  the caller's, so running the task from inside a worktree does not silently
-  stack the new branch on that one; `--base HEAD` stacks deliberately.
+  the caller's — and when that branch has a configured upstream, the base is
+  first verified against it: behind means the fresh upstream tip is used
+  (announced), diverged refuses with a `--base` remedy, so a tree never
+  silently starts from stale history. Running the task from inside a worktree
+  does not silently stack the new branch on that one; `--base HEAD` stacks
+  deliberately. Creating a genuinely new branch also probes every configured
+  remote for a same-named branch first — a branch that exists remotely is
+  tracked, never recreated — so that path needs the remotes reachable: an
+  offline run fails closed with the fix in the message, and an explicit
+  `--base <ref>` skips the remote lookup entirely.
   `--branch` and `--no-install` cover the rest.
   One entrypoint means a second agent session, a terminal multiplexer, or a
   human all get the same tree instead of each rediscovering the setup.

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -830,6 +830,121 @@ rm_wt team-only >/dev/null || fail "cleanup of the slash-remote tree failed"
 git -C "$fixture" branch -D team-only >/dev/null 2>&1 || true
 git -C "$fixture" remote remove team/sub
 
+# ── stale remote state must not decide anything (#813 / #840) ────────
+echo "==> a branch pushed after the last fetch is still detected and tracked"
+# Push, then delete the tracking ref the push just wrote: the local
+# refs/remotes namespace now predates the branch, which is exactly the state
+# after a collaborator pushes and nothing fetches (harmon-init#840).
+git -C "$fixture" push -q origin HEAD:refs/heads/late-remote
+git -C "$fixture" update-ref -d refs/remotes/origin/late-remote
+late_tip="$(git -C "$fixture" ls-remote origin refs/heads/late-remote | awk '{print $1}')"
+# Advance main past the push, so a helper that misses the remote branch
+# creates 'late-remote' at a DIFFERENT commit — the divergence itself, not
+# only the missing tracking, is what the assertion below must catch.
+printf 'ahead of late-remote\n' >"$fixture/LATE.md"
+git -C "$fixture" add LATE.md
+LEFTHOOK=0 git -C "$fixture" commit -qm "chore: move main ahead of the late-pushed branch" >"$test_tmp/commit.log" 2>&1 ||
+    fail "committing ahead of the late-pushed branch failed"
+new late-remote >/dev/null || fail "worktree-new.sh failed for a branch with no local tracking ref"
+[ "$(git -C "$fixture/.worktrees/late-remote" rev-parse HEAD)" = "$late_tip" ] ||
+    fail "worktree-new.sh created 'late-remote' from the default base instead of the remote branch (harmon-init#840)"
+[ "$(git -C "$fixture" rev-parse --abbrev-ref late-remote@{upstream} 2>/dev/null)" = "origin/late-remote" ] ||
+    fail "worktree-new.sh did not set up tracking for the late-pushed branch"
+rm_wt late-remote >/dev/null || fail "cleanup of the late-remote tree failed"
+git -C "$fixture" branch -D late-remote >/dev/null 2>&1 || true
+
+echo "==> a stale tracking ref is refreshed to the remote's current tip"
+git -C "$fixture" push -q origin HEAD:refs/heads/moving-remote
+stale_tip="$(git -C "$fixture" rev-parse refs/remotes/origin/moving-remote)"
+printf 'advance\n' >"$fixture/MOVING.md"
+git -C "$fixture" add MOVING.md
+LEFTHOOK=0 git -C "$fixture" commit -qm "chore: advance the moving branch" >"$test_tmp/commit.log" 2>&1 ||
+    fail "committing the moving-branch advance failed"
+git -C "$fixture" push -q origin HEAD:refs/heads/moving-remote
+moving_tip="$(git -C "$fixture" rev-parse HEAD)"
+# Roll main back and force the tracking ref stale, so only a live probe plus
+# fetch can know where the remote actually is.
+git -C "$fixture" reset -q --hard HEAD~1
+git -C "$fixture" update-ref refs/remotes/origin/moving-remote "$stale_tip"
+new moving-remote >/dev/null || fail "worktree-new.sh failed for a branch with a stale tracking ref"
+[ "$(git -C "$fixture/.worktrees/moving-remote" rev-parse HEAD)" = "$moving_tip" ] ||
+    fail "worktree-new.sh attached 'moving-remote' at the stale tracking tip instead of the remote's current commit (harmon-init#840)"
+rm_wt moving-remote >/dev/null || fail "cleanup of the moving-remote tree failed"
+git -C "$fixture" branch -D moving-remote >/dev/null 2>&1 || true
+
+echo "==> an unqueryable remote fails closed, and an explicit --base opts out"
+git -C "$fixture" remote add badremote "$test_tmp/nonexistent-bare.git"
+if new probe-fail >/dev/null 2>&1; then
+    fail "worktree-new.sh invented a new branch although a remote could not be queried (harmon-init#840)"
+fi
+refute_exists "$fixture/.worktrees/probe-fail" "the fail-closed probe left a tree behind"
+if git -C "$fixture" show-ref --verify --quiet refs/heads/probe-fail; then
+    fail "the fail-closed probe left the branch behind"
+fi
+new probe-fail --base HEAD >/dev/null || fail "an explicit --base did not skip the remote probe"
+rm_wt probe-fail >/dev/null || fail "cleanup of the probe-fail tree failed"
+git -C "$fixture" branch -D probe-fail >/dev/null 2>&1 || true
+git -C "$fixture" remote remove badremote
+
+echo "==> a default base behind its upstream hands out the upstream tip"
+base_upstream="$test_tmp/base-upstream.git"
+git init -q --bare "$base_upstream"
+git -C "$fixture" remote add baseup "$base_upstream"
+fixture_head_branch="$(git -C "$fixture" symbolic-ref --short HEAD)"
+git -C "$fixture" push -q -u baseup "$fixture_head_branch" >/dev/null 2>&1 ||
+    fail "seeding the base upstream failed"
+anchor_sha="$(git -C "$fixture" rev-parse HEAD)"
+printf 'merged upstream\n' >"$fixture/UPSTREAM.md"
+git -C "$fixture" add UPSTREAM.md
+LEFTHOOK=0 git -C "$fixture" commit -qm "chore: land work on the upstream" >"$test_tmp/commit.log" 2>&1 ||
+    fail "committing the upstream advance failed"
+git -C "$fixture" push -q baseup "$fixture_head_branch"
+upstream_sha="$(git -C "$fixture" rev-parse HEAD)"
+# Roll local back AND stale the tracking ref: only the fetch inside
+# worktree-new.sh can now learn where the upstream is (harmon-init#813).
+git -C "$fixture" reset -q --hard "$anchor_sha"
+git -C "$fixture" update-ref "refs/remotes/baseup/$fixture_head_branch" "$anchor_sha"
+base_out="$(new fresh-base)" || fail "worktree-new.sh failed with a behind upstream"
+[ "$(git -C "$fixture/.worktrees/fresh-base" rev-parse HEAD)" = "$upstream_sha" ] ||
+    fail "worktree-new.sh based 'fresh-base' on the stale local HEAD instead of the upstream tip (harmon-init#813)"
+case "$base_out" in *"is behind baseup/$fixture_head_branch"*) : ;; *) fail "worktree-new.sh did not announce the behind-upstream base" ;; esac
+rm_wt fresh-base >/dev/null || fail "cleanup of the fresh-base tree failed"
+git -C "$fixture" branch -D fresh-base >/dev/null 2>&1 || true
+
+echo "==> a default base diverged from its upstream is refused"
+printf 'local divergence\n' >"$fixture/DIVERGED.md"
+git -C "$fixture" add DIVERGED.md
+LEFTHOOK=0 git -C "$fixture" commit -qm "chore: diverge from the upstream" >"$test_tmp/commit.log" 2>&1 ||
+    fail "committing the divergence failed"
+if new diverged-base >/dev/null 2>&1; then
+    fail "worktree-new.sh picked a base although local and upstream have diverged (harmon-init#813)"
+fi
+refute_exists "$fixture/.worktrees/diverged-base" "the diverged-base refusal left a tree behind"
+new diverged-base --base HEAD >/dev/null || fail "an explicit --base did not bypass the divergence refusal"
+rm_wt diverged-base >/dev/null || fail "cleanup of the diverged-base tree failed"
+git -C "$fixture" branch -D diverged-base >/dev/null 2>&1 || true
+
+echo "==> an unreachable upstream warns, and an existing branch still attaches"
+# For a NEW branch an unreachable remote already fails closed at the branch
+# probe (the case above) — the loud failure #813 allows. The warn-and-proceed
+# path is therefore the one the probe skips: attaching a branch that already
+# exists locally, where the base is not used but the staleness warning must
+# still be heard.
+git -C "$fixture" remote set-url baseup "$test_tmp/nonexistent-upstream.git"
+git -C "$fixture" branch warn-base
+local_tip="$(git -C "$fixture" rev-parse HEAD)"
+warn_out="$(new warn-base 2>&1)" || fail "worktree-new.sh failed outright on an unreachable upstream"
+[ "$(git -C "$fixture/.worktrees/warn-base" rev-parse HEAD)" = "$local_tip" ] ||
+    fail "the unreachable-upstream attach did not check out the local branch tip"
+case "$warn_out" in *"could not reach 'baseup'"*) : ;; *) fail "the unreachable upstream produced no warning (harmon-init#813)" ;; esac
+rm_wt warn-base >/dev/null || fail "cleanup of the warn-base tree failed"
+git -C "$fixture" branch -D warn-base >/dev/null 2>&1 || true
+# Teardown: restore the pre-case fixture state so later default-base cases
+# are decided by the local HEAD again, exactly as before this block.
+git -C "$fixture" branch --unset-upstream >/dev/null 2>&1 || true
+git -C "$fixture" remote remove baseup
+git -C "$fixture" reset -q --hard "$anchor_sha"
+
 echo "==> a dot-segment name cannot smuggle a worktree inside another"
 new dotparent >/dev/null || fail "worktree-new.sh failed creating the dot-parent tree"
 if new ./dotparent/child --branch dotchild >/dev/null 2>&1; then

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -911,6 +911,35 @@ case "$base_out" in *"is behind baseup/$fixture_head_branch"*) : ;; *) fail "wor
 rm_wt fresh-base >/dev/null || fail "cleanup of the fresh-base tree failed"
 git -C "$fixture" branch -D fresh-base >/dev/null 2>&1 || true
 
+echo "==> losing the upstream ref-lock race still reads the winner's update"
+# The loser of two parallel worktree:new runs fails its own fetch while the
+# tracking ref already holds the winner's fresher value. Deterministic
+# reconstruction of that instant: the REMOTE is one commit past the winner's
+# value (commit-tree, so the local checkout never moves), the tracking ref
+# holds the winner's value, and a held ref lock makes THIS fetch fail — it
+# has an update to attempt and cannot take the lock. The loser must base on
+# the winner's value, read after the failed fetch, never return early on its
+# stale pre-fetch snapshot (which would base the tree on the local anchor).
+race_tip="$(git -C "$fixture" commit-tree -m "race remote tip" -p "$upstream_sha" "$(git -C "$fixture" rev-parse "$upstream_sha^{tree}")")"
+git -C "$fixture" push -q baseup "$race_tip:refs/heads/$fixture_head_branch"
+git -C "$fixture" update-ref "refs/remotes/baseup/$fixture_head_branch" "$upstream_sha"
+race_lock="$fixture/.git/refs/remotes/baseup/$fixture_head_branch.lock"
+mkdir -p "$(dirname "$race_lock")"
+: >"$race_lock"
+race_out="$(new race-base 2>&1)" || {
+    rm -f "$race_lock"
+    fail "worktree-new.sh failed outright when the upstream fetch lost the ref lock"
+}
+rm -f "$race_lock"
+[ "$(git -C "$fixture/.worktrees/race-base" rev-parse HEAD)" = "$upstream_sha" ] ||
+    fail "the fetch-race loser based on its stale snapshot instead of the winner's ref (harmon-init#813)"
+case "$race_out" in *"could not fetch"*) : ;; *) fail "the lost ref-lock race produced no warning" ;; esac
+rm_wt race-base >/dev/null || fail "cleanup of the race-base tree failed"
+git -C "$fixture" branch -D race-base >/dev/null 2>&1 || true
+# Put the remote back at the winner's value for the cases that follow.
+git -C "$fixture" push -q -f baseup "$upstream_sha:refs/heads/$fixture_head_branch"
+git -C "$fixture" update-ref "refs/remotes/baseup/$fixture_head_branch" "$upstream_sha"
+
 echo "==> a non-identity fetch refspec still verifies against the true source branch"
 # The upstream's short name and its source branch deliberately differ
 # (+refs/heads/trunk-src:refs/remotes/niup/localname): a helper that derives
@@ -973,6 +1002,38 @@ git -C "$fixture" branch -D attach-diverged >/dev/null 2>&1 || true
 git -C "$fixture" branch --unset-upstream >/dev/null 2>&1 || true
 git -C "$fixture" remote remove baseup
 git -C "$fixture" reset -q --hard "$anchor_sha"
+
+echo "==> a remote-only branch under a custom refspec never clobbers foreign tracking refs"
+# The remote maps ONLY decoy into refs/remotes/cref/victim. Creating the
+# remote-only branch 'victim' must attach it at the remote's tip via the
+# probe — not via any ref this script writes — and the mapped tracking ref
+# that belongs to decoy must be exactly as it was afterwards.
+cref_up="$test_tmp/cref-up.git"
+git init -q --bare "$cref_up"
+git -C "$fixture" remote add cref "$cref_up"
+git -C "$fixture" config remote.cref.fetch "+refs/heads/decoy:refs/remotes/cref/victim"
+git -C "$fixture" push -q cref HEAD:refs/heads/decoy
+decoy_tip="$(git -C "$fixture" rev-parse HEAD)"
+printf 'victim work\n' >"$fixture/VICTIM.md"
+git -C "$fixture" add VICTIM.md
+LEFTHOOK=0 git -C "$fixture" commit -qm "chore: advance the victim branch" >"$test_tmp/commit.log" 2>&1 ||
+    fail "committing the victim advance failed"
+git -C "$fixture" push -q cref HEAD:refs/heads/victim
+victim_tip="$(git -C "$fixture" rev-parse HEAD)"
+git -C "$fixture" reset -q --hard "$decoy_tip"
+git -C "$fixture" update-ref refs/remotes/cref/victim "$decoy_tip"
+new victim >/dev/null || fail "worktree-new.sh failed for a remote-only branch under a custom refspec"
+[ "$(git -C "$fixture/.worktrees/victim" rev-parse HEAD)" = "$victim_tip" ] ||
+    fail "worktree-new.sh did not attach 'victim' at the remote tip under a custom refspec"
+[ "$(git -C "$fixture" rev-parse refs/remotes/cref/victim)" = "$decoy_tip" ] ||
+    fail "worktree-new.sh clobbered a tracking ref the custom refspec maps from another branch (harmon-init#840)"
+[ "$(git -C "$fixture" config branch.victim.remote)" = "cref" ] ||
+    fail "the custom-refspec branch is not configured to track its remote"
+[ "$(git -C "$fixture" config branch.victim.merge)" = "refs/heads/victim" ] ||
+    fail "the custom-refspec branch tracks the wrong merge ref"
+rm_wt victim >/dev/null || fail "cleanup of the victim tree failed"
+git -C "$fixture" branch -D victim >/dev/null 2>&1 || true
+git -C "$fixture" remote remove cref
 
 echo "==> a dot-segment name cannot smuggle a worktree inside another"
 new dotparent >/dev/null || fail "worktree-new.sh failed creating the dot-parent tree"

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -1022,7 +1022,7 @@ git -C "$fixture" push -q cref HEAD:refs/heads/victim
 victim_tip="$(git -C "$fixture" rev-parse HEAD)"
 git -C "$fixture" reset -q --hard "$decoy_tip"
 git -C "$fixture" update-ref refs/remotes/cref/victim "$decoy_tip"
-new victim >/dev/null || fail "worktree-new.sh failed for a remote-only branch under a custom refspec"
+victim_out="$(new victim)" || fail "worktree-new.sh failed for a remote-only branch under a custom refspec"
 [ "$(git -C "$fixture/.worktrees/victim" rev-parse HEAD)" = "$victim_tip" ] ||
     fail "worktree-new.sh did not attach 'victim' at the remote tip under a custom refspec"
 [ "$(git -C "$fixture" rev-parse refs/remotes/cref/victim)" = "$decoy_tip" ] ||
@@ -1031,6 +1031,12 @@ new victim >/dev/null || fail "worktree-new.sh failed for a remote-only branch u
     fail "the custom-refspec branch is not configured to track its remote"
 [ "$(git -C "$fixture" config branch.victim.merge)" = "refs/heads/victim" ] ||
     fail "the custom-refspec branch tracks the wrong merge ref"
+# The refspec maps only decoy, so @{upstream} for victim CANNOT resolve —
+# and the command must say so rather than claim full tracking.
+if git -C "$fixture" rev-parse --verify --quiet "victim@{upstream}" >/dev/null 2>&1; then
+    fail "victim@{upstream} resolved although the refspec maps no such branch — fixture assumption broken"
+fi
+case "$victim_out" in *"does not map refs/heads/victim"*) : ;; *) fail "the unmapped-refspec degradation was not announced" ;; esac
 rm_wt victim >/dev/null || fail "cleanup of the victim tree failed"
 git -C "$fixture" branch -D victim >/dev/null 2>&1 || true
 git -C "$fixture" remote remove cref

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -911,6 +911,37 @@ case "$base_out" in *"is behind baseup/$fixture_head_branch"*) : ;; *) fail "wor
 rm_wt fresh-base >/dev/null || fail "cleanup of the fresh-base tree failed"
 git -C "$fixture" branch -D fresh-base >/dev/null 2>&1 || true
 
+echo "==> a non-identity fetch refspec still verifies against the true source branch"
+# The upstream's short name and its source branch deliberately differ
+# (+refs/heads/trunk-src:refs/remotes/niup/localname): a helper that derives
+# the fetch source by splitting the abbreviated upstream name would fetch a
+# branch that does not exist and silently keep the stale base (challenge
+# round 2 of harmon-init#813/#840).
+ni_upstream="$test_tmp/ni-upstream.git"
+git init -q --bare "$ni_upstream"
+git -C "$fixture" remote add niup "$ni_upstream"
+git -C "$fixture" config remote.niup.fetch "+refs/heads/trunk-src:refs/remotes/niup/localname"
+git -C "$fixture" push -q niup HEAD:refs/heads/trunk-src
+ni_anchor="$(git -C "$fixture" rev-parse HEAD)"
+printf 'landed on trunk-src\n' >"$fixture/NI.md"
+git -C "$fixture" add NI.md
+LEFTHOOK=0 git -C "$fixture" commit -qm "chore: advance the non-identity upstream" >"$test_tmp/commit.log" 2>&1 ||
+    fail "committing the non-identity advance failed"
+git -C "$fixture" push -q niup HEAD:refs/heads/trunk-src
+ni_tip="$(git -C "$fixture" rev-parse HEAD)"
+git -C "$fixture" reset -q --hard "$ni_anchor"
+git -C "$fixture" config "branch.$fixture_head_branch.remote" niup
+git -C "$fixture" config "branch.$fixture_head_branch.merge" refs/heads/trunk-src
+git -C "$fixture" update-ref refs/remotes/niup/localname "$ni_anchor"
+new ni-base >/dev/null || fail "worktree-new.sh failed with a non-identity upstream refspec"
+[ "$(git -C "$fixture/.worktrees/ni-base" rev-parse HEAD)" = "$ni_tip" ] ||
+    fail "worktree-new.sh did not fetch the true source branch through the non-identity refspec (harmon-init#813)"
+rm_wt ni-base >/dev/null || fail "cleanup of the ni-base tree failed"
+git -C "$fixture" branch -D ni-base >/dev/null 2>&1 || true
+git -C "$fixture" config "branch.$fixture_head_branch.remote" baseup
+git -C "$fixture" config "branch.$fixture_head_branch.merge" "refs/heads/$fixture_head_branch"
+git -C "$fixture" remote remove niup
+
 echo "==> a default base diverged from its upstream is refused"
 printf 'local divergence\n' >"$fixture/DIVERGED.md"
 git -C "$fixture" add DIVERGED.md

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -924,21 +924,19 @@ new diverged-base --base HEAD >/dev/null || fail "an explicit --base did not byp
 rm_wt diverged-base >/dev/null || fail "cleanup of the diverged-base tree failed"
 git -C "$fixture" branch -D diverged-base >/dev/null 2>&1 || true
 
-echo "==> an unreachable upstream warns, and an existing branch still attaches"
-# For a NEW branch an unreachable remote already fails closed at the branch
-# probe (the case above) — the loud failure #813 allows. The warn-and-proceed
-# path is therefore the one the probe skips: attaching a branch that already
-# exists locally, where the base is not used but the staleness warning must
-# still be heard.
-git -C "$fixture" remote set-url baseup "$test_tmp/nonexistent-upstream.git"
-git -C "$fixture" branch warn-base
+echo "==> attaching an existing branch is never blocked by base staleness"
+# The default base is only consumed when a NEW branch is created from it, so
+# the diverged main that just refused 'diverged-base' must not block — or
+# even warn about — attaching a branch that already exists: the base plays
+# no part in that path (harmon-init#813, challenge round 1).
+git -C "$fixture" branch attach-diverged
 local_tip="$(git -C "$fixture" rev-parse HEAD)"
-warn_out="$(new warn-base 2>&1)" || fail "worktree-new.sh failed outright on an unreachable upstream"
-[ "$(git -C "$fixture/.worktrees/warn-base" rev-parse HEAD)" = "$local_tip" ] ||
-    fail "the unreachable-upstream attach did not check out the local branch tip"
-case "$warn_out" in *"could not reach 'baseup'"*) : ;; *) fail "the unreachable upstream produced no warning (harmon-init#813)" ;; esac
-rm_wt warn-base >/dev/null || fail "cleanup of the warn-base tree failed"
-git -C "$fixture" branch -D warn-base >/dev/null 2>&1 || true
+attach_out="$(new attach-diverged 2>&1)" || fail "worktree-new.sh refused to attach an existing branch while main is diverged from its upstream"
+[ "$(git -C "$fixture/.worktrees/attach-diverged" rev-parse HEAD)" = "$local_tip" ] ||
+    fail "the attach did not check out the existing branch tip"
+case "$attach_out" in *"has diverged from"*) fail "attaching an existing branch surfaced the base divergence it never uses" ;; esac
+rm_wt attach-diverged >/dev/null || fail "cleanup of the attach-diverged tree failed"
+git -C "$fixture" branch -D attach-diverged >/dev/null 2>&1 || true
 # Teardown: restore the pre-case fixture state so later default-base cases
 # are decided by the local HEAD again, exactly as before this block.
 git -C "$fixture" branch --unset-upstream >/dev/null 2>&1 || true

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -126,6 +126,11 @@ if [ -z "$base" ]; then
     base="$(git -C "$main_root" rev-parse --verify --quiet HEAD || true)"
     [ -n "$base" ] ||
         die "the main worktree has no commits yet — make an initial commit, or pass --base <ref>"
+    # Captured HERE, in the same breath as $base, and never re-read: the main
+    # worktree can switch branches while this script runs (parallel use is
+    # this entrypoint's design space), and a verify that re-resolved HEAD
+    # later would compare one branch's upstream against another branch's SHA.
+    default_base_branch="$(git -C "$main_root" symbolic-ref --quiet --short HEAD || true)"
     echo "==> Base: ${base_origin} (${base_label} @ $(git rev-parse --short "$base")) — pass --base <ref> to branch elsewhere"
 fi
 
@@ -133,11 +138,19 @@ fi
 # this entrypoint is run by agents with no terminal, where a credential
 # prompt is an indefinite hang (the same failure shape as harmon-init#802),
 # and a degraded remote that accepts the connection and then stalls would
-# hang it just as hard. GIT_TERMINAL_PROMPT=0 turns a would-be prompt into a
-# fast failure; the low-speed bounds turn an HTTP stall into one. SSH obeys
-# the user's own ssh config and is deliberately not overridden here.
+# hang it just as hard. GIT_TERMINAL_PROMPT=0 turns a would-be HTTP prompt
+# into a fast failure and the low-speed bounds turn an HTTP stall into one;
+# neither reaches an SSH transport, so the ssh command gets BatchMode (no
+# interactive auth) and a connect timeout too. The options are APPENDED to
+# the user's own ssh command — ssh takes the first value obtained for an
+# option, so anything they set explicitly still wins — and core.sshCommand
+# is honoured before falling back to plain ssh, so a configured proxy or
+# jump host keeps working.
 git_net() {
-    GIT_TERMINAL_PROMPT=0 git -C "$main_root" \
+    _ssh_base="${GIT_SSH_COMMAND:-$(git -C "$main_root" config --get core.sshCommand 2>/dev/null || echo ssh)}"
+    GIT_TERMINAL_PROMPT=0 \
+        GIT_SSH_COMMAND="$_ssh_base -o BatchMode=yes -o ConnectTimeout=30" \
+        git -C "$main_root" \
         -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=30 "$@"
 }
 
@@ -151,43 +164,52 @@ git_net() {
 # uses the base, so neither should be blocked (or even warned) by its
 # staleness. May rewrite $base/$base_label or die.
 verify_default_base() {
-    # The remote name comes from branch config, never from splitting the ref
-    # text (a remote name may itself contain '/'), and the fetch SOURCE comes
-    # from branch.<name>.merge, never from the abbreviated upstream name — a
-    # non-identity fetch refspec makes @{u}'s short name differ from the
-    # branch it mirrors on the remote.
-    head_branch="$(git -C "$main_root" symbolic-ref --quiet --short HEAD || true)"
-    [ -n "$head_branch" ] || return 0
-    upstream_remote="$(git -C "$main_root" config --get "branch.$head_branch.remote" 2>/dev/null || true)"
-    upstream_merge="$(git -C "$main_root" config --get "branch.$head_branch.merge" 2>/dev/null || true)"
-    upstream_ref="$(git -C "$main_root" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
-    { [ -n "$upstream_remote" ] && [ -n "$upstream_ref" ]; } || return 0
-    fetch_ok=1
+    # Everything resolves from $default_base_branch, captured with $base —
+    # never from a fresh HEAD read (the main worktree can have switched
+    # branches since). The remote name comes from branch config, never from
+    # splitting ref text (a remote name may itself contain '/'); the fetch
+    # SOURCE comes from branch.<name>.merge, never from the abbreviated
+    # upstream name (a non-identity fetch refspec makes them differ); and the
+    # fetch DESTINATION is the upstream's full symbolic ref, never a
+    # refs/remotes/ prefix guess (a custom refspec can map outside
+    # refs/remotes/, and an ambiguous short name would mislead a prefix).
+    [ -n "$default_base_branch" ] || return 0
+    upstream_remote="$(git -C "$main_root" config --get "branch.$default_base_branch.remote" 2>/dev/null || true)"
+    upstream_merge="$(git -C "$main_root" config --get "branch.$default_base_branch.merge" 2>/dev/null || true)"
+    upstream_full="$(git -C "$main_root" rev-parse --symbolic-full-name "$default_base_branch@{upstream}" 2>/dev/null || true)"
+    { [ -n "$upstream_remote" ] && [ -n "$upstream_full" ]; } || return 0
+    upstream_label="$(git -C "$main_root" rev-parse --abbrev-ref "$default_base_branch@{upstream}" 2>/dev/null || echo "$upstream_full")"
+    fetch_failed=0
     if [ "$upstream_remote" != "." ]; then
         [ -n "$upstream_merge" ] || return 0
         git_net fetch --quiet "$upstream_remote" \
-            "+$upstream_merge:refs/remotes/$upstream_ref" 2>/dev/null ||
-            fetch_ok=0
+            "+$upstream_merge:$upstream_full" 2>/dev/null ||
+            fetch_failed=1
     fi
-    if [ "$fetch_ok" -eq 0 ]; then
-        echo "worktree:new: warning: could not reach '$upstream_remote' to verify ${base_label} against ${upstream_ref} — the base may be missing recently merged work (harmon-init#813)" >&2
-        return 0
+    # The comparison reads the tracking ref AFTER the fetch attempt, success
+    # or not: a parallel worktree:new fetching the same upstream can win the
+    # ref lock and fail THIS fetch while leaving the ref freshly updated —
+    # returning early on failure would base the loser on the stale snapshot.
+    # Only a genuinely unreadable state keeps the base as captured, and a
+    # failed fetch still says so out loud.
+    if [ "$fetch_failed" -eq 1 ]; then
+        echo "worktree:new: warning: could not fetch '$upstream_remote' — verifying ${base_label} against the last-known ${upstream_label}, which may itself be stale (harmon-init#813)" >&2
     fi
-    upstream_tip="$(git -C "$main_root" rev-parse --verify --quiet "$upstream_ref^{commit}" || true)"
+    upstream_tip="$(git -C "$main_root" rev-parse --verify --quiet "$upstream_full^{commit}" || true)"
     { [ -n "$upstream_tip" ] && [ "$upstream_tip" != "$base" ]; } || return 0
     if git -C "$main_root" merge-base --is-ancestor "$base" "$upstream_tip"; then
         # Behind: hand out the current upstream tip, not the stale local one.
         # Resolved to a SHA so branch creation picks up no tracking side
         # effects.
-        echo "==> Base: ${base_label} is behind ${upstream_ref} — using ${upstream_ref} @ $(git rev-parse --short "$upstream_tip")"
+        echo "==> Base: ${base_label} is behind ${upstream_label} — using ${upstream_label} @ $(git rev-parse --short "$upstream_tip")"
         base="$upstream_tip"
-        base_label="$upstream_ref"
+        base_label="$upstream_label"
     elif git -C "$main_root" merge-base --is-ancestor "$upstream_tip" "$base"; then
         # Ahead: local has everything the upstream has, plus unpushed work
         # the caller presumably wants. Say so.
-        echo "==> Note: ${base_label} is ahead of ${upstream_ref}; basing on the local tip"
+        echo "==> Note: ${base_label} is ahead of ${upstream_label}; basing on the local tip"
     else
-        die "${base_label} has diverged from ${upstream_ref} — reconcile them, or pass --base <ref> to choose a start point explicitly"
+        die "${base_label} has diverged from ${upstream_label} — reconcile them, or pass --base <ref> to choose a start point explicitly"
     fi
 }
 

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -460,17 +460,23 @@ EOF
         # present after the fetch rather than read from any ref of ours.
         git_net fetch --quiet "$remote_match_remote" "refs/heads/$branch" ||
             die "found branch '$branch' on remote '$remote_match_remote' but could not fetch it — retry, or pass --base <ref>"
-        if ! git rev-parse --verify --quiet "$remote_probe_sha^{commit}" >/dev/null; then
-            # The remote moved (or force-moved) between the probe and the
-            # fetch, so the probed commit never arrived. Probe once more:
-            # a stable answer this time is usable, anything else is a
-            # remote in motion.
-            probe_out="$(git_net ls-remote --heads "$remote_match_remote" "refs/heads/$branch")" ||
-                die "remote '$remote_match_remote' became unqueryable while fetching '$branch' — retry, or pass --base <ref>"
-            remote_probe_sha="$(printf '%s\n' "$probe_out" | awk -v ref="refs/heads/$branch" -F'\t' '$2 == ref {print $1; exit}')"
-            { [ -n "$remote_probe_sha" ] && git rev-parse --verify --quiet "$remote_probe_sha^{commit}" >/dev/null; } ||
-                die "branch '$branch' on remote '$remote_match_remote' is moving — retry, or pass --base <ref>"
-        fi
+        # One UNCONDITIONAL post-fetch probe. The remote can advance between
+        # the first probe and the fetch, and the first probe's tip resolving
+        # locally is no evidence it stayed current — a stale tracking ref
+        # can make an outdated commit resolve just fine. The fetch already
+        # imported whatever the remote advanced to, so the fresh probe's
+        # answer normally resolves and the attach lands on it; a tip that
+        # arrives unresolvable means the remote moved again mid-operation,
+        # which no client-side sequence can chase — stop and say so. (The
+        # window between this probe and the attach is inherent; this keeps
+        # it one probe wide instead of pretending to close it.)
+        probe_out="$(git_net ls-remote --heads "$remote_match_remote" "refs/heads/$branch")" ||
+            die "remote '$remote_match_remote' became unqueryable while fetching '$branch' — retry, or pass --base <ref>"
+        remote_probe_sha="$(printf '%s\n' "$probe_out" | awk -v ref="refs/heads/$branch" -F'\t' '$2 == ref {print $1; exit}')"
+        [ -n "$remote_probe_sha" ] ||
+            die "branch '$branch' disappeared from remote '$remote_match_remote' while fetching — retry, or pass --base <ref>"
+        git rev-parse --verify --quiet "$remote_probe_sha^{commit}" >/dev/null ||
+            die "branch '$branch' on remote '$remote_match_remote' is moving — retry, or pass --base <ref>"
         remote_ref="$remote_matches"
     fi
 fi
@@ -492,6 +498,14 @@ elif [ -n "$remote_ref" ]; then
     LEFTHOOK=0 git worktree add "$tree" -b "$branch" "$remote_probe_sha"
     git config "branch.$branch.remote" "$remote_match_remote"
     git config "branch.$branch.merge" "refs/heads/$branch"
+    # Honesty check on the tracking claim: pull and push work off the branch
+    # config just written, but @{upstream}-based tooling (status ahead/behind,
+    # verify_default_base if this branch ever becomes the main HEAD) resolves
+    # through the remote's fetch refspec — which a custom refspec may simply
+    # not map for this branch. Say so instead of letting "tracking" imply
+    # more than it delivers.
+    git rev-parse --verify --quiet "$branch@{upstream}" >/dev/null 2>&1 ||
+        echo "==> Note: '$remote_match_remote's fetch refspec does not map refs/heads/$branch — pull/push work via branch config, but @{upstream} tooling will not see an upstream"
 else
     # The one path that consumes the default base — verify its freshness
     # here and nowhere earlier, so attaching an existing branch or tracking

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -168,9 +168,19 @@ fi
 # because closing it means a hand-rolled process watchdog whose own failure
 # modes (PID reuse, signal races, orphan supervision) outweigh the residual.
 git_net() {
-    _ssh_base="${GIT_SSH_COMMAND:-$(git -C "$main_root" config --get core.sshCommand 2>/dev/null || echo ssh)}"
+    _ssh_cmd="${GIT_SSH_COMMAND:-$(git -C "$main_root" config --get core.sshCommand 2>/dev/null || true)}"
+    if [ -z "$_ssh_cmd" ] && [ -n "${GIT_SSH:-}" ]; then
+        # GIT_SSH names a bare program that accepts no extra options —
+        # appending ours would break the wrapper, and exporting
+        # GIT_SSH_COMMAND would silently bypass it. Leave the SSH transport
+        # to it, unbounded; the HTTP bounds and prompt suppression still
+        # apply.
+        GIT_TERMINAL_PROMPT=0 git -C "$main_root" \
+            -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=30 "$@"
+        return
+    fi
     GIT_TERMINAL_PROMPT=0 \
-        GIT_SSH_COMMAND="$_ssh_base -o BatchMode=yes -o ConnectTimeout=30" \
+        GIT_SSH_COMMAND="${_ssh_cmd:-ssh} -o BatchMode=yes -o ConnectTimeout=30" \
         git -C "$main_root" \
         -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=30 "$@"
 }

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -122,15 +122,25 @@ main_root="$(git worktree list --porcelain | awk '/^worktree /{print substr($0, 
 base_origin="explicit"
 if [ -z "$base" ]; then
     base_origin="the main worktree's HEAD"
-    base_label="$(git -C "$main_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
-    base="$(git -C "$main_root" rev-parse --verify --quiet HEAD || true)"
+    # The branch NAME is captured first and the SHA resolved FROM that name,
+    # never from a second HEAD read: parallel use is this entrypoint's design
+    # space, and two separate HEAD reads can straddle a concurrent branch
+    # switch in the main worktree — the pair would then mix one branch's
+    # upstream with another branch's commit. Resolving refs/heads/<captured>
+    # yields a self-consistent pair even if HEAD has moved on; the
+    # verification below reuses the same captured name and never re-reads
+    # HEAD either. A detached HEAD has no branch: its SHA is read directly
+    # and the upstream verification stays off.
+    default_base_branch="$(git -C "$main_root" symbolic-ref --quiet --short HEAD || true)"
+    if [ -n "$default_base_branch" ]; then
+        base_label="$default_base_branch"
+        base="$(git -C "$main_root" rev-parse --verify --quiet "refs/heads/$default_base_branch" || true)"
+    else
+        base_label="HEAD"
+        base="$(git -C "$main_root" rev-parse --verify --quiet HEAD || true)"
+    fi
     [ -n "$base" ] ||
         die "the main worktree has no commits yet — make an initial commit, or pass --base <ref>"
-    # Captured HERE, in the same breath as $base, and never re-read: the main
-    # worktree can switch branches while this script runs (parallel use is
-    # this entrypoint's design space), and a verify that re-resolved HEAD
-    # later would compare one branch's upstream against another branch's SHA.
-    default_base_branch="$(git -C "$main_root" symbolic-ref --quiet --short HEAD || true)"
     echo "==> Base: ${base_origin} (${base_label} @ $(git rev-parse --short "$base")) — pass --base <ref> to branch elsewhere"
 fi
 
@@ -146,6 +156,15 @@ fi
 # option, so anything they set explicitly still wins — and core.sshCommand
 # is honoured before falling back to plain ssh, so a configured proxy or
 # jump host keeps working.
+#
+# Residual, stated so nobody rediscovers it as a surprise: a server that
+# ACCEPTS a connection and then stalls mid-protocol is bounded on HTTP (the
+# low-speed limits) but not on SSH past the handshake, nor on git:// or
+# custom remote helpers. This fleet's transport is HTTPS via gh (provisioned
+# hosts rewrite SSH remotes), so the exposure is an unprovisioned host on an
+# established-then-wedged non-HTTP connection — accepted rather than closed,
+# because closing it means a hand-rolled process watchdog whose own failure
+# modes (PID reuse, signal races, orphan supervision) outweigh the residual.
 git_net() {
     _ssh_base="${GIT_SSH_COMMAND:-$(git -C "$main_root" config --get core.sshCommand 2>/dev/null || echo ssh)}"
     GIT_TERMINAL_PROMPT=0 \
@@ -444,9 +463,21 @@ if git show-ref --verify --quiet "refs/heads/$branch"; then
     echo "==> Attaching existing branch '$branch'"
     LEFTHOOK=0 git worktree add "$tree" "$branch"
 elif [ -n "$remote_ref" ]; then
-    echo "==> Creating branch '$branch' tracking ${remote_ref#refs/remotes/}"
+    echo "==> Creating branch '$branch' tracking $remote_match_remote/$branch"
     branch_created=1
-    LEFTHOOK=0 git worktree add "$tree" --track -b "$branch" "${remote_ref#refs/remotes/}"
+    # Created from the fetched SHA with tracking written as plain branch
+    # config, never via `--track` DWIM: --track derives the upstream by
+    # reverse-mapping the start point through the remote's fetch refspec, and
+    # under a non-identity refspec our synthesized refs/remotes/<r>/<b> ref
+    # maps to nothing — git aborts with "starting point is not a branch".
+    # branch.<name>.remote + branch.<name>.merge are correct under EVERY
+    # refspec, and @{u} then resolves through whatever mapping the repo
+    # actually configures.
+    remote_tip="$(git rev-parse --verify --quiet "$remote_ref^{commit}")" ||
+        die "fetched '$branch' from '$remote_match_remote' but cannot resolve it"
+    LEFTHOOK=0 git worktree add "$tree" -b "$branch" "$remote_tip"
+    git config "branch.$branch.remote" "$remote_match_remote"
+    git config "branch.$branch.merge" "refs/heads/$branch"
 else
     # The one path that consumes the default base — verify its freshness
     # here and nowhere earlier, so attaching an existing branch or tracking

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -12,7 +12,9 @@
 #
 # Options:
 #   --branch <name>   branch to create/attach (default: the worktree name)
-#   --base <ref>      base for a NEW branch (default: HEAD)
+#   --base <ref>      base for a NEW branch (default: the main worktree's
+#                     HEAD, verified against its configured upstream; also
+#                     skips the live remote lookup for the branch name)
 #   --no-install      skip the per-tree dependency install
 #
 # Exits non-zero with the fix in the message when a precondition is missing, and
@@ -440,6 +442,7 @@ if [ "$base_origin" != "explicit" ] && ! git show-ref --verify --quiet "refs/hea
         if [ -n "$probe_sha" ]; then
             remote_matches="refs/remotes/$remote_name/$branch"
             remote_match_remote="$remote_name"
+            remote_probe_sha="$probe_sha"
             remote_count=$((remote_count + 1))
         fi
     done <<EOF
@@ -449,12 +452,25 @@ EOF
         die "branch '$branch' exists on more than one remote — pass --base <remote>/<branch> to choose one"
     fi
     if [ "$remote_count" -eq 1 ]; then
-        # Refresh the tracking ref to the tip the probe just saw, so the
-        # tracked checkout starts at the remote's current commit rather than
-        # a stale local mirror of it.
-        git_net fetch --quiet "$remote_match_remote" \
-            "+refs/heads/$branch:refs/remotes/$remote_match_remote/$branch" ||
+        # Fetched WITHOUT a destination refspec, so the only tracking refs
+        # updated are the ones the remote's OWN configured refspec maps —
+        # a synthesized identity destination could overwrite a tracking ref
+        # that a custom refspec maps a different branch into. The commit to
+        # attach is the one the probe saw ($remote_probe_sha), verified
+        # present after the fetch rather than read from any ref of ours.
+        git_net fetch --quiet "$remote_match_remote" "refs/heads/$branch" ||
             die "found branch '$branch' on remote '$remote_match_remote' but could not fetch it — retry, or pass --base <ref>"
+        if ! git rev-parse --verify --quiet "$remote_probe_sha^{commit}" >/dev/null; then
+            # The remote moved (or force-moved) between the probe and the
+            # fetch, so the probed commit never arrived. Probe once more:
+            # a stable answer this time is usable, anything else is a
+            # remote in motion.
+            probe_out="$(git_net ls-remote --heads "$remote_match_remote" "refs/heads/$branch")" ||
+                die "remote '$remote_match_remote' became unqueryable while fetching '$branch' — retry, or pass --base <ref>"
+            remote_probe_sha="$(printf '%s\n' "$probe_out" | awk -v ref="refs/heads/$branch" -F'\t' '$2 == ref {print $1; exit}')"
+            { [ -n "$remote_probe_sha" ] && git rev-parse --verify --quiet "$remote_probe_sha^{commit}" >/dev/null; } ||
+                die "branch '$branch' on remote '$remote_match_remote' is moving — retry, or pass --base <ref>"
+        fi
         remote_ref="$remote_matches"
     fi
 fi
@@ -465,17 +481,15 @@ if git show-ref --verify --quiet "refs/heads/$branch"; then
 elif [ -n "$remote_ref" ]; then
     echo "==> Creating branch '$branch' tracking $remote_match_remote/$branch"
     branch_created=1
-    # Created from the fetched SHA with tracking written as plain branch
-    # config, never via `--track` DWIM: --track derives the upstream by
-    # reverse-mapping the start point through the remote's fetch refspec, and
-    # under a non-identity refspec our synthesized refs/remotes/<r>/<b> ref
-    # maps to nothing — git aborts with "starting point is not a branch".
-    # branch.<name>.remote + branch.<name>.merge are correct under EVERY
-    # refspec, and @{u} then resolves through whatever mapping the repo
-    # actually configures.
-    remote_tip="$(git rev-parse --verify --quiet "$remote_ref^{commit}")" ||
-        die "fetched '$branch' from '$remote_match_remote' but cannot resolve it"
-    LEFTHOOK=0 git worktree add "$tree" -b "$branch" "$remote_tip"
+    # Created from the PROBED commit with tracking written as plain branch
+    # config, never via `--track` DWIM and never via a ref this script
+    # wrote: --track derives the upstream by reverse-mapping the start point
+    # through the remote's fetch refspec and aborts under a non-identity
+    # one, and any destination ref we synthesized could collide with what a
+    # custom refspec maps there. branch.<name>.remote + branch.<name>.merge
+    # are correct under EVERY refspec, and @{u} then resolves through
+    # whatever mapping the repo actually configures.
+    LEFTHOOK=0 git worktree add "$tree" -b "$branch" "$remote_probe_sha"
     git config "branch.$branch.remote" "$remote_match_remote"
     git config "branch.$branch.merge" "refs/heads/$branch"
 else

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -126,6 +126,50 @@ if [ -z "$base" ]; then
     base="$(git -C "$main_root" rev-parse --verify --quiet HEAD || true)"
     [ -n "$base" ] ||
         die "the main worktree has no commits yet — make an initial commit, or pass --base <ref>"
+    # A local HEAD goes stale: merges land on the forge and nothing pulls, so
+    # an agent handed a fresh tree can be missing recently merged work
+    # (harmon-init#813). When HEAD's branch has an upstream, verify against it
+    # — this is not a guessed branch name; the upstream of whatever HEAD
+    # points at is configuration, which is what keeps #757's no-guessing
+    # design intact. The remote name comes from branch config, never from
+    # splitting the ref text: a remote name may itself contain '/'.
+    head_branch="$(git -C "$main_root" symbolic-ref --quiet --short HEAD || true)"
+    upstream_remote=""
+    upstream_ref=""
+    if [ -n "$head_branch" ]; then
+        upstream_remote="$(git -C "$main_root" config --get "branch.$head_branch.remote" 2>/dev/null || true)"
+        upstream_ref="$(git -C "$main_root" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+    fi
+    if [ -n "$upstream_remote" ] && [ -n "$upstream_ref" ]; then
+        fetch_ok=1
+        if [ "$upstream_remote" != "." ]; then
+            upstream_branch="${upstream_ref#"$upstream_remote"/}"
+            git -C "$main_root" fetch --quiet "$upstream_remote" \
+                "+refs/heads/$upstream_branch:refs/remotes/$upstream_remote/$upstream_branch" 2>/dev/null ||
+                fetch_ok=0
+        fi
+        if [ "$fetch_ok" -eq 1 ]; then
+            upstream_tip="$(git -C "$main_root" rev-parse --verify --quiet "$upstream_ref^{commit}" || true)"
+            if [ -n "$upstream_tip" ] && [ "$upstream_tip" != "$base" ]; then
+                if git -C "$main_root" merge-base --is-ancestor "$base" "$upstream_tip"; then
+                    # Behind: hand out the current upstream tip, not the stale
+                    # local one. Resolved to a SHA so branch creation below
+                    # picks up no tracking side effects.
+                    echo "==> Base: ${base_label} is behind ${upstream_ref} — using ${upstream_ref} @ $(git rev-parse --short "$upstream_tip")"
+                    base="$upstream_tip"
+                    base_label="$upstream_ref"
+                elif git -C "$main_root" merge-base --is-ancestor "$upstream_tip" "$base"; then
+                    # Ahead: local has everything the upstream has, plus
+                    # unpushed work the caller presumably wants. Say so.
+                    echo "==> Note: ${base_label} is ahead of ${upstream_ref}; basing on the local tip"
+                else
+                    die "${base_label} has diverged from ${upstream_ref} — reconcile them, or pass --base <ref> to choose a start point explicitly"
+                fi
+            fi
+        else
+            echo "worktree:new: warning: could not reach '$upstream_remote' to verify ${base_label} against ${upstream_ref} — the base may be missing recently merged work (harmon-init#813)" >&2
+        fi
+    fi
     echo "==> Base: ${base_origin} (${base_label} @ $(git rev-parse --short "$base")) — pass --base <ref> to branch elsewhere"
 fi
 
@@ -319,12 +363,24 @@ trap cleanup EXIT
 remote_ref=""
 if [ "$base_origin" != "explicit" ] && ! git show-ref --verify --quiet "refs/heads/$branch"; then
     remote_matches=""
+    remote_match_remote=""
     remote_count=0
     while IFS= read -r remote_name; do
         [ -n "$remote_name" ] || continue
-        candidate="refs/remotes/$remote_name/$branch"
-        if git show-ref --verify --quiet "$candidate"; then
-            remote_matches="$candidate"
+        # Each remote is probed LIVE (harmon-init#840): the local
+        # refs/remotes/* namespace is only as fresh as the last fetch, so a
+        # branch pushed since then would read as absent and be silently
+        # recreated at the default base — diverging from the collaborator's
+        # branch. `ls-remote` patterns are tail-matched, so the answer is
+        # filtered to the exact ref before it counts. A probe that cannot
+        # answer fails CLOSED: "the remote is unreachable" is not evidence
+        # the branch is new, and guessing here is the data-loss path.
+        probe_out="$(git ls-remote --heads "$remote_name" "refs/heads/$branch")" ||
+            die "could not query remote '$remote_name' for branch '$branch' — offline or unreachable; retry with network, or pass --base <ref> to skip the remote lookup"
+        probe_sha="$(printf '%s\n' "$probe_out" | awk -v ref="refs/heads/$branch" -F'\t' '$2 == ref {print $1; exit}')"
+        if [ -n "$probe_sha" ]; then
+            remote_matches="refs/remotes/$remote_name/$branch"
+            remote_match_remote="$remote_name"
             remote_count=$((remote_count + 1))
         fi
     done <<EOF
@@ -333,7 +389,15 @@ EOF
     if [ "$remote_count" -gt 1 ]; then
         die "branch '$branch' exists on more than one remote — pass --base <remote>/<branch> to choose one"
     fi
-    [ "$remote_count" -eq 1 ] && remote_ref="$remote_matches"
+    if [ "$remote_count" -eq 1 ]; then
+        # Refresh the tracking ref to the tip the probe just saw, so the
+        # tracked checkout starts at the remote's current commit rather than
+        # a stale local mirror of it.
+        git fetch --quiet "$remote_match_remote" \
+            "+refs/heads/$branch:refs/remotes/$remote_match_remote/$branch" ||
+            die "found branch '$branch' on remote '$remote_match_remote' but could not fetch it — retry, or pass --base <ref>"
+        remote_ref="$remote_matches"
+    fi
 fi
 
 if git show-ref --verify --quiet "refs/heads/$branch"; then

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -126,52 +126,70 @@ if [ -z "$base" ]; then
     base="$(git -C "$main_root" rev-parse --verify --quiet HEAD || true)"
     [ -n "$base" ] ||
         die "the main worktree has no commits yet — make an initial commit, or pass --base <ref>"
-    # A local HEAD goes stale: merges land on the forge and nothing pulls, so
-    # an agent handed a fresh tree can be missing recently merged work
-    # (harmon-init#813). When HEAD's branch has an upstream, verify against it
-    # — this is not a guessed branch name; the upstream of whatever HEAD
-    # points at is configuration, which is what keeps #757's no-guessing
-    # design intact. The remote name comes from branch config, never from
-    # splitting the ref text: a remote name may itself contain '/'.
-    head_branch="$(git -C "$main_root" symbolic-ref --quiet --short HEAD || true)"
-    upstream_remote=""
-    upstream_ref=""
-    if [ -n "$head_branch" ]; then
-        upstream_remote="$(git -C "$main_root" config --get "branch.$head_branch.remote" 2>/dev/null || true)"
-        upstream_ref="$(git -C "$main_root" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
-    fi
-    if [ -n "$upstream_remote" ] && [ -n "$upstream_ref" ]; then
-        fetch_ok=1
-        if [ "$upstream_remote" != "." ]; then
-            upstream_branch="${upstream_ref#"$upstream_remote"/}"
-            git -C "$main_root" fetch --quiet "$upstream_remote" \
-                "+refs/heads/$upstream_branch:refs/remotes/$upstream_remote/$upstream_branch" 2>/dev/null ||
-                fetch_ok=0
-        fi
-        if [ "$fetch_ok" -eq 1 ]; then
-            upstream_tip="$(git -C "$main_root" rev-parse --verify --quiet "$upstream_ref^{commit}" || true)"
-            if [ -n "$upstream_tip" ] && [ "$upstream_tip" != "$base" ]; then
-                if git -C "$main_root" merge-base --is-ancestor "$base" "$upstream_tip"; then
-                    # Behind: hand out the current upstream tip, not the stale
-                    # local one. Resolved to a SHA so branch creation below
-                    # picks up no tracking side effects.
-                    echo "==> Base: ${base_label} is behind ${upstream_ref} — using ${upstream_ref} @ $(git rev-parse --short "$upstream_tip")"
-                    base="$upstream_tip"
-                    base_label="$upstream_ref"
-                elif git -C "$main_root" merge-base --is-ancestor "$upstream_tip" "$base"; then
-                    # Ahead: local has everything the upstream has, plus
-                    # unpushed work the caller presumably wants. Say so.
-                    echo "==> Note: ${base_label} is ahead of ${upstream_ref}; basing on the local tip"
-                else
-                    die "${base_label} has diverged from ${upstream_ref} — reconcile them, or pass --base <ref> to choose a start point explicitly"
-                fi
-            fi
-        else
-            echo "worktree:new: warning: could not reach '$upstream_remote' to verify ${base_label} against ${upstream_ref} — the base may be missing recently merged work (harmon-init#813)" >&2
-        fi
-    fi
     echo "==> Base: ${base_origin} (${base_label} @ $(git rev-parse --short "$base")) — pass --base <ref> to branch elsewhere"
 fi
+
+# Every network call this script makes must stay headless-safe and bounded:
+# this entrypoint is run by agents with no terminal, where a credential
+# prompt is an indefinite hang (the same failure shape as harmon-init#802),
+# and a degraded remote that accepts the connection and then stalls would
+# hang it just as hard. GIT_TERMINAL_PROMPT=0 turns a would-be prompt into a
+# fast failure; the low-speed bounds turn an HTTP stall into one. SSH obeys
+# the user's own ssh config and is deliberately not overridden here.
+git_net() {
+    GIT_TERMINAL_PROMPT=0 git -C "$main_root" \
+        -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=30 "$@"
+}
+
+# A local HEAD goes stale: merges land on the forge and nothing pulls, so an
+# agent handed a fresh tree can be missing recently merged work
+# (harmon-init#813). When HEAD's branch has an upstream, verify against it —
+# not a guessed branch name; the upstream of whatever HEAD points at is
+# configuration, which keeps #757's no-guessing design intact. Called ONLY
+# where the default base is actually consumed — creating a NEW branch from
+# it. Attaching an existing branch or tracking a remote-only branch never
+# uses the base, so neither should be blocked (or even warned) by its
+# staleness. May rewrite $base/$base_label or die.
+verify_default_base() {
+    # The remote name comes from branch config, never from splitting the ref
+    # text (a remote name may itself contain '/'), and the fetch SOURCE comes
+    # from branch.<name>.merge, never from the abbreviated upstream name — a
+    # non-identity fetch refspec makes @{u}'s short name differ from the
+    # branch it mirrors on the remote.
+    head_branch="$(git -C "$main_root" symbolic-ref --quiet --short HEAD || true)"
+    [ -n "$head_branch" ] || return 0
+    upstream_remote="$(git -C "$main_root" config --get "branch.$head_branch.remote" 2>/dev/null || true)"
+    upstream_merge="$(git -C "$main_root" config --get "branch.$head_branch.merge" 2>/dev/null || true)"
+    upstream_ref="$(git -C "$main_root" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+    { [ -n "$upstream_remote" ] && [ -n "$upstream_ref" ]; } || return 0
+    fetch_ok=1
+    if [ "$upstream_remote" != "." ]; then
+        [ -n "$upstream_merge" ] || return 0
+        git_net fetch --quiet "$upstream_remote" \
+            "+$upstream_merge:refs/remotes/$upstream_ref" 2>/dev/null ||
+            fetch_ok=0
+    fi
+    if [ "$fetch_ok" -eq 0 ]; then
+        echo "worktree:new: warning: could not reach '$upstream_remote' to verify ${base_label} against ${upstream_ref} — the base may be missing recently merged work (harmon-init#813)" >&2
+        return 0
+    fi
+    upstream_tip="$(git -C "$main_root" rev-parse --verify --quiet "$upstream_ref^{commit}" || true)"
+    { [ -n "$upstream_tip" ] && [ "$upstream_tip" != "$base" ]; } || return 0
+    if git -C "$main_root" merge-base --is-ancestor "$base" "$upstream_tip"; then
+        # Behind: hand out the current upstream tip, not the stale local one.
+        # Resolved to a SHA so branch creation picks up no tracking side
+        # effects.
+        echo "==> Base: ${base_label} is behind ${upstream_ref} — using ${upstream_ref} @ $(git rev-parse --short "$upstream_tip")"
+        base="$upstream_tip"
+        base_label="$upstream_ref"
+    elif git -C "$main_root" merge-base --is-ancestor "$upstream_tip" "$base"; then
+        # Ahead: local has everything the upstream has, plus unpushed work
+        # the caller presumably wants. Say so.
+        echo "==> Note: ${base_label} is ahead of ${upstream_ref}; basing on the local tip"
+    else
+        die "${base_label} has diverged from ${upstream_ref} — reconcile them, or pass --base <ref> to choose a start point explicitly"
+    fi
+}
 
 # Validated here, before anything is created, so a bad --base fails without a
 # rollback message about a tree that never existed.
@@ -375,8 +393,8 @@ if [ "$base_origin" != "explicit" ] && ! git show-ref --verify --quiet "refs/hea
         # filtered to the exact ref before it counts. A probe that cannot
         # answer fails CLOSED: "the remote is unreachable" is not evidence
         # the branch is new, and guessing here is the data-loss path.
-        probe_out="$(git ls-remote --heads "$remote_name" "refs/heads/$branch")" ||
-            die "could not query remote '$remote_name' for branch '$branch' — offline or unreachable; retry with network, or pass --base <ref> to skip the remote lookup"
+        probe_out="$(git_net ls-remote --heads "$remote_name" "refs/heads/$branch")" ||
+            die "could not query remote '$remote_name' for branch '$branch' — offline, unreachable, or needs interactive credentials; retry with network/auth, or pass --base <ref> to skip the remote lookup"
         probe_sha="$(printf '%s\n' "$probe_out" | awk -v ref="refs/heads/$branch" -F'\t' '$2 == ref {print $1; exit}')"
         if [ -n "$probe_sha" ]; then
             remote_matches="refs/remotes/$remote_name/$branch"
@@ -384,7 +402,7 @@ if [ "$base_origin" != "explicit" ] && ! git show-ref --verify --quiet "refs/hea
             remote_count=$((remote_count + 1))
         fi
     done <<EOF
-$(git remote)
+$(git -C "$main_root" remote)
 EOF
     if [ "$remote_count" -gt 1 ]; then
         die "branch '$branch' exists on more than one remote — pass --base <remote>/<branch> to choose one"
@@ -393,7 +411,7 @@ EOF
         # Refresh the tracking ref to the tip the probe just saw, so the
         # tracked checkout starts at the remote's current commit rather than
         # a stale local mirror of it.
-        git fetch --quiet "$remote_match_remote" \
+        git_net fetch --quiet "$remote_match_remote" \
             "+refs/heads/$branch:refs/remotes/$remote_match_remote/$branch" ||
             die "found branch '$branch' on remote '$remote_match_remote' but could not fetch it — retry, or pass --base <ref>"
         remote_ref="$remote_matches"
@@ -408,6 +426,11 @@ elif [ -n "$remote_ref" ]; then
     branch_created=1
     LEFTHOOK=0 git worktree add "$tree" --track -b "$branch" "${remote_ref#refs/remotes/}"
 else
+    # The one path that consumes the default base — verify its freshness
+    # here and nowhere earlier, so attaching an existing branch or tracking
+    # a remote-only one is never blocked by a stale or diverged main
+    # (harmon-init#813).
+    [ "$base_origin" = "explicit" ] || verify_default_base
     echo "==> Creating branch '$branch' from '$base'"
     branch_created=1
     LEFTHOOK=0 git worktree add "$tree" -b "$branch" "$base"


### PR DESCRIPTION
## What

Two stale-local-state defects in `worktree:new`, fixed with one fetch
plumbing (both issues' fixes land in byte-identical root/template twins):

- **#813** — the defaulted base was the main worktree's local HEAD, which
  goes stale because merges land on the forge and nothing pulls. When the
  captured HEAD branch's configured upstream resolves, the base is now
  verified against a freshly fetched upstream: behind uses the upstream tip
  (announced), ahead proceeds on the local tip (noted), diverged refuses
  with a `--base` remedy, unreachable warns loudly. Verification runs
  *only* on the new-branch-from-default-base path — attaching an existing
  branch or tracking a remote-only one is never blocked.
- **#840** — branch existence was read from local `refs/remotes/*`, so a
  branch pushed since the last fetch was silently recreated at the default
  base, diverging from the collaborator's work. Every configured remote is
  now probed live (`ls-remote`, exact-ref filtered); a unique match is
  fetched **through the repo's own refspec** (no synthesized destination —
  nothing of ours ever writes tracking refs) and attached at the probed
  commit with tracking written as plain branch config, correct under every
  refspec; multiple matches stay an explicit-choice error; an unqueryable
  remote fails closed with an offline/`--base` remedy.

All new network calls run through `git_net`: headless-safe
(`GIT_TERMINAL_PROMPT=0`, SSH BatchMode+ConnectTimeout appended to the
user's own command, `GIT_SSH` wrappers left in charge, `core.sshCommand`
honoured) and bounded on HTTP stalls; anchored to the main worktree's
config. Docs updated in both layers (upstream-verified base, live-remote
requirement, `--base` opt-out).

Closes #813
Closes #840

## Verification

Hermetic local-bare-remote regressions, all mutation-verified to fail
against the defect they pin: late-pushed branch detected and tracked at
the remote tip; stale tracking ref refreshed; unqueryable remote fails
closed with no debris; behind-upstream base hands out the upstream tip;
diverged base refused while an existing branch still attaches; fetch-race
loser reads the winner's ref (deterministic held-lock case); non-identity
refspec verified against the true source branch; custom-refspec
remote-only attach never clobbers foreign tracking refs and announces an
unmapped upstream. Suite green on macOS Bash 3.2 and 5.3 plus a Linux
container run of the pinned devcontainer image. Gates: `task check`,
`task verify` (after every round), challenge ×3, review ×3, `task ci` —
all green.

rigor: standard (default_rigor) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1

## Deferred findings

- [x] scripts/worktree-new.sh (git_net) — established-then-stalled connections on SSH/git://../remote-helper transports are not bounded (only HTTP has stall limits); the fleet's transport is HTTPS via gh, so this is an unprovisioned-host edge, documented in the git_net comment. Closing it would need a process watchdog whose own failure modes outweigh the residual — decline, or file follow-up hardening. (challenge r3, adjudicated P2) — declined: the fleet's transport is HTTPS via gh (bounded); the reasoning is recorded durably in the git_net comment, and a hand-rolled watchdog's failure modes (PID reuse, signal races, orphan supervision) outweigh the unprovisioned-host residual it would close
- [x] scripts/test-worktree.sh (tracked-attach cases) — no regression forces the UNCONDITIONAL post-fetch probe: a deterministic test needs the remote to advance between the first probe and the fetch, i.e. an interposition harness around ls-remote/fetch. The #839 concurrency work brings exactly that harness — add the case there. (review r3, adjudicated P2) — filed as #839 (acceptance criterion added: https://github.com/evanharmon1/harmon-init/issues/839#issuecomment-5306164483)

## Adjudication record

<details>
<summary>Per-branch ledger (challenge ×3, review ×3)</summary>

```text
challenge r1 | three P1, one P2 (one sub-finding deferred as P2)
worktree-new.sh:~146 | upstream fetch source derived by splitting @{u} name, wrong under non-identity refspecs | fixed: source from branch.<head>.merge | challenge r1
worktree-new.sh (probe fetch dest) | identity-dest assumption under custom refspecs | deferred P2 (later superseded by r3/rev-r1 fixes) | challenge r1
worktree-new.sh:~166 | base staleness check blocked existing-branch attach | fixed: verify only on the new-branch-from-default-base arm + regression | challenge r1
worktree-new.sh:~378 | network calls can prompt/hang headless | fixed: git_net (prompt off, HTTP bounds, -C main_root); empirically fast-fails | challenge r1
worktree-new.sh:~396 | probes not anchored to main worktree | fixed: git_net carries -C main_root | challenge r1
challenge r2 | three P1, two P2 — all on r1's fixes; provenance: all adjudicated IN SCOPE
git_net | SSH transport unbounded/interactive | fixed: BatchMode+ConnectTimeout appended to user's ssh command | challenge r2
verify | HEAD re-read at verify time vs base captured earlier (TOCTOU) | fixed: branch captured with base, never re-read | challenge r2
verify | fetch-failure early return bases race loser on stale snapshot | fixed: compare after fetch attempt, warning retained | challenge r2
verify | refs/remotes/ prefix guess on abbreviated upstream | fixed: --symbolic-full-name dest | challenge r2
tests | no non-identity refspec regression | fixed: niup fixture, mutation-verified | challenge r2
challenge r3 | three reviewer-P1, all adjudicated P2 with empirical evidence
track arm | --track DWIM hard-fails under non-identity refspec (reproduced; debris claim did NOT reproduce) | fixed: create from SHA + direct branch config | challenge r3
base capture | two-command TOCTOU sliver | fixed: branch first, SHA from refs/heads/<captured> | challenge r3
git_net | established-stall on non-HTTP transports | declined: fleet transport is HTTPS; watchdog scaffolding outweighs residual; documented | challenge r3
challenge EXIT | capped-clean at 3
review r1 | one P1, three P2 — all confirmed, all fixed
probe fetch | forced identity dest can clobber a tracking ref a custom refspec maps from another branch | fixed: destination-free fetch + probed-SHA attach; no-clobber regression, mutation-verified | review r1
tests | fetch-loser path untested | fixed: deterministic held-lock case, mutation-verified | review r1
docs | promised HEAD-of-main, omitted live-remote requirement | fixed: both layers | review r1
review r2 | one reviewer-P1 adjudicated P2 (fixed), one P2 (fixed)
post-fetch | locally-resolvable stale tip suppressed the re-probe | fixed: one unconditional post-fetch probe; window inherent, kept one probe wide | review r2
track arm | @{upstream} unresolvable under refspec-excluding config while claiming tracking | fixed: detected + announced + asserted | review r2
review r3 | zero adjudicated P0/P1 at cap; GIT_SSH preservation fixed, docs qualified, probe-interposition regression deferred
review EXIT | capped-clean at 3
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

