### PR TITLE
fix: reconcile project management guidance

### DIFF
--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -300,10 +300,10 @@ this comment. -->
       name --jq '.[].name' | grep -E '^(suggest|claim):(codex|copilot)$'`
       (the default `gh label list --limit 200` paged listing can miss these
       on a repo with many labels — use this enumeration, not the paged form,
-      everywhere in this item). harmon-init issue #751 renamed those families
-      to `gpt` and `mai`: labels classify the model family, not the harness;
-      Codex runs GPT-family models, while Copilot is represented by its `mai`
-      broker family because it can route across models.
+      everywhere in this item). harmon-init issue #751 replaced those
+      harness-named families with model-family vocabulary: Codex maps to `gpt`;
+      Copilot is a broker that defaults to `mai`, but each association must use
+      the actual family recovered by the procedure below.
       A `setup-github-labels` re-run never deletes the old family, so it
       survives beside the new registry-rendered one.
 

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -301,8 +301,9 @@ this comment. -->
       (the default `gh label list --limit 200` paged listing can miss these
       on a repo with many labels — use this enumeration, not the paged form,
       everywhere in this item). harmon-init issue #751 renamed those families
-      to `gpt` and `mai` (Codex and Copilot are harnesses, not families — the
-      same harness/family split D9 already made elsewhere; see ADR 0005 D8).
+      to `gpt` and `mai`: labels classify the model family, not the harness;
+      Codex runs GPT-family models, while Copilot is represented by its `mai`
+      broker family because it can route across models.
       A `setup-github-labels` re-run never deletes the old family, so it
       survives beside the new registry-rendered one.
 

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -238,13 +238,15 @@ this comment. -->
       the issues they sit on are untouched — then classify open issues with the
       added families.
 - [ ] **[human-only] Retire any legacy `agent:*` claim labels** — needed only
-      where `gh label list --limit 200` still shows the harness-named family
+      where `gh label list --limit 1000` still shows the harness-named family
       (`agent:claude-code`, `agent:gemini-cli`, …) a pre-registry harmon-init
-      seeded. **Pass an explicit `--limit` to every `gh label list`,
-      `gh issue list`, and `gh pr list` in this step**: all three default to 30,
-      the starter set alone is over 40 labels, and an unbounded read reports a
-      clean repo — or a finished migration — while legacy labels, in-flight
-      claims, and labelled pull requests remain.
+      seeded. **Start with an explicit `--limit 1000` on every `gh label list`,
+      `gh issue list`, and `gh pr list` in this step**: all three default to 30.
+      If any list returns exactly 1000 entries (`--json name --jq length` for
+      labels; `--json number --jq length` for issues and PRs), treat it as capped:
+      double the limit and re-run until the count is below the cap before any
+      rename or delete. Otherwise a clean-looking result can leave legacy
+      labels, in-flight claims, or labelled pull requests unseen.
       `setup-github-labels` never deletes a label, so the old family
       survives beside the registry-rendered `claim:*` one, and every reader
       tolerates both — this is cleanup, not a fix for something broken.
@@ -278,7 +280,7 @@ this comment. -->
       X --remove-label Y` pair works on `gh pr edit`), then delete the
       now-empty old label (`gh label delete agent:claude-code --repo
       <owner/repo> --yes`) once a re-read of `gh issue list --label
-      agent:claude-code --state all --limit 200` **and** the equivalent
+      agent:claude-code --state all --limit 1000` **and** the equivalent
       `gh pr list` both return nothing — only then is it safe to delete; the
       other checklist items below that reference this procedure reuse it
       verbatim. Enumerate **`gh pr list` as well as `gh issue list`**
@@ -286,10 +288,10 @@ this comment. -->
       pull requests too and `gh issue list` never returns them, so deleting the
       legacy label afterwards would drop exactly the associations the re-labelling
       missed — the loss this whole item exists to avoid. Check for in-flight
-      claims first — `gh issue list --label agent:… --state all --limit 200`
-      **and** `gh pr list --label agent:… --state all --limit 200`: a claim
+      claims first — `gh issue list --label agent:… --state all --limit 1000`
+      **and** `gh pr list --label agent:… --state all --limit 1000`: a claim
       record naming the old label will not release the renamed one, so settle or
-      amend those records in the same sitting. Re-read `gh label list --limit 200` afterwards — no `agent:*`
+      amend those records in the same sitting. Re-read `gh label list --limit 1000` afterwards — no `agent:*`
       should remain.
 - [ ] **[human-only] Retire pre-2026-refresh `codex`/`copilot` agent labels** —
       needed only where an explicit enumeration shows

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -252,9 +252,11 @@ has.
   to a tag); generated repos configure their own via the `release_content_paths`
   copier answer (empty = no guard). Automated dependency PRs (Renovate/Dependabot)
   are skipped — retitle by hand if a dep bump to guarded content must ship.
-- Issue types map many-to-one onto these commit types — see
-  [project-management.md](project-management.md).
-- **Milestones are named after release versions** (`v1.1.0` = the git tag): the
-  pre-ship "what must land before this version" container, distinct from
-  release-please cutting the tag post-merge — same name, different jobs. See
+- Issue types map many-to-one onto these commit types. Personal-account repos
+  use the equivalent work-type labels as that mapping's substrate because native
+  issue Type is unavailable there; organization repos use native Type and no
+  work-type label. See [project-management.md](project-management.md).
+- **Milestones use an explicit naming mode**: a version milestone is named after
+  its git tag (`v1.1.0`), while a rolling-release or tooling repo may use a
+  finite scope-batch name when the version is not a planning input. See
   [project-management.md](project-management.md).

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -926,7 +926,8 @@ queue up and displace legitimate runs.
 
 ## Milestones
 
-A milestone has **one job — "when it ships"** — and nothing else. Four things
+A milestone has **one job — "which finite, shippable batch is this part of?"** —
+and nothing else. Four things
 could all masquerade as milestones, so keep the lanes clean:
 
 - **Type** — what kind of work (Bug / Feature / Task / Research)
@@ -934,41 +935,37 @@ could all masquerade as milestones, so keep the lanes clean:
 - **Labels** — orthogonal, cross-cutting concerns
 - **Sub-issues** — hierarchy
 
-None of those answers *"which dated, shippable batch does this belong to, and how
-done is that batch?"* — that's the milestone's unique contribution: a
-release/launch container with a **due date** and a **live completion bar**. Labels
-for classification, milestones for goal tracking. The moment you're making a
-milestone that isn't a dated, shippable batch, it's really a label or a saved
-view.
+None of those answers *"which shippable batch does this belong to, and how done
+is that batch?"* — that's the milestone's unique contribution: a finite
+delivery container with a **live completion bar** and, when useful, a due date.
+Labels are for classification; milestones are for goal tracking. An open-ended
+concern with no completion condition is still a label or saved view.
 
-**Name milestones after release versions** — the milestone title *equals* the git
-tag (`v1.0.0`, `v1.1.0`). Then the milestone list doubles as a release-history /
-changelog skeleton, and closing a milestone on publish needs no special plumbing.
-This dovetails with **release-please** because they run at different times and
-never overlap:
+Use one of two explicit milestone naming modes:
 
-- The **milestone** is the *pre-ship planning* artifact — "what must land before
-  we cut `v1.1.0`."
-- **release-please** is the *post-merge machine* that calculates and cuts the
-  actual version from your conventional commits (see
-  [conventions.md](conventions.md)).
+- **Version milestone** — for a product release planned as a version, make the
+  title equal the git tag (`v1.0.0`, `v1.1.0`). The milestone is the pre-ship
+  "what must land before this version" artifact; release-please is the post-merge
+  machine that calculates and cuts the actual version from conventional commits
+  (see [conventions.md](conventions.md)). The shipped
+  `close-milestone-on-release.yml` Action closes the milestone matching a
+  published tag, and the release PR can carry it too.
+- **Scope-batch milestone** — for a rolling-release or tooling repo where
+  versions are outputs rather than planning inputs, name the finite outcome
+  (`Issue strategy overhaul`, `Runner hardening`). It may span several releases;
+  close it when its scoped issues are complete. Release-please continues to
+  version each shipped increment independently, and the tag-matching Action
+  intentionally does not close a non-version milestone.
 
-Naming them identically makes the two legible to each other — the shipped
-`close-milestone-on-release.yml` Action closes the milestone matching a published
-tag (when release-please is on) — without making them one system. Since PRs and
-issues share the milestone namespace, the release PR itself
-can carry the milestone, so the shipped batch is fully self-documenting.
+Do not mix the two modes in one title or invent a version for work whose version
+is not known yet. **Carry one active delivery milestone per stream** — create it
+when it has real scope, close it when that scope ships, and open the next only as
+needed rather than keeping speculative batches in competition.
 
-**One active release milestone at a time (rolling).** Carry one open milestone per
-release line — created when it has real scope and a date, closed when it ships,
-the next opened only as needed. Not five speculative open milestones competing for
-attention.
-
-**Due dates are signals, not gates.** A milestone's due date doesn't block a merge
-or a close and triggers nothing — it's a communication tool; update it honestly
-when the plan slips. That's where milestones earn their keep on a team: the dated
-milestone is the shared artifact that tells collaborators what's shipping and
-roughly when — worth more with others in the loop than in pure solo work.
+**Due dates are signals, not gates.** A milestone's due date is optional, does
+not block a merge or close, and triggers nothing. Add one when a collaborator
+needs a timing signal and update it honestly when the plan slips; the milestone's
+scope and completion bar remain useful without a fabricated date.
 
 ## Milestones over iterations
 
@@ -997,8 +994,9 @@ giant "Launch." A tightly-scoped milestone with a target date is a chunk of valu
 with an expectation attached, doing three jobs at once: coordination (toward
 shippable scope), commitment (to that scope; date as signal), and incremental
 delivery (frequent small releases). It's literally the release-please flow —
-**small frequent milestones == frequent small releases** — so it's one rhythm, not
-two.
+**small frequent milestones == frequent delivery batches** — so it's one rhythm,
+not two, even when a rolling-release repo cuts several versions inside one
+scope-batch milestone.
 
 **Get the forcing-function from tools you already have,** not a sprint clock: a
 **WIP limit** on `In Progress`, sub-issues **sized to one PR**, and continuous
@@ -1024,7 +1022,7 @@ Ready + priority*. Iteration is a human-cadence concept your agents don't have.
 
 There's **no Epic type, by design.** The "big initiative" role splits cleanly
 into two natives — **sub-issues** carry the *hierarchy* axis and **milestones**
-carry the *release* axis — and GitHub stitches them together for you: a
+carry the *delivery-batch* axis — and GitHub stitches them together for you: a
 **sub-issue inherits its parent's Project and Milestone by default** (shipped
 2025-09). Assign them once on the parent and the child tree picks them up — no
 per-child bookkeeping.
@@ -1041,15 +1039,17 @@ the sub-issue's job, and only that. Once that's clear, the rest is just sizing a
 deciding what metadata rides on the parent vs. the leaves.
 
 **The three-tier shape (replaces Epic → Story → Task with natives):** a
-**milestone** (the dated release batch — possibly-unrelated work) contains parent
+**milestone** (the cross-feature shippable batch — possibly-unrelated work)
+contains parent
 **Feature** issues (each a cohesive capability), each of which contains **Task**
 sub-issues (mergeable slices). Full hierarchy, no synthetic Epic.
 
 The boundary that trips people up: **a milestone is a flat batch of unrelated
-features targeting a date; a parent issue is one cohesive thing decomposed.** So
+features targeting one delivery outcome; a parent issue is one cohesive thing
+decomposed.** So
 don't build a giant "Launch" parent with 40 sub-issues spanning unrelated features
 — that's exactly what the milestone is for. Milestone for the cross-feature
-release; the parent-issue tree for a single feature.
+batch; the parent-issue tree for a single feature.
 
 **Where metadata lives — parent vs. leaf.** The **parent** holds the durable
 context: the spec (your Given/When/Then acceptance criteria), the "why," the

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -1193,6 +1193,8 @@ iac | full)
             err "CHECKLIST links to the omitted GitHub project-management doc for project_management=none"
         ! grep -Fq 'ADR 0005' docs/CHECKLIST.md ||
             err "CHECKLIST cites a repository-only ADR for project_management=none"
+        grep -Fq 'Copilot is a broker that defaults to `mai`' docs/CHECKLIST.md ||
+            err "CHECKLIST loses the Copilot broker/default-family distinction"
     fi
     ! grep -q '^review_sender_trust\|^required_review_bots\|^require_codex_cloud_review' .foreman.toml ||
         err ".foreman.toml still ships v1-only keys the v2 CLI ignores"

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -1189,6 +1189,8 @@ iac | full)
             err "CHECKLIST omits legacy-label migration for project_management=none + use_foreman=true"
         grep -Fq 'treat it as capped' docs/CHECKLIST.md ||
             err "CHECKLIST legacy-label migration can silently truncate a capped association sweep"
+        ! grep -Fq '[project-management.md](project-management.md)' docs/CHECKLIST.md ||
+            err "CHECKLIST links to the omitted GitHub project-management doc for project_management=none"
     fi
     ! grep -q '^review_sender_trust\|^required_review_bots\|^require_codex_cloud_review' .foreman.toml ||
         err ".foreman.toml still ships v1-only keys the v2 CLI ignores"

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -1182,6 +1182,14 @@ iac | full)
     node scripts/label-registry-render.mjs labels --foreman | grep -q '^foreman:claude|' ||
         err "rendered label set does not include the registry's foreman:claude adapter selector"
     grep -q 'setup-github-labels.sh --repo "{{.REPO}}" --foreman' Taskfile.yml || err "setup:github-labels does not pass --foreman (use_foreman=true)"
+    if [ "$profile" = "iac" ]; then
+        grep -Fq 'Labels: run `task setup:github-labels`' docs/CHECKLIST.md ||
+            err "CHECKLIST omits label setup for project_management=none + use_foreman=true"
+        grep -Fq 'Retire any legacy `agent:*` claim labels' docs/CHECKLIST.md ||
+            err "CHECKLIST omits legacy-label migration for project_management=none + use_foreman=true"
+        grep -Fq 'treat it as capped' docs/CHECKLIST.md ||
+            err "CHECKLIST legacy-label migration can silently truncate a capped association sweep"
+    fi
     ! grep -q '^review_sender_trust\|^required_review_bots\|^require_codex_cloud_review' .foreman.toml ||
         err ".foreman.toml still ships v1-only keys the v2 CLI ignores"
     # Foreman >= 2.2.0 is draft-first with namespaced PR labels; the rendered

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -1191,6 +1191,8 @@ iac | full)
             err "CHECKLIST legacy-label migration can silently truncate a capped association sweep"
         ! grep -Fq '[project-management.md](project-management.md)' docs/CHECKLIST.md ||
             err "CHECKLIST links to the omitted GitHub project-management doc for project_management=none"
+        ! grep -Fq 'ADR 0005' docs/CHECKLIST.md ||
+            err "CHECKLIST cites a repository-only ADR for project_management=none"
     fi
     ! grep -q '^review_sender_trust\|^required_review_bots\|^require_codex_cloud_review' .foreman.toml ||
         err ".foreman.toml still ships v1-only keys the v2 CLI ignores"

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -275,6 +275,8 @@ environment — against the items below
       Retiring them is a deliberate, irreversible operator step — see
       [project-management.md](project-management.md), "Migrating a board that
       still has one."
+[% endif %]
+[% if project_management == 'github' or use_foreman %]
 - [ ] Labels: run `task setup:github-labels` to seed this repo's starter label
       families from `label-registry.json` (see the generated taxonomy table in
       [project-management.md](project-management.md)) — grow `domain:` values
@@ -288,13 +290,15 @@ environment — against the items below
       the issues they sit on are untouched — then classify open issues with the
       added families.
 - [ ] **[human-only] Retire any legacy `agent:*` claim labels** — needed only
-      where `gh label list --limit 200` still shows the harness-named family
+      where `gh label list --limit 1000` still shows the harness-named family
       (`agent:claude-code`, `agent:gemini-cli`, …) a pre-registry harmon-init
-      seeded. **Pass an explicit `--limit` to every `gh label list`,
-      `gh issue list`, and `gh pr list` in this step**: all three default to 30,
-      the starter set alone is over 40 labels, and an unbounded read reports a
-      clean repo — or a finished migration — while legacy labels, in-flight
-      claims, and labelled pull requests remain.
+      seeded. **Start with an explicit `--limit 1000` on every `gh label list`,
+      `gh issue list`, and `gh pr list` in this step**: all three default to 30.
+      If any list returns exactly 1000 entries (`--json name --jq length` for
+      labels; `--json number --jq length` for issues and PRs), treat it as capped:
+      double the limit and re-run until the count is below the cap before any
+      rename or delete. Otherwise a clean-looking result can leave legacy
+      labels, in-flight claims, or labelled pull requests unseen.
       `setup-github-labels` never deletes a label, so the old family
       survives beside the registry-rendered `claim:*` one, and every reader
       tolerates both — this is cleanup, not a fix for something broken.
@@ -328,7 +332,7 @@ environment — against the items below
       X --remove-label Y` pair works on `gh pr edit`), then delete the
       now-empty old label (`gh label delete agent:claude-code --repo
       <owner/repo> --yes`) once a re-read of `gh issue list --label
-      agent:claude-code --state all --limit 200` **and** the equivalent
+      agent:claude-code --state all --limit 1000` **and** the equivalent
       `gh pr list` both return nothing — only then is it safe to delete; the
       other checklist items below that reference this procedure reuse it
       verbatim. Enumerate **`gh pr list` as well as `gh issue list`**
@@ -336,10 +340,10 @@ environment — against the items below
       pull requests too and `gh issue list` never returns them, so deleting the
       legacy label afterwards would drop exactly the associations the re-labelling
       missed — the loss this whole item exists to avoid. Check for in-flight
-      claims first — `gh issue list --label agent:… --state all --limit 200`
-      **and** `gh pr list --label agent:… --state all --limit 200`: a claim
+      claims first — `gh issue list --label agent:… --state all --limit 1000`
+      **and** `gh pr list --label agent:… --state all --limit 1000`: a claim
       record naming the old label will not release the renamed one, so settle or
-      amend those records in the same sitting. Re-read `gh label list --limit 200` afterwards — no `agent:*`
+      amend those records in the same sitting. Re-read `gh label list --limit 1000` afterwards — no `agent:*`
       should remain.
 - [ ] **[human-only] Retire pre-2026-refresh `codex`/`copilot` agent labels** —
       needed only where an explicit enumeration shows
@@ -414,6 +418,8 @@ environment — against the items below
       `suggest:gpt:sol` and delete `suggest:codex:sol` once it carries no
       issues or PRs, rather than renaming over the existing one. Re-run the
       `grep` above afterwards — it should return nothing.
+[% endif %]
+[% if project_management == 'github' %]
 - [ ] Project views: create the starter views (Board / Triage / Agent queue /
       Planning / Mine) in the Project UI — Projects V2 has no view API,
       so this is a one-time manual step. Filters/layouts are in

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -354,8 +354,9 @@ environment — against the items below
       (the default `gh label list --limit 200` paged listing can miss these
       on a repo with many labels — use this enumeration, not the paged form,
       everywhere in this item). harmon-init issue #751 renamed those families
-      to `gpt` and `mai` (Codex and Copilot are harnesses, not families — the
-      same harness/family split D9 already made elsewhere; see ADR 0005 D8).
+      to `gpt` and `mai`: labels classify the model family, not the harness;
+      Codex runs GPT-family models, while Copilot is represented by its `mai`
+      broker family because it can route across models.
       A `setup-github-labels` re-run never deletes the old family, so it
       survives beside the new registry-rendered one.
 

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -353,10 +353,10 @@ environment — against the items below
       name --jq '.[].name' | grep -E '^(suggest|claim):(codex|copilot)$'`
       (the default `gh label list --limit 200` paged listing can miss these
       on a repo with many labels — use this enumeration, not the paged form,
-      everywhere in this item). harmon-init issue #751 renamed those families
-      to `gpt` and `mai`: labels classify the model family, not the harness;
-      Codex runs GPT-family models, while Copilot is represented by its `mai`
-      broker family because it can route across models.
+      everywhere in this item). harmon-init issue #751 replaced those
+      harness-named families with model-family vocabulary: Codex maps to `gpt`;
+      Copilot is a broker that defaults to `mai`, but each association must use
+      the actual family recovered by the procedure below.
       A `setup-github-labels` re-run never deletes the old family, so it
       survives beside the new registry-rendered one.
 

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -278,8 +278,9 @@ environment — against the items below
 [% endif %]
 [% if project_management == 'github' or use_foreman %]
 - [ ] Labels: run `task setup:github-labels` to seed this repo's starter label
