### PR TITLE
fix: select the worktree Node installer from the repo's declared package manager

### DIFF
--- a/.devcontainer/hooks/post-checkout
+++ b/.devcontainer/hooks/post-checkout
@@ -14,6 +14,14 @@ command -v git-lfs >/dev/null 2>&1 || {
 git lfs post-checkout "$@"
 
 # --- auto-install Node.js dependencies ---
+# LEFTHOOK=0 is this fleet's hook-suppression contract: scripts/worktree-new.sh
+# sets it on every `git worktree add` and then installs with the repo's
+# DECLARED package manager itself (harmon-init#841). Without this guard the
+# lockfile-first fallback below would run first and could pick a competing
+# installer — e.g. pnpm from a stale pnpm-lock.yaml in a repo whose
+# package.json declares npm. The git-lfs chain above deliberately stays
+# outside the guard: checkout correctness is not an install.
+[ "${LEFTHOOK:-}" = "0" ] && exit 0
 # $3 = 1 for branch checkout (including worktree add), 0 for file checkout.
 # Only run on branch checkouts to avoid slowing down file-level operations.
 # Unset NODE_OPTIONS to prevent VS Code's JS debug bootloader from crashing

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -64,14 +64,19 @@ it points here.
 - **The Node installer is selected from the repo's own signals** — a
   `package.json` alone proves "Node repo", never "pnpm repo". Precedence:
   the `packageManager` field in `package.json` (the Corepack declaration)
-  wins outright, even over a contradicting lockfile; otherwise exactly one
-  manager's files at the tree root — `pnpm-lock.yaml`/`pnpm-workspace.yaml`
-  → pnpm, `package-lock.json`/`npm-shrinkwrap.json` → npm, `yarn.lock` →
-  Yarn, `bun.lock`/`bun.lockb` → Bun. Files from two managers at once fail
-  loudly rather than guess, an unsupported `packageManager` value fails
-  loudly without touching the tree, and a bare `package.json` with no signal
-  skips the install with a note — declare `packageManager` to make it
-  deterministic.
+  wins — including over a stale foreign lockfile, when its own manager's
+  files are present; otherwise exactly one manager's files at the tree
+  root — `pnpm-lock.yaml`/`pnpm-workspace.yaml` → pnpm,
+  `package-lock.json`/`npm-shrinkwrap.json` → npm, `yarn.lock` → Yarn,
+  `bun.lock`/`bun.lockb` → Bun. Every contradiction fails loudly before
+  any install touches the tree: files from two managers with no
+  declaration, a declaration whose manager has no files here while other
+  managers' files exist (installing would write a second lockfile), an
+  unsupported `packageManager` value, and a declared numeric major that
+  the installed binary does not match (a drifted major can rewrite the
+  committed lockfile; corepack-shimmed binaries report the pinned version
+  and pass). A bare `package.json` with no signal skips the install with a
+  note — declare `packageManager` to make it deterministic.
 - **Never pass `-c core.hooksPath=.git/hooks` to git in a worktree.** In a
   linked worktree `.git` is a **file**, not a directory, so that path resolves
   to nothing and commits run **hook-less and silently**. Git's own defaults are

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -75,8 +75,12 @@ it points here.
   unsupported `packageManager` value, and a declared numeric major that
   the installed binary does not match (a drifted major can rewrite the
   committed lockfile; corepack-shimmed binaries report the pinned version
-  and pass). A bare `package.json` with no signal skips the install with a
-  note — declare `packageManager` to make it deterministic.
+  and pass). When the selected manager's own lockfile exists the install
+  runs in its immutable mode (`npm ci`, `--frozen-lockfile`, Yarn Berry
+  `--immutable`), so lockfile drift fails and rolls back instead of
+  rewriting a committed file; with no lockfile, plain `install` runs and
+  may create one. A bare `package.json` with no signal skips the install
+  with a note — declare `packageManager` to make it deterministic.
 - **Never pass `-c core.hooksPath=.git/hooks` to git in a worktree.** In a
   linked worktree `.git` is a **file**, not a directory, so that path resolves
   to nothing and commits run **hook-less and silently**. Git's own defaults are

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -61,6 +61,17 @@ it points here.
 - **A fresh worktree has no `node_modules`/`.venv`.** Working files are per-tree,
   so dependency install is per-tree too; that is what `worktree:new` runs and
   why "it worked in the main checkout" is not evidence.
+- **The Node installer is selected from the repo's own signals** — a
+  `package.json` alone proves "Node repo", never "pnpm repo". Precedence:
+  the `packageManager` field in `package.json` (the Corepack declaration)
+  wins outright, even over a contradicting lockfile; otherwise exactly one
+  manager's files at the tree root — `pnpm-lock.yaml`/`pnpm-workspace.yaml`
+  → pnpm, `package-lock.json`/`npm-shrinkwrap.json` → npm, `yarn.lock` →
+  Yarn, `bun.lock`/`bun.lockb` → Bun. Files from two managers at once fail
+  loudly rather than guess, an unsupported `packageManager` value fails
+  loudly without touching the tree, and a bare `package.json` with no signal
+  skips the install with a note — declare `packageManager` to make it
+  deterministic.
 - **Never pass `-c core.hooksPath=.git/hooks` to git in a worktree.** In a
   linked worktree `.git` is a **file**, not a directory, so that path resolves
   to nothing and commits run **hook-less and silently**. Git's own defaults are

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -2262,7 +2262,11 @@ printf '%s %s\n' "\$*" "\$PWD" >>"$pnpm_marker"
 exit 0
 EOF
 chmod +x "$stub_bin/pnpm"
+# The lockfile is what marks this repo as pnpm's: package.json alone is shared
+# by npm, Yarn, and Bun, so it selects no installer (harmon-init#841) — the
+# signal-less case has its own coverage below.
 printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
+printf 'lockfileVersion: "9.0"\n' >"$fixture/pnpm-lock.yaml"
 git -C "$fixture" add -A
 git -C "$fixture" commit -qm "chore: add package.json" >"$test_tmp/commit.log" 2>&1 ||
     {
@@ -2277,7 +2281,9 @@ rm_wt node-tree >/dev/null || fail "cleanup of the node tree failed"
 echo "==> a pnpm workspace without a root package.json still installs"
 : >"$pnpm_marker"
 git -C "$fixture" rm -q --cached package.json >/dev/null
-rm -f "$fixture/package.json"
+# The lockfile goes too: with it present this case would pass even if
+# workspace-file recognition regressed, which is the property it exists for.
+rm -f "$fixture/package.json" "$fixture/pnpm-lock.yaml"
 printf 'packages:\n  - "packages/*"\n' >"$fixture/pnpm-workspace.yaml"
 git -C "$fixture" add -A
 LEFTHOOK=0 git -C "$fixture" commit -qm "chore: workspace without a root manifest" >"$test_tmp/commit.log" 2>&1 ||
@@ -2290,6 +2296,138 @@ printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
 git -C "$fixture" add -A
 LEFTHOOK=0 git -C "$fixture" commit -qm "chore: restore the root manifest" >"$test_tmp/commit.log" 2>&1 ||
     fail "restoring the root package.json failed"
+
+# ── package-manager detection (harmon-init#841) ──────────────────────
+# package.json is shared by npm, Yarn, Bun, and pnpm, so worktree-new.sh
+# selects the installer from the repo's own signals instead of assuming pnpm.
+# Every case states its whole fixture through det_reset (all Node signal files
+# cleared first) and asserts BOTH halves of the invariant: the selected
+# installer ran in the tree, and every competitor stayed silent — the second
+# half is what catches a regression to the old unconditional pnpm.
+for det_name in npm yarn bun; do
+    cat >"$stub_bin/$det_name" <<EOF
+#!/usr/bin/env bash
+printf '%s %s\n' "\$*" "\$PWD" >>"$test_tmp/$det_name-invoked"
+exit 0
+EOF
+    chmod +x "$stub_bin/$det_name"
+done
+
+det_signal_files="package.json pnpm-workspace.yaml pnpm-lock.yaml package-lock.json npm-shrinkwrap.json yarn.lock bun.lock bun.lockb"
+det_reset() {
+    for det_name in pnpm npm yarn bun; do
+        : >"$test_tmp/$det_name-invoked"
+    done
+    for det_name in $det_signal_files; do
+        rm -f "$fixture/$det_name"
+    done
+}
+det_commit() {
+    git -C "$fixture" add -A
+    LEFTHOOK=0 git -C "$fixture" commit -qm "chore: $1" >"$test_tmp/commit.log" 2>&1 ||
+        {
+            cat "$test_tmp/commit.log" >&2
+            fail "committing the detection fixture ($1) failed"
+        }
+}
+det_assert_installer() {
+    # $1 = the manager that must have run `install` in the tree, '' for none;
+    # $2 = the tree path ('' when no tree should exist).
+    for det_name in pnpm npm yarn bun; do
+        if [ "$det_name" = "$1" ]; then
+            grep -qx "install $2" "$test_tmp/$det_name-invoked" 2>/dev/null ||
+                fail "worktree-new.sh did not run '$det_name install' inside $2"
+        elif [ -s "$test_tmp/$det_name-invoked" ]; then
+            fail "worktree-new.sh invoked $det_name in a tree whose manager is '${1:-none}'"
+        fi
+    done
+}
+
+echo "==> an npm lockfile selects npm, and no competing installer runs"
+det_reset
+printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
+printf '{"lockfileVersion": 3}\n' >"$fixture/package-lock.json"
+det_commit "npm lockfile"
+new det-npm >/dev/null || fail "worktree-new.sh failed on an npm repo"
+det_assert_installer npm "$fixture/.worktrees/det-npm"
+rm_wt det-npm >/dev/null || fail "cleanup of the npm tree failed"
+
+echo "==> a yarn.lock selects Yarn"
+det_reset
+printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
+printf '# yarn lockfile v1\n' >"$fixture/yarn.lock"
+det_commit "yarn lockfile"
+new det-yarn >/dev/null || fail "worktree-new.sh failed on a Yarn repo"
+det_assert_installer yarn "$fixture/.worktrees/det-yarn"
+rm_wt det-yarn >/dev/null || fail "cleanup of the yarn tree failed"
+
+echo "==> a bun.lock selects Bun"
+det_reset
+printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
+printf '{}\n' >"$fixture/bun.lock"
+det_commit "bun lockfile"
+new det-bun >/dev/null || fail "worktree-new.sh failed on a Bun repo"
+det_assert_installer bun "$fixture/.worktrees/det-bun"
+rm_wt det-bun >/dev/null || fail "cleanup of the bun tree failed"
+
+echo "==> a declared packageManager wins over a contradicting lockfile"
+det_reset
+printf '{"name":"fixture","private":true,"packageManager":"npm@10.9.2+sha512.0123abcdef"}\n' >"$fixture/package.json"
+printf 'lockfileVersion: "9.0"\n' >"$fixture/pnpm-lock.yaml"
+det_commit "declared npm over a pnpm lockfile"
+new det-declared >/dev/null || fail "worktree-new.sh failed on a declared-manager repo"
+det_assert_installer npm "$fixture/.worktrees/det-declared"
+rm_wt det-declared >/dev/null || fail "cleanup of the declared-manager tree failed"
+
+echo "==> an unsupported packageManager fails loudly, installs nothing, rolls back"
+det_reset
+printf '{"name":"fixture","private":true,"packageManager":"moon@1.2.3"}\n' >"$fixture/package.json"
+det_commit "unsupported manager declaration"
+det_status=0
+det_out="$(new det-unsupported 2>&1)" || det_status=$?
+[ "$det_status" -ne 0 ] || fail "worktree-new.sh succeeded with an unsupported packageManager declaration"
+printf '%s\n' "$det_out" | grep -q "does not support" ||
+    fail "the unsupported-manager refusal did not say the declaration is unsupported"
+det_assert_installer "" ""
+refute_exists "$fixture/.worktrees/det-unsupported" "worktree-new.sh left a tree behind after refusing an unsupported manager"
+if git -C "$fixture" show-ref --verify --quiet refs/heads/det-unsupported; then
+    fail "worktree-new.sh left the branch behind after refusing an unsupported manager"
+fi
+
+echo "==> lockfiles from two managers fail loudly instead of guessing"
+det_reset
+printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
+printf '{"lockfileVersion": 3}\n' >"$fixture/package-lock.json"
+printf 'bun-binary-lockfile\n' >"$fixture/bun.lockb"
+det_commit "conflicting lockfiles"
+det_status=0
+det_out="$(new det-conflict 2>&1)" || det_status=$?
+[ "$det_status" -ne 0 ] || fail "worktree-new.sh succeeded with lockfiles from two package managers"
+printf '%s\n' "$det_out" | grep -q "conflicting Node package-manager signals in this tree: npm bun" ||
+    fail "the conflicting-lockfile refusal did not name both managers"
+det_assert_installer "" ""
+refute_exists "$fixture/.worktrees/det-conflict" "worktree-new.sh left a tree behind after refusing conflicting lockfiles"
+if git -C "$fixture" show-ref --verify --quiet refs/heads/det-conflict; then
+    fail "worktree-new.sh left the branch behind after refusing conflicting lockfiles"
+fi
+
+echo "==> a bare package.json with no signal skips the install, saying why"
+det_reset
+printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
+det_commit "bare manifest, no manager signal"
+det_out="$(new det-bare 2>&1)" || fail "worktree-new.sh failed on a signal-less Node repo"
+printf '%s\n' "$det_out" | grep -q "no package-manager signal" ||
+    fail "the signal-less run did not say why the install was skipped"
+det_assert_installer "" ""
+rm_wt det-bare >/dev/null || fail "cleanup of the signal-less tree failed"
+
+# Restore the pnpm fixture the cases below assume — package.json plus the
+# workspace file, exactly as it stood before this block.
+det_reset
+printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
+printf 'packages:\n  - "packages/*"\n' >"$fixture/pnpm-workspace.yaml"
+det_commit "restore the pnpm fixture"
+: >"$pnpm_marker"
 
 # ── post-checkout runs AFTER dependencies are installed ──────────────
 # `git worktree add` fires post-checkout itself, before anything is installed,

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -2258,6 +2258,10 @@ echo "==> a Node repo gets its dependencies installed in the NEW tree"
 pnpm_marker="$test_tmp/pnpm-invoked"
 cat >"$stub_bin/pnpm" <<EOF
 #!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+    echo 9.0.0
+    exit 0
+fi
 printf '%s %s\n' "\$*" "\$PWD" >>"$pnpm_marker"
 exit 0
 EOF
@@ -2304,9 +2308,20 @@ LEFTHOOK=0 git -C "$fixture" commit -qm "chore: restore the root manifest" >"$te
 # cleared first) and asserts BOTH halves of the invariant: the selected
 # installer ran in the tree, and every competitor stayed silent — the second
 # half is what catches a regression to the old unconditional pnpm.
+# Each stub answers --version without logging (worktree-new.sh reads it to
+# verify a declared version pin) and records every other invocation.
 for det_name in npm yarn bun; do
+    case "$det_name" in
+    npm) det_stub_ver=10.9.2 ;;
+    yarn) det_stub_ver=4.1.0 ;;
+    bun) det_stub_ver=1.2.10 ;;
+    esac
     cat >"$stub_bin/$det_name" <<EOF
 #!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+    echo $det_stub_ver
