### PR TITLE
fix: refuse worktree removal over a deleted in-cone sparse flagged file

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -53,6 +53,13 @@ it points here.
   uncommitted work). It refuses on uncommitted changes **and** on ignored local
   files such as a `.env` — `git worktree remove` counts modified and untracked
   files but not ignored ones, so a plain remove would take those with it.
+  Edits hidden by `skip-worktree`/`assume-unchanged` refuse too, a deleted
+  flagged file included. In a sparse checkout an absent flagged path is exempt
+  only when the tree's active sparse rules exclude it (asked via
+  `git sparse-checkout check-rules`); on git < 2.42, which lacks
+  `check-rules`, the exemption deliberately stays per-tree rather than
+  failing closed, so clean sparse worktrees remain removable on e.g. macOS
+  system git (harmon-init#919).
   Ignored *directories* (`node_modules/`, `.venv/`, `dist/`) do not block it:
   `worktree:new` reinstalls them, and refusing there would make `--force`
   routine and so meaningless. It also prunes the registry and clears leftover

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -390,6 +390,96 @@ rm_wt hidden-sparse >/dev/null ||
     fail "worktree-rm.sh refused an ordinary removal of a clean sparse worktree"
 refute_exists "$fixture/.worktrees/hidden-sparse" "worktree-rm.sh left the tree behind"
 
+echo "==> a DELETED in-cone flagged file in a SPARSE tree blocks removal"
+# Sparse-enabled is a per-tree fact; the skip-worktree flag is per path. A
+# user who manually flags an IN-CONE (included) file and deletes it shows
+# the same absent-`S` state as a sparse-excluded path, and the pre-#919
+# guard skipped it as sparse-absent — discarding the uncommitted
+# deletion-intent. The active rules decide now: excluded stays exempt (the
+# case above), in-cone refuses, naming the path.
+new hidden-sparse-cone >/dev/null || fail "worktree-new.sh failed for the in-cone sparse case"
+git -C "$fixture/.worktrees/hidden-sparse-cone" sparse-checkout set --no-cone '/scripts' >/dev/null 2>&1 ||
+    fail "could not enable sparse checkout in the fixture worktree"
+[ -f "$fixture/.worktrees/hidden-sparse-cone/scripts/worktree-lock.sh" ] ||
+    fail "fixture assumption broken: sparse checkout removed an in-cone file"
+git -C "$fixture/.worktrees/hidden-sparse-cone" update-index --skip-worktree scripts/worktree-lock.sh
+rm "$fixture/.worktrees/hidden-sparse-cone/scripts/worktree-lock.sh"
+[ -z "$(git -C "$fixture/.worktrees/hidden-sparse-cone" status --porcelain)" ] ||
+    fail "fixture assumption broken: the flagged in-cone deletion shows in git status"
+cone_out="$(rm_wt hidden-sparse-cone 2>&1)" &&
+    fail "worktree-rm.sh removed a sparse tree with a deleted in-cone flagged file without --force"
+case "$cone_out" in *"scripts/worktree-lock.sh"*) : ;; *) fail "the in-cone sparse refusal did not name the deleted path" ;; esac
+rm_wt hidden-sparse-cone --force >/dev/null || fail "worktree-rm.sh --force failed on the in-cone sparse case"
+refute_exists "$fixture/.worktrees/hidden-sparse-cone" "worktree-rm.sh --force left the directory behind"
+
+echo "==> on git < 2.42 the whole-tree sparse exemption is kept (#919 decision)"
+# The decided AC-3 behavior: without `sparse-checkout check-rules` the
+# guard cannot ask the rules, and it deliberately keeps the pre-#919
+# per-tree exemption rather than failing closed — which would refuse every
+# clean sparse removal on e.g. macOS system git ~2.39 and teach routine
+# --force. The stub fakes ONLY the version probe; a correct gate then never
+# invokes check-rules, so delegating everything else to the real git is
+# faithful — while a gate that ignores the version DOES reach the real
+# check-rules, refuses the deletion below, and fails this case.
+oldgit_dir="$test_tmp/oldgit-bin"
+mkdir -p "$oldgit_dir"
+real_git="$(command -v git)"
+cat >"$oldgit_dir/git" <<OLDGIT
+#!/usr/bin/env bash
+if [ "\$1" = "--version" ]; then
+    echo "git version 2.39.5"
+    exit 0
+fi
+exec "$real_git" "\$@"
+OLDGIT
+chmod +x "$oldgit_dir/git"
+new hidden-sparse-oldgit >/dev/null || fail "worktree-new.sh failed for the old-git sparse case"
+git -C "$fixture/.worktrees/hidden-sparse-oldgit" sparse-checkout set --no-cone '/scripts' >/dev/null 2>&1 ||
+    fail "could not enable sparse checkout in the fixture worktree"
+git -C "$fixture/.worktrees/hidden-sparse-oldgit" update-index --skip-worktree scripts/worktree-lock.sh
+rm "$fixture/.worktrees/hidden-sparse-oldgit/scripts/worktree-lock.sh"
+(
+    PATH="$oldgit_dir:$PATH"
+    export PATH
+    rm_wt hidden-sparse-oldgit >/dev/null
+) || fail "worktree-rm.sh on git < 2.42 did not keep the documented whole-tree sparse exemption"
+refute_exists "$fixture/.worktrees/hidden-sparse-oldgit" "worktree-rm.sh left the tree behind"
+
+echo "==> a check-rules failure fails CLOSED, refusing the removal"
+# The batch query's success sentinel mirrors the enumeration's: bash does
+# not propagate a process-substitution failure, so without the sentinel a
+# check-rules error would be swallowed and the removal waved through on an
+# unevaluated exemption. The shim passes the version gate (real git
+# answers --version) and breaks exactly the check-rules invocation; the
+# tree's absent excluded entries are candidate enough to force the batch
+# query to run.
+brokenrules_dir="$test_tmp/brokenrules-bin"
+mkdir -p "$brokenrules_dir"
+cat >"$brokenrules_dir/git" <<BROKENRULES
+#!/usr/bin/env bash
+for brk_arg in "\$@"; do
+    if [ "\$brk_arg" = "check-rules" ]; then
+        echo "git: simulated check-rules failure" >&2
+        exit 1
+    fi
+done
+exec "$real_git" "\$@"
+BROKENRULES
+chmod +x "$brokenrules_dir/git"
+new hidden-sparse-broken >/dev/null || fail "worktree-new.sh failed for the broken-rules case"
+git -C "$fixture/.worktrees/hidden-sparse-broken" sparse-checkout set --no-cone '/scripts' >/dev/null 2>&1 ||
+    fail "could not enable sparse checkout in the fixture worktree"
+if (
+    PATH="$brokenrules_dir:$PATH"
+    export PATH
+    rm_wt hidden-sparse-broken >/dev/null 2>&1
+); then
+    fail "worktree-rm.sh removed a sparse tree although the sparse-rules check failed"
+fi
+[ -d "$fixture/.worktrees/hidden-sparse-broken" ] || fail "the tree was removed despite the fail-closed refusal"
+rm_wt hidden-sparse-broken >/dev/null || fail "cleanup of the broken-rules tree failed"
+refute_exists "$fixture/.worktrees/hidden-sparse-broken" "worktree-rm.sh left the tree behind"
+
 echo "==> a DELETED skip-worktree file WITHOUT sparse checkout blocks removal"
 # Absence is only sparse-normal where sparse checkout is actually enabled;
 # without it, an absent flagged file can only be a user's uncommitted

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -41,6 +41,26 @@ shared_refs_containing() {
         grep -Ev '^refs/(worktree|bisect|rewritten)/' || true
 }
 