-      families from `label-registry.json` (see the generated taxonomy table in
-      [project-management.md](project-management.md)) — grow `domain:` values
+      families from `label-registry.json`[% if project_management == 'github' %]
+      (see the generated taxonomy table in
+      [project-management.md](project-management.md))[% endif %] — grow `domain:` values
       there as the product's own vocabulary; `layer:` is product-independent
       and normally needs no edits. Labels are per-repo, so run it in each repo;
       org default labels (org Settings → Repository, UI-only) only seed new

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -1014,7 +1014,8 @@ queue up and displace legitimate runs.
 
 ## Milestones
 
-A milestone has **one job — "when it ships"** — and nothing else. Four things
+A milestone has **one job — "which finite, shippable batch is this part of?"** —
+and nothing else. Four things
 could all masquerade as milestones, so keep the lanes clean:
 
 - **Type** — what kind of work (Bug / Feature / Task / Research)
@@ -1022,41 +1023,37 @@ could all masquerade as milestones, so keep the lanes clean:
 - **Labels** — orthogonal, cross-cutting concerns
 - **Sub-issues** — hierarchy
 
-None of those answers *"which dated, shippable batch does this belong to, and how
-done is that batch?"* — that's the milestone's unique contribution: a
-release/launch container with a **due date** and a **live completion bar**. Labels
-for classification, milestones for goal tracking. The moment you're making a
-milestone that isn't a dated, shippable batch, it's really a label or a saved
-view.
+None of those answers *"which shippable batch does this belong to, and how done
+is that batch?"* — that's the milestone's unique contribution: a finite
+delivery container with a **live completion bar** and, when useful, a due date.
+Labels are for classification; milestones are for goal tracking. An open-ended
+concern with no completion condition is still a label or saved view.
 