+    exit 0
+fi
 printf '%s %s\n' "\$*" "\$PWD" >>"$test_tmp/$det_name-invoked"
 exit 0
 EOF
@@ -2370,14 +2385,47 @@ new det-bun >/dev/null || fail "worktree-new.sh failed on a Bun repo"
 det_assert_installer bun "$fixture/.worktrees/det-bun"
 rm_wt det-bun >/dev/null || fail "cleanup of the bun tree failed"
 
-echo "==> a declared packageManager wins over a contradicting lockfile"
+echo "==> a declared packageManager with its own lockfile wins over a stale foreign one"
 det_reset
 printf '{"name":"fixture","private":true,"packageManager":"npm@10.9.2+sha512.0123abcdef"}\n' >"$fixture/package.json"
+printf '{"lockfileVersion": 3}\n' >"$fixture/package-lock.json"
 printf 'lockfileVersion: "9.0"\n' >"$fixture/pnpm-lock.yaml"
-det_commit "declared npm over a pnpm lockfile"
+det_commit "declared npm with its own lockfile over a stale pnpm one"
 new det-declared >/dev/null || fail "worktree-new.sh failed on a declared-manager repo"
 det_assert_installer npm "$fixture/.worktrees/det-declared"
 rm_wt det-declared >/dev/null || fail "cleanup of the declared-manager tree failed"
+
+echo "==> a declaration whose manager has no files here fails instead of writing a second lockfile"
+det_reset
+printf '{"name":"fixture","private":true,"packageManager":"npm@10.9.2"}\n' >"$fixture/package.json"
+printf 'lockfileVersion: "9.0"\n' >"$fixture/pnpm-lock.yaml"
+det_commit "declared npm against a foreign-only lockfile"
+det_status=0
+det_out="$(new det-foreign 2>&1)" || det_status=$?
+[ "$det_status" -ne 0 ] || fail "worktree-new.sh succeeded for a declaration contradicted by a foreign-only lockfile"
+printf '%s\n' "$det_out" | grep -q "carries other managers' files (pnpm) and none of npm's" ||
+    fail "the foreign-only-lockfile refusal did not name the contradiction"
+det_assert_installer "" ""
+refute_exists "$fixture/.worktrees/det-foreign" "worktree-new.sh left a tree behind after refusing a contradicted declaration"
+if git -C "$fixture" show-ref --verify --quiet refs/heads/det-foreign; then
+    fail "worktree-new.sh left the branch behind after refusing a contradicted declaration"
+fi
+
+echo "==> a declared version pin with a drifted major fails instead of installing"
+det_reset
+printf '{"name":"fixture","private":true,"packageManager":"npm@6.14.18"}\n' >"$fixture/package.json"
+printf '{"lockfileVersion": 1}\n' >"$fixture/package-lock.json"
+det_commit "declared npm@6 against a newer installed npm"
+det_status=0
+det_out="$(new det-verpin 2>&1)" || det_status=$?
+[ "$det_status" -ne 0 ] || fail "worktree-new.sh installed under a version pin its npm does not satisfy"
+printf '%s\n' "$det_out" | grep -q "pins npm@6.14.18 but npm 10.9.2 is installed" ||
+    fail "the version-pin refusal did not name the pinned and installed versions"
+det_assert_installer "" ""
+refute_exists "$fixture/.worktrees/det-verpin" "worktree-new.sh left a tree behind after refusing a version-pin mismatch"
+if git -C "$fixture" show-ref --verify --quiet refs/heads/det-verpin; then
+    fail "worktree-new.sh left the branch behind after refusing a version-pin mismatch"
+fi
 
 echo "==> an unsupported packageManager fails loudly, installs nothing, rolls back"
 det_reset
@@ -2442,6 +2490,7 @@ if [ -f "$repo/.devcontainer/hooks/post-checkout" ]; then
     echo "==> the devcontainer post-checkout hook defers to the detector"
     det_reset
     printf '{"name":"fixture","private":true,"packageManager":"npm@10.9.2"}\n' >"$fixture/package.json"
+    printf '{"lockfileVersion": 3}\n' >"$fixture/package-lock.json"
     printf 'lockfileVersion: "9.0"\n' >"$fixture/pnpm-lock.yaml"
     det_commit "declared npm with a stale pnpm lockfile"
     cp "$repo/.devcontainer/hooks/post-checkout" "$shared_hooks/post-checkout"

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -2421,6 +2421,47 @@ printf '%s\n' "$det_out" | grep -q "no package-manager signal" ||
 det_assert_installer "" ""
 rm_wt det-bare >/dev/null || fail "cleanup of the signal-less tree failed"
 
+echo "==> a packageManager declaration split across lines still parses"
+det_reset
+printf '{\n  "name": "fixture",\n  "private": true,\n  "packageManager":\n    "yarn@4.1.0"\n}\n' >"$fixture/package.json"
+det_commit "multi-line packageManager declaration"
+new det-multiline >/dev/null || fail "worktree-new.sh failed on a multi-line packageManager declaration"
+det_assert_installer yarn "$fixture/.worktrees/det-multiline"
+rm_wt det-multiline >/dev/null || fail "cleanup of the multi-line tree failed"
+
+# The shipped devcontainer post-checkout hook auto-installs Node dependencies
+# and is NOT a lefthook shim — post-create.sh copies it straight into
+# .git/hooks, so `git worktree add` fires it before the detector ever runs.
+# The guard under test is that hook's own LEFTHOOK=0 gate (harmon-init#841):
+# without it, its lockfile-first fallback runs a competing installer — pnpm
+# from a stale pnpm-lock.yaml in a repo whose package.json declares npm. The
+# REAL hook is exercised, not a mimic, so dropping the guard upstream fails
+# this case. A rendered tree without the devcontainer profile has no hook to
+# pin down, and the case skips.
+if [ -f "$repo/.devcontainer/hooks/post-checkout" ]; then
+    echo "==> the devcontainer post-checkout hook defers to the detector"
+    det_reset
+    printf '{"name":"fixture","private":true,"packageManager":"npm@10.9.2"}\n' >"$fixture/package.json"
+    printf 'lockfileVersion: "9.0"\n' >"$fixture/pnpm-lock.yaml"
+    det_commit "declared npm with a stale pnpm lockfile"
+    cp "$repo/.devcontainer/hooks/post-checkout" "$shared_hooks/post-checkout"
+    chmod +x "$shared_hooks/post-checkout"
+    # The hook chains git-lfs before its install section and exits 2 when the
+    # binary is missing — which would fail the worktree add for a reason this
+    # case is not about. Satisfy the chain with a stub.
+    cat >"$stub_bin/git-lfs" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$stub_bin/git-lfs"
+    new det-hook >/dev/null || fail "worktree-new.sh failed with the devcontainer post-checkout hook installed"
+    det_assert_installer npm "$fixture/.worktrees/det-hook"
+    rm_wt det-hook >/dev/null || fail "cleanup of the hook tree failed"
+    rm -f "$shared_hooks/post-checkout" "$stub_bin/git-lfs"
+else
+    echo "==> Note: no devcontainer post-checkout hook in this tree; skipping its suppression case"
+fi
+
 # Restore the pnpm fixture the cases below assume — package.json plus the
 # workspace file, exactly as it stood before this block.
 det_reset

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -2278,8 +2278,8 @@ git -C "$fixture" commit -qm "chore: add package.json" >"$test_tmp/commit.log" 2
         fail "committing package.json in the fixture failed"
     }
 new node-tree >/dev/null || fail "worktree-new.sh failed on a Node repo"
-grep -qx "install $fixture/.worktrees/node-tree" "$pnpm_marker" 2>/dev/null ||
-    fail "worktree-new.sh did not run 'pnpm install' inside the new tree"
+grep -qx "install --frozen-lockfile $fixture/.worktrees/node-tree" "$pnpm_marker" 2>/dev/null ||
+    fail "worktree-new.sh did not run 'pnpm install --frozen-lockfile' inside the new tree"
 rm_wt node-tree >/dev/null || fail "cleanup of the node tree failed"
 
 echo "==> a pnpm workspace without a root package.json still installs"
