### PR TITLE
feat: add guarded clean:worktree-records task for safe worktree admin-record pruning

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -354,7 +354,7 @@ tasks:
       - ./scripts/test-worktree.sh
 
   test:session-cleanup:
-    desc: Behavioral test for audit:session-artifacts / clean:branches (evidence-gated deletion + negative controls, in a throwaway fixture repo)
+    desc: Behavioral test for audit:session-artifacts / clean:branches / clean:worktree-records (evidence-gated deletion + negative controls, in a throwaway fixture repo)
     cmds:
       - ./scripts/test-session-cleanup.sh
 
@@ -842,6 +842,10 @@ tasks:
     cmds:
       - git fetch --all --prune
 
+  clean:worktree-records:
+    desc: Prune stale worktree admin records only — pins a detached commit before its record goes (human settles the pin); never removes a worktree directory
+    cmds:
+      - ./scripts/clean-worktree-records.sh
 
   # ── Status ────────────────────────────────────────────────────
   status:

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -75,8 +75,8 @@ it points here.
   the pending ones). Removal serializes with `worktree:new`/`worktree:rm`
   through the shared lifecycle lock — for trees under the blessed
   `.worktrees/` layout; a tree from a raw `git worktree add` elsewhere is
-  outside that protocol, which is the documented residual for keeping to the
-  tasks.
+  outside that protocol — as is a `git worktree lock` racing the removal
+  itself — which is the documented residual for keeping to the tasks.
 - **A fresh worktree has no `node_modules`/`.venv`.** Working files are per-tree,
   so dependency install is per-tree too; that is what `worktree:new` runs and
   why "it worked in the main checkout" is not evidence.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -65,6 +65,18 @@ it points here.
   routine and so meaningless. It also prunes the registry and clears leftover
   gitlink directories — stale ones make later tooling treat a dead path as a
   live checkout.
+- **Sweep leftover admin records with `task clean:worktree-records`**, never a
+  raw `git worktree prune` — a stale record's detached HEAD can be the only
+  thing keeping a commit alive, and a raw prune makes it unreachable. The task
+  removes records only (never a worktree directory), refuses records carrying
+  single-copy state, and pins a detached commit as
+  `refs/session-cleanup/pin/<record>` *before* the record goes; pins are
+  settled only by explicit human action (`task audit:session-artifacts` lists
+  the pending ones). Removal serializes with `worktree:new`/`worktree:rm`
+  through the shared lifecycle lock — for trees under the blessed
+  `.worktrees/` layout; a tree from a raw `git worktree add` elsewhere is
+  outside that protocol, which is the documented residual for keeping to the
+  tasks.
 - **A fresh worktree has no `node_modules`/`.venv`.** Working files are per-tree,
   so dependency install is per-tree too; that is what `worktree:new` runs and
   why "it worked in the main checkout" is not evidence.

--- a/scripts/audit-session-artifacts.sh
+++ b/scripts/audit-session-artifacts.sh
@@ -297,6 +297,20 @@ else
     echo "  none"
 fi
 
+# ── 5b. Rescue pins ─────────────────────────────────────────────────────────
+
+# clean:worktree-records keeps refs/session-cleanup/pin/<record> when a
+# pruned record held the only reference to a detached commit; a lingering pin
+# is a decision waiting to be made.
+section "Rescue pins (refs/session-cleanup/pin)"
+git for-each-ref refs/session-cleanup/pin \
+    --format='  %(refname:lstrip=3) — pins %(objectname) (branch it or delete the pin)' >"$tmp/pins"
+if [ -s "$tmp/pins" ]; then
+    cat "$tmp/pins"
+else
+    echo "  none"
+fi
+
 # ── 6. Totals ───────────────────────────────────────────────────────────────
 
 section "Totals"

--- a/scripts/clean-worktree-records.sh
+++ b/scripts/clean-worktree-records.sh
@@ -160,12 +160,26 @@ remove_one_record() (
     esac
 
     [ -d "$admin_dir" ] || exit 3 # already gone (another cleaner won)
-    # Re-read under the lock: if the record's gitdir target exists again (a
-    # worktree recreated at the old path), the record is live — leave it.
-    wt_gitfile="$(cat "$admin_dir/gitdir" 2>/dev/null || true)"
-    if [ -n "$wt_gitfile" ] && [ -e "$wt_gitfile" ]; then
+    # Re-read under the lock — failing closed when the gitdir file cannot
+    # be read to a value: an unreadable target is not an absent worktree,
+    # and sweeping on that guess can orphan a live tree (challenge r7).
+    if ! wt_gitfile="$(cat "$admin_dir/gitdir" 2>/dev/null)" || [ -z "$wt_gitfile" ]; then
+        echo "SKIP  record '$record' — cannot read its gitdir file; refusing to sweep an unvalidatable record (inspect $admin_dir)"
+        exit 3 # unreadable gitdir refuses
+    fi
+    # If the gitdir target exists again (a worktree recreated at the old
+    # path), the record is live — leave it.
+    if [ -e "$wt_gitfile" ]; then
         echo "SKIP  record '$record' — its worktree reappeared since the plan"
         exit 3
+    fi
+    # A surviving worktree DIRECTORY whose .git link is gone still holds
+    # the user's files; sweeping its record would orphan them as a plain
+    # directory nothing tracks (challenge r7).
+    tree_dir="${wt_gitfile%/.git}"
+    if [ "$tree_dir" != "$wt_gitfile" ] && [ -d "$tree_dir" ]; then
+        echo "SKIP  record '$record' — its worktree directory still exists ($tree_dir) though the .git link is gone; restore the link or move the directory aside first"
+        exit 3 # surviving tree dir refuses
     fi
 
     # git's own worktree lock (worktrees/<id>/locked) protects e.g. a tree on
@@ -190,6 +204,13 @@ remove_one_record() (
     # --autostash killed before MERGE_HEAD exists leaves the user's dirty
     # work referenced by that one file alone (challenge r6).
     for sub in deferred-findings adjudication-ledger shepherd-codex refs rebase-merge rebase-apply MERGE_HEAD MERGE_AUTOSTASH CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG config.worktree info/sparse-checkout; do
+        # A symlinked state path is carried state whatever it points at —
+        # find would scan the target (or nothing, broken), not the link
+        # (challenge r7).
+        if [ -L "$admin_dir/$sub" ]; then
+            carried="$carried $sub"
+            continue
+        fi
         [ -e "$admin_dir/$sub" ] || continue
         # A failed scan is not an empty scan: treating an errored find as
         # "no state" would sweep exactly the record it could not inspect
@@ -212,14 +233,14 @@ remove_one_record() (
     # that game; the unknown refuses instead (challenge r6 restructure,
     # maintainer-approved).
     for entry in "$admin_dir"/* "$admin_dir"/.[!.]* "$admin_dir"/..?*; do
-        [ -e "$entry" ] || continue
+        [ -e "$entry" ] || [ -L "$entry" ] || continue # -e dereferences: a broken symlink must still be judged
         entry_name="${entry##*/}"
         case "$entry_name" in
         gitdir | commondir | HEAD | locked | COMMIT_EDITMSG | ORIG_HEAD | FETCH_HEAD | index | logs) : ;;                                                                                                  # validated by the guards here, disposable scratch, or reflogs (accepted loss by design)
         deferred-findings | adjudication-ledger | shepherd-codex | refs | rebase-merge | rebase-apply | MERGE_HEAD | MERGE_AUTOSTASH | CHERRY_PICK_HEAD | REVERT_HEAD | BISECT_LOG | config.worktree) : ;; # carried-state names: the scan above refused them when non-empty
         info)
             for info_entry in "$entry"/* "$entry"/.[!.]* "$entry"/..?*; do
-                [ -e "$info_entry" ] || continue
+                [ -e "$info_entry" ] || [ -L "$info_entry" ] || continue
                 case "${info_entry##*/}" in
                 sparse-checkout) : ;; # refused above when present with content
                 *)
@@ -319,6 +340,17 @@ remove_one_record() (
             ! GIT_INDEX_FILE="$admin_dir/index" git diff-index --cached --quiet "$head_commit" 2>/dev/null; then
             echo "SKIP  record '$record' — its index diverges from the recorded HEAD (staged-only changes, or unverifiable); recover them first (GIT_INDEX_FILE=$(shell_quote "$admin_dir/index") git checkout-index ...), then remove the index file"
             exit 3
+        fi
+        # A stage-0-clean index can still carry resolve-undo entries whose
+        # conflict-stage blobs it alone references; an uninspectable index
+        # refuses the same way an unscannable state dir does (challenge r7).
+        if ! resolve_undo="$(GIT_INDEX_FILE="$admin_dir/index" git ls-files --resolve-undo 2>&1)"; then
+            echo "SKIP  record '$record' — cannot inspect its index for resolve-undo state ($resolve_undo); failing closed"
+            exit 3 # resolve-undo-inspect refuses
+        fi
+        if [ -n "$resolve_undo" ]; then
+            echo "SKIP  record '$record' — its index carries resolve-undo (conflict) state the index alone references; recover it (GIT_INDEX_FILE=$(shell_quote "$admin_dir/index") git ls-files --resolve-undo), then remove the index file"
+            exit 3 # resolve-undo refuses
         fi
     fi
 

--- a/scripts/clean-worktree-records.sh
+++ b/scripts/clean-worktree-records.sh
@@ -17,7 +17,9 @@
 #     snapshot. A plan-verified stale record has no working directory, so
 #     its HEAD cannot move. Live records are never touched, and git's own
 #     `locked` marker is re-checked under the lock — a worktree locked
-#     after the plan (removable media) stays preserved.
+#     after the plan (removable media) stays preserved. A `git worktree
+#     lock` racing the removal itself does not take the lifecycle lock;
+#     that is the same native-command residual as raw `git worktree add`.
 #   * Each removal runs under the same per-path lifecycle lock that
 #     worktree:new / worktree:rm hold (for trees under the blessed
 #     .worktrees layout), so a removal cannot race a re-creation of the
@@ -27,7 +29,9 @@
 #     review sidecars, per-worktree ref files, in-progress operation state
 #     (rebase/merge/cherry-pick — the worktree-rm.sh list), and an index
 #     that diverges from the recorded HEAD (staged-but-uncommitted blobs
-#     the index alone keeps alive). Reflogs are deliberately NOT state —
+#     the index alone keeps alive). An unreadable HEAD refuses outright,
+#     and ORIG_HEAD — a ref file, not a reflog — refuses when it names a
+#     commit no shared ref contains. Reflogs are deliberately NOT state —
 #     every record has one, and accepting reflog loss matches git's own
 #     prune semantics.
 #   * A detached record HEAD is pinned as refs/session-cleanup/pin/<record>
@@ -81,6 +85,15 @@ shared_refs_containing() {
 
 common="$(git rev-parse --path-format=absolute --git-common-dir)"
 
+# The blessed-path anchor is the registry's first entry — the SAME source
+# worktree-new.sh reads to place .worktrees/, because these locks only
+# serialize anything if both sides key identically. Empirically git derives
+# this entry as ${common%/.git} in every layout we could produce
+# (separate-git-dir included), so this is consistency by construction with
+# the peer tool rather than a behavioral change: if git's registry
+# computation ever shifts, both tools move together (challenge r2).
+main_root="$(git worktree list --porcelain | sed -n '1s/^worktree //p')"
+
 # Legacy graft files rewrite parentage exactly as replace refs do, but
 # GIT_NO_REPLACE_OBJECTS does NOT disable them (review r1, ported at
 # resurrection): containment walked over grafted history is not evidence, so
@@ -131,7 +144,6 @@ remove_one_record() (
     trap release_locks EXIT
     trap 'exit 129' HUP INT TERM
     wt_gitfile="$(cat "$admin_dir/gitdir" 2>/dev/null || true)"
-    main_root="${common%/.git}"
     tree_path="${wt_gitfile%/.git}"
     case "$tree_path" in
     "$main_root/.worktrees/"*)
@@ -173,6 +185,33 @@ remove_one_record() (
     fi
 
     record_head="$(cat "$admin_dir/HEAD" 2>/dev/null || true)"
+
+    # A record whose HEAD cannot be read would fall through every
+    # HEAD-derived guard below and sweep unpinned; an unvalidatable record
+    # is refused, never swept (challenge r2).
+    if [ -z "$record_head" ]; then
+        echo "SKIP  record '$record' — cannot read its HEAD; refusing to sweep an unvalidatable record (inspect $admin_dir)"
+        exit 3
+    fi
+
+    # ORIG_HEAD is a ref file, not a reflog: a reset --hard's abandoned
+    # commit can live in this one file alone, so reflog accepted-loss does
+    # not cover it. A reachable ORIG_HEAD sweeps normally (every used tree
+    # has one); unreachable or unreadable refuses — and a legacy graft file
+    # makes containment unusable, so it refuses too (challenge r2).
+    if [ -f "$admin_dir/ORIG_HEAD" ]; then
+        orig_head="$(cat "$admin_dir/ORIG_HEAD" 2>/dev/null || true)"
+        orig_commit=""
+        [ -z "$orig_head" ] || orig_commit="$(git rev-parse --quiet --verify "$orig_head^{commit}" || true)"
+        if [ -z "$orig_commit" ]; then
+            echo "SKIP  record '$record' — its ORIG_HEAD is unreadable or names no commit; refusing to sweep (inspect $admin_dir/ORIG_HEAD)"
+            exit 3
+        fi
+        if [ "$grafts_present" = true ] || [ -z "$(shared_refs_containing "$orig_commit")" ]; then
+            echo "SKIP  record '$record' — ORIG_HEAD $orig_commit is reachable from no shared ref, or containment is unusable under a legacy graft file (a reset/rebase abandoned it here); rescue it (git branch $(shell_quote "rescue/$record-orig") $orig_commit) then remove $admin_dir/ORIG_HEAD"
+            exit 3
+        fi
+    fi
 
     # The index can be the only structure referencing staged-but-uncommitted
     # blobs (challenge r7): an index that diverges from the recorded HEAD —
@@ -223,15 +262,20 @@ remove_one_record() (
 
     if [ "$pinned_here" = true ]; then
         pin_ref="refs/session-cleanup/pin/$record"
-        # The pin must have outlived the removal: the audit advertises pins,
-        # so a human settlement can race this run and drop one in the window
-        # between the create and the rm — re-assert before reporting
-        # (challenge r1).
-        if ! git rev-parse --quiet --verify "$pin_ref" >/dev/null; then
+        # The pin must have outlived the removal AND still target the
+        # detached commit: the audit advertises pins, so a settlement can
+        # race this run — a dropped pin is re-asserted, and a retargeted
+        # one fails closed rather than being overwritten or reported kept
+        # (challenge r1, tightened r2: existence alone verifies nothing).
+        pin_now="$(git rev-parse --quiet --verify "$pin_ref" || true)"
+        if [ -z "$pin_now" ]; then
             if ! LEFTHOOK=0 git update-ref "$pin_ref" "$record_head" ""; then
                 echo "CRITICAL  $pin_ref vanished during the prune and could not be recreated — rescue detached commit $record_head NOW: git branch $(shell_quote "rescue/$record") $record_head"
                 exit 5
             fi
+        elif [ "$pin_now" != "$record_head" ]; then
+            echo "CRITICAL  $pin_ref no longer pins $record_head (it now holds $pin_now) — rescue the detached commit NOW: git branch $(shell_quote "rescue/$record") $record_head"
+            exit 5
         fi
         # Reporting only — pins are settled by humans, never auto-dropped
         # (challenge r6): the reachability check picks the wording, and a

--- a/scripts/clean-worktree-records.sh
+++ b/scripts/clean-worktree-records.sh
@@ -47,6 +47,11 @@
 #     the whole run and a legacy graft file forces the conservative wording,
 #     because a forged "also reachable from shared refs" would hand the
 #     human a copyable command that drops the only real reference.
+#   * The sweep is allowlist-gated: a record is removed only when every
+#     entry in its admin dir is known to this tool — validated, refused
+#     when carried, or accepted by design (reflogs). Unknown entries
+#     refuse, so a git version that grows new state files fails closed
+#     instead of being silently swept.
 set -euo pipefail
 
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -199,6 +204,37 @@ remove_one_record() (
         echo "SKIP  record '$record' — carries worktree-local state (${carried# }); adopt or rescue it first, it exists nowhere else"
         exit 3
     fi
+
+    # Fail closed by construction: a record is swept only when EVERY entry
+    # in its admin dir is known to this tool — validated below, refused
+    # above when carried, or accepted by design (reflogs). Git grows state
+    # files over time and an enumeration of dangerous ones can only lose
+    # that game; the unknown refuses instead (challenge r6 restructure,
+    # maintainer-approved).
+    for entry in "$admin_dir"/* "$admin_dir"/.[!.]* "$admin_dir"/..?*; do
+        [ -e "$entry" ] || continue
+        entry_name="${entry##*/}"
+        case "$entry_name" in
+        gitdir | commondir | HEAD | locked | COMMIT_EDITMSG | ORIG_HEAD | FETCH_HEAD | index | logs) : ;;                                                                                                  # validated by the guards here, disposable scratch, or reflogs (accepted loss by design)
+        deferred-findings | adjudication-ledger | shepherd-codex | refs | rebase-merge | rebase-apply | MERGE_HEAD | MERGE_AUTOSTASH | CHERRY_PICK_HEAD | REVERT_HEAD | BISECT_LOG | config.worktree) : ;; # carried-state names: the scan above refused them when non-empty
+        info)
+            for info_entry in "$entry"/* "$entry"/.[!.]* "$entry"/..?*; do
+                [ -e "$info_entry" ] || continue
+                case "${info_entry##*/}" in
+                sparse-checkout) : ;; # refused above when present with content
+                *)
+                    echo "SKIP  record '$record' — unrecognized entry info/${info_entry##*/}; refusing to sweep what this tool does not understand (inspect $admin_dir)"
+                    exit 3 # unknown info entry refuses
+                    ;;
+                esac
+            done
+            ;;
+        *)
+            echo "SKIP  record '$record' — unrecognized entry '$entry_name'; refusing to sweep what this tool does not understand (inspect $admin_dir)"
+            exit 3 # unknown entry refuses
+            ;;
+        esac
+    done
 
     record_head="$(cat "$admin_dir/HEAD" 2>/dev/null || true)"
 