-**Name milestones after release versions** — the milestone title *equals* the git
-tag (`v1.0.0`, `v1.1.0`). Then the milestone list doubles as a release-history /
-changelog skeleton, and closing a milestone on publish needs no special plumbing.
-This dovetails with **release-please** because they run at different times and
-never overlap:
+Use one of two explicit milestone naming modes:
 
-- The **milestone** is the *pre-ship planning* artifact — "what must land before
-  we cut `v1.1.0`."
-- **release-please** is the *post-merge machine* that calculates and cuts the
-  actual version from your conventional commits (see
-  [conventions.md](conventions.md)).
+- **Version milestone** — for a product release planned as a version, make the
+  title equal the git tag (`v1.0.0`, `v1.1.0`). The milestone is the pre-ship
+  "what must land before this version" artifact; release-please is the post-merge
+  machine that calculates and cuts the actual version from conventional commits
+  (see [conventions.md](conventions.md)). The shipped
+  `close-milestone-on-release.yml` Action closes the milestone matching a
+  published tag, and the release PR can carry it too.
+- **Scope-batch milestone** — for a rolling-release or tooling repo where
+  versions are outputs rather than planning inputs, name the finite outcome
+  (`Issue strategy overhaul`, `Runner hardening`). It may span several releases;
+  close it when its scoped issues are complete. Release-please continues to
+  version each shipped increment independently, and the tag-matching Action
+  intentionally does not close a non-version milestone.
 
