### PR TITLE
feat: push each adjudicated challenge/review round to the branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,7 +358,14 @@ allowed.
   `pull_request` and pushes to `main` only, Codex cloud review is
   comment-triggered with Automatic reviews disabled, and a bare `task
   challenge`/`task review` covers branch commits *and* working tree alike, so
-  commit boundaries never change what a round reviews. What it buys is that a
+  commit boundaries never change what a round reviews. Nor does it outrun the
+  gate that matters: lefthook's `pre-push` runs `task security:secrets`, so
+  gitleaks clears every round's commit before it leaves the machine, and the
+  rest of the security suite still runs at `task ci` before the PR exists.
+  **Push to the branch's own writable remote** — the one `gh pr create` will
+  push to, which in a fork checkout is the fork rather than `origin` — and set
+  it on the first push (`git push -u <remote> <branch>`), since a new branch
+  has no upstream to infer. What it buys is that a
   lost environment costs one round instead of a whole converged stage, and
   that a push-permission gap surfaces at round 1 rather than at
   `gh pr create` — both observed failures. It does **not** carry the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,7 +351,8 @@ allowed.
   "Between rounds, check what the findings are about" below is how you catch
   the loop feeding on itself before the cap does, and round 2 is where that
   check is owed rather than optional.
-  **Each adjudicated round ends in one conventional commit, pushed.** Per
+  **Each adjudicated round, before the draft PR exists, ends in one
+  conventional commit, pushed.** Per
   *round*, not per finding: five fixes are one commit, and a round adjudicated
   clean with nothing to fix commits and pushes nothing. Before the draft PR
   exists this costs essentially nothing — `build.yml` triggers on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,15 +366,17 @@ allowed.
   yourself first. The rest of the security suite still runs at `task ci`
   before the PR exists.
   **Push to the branch's own writable remote** — the one `gh pr create` will
-  push to, which in a fork checkout is the fork rather than `origin` — and set
-  it on the first push (`git push -u <remote> <branch>`), since a new branch
-  has no upstream to infer. What it buys is that a
-  lost environment costs one round instead of a whole converged stage, and
+  push to — and set it on the first push (`git push -u <remote> <branch>`),
+  since a new branch has no upstream to infer. What it buys is that a
+  lost environment costs at most the current round's *code* rather than every
+  round's, and
   that a push-permission gap surfaces at round 1 rather than at
-  `gh pr create` — both observed failures. It does **not** carry the
+  `gh pr create` — both observed failures. It buys nothing beyond the code: it
+  does **not** carry the
   deferred-findings sidecar or the adjudication ledger, which live in the git
-  directory and are never pushed; those stay single-copy until the PR body
-  takes them, so the exit precondition above is not discharged by having
+  directory and are never pushed, so a resumed session recovers the commits and
+  still re-runs the stage. Those stay single-copy until the PR body
+  takes them, and the exit precondition above is not discharged by having
   pushed. After the draft PR exists the granularity changes: pushes batch per
   shepherd round, because each one spends a CI matrix run and starts a fresh
   current-head Codex cycle. Amending or otherwise rewriting anything already

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,10 +358,13 @@ allowed.
   `pull_request` and pushes to `main` only, Codex cloud review is
   comment-triggered with Automatic reviews disabled, and a bare `task
   challenge`/`task review` covers branch commits *and* working tree alike, so