+# `git sparse-checkout check-rules` (git >= 2.42) lets the hidden-edit guard
+# ask whether an absent flagged path is genuinely EXCLUDED by a sparse tree's
+# active rules, or was deleted by the user. The gate is an explicit version
+# parse, not a capability probe: probing by running the subcommand cannot
+# distinguish "this git predates check-rules" from "check-rules failed at
+# runtime", and misreading the second as the first would silently widen the
+# exemption on a git that could have answered. A version this parser cannot
+# read is treated as < 2.42 — not provably capable — which lands on the
+# DOCUMENTED old-git behavior below rather than an undefined one.
+git_supports_check_rules() {
+    gate_ver="$(git --version 2>/dev/null)" || return 1
+    gate_ver="${gate_ver#git version }"
+    gate_major="${gate_ver%%.*}"
+    gate_rest="${gate_ver#*.}"
+    gate_minor="${gate_rest%%.*}"
+    case "$gate_major" in '' | *[!0-9]*) return 1 ;; esac
+    case "$gate_minor" in '' | *[!0-9]*) return 1 ;; esac
+    [ "$gate_major" -gt 2 ] || { [ "$gate_major" -eq 2 ] && [ "$gate_minor" -ge 42 ]; }
+}
+
 # Locate the administrative directory backing the registry record for a
 # worktree path. git exposes no porcelain for this mapping; each record's
 # `gitdir` file holds the path of that worktree's `.git` file, which is the