-Naming them identically makes the two legible to each other — the shipped
-`close-milestone-on-release.yml` Action closes the milestone matching a published
-tag (when release-please is on) — without making them one system. Since PRs and
-issues share the milestone namespace, the release PR itself
-can carry the milestone, so the shipped batch is fully self-documenting.
+Do not mix the two modes in one title or invent a version for work whose version
+is not known yet. **Carry one active delivery milestone per stream** — create it
+when it has real scope, close it when that scope ships, and open the next only as
+needed rather than keeping speculative batches in competition.
 
-**One active release milestone at a time (rolling).** Carry one open milestone per
-release line — created when it has real scope and a date, closed when it ships,
-the next opened only as needed. Not five speculative open milestones competing for
-attention.
-
-**Due dates are signals, not gates.** A milestone's due date doesn't block a merge
-or a close and triggers nothing — it's a communication tool; update it honestly
-when the plan slips. That's where milestones earn their keep on a team: the dated
-milestone is the shared artifact that tells collaborators what's shipping and
-roughly when — worth more with others in the loop than in pure solo work.
+**Due dates are signals, not gates.** A milestone's due date is optional, does
+not block a merge or close, and triggers nothing. Add one when a collaborator
+needs a timing signal and update it honestly when the plan slips; the milestone's
+scope and completion bar remain useful without a fabricated date.
 
 ## Milestones over iterations
 