--- a/scripts/clean-worktree-records.sh
+++ b/scripts/clean-worktree-records.sh
@@ -174,10 +174,15 @@ remove_one_record() (
     # nothing else references (challenge r1).
     carried=""
     for sub in deferred-findings adjudication-ledger shepherd-codex refs rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
-        if [ -e "$admin_dir/$sub" ] &&
-            [ -n "$(find "$admin_dir/$sub" -type f 2>/dev/null | head -n 1)" ]; then
-            carried="$carried $sub"
+        [ -e "$admin_dir/$sub" ] || continue
+        # A failed scan is not an empty scan: treating an errored find as
+        # "no state" would sweep exactly the record it could not inspect
+        # (challenge r3).
+        if ! state_scan="$(find "$admin_dir/$sub" -type f 2>&1)"; then
+            echo "SKIP  record '$record' — cannot scan $sub for worktree-local state ($state_scan); failing closed"
+            exit 3
         fi
+        [ -z "$state_scan" ] || carried="$carried $sub"
     done
     if [ -n "$carried" ]; then
         echo "SKIP  record '$record' — carries worktree-local state (${carried# }); adopt or rescue it first, it exists nowhere else"
@@ -237,7 +242,7 @@ remove_one_record() (
         if git rev-parse --quiet --verify "$record_head^{commit}" >/dev/null 2>&1; then
             existing_pin="$(git rev-parse --quiet --verify "refs/session-cleanup/pin/$record" || true)"
             if [ -n "$existing_pin" ] && [ "$existing_pin" != "$record_head" ]; then
-                echo "SKIP  record '$record' — refs/session-cleanup/pin/$record already pins $existing_pin from an earlier run; settle it first (git branch $(shell_quote "rescue/$record") $existing_pin, or git update-ref -d $(shell_quote "refs/session-cleanup/pin/$record"))"
+                echo "SKIP  record '$record' — refs/session-cleanup/pin/$record already pins $existing_pin from an earlier run; settle it first (git branch $(shell_quote "rescue/$record") $existing_pin, or git update-ref -d $(shell_quote "refs/session-cleanup/pin/$record") $existing_pin)"
                 exit 3
             fi
             # Create-only (old value ''): never overwrite a pin this run did
@@ -247,6 +252,13 @@ remove_one_record() (
                 exit 3
             fi
             pinned_here=true
+        else
+            # A nonempty detached HEAD that resolves to no commit — a
+            # truncated file, a missing or promisor-held object — cannot be
+            # pinned, and sweeping would destroy the only recovery
+            # breadcrumb; refuse instead of falling through (challenge r3).
+            echo "SKIP  record '$record' — its detached HEAD $record_head does not resolve to a commit (missing or corrupt object); refusing to sweep the only reference"
+            exit 3 # unresolvable HEAD refuses
         fi
         ;;
     esac
@@ -283,9 +295,13 @@ remove_one_record() (
         # PRESENT safety: reachability is a prune-time snapshot, so the drop
         # remedy instructs re-verification first (challenge r1).
         if [ "$grafts_present" = false ] && [ -n "$(shared_refs_containing "$record_head")" ]; then
-            echo "PINNED  $pin_ref — $record_head was reachable from shared refs at prune time; re-verify before dropping (git --no-replace-objects for-each-ref --contains $record_head refs/heads refs/tags refs/remotes), then: git update-ref -d $(shell_quote "$pin_ref")"
+            # Every printed drop remedy carries the expected OID: update-ref
+            # -d with an old value is compare-and-delete, so a stale command
+            # re-run after record-name reuse cannot delete a newer pin
+            # (challenge r3).
+            echo "PINNED  $pin_ref — $record_head was reachable from shared refs at prune time; re-verify before dropping (git --no-replace-objects for-each-ref --contains $record_head refs/heads refs/tags refs/remotes), then: git update-ref -d $(shell_quote "$pin_ref") $record_head"
         else
-            echo "KEPT  $pin_ref — pruned record '$record' held the only reference to detached commit $record_head; branch it (git branch $(shell_quote "rescue/$record") $record_head) or discard it (git update-ref -d $(shell_quote "$pin_ref"))"
+            echo "KEPT  $pin_ref — pruned record '$record' held the only reference to detached commit $record_head; branch it (git branch $(shell_quote "rescue/$record") $record_head) or discard it (git update-ref -d $(shell_quote "$pin_ref") $record_head)"
         fi
         exit 2
     fi

--- a/scripts/clean-worktree-records.sh
+++ b/scripts/clean-worktree-records.sh
@@ -181,7 +181,10 @@ remove_one_record() (
     # adopt-or-rescue class as the review sidecars, and present only on
     # worktreeConfig-enabled records, so refusing costs no sweepability
     # (challenge r5, reversing r2's "dead config" declination).
-    for sub in deferred-findings adjudication-ledger shepherd-codex refs rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG config.worktree info/sparse-checkout; do
+    # MERGE_AUTOSTASH extends the worktree-rm.sh op-state list: a merge
+    # --autostash killed before MERGE_HEAD exists leaves the user's dirty
+    # work referenced by that one file alone (challenge r6).
+    for sub in deferred-findings adjudication-ledger shepherd-codex refs rebase-merge rebase-apply MERGE_HEAD MERGE_AUTOSTASH CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG config.worktree info/sparse-checkout; do
         [ -e "$admin_dir/$sub" ] || continue
         # A failed scan is not an empty scan: treating an errored find as
         # "no state" would sweep exactly the record it could not inspect
@@ -239,6 +242,20 @@ remove_one_record() (
         while IFS= read -r fetch_line || [ -n "$fetch_line" ]; do
             [ -n "$fetch_line" ] || continue
             fetch_sha="${fetch_line%%[[:space:]]*}"
+            # An annotated tag fetched without a destination ref is its own
+            # object: peeling to the commit would let the tag body (message,
+            # signature) vanish with the record. Exact points-at containment
+            # — object equality, so ancestry forgery does not apply
+            # (challenge r6).
+            fetch_type=""
+            [ -z "$fetch_sha" ] || fetch_type="$(git cat-file -t "$fetch_sha" 2>/dev/null || true)"
+            if [ "$fetch_type" = "tag" ]; then
+                if [ -z "$(git for-each-ref --points-at "$fetch_sha" --format='%(refname)' 2>/dev/null | grep -Ev '^refs/((worktree|bisect|rewritten|replace)/|session-cleanup/pin/)' || true)" ]; then
+                    echo "SKIP  record '$record' — FETCH_HEAD names annotated tag object $fetch_sha with no ref pointing at it; rescue it (git tag $(shell_quote "rescue/$record-fetch-tag-$(printf '%.7s' "$fetch_sha")") $fetch_sha) then remove $admin_dir/FETCH_HEAD"
+                    exit 3
+                fi
+                continue
+            fi
             fetch_commit=""
             [ -z "$fetch_sha" ] || fetch_commit="$(git rev-parse --quiet --verify "$fetch_sha^{commit}" || true)"
             if [ -z "$fetch_commit" ]; then
@@ -246,7 +263,7 @@ remove_one_record() (
                 exit 3
             fi
             if [ "$grafts_present" = true ] || [ -z "$(shared_refs_containing "$fetch_commit")" ]; then
-                echo "SKIP  record '$record' — FETCH_HEAD names $fetch_commit, reachable from no shared ref (a URL fetch left it here); rescue it (git branch $(shell_quote "rescue/$record-fetch") $fetch_commit) then remove $admin_dir/FETCH_HEAD"
+                echo "SKIP  record '$record' — FETCH_HEAD names $fetch_commit, reachable from no shared ref (a URL fetch left it here); rescue it (git branch $(shell_quote "rescue/$record-fetch-$(printf '%.7s' "$fetch_commit")") $fetch_commit) then remove $admin_dir/FETCH_HEAD"
                 exit 3
             fi
         done <"$admin_dir/FETCH_HEAD"

--- a/scripts/clean-worktree-records.sh
+++ b/scripts/clean-worktree-records.sh
@@ -15,23 +15,30 @@
 #     prune re-computes eligibility at its own moment, so a LIVE worktree
 #     whose directory vanishes mid-run could be pruned on a stale HEAD
 #     snapshot. A plan-verified stale record has no working directory, so
-#     its HEAD cannot move. Live records are never touched.
+#     its HEAD cannot move. Live records are never touched, and git's own
+#     `locked` marker is re-checked under the lock — a worktree locked
+#     after the plan (removable media) stays preserved.
 #   * Each removal runs under the same per-path lifecycle lock that
 #     worktree:new / worktree:rm hold (for trees under the blessed
 #     .worktrees layout), so a removal cannot race a re-creation of the
 #     same path by the blessed tooling. Raw `git worktree add` outside the
 #     tooling remains the documented residual.
 #   * A record that carries worktree-local state is refused, never swept:
-#     review sidecars, per-worktree ref files, and an index that diverges
-#     from the recorded HEAD (staged-but-uncommitted blobs the index alone
-#     keeps alive). Reflogs are deliberately NOT state — every record has
-#     one, and accepting reflog loss matches git's own prune semantics.
+#     review sidecars, per-worktree ref files, in-progress operation state
+#     (rebase/merge/cherry-pick — the worktree-rm.sh list), and an index
+#     that diverges from the recorded HEAD (staged-but-uncommitted blobs
+#     the index alone keeps alive). Reflogs are deliberately NOT state —
+#     every record has one, and accepting reflog loss matches git's own
+#     prune semantics.
 #   * A detached record HEAD is pinned as refs/session-cleanup/pin/<record>
 #     BEFORE its record is removed, with a CREATE-ONLY ref write; an
 #     existing mismatched pin from an earlier run refuses that record. Pins
 #     are removed only by EXPLICIT human settlement — an auto-drop races
 #     concurrent ref deletion — and the run exits nonzero while any await
-#     action. Nothing is ever lost.
+#     action, prior runs' pins included. The pin is re-asserted after the
+#     removal (a racing settlement could drop it in the window), and its
+#     drop remedy instructs re-verification, never asserts present safety.
+#     Nothing is ever lost.
 #   * The pin report judges RAW history: replacement refs are disabled for
 #     the whole run and a legacy graft file forces the conservative wording,
 #     because a forged "also reachable from shared refs" would hand the
@@ -86,12 +93,28 @@ if [ -s "$grafts_file" ]; then
     echo "NOTE  legacy graft file present ($grafts_file) — shared-ref containment is unusable while it exists; kept pins are reported conservatively"
 fi
 
+# The header's contract: the run stays nonzero while ANY pin awaits human
+# settlement — including pins left by an earlier run, which an otherwise
+# empty retry would otherwise report as "cleanup complete" (challenge r1).
+# --count=1 avoids a git|head pipeline, which pipefail turns into SIGPIPE.
+pins_outstanding() {
+    git for-each-ref --count=1 refs/session-cleanup/pin --format='%(refname)'
+}
+
+finish_no_work() {
+    if [ -n "$(pins_outstanding)" ]; then
+        echo "clean:worktree-records: nothing to prune, but rescue pins await settlement (task audit:session-artifacts lists them)." >&2
+        exit 2
+    fi
+    echo "clean:worktree-records: nothing to prune."
+    exit 0
+}
+
 # git's own dry run is the authority on what is prunable
 # ("Removing worktrees/<name>: <reason>"); LC_ALL=C pins the message shape.
 prune_plan="$(LC_ALL=C git worktree prune --dry-run -v 2>&1)"
 if [ -z "$prune_plan" ]; then
-    echo "clean:worktree-records: nothing to prune."
-    exit 0
+    finish_no_work
 fi
 
 # remove_one_record <record> — runs in a SUBSHELL so a lock refusal (die)
@@ -125,9 +148,20 @@ remove_one_record() (
         exit 3
     fi
 
-    # Single-copy worktree-local state is refused, never swept.
+    # git's own worktree lock (worktrees/<id>/locked) protects e.g. a tree on
+    # removable media; the plan predates it, so re-check under our lifecycle
+    # lock — git preserves locked records and so must we (challenge r1).
+    if [ -e "$admin_dir/locked" ]; then
+        echo "SKIP  record '$record' — locked by git worktree lock since the plan (git worktree unlock, or remove $admin_dir/locked, to release)"
+        exit 3
+    fi
+
+    # Single-copy worktree-local state is refused, never swept. The op-state
+    # names mirror worktree-rm.sh: a rebase/merge/cherry-pick parked at an
+    # edit leaves sequencer state — and, after an amend there, commits —
+    # nothing else references (challenge r1).
     carried=""
-    for sub in deferred-findings adjudication-ledger shepherd-codex refs; do
+    for sub in deferred-findings adjudication-ledger shepherd-codex refs rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
         if [ -e "$admin_dir/$sub" ] &&
             [ -n "$(find "$admin_dir/$sub" -type f 2>/dev/null | head -n 1)" ]; then
             carried="$carried $sub"
@@ -178,17 +212,34 @@ remove_one_record() (
         ;;
     esac
 
-    # Records only: the stale admin directory is all that goes.
-    rm -rf "$admin_dir"
+    # Records only: the stale admin directory is all that goes. A failed
+    # removal is its own loud outcome, never mislabeled as lock contention
+    # (challenge r1).
+    if ! rm -rf "$admin_dir"; then
+        echo "ERROR  record '$record' — removal failed midway; inspect $admin_dir before re-running"
+        exit 4
+    fi
     echo "pruned record '$record'"
 
     if [ "$pinned_here" = true ]; then
+        pin_ref="refs/session-cleanup/pin/$record"
+        # The pin must have outlived the removal: the audit advertises pins,
+        # so a human settlement can race this run and drop one in the window
+        # between the create and the rm — re-assert before reporting
+        # (challenge r1).
+        if ! git rev-parse --quiet --verify "$pin_ref" >/dev/null; then
+            if ! LEFTHOOK=0 git update-ref "$pin_ref" "$record_head" ""; then
+                echo "CRITICAL  $pin_ref vanished during the prune and could not be recreated — rescue detached commit $record_head NOW: git branch $(shell_quote "rescue/$record") $record_head"
+                exit 5
+            fi
+        fi
         # Reporting only — pins are settled by humans, never auto-dropped
         # (challenge r6): the reachability check picks the wording, and a
-        # race can at worst mislabel, never delete.
-        pin_ref="refs/session-cleanup/pin/$record"
+        # race can at worst mislabel, never delete. The wording never asserts
+        # PRESENT safety: reachability is a prune-time snapshot, so the drop
+        # remedy instructs re-verification first (challenge r1).
         if [ "$grafts_present" = false ] && [ -n "$(shared_refs_containing "$record_head")" ]; then
-            echo "PINNED  $pin_ref — $record_head is also reachable from shared refs; drop it with: git update-ref -d $(shell_quote "$pin_ref")"
+            echo "PINNED  $pin_ref — $record_head was reachable from shared refs at prune time; re-verify before dropping (git --no-replace-objects for-each-ref --contains $record_head refs/heads refs/tags refs/remotes), then: git update-ref -d $(shell_quote "$pin_ref")"
         else
             echo "KEPT  $pin_ref — pruned record '$record' held the only reference to detached commit $record_head; branch it (git branch $(shell_quote "rescue/$record") $record_head) or discard it (git update-ref -d $(shell_quote "$pin_ref"))"
         fi
@@ -198,6 +249,7 @@ remove_one_record() (
 
 removed=0
 skipped=0
+errors=0
 pins_pending=0
 while IFS= read -r line; do
     record="$(printf '%s\n' "$line" | sed -n 's/^Removing worktrees\/\(.*\): .*$/\1/p')"
@@ -211,8 +263,9 @@ while IFS= read -r line; do
         pins_pending=$((pins_pending + 1))
         ;;
     3) skipped=$((skipped + 1)) ;;
+    4 | 5) errors=$((errors + 1)) ;; # own message printed above; never lock-labeled
     *)
-        echo "SKIP  record '$record' — the worktree lifecycle lock refused (a worktree operation is active; details above)"
+        echo "SKIP  record '$record' — the worktree lifecycle lock refused, or an unexpected failure (details above)"
         skipped=$((skipped + 1))
         ;;
     esac
@@ -220,11 +273,14 @@ done <<EOF
 $prune_plan
 EOF
 
-if [ "$removed" -eq 0 ] && [ "$skipped" -eq 0 ]; then
-    echo "clean:worktree-records: nothing to prune."
-    exit 0
+if [ "$removed" -eq 0 ] && [ "$skipped" -eq 0 ] && [ "$errors" -eq 0 ]; then
+    finish_no_work
 fi
-if [ "$pins_pending" -gt 0 ] || [ "$skipped" -gt 0 ]; then
+if [ "$errors" -gt 0 ]; then
+    echo "clean:worktree-records: $removed record(s) pruned; $errors record removal(s) FAILED above — resolve before re-running." >&2
+    exit 1
+fi
+if [ "$pins_pending" -gt 0 ] || [ "$skipped" -gt 0 ] || [ -n "$(pins_outstanding)" ]; then
     echo "clean:worktree-records: $removed record(s) pruned; $pins_pending pin(s) awaiting settlement, $skipped record(s) refused above." >&2
     exit 2
 fi

--- a/scripts/clean-worktree-records.sh
+++ b/scripts/clean-worktree-records.sh
@@ -133,7 +133,11 @@ finish_no_work() {
 
 # git's own dry run is the authority on what is prunable
 # ("Removing worktrees/<name>: <reason>"); LC_ALL=C pins the message shape.
-prune_plan="$(LC_ALL=C git worktree prune --dry-run -v 2>&1)"
+# A failed dry run must surface git's own diagnostic, not a bare set -e
+# death (review r2).
+if ! prune_plan="$(LC_ALL=C git worktree prune --dry-run -v 2>&1)"; then
+    die "git worktree prune --dry-run failed: $prune_plan"
+fi
 if [ -z "$prune_plan" ]; then
     finish_no_work
 fi
@@ -495,7 +499,7 @@ if [ "$pins_pending" -gt 0 ] || [ "$skipped" -gt 0 ] || [ -n "$outstanding" ]; t
     # Total, not just this run's: a pin inherited from an earlier run is
     # exactly as much awaiting settlement as a fresh one, and printing "0"
     # beside a nonzero exit contradicts the disposition (challenge r4).
-    total_pins="$(git for-each-ref refs/session-cleanup/pin --format='%(refname)' | grep -c . || true)"
+    total_pins="$(git for-each-ref refs/session-cleanup/pin --format='%(refname)' | wc -l | tr -d ' ')" || die "cannot enumerate rescue pins (refs/session-cleanup/pin unreadable); refusing to report an unreliable settlement count"
     echo "clean:worktree-records: $removed record(s) pruned; $pins_pending new pin(s) this run, $total_pins total awaiting settlement, $skipped record(s) refused above." >&2
     exit 2
 fi

--- a/scripts/clean-worktree-records.sh
+++ b/scripts/clean-worktree-records.sh
@@ -176,7 +176,12 @@ remove_one_record() (
     # edit leaves sequencer state — and, after an amend there, commits —
     # nothing else references (challenge r1).
     carried=""
-    for sub in deferred-findings adjudication-ledger shepherd-codex refs rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
+    # config.worktree and info/sparse-checkout carry user-set per-worktree
+    # configuration (extensions.worktreeConfig, sparse patterns) — the same
+    # adopt-or-rescue class as the review sidecars, and present only on
+    # worktreeConfig-enabled records, so refusing costs no sweepability
+    # (challenge r5, reversing r2's "dead config" declination).
+    for sub in deferred-findings adjudication-ledger shepherd-codex refs rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG config.worktree info/sparse-checkout; do
         [ -e "$admin_dir/$sub" ] || continue
         # A failed scan is not an empty scan: treating an errored find as
         # "no state" would sweep exactly the record it could not inspect
@@ -228,7 +233,10 @@ remove_one_record() (
     # none of the unsweepability cost an unconditional refusal would
     # (challenge r4, revising r3's declination of the unconditional form).
     if [ -f "$admin_dir/FETCH_HEAD" ]; then
-        while IFS= read -r fetch_line; do
+        # `|| [ -n ... ]`: a truncated write can leave the final record
+        # unterminated, and a plain read would skip exactly that entry
+        # (challenge r5).
+        while IFS= read -r fetch_line || [ -n "$fetch_line" ]; do
             [ -n "$fetch_line" ] || continue
             fetch_sha="${fetch_line%%[[:space:]]*}"
             fetch_commit=""
@@ -256,7 +264,7 @@ remove_one_record() (
         esac
         if [ -z "$head_commit" ] ||
             ! GIT_INDEX_FILE="$admin_dir/index" git diff-index --cached --quiet "$head_commit" 2>/dev/null; then
-            echo "SKIP  record '$record' — its index diverges from the recorded HEAD (staged-only changes, or unverifiable); recover them first (GIT_INDEX_FILE=$admin_dir/index git checkout-index ...), then remove the index file"
+            echo "SKIP  record '$record' — its index diverges from the recorded HEAD (staged-only changes, or unverifiable); recover them first (GIT_INDEX_FILE=$(shell_quote "$admin_dir/index") git checkout-index ...), then remove the index file"
             exit 3
         fi
     fi

--- a/scripts/clean-worktree-records.sh
+++ b/scripts/clean-worktree-records.sh
@@ -167,6 +167,14 @@ remove_one_record() (
         echo "SKIP  record '$record' — cannot read its gitdir file; refusing to sweep an unvalidatable record (inspect $admin_dir)"
         exit 3 # unreadable gitdir refuses
     fi
+    # The lock above was keyed off a PRE-lock read; if the gitdir changed
+    # while the lock was being approached (a record replaced mid-plan), the
+    # held key may be wrong or missing — refuse, and let a re-run evaluate
+    # the new record under the right lock (review r1).
+    if [ "${wt_gitfile%/.git}" != "$tree_path" ]; then
+        echo "SKIP  record '$record' — its gitdir changed while the lock was being acquired; re-run to re-evaluate"
+        exit 3 # lock-key drift refuses
+    fi
     # If the gitdir target exists again (a worktree recreated at the old
     # path), the record is live — leave it.
     if [ -e "$wt_gitfile" ]; then

--- a/scripts/clean-worktree-records.sh
+++ b/scripts/clean-worktree-records.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# clean-worktree-records.sh — prune stale worktree ADMIN RECORDS only, never a
+# worktree directory. Run via `task clean:worktree-records`.
+#
+# A raw `git worktree prune` is not safe here (harmon-init#838, challenge r3):
+# a stale record's HEAD can be DETACHED at a commit no branch, tag or
+# remote-tracking ref contains, in which case the record is the only thing
+# keeping that commit alive — pruning it makes the commit unreachable and
+# eventually GC-collectible.
+#
+# The design decisions, each deliberate (challenge r4-r7):
+#
+#   * Only records in git's own dry-run plan are removed, each one
+#     individually, never via the global `git worktree prune` — a global
+#     prune re-computes eligibility at its own moment, so a LIVE worktree
+#     whose directory vanishes mid-run could be pruned on a stale HEAD
+#     snapshot. A plan-verified stale record has no working directory, so
+#     its HEAD cannot move. Live records are never touched.
+#   * Each removal runs under the same per-path lifecycle lock that
+#     worktree:new / worktree:rm hold (for trees under the blessed
+#     .worktrees layout), so a removal cannot race a re-creation of the
+#     same path by the blessed tooling. Raw `git worktree add` outside the
+#     tooling remains the documented residual.
+#   * A record that carries worktree-local state is refused, never swept:
+#     review sidecars, per-worktree ref files, and an index that diverges
+#     from the recorded HEAD (staged-but-uncommitted blobs the index alone
+#     keeps alive). Reflogs are deliberately NOT state — every record has
+#     one, and accepting reflog loss matches git's own prune semantics.
+#   * A detached record HEAD is pinned as refs/session-cleanup/pin/<record>
+#     BEFORE its record is removed, with a CREATE-ONLY ref write; an
+#     existing mismatched pin from an earlier run refuses that record. Pins
+#     are removed only by EXPLICIT human settlement — an auto-drop races
+#     concurrent ref deletion — and the run exits nonzero while any await
+#     action. Nothing is ever lost.
+#   * The pin report judges RAW history: replacement refs are disabled for
+#     the whole run and a legacy graft file forces the conservative wording,
+#     because a forged "also reachable from shared refs" would hand the
+#     human a copyable command that drops the only real reference.
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Replacement refs rewrite parentage cosmetically; the pin report below must
+# judge RAW history (challenge r8, ported at resurrection: harmon-init#945) —
+# a refs/replace graft could make an orphaned commit read as reachable from
+# shared refs, and the printed remedy would then invite dropping the pin that
+# holds its only real reference.
+export GIT_NO_REPLACE_OBJECTS=1
+
+die() {
+    echo "clean:worktree-records: $*" >&2
+    exit 1
+}
+
+# POSIX shell-quote for values echoed into copyable commands: refnames and
+# record names legally carry shell metacharacters (challenge r7; same class
+# as worktree-new.sh's printed remedies).
+shell_quote() {
+    printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
+# Refs that would STILL reference a commit once the record is gone — the same
+# exclusion set as worktree-rm.sh (per-worktree refs vanish with their
+# worktree), plus this script's own pin namespace: a pin must never vouch for
+# the commit it exists to protect. refs/replace/ is excluded for the same
+# reason GIT_NO_REPLACE_OBJECTS is exported: a replacement's synthetic commit
+# contains the grafted-in parent in RAW history, so the ref itself would
+# vouch for exactly the commit the forgery targets.
+shared_refs_containing() {
+    git for-each-ref --contains "$1" --format='%(refname)' 2>/dev/null |
+        grep -Ev '^refs/((worktree|bisect|rewritten|replace)/|session-cleanup/pin/)' || true
+}
+
+common="$(git rev-parse --path-format=absolute --git-common-dir)"
+
+# Legacy graft files rewrite parentage exactly as replace refs do, but
+# GIT_NO_REPLACE_OBJECTS does NOT disable them (review r1, ported at
+# resurrection): containment walked over grafted history is not evidence, so
+# while one exists every kept pin gets the conservative wording — never the
+# "also reachable, drop it" remedy.
+grafts_present=false
+grafts_file="$(git rev-parse --git-path info/grafts)"
+if [ -s "$grafts_file" ]; then
+    grafts_present=true
+    echo "NOTE  legacy graft file present ($grafts_file) — shared-ref containment is unusable while it exists; kept pins are reported conservatively"
+fi
+
+# git's own dry run is the authority on what is prunable
+# ("Removing worktrees/<name>: <reason>"); LC_ALL=C pins the message shape.
+prune_plan="$(LC_ALL=C git worktree prune --dry-run -v 2>&1)"
+if [ -z "$prune_plan" ]; then
+    echo "clean:worktree-records: nothing to prune."
+    exit 0
+fi
+
+# remove_one_record <record> — runs in a SUBSHELL so a lock refusal (die)
+# aborts this record only. Every validation runs UNDER the lock (challenge
+# r7): checked outside it, worktree:rm clearing the record and worktree:new
+# recreating the same path could interleave before the rm -rf and lose a
+# live record. Exit codes: 0 removed, 2 removed with a pin awaiting
+# settlement, 3 refused cleanly (message printed), else lock/fatal.
+remove_one_record() (
+    record="$1"
+    admin_dir="$common/worktrees/$record"
+    # shellcheck source=scripts/worktree-lock.sh
+    . "$REPO_ROOT/scripts/worktree-lock.sh"
+    trap release_locks EXIT
+    trap 'exit 129' HUP INT TERM
+    wt_gitfile="$(cat "$admin_dir/gitdir" 2>/dev/null || true)"
+    main_root="${common%/.git}"
+    tree_path="${wt_gitfile%/.git}"
+    case "$tree_path" in
+    "$main_root/.worktrees/"*)
+        acquire_path_locks "${tree_path#"$main_root/.worktrees/"}"
+        ;;
+    esac
+
+    [ -d "$admin_dir" ] || exit 3 # already gone (another cleaner won)
+    # Re-read under the lock: if the record's gitdir target exists again (a
+    # worktree recreated at the old path), the record is live — leave it.
+    wt_gitfile="$(cat "$admin_dir/gitdir" 2>/dev/null || true)"
+    if [ -n "$wt_gitfile" ] && [ -e "$wt_gitfile" ]; then
+        echo "SKIP  record '$record' — its worktree reappeared since the plan"
+        exit 3
+    fi
+
+    # Single-copy worktree-local state is refused, never swept.
+    carried=""
+    for sub in deferred-findings adjudication-ledger shepherd-codex refs; do
+        if [ -e "$admin_dir/$sub" ] &&
+            [ -n "$(find "$admin_dir/$sub" -type f 2>/dev/null | head -n 1)" ]; then
+            carried="$carried $sub"
+        fi
+    done
+    if [ -n "$carried" ]; then
+        echo "SKIP  record '$record' — carries worktree-local state (${carried# }); adopt or rescue it first, it exists nowhere else"
+        exit 3
+    fi
+
+    record_head="$(cat "$admin_dir/HEAD" 2>/dev/null || true)"
+
+    # The index can be the only structure referencing staged-but-uncommitted
+    # blobs (challenge r7): an index that diverges from the recorded HEAD —
+    # or that cannot be verified against it — is state, and refused.
+    if [ -f "$admin_dir/index" ]; then
+        head_commit=""
+        case "$record_head" in
+        ref:*) head_commit="$(git rev-parse --quiet --verify "${record_head#ref: }^{commit}" || true)" ;;
+        '') : ;;
+        *) head_commit="$(git rev-parse --quiet --verify "$record_head^{commit}" || true)" ;;
+        esac
+        if [ -z "$head_commit" ] ||
+            ! GIT_INDEX_FILE="$admin_dir/index" git diff-index --cached --quiet "$head_commit" 2>/dev/null; then
+            echo "SKIP  record '$record' — its index diverges from the recorded HEAD (staged-only changes, or unverifiable); recover them first (GIT_INDEX_FILE=$admin_dir/index git checkout-index ...), then remove the index file"
+            exit 3
+        fi
+    fi
+
+    pinned_here=false
+    case "$record_head" in
+    ref:* | '') : ;; # attached to a branch: the branch keeps the commits
+    *)
+        if git rev-parse --quiet --verify "$record_head^{commit}" >/dev/null 2>&1; then
+            existing_pin="$(git rev-parse --quiet --verify "refs/session-cleanup/pin/$record" || true)"
+            if [ -n "$existing_pin" ] && [ "$existing_pin" != "$record_head" ]; then
+                echo "SKIP  record '$record' — refs/session-cleanup/pin/$record already pins $existing_pin from an earlier run; settle it first (git branch $(shell_quote "rescue/$record") $existing_pin, or git update-ref -d $(shell_quote "refs/session-cleanup/pin/$record"))"
+                exit 3
+            fi
+            # Create-only (old value ''): never overwrite a pin this run did
+            # not just verify.
+            if ! LEFTHOOK=0 git update-ref "refs/session-cleanup/pin/$record" "$record_head" "${existing_pin:-}"; then
+                echo "SKIP  record '$record' — cannot pin detached commit $record_head; refusing to remove it unprotected"
+                exit 3
+            fi
+            pinned_here=true
+        fi
+        ;;
+    esac
+
+    # Records only: the stale admin directory is all that goes.
+    rm -rf "$admin_dir"
+    echo "pruned record '$record'"
+
+    if [ "$pinned_here" = true ]; then
+        # Reporting only — pins are settled by humans, never auto-dropped
+        # (challenge r6): the reachability check picks the wording, and a
+        # race can at worst mislabel, never delete.
+        pin_ref="refs/session-cleanup/pin/$record"
+        if [ "$grafts_present" = false ] && [ -n "$(shared_refs_containing "$record_head")" ]; then
+            echo "PINNED  $pin_ref — $record_head is also reachable from shared refs; drop it with: git update-ref -d $(shell_quote "$pin_ref")"
+        else
+            echo "KEPT  $pin_ref — pruned record '$record' held the only reference to detached commit $record_head; branch it (git branch $(shell_quote "rescue/$record") $record_head) or discard it (git update-ref -d $(shell_quote "$pin_ref"))"
+        fi
+        exit 2
+    fi
+)
+
+removed=0
+skipped=0
+pins_pending=0
+while IFS= read -r line; do
+    record="$(printf '%s\n' "$line" | sed -n 's/^Removing worktrees\/\(.*\): .*$/\1/p')"
+    [ -n "$record" ] || continue
+    rc=0
+    remove_one_record "$record" || rc=$?
+    case "$rc" in
+    0) removed=$((removed + 1)) ;;
+    2)
+        removed=$((removed + 1))
+        pins_pending=$((pins_pending + 1))
+        ;;
+    3) skipped=$((skipped + 1)) ;;
+    *)
+        echo "SKIP  record '$record' — the worktree lifecycle lock refused (a worktree operation is active; details above)"
+        skipped=$((skipped + 1))
+        ;;
+    esac
+done <<EOF
+$prune_plan
+EOF
+
+if [ "$removed" -eq 0 ] && [ "$skipped" -eq 0 ]; then
+    echo "clean:worktree-records: nothing to prune."
+    exit 0
+fi
+if [ "$pins_pending" -gt 0 ] || [ "$skipped" -gt 0 ]; then
+    echo "clean:worktree-records: $removed record(s) pruned; $pins_pending pin(s) awaiting settlement, $skipped record(s) refused above." >&2
+    exit 2
+fi
+echo "clean:worktree-records: stale records pruned (worktree directories are never touched)."

--- a/scripts/clean-worktree-records.sh
+++ b/scripts/clean-worktree-records.sh
@@ -30,8 +30,8 @@
 #     (rebase/merge/cherry-pick — the worktree-rm.sh list), and an index
 #     that diverges from the recorded HEAD (staged-but-uncommitted blobs
 #     the index alone keeps alive). An unreadable HEAD refuses outright,
-#     and ORIG_HEAD — a ref file, not a reflog — refuses when it names a
-#     commit no shared ref contains. Reflogs are deliberately NOT state —
+#     and ORIG_HEAD and FETCH_HEAD — ref files, not reflogs — refuse when
+#     they name a commit no shared ref contains. Reflogs are deliberately NOT state —
 #     every record has one, and accepting reflog loss matches git's own
 #     prune semantics.
 #   * A detached record HEAD is pinned as refs/session-cleanup/pin/<record>
@@ -115,7 +115,10 @@ pins_outstanding() {
 }
 
 finish_no_work() {
-    if [ -n "$(pins_outstanding)" ]; then
+    # Enumeration failure is not an empty namespace: a broken ref backend
+    # must never let the run report cleanup complete (challenge r4).
+    outstanding="$(pins_outstanding)" || die "cannot enumerate rescue pins (refs/session-cleanup/pin unreadable); refusing to report cleanup complete"
+    if [ -n "$outstanding" ]; then
         echo "clean:worktree-records: nothing to prune, but rescue pins await settlement (task audit:session-artifacts lists them)." >&2
         exit 2
     fi
@@ -216,6 +219,29 @@ remove_one_record() (
             echo "SKIP  record '$record' — ORIG_HEAD $orig_commit is reachable from no shared ref, or containment is unusable under a legacy graft file (a reset/rebase abandoned it here); rescue it (git branch $(shell_quote "rescue/$record-orig") $orig_commit) then remove $admin_dir/ORIG_HEAD"
             exit 3
         fi
+    fi
+
+    # FETCH_HEAD can hold the only mapping to a URL-fetched, unbranched tip
+    # (a PR head). Ordinary fetches list tips the remote-tracking refs
+    # contain, so — exactly as with ORIG_HEAD — only an unreadable,
+    # unresolvable, or unreachable entry refuses; the conditional guard has
+    # none of the unsweepability cost an unconditional refusal would
+    # (challenge r4, revising r3's declination of the unconditional form).
+    if [ -f "$admin_dir/FETCH_HEAD" ]; then
+        while IFS= read -r fetch_line; do
+            [ -n "$fetch_line" ] || continue
+            fetch_sha="${fetch_line%%[[:space:]]*}"
+            fetch_commit=""
+            [ -z "$fetch_sha" ] || fetch_commit="$(git rev-parse --quiet --verify "$fetch_sha^{commit}" || true)"
+            if [ -z "$fetch_commit" ]; then
+                echo "SKIP  record '$record' — FETCH_HEAD entry '$fetch_sha' is unreadable or names no commit; refusing to sweep (inspect $admin_dir/FETCH_HEAD)"
+                exit 3
+            fi
+            if [ "$grafts_present" = true ] || [ -z "$(shared_refs_containing "$fetch_commit")" ]; then
+                echo "SKIP  record '$record' — FETCH_HEAD names $fetch_commit, reachable from no shared ref (a URL fetch left it here); rescue it (git branch $(shell_quote "rescue/$record-fetch") $fetch_commit) then remove $admin_dir/FETCH_HEAD"
+                exit 3
+            fi
+        done <"$admin_dir/FETCH_HEAD"
     fi
 
     # The index can be the only structure referencing staged-but-uncommitted
@@ -340,8 +366,13 @@ if [ "$errors" -gt 0 ]; then
     echo "clean:worktree-records: $removed record(s) pruned; $errors record removal(s) FAILED above — resolve before re-running." >&2
     exit 1
 fi
-if [ "$pins_pending" -gt 0 ] || [ "$skipped" -gt 0 ] || [ -n "$(pins_outstanding)" ]; then
-    echo "clean:worktree-records: $removed record(s) pruned; $pins_pending pin(s) awaiting settlement, $skipped record(s) refused above." >&2
+outstanding="$(pins_outstanding)" || die "cannot enumerate rescue pins (refs/session-cleanup/pin unreadable); refusing to report cleanup complete"
+if [ "$pins_pending" -gt 0 ] || [ "$skipped" -gt 0 ] || [ -n "$outstanding" ]; then
+    # Total, not just this run's: a pin inherited from an earlier run is
+    # exactly as much awaiting settlement as a fresh one, and printing "0"
+    # beside a nonzero exit contradicts the disposition (challenge r4).
+    total_pins="$(git for-each-ref refs/session-cleanup/pin --format='%(refname)' | grep -c . || true)"
+    echo "clean:worktree-records: $removed record(s) pruned; $pins_pending new pin(s) this run, $total_pins total awaiting settlement, $skipped record(s) refused above." >&2
     exit 2
 fi
 echo "clean:worktree-records: stale records pruned (worktree directories are never touched)."

--- a/scripts/clean-worktree-records.sh
+++ b/scripts/clean-worktree-records.sh
@@ -187,9 +187,15 @@ remove_one_record() (
     fi
     # A surviving worktree DIRECTORY whose .git link is gone still holds
     # the user's files; sweeping its record would orphan them as a plain
-    # directory nothing tracks (challenge r7).
+    # directory nothing tracks (challenge r7). A gitdir value that does not
+    # end in /.git is malformed — and would silently skip this very guard —
+    # so it refuses outright (shepherd r1).
     tree_dir="${wt_gitfile%/.git}"
-    if [ "$tree_dir" != "$wt_gitfile" ] && [ -d "$tree_dir" ]; then
+    if [ "$tree_dir" = "$wt_gitfile" ]; then
+        echo "SKIP  record '$record' — its gitdir value does not end in /.git (malformed); refusing to sweep an unvalidatable record (inspect $admin_dir/gitdir)"
+        exit 3 # malformed gitdir suffix refuses
+    fi
+    if [ -d "$tree_dir" ]; then
         echo "SKIP  record '$record' — its worktree directory still exists ($tree_dir) though the .git link is gone; restore the link or move the directory aside first"
         exit 3 # surviving tree dir refuses
     fi
@@ -268,6 +274,13 @@ remove_one_record() (
             ;;
         deferred-findings | adjudication-ledger | shepherd-codex | refs | rebase-merge | rebase-apply | MERGE_HEAD | MERGE_AUTOSTASH | CHERRY_PICK_HEAD | REVERT_HEAD | BISECT_LOG | config.worktree) : ;; # carried-state names: the scan above refused them when non-empty
         info)
+            # As a regular file or symlink, the child globs below match
+            # nothing and the entry would be accepted uninspected
+            # (shepherd r1) — the same type gate the other slots carry.
+            if [ ! -d "$entry" ] || [ -L "$entry" ]; then
+                echo "SKIP  record '$record' — entry 'info' is not the directory git writes there; refusing to sweep malformed state (inspect $admin_dir)"
+                exit 3 # info type mismatch refuses
+            fi
             for info_entry in "$entry"/* "$entry"/.[!.]* "$entry"/..?*; do
                 [ -e "$info_entry" ] || [ -L "$info_entry" ] || continue
                 case "${info_entry##*/}" in
@@ -453,7 +466,7 @@ remove_one_record() (
             # -d with an old value is compare-and-delete, so a stale command
             # re-run after record-name reuse cannot delete a newer pin
             # (challenge r3).
-            echo "PINNED  $pin_ref — $record_head was reachable from shared refs at prune time; re-verify before dropping (git --no-replace-objects for-each-ref --contains $record_head refs/heads refs/tags refs/remotes), then: git update-ref -d $(shell_quote "$pin_ref") $record_head"
+            echo "PINNED  $pin_ref — $record_head was reachable from shared refs at prune time; re-verify before dropping (GIT_GRAFT_FILE=/dev/null git --no-replace-objects for-each-ref --contains $record_head refs/heads refs/tags refs/remotes), then: git update-ref -d $(shell_quote "$pin_ref") $record_head"
         else
             echo "KEPT  $pin_ref — pruned record '$record' held the only reference to detached commit $record_head; branch it (git branch $(shell_quote "rescue/$record") $record_head) or discard it (git update-ref -d $(shell_quote "$pin_ref") $record_head)"
         fi

--- a/scripts/clean-worktree-records.sh
+++ b/scripts/clean-worktree-records.sh
@@ -236,7 +236,24 @@ remove_one_record() (
         [ -e "$entry" ] || [ -L "$entry" ] || continue # -e dereferences: a broken symlink must still be judged
         entry_name="${entry##*/}"
         case "$entry_name" in
-        gitdir | commondir | HEAD | locked | COMMIT_EDITMSG | ORIG_HEAD | FETCH_HEAD | index | logs) : ;;                                                                                                  # validated by the guards here, disposable scratch, or reflogs (accepted loss by design)
+        gitdir | commondir | HEAD | locked | COMMIT_EDITMSG | ORIG_HEAD | FETCH_HEAD | index)
+            # Validated by the guards here or disposable scratch — but only
+            # as the regular files git writes: a directory or symlink in one
+            # of these slots would skip its -f validator yet still be
+            # rm -rf'd with the record (challenge r8).
+            if [ ! -f "$entry" ] || [ -L "$entry" ]; then
+                echo "SKIP  record '$record' — entry '$entry_name' is not the regular file git writes there; refusing to sweep malformed state (inspect $admin_dir)"
+                exit 3 # type mismatch refuses
+            fi
+            ;;
+        logs)
+            # Reflogs (accepted loss by design) — as the directory git
+            # writes, same type gate as above.
+            if [ ! -d "$entry" ] || [ -L "$entry" ]; then
+                echo "SKIP  record '$record' — entry 'logs' is not the directory git writes there; refusing to sweep malformed state (inspect $admin_dir)"
+                exit 3 # type mismatch refuses
+            fi
+            ;;
         deferred-findings | adjudication-ledger | shepherd-codex | refs | rebase-merge | rebase-apply | MERGE_HEAD | MERGE_AUTOSTASH | CHERRY_PICK_HEAD | REVERT_HEAD | BISECT_LOG | config.worktree) : ;; # carried-state names: the scan above refused them when non-empty
         info)
             for info_entry in "$entry"/* "$entry"/.[!.]* "$entry"/..?*; do
@@ -405,7 +422,13 @@ remove_one_record() (
                 exit 5
             fi
         elif [ "$pin_now" != "$record_head" ]; then
-            echo "CRITICAL  $pin_ref no longer pins $record_head (it now holds $pin_now) — rescue the detached commit NOW: git branch $(shell_quote "rescue/$record") $record_head"
+            # The record is already gone, so the commit must not ride on the
+            # human seeing the diagnostic alone: best-effort re-protect under
+            # a fresh unique name — create-only, so the foreign write to the
+            # original pin is never overwritten (challenge r8).
+            rescue_ref="refs/session-cleanup/pin/$record-rescue-$(printf '%.7s' "$record_head")"
+            LEFTHOOK=0 git update-ref "$rescue_ref" "$record_head" "" 2>/dev/null || true
+            echo "CRITICAL  $pin_ref no longer pins $record_head (it now holds $pin_now) — a rescue ref was created at $rescue_ref if possible (verify: git rev-parse $(shell_quote "$rescue_ref")); rescue the detached commit NOW: git branch $(shell_quote "rescue/$record") $record_head"
             exit 5
         fi
         # Reporting only — pins are settled by humans, never auto-dropped

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -856,17 +856,17 @@ echo "ok: a pin dropped mid-run by a racing settlement is re-asserted"
 # A partial rm is corrupt state needing inspection; reporting it as lock
 # contention hands the operator the wrong remedy.
 
-mkdir -p "$gitdir/worktrees/stuckrec/blocker"
+mkdir -p "$gitdir/worktrees/stuckrec/logs/blocker"
 printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/stuckrec/HEAD"
 printf '%s\n' "/nonexistent/stuckrec/.git" >"$gitdir/worktrees/stuckrec/gitdir"
-touch "$gitdir/worktrees/stuckrec/blocker/held"
-chmod 000 "$gitdir/worktrees/stuckrec/blocker"
+touch "$gitdir/worktrees/stuckrec/logs/blocker/held"
+chmod 000 "$gitdir/worktrees/stuckrec/logs/blocker"
 
 if stuck_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
-    chmod 755 "$gitdir/worktrees/stuckrec/blocker" 2>/dev/null || true
+    chmod 755 "$gitdir/worktrees/stuckrec/logs/blocker" 2>/dev/null || true
     fail "record prune exited zero although removal failed: $stuck_out"
 fi
-chmod 755 "$gitdir/worktrees/stuckrec/blocker" 2>/dev/null || true
+chmod 755 "$gitdir/worktrees/stuckrec/logs/blocker" 2>/dev/null || true
 expect_contains "$stuck_out" "removal failed midway" "rm failure: reported as its own outcome"
 expect_not_contains "$stuck_out" "lifecycle lock refused" "rm failure: never mislabeled as lock contention"
 
@@ -1074,6 +1074,37 @@ tagrec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" 
     fail "record prune failed after the tag object was rescued: $tagrec_ok_out"
 expect_contains "$tagrec_ok_out" "pruned record 'tagrec'" "fetch-tag: referenced tag object sweeps normally"
 echo "ok: an unreferenced annotated tag in FETCH_HEAD refuses the sweep until rescued"
+
+# ── Case E7u: an unrecognized admin-dir entry refuses the sweep ────────────
+# The sweep is allowlist-gated: git grows state files over time (sequencer/,
+# AUTO_MERGE, ...) and enumerating dangerous ones loses that game — anything
+# this tool does not understand fails closed.
+
+mkdir -p "$gitdir/worktrees/oddrec/sequencer"
+echo "pick deadbeef subject" >"$gitdir/worktrees/oddrec/sequencer/todo"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/oddrec/HEAD"
+printf '%s\n' "/nonexistent/oddrec/.git" >"$gitdir/worktrees/oddrec/gitdir"
+
+if odd_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unrecognized admin entry present: $odd_out"
+fi
+expect_contains "$odd_out" "unrecognized entry 'sequencer'" "unknown entry: refused fail-closed"
+[ -d "$gitdir/worktrees/oddrec" ] || fail "unknown entry: record swept despite unrecognized state"
+
+rm -rf "$gitdir/worktrees/oddrec/sequencer"
+mkdir -p "$gitdir/worktrees/oddrec/info"
+echo "mystery" >"$gitdir/worktrees/oddrec/info/attributes-cache"
+if oddinfo_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unrecognized info/ entry present: $oddinfo_out"
+fi
+expect_contains "$oddinfo_out" "unrecognized entry info/attributes-cache" "unknown info entry: refused fail-closed"
+[ -d "$gitdir/worktrees/oddrec" ] || fail "unknown info entry: record swept despite unrecognized state"
+
+rm -rf "$gitdir/worktrees/oddrec/info"
+odd_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the unknown entries were adopted: $odd_ok_out"
+expect_contains "$odd_ok_out" "pruned record 'oddrec'" "unknown entry: understood record prunes normally"
+echo "ok: an unrecognized admin-dir entry refuses the sweep"
 
 # ── Case E7s: pin-enumeration failure never reports cleanup complete ───────
 # A broken ref backend is not an empty pin namespace; the empty-plan path

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -581,6 +581,14 @@ pin_audit_out="$(cd "$fixture" && bash scripts/audit-session-artifacts.sh 2>&1)"
 expect_contains "$pin_audit_out" "wt-det — pins $det_sha" "audit: leftover rescue pin reported"
 echo "ok: audit reports leftover rescue pins"
 
+# The contract holds across retries: an otherwise-empty re-run must stay
+# nonzero while any pin awaits settlement, not report cleanup complete.
+if pin_retry_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero while a rescue pin awaited settlement: $pin_retry_out"
+fi
+expect_contains "$pin_retry_out" "rescue pins await settlement" "retry: pending pin keeps the run nonzero"
+echo "ok: a pending rescue pin keeps retries nonzero"
+
 git -C "$fixture" branch -q rescue-det "$det_sha"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/wt-det
 prune_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
@@ -615,6 +623,7 @@ if reuse_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)
 fi
 expect_contains "$reuse_ok_out" "pruned record 'pin-reuse'" "pin reuse: settled pin lets the removal proceed"
 expect_contains "$reuse_ok_out" "PINNED  refs/session-cleanup/pin/pin-reuse" "pin reuse: fresh pin reported for explicit settlement"
+expect_contains "$reuse_ok_out" "re-verify before dropping" "pin reuse: drop remedy demands execution-time re-verification, not a stale snapshot"
 [ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/pin-reuse)" = "$(git -C "$fixture" rev-parse main)" ] ||
     fail "pin reuse: fresh pin missing or wrong — pins must never be auto-dropped"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/pin-reuse
@@ -624,7 +633,7 @@ echo "ok: an unsettled rescue pin refuses the prune instead of being overwritten
 # Sidecars and per-worktree ref files under worktrees/<id>/ are single-copy;
 # no pin can stand in for them.
 
-for rec in state-rec refs-rec; do
+for rec in state-rec refs-rec op-rec; do
     mkdir -p "$gitdir/worktrees/$rec"
     printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/$rec/HEAD"
     printf '%s\n' "/nonexistent/$rec/.git" >"$gitdir/worktrees/$rec/gitdir"
@@ -634,21 +643,27 @@ echo "p2 from a dead session" >"$gitdir/worktrees/state-rec/deferred-findings/so
 mkdir -p "$gitdir/worktrees/refs-rec/refs/worktree"
 refs_orph="$(git -C "$fixture" commit-tree "main^{tree}" -p main -m "worktree-ref orphan")"
 printf '%s\n' "$refs_orph" >"$gitdir/worktrees/refs-rec/refs/worktree/only"
+# A merge parked at an edit: MERGE_HEAD is sequencer state the record alone
+# holds (the worktree-rm.sh op-state list).
+git -C "$fixture" rev-parse main >"$gitdir/worktrees/op-rec/MERGE_HEAD"
 
 if state_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
     fail "record prune exited zero with refused state-carrying records: $state_out"
 fi
 expect_contains "$state_out" "record 'state-rec' — carries worktree-local state (deferred-findings)" "state: sidecar-carrying record refused"
 expect_contains "$state_out" "record 'refs-rec' — carries worktree-local state (refs)" "state: per-worktree-ref record refused"
+expect_contains "$state_out" "record 'op-rec' — carries worktree-local state (MERGE_HEAD)" "state: in-progress-operation record refused"
 [ -d "$gitdir/worktrees/state-rec" ] || fail "state: sidecar-carrying record was swept"
 [ -d "$gitdir/worktrees/refs-rec" ] || fail "state: ref-carrying record was swept"
+[ -d "$gitdir/worktrees/op-rec" ] || fail "state: op-state record was swept"
 git -C "$fixture" cat-file -e "$refs_orph" || fail "state: worktree-ref orphan commit lost"
 
-rm -rf "$gitdir/worktrees/state-rec/deferred-findings" "$gitdir/worktrees/refs-rec/refs"
+rm -rf "$gitdir/worktrees/state-rec/deferred-findings" "$gitdir/worktrees/refs-rec/refs" "$gitdir/worktrees/op-rec/MERGE_HEAD"
 state_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
     fail "record prune failed after the state was adopted: $state_ok_out"
 expect_contains "$state_ok_out" "pruned record 'state-rec'" "state: adopted record prunes normally"
 expect_contains "$state_ok_out" "pruned record 'refs-rec'" "state: rescued record prunes normally"
+expect_contains "$state_ok_out" "pruned record 'op-rec'" "state: finished-operation record prunes normally"
 echo "ok: state-carrying records are refused until adopted, never swept"
 
 # ── Case E7e: an index diverging from the recorded HEAD refuses the sweep ──
@@ -718,7 +733,7 @@ if repg_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; t
 fi
 git -C "$fixture" update-ref -d "refs/replace/$repg_main"
 expect_contains "$repg_out" "KEPT  refs/session-cleanup/pin/reptrap" "replace ref: pin reported as the only reference"
-expect_not_contains "$repg_out" "also reachable from shared refs" "replace ref: forged containment does not invite dropping the pin"
+expect_not_contains "$repg_out" "reachable from shared refs at prune time" "replace ref: forged containment does not invite dropping the pin"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/reptrap
 echo "ok: a replacement ref cannot forge the pin-drop remedy"
 
@@ -739,9 +754,100 @@ fi
 rm -f "$gitdir/info/grafts"
 expect_contains "$graftrec_out" "legacy graft file present" "grafts: presence announced by the record prune"
 expect_contains "$graftrec_out" "KEPT  refs/session-cleanup/pin/grafttrap" "grafts: pin reported conservatively"
-expect_not_contains "$graftrec_out" "also reachable from shared refs" "grafts: grafted containment does not invite dropping the pin"
+expect_not_contains "$graftrec_out" "reachable from shared refs at prune time" "grafts: grafted containment does not invite dropping the pin"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/grafttrap
 echo "ok: a legacy graft file forces the conservative pin wording"
+
+# The two interleaving guards below need a mid-run event; a PATH shim around
+# git injects it deterministically at the exact seam, then passes through.
+shim_dir="$test_tmp/git-shim"
+mkdir -p "$shim_dir"
+real_git="$(command -v git)"
+
+# ── Case E7i: a git worktree lock taken after the plan still protects ──────
+# `git worktree prune` skips locked records at plan time, but a lock created
+# between the plan and the removal (removable media coming under protection)
+# must be honored by the re-check under the lifecycle lock.
+
+mkdir -p "$gitdir/worktrees/lockedrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/lockedrec/HEAD"
+printf '%s\n' "/nonexistent/lockedrec/.git" >"$gitdir/worktrees/lockedrec/gitdir"
+cat >"$shim_dir/git" <<SHIM
+#!/usr/bin/env bash
+if [[ "\$*" == *"worktree prune --dry-run"* ]]; then
+    "$real_git" "\$@"
+    touch "$gitdir/worktrees/lockedrec/locked"
+    exit 0
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$shim_dir/git"
+
+if lockmark_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although a git worktree lock landed post-plan: $lockmark_out"
+fi
+expect_contains "$lockmark_out" "locked by git worktree lock since the plan" "post-plan lock: record skipped loudly"
+[ -d "$gitdir/worktrees/lockedrec" ] || fail "post-plan lock: locked record was swept"
+
+rm -f "$gitdir/worktrees/lockedrec/locked"
+lockmark_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the git lock was released: $lockmark_ok_out"
+expect_contains "$lockmark_ok_out" "pruned record 'lockedrec'" "post-plan lock: unlocked record prunes normally"
+echo "ok: a git worktree lock taken after the plan still protects the record"
+
+# ── Case E7j: a pin dropped mid-run by a racing settlement is re-asserted ──
+# The audit advertises pins, so a human settlement can delete one in the
+# window between the create and the record removal; the pin is re-asserted
+# before the run reports it kept.
+
+race_orph="$(git -C "$fixture" commit-tree "main^{tree}" -m "orphan-behind-race")"
+mkdir -p "$gitdir/worktrees/racepin"
+printf '%s\n' "$race_orph" >"$gitdir/worktrees/racepin/HEAD"
+printf '%s\n' "/nonexistent/racepin/.git" >"$gitdir/worktrees/racepin/gitdir"
+rm -f "$test_tmp/racepin-dropped"
+cat >"$shim_dir/git" <<SHIM
+#!/usr/bin/env bash
+if [[ "\$1" == "update-ref" && "\$2" == "refs/session-cleanup/pin/racepin" && ! -e "$test_tmp/racepin-dropped" ]]; then
+    touch "$test_tmp/racepin-dropped"
+    "$real_git" "\$@" || exit \$?
+    "$real_git" update-ref -d refs/session-cleanup/pin/racepin
+    exit 0
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$shim_dir/git"
+
+if racepin_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although its re-asserted pin awaits settlement: $racepin_out"
+fi
+expect_contains "$racepin_out" "KEPT  refs/session-cleanup/pin/racepin" "pin race: pin reported kept"
+[ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/racepin)" = "$race_orph" ] ||
+    fail "pin race: pin dropped mid-run was not re-asserted — the KEPT report is a lie"
+git -C "$fixture" cat-file -e "$race_orph" || fail "pin race: orphan commit lost"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/racepin
+echo "ok: a pin dropped mid-run by a racing settlement is re-asserted"
+
+# ── Case E7k: a failed record removal is loud and never lock-labeled ───────
+# A partial rm is corrupt state needing inspection; reporting it as lock
+# contention hands the operator the wrong remedy.
+
+mkdir -p "$gitdir/worktrees/stuckrec/blocker"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/stuckrec/HEAD"
+printf '%s\n' "/nonexistent/stuckrec/.git" >"$gitdir/worktrees/stuckrec/gitdir"
+touch "$gitdir/worktrees/stuckrec/blocker/held"
+chmod 000 "$gitdir/worktrees/stuckrec/blocker"
+
+if stuck_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    chmod 755 "$gitdir/worktrees/stuckrec/blocker" 2>/dev/null || true
+    fail "record prune exited zero although removal failed: $stuck_out"
+fi
+chmod 755 "$gitdir/worktrees/stuckrec/blocker" 2>/dev/null || true
+expect_contains "$stuck_out" "removal failed midway" "rm failure: reported as its own outcome"
+expect_not_contains "$stuck_out" "lifecycle lock refused" "rm failure: never mislabeled as lock contention"
+
+stuck_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the blocker was cleared: $stuck_ok_out"
+echo "ok: a failed record removal is loud and never lock-labeled"
 
 # ── Case E8: a renamed remote default refuses every deletion ───────────────
 # The local origin/HEAD still names the old default; the live remote HEAD

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -845,9 +845,90 @@ chmod 755 "$gitdir/worktrees/stuckrec/blocker" 2>/dev/null || true
 expect_contains "$stuck_out" "removal failed midway" "rm failure: reported as its own outcome"
 expect_not_contains "$stuck_out" "lifecycle lock refused" "rm failure: never mislabeled as lock contention"
 
+# The partial rm may have taken HEAD/gitdir (deletion order is undefined);
+# restore them so the recovery run exercises a validatable record.
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/stuckrec/HEAD"
+printf '%s\n' "/nonexistent/stuckrec/.git" >"$gitdir/worktrees/stuckrec/gitdir"
 stuck_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
     fail "record prune failed after the blocker was cleared: $stuck_ok_out"
 echo "ok: a failed record removal is loud and never lock-labeled"
+
+# ── Case E7m: an unreachable ORIG_HEAD refuses the sweep ───────────────────
+# ORIG_HEAD is a ref file, not a reflog: a reset --hard's abandoned commit
+# can live in it alone, so reflog accepted-loss does not cover it. A
+# reachable ORIG_HEAD sweeps normally.
+
+orph_o="$(git -C "$fixture" commit-tree "main^{tree}" -m "reset-away")"
+mkdir -p "$gitdir/worktrees/origrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/origrec/HEAD"
+printf '%s\n' "/nonexistent/origrec/.git" >"$gitdir/worktrees/origrec/gitdir"
+printf '%s\n' "$orph_o" >"$gitdir/worktrees/origrec/ORIG_HEAD"
+
+if orig_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unreachable ORIG_HEAD present: $orig_out"
+fi
+expect_contains "$orig_out" "ORIG_HEAD $orph_o is reachable from no shared ref" "orig-head: reset-away commit refused"
+[ -d "$gitdir/worktrees/origrec" ] || fail "orig-head: record swept despite its unreachable ORIG_HEAD"
+git -C "$fixture" cat-file -e "$orph_o" || fail "orig-head: reset-away commit lost"
+
+git -C "$fixture" branch -q rescue-orig "$orph_o"
+orig_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the ORIG_HEAD commit was rescued: $orig_ok_out"
+expect_contains "$orig_ok_out" "pruned record 'origrec'" "orig-head: reachable ORIG_HEAD sweeps normally"
+echo "ok: an unreachable ORIG_HEAD refuses the sweep until rescued"
+
+# ── Case E7n: a record with an unreadable HEAD is refused, never swept ─────
+# An empty or missing HEAD would fall through every HEAD-derived guard and
+# sweep unpinned; an unvalidatable record fails closed.
+
+mkdir -p "$gitdir/worktrees/noheadrec"
+printf '%s\n' "/nonexistent/noheadrec/.git" >"$gitdir/worktrees/noheadrec/gitdir"
+
+if nohead_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unvalidatable record present: $nohead_out"
+fi
+expect_contains "$nohead_out" "cannot read its HEAD" "no-head: unvalidatable record refused"
+[ -d "$gitdir/worktrees/noheadrec" ] || fail "no-head: unvalidatable record was swept"
+
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/noheadrec/HEAD"
+nohead_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after HEAD was restored: $nohead_ok_out"
+expect_contains "$nohead_ok_out" "pruned record 'noheadrec'" "no-head: restored record prunes normally"
+echo "ok: a record with an unreadable HEAD is refused, never swept"
+
+# ── Case E7o: a pin retargeted mid-run fails closed, never reported kept ───
+# Existence alone verifies nothing: a pin rewritten between its creation
+# and the post-removal check must fail the run loudly with a rescue remedy,
+# not be overwritten and not be reported as keeping the commit.
+
+ret_orph="$(git -C "$fixture" commit-tree "main^{tree}" -m "orphan-behind-retarget")"
+ret_main="$(git -C "$fixture" rev-parse main)"
+mkdir -p "$gitdir/worktrees/retarg"
+printf '%s\n' "$ret_orph" >"$gitdir/worktrees/retarg/HEAD"
+printf '%s\n' "/nonexistent/retarg/.git" >"$gitdir/worktrees/retarg/gitdir"
+rm -f "$test_tmp/retarg-hit"
+cat >"$shim_dir/git" <<SHIM
+#!/usr/bin/env bash
+if [[ "\$1" == "update-ref" && "\$2" == "refs/session-cleanup/pin/retarg" && ! -e "$test_tmp/retarg-hit" ]]; then
+    touch "$test_tmp/retarg-hit"
+    "$real_git" "\$@" || exit \$?
+    "$real_git" update-ref refs/session-cleanup/pin/retarg "$ret_main"
+    exit 0
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$shim_dir/git"
+
+if retarg_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although its pin was retargeted mid-run: $retarg_out"
+fi
+expect_contains "$retarg_out" "no longer pins $ret_orph" "pin retarget: OID mismatch fails closed with the rescue remedy"
+expect_not_contains "$retarg_out" "KEPT  refs/session-cleanup/pin/retarg" "pin retarget: a retargeted pin is never reported as keeping the commit"
+[ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/retarg)" = "$ret_main" ] ||
+    fail "pin retarget: the foreign write was overwritten — settlement is human-only"
+git -C "$fixture" cat-file -e "$ret_orph" || fail "pin retarget: orphan commit lost from the object db"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/retarg
+echo "ok: a pin retargeted mid-run fails closed, never reported kept"
 
 # ── Case E8: a renamed remote default refuses every deletion ───────────────
 # The local origin/HEAD still names the old default; the live remote HEAD

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -1250,6 +1250,37 @@ typerec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"
 expect_contains "$typerec_ok_out" "pruned record 'typerec'" "type gate: well-formed record prunes normally"
 echo "ok: an allowlisted name of the wrong type refuses the sweep"
 
+# ── Case E7z: a gitdir that changed across the lock refuses the sweep ──────
+# The lifecycle lock is keyed off a pre-lock gitdir read; a record replaced
+# while the lock is approached could otherwise be validated under no lock
+# (or the wrong key) and swept mid-creation.
+
+mkdir -p "$gitdir/worktrees/lockswap"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/lockswap/HEAD"
+printf '%s\n' "$fixture/.worktrees/lockswap/.git" >"$gitdir/worktrees/lockswap/gitdir"
+rm -f "$test_tmp/lockswap-hit"
+cat >"$shim_dir/cat" <<SHIM
+#!/usr/bin/env bash
+if [[ "\${1:-}" == *"/worktrees/lockswap/gitdir" && ! -e "$test_tmp/lockswap-hit" ]]; then
+    touch "$test_tmp/lockswap-hit"
+    exit 1
+fi
+exec /bin/cat "\$@"
+SHIM
+chmod +x "$shim_dir/cat"
+
+if lockswap_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the lock key drifted: $lockswap_out"
+fi
+rm -f "$shim_dir/cat"
+expect_contains "$lockswap_out" "gitdir changed while the lock was being acquired" "lock-key drift: refused for a re-run"
+[ -d "$gitdir/worktrees/lockswap" ] || fail "lock-key drift: record swept under a missing or wrong lock"
+
+lockswap_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed on the stable re-run: $lockswap_ok_out"
+expect_contains "$lockswap_ok_out" "pruned record 'lockswap'" "lock-key drift: stable re-run prunes normally"
+echo "ok: a gitdir that changed across the lock refuses the sweep"
+
 # ── Case E7s: pin-enumeration failure never reports cleanup complete ───────
 # A broken ref backend is not an empty pin namespace; the empty-plan path
 # must fail closed instead of printing "nothing to prune" with exit 0.

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -648,7 +648,7 @@ echo "ok: an unsettled rescue pin refuses the prune instead of being overwritten
 # Sidecars and per-worktree ref files under worktrees/<id>/ are single-copy;
 # no pin can stand in for them.
 
-for rec in state-rec refs-rec op-rec cfg-rec; do
+for rec in state-rec refs-rec op-rec cfg-rec stash-rec; do
     mkdir -p "$gitdir/worktrees/$rec"
     printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/$rec/HEAD"
     printf '%s\n' "/nonexistent/$rec/.git" >"$gitdir/worktrees/$rec/gitdir"
@@ -663,6 +663,9 @@ printf '%s\n' "$refs_orph" >"$gitdir/worktrees/refs-rec/refs/worktree/only"
 git -C "$fixture" rev-parse main >"$gitdir/worktrees/op-rec/MERGE_HEAD"
 # User-set per-worktree configuration is single-copy exactly like a sidecar.
 printf '[review]\n\tunique = KEEP-ME\n' >"$gitdir/worktrees/cfg-rec/config.worktree"
+# An interrupted merge --autostash: the stash commit can be referenced by
+# this one file alone.
+git -C "$fixture" rev-parse main >"$gitdir/worktrees/stash-rec/MERGE_AUTOSTASH"
 
 if state_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
     fail "record prune exited zero with refused state-carrying records: $state_out"
@@ -671,18 +674,20 @@ expect_contains "$state_out" "record 'state-rec' — carries worktree-local stat
 expect_contains "$state_out" "record 'refs-rec' — carries worktree-local state (refs)" "state: per-worktree-ref record refused"
 expect_contains "$state_out" "record 'op-rec' — carries worktree-local state (MERGE_HEAD)" "state: in-progress-operation record refused"
 expect_contains "$state_out" "record 'cfg-rec' — carries worktree-local state (config.worktree)" "state: per-worktree-config record refused"
+expect_contains "$state_out" "record 'stash-rec' — carries worktree-local state (MERGE_AUTOSTASH)" "state: autostash record refused"
 [ -d "$gitdir/worktrees/state-rec" ] || fail "state: sidecar-carrying record was swept"
 [ -d "$gitdir/worktrees/refs-rec" ] || fail "state: ref-carrying record was swept"
 [ -d "$gitdir/worktrees/op-rec" ] || fail "state: op-state record was swept"
 git -C "$fixture" cat-file -e "$refs_orph" || fail "state: worktree-ref orphan commit lost"
 
-rm -rf "$gitdir/worktrees/state-rec/deferred-findings" "$gitdir/worktrees/refs-rec/refs" "$gitdir/worktrees/op-rec/MERGE_HEAD" "$gitdir/worktrees/cfg-rec/config.worktree"
+rm -rf "$gitdir/worktrees/state-rec/deferred-findings" "$gitdir/worktrees/refs-rec/refs" "$gitdir/worktrees/op-rec/MERGE_HEAD" "$gitdir/worktrees/cfg-rec/config.worktree" "$gitdir/worktrees/stash-rec/MERGE_AUTOSTASH"
 state_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
     fail "record prune failed after the state was adopted: $state_ok_out"
 expect_contains "$state_ok_out" "pruned record 'state-rec'" "state: adopted record prunes normally"
 expect_contains "$state_ok_out" "pruned record 'refs-rec'" "state: rescued record prunes normally"
 expect_contains "$state_ok_out" "pruned record 'op-rec'" "state: finished-operation record prunes normally"
 expect_contains "$state_ok_out" "pruned record 'cfg-rec'" "state: adopted-config record prunes normally"
+expect_contains "$state_ok_out" "pruned record 'stash-rec'" "state: recovered-autostash record prunes normally"
 echo "ok: state-carrying records are refused until adopted, never swept"
 
 # ── Case E7e: an index diverging from the recorded HEAD refuses the sweep ──
@@ -1014,6 +1019,8 @@ if fetch_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; 
     fail "record prune exited zero with an unreachable FETCH_HEAD entry present: $fetch_out"
 fi
 expect_contains "$fetch_out" "FETCH_HEAD names $orph_f" "fetch-head: url-fetched tip refused"
+short_f="$(printf '%.7s' "$orph_f")"
+expect_contains "$fetch_out" "rescue/fetchrec-fetch-$short_f" "fetch-head: rescue name is per-OID, successive rescues cannot collide"
 [ -d "$gitdir/worktrees/fetchrec" ] || fail "fetch-head: record swept despite its unreachable FETCH_HEAD"
 git -C "$fixture" cat-file -e "$orph_f" || fail "fetch-head: fetched tip lost"
 
@@ -1041,6 +1048,32 @@ fetch2_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" 
     fail "record prune failed after the truncated FETCH_HEAD was removed: $fetch2_ok_out"
 expect_contains "$fetch2_ok_out" "pruned record 'fetchrec2'" "fetch-head: cleared record prunes normally"
 echo "ok: an unterminated FETCH_HEAD entry is still validated"
+
+# ── Case E7t: an unreferenced annotated tag in FETCH_HEAD refuses the sweep ─
+# Peeling the fetched OID to its commit would let the tag object itself —
+# message and signature — vanish with the record; containment for a tag is
+# exact points-at, not ancestry.
+
+git -C "$fixture" tag -a -m "fetched annotated tag" tmp-fetched-tag main
+tagoid_t="$(git -C "$fixture" rev-parse tmp-fetched-tag)"
+git -C "$fixture" tag -d tmp-fetched-tag >/dev/null
+mkdir -p "$gitdir/worktrees/tagrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/tagrec/HEAD"
+printf '%s\n' "/nonexistent/tagrec/.git" >"$gitdir/worktrees/tagrec/gitdir"
+printf '%s\t\ttag fetched-tag of https://example.invalid/repo\n' "$tagoid_t" >"$gitdir/worktrees/tagrec/FETCH_HEAD"
+
+if tagrec_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unreferenced annotated tag in FETCH_HEAD: $tagrec_out"
+fi
+expect_contains "$tagrec_out" "annotated tag object $tagoid_t with no ref pointing at it" "fetch-tag: unreferenced tag object refused"
+[ -d "$gitdir/worktrees/tagrec" ] || fail "fetch-tag: record swept despite its unreferenced tag object"
+git -C "$fixture" cat-file -e "$tagoid_t" || fail "fetch-tag: tag object lost"
+
+git -C "$fixture" tag rescue-fetched-tag "$tagoid_t"
+tagrec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the tag object was rescued: $tagrec_ok_out"
+expect_contains "$tagrec_ok_out" "pruned record 'tagrec'" "fetch-tag: referenced tag object sweeps normally"
+echo "ok: an unreferenced annotated tag in FETCH_HEAD refuses the sweep until rescued"
 
 # ── Case E7s: pin-enumeration failure never reports cleanup complete ───────
 # A broken ref backend is not an empty pin namespace; the empty-plan path

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -638,7 +638,7 @@ if reuse_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)
 fi
 expect_contains "$reuse_ok_out" "pruned record 'pin-reuse'" "pin reuse: settled pin lets the removal proceed"
 expect_contains "$reuse_ok_out" "PINNED  refs/session-cleanup/pin/pin-reuse" "pin reuse: fresh pin reported for explicit settlement"
-expect_contains "$reuse_ok_out" "re-verify before dropping" "pin reuse: drop remedy demands execution-time re-verification, not a stale snapshot"
+expect_contains "$reuse_ok_out" "re-verify before dropping (GIT_GRAFT_FILE=/dev/null git --no-replace-objects" "pin reuse: the re-verification command itself disables grafts and replacements"
 [ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/pin-reuse)" = "$(git -C "$fixture" rev-parse main)" ] ||
     fail "pin reuse: fresh pin missing or wrong — pins must never be auto-dropped"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/pin-reuse
@@ -854,28 +854,38 @@ echo "ok: a pin dropped mid-run by a racing settlement is re-asserted"
 
 # ── Case E7k: a failed record removal is loud and never lock-labeled ───────
 # A partial rm is corrupt state needing inspection; reporting it as lock
-# contention hands the operator the wrong remedy.
+# contention hands the operator the wrong remedy. An rm shim forces the
+# failure deterministically — chmod tricks do not survive running as root
+# (containers commonly do).
 
-mkdir -p "$gitdir/worktrees/stuckrec/logs/blocker"
+mkdir -p "$gitdir/worktrees/stuckrec"
 printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/stuckrec/HEAD"
 printf '%s\n' "/nonexistent/stuckrec/.git" >"$gitdir/worktrees/stuckrec/gitdir"
-touch "$gitdir/worktrees/stuckrec/logs/blocker/held"
-chmod 000 "$gitdir/worktrees/stuckrec/logs/blocker"
+real_rm="$(command -v rm)"
+cat >"$shim_dir/rm" <<SHIM
+#!/usr/bin/env bash
+for a in "\$@"; do
+    if [[ "\$a" == *"/worktrees/stuckrec" ]]; then
+        echo "rm: simulated I/O failure" >&2
+        exit 1
+    fi
+done
+exec "$real_rm" "\$@"
+SHIM
+chmod +x "$shim_dir/rm"
 
-if stuck_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
-    chmod 755 "$gitdir/worktrees/stuckrec/logs/blocker" 2>/dev/null || true
+if stuck_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    rm -f "$shim_dir/rm"
     fail "record prune exited zero although removal failed: $stuck_out"
 fi
-chmod 755 "$gitdir/worktrees/stuckrec/logs/blocker" 2>/dev/null || true
+rm -f "$shim_dir/rm"
 expect_contains "$stuck_out" "removal failed midway" "rm failure: reported as its own outcome"
 expect_not_contains "$stuck_out" "lifecycle lock refused" "rm failure: never mislabeled as lock contention"
+[ -d "$gitdir/worktrees/stuckrec" ] || fail "rm failure: record vanished although rm was refused"
 
-# The partial rm may have taken HEAD/gitdir (deletion order is undefined);
-# restore them so the recovery run exercises a validatable record.
-printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/stuckrec/HEAD"
-printf '%s\n' "/nonexistent/stuckrec/.git" >"$gitdir/worktrees/stuckrec/gitdir"
 stuck_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
     fail "record prune failed after the blocker was cleared: $stuck_ok_out"
+expect_contains "$stuck_ok_out" "pruned record 'stuckrec'" "rm failure: unshimmed re-run prunes normally"
 echo "ok: a failed record removal is loud and never lock-labeled"
 
 # ── Case E7m: an unreachable ORIG_HEAD refuses the sweep ───────────────────
@@ -1143,6 +1153,21 @@ rm -rf "$test_tmp/live-dir"
 livedir_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
     fail "record prune failed after the directory was moved aside: $livedir_ok_out"
 expect_contains "$livedir_ok_out" "pruned record 'livedir-rec'" "live-dir: cleared record prunes normally"
+
+# A gitdir value without the /.git suffix is malformed AND would skip the
+# surviving-directory guard above — it must refuse outright.
+mkdir -p "$gitdir/worktrees/badsuffix-rec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/badsuffix-rec/HEAD"
+printf '%s\n' "/nonexistent/badsuffix-rec/.gi" >"$gitdir/worktrees/badsuffix-rec/gitdir"
+if badsuffix_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with a malformed gitdir suffix present: $badsuffix_out"
+fi
+expect_contains "$badsuffix_out" "gitdir value does not end in /.git" "bad-suffix: malformed gitdir refused"
+[ -d "$gitdir/worktrees/badsuffix-rec" ] || fail "bad-suffix: record swept despite its malformed gitdir"
+printf '%s\n' "/nonexistent/badsuffix-rec/.git" >"$gitdir/worktrees/badsuffix-rec/gitdir"
+badsuffix_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the gitdir was repaired: $badsuffix_ok_out"
+expect_contains "$badsuffix_ok_out" "pruned record 'badsuffix-rec'" "bad-suffix: repaired record prunes normally"
 echo "ok: an unreadable gitdir or a surviving tree directory refuses the sweep"
 
 # ── Case E7w: resolve-undo state in a stage-0-clean index refuses ──────────
@@ -1245,6 +1270,17 @@ expect_contains "$typerec_out" "entry 'ORIG_HEAD' is not the regular file git wr
 [ -d "$gitdir/worktrees/typerec" ] || fail "type gate: record swept despite malformed state"
 
 rm -rf "$gitdir/worktrees/typerec/ORIG_HEAD"
+
+# info as a regular FILE matches no child glob and would otherwise be
+# accepted uninspected — the same gate, one level up.
+echo "not-a-directory" >"$gitdir/worktrees/typerec/info"
+if typeinfo_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with a non-directory info entry present: $typeinfo_out"
+fi
+expect_contains "$typeinfo_out" "entry 'info' is not the directory git writes there" "type gate: non-directory info refused"
+[ -d "$gitdir/worktrees/typerec" ] || fail "type gate: record swept despite a non-directory info entry"
+rm -f "$gitdir/worktrees/typerec/info"
+
 typerec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
     fail "record prune failed after the malformed entry was cleared: $typerec_ok_out"
 expect_contains "$typerec_ok_out" "pruned record 'typerec'" "type gate: well-formed record prunes normally"

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -537,6 +537,212 @@ expect_contains "$cfg_out" "WARN  sq-cfg was deleted but its branch.sq-cfg" "con
 git -C "$fixture" config --local --remove-section branch.sq-cfg 2>/dev/null || true
 echo "ok: config cleanup failure is reported, never swallowed"
 
+# ── Case E7: worktree-record pruning pins detached commits through the prune ─
+# A stale record whose HEAD is detached at a commit no shared ref contains is
+# the only thing keeping that commit alive (challenge r3); the guard is a pin
+# created BEFORE the prune, so no interleaving can strand the commit
+# (challenge r4). Branch-attached stale records prune normally; a live
+# detached worktree's pin is dropped as redundant.
+
+cp "$repo/scripts/clean-worktree-records.sh" "$fixture/scripts/"
+
+git -C "$fixture" worktree add -q -b prune-br "$test_tmp/wt-br" main
+git -C "$fixture" worktree add -q --detach "$test_tmp/wt-det" main
+git -C "$fixture" worktree add -q --detach "$test_tmp/wt-live" main
+(
+    cd "$test_tmp/wt-det"
+    echo det >det.txt
+    git add det.txt
+    git commit -qm "detached-only work"
+)
+det_sha="$(git -C "$test_tmp/wt-det" rev-parse HEAD)"
+rm -rf "$test_tmp/wt-br" "$test_tmp/wt-det"
+
+if prune_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although an orphan pin should have been kept: $prune_out"
+fi
+expect_contains "$prune_out" "KEPT  refs/session-cleanup/pin/wt-det" "record prune: orphan commit's pin kept and reported"
+worktrees_admin="$(git -C "$fixture" rev-parse --path-format=absolute --git-common-dir)/worktrees"
+if ls "$worktrees_admin" 2>/dev/null | grep -Eq '^(wt-det|wt-br)$'; then
+    fail "record prune: stale records survived the prune"
+fi
+[ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/wt-det)" = "$det_sha" ] ||
+    fail "record prune: pin does not hold the detached commit"
+git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/wt-live >/dev/null &&
+    fail "record prune: redundant pin for a live worktree was kept"
+if git -C "$fixture" fsck --unreachable 2>/dev/null | grep -q "$det_sha"; then
+    fail "record prune: detached commit became unreachable despite the pin"
+fi
+echo "ok: record prune pins an orphan detached commit through the prune"
+
+# The audit surfaces a lingering pin as a decision waiting to be made.
+pin_audit_out="$(cd "$fixture" && bash scripts/audit-session-artifacts.sh 2>&1)" ||
+    fail "audit exited nonzero with a pin present: $pin_audit_out"
+expect_contains "$pin_audit_out" "wt-det — pins $det_sha" "audit: leftover rescue pin reported"
+echo "ok: audit reports leftover rescue pins"
+
+git -C "$fixture" branch -q rescue-det "$det_sha"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/wt-det
+prune_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the pin was settled: $prune_ok_out"
+expect_contains "$prune_ok_out" "nothing to prune" "record prune: live worktrees leave nothing plan-scoped to remove"
+git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/wt-live >/dev/null &&
+    fail "record prune: live-worktree pin left behind on the clean run"
+git -C "$fixture" cat-file -e "$det_sha" || fail "record prune: rescued commit lost from the object db"
+echo "ok: record prune settles cleanly once every commit is referenced"
+
+# ── Case E7c: an unsettled pin from an earlier run is never overwritten ────
+# A record name reused after a kept pin would silently replace the sole
+# reference to the older commit; the create-only pin write must refuse.
+
+orph_sha="$(git -C "$fixture" commit-tree "main^{tree}" -p main -m "old orphan")"
+git -C "$fixture" update-ref refs/session-cleanup/pin/pin-reuse "$orph_sha"
+mkdir -p "$gitdir/worktrees/pin-reuse"
+git -C "$fixture" rev-parse main >"$gitdir/worktrees/pin-reuse/HEAD"
+printf '%s\n' "/nonexistent/pin-reuse/.git" >"$gitdir/worktrees/pin-reuse/gitdir"
+
+if reuse_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune proceeded over a foreign unsettled pin: $reuse_out"
+fi
+expect_contains "$reuse_out" "already pins $orph_sha" "pin reuse: refusal names the earlier pin"
+[ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/pin-reuse)" = "$orph_sha" ] ||
+    fail "pin reuse: the earlier pin was overwritten"
+[ -d "$gitdir/worktrees/pin-reuse" ] || fail "pin reuse: the record was removed despite the refusal"
+
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/pin-reuse "$orph_sha"
+if reuse_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although its fresh pin awaits settlement: $reuse_ok_out"
+fi
+expect_contains "$reuse_ok_out" "pruned record 'pin-reuse'" "pin reuse: settled pin lets the removal proceed"
+expect_contains "$reuse_ok_out" "PINNED  refs/session-cleanup/pin/pin-reuse" "pin reuse: fresh pin reported for explicit settlement"
+[ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/pin-reuse)" = "$(git -C "$fixture" rev-parse main)" ] ||
+    fail "pin reuse: fresh pin missing or wrong — pins must never be auto-dropped"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/pin-reuse
+echo "ok: an unsettled rescue pin refuses the prune instead of being overwritten"
+
+# ── Case E7d: a record carrying worktree-local state is refused, not swept ─
+# Sidecars and per-worktree ref files under worktrees/<id>/ are single-copy;
+# no pin can stand in for them.
+
+for rec in state-rec refs-rec; do
+    mkdir -p "$gitdir/worktrees/$rec"
+    printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/$rec/HEAD"
+    printf '%s\n' "/nonexistent/$rec/.git" >"$gitdir/worktrees/$rec/gitdir"
+done
+mkdir -p "$gitdir/worktrees/state-rec/deferred-findings"
+echo "p2 from a dead session" >"$gitdir/worktrees/state-rec/deferred-findings/some-branch"
+mkdir -p "$gitdir/worktrees/refs-rec/refs/worktree"
+refs_orph="$(git -C "$fixture" commit-tree "main^{tree}" -p main -m "worktree-ref orphan")"
+printf '%s\n' "$refs_orph" >"$gitdir/worktrees/refs-rec/refs/worktree/only"
+
+if state_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with refused state-carrying records: $state_out"
+fi
+expect_contains "$state_out" "record 'state-rec' — carries worktree-local state (deferred-findings)" "state: sidecar-carrying record refused"
+expect_contains "$state_out" "record 'refs-rec' — carries worktree-local state (refs)" "state: per-worktree-ref record refused"
+[ -d "$gitdir/worktrees/state-rec" ] || fail "state: sidecar-carrying record was swept"
+[ -d "$gitdir/worktrees/refs-rec" ] || fail "state: ref-carrying record was swept"
+git -C "$fixture" cat-file -e "$refs_orph" || fail "state: worktree-ref orphan commit lost"
+
+rm -rf "$gitdir/worktrees/state-rec/deferred-findings" "$gitdir/worktrees/refs-rec/refs"
+state_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the state was adopted: $state_ok_out"
+expect_contains "$state_ok_out" "pruned record 'state-rec'" "state: adopted record prunes normally"
+expect_contains "$state_ok_out" "pruned record 'refs-rec'" "state: rescued record prunes normally"
+echo "ok: state-carrying records are refused until adopted, never swept"
+
+# ── Case E7e: an index diverging from the recorded HEAD refuses the sweep ──
+# Staged-but-uncommitted blobs can be referenced by the record's index
+# alone; sweeping the record hands them to the next gc.
+
+git -C "$fixture" worktree add -q --detach "$test_tmp/wt-staged" main
+(
+    cd "$test_tmp/wt-staged"
+    echo staged-only >staged.txt
+    git add staged.txt
+)
+rm -rf "$test_tmp/wt-staged"
+
+if staged_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with a staged-divergent index present: $staged_out"
+fi
+expect_contains "$staged_out" "record 'wt-staged' — its index diverges from the recorded HEAD" "staged: divergent index refused"
+[ -d "$gitdir/worktrees/wt-staged" ] || fail "staged: index-carrying record was swept"
+
+rm -f "$gitdir/worktrees/wt-staged/index"
+if staged_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the detached record's pin awaits settlement: $staged_ok_out"
+fi
+expect_contains "$staged_ok_out" "pruned record 'wt-staged'" "staged: adopted record prunes normally"
+expect_contains "$staged_ok_out" "PINNED  refs/session-cleanup/pin/wt-staged" "staged: detached head pinned for explicit settlement"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/wt-staged
+echo "ok: a staged-divergent index refuses the sweep until adopted"
+
+# ── Case E7f: record removal honors the worktree lifecycle lock ────────────
+# A record for a tree under .worktrees/ takes the same per-path lock that
+# worktree:new/rm hold, so removal cannot race a blessed re-creation.
+
+mkdir -p "$gitdir/worktrees/lockrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/lockrec/HEAD"
+printf '%s\n' "$fixture/.worktrees/lockrec/.git" >"$gitdir/worktrees/lockrec/gitdir"
+commondir_l="$(git -C "$fixture" rev-parse --path-format=absolute --git-common-dir)"
+mkdir -p "$commondir_l/worktree-locks/lockrec+lock"
+
+if lockrec_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the lifecycle lock was held: $lockrec_out"
+fi
+expect_contains "$lockrec_out" "worktree lifecycle lock refused" "record lock: contended record skipped loudly"
+[ -d "$gitdir/worktrees/lockrec" ] || fail "record lock: record removed although its lifecycle lock was held"
+
+rmdir "$commondir_l/worktree-locks/lockrec+lock"
+lockrec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the lock was released: $lockrec_ok_out"
+expect_contains "$lockrec_ok_out" "pruned record 'lockrec'" "record lock: released lock lets the removal proceed"
+echo "ok: record removal is serialized by the worktree lifecycle lock"
+
+# ── Case E7g: a replacement ref cannot forge the pin-drop remedy ───────────
+# The kept-pin report picks its wording from raw history: a refs/replace
+# graft that makes an orphan read as reachable from shared refs would
+# otherwise print a copyable "drop it" command for the only real reference.
+
+orph_g="$(git -C "$fixture" commit-tree "main^{tree}" -m "orphan-behind-replace")"
+mkdir -p "$gitdir/worktrees/reptrap"
+printf '%s\n' "$orph_g" >"$gitdir/worktrees/reptrap/HEAD"
+printf '%s\n' "$test_tmp/gone-reptrap/.git" >"$gitdir/worktrees/reptrap/gitdir"
+repg_main="$(git -C "$fixture" rev-parse refs/heads/main)"
+repg_synth="$(git -C "$fixture" commit-tree "main^{tree}" -p "$repg_main" -p "$orph_g" -m "graft")"
+git -C "$fixture" update-ref "refs/replace/$repg_main" "$repg_synth"
+
+if repg_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although a forged-reachability pin should await settlement: $repg_out"
+fi
+git -C "$fixture" update-ref -d "refs/replace/$repg_main"
+expect_contains "$repg_out" "KEPT  refs/session-cleanup/pin/reptrap" "replace ref: pin reported as the only reference"
+expect_not_contains "$repg_out" "also reachable from shared refs" "replace ref: forged containment does not invite dropping the pin"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/reptrap
+echo "ok: a replacement ref cannot forge the pin-drop remedy"
+
+# ── Case E7h: a legacy graft file forces the conservative pin wording ──────
+# info/grafts rewrites parentage and GIT_NO_REPLACE_OBJECTS does not cover
+# it; while one exists, containment is not evidence and every kept pin gets
+# the conservative wording.
+
+orph_h="$(git -C "$fixture" commit-tree "main^{tree}" -m "orphan-behind-graft")"
+mkdir -p "$gitdir/worktrees/grafttrap"
+printf '%s\n' "$orph_h" >"$gitdir/worktrees/grafttrap/HEAD"
+printf '%s\n' "$test_tmp/gone-grafttrap/.git" >"$gitdir/worktrees/grafttrap/gitdir"
+printf '%s %s\n' "$(git -C "$fixture" rev-parse refs/heads/main)" "$orph_h" >"$gitdir/info/grafts"
+
+if graftrec_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although a grafted-reachability pin should await settlement: $graftrec_out"
+fi
+rm -f "$gitdir/info/grafts"
+expect_contains "$graftrec_out" "legacy graft file present" "grafts: presence announced by the record prune"
+expect_contains "$graftrec_out" "KEPT  refs/session-cleanup/pin/grafttrap" "grafts: pin reported conservatively"
+expect_not_contains "$graftrec_out" "also reachable from shared refs" "grafts: grafted containment does not invite dropping the pin"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/grafttrap
+echo "ok: a legacy graft file forces the conservative pin wording"
+
 # ── Case E8: a renamed remote default refuses every deletion ───────────────
 # The local origin/HEAD still names the old default; the live remote HEAD
 # must be verified before any evidence computed against the old name is

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -648,7 +648,7 @@ echo "ok: an unsettled rescue pin refuses the prune instead of being overwritten
 # Sidecars and per-worktree ref files under worktrees/<id>/ are single-copy;
 # no pin can stand in for them.
 
-for rec in state-rec refs-rec op-rec; do
+for rec in state-rec refs-rec op-rec cfg-rec; do
     mkdir -p "$gitdir/worktrees/$rec"
     printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/$rec/HEAD"
     printf '%s\n' "/nonexistent/$rec/.git" >"$gitdir/worktrees/$rec/gitdir"
@@ -661,6 +661,8 @@ printf '%s\n' "$refs_orph" >"$gitdir/worktrees/refs-rec/refs/worktree/only"
 # A merge parked at an edit: MERGE_HEAD is sequencer state the record alone
 # holds (the worktree-rm.sh op-state list).
 git -C "$fixture" rev-parse main >"$gitdir/worktrees/op-rec/MERGE_HEAD"
+# User-set per-worktree configuration is single-copy exactly like a sidecar.
+printf '[review]\n\tunique = KEEP-ME\n' >"$gitdir/worktrees/cfg-rec/config.worktree"
 
 if state_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
     fail "record prune exited zero with refused state-carrying records: $state_out"
@@ -668,17 +670,19 @@ fi
 expect_contains "$state_out" "record 'state-rec' — carries worktree-local state (deferred-findings)" "state: sidecar-carrying record refused"
 expect_contains "$state_out" "record 'refs-rec' — carries worktree-local state (refs)" "state: per-worktree-ref record refused"
 expect_contains "$state_out" "record 'op-rec' — carries worktree-local state (MERGE_HEAD)" "state: in-progress-operation record refused"
+expect_contains "$state_out" "record 'cfg-rec' — carries worktree-local state (config.worktree)" "state: per-worktree-config record refused"
 [ -d "$gitdir/worktrees/state-rec" ] || fail "state: sidecar-carrying record was swept"
 [ -d "$gitdir/worktrees/refs-rec" ] || fail "state: ref-carrying record was swept"
 [ -d "$gitdir/worktrees/op-rec" ] || fail "state: op-state record was swept"
 git -C "$fixture" cat-file -e "$refs_orph" || fail "state: worktree-ref orphan commit lost"
 
-rm -rf "$gitdir/worktrees/state-rec/deferred-findings" "$gitdir/worktrees/refs-rec/refs" "$gitdir/worktrees/op-rec/MERGE_HEAD"
+rm -rf "$gitdir/worktrees/state-rec/deferred-findings" "$gitdir/worktrees/refs-rec/refs" "$gitdir/worktrees/op-rec/MERGE_HEAD" "$gitdir/worktrees/cfg-rec/config.worktree"
 state_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
     fail "record prune failed after the state was adopted: $state_ok_out"
 expect_contains "$state_ok_out" "pruned record 'state-rec'" "state: adopted record prunes normally"
 expect_contains "$state_ok_out" "pruned record 'refs-rec'" "state: rescued record prunes normally"
 expect_contains "$state_ok_out" "pruned record 'op-rec'" "state: finished-operation record prunes normally"
+expect_contains "$state_ok_out" "pruned record 'cfg-rec'" "state: adopted-config record prunes normally"
 echo "ok: state-carrying records are refused until adopted, never swept"
 
 # ── Case E7e: an index diverging from the recorded HEAD refuses the sweep ──
@@ -697,6 +701,7 @@ if staged_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)";
     fail "record prune exited zero with a staged-divergent index present: $staged_out"
 fi
 expect_contains "$staged_out" "record 'wt-staged' — its index diverges from the recorded HEAD" "staged: divergent index refused"
+expect_contains "$staged_out" "GIT_INDEX_FILE='" "staged: recovery command shell-quotes the index path"
 [ -d "$gitdir/worktrees/wt-staged" ] || fail "staged: index-carrying record was swept"
 
 rm -f "$gitdir/worktrees/wt-staged/index"
@@ -1017,6 +1022,25 @@ fetch_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" |
     fail "record prune failed after the FETCH_HEAD commit was rescued: $fetch_ok_out"
 expect_contains "$fetch_ok_out" "pruned record 'fetchrec'" "fetch-head: reachable FETCH_HEAD sweeps normally"
 echo "ok: an unreachable FETCH_HEAD entry refuses the sweep until rescued"
+
+# A truncated write can leave the final FETCH_HEAD record unterminated; the
+# guard must validate that entry too, not skip it with the read loop.
+orph_f2="$(git -C "$fixture" commit-tree "main^{tree}" -m "truncated-fetch-tip")"
+mkdir -p "$gitdir/worktrees/fetchrec2"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/fetchrec2/HEAD"
+printf '%s\n' "/nonexistent/fetchrec2/.git" >"$gitdir/worktrees/fetchrec2/gitdir"
+printf '%s\t\tbranch other of https://example.invalid/repo' "$orph_f2" >"$gitdir/worktrees/fetchrec2/FETCH_HEAD"
+
+if fetch2_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unterminated FETCH_HEAD entry present: $fetch2_out"
+fi
+expect_contains "$fetch2_out" "FETCH_HEAD names $orph_f2" "fetch-head: unterminated final entry still validated"
+[ -d "$gitdir/worktrees/fetchrec2" ] || fail "fetch-head: record swept despite its unterminated FETCH_HEAD entry"
+rm -f "$gitdir/worktrees/fetchrec2/FETCH_HEAD"
+fetch2_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the truncated FETCH_HEAD was removed: $fetch2_ok_out"
+expect_contains "$fetch2_ok_out" "pruned record 'fetchrec2'" "fetch-head: cleared record prunes normally"
+echo "ok: an unterminated FETCH_HEAD entry is still validated"
 
 # ── Case E7s: pin-enumeration failure never reports cleanup complete ───────
 # A broken ref backend is not an empty pin namespace; the empty-plan path

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -1263,7 +1263,8 @@ cat >"$shim_dir/cat" <<SHIM
 #!/usr/bin/env bash
 if [[ "\${1:-}" == *"/worktrees/lockswap/gitdir" && ! -e "$test_tmp/lockswap-hit" ]]; then
     touch "$test_tmp/lockswap-hit"
-    exit 1
+    echo "$fixture/.worktrees/other-tree/.git"
+    exit 0
 fi
 exec /bin/cat "\$@"
 SHIM
@@ -1303,6 +1304,46 @@ expect_contains "$enum_out" "cannot enumerate rescue pins" "pin enumeration: fai
 expect_not_contains "$enum_out" "nothing to prune." "pin enumeration: no false cleanup-complete report"
 rm -f "$shim_dir/git"
 echo "ok: pin-enumeration failure never reports cleanup complete"
+
+# A failed dry run surfaces git's own diagnostic, never a bare set -e death.
+cat >"$shim_dir/git" <<SHIM
+#!/usr/bin/env bash
+if [[ "\$*" == *"worktree prune --dry-run"* ]]; then
+    echo "fatal: simulated metadata corruption" >&2
+    exit 128
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$shim_dir/git"
+if planfail_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the dry-run failed: $planfail_out"
+fi
+expect_contains "$planfail_out" "worktree prune --dry-run failed" "plan failure: named as the failing step"
+expect_contains "$planfail_out" "simulated metadata corruption" "plan failure: git's own diagnostic preserved"
+rm -f "$shim_dir/git"
+echo "ok: a failed dry run surfaces its diagnostic"
+
+# A failed FULL pin enumeration must not print an unreliable settlement
+# total beside the summary.
+git -C "$fixture" update-ref refs/session-cleanup/pin/stale-old "$(git -C "$fixture" rev-parse main)"
+mkdir -p "$gitdir/worktrees/enumrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/enumrec/HEAD"
+printf '%s\n' "/nonexistent/enumrec/.git" >"$gitdir/worktrees/enumrec/gitdir"
+cat >"$shim_dir/git" <<SHIM
+#!/usr/bin/env bash
+if [[ "\$*" == *"for-each-ref refs/session-cleanup/pin"* && "\$*" != *"--count=1"* ]]; then
+    exit 1
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$shim_dir/git"
+if totalfail_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the total-pin enumeration failed: $totalfail_out"
+fi
+expect_contains "$totalfail_out" "refusing to report an unreliable settlement count" "total enumeration: failure refused, no fabricated count"
+rm -f "$shim_dir/git"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/stale-old
+echo "ok: a failed total-pin enumeration never fabricates a count"
 
 # ── Case E8: a renamed remote default refuses every deletion ───────────────
 # The local origin/HEAD still names the old default; the live remote HEAD

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -952,6 +952,10 @@ expect_not_contains "$retarg_out" "KEPT  refs/session-cleanup/pin/retarg" "pin r
 [ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/retarg)" = "$ret_main" ] ||
     fail "pin retarget: the foreign write was overwritten — settlement is human-only"
 git -C "$fixture" cat-file -e "$ret_orph" || fail "pin retarget: orphan commit lost from the object db"
+short_r="$(printf '%.7s' "$ret_orph")"
+[ "$(git -C "$fixture" rev-parse --quiet --verify "refs/session-cleanup/pin/retarg-rescue-$short_r")" = "$ret_orph" ] ||
+    fail "pin retarget: no rescue ref re-protects the orphan whose record is already gone"
+git -C "$fixture" update-ref -d "refs/session-cleanup/pin/retarg-rescue-$short_r"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/retarg
 echo "ok: a pin retargeted mid-run fails closed, never reported kept"
 
@@ -1224,6 +1228,27 @@ symrec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" 
     fail "record prune failed after the symlinks were cleared: $symrec_ok_out"
 expect_contains "$symrec_ok_out" "pruned record 'symrec'" "symlink: cleared record prunes normally"
 echo "ok: symlinked state paths are carried state and broken links are judged"
+
+# ── Case E7y: an allowlisted name of the wrong type refuses the sweep ──────
+# ORIG_HEAD as a DIRECTORY skips its -f validator yet a basename-only
+# allowlist would still admit it and rm -rf its contents.
+
+mkdir -p "$gitdir/worktrees/typerec/ORIG_HEAD"
+echo "trapped" >"$gitdir/worktrees/typerec/ORIG_HEAD/contents"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/typerec/HEAD"
+printf '%s\n' "/nonexistent/typerec/.git" >"$gitdir/worktrees/typerec/gitdir"
+
+if typerec_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with a mistyped allowlisted entry present: $typerec_out"
+fi
+expect_contains "$typerec_out" "entry 'ORIG_HEAD' is not the regular file git writes there" "type gate: mistyped entry refused"
+[ -d "$gitdir/worktrees/typerec" ] || fail "type gate: record swept despite malformed state"
+
+rm -rf "$gitdir/worktrees/typerec/ORIG_HEAD"
+typerec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the malformed entry was cleared: $typerec_ok_out"
+expect_contains "$typerec_ok_out" "pruned record 'typerec'" "type gate: well-formed record prunes normally"
+echo "ok: an allowlisted name of the wrong type refuses the sweep"
 
 # ── Case E7s: pin-enumeration failure never reports cleanup complete ───────
 # A broken ref backend is not an empty pin namespace; the empty-plan path

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -590,6 +590,19 @@ fi
 expect_contains "$pin_retry_out" "rescue pins await settlement" "retry: pending pin keeps the run nonzero"
 echo "ok: a pending rescue pin keeps retries nonzero"
 
+# A pruning run made while an earlier pin is outstanding reports the TOTAL
+# awaiting settlement, not just this run's — "0 pins" beside a nonzero exit
+# would contradict the disposition.
+mkdir -p "$gitdir/worktrees/plainrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/plainrec/HEAD"
+printf '%s\n' "/nonexistent/plainrec/.git" >"$gitdir/worktrees/plainrec/gitdir"
+if inherit_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero while an inherited pin awaited settlement: $inherit_out"
+fi
+expect_contains "$inherit_out" "pruned record 'plainrec'" "retry-summary: unrelated record still prunes"
+expect_contains "$inherit_out" "1 total awaiting settlement" "retry-summary: inherited pin counted in the total"
+echo "ok: inherited pins are counted in the settlement total"
+
 git -C "$fixture" branch -q rescue-det "$det_sha"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/wt-det
 prune_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
@@ -980,6 +993,53 @@ scanfail_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)
     fail "record prune failed after the scan blocker was cleared: $scanfail_ok_out"
 expect_contains "$scanfail_ok_out" "pruned record 'scanfail'" "scan failure: adopted record prunes normally"
 echo "ok: a failed state scan refuses the record, never sweeps it"
+
+# ── Case E7r: an unreachable FETCH_HEAD entry refuses the sweep ────────────
+# A URL fetch of an unbranched tip (a PR head) can leave FETCH_HEAD as the
+# only mapping to that commit; ordinary fetches list tips the tracking refs
+# contain and sweep normally.
+
+orph_f="$(git -C "$fixture" commit-tree "main^{tree}" -m "url-fetched-tip")"
+mkdir -p "$gitdir/worktrees/fetchrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/fetchrec/HEAD"
+printf '%s\n' "/nonexistent/fetchrec/.git" >"$gitdir/worktrees/fetchrec/gitdir"
+printf '%s\t\tbranch pr-head of https://example.invalid/repo\n' "$orph_f" >"$gitdir/worktrees/fetchrec/FETCH_HEAD"
+
+if fetch_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unreachable FETCH_HEAD entry present: $fetch_out"
+fi
+expect_contains "$fetch_out" "FETCH_HEAD names $orph_f" "fetch-head: url-fetched tip refused"
+[ -d "$gitdir/worktrees/fetchrec" ] || fail "fetch-head: record swept despite its unreachable FETCH_HEAD"
+git -C "$fixture" cat-file -e "$orph_f" || fail "fetch-head: fetched tip lost"
+
+git -C "$fixture" branch -q rescue-fetch "$orph_f"
+fetch_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the FETCH_HEAD commit was rescued: $fetch_ok_out"
+expect_contains "$fetch_ok_out" "pruned record 'fetchrec'" "fetch-head: reachable FETCH_HEAD sweeps normally"
+echo "ok: an unreachable FETCH_HEAD entry refuses the sweep until rescued"
+
+# ── Case E7s: pin-enumeration failure never reports cleanup complete ───────
+# A broken ref backend is not an empty pin namespace; the empty-plan path
+# must fail closed instead of printing "nothing to prune" with exit 0.
+
+rm -f "$shim_dir/find"
+cat >"$shim_dir/git" <<SHIM
+#!/usr/bin/env bash
+if [[ "\$*" == *"--count=1 refs/session-cleanup/pin"* ]]; then
+    echo "fatal: simulated ref backend failure" >&2
+    exit 1
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$shim_dir/git"
+
+if enum_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although pin enumeration failed: $enum_out"
+fi
+expect_contains "$enum_out" "cannot enumerate rescue pins" "pin enumeration: failure refuses to report completion"
+expect_not_contains "$enum_out" "nothing to prune." "pin enumeration: no false cleanup-complete report"
+rm -f "$shim_dir/git"
+echo "ok: pin-enumeration failure never reports cleanup complete"
 
 # ── Case E8: a renamed remote default refuses every deletion ───────────────
 # The local origin/HEAD still names the old default; the live remote HEAD

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -562,6 +562,7 @@ if prune_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; 
     fail "record prune exited zero although an orphan pin should have been kept: $prune_out"
 fi
 expect_contains "$prune_out" "KEPT  refs/session-cleanup/pin/wt-det" "record prune: orphan commit's pin kept and reported"
+expect_contains "$prune_out" "git update-ref -d 'refs/session-cleanup/pin/wt-det' $det_sha" "record prune: drop remedy is compare-and-delete, immune to record-name reuse"
 worktrees_admin="$(git -C "$fixture" rev-parse --path-format=absolute --git-common-dir)/worktrees"
 if ls "$worktrees_admin" 2>/dev/null | grep -Eq '^(wt-det|wt-br)$'; then
     fail "record prune: stale records survived the prune"
@@ -613,6 +614,7 @@ if reuse_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; 
     fail "record prune proceeded over a foreign unsettled pin: $reuse_out"
 fi
 expect_contains "$reuse_out" "already pins $orph_sha" "pin reuse: refusal names the earlier pin"
+expect_contains "$reuse_out" "git update-ref -d 'refs/session-cleanup/pin/pin-reuse' $orph_sha" "pin reuse: refusal drop remedy is compare-and-delete"
 [ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/pin-reuse)" = "$orph_sha" ] ||
     fail "pin reuse: the earlier pin was overwritten"
 [ -d "$gitdir/worktrees/pin-reuse" ] || fail "pin reuse: the record was removed despite the refusal"
@@ -929,6 +931,55 @@ expect_not_contains "$retarg_out" "KEPT  refs/session-cleanup/pin/retarg" "pin r
 git -C "$fixture" cat-file -e "$ret_orph" || fail "pin retarget: orphan commit lost from the object db"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/retarg
 echo "ok: a pin retargeted mid-run fails closed, never reported kept"
+
+# ── Case E7p: an unresolvable detached HEAD refuses the sweep ──────────────
+# A truncated HEAD, a missing object, or a promisor-held commit cannot be
+# pinned; falling through to rm -rf would destroy the only recovery
+# breadcrumb.
+
+mkdir -p "$gitdir/worktrees/badheadrec"
+printf '%s\n' "0123456789abcdef0123456789abcdef01234567" >"$gitdir/worktrees/badheadrec/HEAD"
+printf '%s\n' "/nonexistent/badheadrec/.git" >"$gitdir/worktrees/badheadrec/gitdir"
+
+if badhead_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unresolvable detached HEAD present: $badhead_out"
+fi
+expect_contains "$badhead_out" "does not resolve to a commit" "unresolvable: refusal names the failure"
+[ -d "$gitdir/worktrees/badheadrec" ] || fail "unresolvable: record swept despite an unresolvable HEAD"
+
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/badheadrec/HEAD"
+badhead_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the HEAD was repaired: $badhead_ok_out"
+expect_contains "$badhead_ok_out" "pruned record 'badheadrec'" "unresolvable: repaired record prunes normally"
+echo "ok: an unresolvable detached HEAD refuses the sweep"
+
+# ── Case E7q: a failed state scan refuses the record, never sweeps it ──────
+# An errored find is not an empty find: treating scan failure as "no state"
+# would sweep exactly the record that could not be inspected.
+
+mkdir -p "$gitdir/worktrees/scanfail/deferred-findings"
+echo "p2 note" >"$gitdir/worktrees/scanfail/deferred-findings/some-branch"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/scanfail/HEAD"
+printf '%s\n' "/nonexistent/scanfail/.git" >"$gitdir/worktrees/scanfail/gitdir"
+rm -f "$shim_dir/git"
+cat >"$shim_dir/find" <<'SHIM'
+#!/usr/bin/env bash
+exit 1
+SHIM
+chmod +x "$shim_dir/find"
+
+if scanfail_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the state scan failed: $scanfail_out"
+fi
+expect_contains "$scanfail_out" "cannot scan deferred-findings" "scan failure: refused fail-closed"
+[ -d "$gitdir/worktrees/scanfail" ] || fail "scan failure: uninspectable record was swept"
+
+rm -f "$shim_dir/find"
+rm -rf "$gitdir/worktrees/scanfail/deferred-findings"
+scanfail_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the scan blocker was cleared: $scanfail_ok_out"
+expect_contains "$scanfail_ok_out" "pruned record 'scanfail'" "scan failure: adopted record prunes normally"
+echo "ok: a failed state scan refuses the record, never sweeps it"
 
 # ── Case E8: a renamed remote default refuses every deletion ───────────────
 # The local origin/HEAD still names the old default; the live remote HEAD

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -1106,6 +1106,125 @@ odd_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
 expect_contains "$odd_ok_out" "pruned record 'oddrec'" "unknown entry: understood record prunes normally"
 echo "ok: an unrecognized admin-dir entry refuses the sweep"
 
+# ── Case E7v: an unreadable gitdir or a surviving tree directory refuses ───
+# An unreadable gitdir target is not an absent worktree; and a worktree
+# DIRECTORY that outlives its .git link still holds the user's files —
+# sweeping the record would orphan them as a plain untracked directory.
+
+mkdir -p "$gitdir/worktrees/nogit-rec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/nogit-rec/HEAD"
+
+if nogit_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unreadable gitdir present: $nogit_out"
+fi
+expect_contains "$nogit_out" "cannot read its gitdir file" "no-gitdir: unvalidatable record refused"
+[ -d "$gitdir/worktrees/nogit-rec" ] || fail "no-gitdir: record swept despite its unreadable gitdir"
+printf '%s\n' "/nonexistent/nogit-rec/.git" >"$gitdir/worktrees/nogit-rec/gitdir"
+nogit_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the gitdir was restored: $nogit_ok_out"
+expect_contains "$nogit_ok_out" "pruned record 'nogit-rec'" "no-gitdir: restored record prunes normally"
+
+mkdir -p "$test_tmp/live-dir"
+echo "precious" >"$test_tmp/live-dir/work.txt"
+mkdir -p "$gitdir/worktrees/livedir-rec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/livedir-rec/HEAD"
+printf '%s\n' "$test_tmp/live-dir/.git" >"$gitdir/worktrees/livedir-rec/gitdir"
+
+if livedir_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the worktree directory survives: $livedir_out"
+fi
+expect_contains "$livedir_out" "its worktree directory still exists" "live-dir: surviving directory refused"
+[ -d "$gitdir/worktrees/livedir-rec" ] || fail "live-dir: record swept although its directory survives"
+rm -rf "$test_tmp/live-dir"
+livedir_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the directory was moved aside: $livedir_ok_out"
+expect_contains "$livedir_ok_out" "pruned record 'livedir-rec'" "live-dir: cleared record prunes normally"
+echo "ok: an unreadable gitdir or a surviving tree directory refuses the sweep"
+
+# ── Case E7w: resolve-undo state in a stage-0-clean index refuses ──────────
+# After a conflict is resolved back to HEAD's content, the index compares
+# clean yet its resolve-undo section still holds conflict-stage OIDs the
+# index alone references.
+
+blob_t="$(printf 'theirs\n' | git -C "$fixture" hash-object -w --stdin)"
+reuc_idx="$test_tmp/reuc-idx"
+GIT_INDEX_FILE="$reuc_idx" git -C "$fixture" read-tree main
+GIT_INDEX_FILE="$reuc_idx" git -C "$fixture" update-index --add --cacheinfo "100644,$blob_t,cf.txt"
+ttree="$(GIT_INDEX_FILE="$reuc_idx" git -C "$fixture" write-tree)"
+tcommit="$(git -C "$fixture" commit-tree "$ttree" -p main -m theirs)"
+git -C "$fixture" worktree add -q -b reuc-br "$test_tmp/wt-reuc" main
+(
+    cd "$test_tmp/wt-reuc"
+    printf 'ours\n' >cf.txt
+    git add cf.txt
+    git commit -qm ours
+    git merge -q "$tcommit" >/dev/null 2>&1 || true
+    git checkout -q --ours -- cf.txt
+    git add cf.txt
+)
+reuc_admin="$gitdir/worktrees/wt-reuc"
+rm -rf "$test_tmp/wt-reuc"
+rm -f "$reuc_admin/MERGE_HEAD" "$reuc_admin/MERGE_MSG" "$reuc_admin/MERGE_MODE" "$reuc_admin/AUTO_MERGE" "$reuc_admin/ORIG_HEAD"
+
+if reuc_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with resolve-undo state present: $reuc_out"
+fi
+expect_contains "$reuc_out" "carries resolve-undo (conflict) state" "resolve-undo: clean-looking index refused"
+[ -d "$reuc_admin" ] || fail "resolve-undo: record swept despite conflict state"
+
+# An uninspectable index refuses the same way an unscannable state dir does.
+rm -f "$shim_dir/find"
+cat >"$shim_dir/git" <<SHIM
+#!/usr/bin/env bash
+if [[ "\$*" == *"ls-files --resolve-undo"* ]]; then
+    exit 1
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$shim_dir/git"
+if reuc_shim_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the index was uninspectable: $reuc_shim_out"
+fi
+expect_contains "$reuc_shim_out" "cannot inspect its index for resolve-undo state" "resolve-undo inspect: failure refused fail-closed"
+[ -d "$reuc_admin" ] || fail "resolve-undo inspect: record swept although the index was uninspectable"
+rm -f "$shim_dir/git"
+
+rm -f "$reuc_admin/index"
+reuc_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the resolve-undo state was recovered: $reuc_ok_out"
+expect_contains "$reuc_ok_out" "pruned record 'wt-reuc'" "resolve-undo: recovered record prunes normally"
+echo "ok: resolve-undo state in a clean index refuses the sweep"
+
+# ── Case E7x: symlinked state paths are carried state, broken links judged ─
+# find scans a symlink's target (or nothing when broken), never the link;
+# and [ -e ] dereferences, so a broken unknown symlink would slip past the
+# allowlist unjudged.
+
+mkdir -p "$gitdir/worktrees/symrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/symrec/HEAD"
+printf '%s\n' "/nonexistent/symrec/.git" >"$gitdir/worktrees/symrec/gitdir"
+ln -s /nonexistent-target "$gitdir/worktrees/symrec/refs"
+
+if symrec_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with a symlinked state path present: $symrec_out"
+fi
+expect_contains "$symrec_out" "carries worktree-local state (refs)" "symlink: linked state path refused as carried"
+[ -d "$gitdir/worktrees/symrec" ] || fail "symlink: record swept despite a symlinked state path"
+
+rm -f "$gitdir/worktrees/symrec/refs"
+ln -s /nowhere-at-all "$gitdir/worktrees/symrec/mystery-link"
+if symrec2_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with a broken unknown symlink present: $symrec2_out"
+fi
+expect_contains "$symrec2_out" "unrecognized entry 'mystery-link'" "symlink: broken unknown link judged, not skipped"
+[ -d "$gitdir/worktrees/symrec" ] || fail "symlink: record swept despite a broken unknown symlink"
+
+rm -f "$gitdir/worktrees/symrec/mystery-link"
+symrec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the symlinks were cleared: $symrec_ok_out"
+expect_contains "$symrec_ok_out" "pruned record 'symrec'" "symlink: cleared record prunes normally"
+echo "ok: symlinked state paths are carried state and broken links are judged"
+
 # ── Case E7s: pin-enumeration failure never reports cleanup complete ───────
 # A broken ref backend is not an empty pin namespace; the empty-plan path
 # must fail closed instead of printing "nothing to prune" with exit 0.

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -669,7 +669,7 @@ tasks:
       - ./scripts/test-worktree.sh
 
   test:session-cleanup:
-    desc: Behavioral test for audit:session-artifacts / clean:branches (evidence-gated deletion + negative controls, in a throwaway fixture repo)
+    desc: Behavioral test for audit:session-artifacts / clean:branches / clean:worktree-records (evidence-gated deletion + negative controls, in a throwaway fixture repo)
     cmds:
       - ./scripts/test-session-cleanup.sh
 
@@ -1226,6 +1226,10 @@ tasks:
     cmds:
       - git fetch --all --prune
 
+  clean:worktree-records:
+    desc: Prune stale worktree admin records only — pins a detached commit before its record goes (human settles the pin); never removes a worktree directory
+    cmds:
+      - ./scripts/clean-worktree-records.sh
 
   # ── Status ─────────────────────────────────────────────────────
   status:

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -77,8 +77,8 @@ it points here.
   the pending ones). Removal serializes with `worktree:new`/`worktree:rm`
   through the shared lifecycle lock — for trees under the blessed
   `.worktrees/` layout; a tree from a raw `git worktree add` elsewhere is
-  outside that protocol, which is the documented residual for keeping to the
-  tasks.
+  outside that protocol — as is a `git worktree lock` racing the removal
+  itself — which is the documented residual for keeping to the tasks.
 - **A fresh worktree has no `node_modules`/`.venv`.** Working files are per-tree,
   so dependency install is per-tree too; that is what `worktree:new` runs and
   why "it worked in the main checkout" is not evidence.

--- a/template/docs/conventions.md.jinja
+++ b/template/docs/conventions.md.jinja
@@ -67,6 +67,18 @@ it points here.
   routine and so meaningless. It also prunes the registry and clears leftover
   gitlink directories — stale ones make later tooling treat a dead path as a
   live checkout.
+- **Sweep leftover admin records with `task clean:worktree-records`**, never a
+  raw `git worktree prune` — a stale record's detached HEAD can be the only
+  thing keeping a commit alive, and a raw prune makes it unreachable. The task
+  removes records only (never a worktree directory), refuses records carrying
+  single-copy state, and pins a detached commit as
+  `refs/session-cleanup/pin/<record>` *before* the record goes; pins are
+  settled only by explicit human action (`task audit:session-artifacts` lists
+  the pending ones). Removal serializes with `worktree:new`/`worktree:rm`
+  through the shared lifecycle lock — for trees under the blessed
+  `.worktrees/` layout; a tree from a raw `git worktree add` elsewhere is
+  outside that protocol, which is the documented residual for keeping to the
+  tasks.
 - **A fresh worktree has no `node_modules`/`.venv`.** Working files are per-tree,
   so dependency install is per-tree too; that is what `worktree:new` runs and
   why "it worked in the main checkout" is not evidence.

--- a/template/scripts/audit-session-artifacts.sh
+++ b/template/scripts/audit-session-artifacts.sh
@@ -297,6 +297,20 @@ else
     echo "  none"
 fi
 
+# ── 5b. Rescue pins ─────────────────────────────────────────────────────────
+
+# clean:worktree-records keeps refs/session-cleanup/pin/<record> when a
+# pruned record held the only reference to a detached commit; a lingering pin
+# is a decision waiting to be made.
+section "Rescue pins (refs/session-cleanup/pin)"
+git for-each-ref refs/session-cleanup/pin \
+    --format='  %(refname:lstrip=3) — pins %(objectname) (branch it or delete the pin)' >"$tmp/pins"
+if [ -s "$tmp/pins" ]; then
+    cat "$tmp/pins"
+else
+    echo "  none"
+fi
+
 # ── 6. Totals ───────────────────────────────────────────────────────────────
 
 section "Totals"

--- a/template/scripts/clean-worktree-records.sh
+++ b/template/scripts/clean-worktree-records.sh
@@ -160,12 +160,26 @@ remove_one_record() (
     esac
 
     [ -d "$admin_dir" ] || exit 3 # already gone (another cleaner won)
-    # Re-read under the lock: if the record's gitdir target exists again (a
-    # worktree recreated at the old path), the record is live — leave it.
-    wt_gitfile="$(cat "$admin_dir/gitdir" 2>/dev/null || true)"
-    if [ -n "$wt_gitfile" ] && [ -e "$wt_gitfile" ]; then
+    # Re-read under the lock — failing closed when the gitdir file cannot
+    # be read to a value: an unreadable target is not an absent worktree,
+    # and sweeping on that guess can orphan a live tree (challenge r7).
+    if ! wt_gitfile="$(cat "$admin_dir/gitdir" 2>/dev/null)" || [ -z "$wt_gitfile" ]; then
+        echo "SKIP  record '$record' — cannot read its gitdir file; refusing to sweep an unvalidatable record (inspect $admin_dir)"
+        exit 3 # unreadable gitdir refuses
+    fi
+    # If the gitdir target exists again (a worktree recreated at the old
+    # path), the record is live — leave it.
+    if [ -e "$wt_gitfile" ]; then
         echo "SKIP  record '$record' — its worktree reappeared since the plan"
         exit 3
+    fi
+    # A surviving worktree DIRECTORY whose .git link is gone still holds
+    # the user's files; sweeping its record would orphan them as a plain
+    # directory nothing tracks (challenge r7).
+    tree_dir="${wt_gitfile%/.git}"
+    if [ "$tree_dir" != "$wt_gitfile" ] && [ -d "$tree_dir" ]; then
+        echo "SKIP  record '$record' — its worktree directory still exists ($tree_dir) though the .git link is gone; restore the link or move the directory aside first"
+        exit 3 # surviving tree dir refuses
     fi
 
     # git's own worktree lock (worktrees/<id>/locked) protects e.g. a tree on
@@ -190,6 +204,13 @@ remove_one_record() (
     # --autostash killed before MERGE_HEAD exists leaves the user's dirty
     # work referenced by that one file alone (challenge r6).
     for sub in deferred-findings adjudication-ledger shepherd-codex refs rebase-merge rebase-apply MERGE_HEAD MERGE_AUTOSTASH CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG config.worktree info/sparse-checkout; do
+        # A symlinked state path is carried state whatever it points at —
+        # find would scan the target (or nothing, broken), not the link
+        # (challenge r7).
+        if [ -L "$admin_dir/$sub" ]; then
+            carried="$carried $sub"
+            continue
+        fi
         [ -e "$admin_dir/$sub" ] || continue
         # A failed scan is not an empty scan: treating an errored find as
         # "no state" would sweep exactly the record it could not inspect
@@ -212,14 +233,14 @@ remove_one_record() (
     # that game; the unknown refuses instead (challenge r6 restructure,
     # maintainer-approved).
     for entry in "$admin_dir"/* "$admin_dir"/.[!.]* "$admin_dir"/..?*; do
-        [ -e "$entry" ] || continue
+        [ -e "$entry" ] || [ -L "$entry" ] || continue # -e dereferences: a broken symlink must still be judged
         entry_name="${entry##*/}"
         case "$entry_name" in
         gitdir | commondir | HEAD | locked | COMMIT_EDITMSG | ORIG_HEAD | FETCH_HEAD | index | logs) : ;;                                                                                                  # validated by the guards here, disposable scratch, or reflogs (accepted loss by design)
         deferred-findings | adjudication-ledger | shepherd-codex | refs | rebase-merge | rebase-apply | MERGE_HEAD | MERGE_AUTOSTASH | CHERRY_PICK_HEAD | REVERT_HEAD | BISECT_LOG | config.worktree) : ;; # carried-state names: the scan above refused them when non-empty
         info)
             for info_entry in "$entry"/* "$entry"/.[!.]* "$entry"/..?*; do
-                [ -e "$info_entry" ] || continue
+                [ -e "$info_entry" ] || [ -L "$info_entry" ] || continue
                 case "${info_entry##*/}" in
                 sparse-checkout) : ;; # refused above when present with content
                 *)