@@ -239,13 +259,28 @@ else
     # spawned.
     #
     # What counts as a hidden edit is what a removal would DESTROY:
-    #   - an absent skip-worktree path is skipped only when sparse checkout
-    #     is enabled in the tree — sparse marks every excluded path
-    #     skip-worktree with no file present, so refusing on absence would
-    #     block the removal of every clean sparse worktree. Without sparse,
-    #     absence means the user deleted a file they had flagged — for
-    #     skip-worktree and assume-unchanged alike, that uncommitted
-    #     deletion is what the removal would discard, so it refuses;
+    #   - an absent skip-worktree path in a sparse-enabled tree is skipped
+    #     only when the tree's ACTIVE sparse rules exclude it — sparse marks
+    #     every excluded path skip-worktree with no file present, so refusing
+    #     on absence alone would block the removal of every clean sparse
+    #     worktree. But sparse-enabled is a per-tree fact and the flag is
+    #     per-path: an IN-CONE file the user manually flagged and then
+    #     deleted shows the same absent-`S` state, and skipping it discards
+    #     that uncommitted deletion-intent (harmon-init#919). So absence is
+    #     exempt per PATH, by asking `git sparse-checkout check-rules`
+    #     (git >= 2.42) whether the rules exclude it — batched once per tree,
+    #     because a sparse monorepo can hold hundreds of thousands of absent
+    #     entries and a per-path spawn turned removal into minutes. On
+    #     git < 2.42 the whole-tree exemption is KEPT, deliberately and
+    #     documented (harmon-init#919's decided AC): the residual loss is
+    #     deletion-intent on an exotic, unstable state (git recomputes
+    #     sparse skip-worktree bits itself), while failing closed would
+    #     refuse every clean sparse-worktree removal on e.g. macOS system
+    #     git ~2.39 and teach the routine use of --force, which discards
+    #     every OTHER protection here too. Without sparse, absence means the
+    #     user deleted a file they had flagged — for skip-worktree and
+    #     assume-unchanged alike, that uncommitted deletion is what the
+    #     removal would discard, so it refuses;
     #   - content is compared against the CHECKOUT representation
     #     (`cat-file --filters` — the bytes a fresh checkout would write),
     #     so an unmodified checkout under `eol=crlf`, `core.autocrlf`, or a
@@ -269,6 +304,16 @@ else
         sparse_enabled="$(git -C "$tree" config --get --type=bool --default=false core.sparseCheckout 2>/dev/null || echo false)"
         filemode_enabled="$(git -C "$tree" config --get --type=bool --default=true core.fileMode 2>/dev/null || echo true)"
         symlinks_enabled="$(git -C "$tree" config --get --type=bool --default=true core.symlinks 2>/dev/null || echo true)"
+        sparse_rules_checkable=0
+        if [ "$sparse_enabled" = "true" ] && git_supports_check_rules; then
+            sparse_rules_checkable=1
+        fi
+        # Absent flagged paths whose exemption depends on the sparse rules,
+        # deferred to ONE batched check-rules call after the enumeration. A
+        # bash array, not a delimited string: a variable cannot hold the NUL
+        # this stream frames with, and any other delimiter can occur in a
+        # path.
+        sparse_absent_candidates=()
         hidden_paths=""
         flagged_enum_ok=0
         while IFS= read -r -d '' flagged_entry; do
@@ -293,6 +338,15 @@ else
                 case "$flagged_tag" in
                 S | s)
                     if [ "$sparse_enabled" = "true" ]; then
