### PR TITLE
feat: ADR 0006 (method/tier axes) and rename rigor tiers to levels

### DIFF
--- a/.devflow.toml
+++ b/.devflow.toml
@@ -34,15 +34,15 @@
 #
 # Retuning these is expected. The Dev Loop assumes five invariants, and nothing
 # at runtime will tell you if an edit breaks one:
-#   - every tier defines challenge, review, shepherd and min_rounds, all
+#   - every level defines challenge, review, shepherd and min_rounds, all
 #     integers
 #   - challenge and review are >= 2, because the exit condition needs two
 #     consecutive adjudicated-clean rounds; at 1, one finding is an escalation
 #   - min_rounds is 1 or 2, never more: two consecutive adjudicated-clean
 #     rounds — empty rounds included — exit a stage at round 2 whatever the
 #     floor says, so a value above 2 is a budget no stage ever spends
-#   - shepherd is the same in every tier (see below)
-#   - default_rigor names a tier that exists here
+#   - shepherd is the same in every level (see below)
+#   - default_rigor names a level that exists here
 #
 # `challenge` and `review` are inert wherever no second-model reviewer is
 # configured: those stages never run, so their caps bound nothing. `shepherd`
@@ -50,7 +50,7 @@
 
 default_rigor = "standard"
 
-# `shepherd` is deliberately identical in every tier, and is not a knob to
+# `shepherd` is deliberately identical in every level, and is not a knob to
 # turn down.
 #
 # `challenge` and `review` bound work the agent generates itself — each round's
@@ -58,7 +58,7 @@ default_rigor = "standard"
 # low safe. `shepherd` bounds *other people's* findings: CI failures, human
 # review, Codex. Lowering it does not reduce effort spent; it abandons reviews
 # that are already unanswered, and the readiness gate then refuses to promote
-# the PR anyway. The key is present so that a tier is one consistent shape.
+# the PR anyway. The key is present so that a level is one consistent shape.
 
 # Trivial, low-blast-radius work: doc touch-ups, mechanical bumps, typo fixes.
 [rigor.light]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,33 +245,33 @@ non-draft PR must always mean the automated work is done.
 
 **Round caps are resolved, not stated here.** The challenge, review, and
 shepherd stages below are each capped, but this file names no numbers: they
-live in [`.devflow.toml`](.devflow.toml) as `rigor` tiers, so there is one
+live in [`.devflow.toml`](.devflow.toml) as `rigor` levels, so there is one
 place to change them and a parity gate that catches a change made on only one
 side. Resolve in this order — an explicit instruction in this session, then a
 `rigor:*` label on the issue, then `default_rigor`, then a built-in 4 / 4 / 4
-if the file is absent — with a `min_rounds` floor of 1 for any tier that
+if the file is absent — with a `min_rounds` floor of 1 for any level that
 does not define it — the absent-file case, a legacy config predating the key,
-and a partially migrated one where only some tiers state it alike — which is
-also the floor every shipped tier states explicitly. When the change under review **edits `.devflow.toml`
+and a partially migrated one where only some levels state it alike — which is
+also the floor every shipped level states explicitly. When the change under review **edits `.devflow.toml`
 itself**, resolve its caps **and floor** from the **merge-base** copy rather
 than the branch copy: otherwise a branch can lower the very gate it is
 changing — the floor included, since a self-lowered `min_rounds` buys an
 earlier empty-round exit — dropping every
-tier and `default_rigor` together passes the validator and evades the
+level and `default_rigor` together passes the validator and evades the
 below-default disclosure, because nothing is left to be below. An explicit
 instruction from Evan still overrides, since that is an attributable human
 decision rather than the branch deciding for itself. GitHub labels are
 multi-select and nothing stops an
 issue carrying two, so resolution is **per stage, taking the highest cap
 present**: a conflict can then only ever buy more review, never less, and no
-ranking of the tier names has to be agreed on anywhere. `min_rounds` resolves
+ranking of the level names has to be agreed on anywhere. `min_rounds` resolves
 under the same principle — the highest floor present wins — so a label
 conflict cannot quietly select the lower floor either. Because that is per
-stage, two retuned tiers can yield caps belonging to no single tier — so what
-you announce is the **caps**, naming a tier only when one supplied all of
+stage, two retuned levels can yield caps belonging to no single level — so what
+you announce is the **caps**, naming a level only when one supplied all of
 them — the floor included,
-and the disclosure below compares caps rather than tier names. A `rigor:` value
-that names no tier in the file is ignored rather than guessed at. Treat the
+and the disclosure below compares caps rather than level names. A `rigor:` value
+that names no level in the file is ignored rather than guessed at. Treat the
 label as advisory: it is applied by people and verified by nothing, and
 GitHub's **triage** role can label an issue with no push access at all — so a
 budget can be retuned by someone who could not edit `.devflow.toml`. An agent
@@ -279,16 +279,16 @@ never applies one to itself, and **says so in the announcement and in the PR
 body whenever any resolved cap or floor is below what `default_rigor` would give**, so a
 reduced budget is visible to the human reviewer instead of silent.
 **Announce the resolved caps on entering
-the loop** — "rigor: `<tier>` (`<source>`) → challenge ≤`<n>`, review ≤`<n>`,
+the loop** — "rigor: `<level>` (`<source>`) → challenge ≤`<n>`, review ≤`<n>`,
 shepherd `<n>`, min_rounds `<n>`", filled in by reading the file rather than
 from memory — and
 carry it into the PR body, so a later round or a different session can see
 which budget it is spending instead of inferring one. Everything else about