@@ -1085,8 +1082,9 @@ giant "Launch." A tightly-scoped milestone with a target date is a chunk of valu
 with an expectation attached, doing three jobs at once: coordination (toward
 shippable scope), commitment (to that scope; date as signal), and incremental
 delivery (frequent small releases). It's literally the release-please flow —
-**small frequent milestones == frequent small releases** — so it's one rhythm, not
-two.
+**small frequent milestones == frequent delivery batches** — so it's one rhythm,
+not two, even when a rolling-release repo cuts several versions inside one
+scope-batch milestone.
 
 **Get the forcing-function from tools you already have,** not a sprint clock: a
 **WIP limit** on `In Progress`, sub-issues **sized to one PR**, and continuous
@@ -1112,7 +1110,7 @@ Ready + priority*. Iteration is a human-cadence concept your agents don't have.
 
 There's **no Epic type, by design.** The "big initiative" role splits cleanly
 into two natives — **sub-issues** carry the *hierarchy* axis and **milestones**
-carry the *release* axis — and GitHub stitches them together for you: a
+carry the *delivery-batch* axis — and GitHub stitches them together for you: a
 **sub-issue inherits its parent's Project and Milestone by default** (shipped
 2025-09). Assign them once on the parent and the child tree picks them up — no
 per-child bookkeeping.