@@ -319,6 +340,17 @@ remove_one_record() (
             ! GIT_INDEX_FILE="$admin_dir/index" git diff-index --cached --quiet "$head_commit" 2>/dev/null; then
             echo "SKIP  record '$record' — its index diverges from the recorded HEAD (staged-only changes, or unverifiable); recover them first (GIT_INDEX_FILE=$(shell_quote "$admin_dir/index") git checkout-index ...), then remove the index file"
             exit 3
+        fi
+        # A stage-0-clean index can still carry resolve-undo entries whose
+        # conflict-stage blobs it alone references; an uninspectable index
+        # refuses the same way an unscannable state dir does (challenge r7).
+        if ! resolve_undo="$(GIT_INDEX_FILE="$admin_dir/index" git ls-files --resolve-undo 2>&1)"; then
+            echo "SKIP  record '$record' — cannot inspect its index for resolve-undo state ($resolve_undo); failing closed"
+            exit 3 # resolve-undo-inspect refuses
+        fi
+        if [ -n "$resolve_undo" ]; then
+            echo "SKIP  record '$record' — its index carries resolve-undo (conflict) state the index alone references; recover it (GIT_INDEX_FILE=$(shell_quote "$admin_dir/index") git ls-files --resolve-undo), then remove the index file"
+            exit 3 # resolve-undo refuses
         fi
     fi
 

--- a/template/scripts/clean-worktree-records.sh
+++ b/template/scripts/clean-worktree-records.sh
@@ -17,7 +17,9 @@
 #     snapshot. A plan-verified stale record has no working directory, so
 #     its HEAD cannot move. Live records are never touched, and git's own
 #     `locked` marker is re-checked under the lock — a worktree locked
-#     after the plan (removable media) stays preserved.
+#     after the plan (removable media) stays preserved. A `git worktree
+#     lock` racing the removal itself does not take the lifecycle lock;
+#     that is the same native-command residual as raw `git worktree add`.
 #   * Each removal runs under the same per-path lifecycle lock that
 #     worktree:new / worktree:rm hold (for trees under the blessed
 #     .worktrees layout), so a removal cannot race a re-creation of the
@@ -27,7 +29,9 @@
 #     review sidecars, per-worktree ref files, in-progress operation state
 #     (rebase/merge/cherry-pick — the worktree-rm.sh list), and an index
 #     that diverges from the recorded HEAD (staged-but-uncommitted blobs
-#     the index alone keeps alive). Reflogs are deliberately NOT state —
+#     the index alone keeps alive). An unreadable HEAD refuses outright,
+#     and ORIG_HEAD — a ref file, not a reflog — refuses when it names a
+#     commit no shared ref contains. Reflogs are deliberately NOT state —
 #     every record has one, and accepting reflog loss matches git's own
 #     prune semantics.
 #   * A detached record HEAD is pinned as refs/session-cleanup/pin/<record>
@@ -81,6 +85,15 @@ shared_refs_containing() {
 
 common="$(git rev-parse --path-format=absolute --git-common-dir)"
 
+# The blessed-path anchor is the registry's first entry — the SAME source
+# worktree-new.sh reads to place .worktrees/, because these locks only
+# serialize anything if both sides key identically. Empirically git derives
+# this entry as ${common%/.git} in every layout we could produce
+# (separate-git-dir included), so this is consistency by construction with
+# the peer tool rather than a behavioral change: if git's registry
+# computation ever shifts, both tools move together (challenge r2).
+main_root="$(git worktree list --porcelain | sed -n '1s/^worktree //p')"
+
 # Legacy graft files rewrite parentage exactly as replace refs do, but
 # GIT_NO_REPLACE_OBJECTS does NOT disable them (review r1, ported at
 # resurrection): containment walked over grafted history is not evidence, so
@@ -131,7 +144,6 @@ remove_one_record() (
     trap release_locks EXIT
     trap 'exit 129' HUP INT TERM
     wt_gitfile="$(cat "$admin_dir/gitdir" 2>/dev/null || true)"
-    main_root="${common%/.git}"
     tree_path="${wt_gitfile%/.git}"
     case "$tree_path" in
     "$main_root/.worktrees/"*)
@@ -173,6 +185,33 @@ remove_one_record() (
     fi
 
     record_head="$(cat "$admin_dir/HEAD" 2>/dev/null || true)"
+
+    # A record whose HEAD cannot be read would fall through every
+    # HEAD-derived guard below and sweep unpinned; an unvalidatable record
+    # is refused, never swept (challenge r2).
+    if [ -z "$record_head" ]; then
+        echo "SKIP  record '$record' — cannot read its HEAD; refusing to sweep an unvalidatable record (inspect $admin_dir)"
+        exit 3
+    fi
+
+    # ORIG_HEAD is a ref file, not a reflog: a reset --hard's abandoned
+    # commit can live in this one file alone, so reflog accepted-loss does
+    # not cover it. A reachable ORIG_HEAD sweeps normally (every used tree
+    # has one); unreachable or unreadable refuses — and a legacy graft file
+    # makes containment unusable, so it refuses too (challenge r2).
+    if [ -f "$admin_dir/ORIG_HEAD" ]; then
+        orig_head="$(cat "$admin_dir/ORIG_HEAD" 2>/dev/null || true)"
+        orig_commit=""
+        [ -z "$orig_head" ] || orig_commit="$(git rev-parse --quiet --verify "$orig_head^{commit}" || true)"
+        if [ -z "$orig_commit" ]; then
+            echo "SKIP  record '$record' — its ORIG_HEAD is unreadable or names no commit; refusing to sweep (inspect $admin_dir/ORIG_HEAD)"
+            exit 3
+        fi
+        if [ "$grafts_present" = true ] || [ -z "$(shared_refs_containing "$orig_commit")" ]; then
+            echo "SKIP  record '$record' — ORIG_HEAD $orig_commit is reachable from no shared ref, or containment is unusable under a legacy graft file (a reset/rebase abandoned it here); rescue it (git branch $(shell_quote "rescue/$record-orig") $orig_commit) then remove $admin_dir/ORIG_HEAD"
+            exit 3
+        fi
+    fi
 
     # The index can be the only structure referencing staged-but-uncommitted
     # blobs (challenge r7): an index that diverges from the recorded HEAD —
@@ -223,15 +262,20 @@ remove_one_record() (
 
     if [ "$pinned_here" = true ]; then
         pin_ref="refs/session-cleanup/pin/$record"
-        # The pin must have outlived the removal: the audit advertises pins,
-        # so a human settlement can race this run and drop one in the window
-        # between the create and the rm — re-assert before reporting
-        # (challenge r1).
-        if ! git rev-parse --quiet --verify "$pin_ref" >/dev/null; then
+        # The pin must have outlived the removal AND still target the
+        # detached commit: the audit advertises pins, so a settlement can
+        # race this run — a dropped pin is re-asserted, and a retargeted
+        # one fails closed rather than being overwritten or reported kept
+        # (challenge r1, tightened r2: existence alone verifies nothing).
+        pin_now="$(git rev-parse --quiet --verify "$pin_ref" || true)"
+        if [ -z "$pin_now" ]; then
             if ! LEFTHOOK=0 git update-ref "$pin_ref" "$record_head" ""; then
                 echo "CRITICAL  $pin_ref vanished during the prune and could not be recreated — rescue detached commit $record_head NOW: git branch $(shell_quote "rescue/$record") $record_head"
                 exit 5
             fi
+        elif [ "$pin_now" != "$record_head" ]; then
+            echo "CRITICAL  $pin_ref no longer pins $record_head (it now holds $pin_now) — rescue the detached commit NOW: git branch $(shell_quote "rescue/$record") $record_head"
+            exit 5
         fi
         # Reporting only — pins are settled by humans, never auto-dropped
         # (challenge r6): the reachability check picks the wording, and a

--- a/template/scripts/clean-worktree-records.sh
+++ b/template/scripts/clean-worktree-records.sh
@@ -47,6 +47,11 @@
 #     the whole run and a legacy graft file forces the conservative wording,
 #     because a forged "also reachable from shared refs" would hand the
 #     human a copyable command that drops the only real reference.
+#   * The sweep is allowlist-gated: a record is removed only when every
+#     entry in its admin dir is known to this tool — validated, refused
+#     when carried, or accepted by design (reflogs). Unknown entries
+#     refuse, so a git version that grows new state files fails closed
+#     instead of being silently swept.
 set -euo pipefail
 
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -199,6 +204,37 @@ remove_one_record() (
         echo "SKIP  record '$record' — carries worktree-local state (${carried# }); adopt or rescue it first, it exists nowhere else"
         exit 3
     fi
+
+    # Fail closed by construction: a record is swept only when EVERY entry
+    # in its admin dir is known to this tool — validated below, refused
+    # above when carried, or accepted by design (reflogs). Git grows state
+    # files over time and an enumeration of dangerous ones can only lose
+    # that game; the unknown refuses instead (challenge r6 restructure,
+    # maintainer-approved).
+    for entry in "$admin_dir"/* "$admin_dir"/.[!.]* "$admin_dir"/..?*; do
+        [ -e "$entry" ] || continue
+        entry_name="${entry##*/}"
+        case "$entry_name" in
+        gitdir | commondir | HEAD | locked | COMMIT_EDITMSG | ORIG_HEAD | FETCH_HEAD | index | logs) : ;;                                                                                                  # validated by the guards here, disposable scratch, or reflogs (accepted loss by design)
+        deferred-findings | adjudication-ledger | shepherd-codex | refs | rebase-merge | rebase-apply | MERGE_HEAD | MERGE_AUTOSTASH | CHERRY_PICK_HEAD | REVERT_HEAD | BISECT_LOG | config.worktree) : ;; # carried-state names: the scan above refused them when non-empty
+        info)
+            for info_entry in "$entry"/* "$entry"/.[!.]* "$entry"/..?*; do
+                [ -e "$info_entry" ] || continue
+                case "${info_entry##*/}" in
+                sparse-checkout) : ;; # refused above when present with content
+                *)
+                    echo "SKIP  record '$record' — unrecognized entry info/${info_entry##*/}; refusing to sweep what this tool does not understand (inspect $admin_dir)"
+                    exit 3 # unknown info entry refuses
+                    ;;
+                esac
+            done
+            ;;
+        *)
+            echo "SKIP  record '$record' — unrecognized entry '$entry_name'; refusing to sweep what this tool does not understand (inspect $admin_dir)"
+            exit 3 # unknown entry refuses
+            ;;
+        esac
+    done
 
     record_head="$(cat "$admin_dir/HEAD" 2>/dev/null || true)"
 