-these stages is policy rather than a parameter and does not vary by tier: the
+these stages is policy rather than a parameter and does not vary by level: the
 exit condition,
 the round-2 scaffolding checkpoint, the escalation rule, and the deferred-P2
 sidecar all hold identically at every rigor. A cap is a ceiling, never a quota
-— a stage that meets its exit condition on round 1 is done, whatever the tier
+— a stage that meets its exit condition on round 1 is done, whatever the level
 allowed.
 
 - **Branch** — feature branch off `main`; never commit directly to `main`. For
@@ -328,7 +328,7 @@ allowed.
   extra clean run to buy. A round that returns **no findings at all** ends
   the stage on its own **once at least `min_rounds` rounds have run** — an
   empty round is the old rule's clean re-run, so neither a trivial change nor
-  a clean post-fix re-run pays for a confirmation pass, but a tier that sets a
+  a clean post-fix re-run pays for a confirmation pass, but a level that sets a
   floor buys the rounds it asked for before that shortcut opens. The other two
   exits satisfy any floor of 2 or less by construction — two consecutive clean
   rounds *are* two rounds, and a capped final round is at least the cap, which
@@ -389,7 +389,7 @@ allowed.
   rounds, the same self-referential shape and so the
   same reason for a cap, under
   its own resolved **review cap**. The two stages are counted separately — and
-  capped separately, even where the tier gives them equal numbers: a converged
+  capped separately, even where the level gives them equal numbers: a converged
   challenge says nothing about review.
 - **`task ci`** — the full CI mirror; fix anything it catches.
 - **Open the draft PR** — conventional commit, push whatever the rounds above
@@ -521,7 +521,7 @@ allowed.
   review cap means wait for Evan, not open the PR anyway.
   If checks still fail or findings remain at the shepherd cap, stop and
   summarize what's unresolved on the PR for Evan. That cap does not vary by
-  rigor tier — it bounds other people's findings, not your own work, so
+  rigor level — it bounds other people's findings, not your own work, so
   lowering it would abandon unanswered reviews rather than save effort.
   Where a **vendored** skill (`/shepherd`)
   states a different cap or exit condition, **this file wins** — the skills
@@ -798,11 +798,11 @@ all-P2 as labeled, or P1-labeled and adjudicated down to P2; what counts is
 the **adjudicated** column of the table, not the reviewer's label, and the
 second such round is itself the confirmation, so no further run is owed. Two
 exits are faster still. A round with **no findings at all** ends the stage by