-  commit boundaries never change what a round reviews. Nor does it outrun the
-  gate that matters: lefthook's `pre-push` runs `task security:secrets`, so
-  gitleaks clears every round's commit before it leaves the machine, and the
-  rest of the security suite still runs at `task ci` before the PR exists.
+  commit boundaries never change what a round reviews. It must not outrun
+  secret scanning, though, and that is an obligation rather than a claim about
+  the setup: **every round's commit is secret-scanned before it is pushed.**
+  Where the `pre-push` hook is installed it is automatic (this repo installs
+  it via `task install:hooks`); where it is not, run `task security:secrets`
+  yourself first. The rest of the security suite still runs at `task ci`
+  before the PR exists.
   **Push to the branch's own writable remote** — the one `gh pr create` will
   push to, which in a fork checkout is the fork rather than `origin` — and set
   it on the first push (`git push -u <remote> <branch>`), since a new branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,9 +351,27 @@ allowed.
   "Between rounds, check what the findings are about" below is how you catch
   the loop feeding on itself before the cap does, and round 2 is where that
   check is owed rather than optional.
+  **Each adjudicated round ends in one conventional commit, pushed.** Per
+  *round*, not per finding: five fixes are one commit, and a round adjudicated
+  clean with nothing to fix commits and pushes nothing. Before the draft PR
+  exists this costs essentially nothing — `build.yml` triggers on
+  `pull_request` and pushes to `main` only, Codex cloud review is
+  comment-triggered with Automatic reviews disabled, and a bare `task
+  challenge`/`task review` covers branch commits *and* working tree alike, so
+  commit boundaries never change what a round reviews. What it buys is that a
+  lost environment costs one round instead of a whole converged stage, and
+  that a push-permission gap surfaces at round 1 rather than at
+  `gh pr create` — both observed failures. It does **not** carry the
+  deferred-findings sidecar or the adjudication ledger, which live in the git
+  directory and are never pushed; those stay single-copy until the PR body
+  takes them, so the exit precondition above is not discharged by having
+  pushed. After the draft PR exists the granularity changes: pushes batch per
+  shepherd round, because each one spends a CI matrix run and starts a fresh
+  current-head Codex cycle. Amending or otherwise rewriting anything already
+  pushed stays forbidden at every stage.
 - **`task review`** — verification-checkpoint review, run out of the same
   procedure — the skill where its topology holds, the fallback otherwise;
-  same adjudication, the
+  same adjudication, the same per-round commit-and-push, the
   same exit condition counted over its own
   rounds, the same self-referential shape and so the
   same reason for a cap, under
@@ -361,7 +379,8 @@ allowed.
   capped separately, even where the tier gives them equal numbers: a converged
   challenge says nothing about review.
 - **`task ci`** — the full CI mirror; fix anything it catches.
-- **Open the draft PR** — conventional commit, push the branch,
+- **Open the draft PR** — conventional commit, push whatever the rounds above
+  have not already pushed,
   **`gh pr create --draft`** with a clear what/why/verification summary (mind
   the `template/` → `fix:`/`feat:` title rule below). Then fetch
   `headRefOid,isDraft` and require both the SHA you pushed and

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -151,10 +151,15 @@ Two things not to change when backgrounding:
   mid-loop is risky — an uncommitted fix under `--uncommitted` narrows the
   re-run to just that fix, and the clean pass then attests to the fix rather
   than to the whole change. Bare `task challenge` covers both halves, so it is
-  the right thing to re-run. Committing each round's fixes first is still
-  tidier (it keeps the committed half authoritative and shrinks what Codex has
-  to reconcile), but the loop's exit condition no longer depends on your
-  remembering to.
+  the right thing to re-run — and it is why commit boundaries never change what
+  a round sees.
+
+  Commit anyway, and push: each adjudicated round ends in one conventional
+  commit pushed to the branch, which the Dev Loop makes the rule rather than a
+  tidiness preference. It also keeps the committed half authoritative and
+  shrinks what Codex has to reconcile. What it does not do is decide the exit
+  condition — that is still the adjudicated rounds, whatever the tree looked
+  like when each one ran.
 - **The runner.** Background `task challenge` itself, not
   `/codex:adversarial-review --background`: the slash command calls Codex
   directly, so it never receives the P0/P1/P2 scale that

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -249,13 +249,17 @@ tier allowed.
   clean with nothing to fix commits and pushes nothing. Before the draft PR
   exists this costs essentially nothing — the generated `build.yml` triggers
   on `pull_request` and pushes to the default branch only (re-check your own
-  triggers if you have changed them), Codex cloud review is comment-triggered,
+  triggers if you have changed them),[% if use_codex_cloud_review %] Codex
+  cloud review is comment-triggered,[% endif %]
   and a bare `task challenge`/`task review` covers branch commits *and*
   working tree alike, so commit boundaries never change what a round reviews.