@@ -2346,12 +2346,14 @@ det_commit() {
         }
 }
 det_assert_installer() {
-    # $1 = the manager that must have run `install` in the tree, '' for none;
-    # $2 = the tree path ('' when no tree should exist).
+    # $1 = the manager that must have installed ('' for none); $2 = the exact
+    # arguments it must have been invoked with, so the immutable-mode
+    # selection is asserted too; $3 = the tree path ('' when no tree should
+    # exist).
     for det_name in pnpm npm yarn bun; do
         if [ "$det_name" = "$1" ]; then
-            grep -qx "install $2" "$test_tmp/$det_name-invoked" 2>/dev/null ||
-                fail "worktree-new.sh did not run '$det_name install' inside $2"
+            grep -qx "$2 $3" "$test_tmp/$det_name-invoked" 2>/dev/null ||
+                fail "worktree-new.sh did not run '$det_name $2' inside $3"
         elif [ -s "$test_tmp/$det_name-invoked" ]; then
             fail "worktree-new.sh invoked $det_name in a tree whose manager is '${1:-none}'"
         fi
@@ -2364,7 +2366,7 @@ printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
 printf '{"lockfileVersion": 3}\n' >"$fixture/package-lock.json"
 det_commit "npm lockfile"
 new det-npm >/dev/null || fail "worktree-new.sh failed on an npm repo"
-det_assert_installer npm "$fixture/.worktrees/det-npm"
+det_assert_installer npm ci "$fixture/.worktrees/det-npm"
 rm_wt det-npm >/dev/null || fail "cleanup of the npm tree failed"
 
 echo "==> a yarn.lock selects Yarn"
@@ -2373,7 +2375,7 @@ printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
 printf '# yarn lockfile v1\n' >"$fixture/yarn.lock"
 det_commit "yarn lockfile"
 new det-yarn >/dev/null || fail "worktree-new.sh failed on a Yarn repo"
-det_assert_installer yarn "$fixture/.worktrees/det-yarn"
+det_assert_installer yarn "install --immutable" "$fixture/.worktrees/det-yarn"
 rm_wt det-yarn >/dev/null || fail "cleanup of the yarn tree failed"
 
 echo "==> a bun.lock selects Bun"
@@ -2382,7 +2384,7 @@ printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
 printf '{}\n' >"$fixture/bun.lock"
 det_commit "bun lockfile"
 new det-bun >/dev/null || fail "worktree-new.sh failed on a Bun repo"
-det_assert_installer bun "$fixture/.worktrees/det-bun"
+det_assert_installer bun "install --frozen-lockfile" "$fixture/.worktrees/det-bun"
 rm_wt det-bun >/dev/null || fail "cleanup of the bun tree failed"
 
 echo "==> a declared packageManager with its own lockfile wins over a stale foreign one"
@@ -2392,7 +2394,7 @@ printf '{"lockfileVersion": 3}\n' >"$fixture/package-lock.json"
 printf 'lockfileVersion: "9.0"\n' >"$fixture/pnpm-lock.yaml"
 det_commit "declared npm with its own lockfile over a stale pnpm one"
 new det-declared >/dev/null || fail "worktree-new.sh failed on a declared-manager repo"
-det_assert_installer npm "$fixture/.worktrees/det-declared"
+det_assert_installer npm ci "$fixture/.worktrees/det-declared"
 rm_wt det-declared >/dev/null || fail "cleanup of the declared-manager tree failed"
 
 echo "==> a declaration whose manager has no files here fails instead of writing a second lockfile"
@@ -2405,7 +2407,7 @@ det_out="$(new det-foreign 2>&1)" || det_status=$?
 [ "$det_status" -ne 0 ] || fail "worktree-new.sh succeeded for a declaration contradicted by a foreign-only lockfile"
 printf '%s\n' "$det_out" | grep -q "carries other managers' files (pnpm) and none of npm's" ||
     fail "the foreign-only-lockfile refusal did not name the contradiction"
-det_assert_installer "" ""
+det_assert_installer "" "" ""
 refute_exists "$fixture/.worktrees/det-foreign" "worktree-new.sh left a tree behind after refusing a contradicted declaration"
 if git -C "$fixture" show-ref --verify --quiet refs/heads/det-foreign; then
     fail "worktree-new.sh left the branch behind after refusing a contradicted declaration"
@@ -2421,7 +2423,7 @@ det_out="$(new det-verpin 2>&1)" || det_status=$?
 [ "$det_status" -ne 0 ] || fail "worktree-new.sh installed under a version pin its npm does not satisfy"
 printf '%s\n' "$det_out" | grep -q "pins npm@6.14.18 but npm 10.9.2 is installed" ||
     fail "the version-pin refusal did not name the pinned and installed versions"
-det_assert_installer "" ""
+det_assert_installer "" "" ""
 refute_exists "$fixture/.worktrees/det-verpin" "worktree-new.sh left a tree behind after refusing a version-pin mismatch"
 if git -C "$fixture" show-ref --verify --quiet refs/heads/det-verpin; then
     fail "worktree-new.sh left the branch behind after refusing a version-pin mismatch"
@@ -2436,7 +2438,7 @@ det_out="$(new det-unsupported 2>&1)" || det_status=$?
 [ "$det_status" -ne 0 ] || fail "worktree-new.sh succeeded with an unsupported packageManager declaration"
 printf '%s\n' "$det_out" | grep -q "does not support" ||
     fail "the unsupported-manager refusal did not say the declaration is unsupported"
-det_assert_installer "" ""
+det_assert_installer "" "" ""
 refute_exists "$fixture/.worktrees/det-unsupported" "worktree-new.sh left a tree behind after refusing an unsupported manager"
 if git -C "$fixture" show-ref --verify --quiet refs/heads/det-unsupported; then
     fail "worktree-new.sh left the branch behind after refusing an unsupported manager"
@@ -2453,7 +2455,7 @@ det_out="$(new det-conflict 2>&1)" || det_status=$?
 [ "$det_status" -ne 0 ] || fail "worktree-new.sh succeeded with lockfiles from two package managers"
 printf '%s\n' "$det_out" | grep -q "conflicting Node package-manager signals in this tree: npm bun" ||
     fail "the conflicting-lockfile refusal did not name both managers"
-det_assert_installer "" ""
+det_assert_installer "" "" ""
 refute_exists "$fixture/.worktrees/det-conflict" "worktree-new.sh left a tree behind after refusing conflicting lockfiles"
 if git -C "$fixture" show-ref --verify --quiet refs/heads/det-conflict; then
     fail "worktree-new.sh left the branch behind after refusing conflicting lockfiles"
@@ -2466,7 +2468,7 @@ det_commit "bare manifest, no manager signal"
 det_out="$(new det-bare 2>&1)" || fail "worktree-new.sh failed on a signal-less Node repo"
 printf '%s\n' "$det_out" | grep -q "no package-manager signal" ||
     fail "the signal-less run did not say why the install was skipped"
-det_assert_installer "" ""
+det_assert_installer "" "" ""
 rm_wt det-bare >/dev/null || fail "cleanup of the signal-less tree failed"
 
 echo "==> a packageManager declaration split across lines still parses"
@@ -2474,7 +2476,7 @@ det_reset
 printf '{\n  "name": "fixture",\n  "private": true,\n  "packageManager":\n    "yarn@4.1.0"\n}\n' >"$fixture/package.json"
 det_commit "multi-line packageManager declaration"
 new det-multiline >/dev/null || fail "worktree-new.sh failed on a multi-line packageManager declaration"
-det_assert_installer yarn "$fixture/.worktrees/det-multiline"
+det_assert_installer yarn install "$fixture/.worktrees/det-multiline"
 rm_wt det-multiline >/dev/null || fail "cleanup of the multi-line tree failed"
 
 # The shipped devcontainer post-checkout hook auto-installs Node dependencies
@@ -2504,7 +2506,7 @@ exit 0
 EOF
     chmod +x "$stub_bin/git-lfs"
     new det-hook >/dev/null || fail "worktree-new.sh failed with the devcontainer post-checkout hook installed"
-    det_assert_installer npm "$fixture/.worktrees/det-hook"
+    det_assert_installer npm ci "$fixture/.worktrees/det-hook"
     rm_wt det-hook >/dev/null || fail "cleanup of the hook tree failed"
     rm -f "$shared_hooks/post-checkout" "$stub_bin/git-lfs"
 else

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -778,15 +778,21 @@ if [ "$do_install" -eq 1 ]; then
         # Select the manager deterministically, in this precedence
         # (documented in docs/conventions.md § Worktrees):
         #   1. The `packageManager` field in package.json — the repo's own
-        #      declaration (the Corepack convention), so it wins even over a
-        #      contradicting lockfile, exactly as Corepack itself would.
-        #      Parsed best-effort because jq is not one of this script's
-        #      dependencies: the file is flattened first (the field's name,
-        #      colon, and value legally sit on separate lines, and values
-        #      never contain whitespace), then matched as a string-valued
-        #      key. The spec puts the field at top level with a string
-        #      value; nested objects like devEngines.packageManager carry an
-        #      object value, which this pattern does not match.
+        #      declaration (the Corepack convention). It wins over a stale
+        #      foreign lockfile when the declared manager's own
+        #      infrastructure is present — but a declaration whose manager
+        #      has NO files here while other managers' files exist is a
+        #      contradiction, refused before any install: the declared
+        #      manager would succeed by writing a second lockfile into the
+        #      fresh tree, reporting ready with a dirty worktree
+        #      (challenge round 2). Parsed best-effort because jq is not
+        #      one of this script's dependencies: the file is flattened
+        #      first (the field's name, colon, and value legally sit on
+        #      separate lines, and values never contain whitespace), then
+        #      matched as a string-valued key. The spec puts the field at
+        #      top level with a string value; nested objects like
+        #      devEngines.packageManager carry an object value, which this
+        #      pattern does not match.
         #   2. Exactly one manager's own files at the tree root:
         #      pnpm-lock.yaml or pnpm-workspace.yaml → pnpm;
         #      package-lock.json or npm-shrinkwrap.json → npm;
@@ -806,26 +812,32 @@ if [ "$do_install" -eq 1 ]; then
             # SIGPIPE under pipefail).
             pm_decl="$(tr -d '\n\r\t ' <"$tree/package.json" | sed -n 's/.*"packageManager":"\([^"]*\)".*/\1/p')"
         fi
+        node_signals=""
+        if [ -f "$tree/pnpm-lock.yaml" ] || [ -f "$tree/pnpm-workspace.yaml" ]; then
+            node_signals="$node_signals pnpm"
+        fi
+        if [ -f "$tree/package-lock.json" ] || [ -f "$tree/npm-shrinkwrap.json" ]; then
+            node_signals="$node_signals npm"
+        fi
+        if [ -f "$tree/yarn.lock" ]; then
+            node_signals="$node_signals yarn"
+        fi
+        if [ -f "$tree/bun.lock" ] || [ -f "$tree/bun.lockb" ]; then
+            node_signals="$node_signals bun"
+        fi
         if [ -n "$pm_decl" ]; then
             node_pm=${pm_decl%%@*}
             case "$node_pm" in
             pnpm | npm | yarn | bun) ;;
             *) die "package.json declares packageManager '$pm_decl', which this script does not support (pnpm, npm, yarn, bun) — install dependencies with it yourself, or re-run with --no-install" ;;
             esac
+            if [ -n "$node_signals" ]; then
+                case " $node_signals " in
+                *" $node_pm "*) : ;;
+                *) die "package.json declares packageManager '$pm_decl' but the tree carries other managers' files (${node_signals# }) and none of $node_pm's — remove the stale file(s), or install and commit $node_pm's lockfile in the main checkout, then re-run (or use --no-install)" ;;
+                esac
+            fi
         else
-            node_signals=""
-            if [ -f "$tree/pnpm-lock.yaml" ] || [ -f "$tree/pnpm-workspace.yaml" ]; then
-                node_signals="$node_signals pnpm"
-            fi
-            if [ -f "$tree/package-lock.json" ] || [ -f "$tree/npm-shrinkwrap.json" ]; then
-                node_signals="$node_signals npm"
-            fi
-            if [ -f "$tree/yarn.lock" ]; then
-                node_signals="$node_signals yarn"
-            fi
-            if [ -f "$tree/bun.lock" ] || [ -f "$tree/bun.lockb" ]; then
-                node_signals="$node_signals bun"
-            fi
             node_pm_count=0
             for node_pm_candidate in $node_signals; do
                 node_pm_count=$((node_pm_count + 1))
@@ -837,6 +849,32 @@ if [ "$do_install" -eq 1 ]; then
         fi
         if [ -n "$node_pm" ]; then
             have "$node_pm" || die "this repo's Node package manager is $node_pm but it is not installed — install $node_pm (for pnpm, 'task bootstrap' does) and re-run"
+            # Honor a numeric major in the declaration's version pin
+            # (challenge round 2): a drifted major can rewrite the committed
+            # lockfile in a fresh tree. A corepack-shimmed binary reports the
+            # pinned version itself, so corepack-managed repos pass; a pin
+            # with no numeric major (or none at all) leaves nothing to
+            # verify and skips — signal-selected managers carry no pin.
+            pm_pin=""
+            case "$pm_decl" in
+            *@*)
+                pm_pin=${pm_decl#*@}
+                pm_pin=${pm_pin%%+*}
+                ;;
+            esac
+            pm_pin_major=${pm_pin%%.*}
+            case "$pm_pin_major" in
+            '' | *[!0-9]*) : ;;
+            *)
+                installed_ver="$("$node_pm" --version 2>/dev/null || true)"
+                installed_ver=${installed_ver#v}
+                installed_major=${installed_ver%%.*}
+                case "$installed_major" in
+                '' | *[!0-9]*) die "packageManager pins $node_pm@$pm_pin but the installed $node_pm's version could not be read — reinstall $node_pm and re-run (or use --no-install)" ;;
+                *) [ "$installed_major" = "$pm_pin_major" ] || die "packageManager pins $node_pm@$pm_pin but $node_pm $installed_ver is installed — a different major can rewrite the committed lockfile; install the pinned major (corepack does this) or update the declaration, then re-run (or use --no-install)" ;;
+                esac
+                ;;
+            esac
             echo "==> Installing Node dependencies ($node_pm) in the new tree"
             (cd "$tree" && "$node_pm" install)
         else

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -771,9 +771,72 @@ if [ "$do_install" -eq 1 ]; then
     # keying solely on a root package.json would report such a tree ready with
     # none of its dependencies installed.
     if [ -f "$tree/package.json" ] || [ -f "$tree/pnpm-workspace.yaml" ]; then