+                        if [ "$sparse_rules_checkable" -eq 1 ]; then
+                            # Excluded-or-deleted is decided by the batched
+                            # check-rules call after the enumeration, not
+                            # here: deferring keeps this loop spawn-free
+                            # per entry.
+                            sparse_absent_candidates+=("$flagged_path")
+                        fi
+                        # git < 2.42: the documented whole-tree exemption
+                        # (see the guard comment above).
                         continue
                     fi
                     ;;
@@ -376,6 +430,36 @@ else
         done < <(git -C "$tree" ls-files -v -z && printf '__WORKTREE_RM_ENUM_OK__\0')
         if [ "$flagged_enum_ok" -ne 1 ]; then
             die "could not enumerate $tree's index entries for the hidden-edit check — this guard fails closed; fix the enumeration (or discard the tree with --force)"
+        fi
+        # ONE query for every deferred absent flagged path: check-rules
+        # echoes back exactly the paths the tree's active sparse rules MATCH
+        # (would keep present), so an echoed path is in-cone — its absence is
+        # a user's deletion, refused like any hidden deletion — and a path
+        # not echoed is excluded, absent because sparse removed it. `-C
+        # "$tree"` is load-bearing: check-rules reads the invoking worktree's
+        # own sparse-checkout state, and each linked worktree carries its own
+        # (extensions.worktreeConfig).
+        #
+        # The trailing empty record is this pipeline's success sentinel,
+        # mirroring flagged_enum_ok above: bash does not propagate a
+        # process-substitution failure, so without it a check-rules error or
+        # truncated stream would fail OPEN and wave the removal through. An
+        # empty record is unforgeable here — check-rules only echoes paths it
+        # was fed, and no index entry has an empty path.
+        if [ "${#sparse_absent_candidates[@]}" -gt 0 ]; then
+            sparse_rules_ok=0
+            while IFS= read -r -d '' incone_path; do
+                if [ -z "$incone_path" ]; then
+                    sparse_rules_ok=1
+                    continue
+                fi
+                hidden_paths="${hidden_paths}  ${incone_path}
+"
+            done < <(printf '%s\0' "${sparse_absent_candidates[@]}" |
+                git -C "$tree" sparse-checkout check-rules -z && printf '\0')
+            if [ "$sparse_rules_ok" -ne 1 ]; then
+                die "could not evaluate $tree's sparse rules for the hidden-edit check — this guard fails closed; fix the sparse-checkout state (or discard the tree with --force)"
+            fi
         fi
         if [ -n "$hidden_paths" ]; then
             echo "worktree:rm: $tree has local edits hidden from git status by skip-worktree / assume-unchanged:" >&2

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -55,6 +55,13 @@ it points here.
   uncommitted work). It refuses on uncommitted changes **and** on ignored local
   files such as a `.env` — `git worktree remove` counts modified and untracked
   files but not ignored ones, so a plain remove would take those with it.