-  Nor does it outrun the gate that matters: lefthook's `pre-push` runs
-  `task security:secrets`, so gitleaks clears every round's commit before it
-  leaves the machine, and the rest of the security suite still runs at
-  `task ci` before the PR exists. **Push to the branch's own writable
+  It must not outrun secret scanning, though, and that is an obligation rather
+  than a claim about your setup: **every round's commit is secret-scanned
+  before it is pushed.** Where the `pre-push` hook is installed it is
+  automatic; where it is not — `run_task_install` defaults to no, so a repo
+  that has not run `task install:hooks` has no hooks at all — run
+  `task security:secrets` yourself first. The rest of the security suite still
+  runs at `task ci` before the PR exists. **Push to the branch's own writable
   remote** — the one `gh pr create` will push to, which in a fork checkout is
   the fork rather than `origin` — and set it on the first push
   (`git push -u <remote> <branch>`), since a new branch has no upstream to

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -260,15 +260,16 @@ tier allowed.
   that has not run `task install:hooks` has no hooks at all — run
   `task security:secrets` yourself first. The rest of the security suite still
   runs at `task ci` before the PR exists. **Push to the branch's own writable
-  remote** — the one `gh pr create` will push to, which in a fork checkout is
-  the fork rather than `origin` — and set it on the first push
-  (`git push -u <remote> <branch>`), since a new branch has no upstream to
-  infer.
-  What it buys is that a lost environment costs one round instead of a whole
-  converged stage, and that a push-permission gap surfaces at round 1 rather
-  than at `gh pr create`. It does **not** carry the deferred-findings sidecar
+  remote** — the one `gh pr create` will push to — and set it on the first
+  push (`git push -u <remote> <branch>`), since a new branch has no upstream
+  to infer.
+  What it buys is that a lost environment costs at most the current round's
+  *code* rather than every round's, and that a push-permission gap surfaces at
+  round 1 rather than at `gh pr create`. It buys nothing beyond the code: it
+  does **not** carry the deferred-findings sidecar
   or the adjudication ledger, which live in the git directory and are never
-  pushed; those stay single-copy until the PR body takes them, so the exit
+  pushed, so a resumed session recovers the commits and still re-runs the
+  stage. Those stay single-copy until the PR body takes them, and the exit
   precondition above is not discharged by having pushed. After the draft PR
   exists the granularity changes: pushes batch per shepherd round, because
   each one spends a CI run and starts a fresh current-head Codex cycle.

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -252,6 +252,14 @@ tier allowed.
   triggers if you have changed them), Codex cloud review is comment-triggered,
   and a bare `task challenge`/`task review` covers branch commits *and*
   working tree alike, so commit boundaries never change what a round reviews.
+  Nor does it outrun the gate that matters: lefthook's `pre-push` runs
+  `task security:secrets`, so gitleaks clears every round's commit before it
+  leaves the machine, and the rest of the security suite still runs at
+  `task ci` before the PR exists. **Push to the branch's own writable
+  remote** — the one `gh pr create` will push to, which in a fork checkout is
+  the fork rather than `origin` — and set it on the first push
+  (`git push -u <remote> <branch>`), since a new branch has no upstream to
+  infer.
   What it buys is that a lost environment costs one round instead of a whole
   converged stage, and that a push-permission gap surfaces at round 1 rather
   than at `gh pr create`. It does **not** carry the deferred-findings sidecar

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -244,7 +244,8 @@ tier allowed.
   "Between rounds, check what the findings are about" below is how you catch
   the loop feeding on itself before the cap does, and round 2 is where that
   check is owed rather than optional.