-        have pnpm || die "a Node manifest is present but pnpm is not installed — run 'task bootstrap' (or install pnpm) and re-run"
-        echo "==> Installing Node dependencies (pnpm) in the new tree"
-        (cd "$tree" && pnpm install)
+        # package.json is shared by npm, Yarn, Bun, and pnpm alike, so it
+        # proves "this is a Node repo", never "this repo uses pnpm"
+        # (harmon-init#841) — running the wrong installer resolves a different
+        # dependency graph and writes a foreign lockfile into the new tree.
+        # Select the manager deterministically, in this precedence
+        # (documented in docs/conventions.md § Worktrees):
+        #   1. The `packageManager` field in package.json — the repo's own
+        #      declaration (the Corepack convention), so it wins even over a
+        #      contradicting lockfile, exactly as Corepack itself would.
+        #      Parsed best-effort — the first string-valued occurrence in the
+        #      file — because jq is not one of this script's dependencies;
+        #      the spec puts the field at top level with a string value, and
+        #      nested objects like devEngines.packageManager carry an object
+        #      value, which this pattern does not match.
+        #   2. Exactly one manager's own files at the tree root:
+        #      pnpm-lock.yaml or pnpm-workspace.yaml → pnpm;
+        #      package-lock.json or npm-shrinkwrap.json → npm;
+        #      yarn.lock → yarn; bun.lock or bun.lockb → bun.
+        #      Files from two managers at once is a contradiction only the
+        #      repo can resolve — fail loudly rather than guess, because the
+        #      guess that loses writes the wrong lockfile.
+        #   3. No signal at all (a bare package.json): skip the install with
+        #      a note naming the fix. Installing on a guess here is the exact
+        #      defect this block replaces, and a skipped install is visible
+        #      while a wrong lockfile is not.
+        node_pm=""
+        pm_decl=""
+        if [ -f "$tree/package.json" ]; then
+            pm_decl="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$tree/package.json" | head -n 1)"
+        fi
+        if [ -n "$pm_decl" ]; then
+            node_pm=${pm_decl%%@*}
+            case "$node_pm" in
+            pnpm | npm | yarn | bun) ;;
+            *) die "package.json declares packageManager '$pm_decl', which this script does not support (pnpm, npm, yarn, bun) — install dependencies with it yourself, or re-run with --no-install" ;;
+            esac
+        else
+            node_signals=""
+            if [ -f "$tree/pnpm-lock.yaml" ] || [ -f "$tree/pnpm-workspace.yaml" ]; then
+                node_signals="$node_signals pnpm"
+            fi
+            if [ -f "$tree/package-lock.json" ] || [ -f "$tree/npm-shrinkwrap.json" ]; then
+                node_signals="$node_signals npm"
+            fi
+            if [ -f "$tree/yarn.lock" ]; then
+                node_signals="$node_signals yarn"
+            fi
+            if [ -f "$tree/bun.lock" ] || [ -f "$tree/bun.lockb" ]; then
+                node_signals="$node_signals bun"
+            fi
+            node_pm_count=0
+            for node_pm_candidate in $node_signals; do
+                node_pm_count=$((node_pm_count + 1))
+                node_pm=$node_pm_candidate
+            done
+            if [ "$node_pm_count" -gt 1 ]; then
+                die "conflicting Node package-manager signals in this tree:$node_signals — remove the stale manager's file(s) or declare \"packageManager\" in package.json, then re-run"
+            fi
+        fi
+        if [ -n "$node_pm" ]; then
+            have "$node_pm" || die "this repo's Node package manager is $node_pm but it is not installed — install $node_pm (for pnpm, 'task bootstrap' does) and re-run"
+            echo "==> Installing Node dependencies ($node_pm) in the new tree"
+            (cd "$tree" && "$node_pm" install)
+        else
+            echo "==> Note: package.json carries no package-manager signal (no packageManager field, no lockfile) — skipping the Node install; declare \"packageManager\" in package.json, or install dependencies in the tree yourself"
+        fi
     fi
     if [ -f "$tree/pyproject.toml" ]; then
         have uv || die "pyproject.toml is present but uv is not installed — run 'task bootstrap' (or install uv) and re-run"

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -780,11 +780,13 @@ if [ "$do_install" -eq 1 ]; then
         #   1. The `packageManager` field in package.json — the repo's own
         #      declaration (the Corepack convention), so it wins even over a
         #      contradicting lockfile, exactly as Corepack itself would.
-        #      Parsed best-effort — the first string-valued occurrence in the
-        #      file — because jq is not one of this script's dependencies;
-        #      the spec puts the field at top level with a string value, and
-        #      nested objects like devEngines.packageManager carry an object
-        #      value, which this pattern does not match.
+        #      Parsed best-effort because jq is not one of this script's
+        #      dependencies: the file is flattened first (the field's name,
+        #      colon, and value legally sit on separate lines, and values
+        #      never contain whitespace), then matched as a string-valued
+        #      key. The spec puts the field at top level with a string
+        #      value; nested objects like devEngines.packageManager carry an
+        #      object value, which this pattern does not match.
         #   2. Exactly one manager's own files at the tree root:
         #      pnpm-lock.yaml or pnpm-workspace.yaml → pnpm;
         #      package-lock.json or npm-shrinkwrap.json → npm;
@@ -799,7 +801,10 @@ if [ "$do_install" -eq 1 ]; then
         node_pm=""
         pm_decl=""
         if [ -f "$tree/package.json" ]; then
-            pm_decl="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$tree/package.json" | head -n 1)"
+            # tr collapses the whole file to one line, so sed emits at most
+            # one match and needs no `head` (whose early exit would race a
+            # SIGPIPE under pipefail).
+            pm_decl="$(tr -d '\n\r\t ' <"$tree/package.json" | sed -n 's/.*"packageManager":"\([^"]*\)".*/\1/p')"
         fi
         if [ -n "$pm_decl" ]; then
             node_pm=${pm_decl%%@*}

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -875,8 +875,49 @@ if [ "$do_install" -eq 1 ]; then
                 esac
                 ;;
             esac
-            echo "==> Installing Node dependencies ($node_pm) in the new tree"
-            (cd "$tree" && "$node_pm" install)
+            # When the selected manager's own lockfile is present, install in
+            # its immutable mode (challenge round 3): a plain install can
+            # legally REWRITE a committed lockfile — npm 11 upgrades a
+            # lockfileVersion-1 file in place — and a provisioning step must
+            # fail and roll back on drift, not report a dirty tree as ready.
+            # The devcontainer post-checkout hook set this precedent (npm ci,
+            # --frozen-lockfile). With no lockfile — a workspace-file-only
+            # root, or a declaration with no manager files yet — plain
+            # install remains: there is nothing to preserve, and the first
+            # install legitimately creates the lockfile.
+            node_pm_args=("install")
+            case "$node_pm" in
+            pnpm)
+                if [ -f "$tree/pnpm-lock.yaml" ]; then
+                    node_pm_args=("install" "--frozen-lockfile")
+                fi
+                ;;
+            npm)
+                if [ -f "$tree/package-lock.json" ] || [ -f "$tree/npm-shrinkwrap.json" ]; then
+                    node_pm_args=("ci")
+                fi
+                ;;
+            yarn)
+                # Classic (1.x) spells the immutable mode --frozen-lockfile;
+                # Berry spells it --immutable. Version-split rather than
+                # relying on Berry's deprecated alias.
+                if [ -f "$tree/yarn.lock" ]; then
+                    yarn_ver="$(yarn --version 2>/dev/null || true)"
+                    case "${yarn_ver%%.*}" in
+                    1) node_pm_args=("install" "--frozen-lockfile") ;;
+                    '' | *[!0-9]*) die "yarn.lock is present but yarn's version could not be read — reinstall yarn and re-run (or use --no-install)" ;;
+                    *) node_pm_args=("install" "--immutable") ;;
+                    esac
+                fi
+                ;;
+            bun)
+                if [ -f "$tree/bun.lock" ] || [ -f "$tree/bun.lockb" ]; then
+                    node_pm_args=("install" "--frozen-lockfile")
+                fi
+                ;;
+            esac
+            echo "==> Installing Node dependencies ($node_pm ${node_pm_args[*]}) in the new tree"
+            (cd "$tree" && "$node_pm" "${node_pm_args[@]}")
         else
             echo "==> Note: package.json carries no package-manager signal (no packageManager field, no lockfile) — skipping the Node install; declare \"packageManager\" in package.json, or install dependencies in the tree yourself"
         fi

--- a/template/[% if devcontainer %].devcontainer[% endif %]/hooks/post-checkout
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/hooks/post-checkout
@@ -14,6 +14,14 @@ command -v git-lfs >/dev/null 2>&1 || {
 git lfs post-checkout "$@"
 
 # --- auto-install Node.js dependencies ---
+# LEFTHOOK=0 is this fleet's hook-suppression contract: scripts/worktree-new.sh
+# sets it on every `git worktree add` and then installs with the repo's
+# DECLARED package manager itself (harmon-init#841). Without this guard the
+# lockfile-first fallback below would run first and could pick a competing
+# installer — e.g. pnpm from a stale pnpm-lock.yaml in a repo whose
+# package.json declares npm. The git-lfs chain above deliberately stays
+# outside the guard: checkout correctness is not an install.
+[ "${LEFTHOOK:-}" = "0" ] && exit 0
 # $3 = 1 for branch checkout (including worktree add), 0 for file checkout.
 # Only run on branch checkouts to avoid slowing down file-level operations.
 # Unset NODE_OPTIONS to prevent VS Code's JS debug bootloader from crashing

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -63,6 +63,17 @@ it points here.
 - **A fresh worktree has no `node_modules`/`.venv`.** Working files are per-tree,
   so dependency install is per-tree too; that is what `worktree:new` runs and
   why "it worked in the main checkout" is not evidence.
+- **The Node installer is selected from the repo's own signals** — a
+  `package.json` alone proves "Node repo", never "pnpm repo". Precedence:
+  the `packageManager` field in `package.json` (the Corepack declaration)
+  wins outright, even over a contradicting lockfile; otherwise exactly one
+  manager's files at the tree root — `pnpm-lock.yaml`/`pnpm-workspace.yaml`
+  → pnpm, `package-lock.json`/`npm-shrinkwrap.json` → npm, `yarn.lock` →
+  Yarn, `bun.lock`/`bun.lockb` → Bun. Files from two managers at once fail
+  loudly rather than guess, an unsupported `packageManager` value fails
+  loudly without touching the tree, and a bare `package.json` with no signal
+  skips the install with a note — declare `packageManager` to make it
+  deterministic.
 - **Never pass `-c core.hooksPath=.git/hooks` to git in a worktree.** In a
   linked worktree `.git` is a **file**, not a directory, so that path resolves
   to nothing and commits run **hook-less and silently**. Git's own defaults are

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -66,14 +66,19 @@ it points here.
 - **The Node installer is selected from the repo's own signals** — a
   `package.json` alone proves "Node repo", never "pnpm repo". Precedence:
   the `packageManager` field in `package.json` (the Corepack declaration)
-  wins outright, even over a contradicting lockfile; otherwise exactly one
-  manager's files at the tree root — `pnpm-lock.yaml`/`pnpm-workspace.yaml`
-  → pnpm, `package-lock.json`/`npm-shrinkwrap.json` → npm, `yarn.lock` →
-  Yarn, `bun.lock`/`bun.lockb` → Bun. Files from two managers at once fail
-  loudly rather than guess, an unsupported `packageManager` value fails
-  loudly without touching the tree, and a bare `package.json` with no signal
-  skips the install with a note — declare `packageManager` to make it
-  deterministic.
+  wins — including over a stale foreign lockfile, when its own manager's
+  files are present; otherwise exactly one manager's files at the tree
+  root — `pnpm-lock.yaml`/`pnpm-workspace.yaml` → pnpm,
+  `package-lock.json`/`npm-shrinkwrap.json` → npm, `yarn.lock` → Yarn,
+  `bun.lock`/`bun.lockb` → Bun. Every contradiction fails loudly before
+  any install touches the tree: files from two managers with no
+  declaration, a declaration whose manager has no files here while other
+  managers' files exist (installing would write a second lockfile), an
+  unsupported `packageManager` value, and a declared numeric major that
+  the installed binary does not match (a drifted major can rewrite the
+  committed lockfile; corepack-shimmed binaries report the pinned version
+  and pass). A bare `package.json` with no signal skips the install with a
+  note — declare `packageManager` to make it deterministic.
 - **Never pass `-c core.hooksPath=.git/hooks` to git in a worktree.** In a
   linked worktree `.git` is a **file**, not a directory, so that path resolves
   to nothing and commits run **hook-less and silently**. Git's own defaults are

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -77,8 +77,12 @@ it points here.
   unsupported `packageManager` value, and a declared numeric major that
   the installed binary does not match (a drifted major can rewrite the
   committed lockfile; corepack-shimmed binaries report the pinned version
-  and pass). A bare `package.json` with no signal skips the install with a
-  note — declare `packageManager` to make it deterministic.
+  and pass). When the selected manager's own lockfile exists the install
+  runs in its immutable mode (`npm ci`, `--frozen-lockfile`, Yarn Berry
+  `--immutable`), so lockfile drift fails and rolls back instead of
+  rewriting a committed file; with no lockfile, plain `install` runs and
+  may create one. A bare `package.json` with no signal skips the install
+  with a note — declare `packageManager` to make it deterministic.
 - **Never pass `-c core.hooksPath=.git/hooks` to git in a worktree.** In a
   linked worktree `.git` is a **file**, not a directory, so that path resolves
   to nothing and commits run **hook-less and silently**. Git's own defaults are

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -2262,7 +2262,11 @@ printf '%s %s\n' "\$*" "\$PWD" >>"$pnpm_marker"
 exit 0
 EOF
 chmod +x "$stub_bin/pnpm"