-itself **once the stage has run at least `min_rounds` rounds** (the per-tier
+itself **once the stage has run at least `min_rounds` rounds** (the per-level
 floor in `.devflow.toml`; 1 if the file is absent) — an empty round is exactly
 the old rule's clean re-run, so neither a trivial change nor a clean post-fix
 re-run pays for a confirmation pass, and the floor only stops that shortcut
-being taken before the tier's minimum work has happened. Say plainly what
+being taken before the level's minimum work has happened. Say plainly what
 follows: the other two exits satisfy any floor of 2 or less **by
 construction** — the two-consecutive exit runs two rounds by definition, and
 the capped-clean exit runs the cap, which is never below 2 — so `min_rounds`

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -393,7 +393,7 @@ tasks:
       - ./scripts/test-ci-results.sh
 
   test:devflow-config:
-    desc: Validate the Dev Loop round-cap tiers in .devflow.toml (both copies)
+    desc: Validate the Dev Loop round-cap levels in .devflow.toml (both copies)
     cmds:
       - ./scripts/test-devflow-config.sh
 

--- a/docs/decisions/0005-unified-agent-vocabulary.md
+++ b/docs/decisions/0005-unified-agent-vocabulary.md
@@ -53,6 +53,12 @@ The following decisions are adopted together:
    `suggest:<family>[:<model>]` and `claim:<family>[:<model>]`. Suggestions are
    human-authored advice; claims are live, agent-authored ownership and are
    released at wrap or shepherd completion. Neither arms automation.
+   **Amended 2026-08-16 ([ADR 0006](0006-method-and-tier-axes.md)):**
+   suggestions are now human- **or agent-**authored; `suggest:*` stays
+   `family[:model]` (a vendor preference), `tier:*` is the human-decided policy
+   layer of the model axis, and `suggest:tier:<value>` is reserved, not built.
+   The claim record gains `harness:`/`model:`/`session:` fields
+   (harmon-devkit#450).
 7. **D7 — Foreman selectors name harness adapters.** `foreman:<adapter>` selects
    executable machinery. The registry maps that adapter to a harness and states
    who selects the model. The family and harness axes are intentionally distinct.

--- a/docs/decisions/0006-method-and-tier-axes.md
+++ b/docs/decisions/0006-method-and-tier-axes.md
@@ -160,7 +160,9 @@ amendment.
   confirmation, fail-open/closed) stated as invariants rather than left to each
   implementer's judgement.
 - The `tier`/`method` distinction from rigor is now unambiguous: rigor has
-  **levels**, the model axis has **tiers**. Prose everywhere follows suit.
+  **levels**, the model axis has **tiers**. This repo's own docs and config
+  follow suit; the vendored skills suite renames at its source
+  (harmon-devkit#498).
 - Nothing in a generated repo gains a runtime dependency: the tables are inert,
   and enforcement of the trust invariants rides foreman#139's rails.
 - The capability-monotonicity check and the timeline algorithm are named,

--- a/docs/decisions/0006-method-and-tier-axes.md
+++ b/docs/decisions/0006-method-and-tier-axes.md
@@ -1,0 +1,171 @@
+# 6. Method and tier strategy axes
+
+Date: 2026-08-16
+
+## Status
+
+Accepted
+
+Amends [ADR 0005](0005-unified-agent-vocabulary.md) D6 (see Decision § D6
+amendment). Authoritative requirements live in
+[`specs/issue-strategy.md`](../../specs/issue-strategy.md); on any conflict the
+spec wins. Planned under evanharmon1/harmon-init#855 (milestone "Issue strategy
+overhaul").
+
+## Context
+
+Two strategy axes are decided in the spec but, until now, unrecorded and
+unenforced: **tier** (which model stratum works an issue) and **method** (which
+execution topology). The `tier:*` and `method:*` labels were seeded and are
+provisioned from the manifest, but nothing behind them said how a consumer
+resolves a label to a concrete model or workflow, how the two axes handle
+conflicts, or — the load-bearing part — how an *unattended* consumer may trust a
+label at all. This ADR records those semantics; the config that parameterizes
+them lands in `.devflow.toml` under the same harmon-init#855.
+
+A naming collision is resolved here too: `.devflow.toml`'s Dev Loop round-cap
+values (`light`/`standard`/`deep`) were called "tiers", colliding with the model
+axis. From here they are **rigor levels**; "tier" belongs to the model axis
+alone.
+
+## Decision
+
+### D1 — Two advisory axes, resolved by config, armed by nothing here
+
+`tier:*` and `method:*` are **advisory classification**. A generated repo
+invokes no model and runs no workflow because a label or a config table exists;
+the tables are **inert routing preferences, never dependencies**. An acting
+consumer may select only among vendors and harnesses the operator has already
+configured and authenticated — the shipped defaults create no account, trial, or
+paid-SaaS dependency (the Hard Rule is preserved), and escalation can never
+switch a repo to a vendor it does not already use.
+
+### D2 — The tier ladder
+
+`local → economy → standard → frontier → apex`, plus `adaptive`. `frontier` is
+opus-class; `apex` is mythos-class (`fable`, `sol`). `.devflow.toml` gains
+`default_tier` and `[tier.<value>]` tables mapping families to
+`agent-registry.json` model slugs, `escalate_to` chains, and `endpoint =
+"local"` on the self-hosted tier. `tier:local` escalates to `economy`.
+Privacy-pinning is a **future, separate concern label**, not a tier semantic.
+
+The `local` tier's machinery binding is explicit: its entries resolve to the
+registry's `-local` endpoint-variant harnesses (ADR 0005 D9), and validation
+fails a `local` entry whose family has no registered `-local` harness. Today
+`claude-code-qwen-local` (family `qwen`) is the only such harness, so `local` is
+opt-in per family until more are registered.
+
+### D3 — When escalation fires, and how a candidate is chosen
+
+`escalate_to` chains validate as **referential, acyclic, and monotonic toward
+`apex`**. *When* escalation fires is a policy, not a cost heuristic: **failure,
+refusal, or operator policy — never cost alone**.
+
+Candidate selection is **deterministic**. The resolved tier names the stratum; a
+`suggest:<family>[:<model>]` narrows within it **only when that family is
+configured and eligible** (otherwise it is ignored with a note) — and unattended
+consumption of a suggestion is subject to the same provenance invariant as the
+strategy axes (D6). Absent a suggestion, the consumer's own configured backend
+or harness picks. A tier with no eligible configured candidate escalates along
+the chain, and an **exhausted chain stops with a report** — never a silent
+vendor switch or downgrade.
+
+**Deferred (follow-up):** `escalate_to` here validates the chain's *shape*, not
+that each step maps to a not-weaker model. Encoding per-model capability in the
+registry and validating tier maps monotonically ("a label only ever buys more")
+is deferred to a follow-up issue rather than blocking harmon-init#855; until then the
+guarantee is the chain shape plus the human-authored map.
+
+### D4 — The method rank
+
+`method:*` values are `oneshot | plan | plan-approved | orchestrate | council |
+human-led`; `default_method` lives in `.devflow.toml`. Method conflicts resolve
+by a **config-backed rank** (shipped order, most human oversight first):
+
+```text
+human-led > plan-approved > council > orchestrate > plan > oneshot
+```
+
+so topologies with no inherent ordering still resolve deterministically and
+identically for every consumer.
+
+### D5 — Resolution order and the explicit-instruction channel
+
+Resolution order is **explicit instruction > label > config default >
+built-in**, where an **explicit instruction** is one arriving on the operator's
+**attributable channel** — the interactive session's human input, or the
+automation's own configuration — and **never repository content**: issue bodies,
+comments, and PR text are untrusted input and can never outrank labels or config.
+
+Conflicts resolve **strongest-wins on tier** and by the method rank above (a
+label only ever buys **more** capability or oversight); a **concrete tier beats
+`adaptive`**. Below-default resolutions are **disclosed in the PR body** (the
+harmon-init#809 rigor doctrine, extended). Merge-base copy applies when the change
+review edits `.devflow.toml`, so a branch cannot lower the gate it is changing.
+
+### D6 — Consumer-trust invariants (enforcement delegated)
+
+Consumer trust is stated here as **invariants**; the concrete
+timeline-validation algorithm is deliberately **not** specified in this repo — it
+is design work under ponderousdev/foreman#139, and the adversarial scenarios
+from the spec's review are carried there as required test cases. What is fixed
+here is the contract every consumer must satisfy:
+
+1. **Unattended automation** acts on a strategy or suggestion label only after
+   verifying its provenance end-to-end from its own trusted-actor configuration,
+   re-read immediately before acting — and **no sequence of untrusted mutations,
+   applies or removals**, on any label of the axis, may move the resolved
+   outcome away from what trusted actors' surviving actions alone would produce.
+   Anything short of that resolves to the config default with a warning.
+2. An **interactive session** treats these labels as advisory (the harmon-init#809 rigor
+   posture) and requires operator confirmation for **any off-default
+   resolution** — above or below, since one direction skips oversight and the
+   other spends money — arising from a label not applied by an actor the
+   operator has **authorized** (the operator themselves, or a login their
+   configuration trusts). Attribution to *some* identifiable actor is **not**
+   authorization.
+3. **Advisory families fail open** to the config default; **arming stays
+   fail-closed**.
+
+### D7 — Built-in fallbacks; `adaptive` is never terminal
+
+Absent `.devflow.toml` (or its `[tier]`/`[method]` sections), both axes are
+**advisory-informational only**: the labels still classify, and nothing resolves
+them to a model or workflow. `adaptive` is never a terminal answer — the
+consumer's preflight resolves it to a concrete ladder tier; a consumer with no
+preflight capability treats it as `default_tier` where that key is configured.
+**Validation rejects `adaptive` as a `default_tier`**, so that fallback is
+always concrete; absent the config, `adaptive` resolves to nothing, like every
+tier value under the axes-inert fallback.
+
+### D8 — No auto-merge
+
+No label, tier, or method arms auto-merge. Merging is always a human decision;
+there is no `merge:*` family and no configuration that promotes a PR to merged.
+
+### § D6 amendment to ADR 0005
+
+ADR 0005 D6 recorded suggestions as human-authored advice. **Amended here:**
+suggestions become human- **or agent-**authored. `suggest:*` stays
+`family[:model]` (a vendor preference); `tier:*` is the human-decided **policy**
+layer of the model axis. **`suggest:tier:<value>` is reserved, not built.**
+`claim:*` stays on the family axis; the claim record gains `harness:` / `model:`
+/ `session:` fields (harmon-devkit#450). ADR 0005 D6 carries a pointer to this
+amendment.
+
+## Consequences
+
+- The two axes have a written contract a consumer — attended or unattended — can
+  implement against, with the security-critical part (provenance, off-default
+  confirmation, fail-open/closed) stated as invariants rather than left to each
+  implementer's judgement.
+- The `tier`/`method` distinction from rigor is now unambiguous: rigor has
+  **levels**, the model axis has **tiers**. Prose everywhere follows suit.
+- Nothing in a generated repo gains a runtime dependency: the tables are inert,
+  and enforcement of the trust invariants rides foreman#139's rails.
+- The capability-monotonicity check and the timeline algorithm are named,
+  bounded, and deferred rather than half-built — the follow-up work is
+  discoverable from here.
+- `.devflow.toml` and its validator gain `[tier.*]`/`default_tier`/
+  `default_method` under the same harmon-init#855; this ADR is the reference they
+  implement.

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -240,7 +240,7 @@ task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
                 # until TWO CONSECUTIVE rounds adjudicate to zero P0/P1
-                # (a round with no findings ends it once the tier's
+                # (a round with no findings ends it once the level's
                 # min_rounds floor is met), under the challenge cap
                 # resolved from .devflow.toml
 task review     # verification checkpoint — same convergence rule, under its
@@ -285,8 +285,8 @@ down to
 P2; what counts is the **adjudicated** column of your adjudication table, not
 the label Codex attached. The second such round *is* the confirmation, so no
 extra run is owed after it. Two cases exit faster still. A round with **no
-findings at all** ends the stage on the spot **once the tier's `min_rounds`
-floor is met** (1 wherever a tier does not set it) — an empty round is exactly
+findings at all** ends the stage on the spot **once the level's `min_rounds`
+floor is met** (1 wherever a level does not set it) — an empty round is exactly
 the older "clean re-run" exit, so neither a trivial change nor a clean
 post-fix re-run pays for a confirmation pass, and a floor of 2 only delays
 that shortcut, never the other two exits, which run at least two rounds by

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -259,10 +259,10 @@ gate that ends them — is defined in AGENTS.md ("Dev Loop"). The PR is a
 is the one signal that the automated work is finished.
 
 The caps are not written down here, or in AGENTS.md. They live in
-[`.devflow.toml`](../../.devflow.toml) as `rigor` tiers, and **AGENTS.md alone
+[`.devflow.toml`](../../.devflow.toml) as `rigor` levels, and **AGENTS.md alone
 defines how a change resolves one** — restating that chain here would only give
 it a second place to drift from, and which inputs are even available depends on
-how the repository is set up. `challenge`, `review`, and the `min_rounds` floor vary by tier; the
+how the repository is set up. `challenge`, `review`, and the `min_rounds` floor vary by level; the
 shepherd cap is fixed, because it bounds other people's findings rather than
 self-generated work. Announce the resolved caps — the floor included — when
 you enter the loop.
@@ -335,7 +335,7 @@ left to re-raise and counts toward convergence. Reflexively hardening the
 previous round's fix is the failure mode; naming it on the table is the
 check.
 
-Two things do not move. The **per-stage cap** stands — whatever rigor tier
+Two things do not move. The **per-stage cap** stands — whatever rigor level
 resolved it — and persistent
 P0/P1 disagreement at the cap is escalated rather than iterated on. And the
 deferred-P2 chain is a **precondition** of the exit, not a casualty of it:

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -516,7 +516,7 @@ the taxonomy table below is generated from) and the starter set is created by
   model
 - **Method** — the execution topology to work the issue under — advisory,
   like `tier:`
-- **Rigor** — which round-cap tier in [`.devflow.toml`](../.devflow.toml) an
+- **Rigor** — which round-cap level in [`.devflow.toml`](../.devflow.toml) an
   agent works the issue under (AGENTS.md, "Round caps are resolved, not stated
   here"). An agent reads it and never self-applies one. It is advisory rather
   than an authenticated gate: nothing verifies who applied it, and the

--- a/scripts/test-devflow-config.sh
+++ b/scripts/test-devflow-config.sh
@@ -9,12 +9,12 @@
 # byte-identical, which two identically-broken files also satisfy.
 #
 # This checks the invariants the prose promises, on BOTH copies, plus the one
-# cross-file invariant that byte-equality cannot see: every tier must have a
-# provisioned `rigor:<tier>` label, or the documented label resolution path
+# cross-file invariant that byte-equality cannot see: every level must have a
+# provisioned `rigor:<level>` label, or the documented label resolution path
 # names something GitHub cannot apply.
 #
 # Root-only by design (no template twin): it guards what harmon-init SHIPS.
-# A consumer retuning their own tiers is editing their policy, the same way
+# A consumer retuning their own levels is editing their policy, the same way
 # they may edit their AGENTS.md, and owes no gate here.
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -49,7 +49,7 @@ registry_root, registry_template, agents_root, agents_template, *config_paths = 
 STAGES = ("challenge", "review", "shepherd")
 # `min_rounds` is a floor on rounds actually run, not a cap — it gates only the
 # empty-round instant exit (AGENTS.md, "Loop cap and exit"). It is required in
-# every tier, so both dogfood copies state it rather than relying on a default.
+# every level, so both dogfood copies state it rather than relying on a default.
 MIN_ROUNDS = "min_rounds"
 KNOWN_KEYS = STAGES + (MIN_ROUNDS,)
 # The floor is 2, not 1: a stage exits on two consecutive adjudicated-clean
@@ -58,7 +58,7 @@ FLOOR = {"challenge": 2, "review": 2, "shepherd": 1}
 
 def rigor_values(registry_path):
     # Only values the renderer actually seeds count: a retired or
-    # provision:false rigor value has no live label, so a .devflow.toml tier
+    # provision:false rigor value has no live label, so a .devflow.toml level
     # named after one would be unselectable by the documented label path.
     with open(registry_path, "rb") as fh:
         manifest = json.load(fh)
@@ -87,22 +87,22 @@ for path in config_paths:
             failures.append(f"{path}: not valid TOML — {exc}")
             continue
 
-    tiers = cfg.get("rigor")
-    if not isinstance(tiers, dict) or not tiers:
-        failures.append(f"{path}: no [rigor.*] tiers defined")
+    levels = cfg.get("rigor")
+    if not isinstance(levels, dict) or not levels:
+        failures.append(f"{path}: no [rigor.*] levels defined")
         continue
 
     default = cfg.get("default_rigor")
     if not isinstance(default, str):
         failures.append(f"{path}: default_rigor is missing or not a string")
-    elif default not in tiers:
+    elif default not in levels:
         failures.append(
-            f"{path}: default_rigor={default!r} names no tier "
-            f"(have: {', '.join(sorted(tiers))})"
+            f"{path}: default_rigor={default!r} names no level "
+            f"(have: {', '.join(sorted(levels))})"
         )
 
     shepherd_values = set()
-    for name, caps in sorted(tiers.items()):
+    for name, caps in sorted(levels.items()):
         if not isinstance(caps, dict):
             failures.append(f"{path}: [rigor.{name}] is not a table")
             continue
@@ -153,22 +153,22 @@ for path in config_paths:
         registry_path, provisioned = provisioned_by_config[path]
         if name not in provisioned:
             failures.append(
-                f"{path}: tier {name!r} has no rigor:{name} label in {registry_path} — "
+                f"{path}: level {name!r} has no rigor:{name} label in {registry_path} — "
                 "the documented label resolution path cannot select it"
             )
 
     # shepherd bounds other people's findings, not self-generated work, so it
-    # is fixed across tiers by design (AGENTS.md). Catch a tier-varying edit.
+    # is fixed across levels by design (AGENTS.md). Catch a level-varying edit.
     if len(shepherd_values) > 1:
         failures.append(
-            f"{path}: shepherd varies by tier ({sorted(shepherd_values)}) — it is "
+            f"{path}: shepherd varies by level ({sorted(shepherd_values)}) — it is "
             "fixed by design; lowering it abandons unanswered reviews"
         )
 
 FALLBACK_RE = re.compile(r"built-in (\d+ / \d+ / \d+)")
 # The missing-key floor exists only in prose, so its parity is checked the
 # same way as the caps: exactly one statement per layer, equal across layers.
-FLOOR_FALLBACK_RE = re.compile(r"`min_rounds` floor of\s+(\d+) for any tier that\s+does not define it")
+FLOOR_FALLBACK_RE = re.compile(r"`min_rounds` floor of\s+(\d+) for any level that\s+does not define it")
 fallbacks = {}
 floor_fallbacks = {}
 for path in (agents_root, agents_template):
@@ -184,7 +184,7 @@ for path in (agents_root, agents_template):
     floor_found = set(FLOOR_FALLBACK_RE.findall(text))
     if len(floor_found) != 1:
         failures.append(
-            f"{path}: expected exactly one 'min_rounds floor of N wherever no tier "
+            f"{path}: expected exactly one 'min_rounds floor of N wherever no level "
             f"defines one' fallback, found {sorted(floor_found) if floor_found else 'none'}"
         )
     else:
@@ -203,7 +203,7 @@ if len(set(floor_fallbacks.values())) > 1:
     )
 for path, value in sorted(floor_fallbacks.items()):
     # Same range as configured min_rounds: 1 or 2. A fallback outside it would
-    # hand absent-file/legacy repos an exit rule no shipped tier may state.
+    # hand absent-file/legacy repos an exit rule no shipped level may state.
     if not value.isdigit() or not 1 <= int(value) <= 2:
         failures.append(
             f"{path}: fallback min_rounds floor {value} is outside the supported "
@@ -217,11 +217,11 @@ if failures:
 
 with open(config_paths[0], "rb") as fh:
     cfg = tomllib.load(fh)
-tiers = cfg["rigor"]
+levels = cfg["rigor"]
 summary = "; ".join(
     f"{n}={t['challenge']}/{t['review']}/{t['shepherd']} (min {t['min_rounds']})"
-    for n, t in sorted(tiers.items())
+    for n, t in sorted(levels.items())
 )
 print(f"devflow config OK: default={cfg['default_rigor']} — {summary}")
-print("  (challenge/review/shepherd + min_rounds; both copies valid, every tier has a label)")
+print("  (challenge/review/shepherd + min_rounds; both copies valid, every level has a label)")
 PY

--- a/template/.devflow.toml
+++ b/template/.devflow.toml
@@ -34,15 +34,15 @@
 #
 # Retuning these is expected. The Dev Loop assumes five invariants, and nothing
 # at runtime will tell you if an edit breaks one:
-#   - every tier defines challenge, review, shepherd and min_rounds, all
+#   - every level defines challenge, review, shepherd and min_rounds, all
 #     integers
 #   - challenge and review are >= 2, because the exit condition needs two
 #     consecutive adjudicated-clean rounds; at 1, one finding is an escalation
 #   - min_rounds is 1 or 2, never more: two consecutive adjudicated-clean
 #     rounds — empty rounds included — exit a stage at round 2 whatever the
 #     floor says, so a value above 2 is a budget no stage ever spends
-#   - shepherd is the same in every tier (see below)
-#   - default_rigor names a tier that exists here
+#   - shepherd is the same in every level (see below)
+#   - default_rigor names a level that exists here
 #
 # `challenge` and `review` are inert wherever no second-model reviewer is
 # configured: those stages never run, so their caps bound nothing. `shepherd`
@@ -50,7 +50,7 @@
 
 default_rigor = "standard"
 
-# `shepherd` is deliberately identical in every tier, and is not a knob to
+# `shepherd` is deliberately identical in every level, and is not a knob to
 # turn down.
 #
 # `challenge` and `review` bound work the agent generates itself — each round's
@@ -58,7 +58,7 @@ default_rigor = "standard"
 # low safe. `shepherd` bounds *other people's* findings: CI failures, human
 # review, Codex. Lowering it does not reduce effort spent; it abandons reviews
 # that are already unanswered, and the readiness gate then refuses to promote
-# the PR anyway. The key is present so that a tier is one consistent shape.
+# the PR anyway. The key is present so that a level is one consistent shape.
 
 # Trivial, low-blast-radius work: doc touch-ups, mechanical bumps, typo fixes.
 [rigor.light]

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -138,29 +138,29 @@ error silently reverts the lifecycle rather than fixing anything.
 
 **Round caps are resolved, not stated here.** The stages below are each
 capped, but this file names no numbers: the caps live in
-[`.devflow.toml`](.devflow.toml) as `rigor` tiers, so there is one place to
+[`.devflow.toml`](.devflow.toml) as `rigor` levels, so there is one place to
 change them and one place to read them. Resolve in this order — an explicit
 instruction in this session, then [% if project_management == 'github' or use_foreman %]a `rigor:*` label on the issue, then [% endif %]`default_rigor`,
 then a built-in 4 / 4 / 4 if the file is absent — with a `min_rounds` floor of
-1 for any tier that does not define it — the absent-file case, a legacy config
-predating the key, and a partially migrated one where only some tiers state it
-alike — which is also the floor every shipped tier states explicitly. When the change under review
+1 for any level that does not define it — the absent-file case, a legacy config
+predating the key, and a partially migrated one where only some levels state it
+alike — which is also the floor every shipped level states explicitly. When the change under review
 **edits `.devflow.toml` itself**, resolve its caps **and floor** from the
 **merge-base** copy rather than the branch copy: otherwise a branch can lower
 the very gate it is changing — the floor included, since a self-lowered
-`min_rounds` buys an earlier empty-round exit, and dropping every tier together evades the below-default disclosure
+`min_rounds` buys an earlier empty-round exit, and dropping every level together evades the below-default disclosure
 because nothing is left to be below. An explicit human instruction still
 overrides.
 [% if project_management == 'github' or use_foreman %]Labels are multi-select and nothing stops an issue carrying two, so resolution
 is **per stage, taking the highest cap present**: a conflict can then only ever
-buy more review, never less, and no ranking of the tier names has to be agreed
+buy more review, never less, and no ranking of the level names has to be agreed
 on anywhere. `min_rounds` resolves under the same principle — the highest
 floor present wins — so a label conflict cannot quietly select the lower floor
-either. Because that is per stage, two retuned tiers can yield caps
-belonging to no single tier — so what you announce is the **caps**, naming a
-tier only when one supplied all of them — the floor included — and the
+either. Because that is per stage, two retuned levels can yield caps
+belonging to no single level — so what you announce is the **caps**, naming a
+level only when one supplied all of them — the floor included — and the
 disclosure below compares caps
-rather than tier names. A `rigor:` value naming no tier in the file is ignored
+rather than level names. A `rigor:` value naming no level in the file is ignored
 rather than guessed at. Treat the label as advisory: it is applied by people and
 verified by nothing, and GitHub's **triage** role can label an issue with no
 push access at all — so a budget can be retuned by someone who could not edit
@@ -169,15 +169,15 @@ announcement and in the PR body whenever any resolved cap or floor is below what
 `default_rigor` would give**, so a reduced budget is visible to the human
 reviewer instead of silent.
 [% endif %]**Announce the resolved caps on entering the loop** — "rigor:
-`<tier>` (`<source>`) → [% if use_codex_review %]challenge ≤`<n>`, review ≤`<n>`, [% endif %]shepherd `<n>`[% if use_codex_review %], min_rounds `<n>`[% endif %]", filled in
+`<level>` (`<source>`) → [% if use_codex_review %]challenge ≤`<n>`, review ≤`<n>`, [% endif %]shepherd `<n>`[% if use_codex_review %], min_rounds `<n>`[% endif %]", filled in
 by reading the file rather than from memory — and carry it into the PR body, so
 a later round or a different session can see which budget it is spending
 instead of inferring one. Everything else about these stages is policy rather
-than a parameter and does not vary by tier: the exit condition, the escalation
+than a parameter and does not vary by level: the exit condition, the escalation
 rule, [% if use_codex_review %]the round-2 scaffolding checkpoint, the deferred-P2 sidecar, [% endif %]and the
 readiness gate all hold identically at every rigor. A cap is a ceiling, never a
 quota — a stage that meets its exit condition on round 1 is done, whatever the
-tier allowed.
+level allowed.
 
 - **Branch** — feature branch off `main`; never commit directly to `main`. For
   parallel or isolated work, take the branch in its own worktree via
@@ -221,7 +221,7 @@ tier allowed.
   extra clean run to buy. A round that returns **no findings at all** ends
   the stage on its own **once at least `min_rounds` rounds have run** — an
   empty round is the old rule's clean re-run, so neither a trivial change nor
-  a clean post-fix re-run pays for a confirmation pass, but a tier that sets a
+  a clean post-fix re-run pays for a confirmation pass, but a level that sets a
   floor buys the rounds it asked for before that shortcut opens. The other two
   exits satisfy any floor of 2 or less by construction — two consecutive clean
   rounds *are* two rounds, and a capped final round is at least the cap, which
@@ -283,7 +283,7 @@ tier allowed.
   rounds, the same self-referential shape and so the
   same reason for a cap, under
   its own resolved **review cap**. The two stages are counted separately — and
-  capped separately, even where the tier gives them equal numbers: a converged
+  capped separately, even where the level gives them equal numbers: a converged
   challenge says nothing about review.
 [% endif %]
 - **`task ci`** — the full CI mirror; fix anything it catches.
@@ -423,7 +423,7 @@ tier allowed.
   anyway.
   If checks still fail or findings remain at the shepherd cap,
   stop and summarize what's unresolved on the PR for the maintainer. That cap
-  does not vary by rigor tier — it bounds other people's findings, not your
+  does not vary by rigor level — it bounds other people's findings, not your
   own work, so lowering it would abandon unanswered reviews rather than save
   effort. Where a
   **vendored** skill (`/shepherd`) states a different cap or exit condition,
@@ -699,11 +699,11 @@ all-P2 as labeled, or P1-labeled and adjudicated down to P2; what counts is
 the **adjudicated** column of the table, not the reviewer's label, and the
 second such round is itself the confirmation, so no further run is owed. Two
 exits are faster still. A round with **no findings at all** ends the stage by
-itself **once the stage has run at least `min_rounds` rounds** (the per-tier
+itself **once the stage has run at least `min_rounds` rounds** (the per-level
 floor in `.devflow.toml`; 1 if the file is absent) — an empty round is exactly
 the old rule's clean re-run, so neither a trivial change nor a clean post-fix
 re-run pays for a confirmation pass, and the floor only stops that shortcut
-being taken before the tier's minimum work has happened. Say plainly what
+being taken before the level's minimum work has happened. Say plainly what
 follows: the other two exits satisfy any floor of 2 or less **by
 construction** — the two-consecutive exit runs two rounds by definition, and
 the capped-clean exit runs the cap, which is never below 2 — so `min_rounds`

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -574,7 +574,7 @@ the taxonomy table below is generated from) and the starter set is created by
 - **Work type** — what kind of work the issue is, on personal-account repos
   where native issue Type is unavailable; the issue forms apply it, and org
   repos use native Type with no work-type label
-- **Rigor** — which round-cap tier in [`.devflow.toml`](../.devflow.toml) an
+- **Rigor** — which round-cap level in [`.devflow.toml`](../.devflow.toml) an
   agent works the issue under (AGENTS.md, "Round caps are resolved, not stated
   here"). An agent reads it and never self-applies one. It is advisory rather
   than an authenticated gate: nothing verifies who applied it, and the

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -240,7 +240,7 @@ task check      # fast inner loop while editing
 task verify     # definition-of-done gate
 task challenge  # adversarial second model — adjudicate, fix, re-challenge
                 # until TWO CONSECUTIVE rounds adjudicate to zero P0/P1
-                # (a round with no findings ends it once the tier's
+                # (a round with no findings ends it once the level's
                 # min_rounds floor is met), under the challenge cap
                 # resolved from .devflow.toml
 task review     # verification checkpoint — same convergence rule, under its
@@ -285,8 +285,8 @@ down to
 P2; what counts is the **adjudicated** column of your adjudication table, not
 the label Codex attached. The second such round *is* the confirmation, so no
 extra run is owed after it. Two cases exit faster still. A round with **no
-findings at all** ends the stage on the spot **once the tier's `min_rounds`
-floor is met** (1 wherever a tier does not set it) — an empty round is exactly
+findings at all** ends the stage on the spot **once the level's `min_rounds`
+floor is met** (1 wherever a level does not set it) — an empty round is exactly
 the older "clean re-run" exit, so neither a trivial change nor a clean
 post-fix re-run pays for a confirmation pass, and a floor of 2 only delays
 that shortcut, never the other two exits, which run at least two rounds by

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -259,10 +259,10 @@ gate that ends them — is defined in AGENTS.md ("Dev Loop"). The PR is a
 is the one signal that the automated work is finished.
 
 The caps are not written down here, or in AGENTS.md. They live in
-[`.devflow.toml`](../../.devflow.toml) as `rigor` tiers, and **AGENTS.md alone
+[`.devflow.toml`](../../.devflow.toml) as `rigor` levels, and **AGENTS.md alone
 defines how a change resolves one** — restating that chain here would only give
 it a second place to drift from, and which inputs are even available depends on
-how the repository is set up. `challenge`, `review`, and the `min_rounds` floor vary by tier; the
+how the repository is set up. `challenge`, `review`, and the `min_rounds` floor vary by level; the
 shepherd cap is fixed, because it bounds other people's findings rather than
 self-generated work. Announce the resolved caps — the floor included — when
 you enter the loop.
@@ -335,7 +335,7 @@ left to re-raise and counts toward convergence. Reflexively hardening the
 previous round's fix is the failure mode; naming it on the table is the
 check.
 
-Two things do not move. The **per-stage cap** stands — whatever rigor tier
+Two things do not move. The **per-stage cap** stands — whatever rigor level
 resolved it — and persistent
 P0/P1 disagreement at the cap is escalated rather than iterated on. And the
 deferred-P2 chain is a **precondition** of the exit, not a casualty of it:


### PR DESCRIPTION
## What

**PR 1 of 2 for #855.** Lands the decision record for the method and tier
strategy axes, and resolves the rigor/model "tier" naming collision. The
behavioral config (`.devflow.toml` tables + validator) and the AGENTS.md
resolution rules follow in PR 2, per the approved two-PR plan.

- **`docs/decisions/0006-method-and-tier-axes.md`** (new) — records: the tier
  ladder `local→economy→standard→frontier→apex` (+`adaptive`); the method rank
  `human-led>plan-approved>council>orchestrate>plan>oneshot`; resolution order
  `explicit instruction > label > config default > built-in` with the
  explicit-instruction **channel restriction** (repo content never outranks
  labels/config); strongest-wins / concrete-beats-`adaptive`; the three
  **consumer-trust invariants** (provenance re-read before acting incl. removals;
  interactive off-default confirmation; advisory fails open / arming fails
  closed) with the concrete timeline algorithm **delegated to foreman#139**;
  below-default PR disclosure (#809 extended); **auto-merge rejection**;
  `suggest:tier:*` reserved-not-built; and the **deferred** capability-monotonicity
  follow-up (chain-shape validated now).
- **`docs/decisions/0005-unified-agent-vocabulary.md`** — D6 gains an amendment
  pointer (suggestions now human- *or agent*-authored; `tier:*` = policy layer;
  `suggest:tier` reserved).
- **Rigor "tier(s)" → "level(s)"** in AGENTS.md (both layers), `.devflow.toml`
  comments (both, kept byte-identical), the `test-devflow-config` validator
  (including its prose-parity regex, so the gate still matches), and the Taskfile
  desc. Untouched: the rigor axis, `[rigor.*]` keys, `default_rigor`, and the
  `rigor:*` label. The model axis keeps "tier".

## Why

The axes were decided in `specs/issue-strategy.md` but unrecorded; and calling
rigor's round-cap values "tiers" collided with the model axis. This PR records
the semantics (the reference PR 2 implements against) and does the collision-free
rename as a self-contained doc/prose change with no behavior change.

## Verification

- `task verify` — green (incl. `test:devflow-config`, whose AGENTS.md
  prose-parity check confirms the rename kept the validator matching).
- `task ci` — green (Semgrep 0 findings).
- `task guard:release-title` — `feat:` accepted (touches `template/`).
- ADR docs markdownlint-clean.

## Second-model review

Local advisory `task challenge`/`task review` could not run (Codex CLI logged out,
no non-interactive auth). The mandated cloud `@codex review` runs on this PR at
the shepherd stage.

## Deferred findings

None — a doc/prose-only change fully covered by the offline gates.

## Scope note

`Refs #855`, not `Closes`: this PR ticks the label-manifest and plan-approved ACs;
the `.devflow.toml` validation AC, the AGENTS.md method/tier-rules AC, and the
`#754` disposition are completed by PR 2 / bookkeeping.

Refs #855