-  **Each adjudicated round ends in one conventional commit, pushed.** Per
+  **Each adjudicated round, before the draft PR exists, ends in one
+  conventional commit, pushed.** Per
   *round*, not per finding: five fixes are one commit, and a round adjudicated
   clean with nothing to fix commits and pushes nothing. Before the draft PR
   exists this costs essentially nothing — the generated `build.yml` triggers

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -273,7 +273,8 @@ tier allowed.
   stage. Those stay single-copy until the PR body takes them, and the exit
   precondition above is not discharged by having pushed. After the draft PR
   exists the granularity changes: pushes batch per shepherd round, because
-  each one spends a CI run and starts a fresh current-head Codex cycle.
+  each one spends a CI run[% if use_codex_cloud_review %] and starts a fresh
+  current-head Codex cycle[% endif %].
   Amending or otherwise rewriting anything already pushed stays forbidden at
   every stage.
 - **`task review`** — verification-checkpoint review, run out of the same

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -244,8 +244,26 @@ tier allowed.
   "Between rounds, check what the findings are about" below is how you catch
   the loop feeding on itself before the cap does, and round 2 is where that
   check is owed rather than optional.
+  **Each adjudicated round ends in one conventional commit, pushed.** Per
+  *round*, not per finding: five fixes are one commit, and a round adjudicated
+  clean with nothing to fix commits and pushes nothing. Before the draft PR
+  exists this costs essentially nothing — the generated `build.yml` triggers
+  on `pull_request` and pushes to the default branch only (re-check your own
+  triggers if you have changed them), Codex cloud review is comment-triggered,
+  and a bare `task challenge`/`task review` covers branch commits *and*
+  working tree alike, so commit boundaries never change what a round reviews.
+  What it buys is that a lost environment costs one round instead of a whole
+  converged stage, and that a push-permission gap surfaces at round 1 rather
+  than at `gh pr create`. It does **not** carry the deferred-findings sidecar
+  or the adjudication ledger, which live in the git directory and are never
+  pushed; those stay single-copy until the PR body takes them, so the exit
+  precondition above is not discharged by having pushed. After the draft PR
+  exists the granularity changes: pushes batch per shepherd round, because
+  each one spends a CI run and starts a fresh current-head Codex cycle.
+  Amending or otherwise rewriting anything already pushed stays forbidden at
+  every stage.
 - **`task review`** — verification-checkpoint review, run out of the same
-  procedure; same adjudication, the
+  procedure; same adjudication, the same per-round commit-and-push, the
   same exit condition counted over its own
   rounds, the same self-referential shape and so the
   same reason for a cap, under
@@ -254,7 +272,8 @@ tier allowed.
   challenge says nothing about review.
 [% endif %]
 - **`task ci`** — the full CI mirror; fix anything it catches.
-- **Open the draft PR** — conventional commit, push the branch,
+- **Open the draft PR** — conventional commit, push [% if use_codex_review %]whatever the rounds above
+  have not already pushed[% else %]the branch[% endif %],
   **`gh pr create --draft`** with a clear what/why/verification summary. Then
   fetch `headRefOid,isDraft` and require both the SHA you pushed and
   `isDraft == true`: a non-draft result is not the normal publication path, so

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -151,10 +151,15 @@ Two things not to change when backgrounding:
   mid-loop is risky — an uncommitted fix under `--uncommitted` narrows the
   re-run to just that fix, and the clean pass then attests to the fix rather
   than to the whole change. Bare `task challenge` covers both halves, so it is