+# The lockfile is what marks this repo as pnpm's: package.json alone is shared
+# by npm, Yarn, and Bun, so it selects no installer (harmon-init#841) — the
+# signal-less case has its own coverage below.
 printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
+printf 'lockfileVersion: "9.0"\n' >"$fixture/pnpm-lock.yaml"
 git -C "$fixture" add -A
 git -C "$fixture" commit -qm "chore: add package.json" >"$test_tmp/commit.log" 2>&1 ||
     {
@@ -2277,7 +2281,9 @@ rm_wt node-tree >/dev/null || fail "cleanup of the node tree failed"
 echo "==> a pnpm workspace without a root package.json still installs"
 : >"$pnpm_marker"
 git -C "$fixture" rm -q --cached package.json >/dev/null
-rm -f "$fixture/package.json"
+# The lockfile goes too: with it present this case would pass even if
+# workspace-file recognition regressed, which is the property it exists for.
+rm -f "$fixture/package.json" "$fixture/pnpm-lock.yaml"
 printf 'packages:\n  - "packages/*"\n' >"$fixture/pnpm-workspace.yaml"
 git -C "$fixture" add -A
 LEFTHOOK=0 git -C "$fixture" commit -qm "chore: workspace without a root manifest" >"$test_tmp/commit.log" 2>&1 ||
@@ -2290,6 +2296,138 @@ printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
 git -C "$fixture" add -A
 LEFTHOOK=0 git -C "$fixture" commit -qm "chore: restore the root manifest" >"$test_tmp/commit.log" 2>&1 ||
     fail "restoring the root package.json failed"
+
+# ── package-manager detection (harmon-init#841) ──────────────────────
+# package.json is shared by npm, Yarn, Bun, and pnpm, so worktree-new.sh
+# selects the installer from the repo's own signals instead of assuming pnpm.
+# Every case states its whole fixture through det_reset (all Node signal files
+# cleared first) and asserts BOTH halves of the invariant: the selected
+# installer ran in the tree, and every competitor stayed silent — the second
+# half is what catches a regression to the old unconditional pnpm.
+for det_name in npm yarn bun; do
+    cat >"$stub_bin/$det_name" <<EOF
+#!/usr/bin/env bash
+printf '%s %s\n' "\$*" "\$PWD" >>"$test_tmp/$det_name-invoked"
+exit 0
+EOF
+    chmod +x "$stub_bin/$det_name"
+done
+
+det_signal_files="package.json pnpm-workspace.yaml pnpm-lock.yaml package-lock.json npm-shrinkwrap.json yarn.lock bun.lock bun.lockb"
+det_reset() {
+    for det_name in pnpm npm yarn bun; do
+        : >"$test_tmp/$det_name-invoked"
+    done
+    for det_name in $det_signal_files; do
+        rm -f "$fixture/$det_name"
+    done
+}
+det_commit() {
+    git -C "$fixture" add -A
+    LEFTHOOK=0 git -C "$fixture" commit -qm "chore: $1" >"$test_tmp/commit.log" 2>&1 ||
+        {
+            cat "$test_tmp/commit.log" >&2
+            fail "committing the detection fixture ($1) failed"
+        }
+}
+det_assert_installer() {
+    # $1 = the manager that must have run `install` in the tree, '' for none;
+    # $2 = the tree path ('' when no tree should exist).
+    for det_name in pnpm npm yarn bun; do
+        if [ "$det_name" = "$1" ]; then
+            grep -qx "install $2" "$test_tmp/$det_name-invoked" 2>/dev/null ||
+                fail "worktree-new.sh did not run '$det_name install' inside $2"
+        elif [ -s "$test_tmp/$det_name-invoked" ]; then
+            fail "worktree-new.sh invoked $det_name in a tree whose manager is '${1:-none}'"
+        fi
+    done
+}
+
+echo "==> an npm lockfile selects npm, and no competing installer runs"
+det_reset
+printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
+printf '{"lockfileVersion": 3}\n' >"$fixture/package-lock.json"
+det_commit "npm lockfile"
+new det-npm >/dev/null || fail "worktree-new.sh failed on an npm repo"
+det_assert_installer npm "$fixture/.worktrees/det-npm"
+rm_wt det-npm >/dev/null || fail "cleanup of the npm tree failed"
+
+echo "==> a yarn.lock selects Yarn"
+det_reset
+printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
+printf '# yarn lockfile v1\n' >"$fixture/yarn.lock"
+det_commit "yarn lockfile"
+new det-yarn >/dev/null || fail "worktree-new.sh failed on a Yarn repo"
+det_assert_installer yarn "$fixture/.worktrees/det-yarn"
+rm_wt det-yarn >/dev/null || fail "cleanup of the yarn tree failed"
+
+echo "==> a bun.lock selects Bun"
+det_reset
+printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
+printf '{}\n' >"$fixture/bun.lock"
+det_commit "bun lockfile"
+new det-bun >/dev/null || fail "worktree-new.sh failed on a Bun repo"
+det_assert_installer bun "$fixture/.worktrees/det-bun"
+rm_wt det-bun >/dev/null || fail "cleanup of the bun tree failed"
+
+echo "==> a declared packageManager wins over a contradicting lockfile"
+det_reset
+printf '{"name":"fixture","private":true,"packageManager":"npm@10.9.2+sha512.0123abcdef"}\n' >"$fixture/package.json"
+printf 'lockfileVersion: "9.0"\n' >"$fixture/pnpm-lock.yaml"
+det_commit "declared npm over a pnpm lockfile"
+new det-declared >/dev/null || fail "worktree-new.sh failed on a declared-manager repo"
+det_assert_installer npm "$fixture/.worktrees/det-declared"
+rm_wt det-declared >/dev/null || fail "cleanup of the declared-manager tree failed"
+
+echo "==> an unsupported packageManager fails loudly, installs nothing, rolls back"
+det_reset
+printf '{"name":"fixture","private":true,"packageManager":"moon@1.2.3"}\n' >"$fixture/package.json"
+det_commit "unsupported manager declaration"
+det_status=0
+det_out="$(new det-unsupported 2>&1)" || det_status=$?
+[ "$det_status" -ne 0 ] || fail "worktree-new.sh succeeded with an unsupported packageManager declaration"
+printf '%s\n' "$det_out" | grep -q "does not support" ||
+    fail "the unsupported-manager refusal did not say the declaration is unsupported"
+det_assert_installer "" ""
+refute_exists "$fixture/.worktrees/det-unsupported" "worktree-new.sh left a tree behind after refusing an unsupported manager"
+if git -C "$fixture" show-ref --verify --quiet refs/heads/det-unsupported; then
+    fail "worktree-new.sh left the branch behind after refusing an unsupported manager"
+fi
+
+echo "==> lockfiles from two managers fail loudly instead of guessing"
+det_reset
+printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
+printf '{"lockfileVersion": 3}\n' >"$fixture/package-lock.json"
+printf 'bun-binary-lockfile\n' >"$fixture/bun.lockb"
+det_commit "conflicting lockfiles"
+det_status=0
+det_out="$(new det-conflict 2>&1)" || det_status=$?
+[ "$det_status" -ne 0 ] || fail "worktree-new.sh succeeded with lockfiles from two package managers"
+printf '%s\n' "$det_out" | grep -q "conflicting Node package-manager signals in this tree: npm bun" ||
+    fail "the conflicting-lockfile refusal did not name both managers"
+det_assert_installer "" ""
+refute_exists "$fixture/.worktrees/det-conflict" "worktree-new.sh left a tree behind after refusing conflicting lockfiles"
+if git -C "$fixture" show-ref --verify --quiet refs/heads/det-conflict; then
+    fail "worktree-new.sh left the branch behind after refusing conflicting lockfiles"
+fi
+
+echo "==> a bare package.json with no signal skips the install, saying why"
+det_reset
+printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
+det_commit "bare manifest, no manager signal"
+det_out="$(new det-bare 2>&1)" || fail "worktree-new.sh failed on a signal-less Node repo"
+printf '%s\n' "$det_out" | grep -q "no package-manager signal" ||
+    fail "the signal-less run did not say why the install was skipped"
+det_assert_installer "" ""
+rm_wt det-bare >/dev/null || fail "cleanup of the signal-less tree failed"
+
+# Restore the pnpm fixture the cases below assume — package.json plus the
+# workspace file, exactly as it stood before this block.
+det_reset
+printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
+printf 'packages:\n  - "packages/*"\n' >"$fixture/pnpm-workspace.yaml"
+det_commit "restore the pnpm fixture"
+: >"$pnpm_marker"
 
 # ── post-checkout runs AFTER dependencies are installed ──────────────
 # `git worktree add` fires post-checkout itself, before anything is installed,

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -2258,6 +2258,10 @@ echo "==> a Node repo gets its dependencies installed in the NEW tree"
 pnpm_marker="$test_tmp/pnpm-invoked"
 cat >"$stub_bin/pnpm" <<EOF
 #!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+    echo 9.0.0
+    exit 0
+fi
 printf '%s %s\n' "\$*" "\$PWD" >>"$pnpm_marker"
 exit 0
 EOF
@@ -2304,9 +2308,20 @@ LEFTHOOK=0 git -C "$fixture" commit -qm "chore: restore the root manifest" >"$te
 # cleared first) and asserts BOTH halves of the invariant: the selected
 # installer ran in the tree, and every competitor stayed silent — the second
 # half is what catches a regression to the old unconditional pnpm.
+# Each stub answers --version without logging (worktree-new.sh reads it to
+# verify a declared version pin) and records every other invocation.
 for det_name in npm yarn bun; do
+    case "$det_name" in
+    npm) det_stub_ver=10.9.2 ;;
+    yarn) det_stub_ver=4.1.0 ;;
+    bun) det_stub_ver=1.2.10 ;;
+    esac
     cat >"$stub_bin/$det_name" <<EOF
 #!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+    echo $det_stub_ver
+    exit 0
+fi
 printf '%s %s\n' "\$*" "\$PWD" >>"$test_tmp/$det_name-invoked"
 exit 0
 EOF
@@ -2370,14 +2385,47 @@ new det-bun >/dev/null || fail "worktree-new.sh failed on a Bun repo"
 det_assert_installer bun "$fixture/.worktrees/det-bun"
 rm_wt det-bun >/dev/null || fail "cleanup of the bun tree failed"
 
-echo "==> a declared packageManager wins over a contradicting lockfile"
+echo "==> a declared packageManager with its own lockfile wins over a stale foreign one"
 det_reset
 printf '{"name":"fixture","private":true,"packageManager":"npm@10.9.2+sha512.0123abcdef"}\n' >"$fixture/package.json"
+printf '{"lockfileVersion": 3}\n' >"$fixture/package-lock.json"
 printf 'lockfileVersion: "9.0"\n' >"$fixture/pnpm-lock.yaml"