@@ -1129,15 +1127,17 @@ the sub-issue's job, and only that. Once that's clear, the rest is just sizing a
 deciding what metadata rides on the parent vs. the leaves.
 
 **The three-tier shape (replaces Epic → Story → Task with natives):** a
-**milestone** (the dated release batch — possibly-unrelated work) contains parent
+**milestone** (the cross-feature shippable batch — possibly-unrelated work)
+contains parent
 **Feature** issues (each a cohesive capability), each of which contains **Task**
 sub-issues (mergeable slices). Full hierarchy, no synthetic Epic.
 
 The boundary that trips people up: **a milestone is a flat batch of unrelated
-features targeting a date; a parent issue is one cohesive thing decomposed.** So
+features targeting one delivery outcome; a parent issue is one cohesive thing
+decomposed.** So
 don't build a giant "Launch" parent with 40 sub-issues spanning unrelated features
 — that's exactly what the milestone is for. Milestone for the cross-feature
-release; the parent-issue tree for a single feature.
+batch; the parent-issue tree for a single feature.
 
 **Where metadata lives — parent vs. leaf.** The **parent** holds the durable
 context: the spec (your Given/When/Then acceptance criteria), the "why," the

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -246,11 +246,13 @@ it points here.
   PRs (Renovate/Dependabot) are skipped.
 [% endif %]
 [% if project_management == 'github' %]