+  Edits hidden by `skip-worktree`/`assume-unchanged` refuse too, a deleted
+  flagged file included. In a sparse checkout an absent flagged path is exempt
+  only when the tree's active sparse rules exclude it (asked via
+  `git sparse-checkout check-rules`); on git < 2.42, which lacks
+  `check-rules`, the exemption deliberately stays per-tree rather than
+  failing closed, so clean sparse worktrees remain removable on e.g. macOS
+  system git (harmon-init#919).
   Ignored *directories* (`node_modules/`, `.venv/`, `dist/`) do not block it:
   `worktree:new` reinstalls them, and refusing there would make `--force`
   routine and so meaningless. It also prunes the registry and clears leftover

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -390,6 +390,96 @@ rm_wt hidden-sparse >/dev/null ||
     fail "worktree-rm.sh refused an ordinary removal of a clean sparse worktree"
 refute_exists "$fixture/.worktrees/hidden-sparse" "worktree-rm.sh left the tree behind"
 
+echo "==> a DELETED in-cone flagged file in a SPARSE tree blocks removal"
+# Sparse-enabled is a per-tree fact; the skip-worktree flag is per path. A
+# user who manually flags an IN-CONE (included) file and deletes it shows
+# the same absent-`S` state as a sparse-excluded path, and the pre-#919
+# guard skipped it as sparse-absent — discarding the uncommitted
+# deletion-intent. The active rules decide now: excluded stays exempt (the
+# case above), in-cone refuses, naming the path.
+new hidden-sparse-cone >/dev/null || fail "worktree-new.sh failed for the in-cone sparse case"
+git -C "$fixture/.worktrees/hidden-sparse-cone" sparse-checkout set --no-cone '/scripts' >/dev/null 2>&1 ||
+    fail "could not enable sparse checkout in the fixture worktree"
+[ -f "$fixture/.worktrees/hidden-sparse-cone/scripts/worktree-lock.sh" ] ||
+    fail "fixture assumption broken: sparse checkout removed an in-cone file"
+git -C "$fixture/.worktrees/hidden-sparse-cone" update-index --skip-worktree scripts/worktree-lock.sh
+rm "$fixture/.worktrees/hidden-sparse-cone/scripts/worktree-lock.sh"
+[ -z "$(git -C "$fixture/.worktrees/hidden-sparse-cone" status --porcelain)" ] ||
+    fail "fixture assumption broken: the flagged in-cone deletion shows in git status"
+cone_out="$(rm_wt hidden-sparse-cone 2>&1)" &&
+    fail "worktree-rm.sh removed a sparse tree with a deleted in-cone flagged file without --force"
+case "$cone_out" in *"scripts/worktree-lock.sh"*) : ;; *) fail "the in-cone sparse refusal did not name the deleted path" ;; esac
+rm_wt hidden-sparse-cone --force >/dev/null || fail "worktree-rm.sh --force failed on the in-cone sparse case"
+refute_exists "$fixture/.worktrees/hidden-sparse-cone" "worktree-rm.sh --force left the directory behind"
+
+echo "==> on git < 2.42 the whole-tree sparse exemption is kept (#919 decision)"
+# The decided AC-3 behavior: without `sparse-checkout check-rules` the
+# guard cannot ask the rules, and it deliberately keeps the pre-#919
+# per-tree exemption rather than failing closed — which would refuse every
+# clean sparse removal on e.g. macOS system git ~2.39 and teach routine
+# --force. The stub fakes ONLY the version probe; a correct gate then never
+# invokes check-rules, so delegating everything else to the real git is
+# faithful — while a gate that ignores the version DOES reach the real
+# check-rules, refuses the deletion below, and fails this case.
+oldgit_dir="$test_tmp/oldgit-bin"
+mkdir -p "$oldgit_dir"
+real_git="$(command -v git)"
+cat >"$oldgit_dir/git" <<OLDGIT
+#!/usr/bin/env bash
+if [ "\$1" = "--version" ]; then
+    echo "git version 2.39.5"
+    exit 0
+fi
+exec "$real_git" "\$@"
+OLDGIT
+chmod +x "$oldgit_dir/git"
+new hidden-sparse-oldgit >/dev/null || fail "worktree-new.sh failed for the old-git sparse case"
+git -C "$fixture/.worktrees/hidden-sparse-oldgit" sparse-checkout set --no-cone '/scripts' >/dev/null 2>&1 ||
+    fail "could not enable sparse checkout in the fixture worktree"
+git -C "$fixture/.worktrees/hidden-sparse-oldgit" update-index --skip-worktree scripts/worktree-lock.sh
+rm "$fixture/.worktrees/hidden-sparse-oldgit/scripts/worktree-lock.sh"
+(
+    PATH="$oldgit_dir:$PATH"
+    export PATH
+    rm_wt hidden-sparse-oldgit >/dev/null
+) || fail "worktree-rm.sh on git < 2.42 did not keep the documented whole-tree sparse exemption"
+refute_exists "$fixture/.worktrees/hidden-sparse-oldgit" "worktree-rm.sh left the tree behind"
+
+echo "==> a check-rules failure fails CLOSED, refusing the removal"
+# The batch query's success sentinel mirrors the enumeration's: bash does
+# not propagate a process-substitution failure, so without the sentinel a
+# check-rules error would be swallowed and the removal waved through on an
+# unevaluated exemption. The shim passes the version gate (real git
+# answers --version) and breaks exactly the check-rules invocation; the
+# tree's absent excluded entries are candidate enough to force the batch
+# query to run.
+brokenrules_dir="$test_tmp/brokenrules-bin"
+mkdir -p "$brokenrules_dir"
+cat >"$brokenrules_dir/git" <<BROKENRULES
+#!/usr/bin/env bash
+for brk_arg in "\$@"; do
+    if [ "\$brk_arg" = "check-rules" ]; then
+        echo "git: simulated check-rules failure" >&2
+        exit 1
+    fi
+done
+exec "$real_git" "\$@"
+BROKENRULES
+chmod +x "$brokenrules_dir/git"
+new hidden-sparse-broken >/dev/null || fail "worktree-new.sh failed for the broken-rules case"
+git -C "$fixture/.worktrees/hidden-sparse-broken" sparse-checkout set --no-cone '/scripts' >/dev/null 2>&1 ||
+    fail "could not enable sparse checkout in the fixture worktree"
+if (
+    PATH="$brokenrules_dir:$PATH"
+    export PATH
+    rm_wt hidden-sparse-broken >/dev/null 2>&1
+); then
+    fail "worktree-rm.sh removed a sparse tree although the sparse-rules check failed"
+fi
+[ -d "$fixture/.worktrees/hidden-sparse-broken" ] || fail "the tree was removed despite the fail-closed refusal"
+rm_wt hidden-sparse-broken >/dev/null || fail "cleanup of the broken-rules tree failed"
+refute_exists "$fixture/.worktrees/hidden-sparse-broken" "worktree-rm.sh left the tree behind"
+
 echo "==> a DELETED skip-worktree file WITHOUT sparse checkout blocks removal"
 # Absence is only sparse-normal where sparse checkout is actually enabled;
 # without it, an absent flagged file can only be a user's uncommitted

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -41,6 +41,26 @@ shared_refs_containing() {
         grep -Ev '^refs/(worktree|bisect|rewritten)/' || true
 }
 