-det_commit "declared npm over a pnpm lockfile"
+det_commit "declared npm with its own lockfile over a stale pnpm one"
 new det-declared >/dev/null || fail "worktree-new.sh failed on a declared-manager repo"
 det_assert_installer npm "$fixture/.worktrees/det-declared"
 rm_wt det-declared >/dev/null || fail "cleanup of the declared-manager tree failed"
+
+echo "==> a declaration whose manager has no files here fails instead of writing a second lockfile"
+det_reset
+printf '{"name":"fixture","private":true,"packageManager":"npm@10.9.2"}\n' >"$fixture/package.json"
+printf 'lockfileVersion: "9.0"\n' >"$fixture/pnpm-lock.yaml"
+det_commit "declared npm against a foreign-only lockfile"
+det_status=0
+det_out="$(new det-foreign 2>&1)" || det_status=$?
+[ "$det_status" -ne 0 ] || fail "worktree-new.sh succeeded for a declaration contradicted by a foreign-only lockfile"
+printf '%s\n' "$det_out" | grep -q "carries other managers' files (pnpm) and none of npm's" ||
+    fail "the foreign-only-lockfile refusal did not name the contradiction"
+det_assert_installer "" ""
+refute_exists "$fixture/.worktrees/det-foreign" "worktree-new.sh left a tree behind after refusing a contradicted declaration"
+if git -C "$fixture" show-ref --verify --quiet refs/heads/det-foreign; then
+    fail "worktree-new.sh left the branch behind after refusing a contradicted declaration"
+fi
+
+echo "==> a declared version pin with a drifted major fails instead of installing"
+det_reset
+printf '{"name":"fixture","private":true,"packageManager":"npm@6.14.18"}\n' >"$fixture/package.json"
+printf '{"lockfileVersion": 1}\n' >"$fixture/package-lock.json"
+det_commit "declared npm@6 against a newer installed npm"
+det_status=0
+det_out="$(new det-verpin 2>&1)" || det_status=$?
+[ "$det_status" -ne 0 ] || fail "worktree-new.sh installed under a version pin its npm does not satisfy"
+printf '%s\n' "$det_out" | grep -q "pins npm@6.14.18 but npm 10.9.2 is installed" ||
+    fail "the version-pin refusal did not name the pinned and installed versions"
+det_assert_installer "" ""
+refute_exists "$fixture/.worktrees/det-verpin" "worktree-new.sh left a tree behind after refusing a version-pin mismatch"
+if git -C "$fixture" show-ref --verify --quiet refs/heads/det-verpin; then
+    fail "worktree-new.sh left the branch behind after refusing a version-pin mismatch"
+fi
 
 echo "==> an unsupported packageManager fails loudly, installs nothing, rolls back"
 det_reset
@@ -2442,6 +2490,7 @@ if [ -f "$repo/.devcontainer/hooks/post-checkout" ]; then
     echo "==> the devcontainer post-checkout hook defers to the detector"
     det_reset
     printf '{"name":"fixture","private":true,"packageManager":"npm@10.9.2"}\n' >"$fixture/package.json"
+    printf '{"lockfileVersion": 3}\n' >"$fixture/package-lock.json"
     printf 'lockfileVersion: "9.0"\n' >"$fixture/pnpm-lock.yaml"
     det_commit "declared npm with a stale pnpm lockfile"
     cp "$repo/.devcontainer/hooks/post-checkout" "$shared_hooks/post-checkout"

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -2421,6 +2421,47 @@ printf '%s\n' "$det_out" | grep -q "no package-manager signal" ||
 det_assert_installer "" ""
 rm_wt det-bare >/dev/null || fail "cleanup of the signal-less tree failed"
 
+echo "==> a packageManager declaration split across lines still parses"
+det_reset
+printf '{\n  "name": "fixture",\n  "private": true,\n  "packageManager":\n    "yarn@4.1.0"\n}\n' >"$fixture/package.json"
+det_commit "multi-line packageManager declaration"
+new det-multiline >/dev/null || fail "worktree-new.sh failed on a multi-line packageManager declaration"
+det_assert_installer yarn "$fixture/.worktrees/det-multiline"
+rm_wt det-multiline >/dev/null || fail "cleanup of the multi-line tree failed"
+
+# The shipped devcontainer post-checkout hook auto-installs Node dependencies
+# and is NOT a lefthook shim — post-create.sh copies it straight into
+# .git/hooks, so `git worktree add` fires it before the detector ever runs.
+# The guard under test is that hook's own LEFTHOOK=0 gate (harmon-init#841):
+# without it, its lockfile-first fallback runs a competing installer — pnpm
+# from a stale pnpm-lock.yaml in a repo whose package.json declares npm. The
+# REAL hook is exercised, not a mimic, so dropping the guard upstream fails
+# this case. A rendered tree without the devcontainer profile has no hook to
+# pin down, and the case skips.
+if [ -f "$repo/.devcontainer/hooks/post-checkout" ]; then
+    echo "==> the devcontainer post-checkout hook defers to the detector"
+    det_reset
+    printf '{"name":"fixture","private":true,"packageManager":"npm@10.9.2"}\n' >"$fixture/package.json"
+    printf 'lockfileVersion: "9.0"\n' >"$fixture/pnpm-lock.yaml"
+    det_commit "declared npm with a stale pnpm lockfile"
+    cp "$repo/.devcontainer/hooks/post-checkout" "$shared_hooks/post-checkout"
+    chmod +x "$shared_hooks/post-checkout"
+    # The hook chains git-lfs before its install section and exits 2 when the
+    # binary is missing — which would fail the worktree add for a reason this
+    # case is not about. Satisfy the chain with a stub.
+    cat >"$stub_bin/git-lfs" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$stub_bin/git-lfs"
+    new det-hook >/dev/null || fail "worktree-new.sh failed with the devcontainer post-checkout hook installed"
+    det_assert_installer npm "$fixture/.worktrees/det-hook"
+    rm_wt det-hook >/dev/null || fail "cleanup of the hook tree failed"
+    rm -f "$shared_hooks/post-checkout" "$stub_bin/git-lfs"
+else
+    echo "==> Note: no devcontainer post-checkout hook in this tree; skipping its suppression case"
+fi
+
 # Restore the pnpm fixture the cases below assume — package.json plus the
 # workspace file, exactly as it stood before this block.
 det_reset

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -2278,8 +2278,8 @@ git -C "$fixture" commit -qm "chore: add package.json" >"$test_tmp/commit.log" 2
         fail "committing package.json in the fixture failed"
     }
 new node-tree >/dev/null || fail "worktree-new.sh failed on a Node repo"
-grep -qx "install $fixture/.worktrees/node-tree" "$pnpm_marker" 2>/dev/null ||
-    fail "worktree-new.sh did not run 'pnpm install' inside the new tree"
+grep -qx "install --frozen-lockfile $fixture/.worktrees/node-tree" "$pnpm_marker" 2>/dev/null ||
+    fail "worktree-new.sh did not run 'pnpm install --frozen-lockfile' inside the new tree"
 rm_wt node-tree >/dev/null || fail "cleanup of the node tree failed"
 
 echo "==> a pnpm workspace without a root package.json still installs"