--- a/template/scripts/clean-worktree-records.sh
+++ b/template/scripts/clean-worktree-records.sh
@@ -174,10 +174,15 @@ remove_one_record() (
     # nothing else references (challenge r1).
     carried=""
     for sub in deferred-findings adjudication-ledger shepherd-codex refs rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
-        if [ -e "$admin_dir/$sub" ] &&
-            [ -n "$(find "$admin_dir/$sub" -type f 2>/dev/null | head -n 1)" ]; then
-            carried="$carried $sub"
+        [ -e "$admin_dir/$sub" ] || continue
+        # A failed scan is not an empty scan: treating an errored find as
+        # "no state" would sweep exactly the record it could not inspect
+        # (challenge r3).
+        if ! state_scan="$(find "$admin_dir/$sub" -type f 2>&1)"; then
+            echo "SKIP  record '$record' — cannot scan $sub for worktree-local state ($state_scan); failing closed"
+            exit 3
         fi
+        [ -z "$state_scan" ] || carried="$carried $sub"
     done
     if [ -n "$carried" ]; then
         echo "SKIP  record '$record' — carries worktree-local state (${carried# }); adopt or rescue it first, it exists nowhere else"
@@ -237,7 +242,7 @@ remove_one_record() (
         if git rev-parse --quiet --verify "$record_head^{commit}" >/dev/null 2>&1; then
             existing_pin="$(git rev-parse --quiet --verify "refs/session-cleanup/pin/$record" || true)"
             if [ -n "$existing_pin" ] && [ "$existing_pin" != "$record_head" ]; then
-                echo "SKIP  record '$record' — refs/session-cleanup/pin/$record already pins $existing_pin from an earlier run; settle it first (git branch $(shell_quote "rescue/$record") $existing_pin, or git update-ref -d $(shell_quote "refs/session-cleanup/pin/$record"))"
+                echo "SKIP  record '$record' — refs/session-cleanup/pin/$record already pins $existing_pin from an earlier run; settle it first (git branch $(shell_quote "rescue/$record") $existing_pin, or git update-ref -d $(shell_quote "refs/session-cleanup/pin/$record") $existing_pin)"
                 exit 3
             fi
             # Create-only (old value ''): never overwrite a pin this run did
@@ -247,6 +252,13 @@ remove_one_record() (
                 exit 3
             fi
             pinned_here=true
+        else
+            # A nonempty detached HEAD that resolves to no commit — a
+            # truncated file, a missing or promisor-held object — cannot be
+            # pinned, and sweeping would destroy the only recovery
+            # breadcrumb; refuse instead of falling through (challenge r3).
+            echo "SKIP  record '$record' — its detached HEAD $record_head does not resolve to a commit (missing or corrupt object); refusing to sweep the only reference"
+            exit 3 # unresolvable HEAD refuses
         fi
         ;;
     esac
@@ -283,9 +295,13 @@ remove_one_record() (
         # PRESENT safety: reachability is a prune-time snapshot, so the drop
         # remedy instructs re-verification first (challenge r1).
         if [ "$grafts_present" = false ] && [ -n "$(shared_refs_containing "$record_head")" ]; then
-            echo "PINNED  $pin_ref — $record_head was reachable from shared refs at prune time; re-verify before dropping (git --no-replace-objects for-each-ref --contains $record_head refs/heads refs/tags refs/remotes), then: git update-ref -d $(shell_quote "$pin_ref")"
+            # Every printed drop remedy carries the expected OID: update-ref
+            # -d with an old value is compare-and-delete, so a stale command
+            # re-run after record-name reuse cannot delete a newer pin
+            # (challenge r3).
+            echo "PINNED  $pin_ref — $record_head was reachable from shared refs at prune time; re-verify before dropping (git --no-replace-objects for-each-ref --contains $record_head refs/heads refs/tags refs/remotes), then: git update-ref -d $(shell_quote "$pin_ref") $record_head"
         else
-            echo "KEPT  $pin_ref — pruned record '$record' held the only reference to detached commit $record_head; branch it (git branch $(shell_quote "rescue/$record") $record_head) or discard it (git update-ref -d $(shell_quote "$pin_ref"))"
+            echo "KEPT  $pin_ref — pruned record '$record' held the only reference to detached commit $record_head; branch it (git branch $(shell_quote "rescue/$record") $record_head) or discard it (git update-ref -d $(shell_quote "$pin_ref") $record_head)"
         fi
         exit 2
     fi

--- a/template/scripts/clean-worktree-records.sh
+++ b/template/scripts/clean-worktree-records.sh
@@ -181,7 +181,10 @@ remove_one_record() (
     # adopt-or-rescue class as the review sidecars, and present only on
     # worktreeConfig-enabled records, so refusing costs no sweepability
     # (challenge r5, reversing r2's "dead config" declination).
-    for sub in deferred-findings adjudication-ledger shepherd-codex refs rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG config.worktree info/sparse-checkout; do
+    # MERGE_AUTOSTASH extends the worktree-rm.sh op-state list: a merge
+    # --autostash killed before MERGE_HEAD exists leaves the user's dirty
+    # work referenced by that one file alone (challenge r6).
+    for sub in deferred-findings adjudication-ledger shepherd-codex refs rebase-merge rebase-apply MERGE_HEAD MERGE_AUTOSTASH CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG config.worktree info/sparse-checkout; do
         [ -e "$admin_dir/$sub" ] || continue
         # A failed scan is not an empty scan: treating an errored find as
         # "no state" would sweep exactly the record it could not inspect
@@ -239,6 +242,20 @@ remove_one_record() (
         while IFS= read -r fetch_line || [ -n "$fetch_line" ]; do
             [ -n "$fetch_line" ] || continue
             fetch_sha="${fetch_line%%[[:space:]]*}"
+            # An annotated tag fetched without a destination ref is its own
+            # object: peeling to the commit would let the tag body (message,
+            # signature) vanish with the record. Exact points-at containment
+            # — object equality, so ancestry forgery does not apply
+            # (challenge r6).
+            fetch_type=""
+            [ -z "$fetch_sha" ] || fetch_type="$(git cat-file -t "$fetch_sha" 2>/dev/null || true)"
+            if [ "$fetch_type" = "tag" ]; then
+                if [ -z "$(git for-each-ref --points-at "$fetch_sha" --format='%(refname)' 2>/dev/null | grep -Ev '^refs/((worktree|bisect|rewritten|replace)/|session-cleanup/pin/)' || true)" ]; then
+                    echo "SKIP  record '$record' — FETCH_HEAD names annotated tag object $fetch_sha with no ref pointing at it; rescue it (git tag $(shell_quote "rescue/$record-fetch-tag-$(printf '%.7s' "$fetch_sha")") $fetch_sha) then remove $admin_dir/FETCH_HEAD"
+                    exit 3
+                fi
+                continue
+            fi
             fetch_commit=""
             [ -z "$fetch_sha" ] || fetch_commit="$(git rev-parse --quiet --verify "$fetch_sha^{commit}" || true)"
             if [ -z "$fetch_commit" ]; then
@@ -246,7 +263,7 @@ remove_one_record() (
                 exit 3
             fi
             if [ "$grafts_present" = true ] || [ -z "$(shared_refs_containing "$fetch_commit")" ]; then
-                echo "SKIP  record '$record' — FETCH_HEAD names $fetch_commit, reachable from no shared ref (a URL fetch left it here); rescue it (git branch $(shell_quote "rescue/$record-fetch") $fetch_commit) then remove $admin_dir/FETCH_HEAD"
+                echo "SKIP  record '$record' — FETCH_HEAD names $fetch_commit, reachable from no shared ref (a URL fetch left it here); rescue it (git branch $(shell_quote "rescue/$record-fetch-$(printf '%.7s' "$fetch_commit")") $fetch_commit) then remove $admin_dir/FETCH_HEAD"
                 exit 3
             fi
         done <"$admin_dir/FETCH_HEAD"

--- a/template/scripts/clean-worktree-records.sh
+++ b/template/scripts/clean-worktree-records.sh
@@ -15,23 +15,30 @@
 #     prune re-computes eligibility at its own moment, so a LIVE worktree
 #     whose directory vanishes mid-run could be pruned on a stale HEAD
 #     snapshot. A plan-verified stale record has no working directory, so
-#     its HEAD cannot move. Live records are never touched.
+#     its HEAD cannot move. Live records are never touched, and git's own
+#     `locked` marker is re-checked under the lock — a worktree locked
+#     after the plan (removable media) stays preserved.
 #   * Each removal runs under the same per-path lifecycle lock that
 #     worktree:new / worktree:rm hold (for trees under the blessed
 #     .worktrees layout), so a removal cannot race a re-creation of the
 #     same path by the blessed tooling. Raw `git worktree add` outside the
 #     tooling remains the documented residual.
 #   * A record that carries worktree-local state is refused, never swept:
-#     review sidecars, per-worktree ref files, and an index that diverges
-#     from the recorded HEAD (staged-but-uncommitted blobs the index alone
-#     keeps alive). Reflogs are deliberately NOT state — every record has
-#     one, and accepting reflog loss matches git's own prune semantics.
+#     review sidecars, per-worktree ref files, in-progress operation state
+#     (rebase/merge/cherry-pick — the worktree-rm.sh list), and an index
+#     that diverges from the recorded HEAD (staged-but-uncommitted blobs
+#     the index alone keeps alive). Reflogs are deliberately NOT state —
+#     every record has one, and accepting reflog loss matches git's own
+#     prune semantics.
 #   * A detached record HEAD is pinned as refs/session-cleanup/pin/<record>
 #     BEFORE its record is removed, with a CREATE-ONLY ref write; an
 #     existing mismatched pin from an earlier run refuses that record. Pins
 #     are removed only by EXPLICIT human settlement — an auto-drop races
 #     concurrent ref deletion — and the run exits nonzero while any await
-#     action. Nothing is ever lost.
+#     action, prior runs' pins included. The pin is re-asserted after the
+#     removal (a racing settlement could drop it in the window), and its
+#     drop remedy instructs re-verification, never asserts present safety.
+#     Nothing is ever lost.
 #   * The pin report judges RAW history: replacement refs are disabled for
 #     the whole run and a legacy graft file forces the conservative wording,
 #     because a forged "also reachable from shared refs" would hand the
@@ -86,12 +93,28 @@ if [ -s "$grafts_file" ]; then
     echo "NOTE  legacy graft file present ($grafts_file) — shared-ref containment is unusable while it exists; kept pins are reported conservatively"
 fi
 
+# The header's contract: the run stays nonzero while ANY pin awaits human
+# settlement — including pins left by an earlier run, which an otherwise
+# empty retry would otherwise report as "cleanup complete" (challenge r1).
+# --count=1 avoids a git|head pipeline, which pipefail turns into SIGPIPE.
+pins_outstanding() {
+    git for-each-ref --count=1 refs/session-cleanup/pin --format='%(refname)'
+}
+
+finish_no_work() {
+    if [ -n "$(pins_outstanding)" ]; then
+        echo "clean:worktree-records: nothing to prune, but rescue pins await settlement (task audit:session-artifacts lists them)." >&2
+        exit 2
+    fi
+    echo "clean:worktree-records: nothing to prune."
+    exit 0
+}
+
 # git's own dry run is the authority on what is prunable
 # ("Removing worktrees/<name>: <reason>"); LC_ALL=C pins the message shape.
 prune_plan="$(LC_ALL=C git worktree prune --dry-run -v 2>&1)"
 if [ -z "$prune_plan" ]; then
-    echo "clean:worktree-records: nothing to prune."
-    exit 0
+    finish_no_work
 fi
 
 # remove_one_record <record> — runs in a SUBSHELL so a lock refusal (die)
@@ -125,9 +148,20 @@ remove_one_record() (
         exit 3
     fi
 
-    # Single-copy worktree-local state is refused, never swept.
+    # git's own worktree lock (worktrees/<id>/locked) protects e.g. a tree on
+    # removable media; the plan predates it, so re-check under our lifecycle
+    # lock — git preserves locked records and so must we (challenge r1).
+    if [ -e "$admin_dir/locked" ]; then
+        echo "SKIP  record '$record' — locked by git worktree lock since the plan (git worktree unlock, or remove $admin_dir/locked, to release)"
+        exit 3
+    fi
+
+    # Single-copy worktree-local state is refused, never swept. The op-state
+    # names mirror worktree-rm.sh: a rebase/merge/cherry-pick parked at an
+    # edit leaves sequencer state — and, after an amend there, commits —
+    # nothing else references (challenge r1).
     carried=""
-    for sub in deferred-findings adjudication-ledger shepherd-codex refs; do
+    for sub in deferred-findings adjudication-ledger shepherd-codex refs rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
         if [ -e "$admin_dir/$sub" ] &&
             [ -n "$(find "$admin_dir/$sub" -type f 2>/dev/null | head -n 1)" ]; then
             carried="$carried $sub"
@@ -178,17 +212,34 @@ remove_one_record() (
         ;;
     esac
 
-    # Records only: the stale admin directory is all that goes.
-    rm -rf "$admin_dir"
+    # Records only: the stale admin directory is all that goes. A failed
+    # removal is its own loud outcome, never mislabeled as lock contention
+    # (challenge r1).
+    if ! rm -rf "$admin_dir"; then
+        echo "ERROR  record '$record' — removal failed midway; inspect $admin_dir before re-running"
+        exit 4
+    fi
     echo "pruned record '$record'"
 
     if [ "$pinned_here" = true ]; then
+        pin_ref="refs/session-cleanup/pin/$record"
+        # The pin must have outlived the removal: the audit advertises pins,
+        # so a human settlement can race this run and drop one in the window
+        # between the create and the rm — re-assert before reporting
+        # (challenge r1).
+        if ! git rev-parse --quiet --verify "$pin_ref" >/dev/null; then
+            if ! LEFTHOOK=0 git update-ref "$pin_ref" "$record_head" ""; then
+                echo "CRITICAL  $pin_ref vanished during the prune and could not be recreated — rescue detached commit $record_head NOW: git branch $(shell_quote "rescue/$record") $record_head"
+                exit 5
+            fi
+        fi
         # Reporting only — pins are settled by humans, never auto-dropped
         # (challenge r6): the reachability check picks the wording, and a
-        # race can at worst mislabel, never delete.
-        pin_ref="refs/session-cleanup/pin/$record"
+        # race can at worst mislabel, never delete. The wording never asserts
+        # PRESENT safety: reachability is a prune-time snapshot, so the drop
+        # remedy instructs re-verification first (challenge r1).
         if [ "$grafts_present" = false ] && [ -n "$(shared_refs_containing "$record_head")" ]; then
-            echo "PINNED  $pin_ref — $record_head is also reachable from shared refs; drop it with: git update-ref -d $(shell_quote "$pin_ref")"
+            echo "PINNED  $pin_ref — $record_head was reachable from shared refs at prune time; re-verify before dropping (git --no-replace-objects for-each-ref --contains $record_head refs/heads refs/tags refs/remotes), then: git update-ref -d $(shell_quote "$pin_ref")"
         else
             echo "KEPT  $pin_ref — pruned record '$record' held the only reference to detached commit $record_head; branch it (git branch $(shell_quote "rescue/$record") $record_head) or discard it (git update-ref -d $(shell_quote "$pin_ref"))"
         fi
@@ -198,6 +249,7 @@ remove_one_record() (
 
 removed=0
 skipped=0
+errors=0
 pins_pending=0
 while IFS= read -r line; do
     record="$(printf '%s\n' "$line" | sed -n 's/^Removing worktrees\/\(.*\): .*$/\1/p')"
@@ -211,8 +263,9 @@ while IFS= read -r line; do
         pins_pending=$((pins_pending + 1))
         ;;
     3) skipped=$((skipped + 1)) ;;
+    4 | 5) errors=$((errors + 1)) ;; # own message printed above; never lock-labeled
     *)
-        echo "SKIP  record '$record' — the worktree lifecycle lock refused (a worktree operation is active; details above)"
+        echo "SKIP  record '$record' — the worktree lifecycle lock refused, or an unexpected failure (details above)"
         skipped=$((skipped + 1))
         ;;
     esac
@@ -220,11 +273,14 @@ done <<EOF
 $prune_plan
 EOF
 
-if [ "$removed" -eq 0 ] && [ "$skipped" -eq 0 ]; then
-    echo "clean:worktree-records: nothing to prune."
-    exit 0
+if [ "$removed" -eq 0 ] && [ "$skipped" -eq 0 ] && [ "$errors" -eq 0 ]; then
+    finish_no_work
 fi
-if [ "$pins_pending" -gt 0 ] || [ "$skipped" -gt 0 ]; then
+if [ "$errors" -gt 0 ]; then
+    echo "clean:worktree-records: $removed record(s) pruned; $errors record removal(s) FAILED above — resolve before re-running." >&2
+    exit 1
+fi
+if [ "$pins_pending" -gt 0 ] || [ "$skipped" -gt 0 ] || [ -n "$(pins_outstanding)" ]; then
     echo "clean:worktree-records: $removed record(s) pruned; $pins_pending pin(s) awaiting settlement, $skipped record(s) refused above." >&2
     exit 2
 fi

--- a/template/scripts/clean-worktree-records.sh
+++ b/template/scripts/clean-worktree-records.sh
@@ -133,7 +133,11 @@ finish_no_work() {
 
 # git's own dry run is the authority on what is prunable
 # ("Removing worktrees/<name>: <reason>"); LC_ALL=C pins the message shape.
-prune_plan="$(LC_ALL=C git worktree prune --dry-run -v 2>&1)"
+# A failed dry run must surface git's own diagnostic, not a bare set -e
+# death (review r2).
+if ! prune_plan="$(LC_ALL=C git worktree prune --dry-run -v 2>&1)"; then
+    die "git worktree prune --dry-run failed: $prune_plan"
+fi
 if [ -z "$prune_plan" ]; then
     finish_no_work
 fi
@@ -495,7 +499,7 @@ if [ "$pins_pending" -gt 0 ] || [ "$skipped" -gt 0 ] || [ -n "$outstanding" ]; t
     # Total, not just this run's: a pin inherited from an earlier run is
     # exactly as much awaiting settlement as a fresh one, and printing "0"
     # beside a nonzero exit contradicts the disposition (challenge r4).
-    total_pins="$(git for-each-ref refs/session-cleanup/pin --format='%(refname)' | grep -c . || true)"
+    total_pins="$(git for-each-ref refs/session-cleanup/pin --format='%(refname)' | wc -l | tr -d ' ')" || die "cannot enumerate rescue pins (refs/session-cleanup/pin unreadable); refusing to report an unreliable settlement count"
     echo "clean:worktree-records: $removed record(s) pruned; $pins_pending new pin(s) this run, $total_pins total awaiting settlement, $skipped record(s) refused above." >&2
     exit 2
 fi

--- a/template/scripts/clean-worktree-records.sh
+++ b/template/scripts/clean-worktree-records.sh
@@ -176,7 +176,12 @@ remove_one_record() (
     # edit leaves sequencer state — and, after an amend there, commits —
     # nothing else references (challenge r1).
     carried=""
-    for sub in deferred-findings adjudication-ledger shepherd-codex refs rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
+    # config.worktree and info/sparse-checkout carry user-set per-worktree
+    # configuration (extensions.worktreeConfig, sparse patterns) — the same
+    # adopt-or-rescue class as the review sidecars, and present only on
+    # worktreeConfig-enabled records, so refusing costs no sweepability
+    # (challenge r5, reversing r2's "dead config" declination).
+    for sub in deferred-findings adjudication-ledger shepherd-codex refs rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG config.worktree info/sparse-checkout; do
         [ -e "$admin_dir/$sub" ] || continue
         # A failed scan is not an empty scan: treating an errored find as
         # "no state" would sweep exactly the record it could not inspect
@@ -228,7 +233,10 @@ remove_one_record() (
     # none of the unsweepability cost an unconditional refusal would
     # (challenge r4, revising r3's declination of the unconditional form).
     if [ -f "$admin_dir/FETCH_HEAD" ]; then
-        while IFS= read -r fetch_line; do
+        # `|| [ -n ... ]`: a truncated write can leave the final record
+        # unterminated, and a plain read would skip exactly that entry
+        # (challenge r5).
+        while IFS= read -r fetch_line || [ -n "$fetch_line" ]; do
             [ -n "$fetch_line" ] || continue
             fetch_sha="${fetch_line%%[[:space:]]*}"
             fetch_commit=""
@@ -256,7 +264,7 @@ remove_one_record() (
         esac
         if [ -z "$head_commit" ] ||
             ! GIT_INDEX_FILE="$admin_dir/index" git diff-index --cached --quiet "$head_commit" 2>/dev/null; then
-            echo "SKIP  record '$record' — its index diverges from the recorded HEAD (staged-only changes, or unverifiable); recover them first (GIT_INDEX_FILE=$admin_dir/index git checkout-index ...), then remove the index file"
+            echo "SKIP  record '$record' — its index diverges from the recorded HEAD (staged-only changes, or unverifiable); recover them first (GIT_INDEX_FILE=$(shell_quote "$admin_dir/index") git checkout-index ...), then remove the index file"
             exit 3
         fi
     fi

--- a/template/scripts/clean-worktree-records.sh
+++ b/template/scripts/clean-worktree-records.sh
@@ -167,6 +167,14 @@ remove_one_record() (
         echo "SKIP  record '$record' — cannot read its gitdir file; refusing to sweep an unvalidatable record (inspect $admin_dir)"
         exit 3 # unreadable gitdir refuses
     fi
+    # The lock above was keyed off a PRE-lock read; if the gitdir changed
+    # while the lock was being approached (a record replaced mid-plan), the
+    # held key may be wrong or missing — refuse, and let a re-run evaluate
+    # the new record under the right lock (review r1).
+    if [ "${wt_gitfile%/.git}" != "$tree_path" ]; then
+        echo "SKIP  record '$record' — its gitdir changed while the lock was being acquired; re-run to re-evaluate"
+        exit 3 # lock-key drift refuses
+    fi
     # If the gitdir target exists again (a worktree recreated at the old
     # path), the record is live — leave it.
     if [ -e "$wt_gitfile" ]; then

--- a/template/scripts/clean-worktree-records.sh
+++ b/template/scripts/clean-worktree-records.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# clean-worktree-records.sh — prune stale worktree ADMIN RECORDS only, never a
+# worktree directory. Run via `task clean:worktree-records`.
+#
+# A raw `git worktree prune` is not safe here (harmon-init#838, challenge r3):
+# a stale record's HEAD can be DETACHED at a commit no branch, tag or
+# remote-tracking ref contains, in which case the record is the only thing
+# keeping that commit alive — pruning it makes the commit unreachable and
+# eventually GC-collectible.
+#
+# The design decisions, each deliberate (challenge r4-r7):
+#
+#   * Only records in git's own dry-run plan are removed, each one
+#     individually, never via the global `git worktree prune` — a global
+#     prune re-computes eligibility at its own moment, so a LIVE worktree
+#     whose directory vanishes mid-run could be pruned on a stale HEAD
+#     snapshot. A plan-verified stale record has no working directory, so
+#     its HEAD cannot move. Live records are never touched.
+#   * Each removal runs under the same per-path lifecycle lock that
+#     worktree:new / worktree:rm hold (for trees under the blessed
+#     .worktrees layout), so a removal cannot race a re-creation of the
+#     same path by the blessed tooling. Raw `git worktree add` outside the
+#     tooling remains the documented residual.
+#   * A record that carries worktree-local state is refused, never swept:
+#     review sidecars, per-worktree ref files, and an index that diverges
+#     from the recorded HEAD (staged-but-uncommitted blobs the index alone
+#     keeps alive). Reflogs are deliberately NOT state — every record has
+#     one, and accepting reflog loss matches git's own prune semantics.
+#   * A detached record HEAD is pinned as refs/session-cleanup/pin/<record>
+#     BEFORE its record is removed, with a CREATE-ONLY ref write; an
+#     existing mismatched pin from an earlier run refuses that record. Pins
+#     are removed only by EXPLICIT human settlement — an auto-drop races
+#     concurrent ref deletion — and the run exits nonzero while any await
+#     action. Nothing is ever lost.
+#   * The pin report judges RAW history: replacement refs are disabled for
+#     the whole run and a legacy graft file forces the conservative wording,
+#     because a forged "also reachable from shared refs" would hand the
+#     human a copyable command that drops the only real reference.
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Replacement refs rewrite parentage cosmetically; the pin report below must
+# judge RAW history (challenge r8, ported at resurrection: harmon-init#945) —
+# a refs/replace graft could make an orphaned commit read as reachable from
+# shared refs, and the printed remedy would then invite dropping the pin that
+# holds its only real reference.
+export GIT_NO_REPLACE_OBJECTS=1
+
+die() {
+    echo "clean:worktree-records: $*" >&2
+    exit 1
+}
+
+# POSIX shell-quote for values echoed into copyable commands: refnames and
+# record names legally carry shell metacharacters (challenge r7; same class
+# as worktree-new.sh's printed remedies).
+shell_quote() {
+    printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
+# Refs that would STILL reference a commit once the record is gone — the same
+# exclusion set as worktree-rm.sh (per-worktree refs vanish with their
+# worktree), plus this script's own pin namespace: a pin must never vouch for
+# the commit it exists to protect. refs/replace/ is excluded for the same
+# reason GIT_NO_REPLACE_OBJECTS is exported: a replacement's synthetic commit
+# contains the grafted-in parent in RAW history, so the ref itself would
+# vouch for exactly the commit the forgery targets.
+shared_refs_containing() {
+    git for-each-ref --contains "$1" --format='%(refname)' 2>/dev/null |
+        grep -Ev '^refs/((worktree|bisect|rewritten|replace)/|session-cleanup/pin/)' || true
+}
+
+common="$(git rev-parse --path-format=absolute --git-common-dir)"
+
+# Legacy graft files rewrite parentage exactly as replace refs do, but
+# GIT_NO_REPLACE_OBJECTS does NOT disable them (review r1, ported at
+# resurrection): containment walked over grafted history is not evidence, so
+# while one exists every kept pin gets the conservative wording — never the
+# "also reachable, drop it" remedy.
+grafts_present=false
+grafts_file="$(git rev-parse --git-path info/grafts)"
+if [ -s "$grafts_file" ]; then
+    grafts_present=true
+    echo "NOTE  legacy graft file present ($grafts_file) — shared-ref containment is unusable while it exists; kept pins are reported conservatively"
+fi
+
+# git's own dry run is the authority on what is prunable
+# ("Removing worktrees/<name>: <reason>"); LC_ALL=C pins the message shape.
+prune_plan="$(LC_ALL=C git worktree prune --dry-run -v 2>&1)"
+if [ -z "$prune_plan" ]; then
+    echo "clean:worktree-records: nothing to prune."
+    exit 0
+fi
+
+# remove_one_record <record> — runs in a SUBSHELL so a lock refusal (die)
+# aborts this record only. Every validation runs UNDER the lock (challenge
+# r7): checked outside it, worktree:rm clearing the record and worktree:new
+# recreating the same path could interleave before the rm -rf and lose a
+# live record. Exit codes: 0 removed, 2 removed with a pin awaiting
+# settlement, 3 refused cleanly (message printed), else lock/fatal.
+remove_one_record() (
+    record="$1"
+    admin_dir="$common/worktrees/$record"
+    # shellcheck source=scripts/worktree-lock.sh
+    . "$REPO_ROOT/scripts/worktree-lock.sh"
+    trap release_locks EXIT
+    trap 'exit 129' HUP INT TERM
+    wt_gitfile="$(cat "$admin_dir/gitdir" 2>/dev/null || true)"
+    main_root="${common%/.git}"
+    tree_path="${wt_gitfile%/.git}"
+    case "$tree_path" in
+    "$main_root/.worktrees/"*)
+        acquire_path_locks "${tree_path#"$main_root/.worktrees/"}"
+        ;;
+    esac
+
+    [ -d "$admin_dir" ] || exit 3 # already gone (another cleaner won)
+    # Re-read under the lock: if the record's gitdir target exists again (a
+    # worktree recreated at the old path), the record is live — leave it.
+    wt_gitfile="$(cat "$admin_dir/gitdir" 2>/dev/null || true)"
+    if [ -n "$wt_gitfile" ] && [ -e "$wt_gitfile" ]; then
+        echo "SKIP  record '$record' — its worktree reappeared since the plan"
+        exit 3
+    fi
+
+    # Single-copy worktree-local state is refused, never swept.
+    carried=""
+    for sub in deferred-findings adjudication-ledger shepherd-codex refs; do
+        if [ -e "$admin_dir/$sub" ] &&
+            [ -n "$(find "$admin_dir/$sub" -type f 2>/dev/null | head -n 1)" ]; then
+            carried="$carried $sub"
+        fi
+    done
+    if [ -n "$carried" ]; then
+        echo "SKIP  record '$record' — carries worktree-local state (${carried# }); adopt or rescue it first, it exists nowhere else"
+        exit 3
+    fi
+
+    record_head="$(cat "$admin_dir/HEAD" 2>/dev/null || true)"
+
+    # The index can be the only structure referencing staged-but-uncommitted
+    # blobs (challenge r7): an index that diverges from the recorded HEAD —
+    # or that cannot be verified against it — is state, and refused.
+    if [ -f "$admin_dir/index" ]; then
+        head_commit=""
+        case "$record_head" in
+        ref:*) head_commit="$(git rev-parse --quiet --verify "${record_head#ref: }^{commit}" || true)" ;;
+        '') : ;;
+        *) head_commit="$(git rev-parse --quiet --verify "$record_head^{commit}" || true)" ;;
+        esac
+        if [ -z "$head_commit" ] ||
+            ! GIT_INDEX_FILE="$admin_dir/index" git diff-index --cached --quiet "$head_commit" 2>/dev/null; then
+            echo "SKIP  record '$record' — its index diverges from the recorded HEAD (staged-only changes, or unverifiable); recover them first (GIT_INDEX_FILE=$admin_dir/index git checkout-index ...), then remove the index file"
+            exit 3
+        fi
+    fi
+
+    pinned_here=false
+    case "$record_head" in
+    ref:* | '') : ;; # attached to a branch: the branch keeps the commits
+    *)
+        if git rev-parse --quiet --verify "$record_head^{commit}" >/dev/null 2>&1; then
+            existing_pin="$(git rev-parse --quiet --verify "refs/session-cleanup/pin/$record" || true)"
+            if [ -n "$existing_pin" ] && [ "$existing_pin" != "$record_head" ]; then
+                echo "SKIP  record '$record' — refs/session-cleanup/pin/$record already pins $existing_pin from an earlier run; settle it first (git branch $(shell_quote "rescue/$record") $existing_pin, or git update-ref -d $(shell_quote "refs/session-cleanup/pin/$record"))"
+                exit 3
+            fi
+            # Create-only (old value ''): never overwrite a pin this run did
+            # not just verify.
+            if ! LEFTHOOK=0 git update-ref "refs/session-cleanup/pin/$record" "$record_head" "${existing_pin:-}"; then
+                echo "SKIP  record '$record' — cannot pin detached commit $record_head; refusing to remove it unprotected"
+                exit 3
+            fi
+            pinned_here=true
+        fi
+        ;;
+    esac
+
+    # Records only: the stale admin directory is all that goes.
+    rm -rf "$admin_dir"
+    echo "pruned record '$record'"
+
+    if [ "$pinned_here" = true ]; then
+        # Reporting only — pins are settled by humans, never auto-dropped
+        # (challenge r6): the reachability check picks the wording, and a
+        # race can at worst mislabel, never delete.
+        pin_ref="refs/session-cleanup/pin/$record"
+        if [ "$grafts_present" = false ] && [ -n "$(shared_refs_containing "$record_head")" ]; then
+            echo "PINNED  $pin_ref — $record_head is also reachable from shared refs; drop it with: git update-ref -d $(shell_quote "$pin_ref")"
+        else
+            echo "KEPT  $pin_ref — pruned record '$record' held the only reference to detached commit $record_head; branch it (git branch $(shell_quote "rescue/$record") $record_head) or discard it (git update-ref -d $(shell_quote "$pin_ref"))"
+        fi
+        exit 2
+    fi
+)
+
+removed=0
+skipped=0
+pins_pending=0
+while IFS= read -r line; do
+    record="$(printf '%s\n' "$line" | sed -n 's/^Removing worktrees\/\(.*\): .*$/\1/p')"
+    [ -n "$record" ] || continue
+    rc=0
+    remove_one_record "$record" || rc=$?
+    case "$rc" in
+    0) removed=$((removed + 1)) ;;
+    2)
+        removed=$((removed + 1))
+        pins_pending=$((pins_pending + 1))
+        ;;
+    3) skipped=$((skipped + 1)) ;;
+    *)
+        echo "SKIP  record '$record' — the worktree lifecycle lock refused (a worktree operation is active; details above)"
+        skipped=$((skipped + 1))
+        ;;
+    esac
+done <<EOF
+$prune_plan
+EOF
+
+if [ "$removed" -eq 0 ] && [ "$skipped" -eq 0 ]; then
+    echo "clean:worktree-records: nothing to prune."
+    exit 0
+fi
+if [ "$pins_pending" -gt 0 ] || [ "$skipped" -gt 0 ]; then
+    echo "clean:worktree-records: $removed record(s) pruned; $pins_pending pin(s) awaiting settlement, $skipped record(s) refused above." >&2
+    exit 2
+fi
+echo "clean:worktree-records: stale records pruned (worktree directories are never touched)."

--- a/template/scripts/clean-worktree-records.sh
+++ b/template/scripts/clean-worktree-records.sh
@@ -30,8 +30,8 @@
 #     (rebase/merge/cherry-pick — the worktree-rm.sh list), and an index
 #     that diverges from the recorded HEAD (staged-but-uncommitted blobs
 #     the index alone keeps alive). An unreadable HEAD refuses outright,
-#     and ORIG_HEAD — a ref file, not a reflog — refuses when it names a
-#     commit no shared ref contains. Reflogs are deliberately NOT state —
+#     and ORIG_HEAD and FETCH_HEAD — ref files, not reflogs — refuse when
+#     they name a commit no shared ref contains. Reflogs are deliberately NOT state —
 #     every record has one, and accepting reflog loss matches git's own
 #     prune semantics.
 #   * A detached record HEAD is pinned as refs/session-cleanup/pin/<record>
@@ -115,7 +115,10 @@ pins_outstanding() {
 }
 
 finish_no_work() {
-    if [ -n "$(pins_outstanding)" ]; then
+    # Enumeration failure is not an empty namespace: a broken ref backend
+    # must never let the run report cleanup complete (challenge r4).
+    outstanding="$(pins_outstanding)" || die "cannot enumerate rescue pins (refs/session-cleanup/pin unreadable); refusing to report cleanup complete"
+    if [ -n "$outstanding" ]; then
         echo "clean:worktree-records: nothing to prune, but rescue pins await settlement (task audit:session-artifacts lists them)." >&2
         exit 2
     fi
@@ -216,6 +219,29 @@ remove_one_record() (
             echo "SKIP  record '$record' — ORIG_HEAD $orig_commit is reachable from no shared ref, or containment is unusable under a legacy graft file (a reset/rebase abandoned it here); rescue it (git branch $(shell_quote "rescue/$record-orig") $orig_commit) then remove $admin_dir/ORIG_HEAD"
             exit 3
         fi
+    fi
+
+    # FETCH_HEAD can hold the only mapping to a URL-fetched, unbranched tip
+    # (a PR head). Ordinary fetches list tips the remote-tracking refs
+    # contain, so — exactly as with ORIG_HEAD — only an unreadable,
+    # unresolvable, or unreachable entry refuses; the conditional guard has
+    # none of the unsweepability cost an unconditional refusal would
+    # (challenge r4, revising r3's declination of the unconditional form).
+    if [ -f "$admin_dir/FETCH_HEAD" ]; then
+        while IFS= read -r fetch_line; do
+            [ -n "$fetch_line" ] || continue
+            fetch_sha="${fetch_line%%[[:space:]]*}"
+            fetch_commit=""
+            [ -z "$fetch_sha" ] || fetch_commit="$(git rev-parse --quiet --verify "$fetch_sha^{commit}" || true)"
+            if [ -z "$fetch_commit" ]; then
+                echo "SKIP  record '$record' — FETCH_HEAD entry '$fetch_sha' is unreadable or names no commit; refusing to sweep (inspect $admin_dir/FETCH_HEAD)"
+                exit 3
+            fi
+            if [ "$grafts_present" = true ] || [ -z "$(shared_refs_containing "$fetch_commit")" ]; then
+                echo "SKIP  record '$record' — FETCH_HEAD names $fetch_commit, reachable from no shared ref (a URL fetch left it here); rescue it (git branch $(shell_quote "rescue/$record-fetch") $fetch_commit) then remove $admin_dir/FETCH_HEAD"
+                exit 3
+            fi
+        done <"$admin_dir/FETCH_HEAD"
     fi
 
     # The index can be the only structure referencing staged-but-uncommitted
@@ -340,8 +366,13 @@ if [ "$errors" -gt 0 ]; then
     echo "clean:worktree-records: $removed record(s) pruned; $errors record removal(s) FAILED above — resolve before re-running." >&2
     exit 1
 fi
-if [ "$pins_pending" -gt 0 ] || [ "$skipped" -gt 0 ] || [ -n "$(pins_outstanding)" ]; then
-    echo "clean:worktree-records: $removed record(s) pruned; $pins_pending pin(s) awaiting settlement, $skipped record(s) refused above." >&2
+outstanding="$(pins_outstanding)" || die "cannot enumerate rescue pins (refs/session-cleanup/pin unreadable); refusing to report cleanup complete"
+if [ "$pins_pending" -gt 0 ] || [ "$skipped" -gt 0 ] || [ -n "$outstanding" ]; then
+    # Total, not just this run's: a pin inherited from an earlier run is
+    # exactly as much awaiting settlement as a fresh one, and printing "0"
+    # beside a nonzero exit contradicts the disposition (challenge r4).
+    total_pins="$(git for-each-ref refs/session-cleanup/pin --format='%(refname)' | grep -c . || true)"
+    echo "clean:worktree-records: $removed record(s) pruned; $pins_pending new pin(s) this run, $total_pins total awaiting settlement, $skipped record(s) refused above." >&2
     exit 2
 fi
 echo "clean:worktree-records: stale records pruned (worktree directories are never touched)."

--- a/template/scripts/clean-worktree-records.sh
+++ b/template/scripts/clean-worktree-records.sh
@@ -187,9 +187,15 @@ remove_one_record() (
     fi
     # A surviving worktree DIRECTORY whose .git link is gone still holds
     # the user's files; sweeping its record would orphan them as a plain
-    # directory nothing tracks (challenge r7).
+    # directory nothing tracks (challenge r7). A gitdir value that does not
+    # end in /.git is malformed — and would silently skip this very guard —
+    # so it refuses outright (shepherd r1).
     tree_dir="${wt_gitfile%/.git}"
-    if [ "$tree_dir" != "$wt_gitfile" ] && [ -d "$tree_dir" ]; then
+    if [ "$tree_dir" = "$wt_gitfile" ]; then
+        echo "SKIP  record '$record' — its gitdir value does not end in /.git (malformed); refusing to sweep an unvalidatable record (inspect $admin_dir/gitdir)"
+        exit 3 # malformed gitdir suffix refuses
+    fi
+    if [ -d "$tree_dir" ]; then
         echo "SKIP  record '$record' — its worktree directory still exists ($tree_dir) though the .git link is gone; restore the link or move the directory aside first"
         exit 3 # surviving tree dir refuses
     fi
@@ -268,6 +274,13 @@ remove_one_record() (
             ;;
         deferred-findings | adjudication-ledger | shepherd-codex | refs | rebase-merge | rebase-apply | MERGE_HEAD | MERGE_AUTOSTASH | CHERRY_PICK_HEAD | REVERT_HEAD | BISECT_LOG | config.worktree) : ;; # carried-state names: the scan above refused them when non-empty
         info)
+            # As a regular file or symlink, the child globs below match
+            # nothing and the entry would be accepted uninspected
+            # (shepherd r1) — the same type gate the other slots carry.
+            if [ ! -d "$entry" ] || [ -L "$entry" ]; then
+                echo "SKIP  record '$record' — entry 'info' is not the directory git writes there; refusing to sweep malformed state (inspect $admin_dir)"
+                exit 3 # info type mismatch refuses
+            fi
             for info_entry in "$entry"/* "$entry"/.[!.]* "$entry"/..?*; do
                 [ -e "$info_entry" ] || [ -L "$info_entry" ] || continue
                 case "${info_entry##*/}" in
@@ -453,7 +466,7 @@ remove_one_record() (
             # -d with an old value is compare-and-delete, so a stale command
             # re-run after record-name reuse cannot delete a newer pin
             # (challenge r3).
-            echo "PINNED  $pin_ref — $record_head was reachable from shared refs at prune time; re-verify before dropping (git --no-replace-objects for-each-ref --contains $record_head refs/heads refs/tags refs/remotes), then: git update-ref -d $(shell_quote "$pin_ref") $record_head"
+            echo "PINNED  $pin_ref — $record_head was reachable from shared refs at prune time; re-verify before dropping (GIT_GRAFT_FILE=/dev/null git --no-replace-objects for-each-ref --contains $record_head refs/heads refs/tags refs/remotes), then: git update-ref -d $(shell_quote "$pin_ref") $record_head"
         else
             echo "KEPT  $pin_ref — pruned record '$record' held the only reference to detached commit $record_head; branch it (git branch $(shell_quote "rescue/$record") $record_head) or discard it (git update-ref -d $(shell_quote "$pin_ref") $record_head)"
         fi

--- a/template/scripts/clean-worktree-records.sh
+++ b/template/scripts/clean-worktree-records.sh
@@ -236,7 +236,24 @@ remove_one_record() (
         [ -e "$entry" ] || [ -L "$entry" ] || continue # -e dereferences: a broken symlink must still be judged
         entry_name="${entry##*/}"
         case "$entry_name" in
-        gitdir | commondir | HEAD | locked | COMMIT_EDITMSG | ORIG_HEAD | FETCH_HEAD | index | logs) : ;;                                                                                                  # validated by the guards here, disposable scratch, or reflogs (accepted loss by design)
+        gitdir | commondir | HEAD | locked | COMMIT_EDITMSG | ORIG_HEAD | FETCH_HEAD | index)
+            # Validated by the guards here or disposable scratch — but only
+            # as the regular files git writes: a directory or symlink in one
+            # of these slots would skip its -f validator yet still be
+            # rm -rf'd with the record (challenge r8).
+            if [ ! -f "$entry" ] || [ -L "$entry" ]; then
+                echo "SKIP  record '$record' — entry '$entry_name' is not the regular file git writes there; refusing to sweep malformed state (inspect $admin_dir)"
+                exit 3 # type mismatch refuses
+            fi
+            ;;
+        logs)
+            # Reflogs (accepted loss by design) — as the directory git
+            # writes, same type gate as above.
+            if [ ! -d "$entry" ] || [ -L "$entry" ]; then
+                echo "SKIP  record '$record' — entry 'logs' is not the directory git writes there; refusing to sweep malformed state (inspect $admin_dir)"
+                exit 3 # type mismatch refuses
+            fi
+            ;;
         deferred-findings | adjudication-ledger | shepherd-codex | refs | rebase-merge | rebase-apply | MERGE_HEAD | MERGE_AUTOSTASH | CHERRY_PICK_HEAD | REVERT_HEAD | BISECT_LOG | config.worktree) : ;; # carried-state names: the scan above refused them when non-empty
         info)
             for info_entry in "$entry"/* "$entry"/.[!.]* "$entry"/..?*; do
@@ -405,7 +422,13 @@ remove_one_record() (
                 exit 5
             fi
         elif [ "$pin_now" != "$record_head" ]; then
-            echo "CRITICAL  $pin_ref no longer pins $record_head (it now holds $pin_now) — rescue the detached commit NOW: git branch $(shell_quote "rescue/$record") $record_head"
+            # The record is already gone, so the commit must not ride on the
+            # human seeing the diagnostic alone: best-effort re-protect under
+            # a fresh unique name — create-only, so the foreign write to the
+            # original pin is never overwritten (challenge r8).
+            rescue_ref="refs/session-cleanup/pin/$record-rescue-$(printf '%.7s' "$record_head")"
+            LEFTHOOK=0 git update-ref "$rescue_ref" "$record_head" "" 2>/dev/null || true
+            echo "CRITICAL  $pin_ref no longer pins $record_head (it now holds $pin_now) — a rescue ref was created at $rescue_ref if possible (verify: git rev-parse $(shell_quote "$rescue_ref")); rescue the detached commit NOW: git branch $(shell_quote "rescue/$record") $record_head"
             exit 5
         fi
         # Reporting only — pins are settled by humans, never auto-dropped

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -856,17 +856,17 @@ echo "ok: a pin dropped mid-run by a racing settlement is re-asserted"
 # A partial rm is corrupt state needing inspection; reporting it as lock
 # contention hands the operator the wrong remedy.
 
-mkdir -p "$gitdir/worktrees/stuckrec/blocker"
+mkdir -p "$gitdir/worktrees/stuckrec/logs/blocker"
 printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/stuckrec/HEAD"
 printf '%s\n' "/nonexistent/stuckrec/.git" >"$gitdir/worktrees/stuckrec/gitdir"
-touch "$gitdir/worktrees/stuckrec/blocker/held"
-chmod 000 "$gitdir/worktrees/stuckrec/blocker"
+touch "$gitdir/worktrees/stuckrec/logs/blocker/held"
+chmod 000 "$gitdir/worktrees/stuckrec/logs/blocker"
 
 if stuck_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
-    chmod 755 "$gitdir/worktrees/stuckrec/blocker" 2>/dev/null || true
+    chmod 755 "$gitdir/worktrees/stuckrec/logs/blocker" 2>/dev/null || true
     fail "record prune exited zero although removal failed: $stuck_out"
 fi
-chmod 755 "$gitdir/worktrees/stuckrec/blocker" 2>/dev/null || true
+chmod 755 "$gitdir/worktrees/stuckrec/logs/blocker" 2>/dev/null || true
 expect_contains "$stuck_out" "removal failed midway" "rm failure: reported as its own outcome"
 expect_not_contains "$stuck_out" "lifecycle lock refused" "rm failure: never mislabeled as lock contention"
 
@@ -1074,6 +1074,37 @@ tagrec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" 
     fail "record prune failed after the tag object was rescued: $tagrec_ok_out"
 expect_contains "$tagrec_ok_out" "pruned record 'tagrec'" "fetch-tag: referenced tag object sweeps normally"
 echo "ok: an unreferenced annotated tag in FETCH_HEAD refuses the sweep until rescued"
+
+# ── Case E7u: an unrecognized admin-dir entry refuses the sweep ────────────
+# The sweep is allowlist-gated: git grows state files over time (sequencer/,
+# AUTO_MERGE, ...) and enumerating dangerous ones loses that game — anything
+# this tool does not understand fails closed.
+
+mkdir -p "$gitdir/worktrees/oddrec/sequencer"
+echo "pick deadbeef subject" >"$gitdir/worktrees/oddrec/sequencer/todo"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/oddrec/HEAD"
+printf '%s\n' "/nonexistent/oddrec/.git" >"$gitdir/worktrees/oddrec/gitdir"
+
+if odd_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unrecognized admin entry present: $odd_out"
+fi
+expect_contains "$odd_out" "unrecognized entry 'sequencer'" "unknown entry: refused fail-closed"
+[ -d "$gitdir/worktrees/oddrec" ] || fail "unknown entry: record swept despite unrecognized state"
+
+rm -rf "$gitdir/worktrees/oddrec/sequencer"
+mkdir -p "$gitdir/worktrees/oddrec/info"
+echo "mystery" >"$gitdir/worktrees/oddrec/info/attributes-cache"
+if oddinfo_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unrecognized info/ entry present: $oddinfo_out"
+fi
+expect_contains "$oddinfo_out" "unrecognized entry info/attributes-cache" "unknown info entry: refused fail-closed"
+[ -d "$gitdir/worktrees/oddrec" ] || fail "unknown info entry: record swept despite unrecognized state"
+
+rm -rf "$gitdir/worktrees/oddrec/info"
+odd_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the unknown entries were adopted: $odd_ok_out"
+expect_contains "$odd_ok_out" "pruned record 'oddrec'" "unknown entry: understood record prunes normally"
+echo "ok: an unrecognized admin-dir entry refuses the sweep"
 
 # ── Case E7s: pin-enumeration failure never reports cleanup complete ───────
 # A broken ref backend is not an empty pin namespace; the empty-plan path

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -581,6 +581,14 @@ pin_audit_out="$(cd "$fixture" && bash scripts/audit-session-artifacts.sh 2>&1)"
 expect_contains "$pin_audit_out" "wt-det — pins $det_sha" "audit: leftover rescue pin reported"
 echo "ok: audit reports leftover rescue pins"
 
+# The contract holds across retries: an otherwise-empty re-run must stay
+# nonzero while any pin awaits settlement, not report cleanup complete.
+if pin_retry_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero while a rescue pin awaited settlement: $pin_retry_out"
+fi
+expect_contains "$pin_retry_out" "rescue pins await settlement" "retry: pending pin keeps the run nonzero"
+echo "ok: a pending rescue pin keeps retries nonzero"
+
 git -C "$fixture" branch -q rescue-det "$det_sha"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/wt-det
 prune_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
@@ -615,6 +623,7 @@ if reuse_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)
 fi
 expect_contains "$reuse_ok_out" "pruned record 'pin-reuse'" "pin reuse: settled pin lets the removal proceed"
 expect_contains "$reuse_ok_out" "PINNED  refs/session-cleanup/pin/pin-reuse" "pin reuse: fresh pin reported for explicit settlement"
+expect_contains "$reuse_ok_out" "re-verify before dropping" "pin reuse: drop remedy demands execution-time re-verification, not a stale snapshot"
 [ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/pin-reuse)" = "$(git -C "$fixture" rev-parse main)" ] ||
     fail "pin reuse: fresh pin missing or wrong — pins must never be auto-dropped"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/pin-reuse
@@ -624,7 +633,7 @@ echo "ok: an unsettled rescue pin refuses the prune instead of being overwritten
 # Sidecars and per-worktree ref files under worktrees/<id>/ are single-copy;
 # no pin can stand in for them.
 
-for rec in state-rec refs-rec; do
+for rec in state-rec refs-rec op-rec; do
     mkdir -p "$gitdir/worktrees/$rec"
     printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/$rec/HEAD"
     printf '%s\n' "/nonexistent/$rec/.git" >"$gitdir/worktrees/$rec/gitdir"
@@ -634,21 +643,27 @@ echo "p2 from a dead session" >"$gitdir/worktrees/state-rec/deferred-findings/so
 mkdir -p "$gitdir/worktrees/refs-rec/refs/worktree"
 refs_orph="$(git -C "$fixture" commit-tree "main^{tree}" -p main -m "worktree-ref orphan")"
 printf '%s\n' "$refs_orph" >"$gitdir/worktrees/refs-rec/refs/worktree/only"
+# A merge parked at an edit: MERGE_HEAD is sequencer state the record alone
+# holds (the worktree-rm.sh op-state list).
+git -C "$fixture" rev-parse main >"$gitdir/worktrees/op-rec/MERGE_HEAD"
 
 if state_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
     fail "record prune exited zero with refused state-carrying records: $state_out"
 fi
 expect_contains "$state_out" "record 'state-rec' — carries worktree-local state (deferred-findings)" "state: sidecar-carrying record refused"
 expect_contains "$state_out" "record 'refs-rec' — carries worktree-local state (refs)" "state: per-worktree-ref record refused"
+expect_contains "$state_out" "record 'op-rec' — carries worktree-local state (MERGE_HEAD)" "state: in-progress-operation record refused"
 [ -d "$gitdir/worktrees/state-rec" ] || fail "state: sidecar-carrying record was swept"
 [ -d "$gitdir/worktrees/refs-rec" ] || fail "state: ref-carrying record was swept"
+[ -d "$gitdir/worktrees/op-rec" ] || fail "state: op-state record was swept"
 git -C "$fixture" cat-file -e "$refs_orph" || fail "state: worktree-ref orphan commit lost"
 
-rm -rf "$gitdir/worktrees/state-rec/deferred-findings" "$gitdir/worktrees/refs-rec/refs"
+rm -rf "$gitdir/worktrees/state-rec/deferred-findings" "$gitdir/worktrees/refs-rec/refs" "$gitdir/worktrees/op-rec/MERGE_HEAD"
 state_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
     fail "record prune failed after the state was adopted: $state_ok_out"
 expect_contains "$state_ok_out" "pruned record 'state-rec'" "state: adopted record prunes normally"
 expect_contains "$state_ok_out" "pruned record 'refs-rec'" "state: rescued record prunes normally"
+expect_contains "$state_ok_out" "pruned record 'op-rec'" "state: finished-operation record prunes normally"
 echo "ok: state-carrying records are refused until adopted, never swept"
 
 # ── Case E7e: an index diverging from the recorded HEAD refuses the sweep ──
@@ -718,7 +733,7 @@ if repg_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; t
 fi
 git -C "$fixture" update-ref -d "refs/replace/$repg_main"
 expect_contains "$repg_out" "KEPT  refs/session-cleanup/pin/reptrap" "replace ref: pin reported as the only reference"
-expect_not_contains "$repg_out" "also reachable from shared refs" "replace ref: forged containment does not invite dropping the pin"
+expect_not_contains "$repg_out" "reachable from shared refs at prune time" "replace ref: forged containment does not invite dropping the pin"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/reptrap
 echo "ok: a replacement ref cannot forge the pin-drop remedy"
 
@@ -739,9 +754,100 @@ fi
 rm -f "$gitdir/info/grafts"
 expect_contains "$graftrec_out" "legacy graft file present" "grafts: presence announced by the record prune"
 expect_contains "$graftrec_out" "KEPT  refs/session-cleanup/pin/grafttrap" "grafts: pin reported conservatively"
-expect_not_contains "$graftrec_out" "also reachable from shared refs" "grafts: grafted containment does not invite dropping the pin"
+expect_not_contains "$graftrec_out" "reachable from shared refs at prune time" "grafts: grafted containment does not invite dropping the pin"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/grafttrap
 echo "ok: a legacy graft file forces the conservative pin wording"
+
+# The two interleaving guards below need a mid-run event; a PATH shim around
+# git injects it deterministically at the exact seam, then passes through.
+shim_dir="$test_tmp/git-shim"
+mkdir -p "$shim_dir"
+real_git="$(command -v git)"
+
+# ── Case E7i: a git worktree lock taken after the plan still protects ──────
+# `git worktree prune` skips locked records at plan time, but a lock created
+# between the plan and the removal (removable media coming under protection)
+# must be honored by the re-check under the lifecycle lock.
+
+mkdir -p "$gitdir/worktrees/lockedrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/lockedrec/HEAD"
+printf '%s\n' "/nonexistent/lockedrec/.git" >"$gitdir/worktrees/lockedrec/gitdir"
+cat >"$shim_dir/git" <<SHIM
+#!/usr/bin/env bash
+if [[ "\$*" == *"worktree prune --dry-run"* ]]; then
+    "$real_git" "\$@"
+    touch "$gitdir/worktrees/lockedrec/locked"
+    exit 0
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$shim_dir/git"
+
+if lockmark_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although a git worktree lock landed post-plan: $lockmark_out"
+fi
+expect_contains "$lockmark_out" "locked by git worktree lock since the plan" "post-plan lock: record skipped loudly"
+[ -d "$gitdir/worktrees/lockedrec" ] || fail "post-plan lock: locked record was swept"
+
+rm -f "$gitdir/worktrees/lockedrec/locked"
+lockmark_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the git lock was released: $lockmark_ok_out"
+expect_contains "$lockmark_ok_out" "pruned record 'lockedrec'" "post-plan lock: unlocked record prunes normally"
+echo "ok: a git worktree lock taken after the plan still protects the record"
+
+# ── Case E7j: a pin dropped mid-run by a racing settlement is re-asserted ──
+# The audit advertises pins, so a human settlement can delete one in the
+# window between the create and the record removal; the pin is re-asserted
+# before the run reports it kept.
+
+race_orph="$(git -C "$fixture" commit-tree "main^{tree}" -m "orphan-behind-race")"
+mkdir -p "$gitdir/worktrees/racepin"
+printf '%s\n' "$race_orph" >"$gitdir/worktrees/racepin/HEAD"
+printf '%s\n' "/nonexistent/racepin/.git" >"$gitdir/worktrees/racepin/gitdir"
+rm -f "$test_tmp/racepin-dropped"
+cat >"$shim_dir/git" <<SHIM
+#!/usr/bin/env bash
+if [[ "\$1" == "update-ref" && "\$2" == "refs/session-cleanup/pin/racepin" && ! -e "$test_tmp/racepin-dropped" ]]; then
+    touch "$test_tmp/racepin-dropped"
+    "$real_git" "\$@" || exit \$?
+    "$real_git" update-ref -d refs/session-cleanup/pin/racepin
+    exit 0
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$shim_dir/git"
+
+if racepin_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although its re-asserted pin awaits settlement: $racepin_out"
+fi
+expect_contains "$racepin_out" "KEPT  refs/session-cleanup/pin/racepin" "pin race: pin reported kept"
+[ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/racepin)" = "$race_orph" ] ||
+    fail "pin race: pin dropped mid-run was not re-asserted — the KEPT report is a lie"
+git -C "$fixture" cat-file -e "$race_orph" || fail "pin race: orphan commit lost"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/racepin
+echo "ok: a pin dropped mid-run by a racing settlement is re-asserted"
+
+# ── Case E7k: a failed record removal is loud and never lock-labeled ───────
+# A partial rm is corrupt state needing inspection; reporting it as lock
+# contention hands the operator the wrong remedy.
+
+mkdir -p "$gitdir/worktrees/stuckrec/blocker"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/stuckrec/HEAD"
+printf '%s\n' "/nonexistent/stuckrec/.git" >"$gitdir/worktrees/stuckrec/gitdir"
+touch "$gitdir/worktrees/stuckrec/blocker/held"
+chmod 000 "$gitdir/worktrees/stuckrec/blocker"
+
+if stuck_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    chmod 755 "$gitdir/worktrees/stuckrec/blocker" 2>/dev/null || true
+    fail "record prune exited zero although removal failed: $stuck_out"
+fi
+chmod 755 "$gitdir/worktrees/stuckrec/blocker" 2>/dev/null || true
+expect_contains "$stuck_out" "removal failed midway" "rm failure: reported as its own outcome"
+expect_not_contains "$stuck_out" "lifecycle lock refused" "rm failure: never mislabeled as lock contention"
+
+stuck_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the blocker was cleared: $stuck_ok_out"
+echo "ok: a failed record removal is loud and never lock-labeled"
 
 # ── Case E8: a renamed remote default refuses every deletion ───────────────
 # The local origin/HEAD still names the old default; the live remote HEAD

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -845,9 +845,90 @@ chmod 755 "$gitdir/worktrees/stuckrec/blocker" 2>/dev/null || true
 expect_contains "$stuck_out" "removal failed midway" "rm failure: reported as its own outcome"
 expect_not_contains "$stuck_out" "lifecycle lock refused" "rm failure: never mislabeled as lock contention"
 
+# The partial rm may have taken HEAD/gitdir (deletion order is undefined);
+# restore them so the recovery run exercises a validatable record.
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/stuckrec/HEAD"
+printf '%s\n' "/nonexistent/stuckrec/.git" >"$gitdir/worktrees/stuckrec/gitdir"
 stuck_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
     fail "record prune failed after the blocker was cleared: $stuck_ok_out"
 echo "ok: a failed record removal is loud and never lock-labeled"
+
+# ── Case E7m: an unreachable ORIG_HEAD refuses the sweep ───────────────────
+# ORIG_HEAD is a ref file, not a reflog: a reset --hard's abandoned commit
+# can live in it alone, so reflog accepted-loss does not cover it. A
+# reachable ORIG_HEAD sweeps normally.
+
+orph_o="$(git -C "$fixture" commit-tree "main^{tree}" -m "reset-away")"
+mkdir -p "$gitdir/worktrees/origrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/origrec/HEAD"
+printf '%s\n' "/nonexistent/origrec/.git" >"$gitdir/worktrees/origrec/gitdir"
+printf '%s\n' "$orph_o" >"$gitdir/worktrees/origrec/ORIG_HEAD"
+
+if orig_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unreachable ORIG_HEAD present: $orig_out"
+fi
+expect_contains "$orig_out" "ORIG_HEAD $orph_o is reachable from no shared ref" "orig-head: reset-away commit refused"
+[ -d "$gitdir/worktrees/origrec" ] || fail "orig-head: record swept despite its unreachable ORIG_HEAD"
+git -C "$fixture" cat-file -e "$orph_o" || fail "orig-head: reset-away commit lost"
+
+git -C "$fixture" branch -q rescue-orig "$orph_o"
+orig_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the ORIG_HEAD commit was rescued: $orig_ok_out"
+expect_contains "$orig_ok_out" "pruned record 'origrec'" "orig-head: reachable ORIG_HEAD sweeps normally"
+echo "ok: an unreachable ORIG_HEAD refuses the sweep until rescued"
+
+# ── Case E7n: a record with an unreadable HEAD is refused, never swept ─────
+# An empty or missing HEAD would fall through every HEAD-derived guard and
+# sweep unpinned; an unvalidatable record fails closed.
+
+mkdir -p "$gitdir/worktrees/noheadrec"
+printf '%s\n' "/nonexistent/noheadrec/.git" >"$gitdir/worktrees/noheadrec/gitdir"
+
+if nohead_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unvalidatable record present: $nohead_out"
+fi
+expect_contains "$nohead_out" "cannot read its HEAD" "no-head: unvalidatable record refused"
+[ -d "$gitdir/worktrees/noheadrec" ] || fail "no-head: unvalidatable record was swept"
+
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/noheadrec/HEAD"
+nohead_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after HEAD was restored: $nohead_ok_out"
+expect_contains "$nohead_ok_out" "pruned record 'noheadrec'" "no-head: restored record prunes normally"
+echo "ok: a record with an unreadable HEAD is refused, never swept"
+
+# ── Case E7o: a pin retargeted mid-run fails closed, never reported kept ───
+# Existence alone verifies nothing: a pin rewritten between its creation
+# and the post-removal check must fail the run loudly with a rescue remedy,
+# not be overwritten and not be reported as keeping the commit.
+
+ret_orph="$(git -C "$fixture" commit-tree "main^{tree}" -m "orphan-behind-retarget")"
+ret_main="$(git -C "$fixture" rev-parse main)"
+mkdir -p "$gitdir/worktrees/retarg"
+printf '%s\n' "$ret_orph" >"$gitdir/worktrees/retarg/HEAD"
+printf '%s\n' "/nonexistent/retarg/.git" >"$gitdir/worktrees/retarg/gitdir"
+rm -f "$test_tmp/retarg-hit"
+cat >"$shim_dir/git" <<SHIM
+#!/usr/bin/env bash
+if [[ "\$1" == "update-ref" && "\$2" == "refs/session-cleanup/pin/retarg" && ! -e "$test_tmp/retarg-hit" ]]; then
+    touch "$test_tmp/retarg-hit"
+    "$real_git" "\$@" || exit \$?
+    "$real_git" update-ref refs/session-cleanup/pin/retarg "$ret_main"
+    exit 0
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$shim_dir/git"
+
+if retarg_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although its pin was retargeted mid-run: $retarg_out"
+fi
+expect_contains "$retarg_out" "no longer pins $ret_orph" "pin retarget: OID mismatch fails closed with the rescue remedy"
+expect_not_contains "$retarg_out" "KEPT  refs/session-cleanup/pin/retarg" "pin retarget: a retargeted pin is never reported as keeping the commit"
+[ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/retarg)" = "$ret_main" ] ||
+    fail "pin retarget: the foreign write was overwritten — settlement is human-only"
+git -C "$fixture" cat-file -e "$ret_orph" || fail "pin retarget: orphan commit lost from the object db"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/retarg
+echo "ok: a pin retargeted mid-run fails closed, never reported kept"
 
 # ── Case E8: a renamed remote default refuses every deletion ───────────────
 # The local origin/HEAD still names the old default; the live remote HEAD

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -1250,6 +1250,37 @@ typerec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"
 expect_contains "$typerec_ok_out" "pruned record 'typerec'" "type gate: well-formed record prunes normally"
 echo "ok: an allowlisted name of the wrong type refuses the sweep"
 
+# ── Case E7z: a gitdir that changed across the lock refuses the sweep ──────
+# The lifecycle lock is keyed off a pre-lock gitdir read; a record replaced
+# while the lock is approached could otherwise be validated under no lock
+# (or the wrong key) and swept mid-creation.
+
+mkdir -p "$gitdir/worktrees/lockswap"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/lockswap/HEAD"
+printf '%s\n' "$fixture/.worktrees/lockswap/.git" >"$gitdir/worktrees/lockswap/gitdir"
+rm -f "$test_tmp/lockswap-hit"
+cat >"$shim_dir/cat" <<SHIM
+#!/usr/bin/env bash
+if [[ "\${1:-}" == *"/worktrees/lockswap/gitdir" && ! -e "$test_tmp/lockswap-hit" ]]; then
+    touch "$test_tmp/lockswap-hit"
+    exit 1
+fi
+exec /bin/cat "\$@"
+SHIM
+chmod +x "$shim_dir/cat"
+
+if lockswap_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the lock key drifted: $lockswap_out"
+fi
+rm -f "$shim_dir/cat"
+expect_contains "$lockswap_out" "gitdir changed while the lock was being acquired" "lock-key drift: refused for a re-run"
+[ -d "$gitdir/worktrees/lockswap" ] || fail "lock-key drift: record swept under a missing or wrong lock"
+
+lockswap_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed on the stable re-run: $lockswap_ok_out"
+expect_contains "$lockswap_ok_out" "pruned record 'lockswap'" "lock-key drift: stable re-run prunes normally"
+echo "ok: a gitdir that changed across the lock refuses the sweep"
+
 # ── Case E7s: pin-enumeration failure never reports cleanup complete ───────
 # A broken ref backend is not an empty pin namespace; the empty-plan path
 # must fail closed instead of printing "nothing to prune" with exit 0.

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -648,7 +648,7 @@ echo "ok: an unsettled rescue pin refuses the prune instead of being overwritten
 # Sidecars and per-worktree ref files under worktrees/<id>/ are single-copy;
 # no pin can stand in for them.
 
-for rec in state-rec refs-rec op-rec cfg-rec; do
+for rec in state-rec refs-rec op-rec cfg-rec stash-rec; do
     mkdir -p "$gitdir/worktrees/$rec"
     printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/$rec/HEAD"
     printf '%s\n' "/nonexistent/$rec/.git" >"$gitdir/worktrees/$rec/gitdir"
@@ -663,6 +663,9 @@ printf '%s\n' "$refs_orph" >"$gitdir/worktrees/refs-rec/refs/worktree/only"
 git -C "$fixture" rev-parse main >"$gitdir/worktrees/op-rec/MERGE_HEAD"
 # User-set per-worktree configuration is single-copy exactly like a sidecar.
 printf '[review]\n\tunique = KEEP-ME\n' >"$gitdir/worktrees/cfg-rec/config.worktree"
+# An interrupted merge --autostash: the stash commit can be referenced by
+# this one file alone.
+git -C "$fixture" rev-parse main >"$gitdir/worktrees/stash-rec/MERGE_AUTOSTASH"
 
 if state_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
     fail "record prune exited zero with refused state-carrying records: $state_out"
@@ -671,18 +674,20 @@ expect_contains "$state_out" "record 'state-rec' — carries worktree-local stat
 expect_contains "$state_out" "record 'refs-rec' — carries worktree-local state (refs)" "state: per-worktree-ref record refused"
 expect_contains "$state_out" "record 'op-rec' — carries worktree-local state (MERGE_HEAD)" "state: in-progress-operation record refused"
 expect_contains "$state_out" "record 'cfg-rec' — carries worktree-local state (config.worktree)" "state: per-worktree-config record refused"
+expect_contains "$state_out" "record 'stash-rec' — carries worktree-local state (MERGE_AUTOSTASH)" "state: autostash record refused"
 [ -d "$gitdir/worktrees/state-rec" ] || fail "state: sidecar-carrying record was swept"
 [ -d "$gitdir/worktrees/refs-rec" ] || fail "state: ref-carrying record was swept"
 [ -d "$gitdir/worktrees/op-rec" ] || fail "state: op-state record was swept"
 git -C "$fixture" cat-file -e "$refs_orph" || fail "state: worktree-ref orphan commit lost"
 
-rm -rf "$gitdir/worktrees/state-rec/deferred-findings" "$gitdir/worktrees/refs-rec/refs" "$gitdir/worktrees/op-rec/MERGE_HEAD" "$gitdir/worktrees/cfg-rec/config.worktree"
+rm -rf "$gitdir/worktrees/state-rec/deferred-findings" "$gitdir/worktrees/refs-rec/refs" "$gitdir/worktrees/op-rec/MERGE_HEAD" "$gitdir/worktrees/cfg-rec/config.worktree" "$gitdir/worktrees/stash-rec/MERGE_AUTOSTASH"
 state_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
     fail "record prune failed after the state was adopted: $state_ok_out"
 expect_contains "$state_ok_out" "pruned record 'state-rec'" "state: adopted record prunes normally"
 expect_contains "$state_ok_out" "pruned record 'refs-rec'" "state: rescued record prunes normally"
 expect_contains "$state_ok_out" "pruned record 'op-rec'" "state: finished-operation record prunes normally"
 expect_contains "$state_ok_out" "pruned record 'cfg-rec'" "state: adopted-config record prunes normally"
+expect_contains "$state_ok_out" "pruned record 'stash-rec'" "state: recovered-autostash record prunes normally"
 echo "ok: state-carrying records are refused until adopted, never swept"
 
 # ── Case E7e: an index diverging from the recorded HEAD refuses the sweep ──
@@ -1014,6 +1019,8 @@ if fetch_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; 
     fail "record prune exited zero with an unreachable FETCH_HEAD entry present: $fetch_out"
 fi
 expect_contains "$fetch_out" "FETCH_HEAD names $orph_f" "fetch-head: url-fetched tip refused"
+short_f="$(printf '%.7s' "$orph_f")"
+expect_contains "$fetch_out" "rescue/fetchrec-fetch-$short_f" "fetch-head: rescue name is per-OID, successive rescues cannot collide"
 [ -d "$gitdir/worktrees/fetchrec" ] || fail "fetch-head: record swept despite its unreachable FETCH_HEAD"
 git -C "$fixture" cat-file -e "$orph_f" || fail "fetch-head: fetched tip lost"
 
@@ -1041,6 +1048,32 @@ fetch2_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" 
     fail "record prune failed after the truncated FETCH_HEAD was removed: $fetch2_ok_out"
 expect_contains "$fetch2_ok_out" "pruned record 'fetchrec2'" "fetch-head: cleared record prunes normally"
 echo "ok: an unterminated FETCH_HEAD entry is still validated"
+
+# ── Case E7t: an unreferenced annotated tag in FETCH_HEAD refuses the sweep ─
+# Peeling the fetched OID to its commit would let the tag object itself —
+# message and signature — vanish with the record; containment for a tag is
+# exact points-at, not ancestry.
+
+git -C "$fixture" tag -a -m "fetched annotated tag" tmp-fetched-tag main
+tagoid_t="$(git -C "$fixture" rev-parse tmp-fetched-tag)"
+git -C "$fixture" tag -d tmp-fetched-tag >/dev/null
+mkdir -p "$gitdir/worktrees/tagrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/tagrec/HEAD"
+printf '%s\n' "/nonexistent/tagrec/.git" >"$gitdir/worktrees/tagrec/gitdir"
+printf '%s\t\ttag fetched-tag of https://example.invalid/repo\n' "$tagoid_t" >"$gitdir/worktrees/tagrec/FETCH_HEAD"
+
+if tagrec_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unreferenced annotated tag in FETCH_HEAD: $tagrec_out"
+fi
+expect_contains "$tagrec_out" "annotated tag object $tagoid_t with no ref pointing at it" "fetch-tag: unreferenced tag object refused"
+[ -d "$gitdir/worktrees/tagrec" ] || fail "fetch-tag: record swept despite its unreferenced tag object"
+git -C "$fixture" cat-file -e "$tagoid_t" || fail "fetch-tag: tag object lost"
+
+git -C "$fixture" tag rescue-fetched-tag "$tagoid_t"
+tagrec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the tag object was rescued: $tagrec_ok_out"
+expect_contains "$tagrec_ok_out" "pruned record 'tagrec'" "fetch-tag: referenced tag object sweeps normally"
+echo "ok: an unreferenced annotated tag in FETCH_HEAD refuses the sweep until rescued"
 
 # ── Case E7s: pin-enumeration failure never reports cleanup complete ───────
 # A broken ref backend is not an empty pin namespace; the empty-plan path

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -638,7 +638,7 @@ if reuse_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)
 fi
 expect_contains "$reuse_ok_out" "pruned record 'pin-reuse'" "pin reuse: settled pin lets the removal proceed"
 expect_contains "$reuse_ok_out" "PINNED  refs/session-cleanup/pin/pin-reuse" "pin reuse: fresh pin reported for explicit settlement"
-expect_contains "$reuse_ok_out" "re-verify before dropping" "pin reuse: drop remedy demands execution-time re-verification, not a stale snapshot"
+expect_contains "$reuse_ok_out" "re-verify before dropping (GIT_GRAFT_FILE=/dev/null git --no-replace-objects" "pin reuse: the re-verification command itself disables grafts and replacements"
 [ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/pin-reuse)" = "$(git -C "$fixture" rev-parse main)" ] ||
     fail "pin reuse: fresh pin missing or wrong — pins must never be auto-dropped"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/pin-reuse
@@ -854,28 +854,38 @@ echo "ok: a pin dropped mid-run by a racing settlement is re-asserted"
 
 # ── Case E7k: a failed record removal is loud and never lock-labeled ───────
 # A partial rm is corrupt state needing inspection; reporting it as lock
-# contention hands the operator the wrong remedy.
+# contention hands the operator the wrong remedy. An rm shim forces the
+# failure deterministically — chmod tricks do not survive running as root
+# (containers commonly do).
 
-mkdir -p "$gitdir/worktrees/stuckrec/logs/blocker"
+mkdir -p "$gitdir/worktrees/stuckrec"
 printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/stuckrec/HEAD"
 printf '%s\n' "/nonexistent/stuckrec/.git" >"$gitdir/worktrees/stuckrec/gitdir"
-touch "$gitdir/worktrees/stuckrec/logs/blocker/held"
-chmod 000 "$gitdir/worktrees/stuckrec/logs/blocker"
+real_rm="$(command -v rm)"
+cat >"$shim_dir/rm" <<SHIM
+#!/usr/bin/env bash
+for a in "\$@"; do
+    if [[ "\$a" == *"/worktrees/stuckrec" ]]; then
+        echo "rm: simulated I/O failure" >&2
+        exit 1
+    fi
+done
+exec "$real_rm" "\$@"
+SHIM
+chmod +x "$shim_dir/rm"
 
-if stuck_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
-    chmod 755 "$gitdir/worktrees/stuckrec/logs/blocker" 2>/dev/null || true
+if stuck_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    rm -f "$shim_dir/rm"
     fail "record prune exited zero although removal failed: $stuck_out"
 fi
-chmod 755 "$gitdir/worktrees/stuckrec/logs/blocker" 2>/dev/null || true
+rm -f "$shim_dir/rm"
 expect_contains "$stuck_out" "removal failed midway" "rm failure: reported as its own outcome"
 expect_not_contains "$stuck_out" "lifecycle lock refused" "rm failure: never mislabeled as lock contention"
+[ -d "$gitdir/worktrees/stuckrec" ] || fail "rm failure: record vanished although rm was refused"
 
-# The partial rm may have taken HEAD/gitdir (deletion order is undefined);
-# restore them so the recovery run exercises a validatable record.
-printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/stuckrec/HEAD"
-printf '%s\n' "/nonexistent/stuckrec/.git" >"$gitdir/worktrees/stuckrec/gitdir"
 stuck_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
     fail "record prune failed after the blocker was cleared: $stuck_ok_out"
+expect_contains "$stuck_ok_out" "pruned record 'stuckrec'" "rm failure: unshimmed re-run prunes normally"
 echo "ok: a failed record removal is loud and never lock-labeled"
 
 # ── Case E7m: an unreachable ORIG_HEAD refuses the sweep ───────────────────
@@ -1143,6 +1153,21 @@ rm -rf "$test_tmp/live-dir"
 livedir_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
     fail "record prune failed after the directory was moved aside: $livedir_ok_out"
 expect_contains "$livedir_ok_out" "pruned record 'livedir-rec'" "live-dir: cleared record prunes normally"
+
+# A gitdir value without the /.git suffix is malformed AND would skip the
+# surviving-directory guard above — it must refuse outright.
+mkdir -p "$gitdir/worktrees/badsuffix-rec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/badsuffix-rec/HEAD"
+printf '%s\n' "/nonexistent/badsuffix-rec/.gi" >"$gitdir/worktrees/badsuffix-rec/gitdir"
+if badsuffix_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with a malformed gitdir suffix present: $badsuffix_out"
+fi
+expect_contains "$badsuffix_out" "gitdir value does not end in /.git" "bad-suffix: malformed gitdir refused"
+[ -d "$gitdir/worktrees/badsuffix-rec" ] || fail "bad-suffix: record swept despite its malformed gitdir"
+printf '%s\n' "/nonexistent/badsuffix-rec/.git" >"$gitdir/worktrees/badsuffix-rec/gitdir"
+badsuffix_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the gitdir was repaired: $badsuffix_ok_out"
+expect_contains "$badsuffix_ok_out" "pruned record 'badsuffix-rec'" "bad-suffix: repaired record prunes normally"
 echo "ok: an unreadable gitdir or a surviving tree directory refuses the sweep"
 
 # ── Case E7w: resolve-undo state in a stage-0-clean index refuses ──────────
@@ -1245,6 +1270,17 @@ expect_contains "$typerec_out" "entry 'ORIG_HEAD' is not the regular file git wr
 [ -d "$gitdir/worktrees/typerec" ] || fail "type gate: record swept despite malformed state"
 
 rm -rf "$gitdir/worktrees/typerec/ORIG_HEAD"
+
+# info as a regular FILE matches no child glob and would otherwise be
+# accepted uninspected — the same gate, one level up.
+echo "not-a-directory" >"$gitdir/worktrees/typerec/info"
+if typeinfo_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with a non-directory info entry present: $typeinfo_out"
+fi
+expect_contains "$typeinfo_out" "entry 'info' is not the directory git writes there" "type gate: non-directory info refused"
+[ -d "$gitdir/worktrees/typerec" ] || fail "type gate: record swept despite a non-directory info entry"
+rm -f "$gitdir/worktrees/typerec/info"
+
 typerec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
     fail "record prune failed after the malformed entry was cleared: $typerec_ok_out"
 expect_contains "$typerec_ok_out" "pruned record 'typerec'" "type gate: well-formed record prunes normally"

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -537,6 +537,212 @@ expect_contains "$cfg_out" "WARN  sq-cfg was deleted but its branch.sq-cfg" "con
 git -C "$fixture" config --local --remove-section branch.sq-cfg 2>/dev/null || true
 echo "ok: config cleanup failure is reported, never swallowed"
 
+# ── Case E7: worktree-record pruning pins detached commits through the prune ─
+# A stale record whose HEAD is detached at a commit no shared ref contains is
+# the only thing keeping that commit alive (challenge r3); the guard is a pin
+# created BEFORE the prune, so no interleaving can strand the commit
+# (challenge r4). Branch-attached stale records prune normally; a live
+# detached worktree's pin is dropped as redundant.
+
+cp "$repo/scripts/clean-worktree-records.sh" "$fixture/scripts/"
+
+git -C "$fixture" worktree add -q -b prune-br "$test_tmp/wt-br" main
+git -C "$fixture" worktree add -q --detach "$test_tmp/wt-det" main
+git -C "$fixture" worktree add -q --detach "$test_tmp/wt-live" main
+(
+    cd "$test_tmp/wt-det"
+    echo det >det.txt
+    git add det.txt
+    git commit -qm "detached-only work"
+)
+det_sha="$(git -C "$test_tmp/wt-det" rev-parse HEAD)"
+rm -rf "$test_tmp/wt-br" "$test_tmp/wt-det"
+
+if prune_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although an orphan pin should have been kept: $prune_out"
+fi
+expect_contains "$prune_out" "KEPT  refs/session-cleanup/pin/wt-det" "record prune: orphan commit's pin kept and reported"
+worktrees_admin="$(git -C "$fixture" rev-parse --path-format=absolute --git-common-dir)/worktrees"
+if ls "$worktrees_admin" 2>/dev/null | grep -Eq '^(wt-det|wt-br)$'; then
+    fail "record prune: stale records survived the prune"
+fi
+[ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/wt-det)" = "$det_sha" ] ||
+    fail "record prune: pin does not hold the detached commit"
+git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/wt-live >/dev/null &&
+    fail "record prune: redundant pin for a live worktree was kept"
+if git -C "$fixture" fsck --unreachable 2>/dev/null | grep -q "$det_sha"; then
+    fail "record prune: detached commit became unreachable despite the pin"
+fi
+echo "ok: record prune pins an orphan detached commit through the prune"
+
+# The audit surfaces a lingering pin as a decision waiting to be made.
+pin_audit_out="$(cd "$fixture" && bash scripts/audit-session-artifacts.sh 2>&1)" ||
+    fail "audit exited nonzero with a pin present: $pin_audit_out"
+expect_contains "$pin_audit_out" "wt-det — pins $det_sha" "audit: leftover rescue pin reported"
+echo "ok: audit reports leftover rescue pins"
+
+git -C "$fixture" branch -q rescue-det "$det_sha"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/wt-det
+prune_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the pin was settled: $prune_ok_out"
+expect_contains "$prune_ok_out" "nothing to prune" "record prune: live worktrees leave nothing plan-scoped to remove"
+git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/wt-live >/dev/null &&
+    fail "record prune: live-worktree pin left behind on the clean run"
+git -C "$fixture" cat-file -e "$det_sha" || fail "record prune: rescued commit lost from the object db"
+echo "ok: record prune settles cleanly once every commit is referenced"
+
+# ── Case E7c: an unsettled pin from an earlier run is never overwritten ────
+# A record name reused after a kept pin would silently replace the sole
+# reference to the older commit; the create-only pin write must refuse.
+
+orph_sha="$(git -C "$fixture" commit-tree "main^{tree}" -p main -m "old orphan")"
+git -C "$fixture" update-ref refs/session-cleanup/pin/pin-reuse "$orph_sha"
+mkdir -p "$gitdir/worktrees/pin-reuse"
+git -C "$fixture" rev-parse main >"$gitdir/worktrees/pin-reuse/HEAD"
+printf '%s\n' "/nonexistent/pin-reuse/.git" >"$gitdir/worktrees/pin-reuse/gitdir"
+
+if reuse_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune proceeded over a foreign unsettled pin: $reuse_out"
+fi
+expect_contains "$reuse_out" "already pins $orph_sha" "pin reuse: refusal names the earlier pin"
+[ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/pin-reuse)" = "$orph_sha" ] ||
+    fail "pin reuse: the earlier pin was overwritten"
+[ -d "$gitdir/worktrees/pin-reuse" ] || fail "pin reuse: the record was removed despite the refusal"
+
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/pin-reuse "$orph_sha"
+if reuse_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although its fresh pin awaits settlement: $reuse_ok_out"
+fi
+expect_contains "$reuse_ok_out" "pruned record 'pin-reuse'" "pin reuse: settled pin lets the removal proceed"
+expect_contains "$reuse_ok_out" "PINNED  refs/session-cleanup/pin/pin-reuse" "pin reuse: fresh pin reported for explicit settlement"
+[ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/pin-reuse)" = "$(git -C "$fixture" rev-parse main)" ] ||
+    fail "pin reuse: fresh pin missing or wrong — pins must never be auto-dropped"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/pin-reuse
+echo "ok: an unsettled rescue pin refuses the prune instead of being overwritten"
+
+# ── Case E7d: a record carrying worktree-local state is refused, not swept ─
+# Sidecars and per-worktree ref files under worktrees/<id>/ are single-copy;
+# no pin can stand in for them.
+
+for rec in state-rec refs-rec; do
+    mkdir -p "$gitdir/worktrees/$rec"
+    printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/$rec/HEAD"
+    printf '%s\n' "/nonexistent/$rec/.git" >"$gitdir/worktrees/$rec/gitdir"
+done
+mkdir -p "$gitdir/worktrees/state-rec/deferred-findings"
+echo "p2 from a dead session" >"$gitdir/worktrees/state-rec/deferred-findings/some-branch"
+mkdir -p "$gitdir/worktrees/refs-rec/refs/worktree"
+refs_orph="$(git -C "$fixture" commit-tree "main^{tree}" -p main -m "worktree-ref orphan")"
+printf '%s\n' "$refs_orph" >"$gitdir/worktrees/refs-rec/refs/worktree/only"
+
+if state_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with refused state-carrying records: $state_out"
+fi
+expect_contains "$state_out" "record 'state-rec' — carries worktree-local state (deferred-findings)" "state: sidecar-carrying record refused"
+expect_contains "$state_out" "record 'refs-rec' — carries worktree-local state (refs)" "state: per-worktree-ref record refused"
+[ -d "$gitdir/worktrees/state-rec" ] || fail "state: sidecar-carrying record was swept"
+[ -d "$gitdir/worktrees/refs-rec" ] || fail "state: ref-carrying record was swept"
+git -C "$fixture" cat-file -e "$refs_orph" || fail "state: worktree-ref orphan commit lost"
+
+rm -rf "$gitdir/worktrees/state-rec/deferred-findings" "$gitdir/worktrees/refs-rec/refs"
+state_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the state was adopted: $state_ok_out"
+expect_contains "$state_ok_out" "pruned record 'state-rec'" "state: adopted record prunes normally"
+expect_contains "$state_ok_out" "pruned record 'refs-rec'" "state: rescued record prunes normally"
+echo "ok: state-carrying records are refused until adopted, never swept"
+
+# ── Case E7e: an index diverging from the recorded HEAD refuses the sweep ──
+# Staged-but-uncommitted blobs can be referenced by the record's index
+# alone; sweeping the record hands them to the next gc.
+
+git -C "$fixture" worktree add -q --detach "$test_tmp/wt-staged" main
+(
+    cd "$test_tmp/wt-staged"
+    echo staged-only >staged.txt
+    git add staged.txt
+)
+rm -rf "$test_tmp/wt-staged"
+
+if staged_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with a staged-divergent index present: $staged_out"
+fi
+expect_contains "$staged_out" "record 'wt-staged' — its index diverges from the recorded HEAD" "staged: divergent index refused"
+[ -d "$gitdir/worktrees/wt-staged" ] || fail "staged: index-carrying record was swept"
+
+rm -f "$gitdir/worktrees/wt-staged/index"
+if staged_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the detached record's pin awaits settlement: $staged_ok_out"
+fi
+expect_contains "$staged_ok_out" "pruned record 'wt-staged'" "staged: adopted record prunes normally"
+expect_contains "$staged_ok_out" "PINNED  refs/session-cleanup/pin/wt-staged" "staged: detached head pinned for explicit settlement"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/wt-staged
+echo "ok: a staged-divergent index refuses the sweep until adopted"
+
+# ── Case E7f: record removal honors the worktree lifecycle lock ────────────
+# A record for a tree under .worktrees/ takes the same per-path lock that
+# worktree:new/rm hold, so removal cannot race a blessed re-creation.
+
+mkdir -p "$gitdir/worktrees/lockrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/lockrec/HEAD"
+printf '%s\n' "$fixture/.worktrees/lockrec/.git" >"$gitdir/worktrees/lockrec/gitdir"
+commondir_l="$(git -C "$fixture" rev-parse --path-format=absolute --git-common-dir)"
+mkdir -p "$commondir_l/worktree-locks/lockrec+lock"
+
+if lockrec_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the lifecycle lock was held: $lockrec_out"
+fi
+expect_contains "$lockrec_out" "worktree lifecycle lock refused" "record lock: contended record skipped loudly"
+[ -d "$gitdir/worktrees/lockrec" ] || fail "record lock: record removed although its lifecycle lock was held"
+
+rmdir "$commondir_l/worktree-locks/lockrec+lock"
+lockrec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the lock was released: $lockrec_ok_out"
+expect_contains "$lockrec_ok_out" "pruned record 'lockrec'" "record lock: released lock lets the removal proceed"
+echo "ok: record removal is serialized by the worktree lifecycle lock"
+
+# ── Case E7g: a replacement ref cannot forge the pin-drop remedy ───────────
+# The kept-pin report picks its wording from raw history: a refs/replace
+# graft that makes an orphan read as reachable from shared refs would
+# otherwise print a copyable "drop it" command for the only real reference.
+
+orph_g="$(git -C "$fixture" commit-tree "main^{tree}" -m "orphan-behind-replace")"
+mkdir -p "$gitdir/worktrees/reptrap"
+printf '%s\n' "$orph_g" >"$gitdir/worktrees/reptrap/HEAD"
+printf '%s\n' "$test_tmp/gone-reptrap/.git" >"$gitdir/worktrees/reptrap/gitdir"
+repg_main="$(git -C "$fixture" rev-parse refs/heads/main)"
+repg_synth="$(git -C "$fixture" commit-tree "main^{tree}" -p "$repg_main" -p "$orph_g" -m "graft")"
+git -C "$fixture" update-ref "refs/replace/$repg_main" "$repg_synth"
+
+if repg_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although a forged-reachability pin should await settlement: $repg_out"
+fi
+git -C "$fixture" update-ref -d "refs/replace/$repg_main"
+expect_contains "$repg_out" "KEPT  refs/session-cleanup/pin/reptrap" "replace ref: pin reported as the only reference"
+expect_not_contains "$repg_out" "also reachable from shared refs" "replace ref: forged containment does not invite dropping the pin"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/reptrap
+echo "ok: a replacement ref cannot forge the pin-drop remedy"
+
+# ── Case E7h: a legacy graft file forces the conservative pin wording ──────
+# info/grafts rewrites parentage and GIT_NO_REPLACE_OBJECTS does not cover
+# it; while one exists, containment is not evidence and every kept pin gets
+# the conservative wording.
+
+orph_h="$(git -C "$fixture" commit-tree "main^{tree}" -m "orphan-behind-graft")"
+mkdir -p "$gitdir/worktrees/grafttrap"
+printf '%s\n' "$orph_h" >"$gitdir/worktrees/grafttrap/HEAD"
+printf '%s\n' "$test_tmp/gone-grafttrap/.git" >"$gitdir/worktrees/grafttrap/gitdir"
+printf '%s %s\n' "$(git -C "$fixture" rev-parse refs/heads/main)" "$orph_h" >"$gitdir/info/grafts"
+
+if graftrec_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although a grafted-reachability pin should await settlement: $graftrec_out"
+fi
+rm -f "$gitdir/info/grafts"
+expect_contains "$graftrec_out" "legacy graft file present" "grafts: presence announced by the record prune"
+expect_contains "$graftrec_out" "KEPT  refs/session-cleanup/pin/grafttrap" "grafts: pin reported conservatively"
+expect_not_contains "$graftrec_out" "also reachable from shared refs" "grafts: grafted containment does not invite dropping the pin"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/grafttrap
+echo "ok: a legacy graft file forces the conservative pin wording"
+
 # ── Case E8: a renamed remote default refuses every deletion ───────────────
 # The local origin/HEAD still names the old default; the live remote HEAD
 # must be verified before any evidence computed against the old name is

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -648,7 +648,7 @@ echo "ok: an unsettled rescue pin refuses the prune instead of being overwritten
 # Sidecars and per-worktree ref files under worktrees/<id>/ are single-copy;
 # no pin can stand in for them.
 
-for rec in state-rec refs-rec op-rec; do
+for rec in state-rec refs-rec op-rec cfg-rec; do
     mkdir -p "$gitdir/worktrees/$rec"
     printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/$rec/HEAD"
     printf '%s\n' "/nonexistent/$rec/.git" >"$gitdir/worktrees/$rec/gitdir"
@@ -661,6 +661,8 @@ printf '%s\n' "$refs_orph" >"$gitdir/worktrees/refs-rec/refs/worktree/only"
 # A merge parked at an edit: MERGE_HEAD is sequencer state the record alone
 # holds (the worktree-rm.sh op-state list).
 git -C "$fixture" rev-parse main >"$gitdir/worktrees/op-rec/MERGE_HEAD"
+# User-set per-worktree configuration is single-copy exactly like a sidecar.
+printf '[review]\n\tunique = KEEP-ME\n' >"$gitdir/worktrees/cfg-rec/config.worktree"
 
 if state_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
     fail "record prune exited zero with refused state-carrying records: $state_out"
@@ -668,17 +670,19 @@ fi
 expect_contains "$state_out" "record 'state-rec' — carries worktree-local state (deferred-findings)" "state: sidecar-carrying record refused"
 expect_contains "$state_out" "record 'refs-rec' — carries worktree-local state (refs)" "state: per-worktree-ref record refused"
 expect_contains "$state_out" "record 'op-rec' — carries worktree-local state (MERGE_HEAD)" "state: in-progress-operation record refused"
+expect_contains "$state_out" "record 'cfg-rec' — carries worktree-local state (config.worktree)" "state: per-worktree-config record refused"
 [ -d "$gitdir/worktrees/state-rec" ] || fail "state: sidecar-carrying record was swept"
 [ -d "$gitdir/worktrees/refs-rec" ] || fail "state: ref-carrying record was swept"
 [ -d "$gitdir/worktrees/op-rec" ] || fail "state: op-state record was swept"
 git -C "$fixture" cat-file -e "$refs_orph" || fail "state: worktree-ref orphan commit lost"
 
-rm -rf "$gitdir/worktrees/state-rec/deferred-findings" "$gitdir/worktrees/refs-rec/refs" "$gitdir/worktrees/op-rec/MERGE_HEAD"
+rm -rf "$gitdir/worktrees/state-rec/deferred-findings" "$gitdir/worktrees/refs-rec/refs" "$gitdir/worktrees/op-rec/MERGE_HEAD" "$gitdir/worktrees/cfg-rec/config.worktree"
 state_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
     fail "record prune failed after the state was adopted: $state_ok_out"
 expect_contains "$state_ok_out" "pruned record 'state-rec'" "state: adopted record prunes normally"
 expect_contains "$state_ok_out" "pruned record 'refs-rec'" "state: rescued record prunes normally"
 expect_contains "$state_ok_out" "pruned record 'op-rec'" "state: finished-operation record prunes normally"
+expect_contains "$state_ok_out" "pruned record 'cfg-rec'" "state: adopted-config record prunes normally"
 echo "ok: state-carrying records are refused until adopted, never swept"
 
 # ── Case E7e: an index diverging from the recorded HEAD refuses the sweep ──
@@ -697,6 +701,7 @@ if staged_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)";
     fail "record prune exited zero with a staged-divergent index present: $staged_out"
 fi
 expect_contains "$staged_out" "record 'wt-staged' — its index diverges from the recorded HEAD" "staged: divergent index refused"
+expect_contains "$staged_out" "GIT_INDEX_FILE='" "staged: recovery command shell-quotes the index path"
 [ -d "$gitdir/worktrees/wt-staged" ] || fail "staged: index-carrying record was swept"
 
 rm -f "$gitdir/worktrees/wt-staged/index"
@@ -1017,6 +1022,25 @@ fetch_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" |
     fail "record prune failed after the FETCH_HEAD commit was rescued: $fetch_ok_out"
 expect_contains "$fetch_ok_out" "pruned record 'fetchrec'" "fetch-head: reachable FETCH_HEAD sweeps normally"
 echo "ok: an unreachable FETCH_HEAD entry refuses the sweep until rescued"
+
+# A truncated write can leave the final FETCH_HEAD record unterminated; the
+# guard must validate that entry too, not skip it with the read loop.
+orph_f2="$(git -C "$fixture" commit-tree "main^{tree}" -m "truncated-fetch-tip")"
+mkdir -p "$gitdir/worktrees/fetchrec2"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/fetchrec2/HEAD"
+printf '%s\n' "/nonexistent/fetchrec2/.git" >"$gitdir/worktrees/fetchrec2/gitdir"
+printf '%s\t\tbranch other of https://example.invalid/repo' "$orph_f2" >"$gitdir/worktrees/fetchrec2/FETCH_HEAD"
+
+if fetch2_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unterminated FETCH_HEAD entry present: $fetch2_out"
+fi
+expect_contains "$fetch2_out" "FETCH_HEAD names $orph_f2" "fetch-head: unterminated final entry still validated"
+[ -d "$gitdir/worktrees/fetchrec2" ] || fail "fetch-head: record swept despite its unterminated FETCH_HEAD entry"
+rm -f "$gitdir/worktrees/fetchrec2/FETCH_HEAD"
+fetch2_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the truncated FETCH_HEAD was removed: $fetch2_ok_out"
+expect_contains "$fetch2_ok_out" "pruned record 'fetchrec2'" "fetch-head: cleared record prunes normally"
+echo "ok: an unterminated FETCH_HEAD entry is still validated"
 
 # ── Case E7s: pin-enumeration failure never reports cleanup complete ───────
 # A broken ref backend is not an empty pin namespace; the empty-plan path

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -1263,7 +1263,8 @@ cat >"$shim_dir/cat" <<SHIM
 #!/usr/bin/env bash
 if [[ "\${1:-}" == *"/worktrees/lockswap/gitdir" && ! -e "$test_tmp/lockswap-hit" ]]; then
     touch "$test_tmp/lockswap-hit"
-    exit 1
+    echo "$fixture/.worktrees/other-tree/.git"
+    exit 0
 fi
 exec /bin/cat "\$@"
 SHIM
@@ -1303,6 +1304,46 @@ expect_contains "$enum_out" "cannot enumerate rescue pins" "pin enumeration: fai
 expect_not_contains "$enum_out" "nothing to prune." "pin enumeration: no false cleanup-complete report"
 rm -f "$shim_dir/git"
 echo "ok: pin-enumeration failure never reports cleanup complete"
+
+# A failed dry run surfaces git's own diagnostic, never a bare set -e death.
+cat >"$shim_dir/git" <<SHIM
+#!/usr/bin/env bash
+if [[ "\$*" == *"worktree prune --dry-run"* ]]; then
+    echo "fatal: simulated metadata corruption" >&2
+    exit 128
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$shim_dir/git"
+if planfail_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the dry-run failed: $planfail_out"
+fi
+expect_contains "$planfail_out" "worktree prune --dry-run failed" "plan failure: named as the failing step"
+expect_contains "$planfail_out" "simulated metadata corruption" "plan failure: git's own diagnostic preserved"
+rm -f "$shim_dir/git"
+echo "ok: a failed dry run surfaces its diagnostic"
+
+# A failed FULL pin enumeration must not print an unreliable settlement
+# total beside the summary.
+git -C "$fixture" update-ref refs/session-cleanup/pin/stale-old "$(git -C "$fixture" rev-parse main)"
+mkdir -p "$gitdir/worktrees/enumrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/enumrec/HEAD"
+printf '%s\n' "/nonexistent/enumrec/.git" >"$gitdir/worktrees/enumrec/gitdir"
+cat >"$shim_dir/git" <<SHIM
+#!/usr/bin/env bash
+if [[ "\$*" == *"for-each-ref refs/session-cleanup/pin"* && "\$*" != *"--count=1"* ]]; then
+    exit 1
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$shim_dir/git"
+if totalfail_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the total-pin enumeration failed: $totalfail_out"
+fi
+expect_contains "$totalfail_out" "refusing to report an unreliable settlement count" "total enumeration: failure refused, no fabricated count"
+rm -f "$shim_dir/git"
+git -C "$fixture" update-ref -d refs/session-cleanup/pin/stale-old
+echo "ok: a failed total-pin enumeration never fabricates a count"
 
 # ── Case E8: a renamed remote default refuses every deletion ───────────────
 # The local origin/HEAD still names the old default; the live remote HEAD

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -952,6 +952,10 @@ expect_not_contains "$retarg_out" "KEPT  refs/session-cleanup/pin/retarg" "pin r
 [ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/retarg)" = "$ret_main" ] ||
     fail "pin retarget: the foreign write was overwritten — settlement is human-only"
 git -C "$fixture" cat-file -e "$ret_orph" || fail "pin retarget: orphan commit lost from the object db"
+short_r="$(printf '%.7s' "$ret_orph")"
+[ "$(git -C "$fixture" rev-parse --quiet --verify "refs/session-cleanup/pin/retarg-rescue-$short_r")" = "$ret_orph" ] ||
+    fail "pin retarget: no rescue ref re-protects the orphan whose record is already gone"
+git -C "$fixture" update-ref -d "refs/session-cleanup/pin/retarg-rescue-$short_r"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/retarg
 echo "ok: a pin retargeted mid-run fails closed, never reported kept"
 
@@ -1224,6 +1228,27 @@ symrec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" 
     fail "record prune failed after the symlinks were cleared: $symrec_ok_out"
 expect_contains "$symrec_ok_out" "pruned record 'symrec'" "symlink: cleared record prunes normally"
 echo "ok: symlinked state paths are carried state and broken links are judged"
+
+# ── Case E7y: an allowlisted name of the wrong type refuses the sweep ──────
+# ORIG_HEAD as a DIRECTORY skips its -f validator yet a basename-only
+# allowlist would still admit it and rm -rf its contents.
+
+mkdir -p "$gitdir/worktrees/typerec/ORIG_HEAD"
+echo "trapped" >"$gitdir/worktrees/typerec/ORIG_HEAD/contents"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/typerec/HEAD"
+printf '%s\n' "/nonexistent/typerec/.git" >"$gitdir/worktrees/typerec/gitdir"
+
+if typerec_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with a mistyped allowlisted entry present: $typerec_out"
+fi
+expect_contains "$typerec_out" "entry 'ORIG_HEAD' is not the regular file git writes there" "type gate: mistyped entry refused"
+[ -d "$gitdir/worktrees/typerec" ] || fail "type gate: record swept despite malformed state"
+
+rm -rf "$gitdir/worktrees/typerec/ORIG_HEAD"
+typerec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the malformed entry was cleared: $typerec_ok_out"
+expect_contains "$typerec_ok_out" "pruned record 'typerec'" "type gate: well-formed record prunes normally"
+echo "ok: an allowlisted name of the wrong type refuses the sweep"
 
 # ── Case E7s: pin-enumeration failure never reports cleanup complete ───────
 # A broken ref backend is not an empty pin namespace; the empty-plan path

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -590,6 +590,19 @@ fi
 expect_contains "$pin_retry_out" "rescue pins await settlement" "retry: pending pin keeps the run nonzero"
 echo "ok: a pending rescue pin keeps retries nonzero"
 
+# A pruning run made while an earlier pin is outstanding reports the TOTAL
+# awaiting settlement, not just this run's — "0 pins" beside a nonzero exit
+# would contradict the disposition.
+mkdir -p "$gitdir/worktrees/plainrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/plainrec/HEAD"
+printf '%s\n' "/nonexistent/plainrec/.git" >"$gitdir/worktrees/plainrec/gitdir"
+if inherit_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero while an inherited pin awaited settlement: $inherit_out"
+fi
+expect_contains "$inherit_out" "pruned record 'plainrec'" "retry-summary: unrelated record still prunes"
+expect_contains "$inherit_out" "1 total awaiting settlement" "retry-summary: inherited pin counted in the total"
+echo "ok: inherited pins are counted in the settlement total"
+
 git -C "$fixture" branch -q rescue-det "$det_sha"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/wt-det
 prune_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
@@ -980,6 +993,53 @@ scanfail_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)
     fail "record prune failed after the scan blocker was cleared: $scanfail_ok_out"
 expect_contains "$scanfail_ok_out" "pruned record 'scanfail'" "scan failure: adopted record prunes normally"
 echo "ok: a failed state scan refuses the record, never sweeps it"
+
+# ── Case E7r: an unreachable FETCH_HEAD entry refuses the sweep ────────────
+# A URL fetch of an unbranched tip (a PR head) can leave FETCH_HEAD as the
+# only mapping to that commit; ordinary fetches list tips the tracking refs
+# contain and sweep normally.
+
+orph_f="$(git -C "$fixture" commit-tree "main^{tree}" -m "url-fetched-tip")"
+mkdir -p "$gitdir/worktrees/fetchrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/fetchrec/HEAD"
+printf '%s\n' "/nonexistent/fetchrec/.git" >"$gitdir/worktrees/fetchrec/gitdir"
+printf '%s\t\tbranch pr-head of https://example.invalid/repo\n' "$orph_f" >"$gitdir/worktrees/fetchrec/FETCH_HEAD"
+
+if fetch_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unreachable FETCH_HEAD entry present: $fetch_out"
+fi
+expect_contains "$fetch_out" "FETCH_HEAD names $orph_f" "fetch-head: url-fetched tip refused"
+[ -d "$gitdir/worktrees/fetchrec" ] || fail "fetch-head: record swept despite its unreachable FETCH_HEAD"
+git -C "$fixture" cat-file -e "$orph_f" || fail "fetch-head: fetched tip lost"
+
+git -C "$fixture" branch -q rescue-fetch "$orph_f"
+fetch_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the FETCH_HEAD commit was rescued: $fetch_ok_out"
+expect_contains "$fetch_ok_out" "pruned record 'fetchrec'" "fetch-head: reachable FETCH_HEAD sweeps normally"
+echo "ok: an unreachable FETCH_HEAD entry refuses the sweep until rescued"
+
+# ── Case E7s: pin-enumeration failure never reports cleanup complete ───────
+# A broken ref backend is not an empty pin namespace; the empty-plan path
+# must fail closed instead of printing "nothing to prune" with exit 0.
+
+rm -f "$shim_dir/find"
+cat >"$shim_dir/git" <<SHIM
+#!/usr/bin/env bash
+if [[ "\$*" == *"--count=1 refs/session-cleanup/pin"* ]]; then
+    echo "fatal: simulated ref backend failure" >&2
+    exit 1
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$shim_dir/git"
+
+if enum_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although pin enumeration failed: $enum_out"
+fi
+expect_contains "$enum_out" "cannot enumerate rescue pins" "pin enumeration: failure refuses to report completion"
+expect_not_contains "$enum_out" "nothing to prune." "pin enumeration: no false cleanup-complete report"
+rm -f "$shim_dir/git"
+echo "ok: pin-enumeration failure never reports cleanup complete"
 
 # ── Case E8: a renamed remote default refuses every deletion ───────────────
 # The local origin/HEAD still names the old default; the live remote HEAD

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -562,6 +562,7 @@ if prune_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; 
     fail "record prune exited zero although an orphan pin should have been kept: $prune_out"
 fi
 expect_contains "$prune_out" "KEPT  refs/session-cleanup/pin/wt-det" "record prune: orphan commit's pin kept and reported"
+expect_contains "$prune_out" "git update-ref -d 'refs/session-cleanup/pin/wt-det' $det_sha" "record prune: drop remedy is compare-and-delete, immune to record-name reuse"
 worktrees_admin="$(git -C "$fixture" rev-parse --path-format=absolute --git-common-dir)/worktrees"
 if ls "$worktrees_admin" 2>/dev/null | grep -Eq '^(wt-det|wt-br)$'; then
     fail "record prune: stale records survived the prune"
@@ -613,6 +614,7 @@ if reuse_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; 
     fail "record prune proceeded over a foreign unsettled pin: $reuse_out"
 fi
 expect_contains "$reuse_out" "already pins $orph_sha" "pin reuse: refusal names the earlier pin"
+expect_contains "$reuse_out" "git update-ref -d 'refs/session-cleanup/pin/pin-reuse' $orph_sha" "pin reuse: refusal drop remedy is compare-and-delete"
 [ "$(git -C "$fixture" rev-parse --quiet --verify refs/session-cleanup/pin/pin-reuse)" = "$orph_sha" ] ||
     fail "pin reuse: the earlier pin was overwritten"
 [ -d "$gitdir/worktrees/pin-reuse" ] || fail "pin reuse: the record was removed despite the refusal"
@@ -929,6 +931,55 @@ expect_not_contains "$retarg_out" "KEPT  refs/session-cleanup/pin/retarg" "pin r
 git -C "$fixture" cat-file -e "$ret_orph" || fail "pin retarget: orphan commit lost from the object db"
 git -C "$fixture" update-ref -d refs/session-cleanup/pin/retarg
 echo "ok: a pin retargeted mid-run fails closed, never reported kept"
+
+# ── Case E7p: an unresolvable detached HEAD refuses the sweep ──────────────
+# A truncated HEAD, a missing object, or a promisor-held commit cannot be
+# pinned; falling through to rm -rf would destroy the only recovery
+# breadcrumb.
+
+mkdir -p "$gitdir/worktrees/badheadrec"
+printf '%s\n' "0123456789abcdef0123456789abcdef01234567" >"$gitdir/worktrees/badheadrec/HEAD"
+printf '%s\n' "/nonexistent/badheadrec/.git" >"$gitdir/worktrees/badheadrec/gitdir"
+
+if badhead_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unresolvable detached HEAD present: $badhead_out"
+fi
+expect_contains "$badhead_out" "does not resolve to a commit" "unresolvable: refusal names the failure"
+[ -d "$gitdir/worktrees/badheadrec" ] || fail "unresolvable: record swept despite an unresolvable HEAD"
+
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/badheadrec/HEAD"
+badhead_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the HEAD was repaired: $badhead_ok_out"
+expect_contains "$badhead_ok_out" "pruned record 'badheadrec'" "unresolvable: repaired record prunes normally"
+echo "ok: an unresolvable detached HEAD refuses the sweep"
+
+# ── Case E7q: a failed state scan refuses the record, never sweeps it ──────
+# An errored find is not an empty find: treating scan failure as "no state"
+# would sweep exactly the record that could not be inspected.
+
+mkdir -p "$gitdir/worktrees/scanfail/deferred-findings"
+echo "p2 note" >"$gitdir/worktrees/scanfail/deferred-findings/some-branch"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/scanfail/HEAD"
+printf '%s\n' "/nonexistent/scanfail/.git" >"$gitdir/worktrees/scanfail/gitdir"
+rm -f "$shim_dir/git"
+cat >"$shim_dir/find" <<'SHIM'
+#!/usr/bin/env bash
+exit 1
+SHIM
+chmod +x "$shim_dir/find"
+
+if scanfail_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the state scan failed: $scanfail_out"
+fi
+expect_contains "$scanfail_out" "cannot scan deferred-findings" "scan failure: refused fail-closed"
+[ -d "$gitdir/worktrees/scanfail" ] || fail "scan failure: uninspectable record was swept"
+
+rm -f "$shim_dir/find"
+rm -rf "$gitdir/worktrees/scanfail/deferred-findings"
+scanfail_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the scan blocker was cleared: $scanfail_ok_out"
+expect_contains "$scanfail_ok_out" "pruned record 'scanfail'" "scan failure: adopted record prunes normally"
+echo "ok: a failed state scan refuses the record, never sweeps it"
 
 # ── Case E8: a renamed remote default refuses every deletion ───────────────
 # The local origin/HEAD still names the old default; the live remote HEAD

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -1106,6 +1106,125 @@ odd_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
 expect_contains "$odd_ok_out" "pruned record 'oddrec'" "unknown entry: understood record prunes normally"
 echo "ok: an unrecognized admin-dir entry refuses the sweep"
 
+# ── Case E7v: an unreadable gitdir or a surviving tree directory refuses ───
+# An unreadable gitdir target is not an absent worktree; and a worktree
+# DIRECTORY that outlives its .git link still holds the user's files —
+# sweeping the record would orphan them as a plain untracked directory.
+
+mkdir -p "$gitdir/worktrees/nogit-rec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/nogit-rec/HEAD"
+
+if nogit_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with an unreadable gitdir present: $nogit_out"
+fi
+expect_contains "$nogit_out" "cannot read its gitdir file" "no-gitdir: unvalidatable record refused"
+[ -d "$gitdir/worktrees/nogit-rec" ] || fail "no-gitdir: record swept despite its unreadable gitdir"
+printf '%s\n' "/nonexistent/nogit-rec/.git" >"$gitdir/worktrees/nogit-rec/gitdir"
+nogit_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the gitdir was restored: $nogit_ok_out"
+expect_contains "$nogit_ok_out" "pruned record 'nogit-rec'" "no-gitdir: restored record prunes normally"
+
+mkdir -p "$test_tmp/live-dir"
+echo "precious" >"$test_tmp/live-dir/work.txt"
+mkdir -p "$gitdir/worktrees/livedir-rec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/livedir-rec/HEAD"
+printf '%s\n' "$test_tmp/live-dir/.git" >"$gitdir/worktrees/livedir-rec/gitdir"
+
+if livedir_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the worktree directory survives: $livedir_out"
+fi
+expect_contains "$livedir_out" "its worktree directory still exists" "live-dir: surviving directory refused"
+[ -d "$gitdir/worktrees/livedir-rec" ] || fail "live-dir: record swept although its directory survives"
+rm -rf "$test_tmp/live-dir"
+livedir_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the directory was moved aside: $livedir_ok_out"
+expect_contains "$livedir_ok_out" "pruned record 'livedir-rec'" "live-dir: cleared record prunes normally"
+echo "ok: an unreadable gitdir or a surviving tree directory refuses the sweep"
+
+# ── Case E7w: resolve-undo state in a stage-0-clean index refuses ──────────
+# After a conflict is resolved back to HEAD's content, the index compares
+# clean yet its resolve-undo section still holds conflict-stage OIDs the
+# index alone references.
+
+blob_t="$(printf 'theirs\n' | git -C "$fixture" hash-object -w --stdin)"
+reuc_idx="$test_tmp/reuc-idx"
+GIT_INDEX_FILE="$reuc_idx" git -C "$fixture" read-tree main
+GIT_INDEX_FILE="$reuc_idx" git -C "$fixture" update-index --add --cacheinfo "100644,$blob_t,cf.txt"
+ttree="$(GIT_INDEX_FILE="$reuc_idx" git -C "$fixture" write-tree)"
+tcommit="$(git -C "$fixture" commit-tree "$ttree" -p main -m theirs)"
+git -C "$fixture" worktree add -q -b reuc-br "$test_tmp/wt-reuc" main
+(
+    cd "$test_tmp/wt-reuc"
+    printf 'ours\n' >cf.txt
+    git add cf.txt
+    git commit -qm ours
+    git merge -q "$tcommit" >/dev/null 2>&1 || true
+    git checkout -q --ours -- cf.txt
+    git add cf.txt
+)
+reuc_admin="$gitdir/worktrees/wt-reuc"
+rm -rf "$test_tmp/wt-reuc"
+rm -f "$reuc_admin/MERGE_HEAD" "$reuc_admin/MERGE_MSG" "$reuc_admin/MERGE_MODE" "$reuc_admin/AUTO_MERGE" "$reuc_admin/ORIG_HEAD"
+
+if reuc_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with resolve-undo state present: $reuc_out"
+fi
+expect_contains "$reuc_out" "carries resolve-undo (conflict) state" "resolve-undo: clean-looking index refused"
+[ -d "$reuc_admin" ] || fail "resolve-undo: record swept despite conflict state"
+
+# An uninspectable index refuses the same way an unscannable state dir does.
+rm -f "$shim_dir/find"
+cat >"$shim_dir/git" <<SHIM
+#!/usr/bin/env bash
+if [[ "\$*" == *"ls-files --resolve-undo"* ]]; then
+    exit 1
+fi
+exec "$real_git" "\$@"
+SHIM
+chmod +x "$shim_dir/git"
+if reuc_shim_out="$(cd "$fixture" && PATH="$shim_dir:$PATH" bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero although the index was uninspectable: $reuc_shim_out"
+fi
+expect_contains "$reuc_shim_out" "cannot inspect its index for resolve-undo state" "resolve-undo inspect: failure refused fail-closed"
+[ -d "$reuc_admin" ] || fail "resolve-undo inspect: record swept although the index was uninspectable"
+rm -f "$shim_dir/git"
+
+rm -f "$reuc_admin/index"
+reuc_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the resolve-undo state was recovered: $reuc_ok_out"
+expect_contains "$reuc_ok_out" "pruned record 'wt-reuc'" "resolve-undo: recovered record prunes normally"
+echo "ok: resolve-undo state in a clean index refuses the sweep"
+
+# ── Case E7x: symlinked state paths are carried state, broken links judged ─
+# find scans a symlink's target (or nothing when broken), never the link;
+# and [ -e ] dereferences, so a broken unknown symlink would slip past the
+# allowlist unjudged.
+
+mkdir -p "$gitdir/worktrees/symrec"
+printf 'ref: refs/heads/main\n' >"$gitdir/worktrees/symrec/HEAD"
+printf '%s\n' "/nonexistent/symrec/.git" >"$gitdir/worktrees/symrec/gitdir"
+ln -s /nonexistent-target "$gitdir/worktrees/symrec/refs"
+
+if symrec_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with a symlinked state path present: $symrec_out"
+fi
+expect_contains "$symrec_out" "carries worktree-local state (refs)" "symlink: linked state path refused as carried"
+[ -d "$gitdir/worktrees/symrec" ] || fail "symlink: record swept despite a symlinked state path"
+
+rm -f "$gitdir/worktrees/symrec/refs"
+ln -s /nowhere-at-all "$gitdir/worktrees/symrec/mystery-link"
+if symrec2_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)"; then
+    fail "record prune exited zero with a broken unknown symlink present: $symrec2_out"
+fi
+expect_contains "$symrec2_out" "unrecognized entry 'mystery-link'" "symlink: broken unknown link judged, not skipped"
+[ -d "$gitdir/worktrees/symrec" ] || fail "symlink: record swept despite a broken unknown symlink"
+
+rm -f "$gitdir/worktrees/symrec/mystery-link"
+symrec_ok_out="$(cd "$fixture" && bash scripts/clean-worktree-records.sh 2>&1)" ||
+    fail "record prune failed after the symlinks were cleared: $symrec_ok_out"
+expect_contains "$symrec_ok_out" "pruned record 'symrec'" "symlink: cleared record prunes normally"
+echo "ok: symlinked state paths are carried state and broken links are judged"
+
 # ── Case E7s: pin-enumeration failure never reports cleanup complete ───────
 # A broken ref backend is not an empty pin namespace; the empty-plan path
 # must fail closed instead of printing "nothing to prune" with exit 0.


### PR DESCRIPTION
## What

Resurrects the guarded `clean:worktree-records` task descoped from #838 — safe pruning of stale worktree **admin records** (never a worktree directory, never a raw `git worktree prune`), in both layers with byte-twin scripts.

The design settled with Evan at claim (recorded on #945): human-only pin settlement with audit visibility, reflog loss stays accepted (git's own prune semantics), and the raw `git worktree add` / `git worktree lock` native-command races are documented residuals. Implementation resumed from the descoped branch state (`0271934`, five #838 review rounds baked in), then hardened through this PR's own gauntlet.

## How it works

- **Plan-scoped**: only records in git's own `worktree prune --dry-run` plan are touched, one at a time, each under the worktree lifecycle lock (`scripts/worktree-lock.sh`) — keyed identically to `worktree:new`/`worktree:rm`, with a post-lock re-validation that the lock key did not drift.
- **Allowlist-gated sweep**: a record is removed only when every admin-dir entry is known — validated (HEAD, index, ORIG_HEAD, FETCH_HEAD), refused when carried (sidecars, per-worktree refs, op-state incl. MERGE_AUTOSTASH, per-worktree config), disposable scratch, or accepted by design (reflogs). Unknown entries, mistyped entries, symlinks, unreadable files, and failed scans all refuse fail-closed.
- **Rescue pins**: a detached record HEAD is pinned as `refs/session-cleanup/pin/<record>` create-only *before* removal, re-asserted (by OID) after it, and settled only by explicit human action; every printed drop remedy is compare-and-delete and instructs execution-time re-verification. The run stays nonzero while any pin awaits settlement, prior runs' pins included. Pin reporting judges raw history (`GIT_NO_REPLACE_OBJECTS`, `refs/replace/` exclusion, legacy-graft conservatism).

## Verification

- `task verify` green (includes `test:session-cleanup`: **54 behavioral cases**, E7–E7z, fsck-proven detached-HEAD safety, PATH-shim interleaving cases for the post-plan lock, pin races, scan failures, and lock-key drift).
- **46 guard mutants killed at their intended cases** (cp-backup protocol, `bash -n` validity gate, per-case kill assertion).
- `task ci` (full mirror) green before PR creation.
- Gauntlet under **rigor: deep (explicit instruction from Evan, this session) → challenge ≤5 (+r6/r8 granted by Evan), review ≤5, shepherd 4, min_rounds 1** — read from `.devflow.toml`; above-default source disclosed here. Challenge converged at round 8 (zero adjudicated P0/P1 on the sanctioned confirmation round, mirroring the #838 arc); review converged at rounds 1–2 (two consecutive zero-P0/P1 rounds). Every confirmed P0/P1 was fixed in the round that found it.

Closes #945

## Deferred findings

- [x] scripts/worktree-rm.sh:479 — op-state refusal list omits MERGE_AUTOSTASH: a `git merge --autostash` killed before MERGE_HEAD exists leaves dirty work referenced by that file alone, and worktree:rm would remove the live tree over it (same gap challenge r6 confirmed and fixed in clean-worktree-records.sh; the removal-path twin belongs to its own change). P2, deferred from #945 challenge r6. — filed as #951.

## Adjudication record

<details>
<summary>Full per-round ledger (challenge r1–r8, review r1–r2)</summary>

```text
challenge r1 | 4 P1 + 2 P2, all confirmed, all fixed
scripts/clean-worktree-records.sh:130 | op-state files (rebase-merge, MERGE_HEAD...) not in state refusal list | confirmed P1, fixed: list mirrors worktree-rm.sh; E7d op-rec case; mutant M10 | challenge r1
scripts/clean-worktree-records.sh:172 | pin dropped by racing settlement between create and rm | confirmed P1, fixed: post-rm re-assert + CRITICAL rescue path; shim case E7j; mutant M12 | challenge r1
scripts/clean-worktree-records.sh:120 | git worktree lock taken post-plan ignored at removal | confirmed P1, fixed: locked-marker SKIP under lifecycle lock; shim case E7i; mutant M11 | challenge r1
scripts/clean-worktree-records.sh:190 | PINNED drop remedy asserts stale snapshot safety | confirmed P1, fixed: wording instructs execution-time re-verify before drop; E7c assert; mutant M13 | challenge r1
scripts/clean-worktree-records.sh:91 | retry exits 0 while pins await settlement, contract says nonzero | confirmed P2, fixed now: pins_outstanding on both exit paths; E7 retry case; mutant M14 | challenge r1
scripts/clean-worktree-records.sh:213 | rm failure mislabeled as lock contention | confirmed P2, fixed now: exit 4/5 error class, errors counter, exit 1; case E7k; mutant M15 | challenge r1
challenge r2 | 1 P1 + 4 P2; 1 P1 fixed, 3 P2 fixed, 1 P2 declined-as-residual (documented), 1 sub-claim + 1 finding refuted with evidence
scripts/clean-worktree-records.sh:164 | ORIG_HEAD reset-away commit swept | confirmed P1 (ORIG_HEAD half), fixed: unreachable/unreadable ORIG_HEAD refuses, reachable sweeps; E7m; mutant M16 | challenge r2
scripts/clean-worktree-records.sh:164 | config.worktree silently deleted (same finding, sub-claim) | declined: dead config for a dead tree, matches git prune semantics, nothing irreplaceable | challenge r2
scripts/clean-worktree-records.sh:175 | unreadable HEAD sweeps unpinned | confirmed P2, fixed: fail-closed refusal; E7n; mutant M17 | challenge r2
scripts/clean-worktree-records.sh:230 | pin re-assert checks existence not OID | confirmed P2 (provenance: r1 fix, in scope - completes the pin contract), fixed: OID compare, retarget fails closed, never overwritten; shim case E7o; mutant M18; r1 re-assert re-covered by M20 | challenge r2
scripts/clean-worktree-records.sh:134 | separate-git-dir breaks main_root/lock keying | REFUTED: empirically git worktree list first entry == ${common%/.git} in every producible layout incl. both sep-git-dir forms and core.worktree set; worktree-new.sh:118 reads the registry, so keys always agreed; derivation still switched to the registry for consistency-by-construction (not a guard, no case) | challenge r2
scripts/clean-worktree-records.sh:154 | native git worktree lock racing removal | confirmed-as-residual P2, declined mechanical fix: native command cannot take the lifecycle lock (same class as raw worktree add, Evan design (c)); documented in header + conventions both layers | challenge r2
challenge r3 | 2 P1 + 2 P2; 1 P1 fixed, 1 P1 split (half declined by maintainer design, half fixed as P2), 1 P2 fixed, 1 P2 declined
scripts/clean-worktree-records.sh:237 | unresolvable detached HEAD falls through to rm | confirmed P1 (reviewer repro), fixed: nonempty non-resolving HEAD refuses; E7p; mutant M21 | challenge r3
scripts/clean-worktree-records.sh:288 | settlement race needs settle-under-lock helper | declined: settlement helper explicitly declined by Evan design (a) - new ref-deletion surface; ms window vs raw human git is irreducible; documented residual class | challenge r3
scripts/clean-worktree-records.sh:288 | unconditional printed update-ref -d can delete a newer pin after name reuse (same finding, actionable half) | confirmed, adjudicated P2, fixed: all printed drop remedies are compare-and-delete (OID old-value arg); E7+E7c asserts; mutants M22+M23 | challenge r3
scripts/clean-worktree-records.sh:176 | find failure fail-open in state scan | confirmed P2 (reviewer repro), fixed: scan status checked, refuse on error; shim case E7q; mutant M24 | challenge r3
scripts/clean-worktree-records.sh:175 | FETCH_HEAD not in refusal set | declined: single-generation fetch bookkeeping of remote-origin commits, weaker than reflogs which are accepted-loss by Evan design (b); refusing would make most fetched-in records unsweepable | challenge r3
challenge r4 | 3 P1 + 1 P2; 1 P1 fixed (revising an r3 declination), 1 P1 fixed (contract completion on r1 guard), 1 P1 declined (attacks maintainer design decision b), 1 P2 fixed
scripts/clean-worktree-records.sh:34 | reflog-only commits must be pinned/refused | declined: directly contradicts Evan design decision (b) made this session (reflog accepted-loss, git prune semantics, unsweepability); design record on issue #945 | challenge r4
scripts/clean-worktree-records.sh:176 | FETCH_HEAD-only commits swept (re-raise of r3 H4 with conditional remedy) | confirmed P1, fixed: ORIG_HEAD-style per-entry guard - only unreadable/unresolvable/unreachable entries refuse, no unsweepability cost; E7r; mutant M25 | challenge r4
scripts/clean-worktree-records.sh:117 | pin-enumeration failure swallowed, false cleanup-complete | confirmed P1 (provenance: r1 guard, in scope - completes its contract), fixed: fail-closed die on enumeration error, both call sites; shim case E7s; mutant M26 | challenge r4
scripts/clean-worktree-records.sh:343 | summary prints current-run pins as if total | confirmed P2 (provenance: r1 summary, in scope), fixed: total + per-run counts; E7 inherited-pin sub-case; mutant M27 | challenge r4
challenge r5 (cap) | 1 P1 + 2 P2, all confirmed, all fixed; NOT a clean round - stage cannot self-exit, escalated to Evan
scripts/clean-worktree-records.sh:179 | config.worktree + info/sparse-checkout swept (re-raise of r2 sub-claim with repro) | confirmed P1, REVERSING r2 declination: sidecar precedent makes "dead config" inconsistent; user-set per-worktree config is single-copy; present only on worktreeConfig records so no unsweepability cost; E7d cfg-rec; mutant M28 | challenge r5
scripts/clean-worktree-records.sh:231 | unterminated final FETCH_HEAD entry skipped by read loop | confirmed P2 (provenance: r4 guard, in scope - completes it), fixed: read || [ -n ] idiom; E7r sub-case; mutant M29 | challenge r5
scripts/clean-worktree-records.sh:259 | index path unquoted in copyable remedy | confirmed P2, fixed: shell_quote; E7e assert; mutant M30 | challenge r5
challenge r6 (granted by Evan) | 3 P1 + 1 P2; 1 P1 fixed, 1 adjudicated-down-to-P2 fixed, 1 P1 declined, 1 P2 fixed; provenance: L2-L4 target r4/r5 guards, only L1 targets the original list
scripts/clean-worktree-records.sh:184 | MERGE_AUTOSTASH missing from op-state list | confirmed P1, fixed: added to refusal set; E7d stash-rec; mutant M31; worktree-rm.sh has the same gap - DEFERRED to sidecar as P2 (its own change) | challenge r6
scripts/clean-worktree-records.sh:241 | annotated tag object peeled to commit, tag body lost | confirmed, adjudicated P2 (rare fetch shape, metadata), fixed: tag objects require exact --points-at containment; E7t; mutant M32; provenance: r4 guard, in scope | challenge r6
scripts/clean-worktree-records.sh:248 | aux-head containment races concurrent ref deletion, wants per-aux pins | declined: clean:branches is evidence-gated and cannot orphan what it deletes; arbitrary concurrent ref mutation in the ms window is the documented native-git residual class (G5/H2a); per-aux pins multiply the settlement surface against Evan design (a) | challenge r6
scripts/clean-worktree-records.sh:248 | rescue branch name collides across FETCH_HEAD entries | confirmed P2, fixed: per-OID short-hash suffix; E7r assert; mutant M33; provenance: r4 remedy, in scope | challenge r6
restructure (post-r6, Evan-approved) | allowlist inversion per damper 5: sweep only when every admin-dir entry is known (validated / carried-refused / accepted-by-design); unknown entries refuse fail-closed - mechanically ends the state-file enumeration finding class (r1 op-state, r5 config.worktree, r6 MERGE_AUTOSTASH were all instances). Case E7u (sequencer/ + info/ unknowns); mutants M34+M35 killed - 34 total. E7k blocker moved inside allowlisted logs/.
challenge r7 (confirmation, post-inversion) | 3 P1 + 3 P2; 1 P1 fixed, 2 P1 declined-from-record, 2 P2 fixed, 1 P2 declined
scripts/clean-worktree-records.sh:165 | unreadable gitdir fails open + surviving tree dir orphaned by sweep | confirmed P1 (original descoped code - can orphan a LIVE tree), fixed: unreadable gitdir refuses; a surviving worktree directory whose .git link is gone refuses; E7v; mutants M36+M37 | challenge r7
scripts/clean-worktree-records.sh:218 | reflog-only commits (3rd raise) | declined from record: Evan design decision (b), ledger r4+r6; code unchanged | challenge r7
scripts/clean-worktree-records.sh:262 | aux-head snapshot race, wants pins (2nd raise) | declined from record: ledger r6 - clean:branches evidence-gated cannot orphan; native-git ms-window residual class; code unchanged | challenge r7
scripts/clean-worktree-records.sh:218 | nonempty COMMIT_EDITMSG is user prose | declined: nonempty after EVERY successful commit (recoverable from the commit), so refusal is unsweepability; failed-commit residue indistinguishable; same accepted-loss class as reflogs per design (b) | challenge r7
scripts/clean-worktree-records.sh:318 | resolve-undo entries in a stage-0-clean index | confirmed P2, fixed: REUC state refuses, uninspectable index refuses fail-closed; E7w + shim sub-case; mutants M40+M41 | challenge r7
scripts/clean-worktree-records.sh:197 | symlinked state paths evade find, broken symlinks evade -e | confirmed P2, fixed: -L is carried state, catch-all judges links; E7x; mutants M38+M39 | challenge r7
challenge r8 (sanctioned confirmation) | 1 P1 declined + 2 P2 fixed = ZERO adjudicated P0/P1 - CHALLENGE CONVERGED (8 rounds, Evan-granted r6/r8, mirroring the #838 arc)
scripts/clean-worktree-records.sh:283 | aux-head race via squash-merged branch deletion (3rd raise of the snapshot race) | declined, corrected reasoning: SEQUENTIAL EQUIVALENCE - deleting the squash-merged branch a minute AFTER the sweep produces the identical end state with no race, and that is clean:branches' own sanctioned semantic; a point-in-time containment check can never guarantee against future deletion of a legitimately deletable ref; the aux file was an incidental second protector, not the commit's contract; persistent aux pins would flood settlement against design (a) | challenge r8
scripts/clean-worktree-records.sh:407 | retargeted pin leaves swept record's head unprotected | confirmed P2, fixed: best-effort create-only rescue ref under a fresh unique name before the CRITICAL exit; E7o assert; mutant M42 | challenge r8
scripts/clean-worktree-records.sh:239 | allowlisted names admitted regardless of type | confirmed P2, fixed: known file slots must be regular files, logs must be a directory, symlinks refuse; E7y; mutant M43 | challenge r8
review r1 | 1 P1 declined-from-record + 1 P2 fixed = zero adjudicated P0/P1
scripts/clean-worktree-records.sh:300 | aux-head snapshot race (4th raise, now via review pass) | declined from record: ledger r6/r7/r8 - sequential equivalence + design (a); code unchanged; cross-pass re-raise noted, record carries the full reasoning into the PR body | review r1
scripts/clean-worktree-records.sh:154 | lifecycle lock keyed off the pre-lock gitdir read | confirmed P2, fixed: post-lock gitdir must equal the lock key or the record refuses for a re-run; cat-shim case E7z; mutant M44 - 43 total, 52 cases | review r1
review r2 | zero P0/P1 (reviewer-stated), 3 P2 all fixed post-convergence - REVIEW CONVERGED (two consecutive zero-P0/P1 rounds: r1+r2)
scripts/test-session-cleanup.sh:1264 | E7z shim covered only empty-to-path drift | confirmed P2, fixed: shim returns a different valid blessed path first - path-to-path drift; mutant M44 re-killed under new shim | review r2
scripts/clean-worktree-records.sh:136 | prune dry-run failure dies bare, diagnostic swallowed | confirmed P2, fixed: guarded assignment, die surfaces git's own output; E7s sub-case; mutant M45 | review r2
scripts/clean-worktree-records.sh:498 | || true could print fabricated pin total on enum failure | confirmed P2, fixed: wc pipeline under pipefail, die on failure; E7s sub-case; mutant M46 - 46 mutants, 54 cases total | review r2
shepherd r1 (Codex cloud) | 1 P1 declined-from-record + 4 P2 confirmed-fixed in 66de154
scripts/clean-worktree-records.sh:315 | aux-head snapshot race (5th cross-pass raise) | declined from record: sequential equivalence + design (a); in-thread reply carries the reasoning | shepherd r1
scripts/clean-worktree-records.sh:274 | info entry as regular file/symlink accepted uninspected | confirmed P2, fixed: type gate; mutant M47 | shepherd r1
scripts/test-session-cleanup.sh:865 | E7k chmod 000 fails under UID 0 | confirmed P2, fixed: rm PATH shim; mutant M48 | shepherd r1
scripts/clean-worktree-records.sh:456 | printed re-verify command graftable | confirmed P2, fixed: GIT_GRAFT_FILE=/dev/null added, verified empirically; mutant M49 | shepherd r1
scripts/clean-worktree-records.sh:194 | gitdir without /.git suffix skips surviving-dir guard | confirmed P2, fixed: malformed suffix refuses; mutant M50 | shepherd r1
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSKYXiYjRCYi5rqMT39Jus