+# `git sparse-checkout check-rules` (git >= 2.42) lets the hidden-edit guard
+# ask whether an absent flagged path is genuinely EXCLUDED by a sparse tree's
+# active rules, or was deleted by the user. The gate is an explicit version
+# parse, not a capability probe: probing by running the subcommand cannot
+# distinguish "this git predates check-rules" from "check-rules failed at
+# runtime", and misreading the second as the first would silently widen the
+# exemption on a git that could have answered. A version this parser cannot
+# read is treated as < 2.42 — not provably capable — which lands on the
+# DOCUMENTED old-git behavior below rather than an undefined one.
+git_supports_check_rules() {
+    gate_ver="$(git --version 2>/dev/null)" || return 1
+    gate_ver="${gate_ver#git version }"
+    gate_major="${gate_ver%%.*}"
+    gate_rest="${gate_ver#*.}"
+    gate_minor="${gate_rest%%.*}"
+    case "$gate_major" in '' | *[!0-9]*) return 1 ;; esac
+    case "$gate_minor" in '' | *[!0-9]*) return 1 ;; esac
+    [ "$gate_major" -gt 2 ] || { [ "$gate_major" -eq 2 ] && [ "$gate_minor" -ge 42 ]; }
+}
+
 # Locate the administrative directory backing the registry record for a
 # worktree path. git exposes no porcelain for this mapping; each record's
 # `gitdir` file holds the path of that worktree's `.git` file, which is the
@@ -239,13 +259,28 @@ else
     # spawned.
     #
     # What counts as a hidden edit is what a removal would DESTROY:
-    #   - an absent skip-worktree path is skipped only when sparse checkout
-    #     is enabled in the tree — sparse marks every excluded path
-    #     skip-worktree with no file present, so refusing on absence would
-    #     block the removal of every clean sparse worktree. Without sparse,
-    #     absence means the user deleted a file they had flagged — for
-    #     skip-worktree and assume-unchanged alike, that uncommitted
-    #     deletion is what the removal would discard, so it refuses;
+    #   - an absent skip-worktree path in a sparse-enabled tree is skipped
+    #     only when the tree's ACTIVE sparse rules exclude it — sparse marks
+    #     every excluded path skip-worktree with no file present, so refusing
+    #     on absence alone would block the removal of every clean sparse
+    #     worktree. But sparse-enabled is a per-tree fact and the flag is
+    #     per-path: an IN-CONE file the user manually flagged and then
+    #     deleted shows the same absent-`S` state, and skipping it discards
+    #     that uncommitted deletion-intent (harmon-init#919). So absence is
+    #     exempt per PATH, by asking `git sparse-checkout check-rules`
+    #     (git >= 2.42) whether the rules exclude it — batched once per tree,
+    #     because a sparse monorepo can hold hundreds of thousands of absent
+    #     entries and a per-path spawn turned removal into minutes. On
+    #     git < 2.42 the whole-tree exemption is KEPT, deliberately and
+    #     documented (harmon-init#919's decided AC): the residual loss is
+    #     deletion-intent on an exotic, unstable state (git recomputes
+    #     sparse skip-worktree bits itself), while failing closed would
+    #     refuse every clean sparse-worktree removal on e.g. macOS system
+    #     git ~2.39 and teach the routine use of --force, which discards
+    #     every OTHER protection here too. Without sparse, absence means the
+    #     user deleted a file they had flagged — for skip-worktree and
+    #     assume-unchanged alike, that uncommitted deletion is what the
+    #     removal would discard, so it refuses;
     #   - content is compared against the CHECKOUT representation
     #     (`cat-file --filters` — the bytes a fresh checkout would write),
     #     so an unmodified checkout under `eol=crlf`, `core.autocrlf`, or a
@@ -269,6 +304,16 @@ else
         sparse_enabled="$(git -C "$tree" config --get --type=bool --default=false core.sparseCheckout 2>/dev/null || echo false)"
         filemode_enabled="$(git -C "$tree" config --get --type=bool --default=true core.fileMode 2>/dev/null || echo true)"
         symlinks_enabled="$(git -C "$tree" config --get --type=bool --default=true core.symlinks 2>/dev/null || echo true)"
+        sparse_rules_checkable=0
+        if [ "$sparse_enabled" = "true" ] && git_supports_check_rules; then
+            sparse_rules_checkable=1
+        fi
+        # Absent flagged paths whose exemption depends on the sparse rules,
+        # deferred to ONE batched check-rules call after the enumeration. A
+        # bash array, not a delimited string: a variable cannot hold the NUL
+        # this stream frames with, and any other delimiter can occur in a
+        # path.
+        sparse_absent_candidates=()
         hidden_paths=""
         flagged_enum_ok=0
         while IFS= read -r -d '' flagged_entry; do
@@ -293,6 +338,15 @@ else
                 case "$flagged_tag" in
                 S | s)
                     if [ "$sparse_enabled" = "true" ]; then
+                        if [ "$sparse_rules_checkable" -eq 1 ]; then
+                            # Excluded-or-deleted is decided by the batched
+                            # check-rules call after the enumeration, not
+                            # here: deferring keeps this loop spawn-free
+                            # per entry.
+                            sparse_absent_candidates+=("$flagged_path")
+                        fi
+                        # git < 2.42: the documented whole-tree exemption
+                        # (see the guard comment above).
                         continue
                     fi
                     ;;
@@ -376,6 +430,36 @@ else
         done < <(git -C "$tree" ls-files -v -z && printf '__WORKTREE_RM_ENUM_OK__\0')
         if [ "$flagged_enum_ok" -ne 1 ]; then
             die "could not enumerate $tree's index entries for the hidden-edit check — this guard fails closed; fix the enumeration (or discard the tree with --force)"
+        fi
+        # ONE query for every deferred absent flagged path: check-rules
+        # echoes back exactly the paths the tree's active sparse rules MATCH
+        # (would keep present), so an echoed path is in-cone — its absence is
+        # a user's deletion, refused like any hidden deletion — and a path
+        # not echoed is excluded, absent because sparse removed it. `-C
+        # "$tree"` is load-bearing: check-rules reads the invoking worktree's
+        # own sparse-checkout state, and each linked worktree carries its own
+        # (extensions.worktreeConfig).
+        #
+        # The trailing empty record is this pipeline's success sentinel,
+        # mirroring flagged_enum_ok above: bash does not propagate a
+        # process-substitution failure, so without it a check-rules error or
+        # truncated stream would fail OPEN and wave the removal through. An
+        # empty record is unforgeable here — check-rules only echoes paths it
+        # was fed, and no index entry has an empty path.
+        if [ "${#sparse_absent_candidates[@]}" -gt 0 ]; then
+            sparse_rules_ok=0
+            while IFS= read -r -d '' incone_path; do
+                if [ -z "$incone_path" ]; then
+                    sparse_rules_ok=1
+                    continue
+                fi
+                hidden_paths="${hidden_paths}  ${incone_path}
+"
+            done < <(printf '%s\0' "${sparse_absent_candidates[@]}" |
+                git -C "$tree" sparse-checkout check-rules -z && printf '\0')
+            if [ "$sparse_rules_ok" -ne 1 ]; then
+                die "could not evaluate $tree's sparse rules for the hidden-edit check — this guard fails closed; fix the sparse-checkout state (or discard the tree with --force)"
+            fi
         fi
         if [ -n "$hidden_paths" ]; then
             echo "worktree:rm: $tree has local edits hidden from git status by skip-worktree / assume-unchanged:" >&2