-  the right thing to re-run. Committing each round's fixes first is still
-  tidier (it keeps the committed half authoritative and shrinks what Codex has
-  to reconcile), but the loop's exit condition no longer depends on your
-  remembering to.
+  the right thing to re-run — and it is why commit boundaries never change what
+  a round sees.
+
+  Commit anyway, and push: each adjudicated round ends in one conventional
+  commit pushed to the branch, which the Dev Loop makes the rule rather than a
+  tidiness preference. It also keeps the committed half authoritative and
+  shrinks what Codex has to reconcile. What it does not do is decide the exit
+  condition — that is still the adjudicated rounds, whatever the tree looked
+  like when each one ran.
 - **The runner.** Background `task challenge` itself, not
   `/codex:adversarial-review --background`: the slash command calls Codex
   directly, so it never receives the P0/P1/P2 scale that


### PR DESCRIPTION
## What

The Dev Loop's challenge and review stages already commit each adjudicated
round's fixes. They now **push** that commit too, before the draft PR exists.
Per *round*, not per finding: five fixes are one commit, and a round
adjudicated clean with nothing to fix commits and pushes nothing.

Three layers change in lockstep:

- `AGENTS.md` — the normative rule, in the challenge bullet, referenced from
  the review bullet.
- `template/AGENTS.md.jinja` — the twin, with the Codex-specific clauses gated
  on the answers that actually enable them.
- `docs/guides/codex-review.md` and its verbatim template twin — the fallback
  procedure for repos with no gauntlet skill vendored, and for fork checkouts
  where the skill's entry gate stops by design. It still taught the
  optional-commit rule this PR replaces.

## Why

Everything before `gh pr create --draft` lived on exactly one machine. Two
observed failures, both recorded on #874:

- A devcontainer codespace crashed mid-loop and lost work in progress.
- On 2026-08-15 (#851's session), the first push attempt happened only at
  PR-creation time — after challenge and review had both fully converged — and
  failed on a push-permission gap nobody knew about. A per-round push surfaces
  that at round 1.

Costs are near zero before the draft exists: `build.yml` triggers on
`pull_request` and pushes to `main` only, Codex cloud review is
comment-triggered with Automatic reviews disabled, and a bare `task
challenge`/`task review` covers branch commits *and* working tree, so commit
boundaries never change what a round reviews.

**What the rule deliberately does not claim.** The push carries code and
nothing else. The deferred-findings sidecar and the adjudication ledger live in
the git directory and are never pushed, so a resumed session recovers the
commits and still re-runs the stage. Saying so is an acceptance criterion on
the issue, not an aside — the motivating incident was about losing adjudication
work, and a rule that reads as protecting it would be worse than no rule.

## Scope

This is the **policy** half. The gauntlet skill's procedure half — its
round-loop step, damper 9's revert semantics on published history, and a
push-capability probe at its entry gate — is
[evanharmon1/harmon-devkit#478](https://github.com/evanharmon1/harmon-devkit/issues/478).

The split is not a compromise. `use_codex_review` does not imply
`use_skills_sync`: a generated repo can run these stages with no gauntlet skill
vendored at all, and there `AGENTS.md` is the only source. `AGENTS.md` also
wins on conflict with a vendored skill, which lags on harmon-devkit's release
cadence.

Closes #874

## Verification

- `task verify` — green (run after every round).
- `task ci` — green, the full mirror: lint, the render matrix, skills drift,
  the devcontainer permission assert, gitleaks, Semgrep.
- `task test:dogfood-parity` — 127 verbatim twins identical. The
  `codex-review.md` pair is byte-gated, not structure-gated, so both layers had
  to match exactly.
- `PR_TITLE=… BASE_SHA=main task guard:release-title` — passes; `feat:` is a
  releasing type, required because this touches `template/`.
- The issue's own `Verify` block: both layers' challenge bullets now mention
  the push.

**This PR dogfoods the rule it adds.** All five commits below are one
adjudicated round each, pushed as the round closed.

## Gauntlet

**Rigor `standard`** (`default_rigor`, no `rigor:*` label) → challenge ≤3,
review ≤3, shepherd 4, `min_rounds` 1. Challenge's cap was raised to 4 by
@evanharmon1's explicit instruction after it escalated — an attributable human
decision, which outranks the file. No cap was below default.

**Challenge: 4 rounds, capped-clean exit.** Round 3 hit the cap of 3 with an
adjudicated P1 and escalated, as policy requires; @evanharmon1 authorized a
fourth, which adjudicated clean.

**Review: 2 rounds, exited at 2 of 3** — two consecutive adjudicated-clean
rounds, and round 2 returned no findings at all.

7 findings: 0 P0, 1 P1, 6 P2.

<details>
<summary><strong>Adjudication record</strong></summary>

| Round | Finding | Reviewer P | Adjudicated P | Action |
|---|---|---|---|---|
| challenge r1 | Publishes before the security gate | P1 | P2 | Overstated — `pre-push` runs `task security:secrets` in both layers. Clause added. |
| challenge r1 | Writable remote unnamed | P1 | P2 | Confirmed. Named the remote, required `-u` on first push. |
| challenge r2 | The pre-push gate may not exist — `run_task_install` defaults `no` | P1 | **P1** | Confirmed, and it was r1's own scaffolding. **Restructured to the invariant**: states the obligation, names the hook as one implementation. |
| challenge r2 | Cloud-review claim ungated | P2 | P2 | Confirmed. Gated on `use_codex_cloud_review`. |
| challenge r3 | "the fork rather than `origin`" contradicts this file's own fork topology | P1 | **P1** | Confirmed, r1's scaffolding again. **Deleted** — the surviving wording is correct under both conventions. |
| challenge r3 | "costs one round" overclaims recovery | P1 | P2 | Narrowed to the round's *code*; the limitation now stated outright. |
| challenge r4 | Round pushes could update an existing PR | P1 | P2 | Paragraph already scoped the cadence; the opening sentence now carries its own scope. Entry-gate half scope-split → harmon-devkit#478. |
| review r1 | Fallback guide still teaches the optional-commit rule | P2 | P2 | Confirmed — a missed surface. Fixed in both layers. |
| review r1 | Post-PR cloud-cycle rationale ungated | P2 | P2 | Confirmed. Gated on `use_codex_cloud_review`. |
| review r2 | — | — | — | No findings. |

**The convergence story is the interesting part.** One clause added in
challenge round 1 generated a P1 in round 2 and a *different* P1 in round 3.
Both were real; both were about scaffolding rather than the change. Round 2's
remedy was to restructure to an invariant, round 3's was to delete — and round
4 was the first round since round 1 to find anything about the actual rule,
which is what convergence looks like. Hardening those clauses a third time
would have spent the cap on prose that only existed because an earlier round
asked for it.

</details>

## Deferred findings

- [x] `.claude/skills/gauntlet/SKILL.md` §1 (entry gate) — the gate does not
      check whether the branch already has an open PR, so a re-entered stage's
      per-round push can update one mid-stage. Harmless on a draft (the draft
      is the workbench); on an already-promoted non-draft PR the push moves the
      head and breaks the invariant that non-draft means the automated
      lifecycle is complete. The skill's ownership re-check exists only at the
      PR-open step (`SKILL.md:546-551`) — the right end for creating a PR, the
      wrong end for pushing into one. Adjudicated P2 here because AGENTS.md
      already scopes per-round pushing to before the PR exists; the missing
      check is skill procedure. Filed upstream as
      [harmon-devkit#478 (comment)](https://github.com/evanharmon1/harmon-devkit/issues/478#issuecomment-5306013733).
      **Settled: filed as harmon-devkit#478.** It is that skill's entry gate,
      not this repo's policy prose, and harmon-init vendors the skill from a
      pinned harmon-devkit tag — so the fix cannot land here without shipping
      drift the next skills sync would revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