@@ -2346,12 +2346,14 @@ det_commit() {
         }
 }
 det_assert_installer() {
-    # $1 = the manager that must have run `install` in the tree, '' for none;
-    # $2 = the tree path ('' when no tree should exist).
+    # $1 = the manager that must have installed ('' for none); $2 = the exact
+    # arguments it must have been invoked with, so the immutable-mode
+    # selection is asserted too; $3 = the tree path ('' when no tree should
+    # exist).
     for det_name in pnpm npm yarn bun; do
         if [ "$det_name" = "$1" ]; then
-            grep -qx "install $2" "$test_tmp/$det_name-invoked" 2>/dev/null ||
-                fail "worktree-new.sh did not run '$det_name install' inside $2"
+            grep -qx "$2 $3" "$test_tmp/$det_name-invoked" 2>/dev/null ||
+                fail "worktree-new.sh did not run '$det_name $2' inside $3"
         elif [ -s "$test_tmp/$det_name-invoked" ]; then
             fail "worktree-new.sh invoked $det_name in a tree whose manager is '${1:-none}'"
         fi
@@ -2364,7 +2366,7 @@ printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
 printf '{"lockfileVersion": 3}\n' >"$fixture/package-lock.json"
 det_commit "npm lockfile"
 new det-npm >/dev/null || fail "worktree-new.sh failed on an npm repo"
-det_assert_installer npm "$fixture/.worktrees/det-npm"
+det_assert_installer npm ci "$fixture/.worktrees/det-npm"
 rm_wt det-npm >/dev/null || fail "cleanup of the npm tree failed"
 
 echo "==> a yarn.lock selects Yarn"
@@ -2373,7 +2375,7 @@ printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
 printf '# yarn lockfile v1\n' >"$fixture/yarn.lock"
 det_commit "yarn lockfile"
 new det-yarn >/dev/null || fail "worktree-new.sh failed on a Yarn repo"
-det_assert_installer yarn "$fixture/.worktrees/det-yarn"
+det_assert_installer yarn "install --immutable" "$fixture/.worktrees/det-yarn"
 rm_wt det-yarn >/dev/null || fail "cleanup of the yarn tree failed"
 
 echo "==> a bun.lock selects Bun"
@@ -2382,7 +2384,7 @@ printf '{"name":"fixture","private":true}\n' >"$fixture/package.json"
 printf '{}\n' >"$fixture/bun.lock"
 det_commit "bun lockfile"
 new det-bun >/dev/null || fail "worktree-new.sh failed on a Bun repo"
-det_assert_installer bun "$fixture/.worktrees/det-bun"
+det_assert_installer bun "install --frozen-lockfile" "$fixture/.worktrees/det-bun"
 rm_wt det-bun >/dev/null || fail "cleanup of the bun tree failed"
 
 echo "==> a declared packageManager with its own lockfile wins over a stale foreign one"
@@ -2392,7 +2394,7 @@ printf '{"lockfileVersion": 3}\n' >"$fixture/package-lock.json"
 printf 'lockfileVersion: "9.0"\n' >"$fixture/pnpm-lock.yaml"
 det_commit "declared npm with its own lockfile over a stale pnpm one"
 new det-declared >/dev/null || fail "worktree-new.sh failed on a declared-manager repo"
-det_assert_installer npm "$fixture/.worktrees/det-declared"
+det_assert_installer npm ci "$fixture/.worktrees/det-declared"
 rm_wt det-declared >/dev/null || fail "cleanup of the declared-manager tree failed"
 
 echo "==> a declaration whose manager has no files here fails instead of writing a second lockfile"
@@ -2405,7 +2407,7 @@ det_out="$(new det-foreign 2>&1)" || det_status=$?
 [ "$det_status" -ne 0 ] || fail "worktree-new.sh succeeded for a declaration contradicted by a foreign-only lockfile"
 printf '%s\n' "$det_out" | grep -q "carries other managers' files (pnpm) and none of npm's" ||
     fail "the foreign-only-lockfile refusal did not name the contradiction"
-det_assert_installer "" ""
+det_assert_installer "" "" ""
 refute_exists "$fixture/.worktrees/det-foreign" "worktree-new.sh left a tree behind after refusing a contradicted declaration"
 if git -C "$fixture" show-ref --verify --quiet refs/heads/det-foreign; then
     fail "worktree-new.sh left the branch behind after refusing a contradicted declaration"
@@ -2421,7 +2423,7 @@ det_out="$(new det-verpin 2>&1)" || det_status=$?
 [ "$det_status" -ne 0 ] || fail "worktree-new.sh installed under a version pin its npm does not satisfy"
 printf '%s\n' "$det_out" | grep -q "pins npm@6.14.18 but npm 10.9.2 is installed" ||
     fail "the version-pin refusal did not name the pinned and installed versions"
-det_assert_installer "" ""
+det_assert_installer "" "" ""
 refute_exists "$fixture/.worktrees/det-verpin" "worktree-new.sh left a tree behind after refusing a version-pin mismatch"
 if git -C "$fixture" show-ref --verify --quiet refs/heads/det-verpin; then
     fail "worktree-new.sh left the branch behind after refusing a version-pin mismatch"
@@ -2436,7 +2438,7 @@ det_out="$(new det-unsupported 2>&1)" || det_status=$?
 [ "$det_status" -ne 0 ] || fail "worktree-new.sh succeeded with an unsupported packageManager declaration"
 printf '%s\n' "$det_out" | grep -q "does not support" ||
     fail "the unsupported-manager refusal did not say the declaration is unsupported"
-det_assert_installer "" ""
+det_assert_installer "" "" ""
 refute_exists "$fixture/.worktrees/det-unsupported" "worktree-new.sh left a tree behind after refusing an unsupported manager"
 if git -C "$fixture" show-ref --verify --quiet refs/heads/det-unsupported; then
     fail "worktree-new.sh left the branch behind after refusing an unsupported manager"
@@ -2453,7 +2455,7 @@ det_out="$(new det-conflict 2>&1)" || det_status=$?
 [ "$det_status" -ne 0 ] || fail "worktree-new.sh succeeded with lockfiles from two package managers"
 printf '%s\n' "$det_out" | grep -q "conflicting Node package-manager signals in this tree: npm bun" ||
     fail "the conflicting-lockfile refusal did not name both managers"
-det_assert_installer "" ""
+det_assert_installer "" "" ""
 refute_exists "$fixture/.worktrees/det-conflict" "worktree-new.sh left a tree behind after refusing conflicting lockfiles"
 if git -C "$fixture" show-ref --verify --quiet refs/heads/det-conflict; then
     fail "worktree-new.sh left the branch behind after refusing conflicting lockfiles"
@@ -2466,7 +2468,7 @@ det_commit "bare manifest, no manager signal"
 det_out="$(new det-bare 2>&1)" || fail "worktree-new.sh failed on a signal-less Node repo"
 printf '%s\n' "$det_out" | grep -q "no package-manager signal" ||
     fail "the signal-less run did not say why the install was skipped"
-det_assert_installer "" ""
+det_assert_installer "" "" ""
 rm_wt det-bare >/dev/null || fail "cleanup of the signal-less tree failed"
 
 echo "==> a packageManager declaration split across lines still parses"
@@ -2474,7 +2476,7 @@ det_reset
 printf '{\n  "name": "fixture",\n  "private": true,\n  "packageManager":\n    "yarn@4.1.0"\n}\n' >"$fixture/package.json"
 det_commit "multi-line packageManager declaration"
 new det-multiline >/dev/null || fail "worktree-new.sh failed on a multi-line packageManager declaration"
-det_assert_installer yarn "$fixture/.worktrees/det-multiline"
+det_assert_installer yarn install "$fixture/.worktrees/det-multiline"
 rm_wt det-multiline >/dev/null || fail "cleanup of the multi-line tree failed"
 
 # The shipped devcontainer post-checkout hook auto-installs Node dependencies
@@ -2504,7 +2506,7 @@ exit 0
 EOF
     chmod +x "$stub_bin/git-lfs"
     new det-hook >/dev/null || fail "worktree-new.sh failed with the devcontainer post-checkout hook installed"
-    det_assert_installer npm "$fixture/.worktrees/det-hook"
+    det_assert_installer npm ci "$fixture/.worktrees/det-hook"
     rm_wt det-hook >/dev/null || fail "cleanup of the hook tree failed"
     rm -f "$shared_hooks/post-checkout" "$stub_bin/git-lfs"
 else

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -778,15 +778,21 @@ if [ "$do_install" -eq 1 ]; then
         # Select the manager deterministically, in this precedence
         # (documented in docs/conventions.md § Worktrees):
         #   1. The `packageManager` field in package.json — the repo's own
-        #      declaration (the Corepack convention), so it wins even over a
-        #      contradicting lockfile, exactly as Corepack itself would.
-        #      Parsed best-effort because jq is not one of this script's
-        #      dependencies: the file is flattened first (the field's name,
-        #      colon, and value legally sit on separate lines, and values
-        #      never contain whitespace), then matched as a string-valued
-        #      key. The spec puts the field at top level with a string
-        #      value; nested objects like devEngines.packageManager carry an
-        #      object value, which this pattern does not match.
+        #      declaration (the Corepack convention). It wins over a stale
+        #      foreign lockfile when the declared manager's own
+        #      infrastructure is present — but a declaration whose manager
+        #      has NO files here while other managers' files exist is a
+        #      contradiction, refused before any install: the declared
+        #      manager would succeed by writing a second lockfile into the
+        #      fresh tree, reporting ready with a dirty worktree
+        #      (challenge round 2). Parsed best-effort because jq is not
+        #      one of this script's dependencies: the file is flattened
+        #      first (the field's name, colon, and value legally sit on
+        #      separate lines, and values never contain whitespace), then
+        #      matched as a string-valued key. The spec puts the field at
+        #      top level with a string value; nested objects like
+        #      devEngines.packageManager carry an object value, which this
+        #      pattern does not match.
         #   2. Exactly one manager's own files at the tree root:
         #      pnpm-lock.yaml or pnpm-workspace.yaml → pnpm;
         #      package-lock.json or npm-shrinkwrap.json → npm;
@@ -806,26 +812,32 @@ if [ "$do_install" -eq 1 ]; then
             # SIGPIPE under pipefail).
             pm_decl="$(tr -d '\n\r\t ' <"$tree/package.json" | sed -n 's/.*"packageManager":"\([^"]*\)".*/\1/p')"
         fi
+        node_signals=""
+        if [ -f "$tree/pnpm-lock.yaml" ] || [ -f "$tree/pnpm-workspace.yaml" ]; then
+            node_signals="$node_signals pnpm"
+        fi
+        if [ -f "$tree/package-lock.json" ] || [ -f "$tree/npm-shrinkwrap.json" ]; then
+            node_signals="$node_signals npm"
+        fi
+        if [ -f "$tree/yarn.lock" ]; then
+            node_signals="$node_signals yarn"
+        fi
+        if [ -f "$tree/bun.lock" ] || [ -f "$tree/bun.lockb" ]; then
+            node_signals="$node_signals bun"
+        fi
         if [ -n "$pm_decl" ]; then
             node_pm=${pm_decl%%@*}
             case "$node_pm" in
             pnpm | npm | yarn | bun) ;;
             *) die "package.json declares packageManager '$pm_decl', which this script does not support (pnpm, npm, yarn, bun) — install dependencies with it yourself, or re-run with --no-install" ;;
             esac
+            if [ -n "$node_signals" ]; then
+                case " $node_signals " in
+                *" $node_pm "*) : ;;
+                *) die "package.json declares packageManager '$pm_decl' but the tree carries other managers' files (${node_signals# }) and none of $node_pm's — remove the stale file(s), or install and commit $node_pm's lockfile in the main checkout, then re-run (or use --no-install)" ;;
+                esac
+            fi
         else
-            node_signals=""
-            if [ -f "$tree/pnpm-lock.yaml" ] || [ -f "$tree/pnpm-workspace.yaml" ]; then
-                node_signals="$node_signals pnpm"
-            fi
-            if [ -f "$tree/package-lock.json" ] || [ -f "$tree/npm-shrinkwrap.json" ]; then
-                node_signals="$node_signals npm"
-            fi
-            if [ -f "$tree/yarn.lock" ]; then
-                node_signals="$node_signals yarn"
-            fi
-            if [ -f "$tree/bun.lock" ] || [ -f "$tree/bun.lockb" ]; then
-                node_signals="$node_signals bun"
-            fi
             node_pm_count=0
             for node_pm_candidate in $node_signals; do
                 node_pm_count=$((node_pm_count + 1))
@@ -837,6 +849,32 @@ if [ "$do_install" -eq 1 ]; then
         fi
         if [ -n "$node_pm" ]; then
             have "$node_pm" || die "this repo's Node package manager is $node_pm but it is not installed — install $node_pm (for pnpm, 'task bootstrap' does) and re-run"
+            # Honor a numeric major in the declaration's version pin
+            # (challenge round 2): a drifted major can rewrite the committed
+            # lockfile in a fresh tree. A corepack-shimmed binary reports the
+            # pinned version itself, so corepack-managed repos pass; a pin
+            # with no numeric major (or none at all) leaves nothing to
+            # verify and skips — signal-selected managers carry no pin.
+            pm_pin=""
+            case "$pm_decl" in
+            *@*)
+                pm_pin=${pm_decl#*@}
+                pm_pin=${pm_pin%%+*}
+                ;;
+            esac
+            pm_pin_major=${pm_pin%%.*}
+            case "$pm_pin_major" in
+            '' | *[!0-9]*) : ;;
+            *)
+                installed_ver="$("$node_pm" --version 2>/dev/null || true)"
+                installed_ver=${installed_ver#v}
+                installed_major=${installed_ver%%.*}
+                case "$installed_major" in
+                '' | *[!0-9]*) die "packageManager pins $node_pm@$pm_pin but the installed $node_pm's version could not be read — reinstall $node_pm and re-run (or use --no-install)" ;;
+                *) [ "$installed_major" = "$pm_pin_major" ] || die "packageManager pins $node_pm@$pm_pin but $node_pm $installed_ver is installed — a different major can rewrite the committed lockfile; install the pinned major (corepack does this) or update the declaration, then re-run (or use --no-install)" ;;
+                esac
+                ;;
+            esac
             echo "==> Installing Node dependencies ($node_pm) in the new tree"
             (cd "$tree" && "$node_pm" install)
         else

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -771,9 +771,72 @@ if [ "$do_install" -eq 1 ]; then
     # keying solely on a root package.json would report such a tree ready with
     # none of its dependencies installed.
     if [ -f "$tree/package.json" ] || [ -f "$tree/pnpm-workspace.yaml" ]; then
-        have pnpm || die "a Node manifest is present but pnpm is not installed — run 'task bootstrap' (or install pnpm) and re-run"
-        echo "==> Installing Node dependencies (pnpm) in the new tree"
-        (cd "$tree" && pnpm install)
+        # package.json is shared by npm, Yarn, Bun, and pnpm alike, so it
+        # proves "this is a Node repo", never "this repo uses pnpm"
+        # (harmon-init#841) — running the wrong installer resolves a different
+        # dependency graph and writes a foreign lockfile into the new tree.
+        # Select the manager deterministically, in this precedence
+        # (documented in docs/conventions.md § Worktrees):
+        #   1. The `packageManager` field in package.json — the repo's own
+        #      declaration (the Corepack convention), so it wins even over a
+        #      contradicting lockfile, exactly as Corepack itself would.
+        #      Parsed best-effort — the first string-valued occurrence in the
+        #      file — because jq is not one of this script's dependencies;
+        #      the spec puts the field at top level with a string value, and
+        #      nested objects like devEngines.packageManager carry an object
+        #      value, which this pattern does not match.
+        #   2. Exactly one manager's own files at the tree root:
+        #      pnpm-lock.yaml or pnpm-workspace.yaml → pnpm;
+        #      package-lock.json or npm-shrinkwrap.json → npm;
+        #      yarn.lock → yarn; bun.lock or bun.lockb → bun.
+        #      Files from two managers at once is a contradiction only the
+        #      repo can resolve — fail loudly rather than guess, because the
+        #      guess that loses writes the wrong lockfile.
+        #   3. No signal at all (a bare package.json): skip the install with
+        #      a note naming the fix. Installing on a guess here is the exact
+        #      defect this block replaces, and a skipped install is visible
+        #      while a wrong lockfile is not.
+        node_pm=""
+        pm_decl=""
+        if [ -f "$tree/package.json" ]; then
+            pm_decl="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$tree/package.json" | head -n 1)"
+        fi
+        if [ -n "$pm_decl" ]; then
+            node_pm=${pm_decl%%@*}
+            case "$node_pm" in
+            pnpm | npm | yarn | bun) ;;
+            *) die "package.json declares packageManager '$pm_decl', which this script does not support (pnpm, npm, yarn, bun) — install dependencies with it yourself, or re-run with --no-install" ;;
+            esac
+        else
+            node_signals=""
+            if [ -f "$tree/pnpm-lock.yaml" ] || [ -f "$tree/pnpm-workspace.yaml" ]; then
+                node_signals="$node_signals pnpm"
+            fi
+            if [ -f "$tree/package-lock.json" ] || [ -f "$tree/npm-shrinkwrap.json" ]; then
+                node_signals="$node_signals npm"
+            fi
+            if [ -f "$tree/yarn.lock" ]; then
+                node_signals="$node_signals yarn"
+            fi
+            if [ -f "$tree/bun.lock" ] || [ -f "$tree/bun.lockb" ]; then
+                node_signals="$node_signals bun"
+            fi
+            node_pm_count=0
+            for node_pm_candidate in $node_signals; do
+                node_pm_count=$((node_pm_count + 1))
+                node_pm=$node_pm_candidate
+            done
+            if [ "$node_pm_count" -gt 1 ]; then
+                die "conflicting Node package-manager signals in this tree:$node_signals — remove the stale manager's file(s) or declare \"packageManager\" in package.json, then re-run"
+            fi
+        fi
+        if [ -n "$node_pm" ]; then
+            have "$node_pm" || die "this repo's Node package manager is $node_pm but it is not installed — install $node_pm (for pnpm, 'task bootstrap' does) and re-run"
+            echo "==> Installing Node dependencies ($node_pm) in the new tree"
+            (cd "$tree" && "$node_pm" install)
+        else
+            echo "==> Note: package.json carries no package-manager signal (no packageManager field, no lockfile) — skipping the Node install; declare \"packageManager\" in package.json, or install dependencies in the tree yourself"
+        fi
     fi
     if [ -f "$tree/pyproject.toml" ]; then
         have uv || die "pyproject.toml is present but uv is not installed — run 'task bootstrap' (or install uv) and re-run"

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -780,11 +780,13 @@ if [ "$do_install" -eq 1 ]; then
         #   1. The `packageManager` field in package.json — the repo's own
         #      declaration (the Corepack convention), so it wins even over a
         #      contradicting lockfile, exactly as Corepack itself would.