### PR DESCRIPTION
## What

Narrows the `worktree:rm` hidden-edit guard's sparse exemption from per-tree
to per-path. The #918 guard exempted **any** absent skip-worktree path once a
tree had `core.sparseCheckout=true`, so a manually flagged **in-cone** file
the user then deleted was skipped as sparse-absent and the uncommitted
deletion-intent silently discarded.

Absent flagged paths in a sparse tree are now batched through **one**
`git sparse-checkout check-rules -z` call per tree (git ≥ 2.42), run
`-C` the worktree so its **own** per-worktree sparse state answers:

- a path the active rules **exclude** stays exempt (sparse made it absent);
- an **in-cone** path refuses without `--force`, naming the path;
- the batch **fails closed** behind the same success-sentinel pattern as the
  index enumeration — a check-rules error refuses rather than waving the
  removal through on an unevaluated exemption.

**git < 2.42 (no `check-rules`) keeps the per-tree exemption, deliberately
and documented** — Evan's AC-3 decision on #919. Failing closed there would
refuse every clean sparse-worktree removal on e.g. macOS system git ~2.39
and teach routine `--force`, which discards every other protection too. The
gate is an explicit version parse, not a capability probe, so a runtime
check-rules failure on capable git can never be misread as old git and
silently widen the exemption.

## Acceptance criteria

- **AC 1** — excluded absent flagged path still removes without `--force`:
  existing `hidden-sparse` case unchanged and passing.
- **AC 2** — in-cone absent flagged path refuses, naming the path: new
  `hidden-sparse-cone` case (asserts the path appears in the refusal).
- **AC 3** — git < 2.42 behavior decided and documented: keep the per-tree
  exemption, documented in the guard comment and `docs/conventions.md`
  (both layers); new `hidden-sparse-oldgit` case proves it behind a version
  stub (the stub fakes only `--version`; a gate that ignores the version
  reaches the real check-rules, refuses, and fails the case). A fourth case,
  `hidden-sparse-broken`, pins the fail-closed path on capable git.
- **AC 4** — root and `template/` twins byte-identical (`scripts/worktree-rm.sh`,
  `scripts/test-worktree.sh`); `docs/conventions.md` and its jinja twin carry
  the same added sentence.

## Verification

- `task verify` green (includes `test:worktree`: 122 cases, 3 new).
- `task ci` green (full local mirror).
- Mutation checks (cp-backup revert): 4 guard mutants — candidate collection
  dropped, version gate forced always-new, check-rules output sunk, sentinel
  die disabled — each fails the suite **at the intended case**.
- Empirical probes on git 2.55: check-rules exits 0 with zero matches, echoes
  matched paths NUL-terminated, resolves the invoking worktree's own rules,
  and fails loudly (128) without a sparse state; `--skip-checks` is rejected
  by the parser despite appearing in usage, so it is not passed.

rigor: standard (`default_rigor`) → challenge ≤3, review ≤3, shepherd 4,
min_rounds 1. Tier/method at config defaults (`standard`/`plan`); nothing
off-default.

## Deferred findings

None — challenge and review each converged on an empty round 1 (no findings
of any priority); no P2s were deferred.

## Adjudication record

<details>
<summary>Ledger</summary>

```text
challenge r1 | no findings (empty round, min_rounds 1 met — stage exit)
review r1 | no findings (empty round, min_rounds 1 met — stage exit)
```

</details>

Closes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)