-- Issue types map many-to-one onto these commit types — see
-  [project-management.md](project-management.md).
-- **Milestones are named after release versions** (`v1.1.0` = the git tag): the
-  pre-ship "what must land before this version" container, distinct from
-  release-please cutting the tag post-merge — same name, different jobs. See
+- Issue types map many-to-one onto these commit types. Personal-account repos
+  use the equivalent work-type labels as that mapping's substrate because native
+  issue Type is unavailable there; organization repos use native Type and no
+  work-type label. See [project-management.md](project-management.md).
+- **Milestones use an explicit naming mode**: a version milestone is named after
+  its git tag (`v1.1.0`), while a rolling-release or tooling repo may use a
+  finite scope-batch name when the version is not a planning input. See
   [project-management.md](project-management.md).
 [% endif %]
 [% else %]


### PR DESCRIPTION
## Description

Reconciles the project-management guidance with the repository's live label registry and milestone practice. It documents version and scope-batch milestone modes, explains the personal-account work-type-label substrate, and keeps the root/template twins aligned.

It also absorbs the actionable follow-ups from #702 and #703: Foreman-only repositories now receive the label setup and migration checklist, and destructive legacy-label sweeps detect and recover from result caps. Render assertions prevent broken links or root-only rationale from leaking into that profile.