-        #      Parsed best-effort — the first string-valued occurrence in the
-        #      file — because jq is not one of this script's dependencies;
-        #      the spec puts the field at top level with a string value, and
-        #      nested objects like devEngines.packageManager carry an object
-        #      value, which this pattern does not match.
+        #      Parsed best-effort because jq is not one of this script's
+        #      dependencies: the file is flattened first (the field's name,
+        #      colon, and value legally sit on separate lines, and values
+        #      never contain whitespace), then matched as a string-valued
+        #      key. The spec puts the field at top level with a string
+        #      value; nested objects like devEngines.packageManager carry an
+        #      object value, which this pattern does not match.
         #   2. Exactly one manager's own files at the tree root:
         #      pnpm-lock.yaml or pnpm-workspace.yaml → pnpm;
         #      package-lock.json or npm-shrinkwrap.json → npm;
@@ -799,7 +801,10 @@ if [ "$do_install" -eq 1 ]; then
         node_pm=""
         pm_decl=""
         if [ -f "$tree/package.json" ]; then
-            pm_decl="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$tree/package.json" | head -n 1)"
+            # tr collapses the whole file to one line, so sed emits at most
+            # one match and needs no `head` (whose early exit would race a
+            # SIGPIPE under pipefail).
+            pm_decl="$(tr -d '\n\r\t ' <"$tree/package.json" | sed -n 's/.*"packageManager":"\([^"]*\)".*/\1/p')"
         fi
         if [ -n "$pm_decl" ]; then
             node_pm=${pm_decl%%@*}

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -875,8 +875,49 @@ if [ "$do_install" -eq 1 ]; then
                 esac
                 ;;
             esac
-            echo "==> Installing Node dependencies ($node_pm) in the new tree"
-            (cd "$tree" && "$node_pm" install)
+            # When the selected manager's own lockfile is present, install in
+            # its immutable mode (challenge round 3): a plain install can
+            # legally REWRITE a committed lockfile — npm 11 upgrades a
+            # lockfileVersion-1 file in place — and a provisioning step must
+            # fail and roll back on drift, not report a dirty tree as ready.
+            # The devcontainer post-checkout hook set this precedent (npm ci,
+            # --frozen-lockfile). With no lockfile — a workspace-file-only
+            # root, or a declaration with no manager files yet — plain
+            # install remains: there is nothing to preserve, and the first
+            # install legitimately creates the lockfile.
+            node_pm_args=("install")
+            case "$node_pm" in
+            pnpm)
+                if [ -f "$tree/pnpm-lock.yaml" ]; then
+                    node_pm_args=("install" "--frozen-lockfile")
+                fi
+                ;;
+            npm)
+                if [ -f "$tree/package-lock.json" ] || [ -f "$tree/npm-shrinkwrap.json" ]; then
+                    node_pm_args=("ci")
+                fi
+                ;;
+            yarn)
+                # Classic (1.x) spells the immutable mode --frozen-lockfile;
+                # Berry spells it --immutable. Version-split rather than
+                # relying on Berry's deprecated alias.
+                if [ -f "$tree/yarn.lock" ]; then
+                    yarn_ver="$(yarn --version 2>/dev/null || true)"
+                    case "${yarn_ver%%.*}" in
+                    1) node_pm_args=("install" "--frozen-lockfile") ;;
+                    '' | *[!0-9]*) die "yarn.lock is present but yarn's version could not be read — reinstall yarn and re-run (or use --no-install)" ;;
+                    *) node_pm_args=("install" "--immutable") ;;
+                    esac
+                fi
+                ;;
+            bun)
+                if [ -f "$tree/bun.lock" ] || [ -f "$tree/bun.lockb" ]; then
+                    node_pm_args=("install" "--frozen-lockfile")
+                fi
+                ;;
+            esac
+            echo "==> Installing Node dependencies ($node_pm ${node_pm_args[*]}) in the new tree"
+            (cd "$tree" && "$node_pm" "${node_pm_args[@]}")
         else
             echo "==> Note: package.json carries no package-manager signal (no packageManager field, no lockfile) — skipping the Node install; declare \"packageManager\" in package.json, or install dependencies in the tree yourself"
         fi


### PR DESCRIPTION
Closes #841

## What

`task worktree:new` installed Node dependencies with `pnpm install` whenever `package.json` existed — handing npm, Yarn, and Bun repos the wrong installer (wrong dependency graph, foreign lockfile written into the fresh tree). The installer is now selected deterministically from the repo's own signals, and every contradiction fails loudly **before** any install touches the tree:

- **Precedence**: the `packageManager` declaration (Corepack convention) wins — including over a stale foreign lockfile when its own manager's files are present; otherwise exactly one manager's files at the tree root (`pnpm-lock.yaml`/`pnpm-workspace.yaml` → pnpm, `package-lock.json`/`npm-shrinkwrap.json` → npm, `yarn.lock` → Yarn, `bun.lock`/`bun.lockb` → Bun).
- **Fail-closed contradictions**: lockfiles from two managers with no declaration; a declaration whose manager has no files here while other managers' files exist (installing would write a second lockfile); an unsupported `packageManager` value; a declared numeric major the installed binary does not match (a drifted major can rewrite the committed lockfile — corepack shims report the pin and pass). Each refusal rolls the tree back.
- **Immutable installs**: when the selected manager's own lockfile exists, install runs in its immutable mode (`pnpm install --frozen-lockfile`, `npm ci`, `yarn install --frozen-lockfile`/`--immutable` split by major, `bun install --frozen-lockfile`) so lockfile drift fails and rolls back instead of mutating committed state. No-lockfile paths keep plain `install`.
- **No-signal case**: a bare `package.json` skips the install with a note naming the fix — documented in `docs/conventions.md` § Worktrees.
- **Devcontainer hook brought under the suppression contract**: the shipped `.devcontainer/hooks/post-checkout` (a hand-written hook, not a lefthook shim) fired during `git worktree add` and ran its own lockfile-first installer before the detector; its node-install section now honors `LEFTHOOK=0` (the git-lfs chain stays outside the guard).

## Acceptance criteria (issue #841)

- pnpm stays pnpm, including workspace-file-only roots ✔ (suite cases; workspace case isolated from the lockfile signal)
- npm/Yarn/Bun get their declared manager, or unsupported fails loudly without modifying the tree ✔
- ambiguous/no-lockfile behavior documented and deterministic ✔ (`docs/conventions.md` § Worktrees, both twins)
- hermetic tests assert the selected command AND that competing installers were not invoked ✔ (`det_assert_installer` checks the exact argument vector for the selected manager and emptiness for every other marker)
- root/template twins byte-identical ✔ (`worktree-new.sh`, `test-worktree.sh`, `.devcontainer/hooks/post-checkout`; conventions docs are jinja twins, updated in lockstep)

## Verification

- `task verify` green after every round; `task ci` (full mirror) green on the final tree.
- 11 mutation checks, each reverting one guard in a `cp` backup and proving the suite fails: unconditional-pnpm regression, ambiguity die, unsupported-declaration die, silent pnpm default, dropped workspace signal, ignored declaration, dropped hook `LEFTHOOK=0` guard (against the REAL shipped hook), reverted multi-line parse, disabled version-pin gate, disabled foreign-contradiction die, and each immutable-mode branch (npm ci / frozen-lockfile / yarn immutable).

## Review budget

rigor: `standard` (`default_rigor`) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1.
Challenge ran **4 rounds**: the cap round adjudicated a confirmed P1 (fixed in-round), which is a stop-and-escalate; Evan explicitly granted one extension round in-session (above default — disclosed), and round 4 adjudicated clean (capped-clean exit). Review converged in 2 rounds (two consecutive adjudicated-clean). Tier/method: method `plan` (`default_method`); tier resolved **apex** (Fable) by explicit session instruction — above the `standard` default, disclosed per ADR 0006.

## Deferred findings

- [x] scripts/worktree-new.sh:~813 — the packageManager parse establishes no JSON depth: a nested string-valued "packageManager" key can be read as the declaration, and because the flattened match is greedy the LAST occurrence wins, so a nested one after the top-level field outvotes it (challenge r1 P2, re-raised sharper in r3). Flattened matching already fixed the multi-line-formatting half (r1); a true top-level-only parse needs a JSON parser this script deliberately does not depend on. Hardening only — the spec puts the field at top level and real-world manifests keep it there and nowhere else. — filed as #939
- [x] scripts/worktree-new.sh:~880 — with no lockfile present (a pnpm-workspace-only root, or a declaration with no manager files yet) the plain install legitimately creates the manager's lockfile, which the fresh tree then carries as an untracked file; worktree:rm will refuse without --force. Historic behavior (pre-#841 pnpm did the same); acceptable for fresh repos, noted for completeness against the immutable-mode guard added in challenge r3. — declined: accepted residual — historic pre-#841 behavior, only reachable on repos with no lockfile at all, and the visible worktree:rm refusal is the safe failure direction; filing tracked hardening would add a mechanism no consumer has asked for

## Adjudication record

<details><summary>Per-round ledger (challenge 4 rounds, review 2 rounds)</summary>

```text
challenge r1 | 1 P1 + 1 P2
scripts/worktree-new.sh:833 | devcontainer post-checkout hook installs before detector, ignores LEFTHOOK=0 | confirmed P1: fixed — hook's node-install section now honors LEFTHOOK=0; e2e case with the real hook | challenge r1
scripts/worktree-new.sh:801 | packageManager sed is line-oriented; misses multi-line declarations, no JSON depth | confirmed-in-part P2: formatting half fixed (flatten before match); structural-depth half deferred to sidecar | challenge r1
challenge r2 | 2 P1
scripts/worktree-new.sh:841 | declared manager with no own lockfile over foreign lockfile installs + writes second lockfile, dirty tree | confirmed P1: fixed — foreign-only contradiction now dies before install (det-foreign case, M10 caught); provenance: in scope, original change's declared-wins design | challenge r2
scripts/worktree-new.sh:810 | version pin discarded — host major drift can rewrite committed lockfile | confirmed P1: fixed — numeric declared major verified against installed binary, mismatch dies (det-verpin case, M9 caught); corepack shims report the pin and pass; provenance: in scope, original change | challenge r2
challenge r3 | 1 P1 + 1 P2 (cap round)
scripts/worktree-new.sh:878 | plain install can rewrite committed lockfile (npm 11 upgrades lockfileVersion 1) -> dirty tree reported ready | confirmed P1: fixed — immutable mode when own lockfile exists (npm ci / --frozen-lockfile / yarn --immutable by major), matching the devcontainer hook's precedent; M11/M12/M13 caught; provenance: in scope, original install invocation | challenge r3
scripts/worktree-new.sh:813 | greedy flattened match lets a nested later packageManager outvote top-level | P2, ledger match: same structural-depth residual as r1's P2 — already deferred; sidecar entry sharpened with last-occurrence example; no code change | challenge r3
challenge r4 (granted extension) | 0 P0/P1, 1 P2 — stage converged (capped-clean exit)
scripts/worktree-new.sh:813 | nested packageManager can outvote top-level (structural parse) | P2, ledger match: third raise of r1's deferred residual; answered from the record, already in sidecar; no code change | challenge r4
review r1 | 0 P0/P1, 1 P2 (clean round 1 of 2)
scripts/worktree-new.sh:813 | nested/in-string packageManager occurrence can outvote top-level | P2, ledger match: fourth raise of the deferred structural-parse residual; in sidecar; no code change | review r1
review r2 | 0 P0/P1, 1 P2 — stage converged (two consecutive adjudicated-clean rounds)
scripts/worktree-new.sh:813 | same structural-parse P2 | P2, ledger match: fifth raise; in sidecar; no code change | review r2
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