#683 was re-dispositioned as not planned: #699 already delivered the valid `claim:*` wording, while its remaining no-`agent:*` grep criterion conflicts with the intentionally accurate legacy-compatibility note.

Closes #857
Closes #702
Closes #703

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Verification

- [x] `task check`
- [x] `task verify` (including all six rendered template profiles)
- [x] `task audit:dogfood -- --summary`
- [x] `task challenge` converged in 3 rounds
- [x] `task review` converged in 2 rounds
- [x] `task ci` (skills drift, devcontainer assertions, gitleaks, Semgrep)
- [x] `PR_TITLE="fix: reconcile project management guidance" BASE_SHA=origin/main task guard:release-title`

## Execution policy

- rigor: `standard` (`default_rigor`) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1
- tier: `standard` (config default)
- method: `plan` (explicit operator instruction; off-default from the issue's advisory `method:oneshot` label)
- Reviewer independence: the authoring session and local reviewer share the GPT family; the required current-head Codex cloud cycle is the nearest independent cross-check during shepherding.

## Deferred findings

None. Every P2 raised locally was fixed and verified before PR creation.

## Checklist

- [x] Root and template documentation were updated together.
- [x] Regression assertions cover the Foreman-only `project_management=none` render.
- [x] Existing and new tests pass locally.
- [x] No new warnings or secret-scan findings were introduced.

## Adjudication record

<details>
<summary>Local challenge and verification-review ledger</summary>

```text
template/docs/CHECKLIST.md.jinja:281 | Foreman-only checklist linked to omitted project-management.md | confirmed P1: condition link on GitHub PM and assert absence in iac render | challenge r1
template/docs/CHECKLIST.md.jinja:358 | Foreman-only checklist cited repository-only ADR 0005 | confirmed P2: replace citation with self-contained harness/family rationale and assert its absence in iac render | challenge r2 | prior-round-only: no; exposed by the original Foreman-only conditional expansion
none | no materially defensible P0, P1, or P2 findings | clean; no action | challenge r3 (capped-clean convergence)
template/docs/CHECKLIST.md.jinja:357 | Copilot summary treated broker default MAI as every association's family | confirmed P2: state that Copilot defaults to MAI but requires recovering each association's actual family; mirror root and assert rendered wording | review r1
none | no P0 or P1 findings; implementation and regression coverage consistent | clean; no action | review r2 (two-consecutive-clean convergence) | prior-round-only: none
```

</details>
