### PR TITLE
fix: refuse worktree removal and stale-record pruning over a merge autostash

### DIFF
--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -732,6 +732,20 @@ fi
 rm -rf "$midrebase_git/rebase-merge"
 rm_wt midrebase >/dev/null || fail "worktree-rm.sh failed once the rebase state was cleared"
 
+# MERGE_AUTOSTASH can be the ONLY marker: a `git merge --autostash` killed
+# after the autostash is written but before MERGE_HEAD exists leaves the
+# user's dirty work referenced by that one file alone (#951).
+echo "==> worktree:rm refuses a tree holding only MERGE_AUTOSTASH"
+new autostash >/dev/null || fail "worktree-new.sh failed for the autostash case"
+autostash_git="$(git -C "$fixture/.worktrees/autostash" rev-parse --path-format=absolute --git-dir)"
+printf '%s\n' "$(git -C "$fixture/.worktrees/autostash" rev-parse HEAD)" >"$autostash_git/MERGE_AUTOSTASH"
+if rm_wt autostash >/dev/null 2>&1; then
+    fail "worktree-rm.sh removed a tree with an interrupted merge --autostash"
+fi
+[ -d "$fixture/.worktrees/autostash" ] || fail "the autostash tree was removed despite the refusal"
+rm -f "$autostash_git/MERGE_AUTOSTASH"
+rm_wt autostash >/dev/null || fail "worktree-rm.sh failed once the autostash state was cleared"
+
 echo "==> worktree:rm refuses a detached HEAD no branch contains"
 new detached >/dev/null || fail "worktree-new.sh failed for the detached case"
 git -C "$fixture/.worktrees/detached" checkout -q --detach

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -749,29 +749,41 @@ rm_wt autostash >/dev/null || fail "worktree-rm.sh failed once the autostash sta
 # The same marker must also block STALE-RECORD cleanup: with the directory
 # already gone, the record's admin dir holds the only MERGE_AUTOSTASH
 # reference, and pruning the record would drop it (#951, challenge r2).
+# The fixture path deliberately carries a single quote AND a space so the
+# emitted recovery recipe (executed verbatim below) proves its printf %q
+# escaping under exactly the characters that broke earlier revisions.
 echo "==> worktree:rm refuses to prune a stale record holding MERGE_AUTOSTASH"
-new stalestash >/dev/null || fail "worktree-new.sh failed for the stale-autostash case"
-stalestash_git="$(git -C "$fixture/.worktrees/stalestash" rev-parse --path-format=absolute --git-dir)"
+qfix="$test_tmp/q'uote fixture"
+mkdir -p "$qfix/scripts"
+cp "$repo/scripts/worktree-rm.sh" "$repo/scripts/worktree-lock.sh" "$qfix/scripts/"
+git -C "$qfix" init -q
+git -C "$qfix" config user.name "Worktree Test"
+git -C "$qfix" config user.email "worktree-test@example.invalid"
+git -C "$qfix" config commit.gpgsign false
+printf 'fixture\n' >"$qfix/README.md"
+git -C "$qfix" add -A
+git -C "$qfix" commit -qm "chore: quote fixture"
+git -C "$qfix" worktree add -q "$qfix/.worktrees/stalestash" -b stalestash
+stalestash_git="$(git -C "$qfix/.worktrees/stalestash" rev-parse --path-format=absolute --git-dir)"
 # A real autostash OID, not a bare HEAD: `git stash store` (the emitted
 # recovery recipe, executed below) refuses commits that are not stash-shaped.
-printf 'dirty\n' >>"$fixture/.worktrees/stalestash/README.md"
-printf '%s\n' "$(git -C "$fixture/.worktrees/stalestash" stash create)" >"$stalestash_git/MERGE_AUTOSTASH"
-rm -rf "$fixture/.worktrees/stalestash"
-stalestash_err="$(rm_wt stalestash 2>&1 >/dev/null)" &&
+printf 'dirty\n' >>"$qfix/.worktrees/stalestash/README.md"
+printf '%s\n' "$(git -C "$qfix/.worktrees/stalestash" stash create)" >"$stalestash_git/MERGE_AUTOSTASH"
+rm -rf "$qfix/.worktrees/stalestash"
+stalestash_err="$(rm_in "$qfix" scripts/worktree-rm.sh stalestash 2>&1 >/dev/null)" &&
     fail "worktree-rm.sh pruned a stale record whose admin dir holds a merge autostash"
 [ -s "$stalestash_git/MERGE_AUTOSTASH" ] || fail "the stale record's autostash reference was dropped despite the refusal"
 # The refusal's recovery recipe must be RUNNABLE as emitted — a malformed
 # quoting of the marker path once shipped a recipe that failed even on
 # space-free paths (#951 review r1). Execute it verbatim.
-stalestash_cmd="$(printf '%s\n' "$stalestash_err" | sed -n 's/.*keep the work with: \(.*\) — or re-run.*/\1/p')"
+stalestash_cmd="$(printf '%s\n' "$stalestash_err" | sed -n 's/.*keep the work with: \(.*\) — then re-run.*/\1/p')"
 [ -n "$stalestash_cmd" ] || fail "the stale-autostash refusal did not carry a recovery command"
-(cd "$fixture" && eval "$stalestash_cmd" >/dev/null 2>&1) ||
+(cd "$qfix" && eval "$stalestash_cmd" >/dev/null 2>&1) ||
     fail "the emitted stale-autostash recovery command is not runnable: $stalestash_cmd"
-[ "$(git -C "$fixture" rev-parse refs/stash)" = "$(cat "$stalestash_git/MERGE_AUTOSTASH")" ] ||
+[ "$(git -C "$qfix" rev-parse refs/stash)" = "$(cat "$stalestash_git/MERGE_AUTOSTASH")" ] ||
     fail "the recovery command did not store the autostash commit in refs/stash"
-git -C "$fixture" update-ref -d refs/stash
-rm_wt stalestash --force >/dev/null || fail "worktree-rm.sh --force failed on the stale autostash record"
-git -C "$fixture" branch -D stalestash >/dev/null 2>&1 || true
+rm_in "$qfix" scripts/worktree-rm.sh stalestash --force >/dev/null ||
+    fail "worktree-rm.sh --force failed on the stale autostash record"
 
 echo "==> worktree:rm refuses a detached HEAD no branch contains"
 new detached >/dev/null || fail "worktree-new.sh failed for the detached case"

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -752,12 +752,24 @@ rm_wt autostash >/dev/null || fail "worktree-rm.sh failed once the autostash sta
 echo "==> worktree:rm refuses to prune a stale record holding MERGE_AUTOSTASH"
 new stalestash >/dev/null || fail "worktree-new.sh failed for the stale-autostash case"
 stalestash_git="$(git -C "$fixture/.worktrees/stalestash" rev-parse --path-format=absolute --git-dir)"
-printf '%s\n' "$(git -C "$fixture/.worktrees/stalestash" rev-parse HEAD)" >"$stalestash_git/MERGE_AUTOSTASH"
+# A real autostash OID, not a bare HEAD: `git stash store` (the emitted
+# recovery recipe, executed below) refuses commits that are not stash-shaped.
+printf 'dirty\n' >>"$fixture/.worktrees/stalestash/README.md"
+printf '%s\n' "$(git -C "$fixture/.worktrees/stalestash" stash create)" >"$stalestash_git/MERGE_AUTOSTASH"
 rm -rf "$fixture/.worktrees/stalestash"
-if rm_wt stalestash >/dev/null 2>&1; then
+stalestash_err="$(rm_wt stalestash 2>&1 >/dev/null)" &&
     fail "worktree-rm.sh pruned a stale record whose admin dir holds a merge autostash"
-fi
 [ -s "$stalestash_git/MERGE_AUTOSTASH" ] || fail "the stale record's autostash reference was dropped despite the refusal"
+# The refusal's recovery recipe must be RUNNABLE as emitted — a malformed
+# quoting of the marker path once shipped a recipe that failed even on
+# space-free paths (#951 review r1). Execute it verbatim.
+stalestash_cmd="$(printf '%s\n' "$stalestash_err" | sed -n 's/.*keep the work with: \(.*\) — or re-run.*/\1/p')"
+[ -n "$stalestash_cmd" ] || fail "the stale-autostash refusal did not carry a recovery command"
+(cd "$fixture" && eval "$stalestash_cmd" >/dev/null 2>&1) ||
+    fail "the emitted stale-autostash recovery command is not runnable: $stalestash_cmd"
+[ "$(git -C "$fixture" rev-parse refs/stash)" = "$(cat "$stalestash_git/MERGE_AUTOSTASH")" ] ||
+    fail "the recovery command did not store the autostash commit in refs/stash"
+git -C "$fixture" update-ref -d refs/stash
 rm_wt stalestash --force >/dev/null || fail "worktree-rm.sh --force failed on the stale autostash record"
 git -C "$fixture" branch -D stalestash >/dev/null 2>&1 || true
 

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -746,6 +746,21 @@ fi
 rm -f "$autostash_git/MERGE_AUTOSTASH"
 rm_wt autostash >/dev/null || fail "worktree-rm.sh failed once the autostash state was cleared"
 
+# The same marker must also block STALE-RECORD cleanup: with the directory
+# already gone, the record's admin dir holds the only MERGE_AUTOSTASH
+# reference, and pruning the record would drop it (#951, challenge r2).
+echo "==> worktree:rm refuses to prune a stale record holding MERGE_AUTOSTASH"
+new stalestash >/dev/null || fail "worktree-new.sh failed for the stale-autostash case"
+stalestash_git="$(git -C "$fixture/.worktrees/stalestash" rev-parse --path-format=absolute --git-dir)"
+printf '%s\n' "$(git -C "$fixture/.worktrees/stalestash" rev-parse HEAD)" >"$stalestash_git/MERGE_AUTOSTASH"
+rm -rf "$fixture/.worktrees/stalestash"
+if rm_wt stalestash >/dev/null 2>&1; then
+    fail "worktree-rm.sh pruned a stale record whose admin dir holds a merge autostash"
+fi
+[ -s "$stalestash_git/MERGE_AUTOSTASH" ] || fail "the stale record's autostash reference was dropped despite the refusal"
+rm_wt stalestash --force >/dev/null || fail "worktree-rm.sh --force failed on the stale autostash record"
+git -C "$fixture" branch -D stalestash >/dev/null 2>&1 || true
+
 echo "==> worktree:rm refuses a detached HEAD no branch contains"
 new detached >/dev/null || fail "worktree-new.sh failed for the detached case"
 git -C "$fixture/.worktrees/detached" checkout -q --detach

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -227,7 +227,10 @@ if [ "$tree_exists" -eq 0 ]; then
             # metacharacters) rather than one corner of it; the test suite
             # executes this emitted command verbatim.
             stale_marker_q="$(printf '%q' "$stale_admin/MERGE_AUTOSTASH")"
-            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with: git stash store \"\$(cat $stale_marker_q)\" — or re-run with --force to discard it"
+            # Storing does not remove the marker, so a plain re-run refuses
+            # again — the completing sequence is store, THEN --force (safe:
+            # the work now lives in refs/stash).
+            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with: git stash store \"\$(cat $stale_marker_q)\" — then re-run with --force to clear the record (the stored work survives in refs/stash); --force without storing discards it"
         fi
         if [ -n "$stale_admin" ] && [ -f "$stale_admin/HEAD" ]; then
             stale_head="$(cat "$stale_admin/HEAD" 2>/dev/null || true)"

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -223,7 +223,7 @@ if [ "$tree_exists" -eq 0 ]; then
         # with the directory already gone. Dropping the record drops the
         # only reference.
         if [ -n "$stale_admin" ] && [ -s "$stale_admin/MERGE_AUTOSTASH" ]; then
-            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with 'git stash store \"\$(cat $stale_admin/MERGE_AUTOSTASH)\"', or re-run with --force to discard it"
+            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with 'git stash store \"\$(cat \\\"$stale_admin/MERGE_AUTOSTASH\\\")\"', or re-run with --force to discard it"
         fi
         if [ -n "$stale_admin" ] && [ -f "$stale_admin/HEAD" ]; then
             stale_head="$(cat "$stale_admin/HEAD" 2>/dev/null || true)"

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -223,9 +223,11 @@ if [ "$tree_exists" -eq 0 ]; then
         # with the directory already gone. Dropping the record drops the
         # only reference.
         if [ -n "$stale_admin" ] && [ -s "$stale_admin/MERGE_AUTOSTASH" ]; then
-            # Single-quote the path so the recipe survives whitespace when
-            # pasted; the test suite executes this emitted command verbatim.
-            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with: git stash store \"\$(cat '$stale_admin/MERGE_AUTOSTASH')\" — or re-run with --force to discard it"
+            # printf %q escapes the WHOLE quoting class (whitespace, quotes,
+            # metacharacters) rather than one corner of it; the test suite
+            # executes this emitted command verbatim.
+            stale_marker_q="$(printf '%q' "$stale_admin/MERGE_AUTOSTASH")"
+            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with: git stash store \"\$(cat $stale_marker_q)\" — or re-run with --force to discard it"
         fi
         if [ -n "$stale_admin" ] && [ -f "$stale_admin/HEAD" ]; then
             stale_head="$(cat "$stale_admin/HEAD" 2>/dev/null || true)"

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -473,9 +473,13 @@ else
     # --amend` at that stop, a commit reachable from nothing else. Removing the
     # tree drops that state, and gc eventually collects the commit. Likewise a
     # detached HEAD ahead of every branch: nothing else references it.
+    # MERGE_AUTOSTASH is listed on its own because it can exist alone: a
+    # `git merge --autostash` killed after the autostash is written but before
+    # MERGE_HEAD exists leaves the user's dirty work referenced by that one
+    # file and nothing else.
     if [ "$force" -eq 0 ]; then
         tree_git_dir="$(git -C "$tree" rev-parse --path-format=absolute --git-dir)"
-        for op_state in rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
+        for op_state in rebase-merge rebase-apply MERGE_HEAD MERGE_AUTOSTASH CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
             if [ -e "$tree_git_dir/$op_state" ]; then
                 die "$tree has an in-progress git operation ($op_state) — finish or abort it, or re-run with --force to discard it"
             fi

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -217,6 +217,14 @@ if [ "$tree_exists" -eq 0 ]; then
     # radius without giving this path the guard the live one has.)
     if [ "$force" -eq 0 ] && [ "$stale_record" -eq 1 ]; then
         stale_admin="$(record_admin_dir "$tree" || true)"
+        # An interrupted `git merge --autostash` can leave the stashed work
+        # referenced by the record's MERGE_AUTOSTASH file and nothing else —
+        # the same marker the live-tree guard below refuses, reachable here
+        # with the directory already gone. Dropping the record drops the
+        # only reference.
+        if [ -n "$stale_admin" ] && [ -s "$stale_admin/MERGE_AUTOSTASH" ]; then
+            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with 'git stash store \"\$(cat $stale_admin/MERGE_AUTOSTASH)\"', or re-run with --force to discard it"
+        fi
         if [ -n "$stale_admin" ] && [ -f "$stale_admin/HEAD" ]; then
             stale_head="$(cat "$stale_admin/HEAD" 2>/dev/null || true)"
             case "$stale_head" in
@@ -486,7 +494,7 @@ else
                 # `--abort` both refuse, and `git merge --quit` is the command
                 # that moves the referenced work to refs/stash.
                 if [ "$op_state" = MERGE_AUTOSTASH ]; then
-                    die "$tree has an autostash from an interrupted merge ($op_state) — run 'git merge --quit' there to move it to the stash, then 'git stash pop' to recover the work, or re-run with --force to discard it"
+                    die "$tree has an autostash from an interrupted merge ($op_state) — run 'git merge --quit' there to move it to the stash, then recover it from 'git stash list' (the stash is repository-wide, so pop that entry, not blindly the newest), or re-run with --force to discard it"
                 fi
                 die "$tree has an in-progress git operation ($op_state) — finish or abort it, or re-run with --force to discard it"
             fi

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -481,6 +481,13 @@ else
         tree_git_dir="$(git -C "$tree" rev-parse --path-format=absolute --git-dir)"
         for op_state in rebase-merge rebase-apply MERGE_HEAD MERGE_AUTOSTASH CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
             if [ -e "$tree_git_dir/$op_state" ]; then
+                # "finish or abort" is impossible advice for a marker-only
+                # autostash: with MERGE_HEAD absent, `git merge --continue` and
+                # `--abort` both refuse, and `git merge --quit` is the command
+                # that moves the referenced work to refs/stash.
+                if [ "$op_state" = MERGE_AUTOSTASH ]; then
+                    die "$tree has an autostash from an interrupted merge ($op_state) — run 'git merge --quit' there to move it to the stash, then 'git stash pop' to recover the work, or re-run with --force to discard it"
+                fi
                 die "$tree has an in-progress git operation ($op_state) — finish or abort it, or re-run with --force to discard it"
             fi
         done

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -223,7 +223,9 @@ if [ "$tree_exists" -eq 0 ]; then
         # with the directory already gone. Dropping the record drops the
         # only reference.
         if [ -n "$stale_admin" ] && [ -s "$stale_admin/MERGE_AUTOSTASH" ]; then
-            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with 'git stash store \"\$(cat \\\"$stale_admin/MERGE_AUTOSTASH\\\")\"', or re-run with --force to discard it"
+            # Single-quote the path so the recipe survives whitespace when
+            # pasted; the test suite executes this emitted command verbatim.
+            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with: git stash store \"\$(cat '$stale_admin/MERGE_AUTOSTASH')\" — or re-run with --force to discard it"
         fi
         if [ -n "$stale_admin" ] && [ -f "$stale_admin/HEAD" ]; then
             stale_head="$(cat "$stale_admin/HEAD" 2>/dev/null || true)"

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -732,6 +732,20 @@ fi
 rm -rf "$midrebase_git/rebase-merge"
 rm_wt midrebase >/dev/null || fail "worktree-rm.sh failed once the rebase state was cleared"
 
+# MERGE_AUTOSTASH can be the ONLY marker: a `git merge --autostash` killed
+# after the autostash is written but before MERGE_HEAD exists leaves the
+# user's dirty work referenced by that one file alone (#951).
+echo "==> worktree:rm refuses a tree holding only MERGE_AUTOSTASH"
+new autostash >/dev/null || fail "worktree-new.sh failed for the autostash case"
+autostash_git="$(git -C "$fixture/.worktrees/autostash" rev-parse --path-format=absolute --git-dir)"
+printf '%s\n' "$(git -C "$fixture/.worktrees/autostash" rev-parse HEAD)" >"$autostash_git/MERGE_AUTOSTASH"
+if rm_wt autostash >/dev/null 2>&1; then
+    fail "worktree-rm.sh removed a tree with an interrupted merge --autostash"
+fi
+[ -d "$fixture/.worktrees/autostash" ] || fail "the autostash tree was removed despite the refusal"
+rm -f "$autostash_git/MERGE_AUTOSTASH"
+rm_wt autostash >/dev/null || fail "worktree-rm.sh failed once the autostash state was cleared"
+
 echo "==> worktree:rm refuses a detached HEAD no branch contains"
 new detached >/dev/null || fail "worktree-new.sh failed for the detached case"
 git -C "$fixture/.worktrees/detached" checkout -q --detach

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -749,29 +749,41 @@ rm_wt autostash >/dev/null || fail "worktree-rm.sh failed once the autostash sta
 # The same marker must also block STALE-RECORD cleanup: with the directory
 # already gone, the record's admin dir holds the only MERGE_AUTOSTASH
 # reference, and pruning the record would drop it (#951, challenge r2).
+# The fixture path deliberately carries a single quote AND a space so the
+# emitted recovery recipe (executed verbatim below) proves its printf %q
+# escaping under exactly the characters that broke earlier revisions.
 echo "==> worktree:rm refuses to prune a stale record holding MERGE_AUTOSTASH"
-new stalestash >/dev/null || fail "worktree-new.sh failed for the stale-autostash case"
-stalestash_git="$(git -C "$fixture/.worktrees/stalestash" rev-parse --path-format=absolute --git-dir)"
+qfix="$test_tmp/q'uote fixture"
+mkdir -p "$qfix/scripts"
+cp "$repo/scripts/worktree-rm.sh" "$repo/scripts/worktree-lock.sh" "$qfix/scripts/"
+git -C "$qfix" init -q
+git -C "$qfix" config user.name "Worktree Test"
+git -C "$qfix" config user.email "worktree-test@example.invalid"
+git -C "$qfix" config commit.gpgsign false
+printf 'fixture\n' >"$qfix/README.md"
+git -C "$qfix" add -A
+git -C "$qfix" commit -qm "chore: quote fixture"
+git -C "$qfix" worktree add -q "$qfix/.worktrees/stalestash" -b stalestash
+stalestash_git="$(git -C "$qfix/.worktrees/stalestash" rev-parse --path-format=absolute --git-dir)"
 # A real autostash OID, not a bare HEAD: `git stash store` (the emitted
 # recovery recipe, executed below) refuses commits that are not stash-shaped.
-printf 'dirty\n' >>"$fixture/.worktrees/stalestash/README.md"
-printf '%s\n' "$(git -C "$fixture/.worktrees/stalestash" stash create)" >"$stalestash_git/MERGE_AUTOSTASH"
-rm -rf "$fixture/.worktrees/stalestash"
-stalestash_err="$(rm_wt stalestash 2>&1 >/dev/null)" &&
+printf 'dirty\n' >>"$qfix/.worktrees/stalestash/README.md"
+printf '%s\n' "$(git -C "$qfix/.worktrees/stalestash" stash create)" >"$stalestash_git/MERGE_AUTOSTASH"
+rm -rf "$qfix/.worktrees/stalestash"
+stalestash_err="$(rm_in "$qfix" scripts/worktree-rm.sh stalestash 2>&1 >/dev/null)" &&
     fail "worktree-rm.sh pruned a stale record whose admin dir holds a merge autostash"
 [ -s "$stalestash_git/MERGE_AUTOSTASH" ] || fail "the stale record's autostash reference was dropped despite the refusal"
 # The refusal's recovery recipe must be RUNNABLE as emitted — a malformed
 # quoting of the marker path once shipped a recipe that failed even on
 # space-free paths (#951 review r1). Execute it verbatim.
-stalestash_cmd="$(printf '%s\n' "$stalestash_err" | sed -n 's/.*keep the work with: \(.*\) — or re-run.*/\1/p')"
+stalestash_cmd="$(printf '%s\n' "$stalestash_err" | sed -n 's/.*keep the work with: \(.*\) — then re-run.*/\1/p')"
 [ -n "$stalestash_cmd" ] || fail "the stale-autostash refusal did not carry a recovery command"
-(cd "$fixture" && eval "$stalestash_cmd" >/dev/null 2>&1) ||
+(cd "$qfix" && eval "$stalestash_cmd" >/dev/null 2>&1) ||
     fail "the emitted stale-autostash recovery command is not runnable: $stalestash_cmd"
-[ "$(git -C "$fixture" rev-parse refs/stash)" = "$(cat "$stalestash_git/MERGE_AUTOSTASH")" ] ||
+[ "$(git -C "$qfix" rev-parse refs/stash)" = "$(cat "$stalestash_git/MERGE_AUTOSTASH")" ] ||
     fail "the recovery command did not store the autostash commit in refs/stash"
-git -C "$fixture" update-ref -d refs/stash
-rm_wt stalestash --force >/dev/null || fail "worktree-rm.sh --force failed on the stale autostash record"
-git -C "$fixture" branch -D stalestash >/dev/null 2>&1 || true
+rm_in "$qfix" scripts/worktree-rm.sh stalestash --force >/dev/null ||
+    fail "worktree-rm.sh --force failed on the stale autostash record"
 
 echo "==> worktree:rm refuses a detached HEAD no branch contains"
 new detached >/dev/null || fail "worktree-new.sh failed for the detached case"

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -752,12 +752,24 @@ rm_wt autostash >/dev/null || fail "worktree-rm.sh failed once the autostash sta
 echo "==> worktree:rm refuses to prune a stale record holding MERGE_AUTOSTASH"
 new stalestash >/dev/null || fail "worktree-new.sh failed for the stale-autostash case"
 stalestash_git="$(git -C "$fixture/.worktrees/stalestash" rev-parse --path-format=absolute --git-dir)"
-printf '%s\n' "$(git -C "$fixture/.worktrees/stalestash" rev-parse HEAD)" >"$stalestash_git/MERGE_AUTOSTASH"
+# A real autostash OID, not a bare HEAD: `git stash store` (the emitted
+# recovery recipe, executed below) refuses commits that are not stash-shaped.
+printf 'dirty\n' >>"$fixture/.worktrees/stalestash/README.md"
+printf '%s\n' "$(git -C "$fixture/.worktrees/stalestash" stash create)" >"$stalestash_git/MERGE_AUTOSTASH"
 rm -rf "$fixture/.worktrees/stalestash"
-if rm_wt stalestash >/dev/null 2>&1; then
+stalestash_err="$(rm_wt stalestash 2>&1 >/dev/null)" &&
     fail "worktree-rm.sh pruned a stale record whose admin dir holds a merge autostash"
-fi
 [ -s "$stalestash_git/MERGE_AUTOSTASH" ] || fail "the stale record's autostash reference was dropped despite the refusal"
+# The refusal's recovery recipe must be RUNNABLE as emitted — a malformed
+# quoting of the marker path once shipped a recipe that failed even on
+# space-free paths (#951 review r1). Execute it verbatim.
+stalestash_cmd="$(printf '%s\n' "$stalestash_err" | sed -n 's/.*keep the work with: \(.*\) — or re-run.*/\1/p')"
+[ -n "$stalestash_cmd" ] || fail "the stale-autostash refusal did not carry a recovery command"
+(cd "$fixture" && eval "$stalestash_cmd" >/dev/null 2>&1) ||
+    fail "the emitted stale-autostash recovery command is not runnable: $stalestash_cmd"
+[ "$(git -C "$fixture" rev-parse refs/stash)" = "$(cat "$stalestash_git/MERGE_AUTOSTASH")" ] ||
+    fail "the recovery command did not store the autostash commit in refs/stash"
+git -C "$fixture" update-ref -d refs/stash
 rm_wt stalestash --force >/dev/null || fail "worktree-rm.sh --force failed on the stale autostash record"
 git -C "$fixture" branch -D stalestash >/dev/null 2>&1 || true
 

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -746,6 +746,21 @@ fi
 rm -f "$autostash_git/MERGE_AUTOSTASH"
 rm_wt autostash >/dev/null || fail "worktree-rm.sh failed once the autostash state was cleared"
 
+# The same marker must also block STALE-RECORD cleanup: with the directory
+# already gone, the record's admin dir holds the only MERGE_AUTOSTASH
+# reference, and pruning the record would drop it (#951, challenge r2).
+echo "==> worktree:rm refuses to prune a stale record holding MERGE_AUTOSTASH"
+new stalestash >/dev/null || fail "worktree-new.sh failed for the stale-autostash case"
+stalestash_git="$(git -C "$fixture/.worktrees/stalestash" rev-parse --path-format=absolute --git-dir)"
+printf '%s\n' "$(git -C "$fixture/.worktrees/stalestash" rev-parse HEAD)" >"$stalestash_git/MERGE_AUTOSTASH"
+rm -rf "$fixture/.worktrees/stalestash"
+if rm_wt stalestash >/dev/null 2>&1; then
+    fail "worktree-rm.sh pruned a stale record whose admin dir holds a merge autostash"
+fi
+[ -s "$stalestash_git/MERGE_AUTOSTASH" ] || fail "the stale record's autostash reference was dropped despite the refusal"
+rm_wt stalestash --force >/dev/null || fail "worktree-rm.sh --force failed on the stale autostash record"
+git -C "$fixture" branch -D stalestash >/dev/null 2>&1 || true
+
 echo "==> worktree:rm refuses a detached HEAD no branch contains"
 new detached >/dev/null || fail "worktree-new.sh failed for the detached case"
 git -C "$fixture/.worktrees/detached" checkout -q --detach

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -227,7 +227,10 @@ if [ "$tree_exists" -eq 0 ]; then
             # metacharacters) rather than one corner of it; the test suite
             # executes this emitted command verbatim.
             stale_marker_q="$(printf '%q' "$stale_admin/MERGE_AUTOSTASH")"
-            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with: git stash store \"\$(cat $stale_marker_q)\" — or re-run with --force to discard it"
+            # Storing does not remove the marker, so a plain re-run refuses
+            # again — the completing sequence is store, THEN --force (safe:
+            # the work now lives in refs/stash).
+            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with: git stash store \"\$(cat $stale_marker_q)\" — then re-run with --force to clear the record (the stored work survives in refs/stash); --force without storing discards it"
         fi
         if [ -n "$stale_admin" ] && [ -f "$stale_admin/HEAD" ]; then
             stale_head="$(cat "$stale_admin/HEAD" 2>/dev/null || true)"

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -223,7 +223,7 @@ if [ "$tree_exists" -eq 0 ]; then
         # with the directory already gone. Dropping the record drops the
         # only reference.
         if [ -n "$stale_admin" ] && [ -s "$stale_admin/MERGE_AUTOSTASH" ]; then
-            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with 'git stash store \"\$(cat $stale_admin/MERGE_AUTOSTASH)\"', or re-run with --force to discard it"
+            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with 'git stash store \"\$(cat \\\"$stale_admin/MERGE_AUTOSTASH\\\")\"', or re-run with --force to discard it"
         fi
         if [ -n "$stale_admin" ] && [ -f "$stale_admin/HEAD" ]; then
             stale_head="$(cat "$stale_admin/HEAD" 2>/dev/null || true)"

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -223,9 +223,11 @@ if [ "$tree_exists" -eq 0 ]; then
         # with the directory already gone. Dropping the record drops the
         # only reference.
         if [ -n "$stale_admin" ] && [ -s "$stale_admin/MERGE_AUTOSTASH" ]; then
-            # Single-quote the path so the recipe survives whitespace when
-            # pasted; the test suite executes this emitted command verbatim.
-            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with: git stash store \"\$(cat '$stale_admin/MERGE_AUTOSTASH')\" — or re-run with --force to discard it"
+            # printf %q escapes the WHOLE quoting class (whitespace, quotes,
+            # metacharacters) rather than one corner of it; the test suite
+            # executes this emitted command verbatim.
+            stale_marker_q="$(printf '%q' "$stale_admin/MERGE_AUTOSTASH")"
+            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with: git stash store \"\$(cat $stale_marker_q)\" — or re-run with --force to discard it"
         fi
         if [ -n "$stale_admin" ] && [ -f "$stale_admin/HEAD" ]; then
             stale_head="$(cat "$stale_admin/HEAD" 2>/dev/null || true)"

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -473,9 +473,13 @@ else
     # --amend` at that stop, a commit reachable from nothing else. Removing the
     # tree drops that state, and gc eventually collects the commit. Likewise a
     # detached HEAD ahead of every branch: nothing else references it.
+    # MERGE_AUTOSTASH is listed on its own because it can exist alone: a
+    # `git merge --autostash` killed after the autostash is written but before
+    # MERGE_HEAD exists leaves the user's dirty work referenced by that one
+    # file and nothing else.
     if [ "$force" -eq 0 ]; then
         tree_git_dir="$(git -C "$tree" rev-parse --path-format=absolute --git-dir)"
-        for op_state in rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
+        for op_state in rebase-merge rebase-apply MERGE_HEAD MERGE_AUTOSTASH CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
             if [ -e "$tree_git_dir/$op_state" ]; then
                 die "$tree has an in-progress git operation ($op_state) — finish or abort it, or re-run with --force to discard it"
             fi

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -217,6 +217,14 @@ if [ "$tree_exists" -eq 0 ]; then
     # radius without giving this path the guard the live one has.)
     if [ "$force" -eq 0 ] && [ "$stale_record" -eq 1 ]; then
         stale_admin="$(record_admin_dir "$tree" || true)"
+        # An interrupted `git merge --autostash` can leave the stashed work
+        # referenced by the record's MERGE_AUTOSTASH file and nothing else —
+        # the same marker the live-tree guard below refuses, reachable here
+        # with the directory already gone. Dropping the record drops the
+        # only reference.
+        if [ -n "$stale_admin" ] && [ -s "$stale_admin/MERGE_AUTOSTASH" ]; then
+            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with 'git stash store \"\$(cat $stale_admin/MERGE_AUTOSTASH)\"', or re-run with --force to discard it"
+        fi
         if [ -n "$stale_admin" ] && [ -f "$stale_admin/HEAD" ]; then
             stale_head="$(cat "$stale_admin/HEAD" 2>/dev/null || true)"
             case "$stale_head" in
@@ -486,7 +494,7 @@ else
                 # `--abort` both refuse, and `git merge --quit` is the command
                 # that moves the referenced work to refs/stash.
                 if [ "$op_state" = MERGE_AUTOSTASH ]; then
-                    die "$tree has an autostash from an interrupted merge ($op_state) — run 'git merge --quit' there to move it to the stash, then 'git stash pop' to recover the work, or re-run with --force to discard it"
+                    die "$tree has an autostash from an interrupted merge ($op_state) — run 'git merge --quit' there to move it to the stash, then recover it from 'git stash list' (the stash is repository-wide, so pop that entry, not blindly the newest), or re-run with --force to discard it"
                 fi
                 die "$tree has an in-progress git operation ($op_state) — finish or abort it, or re-run with --force to discard it"
             fi

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -481,6 +481,13 @@ else
         tree_git_dir="$(git -C "$tree" rev-parse --path-format=absolute --git-dir)"
         for op_state in rebase-merge rebase-apply MERGE_HEAD MERGE_AUTOSTASH CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
             if [ -e "$tree_git_dir/$op_state" ]; then
+                # "finish or abort" is impossible advice for a marker-only
+                # autostash: with MERGE_HEAD absent, `git merge --continue` and
+                # `--abort` both refuse, and `git merge --quit` is the command
+                # that moves the referenced work to refs/stash.
+                if [ "$op_state" = MERGE_AUTOSTASH ]; then
+                    die "$tree has an autostash from an interrupted merge ($op_state) — run 'git merge --quit' there to move it to the stash, then 'git stash pop' to recover the work, or re-run with --force to discard it"
+                fi
                 die "$tree has an in-progress git operation ($op_state) — finish or abort it, or re-run with --force to discard it"
             fi
         done

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -223,7 +223,9 @@ if [ "$tree_exists" -eq 0 ]; then
         # with the directory already gone. Dropping the record drops the
         # only reference.
         if [ -n "$stale_admin" ] && [ -s "$stale_admin/MERGE_AUTOSTASH" ]; then
-            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with 'git stash store \"\$(cat \\\"$stale_admin/MERGE_AUTOSTASH\\\")\"', or re-run with --force to discard it"
+            # Single-quote the path so the recipe survives whitespace when
+            # pasted; the test suite executes this emitted command verbatim.
+            die "$tree is gone but its record still holds a merge autostash ($stale_admin/MERGE_AUTOSTASH) — keep the work with: git stash store \"\$(cat '$stale_admin/MERGE_AUTOSTASH')\" — or re-run with --force to discard it"
         fi
         if [ -n "$stale_admin" ] && [ -f "$stale_admin/HEAD" ]; then
             stale_head="$(cat "$stale_admin/HEAD" 2>/dev/null || true)"


### PR DESCRIPTION
## What

`worktree:rm`'s in-progress-operation guard omitted `MERGE_AUTOSTASH`: a `git merge --autostash` killed after the autostash is written but before `MERGE_HEAD` exists leaves the user's dirty work referenced by that one file alone, and removal would drop the live tree — or the stale record — over it. This closes the gap PR #950 already closed for the record cleaner (`clean-worktree-records.sh`), on the removal path:

- `MERGE_AUTOSTASH` joins the op-state refusal list (live-tree path), with a state-specific message — `git merge --continue`/`--abort` are impossible in the marker-only state, so it names `git merge --quit` + the stash.
- The stale-record path (`tree_exists == 0`) now refuses to prune a record whose admin dir holds `MERGE_AUTOSTASH` — previously it dropped the sole reference (challenge r2 P1) — and emits a runnable, `printf %q`-escaped `git stash store` recovery recipe.
- Both files' `template/scripts/` byte twins updated in lockstep.

## Why

Shipping a release where the record cleaner refuses this state but the live-tree remover doesn't is exactly the asymmetry a fresh adopter would hit (#951, deferred from #945's challenge r6).

## Verification

- `task verify` green (repeatedly, after every round), `task ci` green.
- Deterministic regression cases in `test:worktree`: live tree holding only `MERGE_AUTOSTASH` refused; stale record holding it refused with the reference preserved; the emitted recovery recipe is extracted from the refusal and executed verbatim against a real `git stash create` OID, asserting `refs/stash` lands on it.
- Mutants killed (cp-backup protocol): word removed from the op-state list → live case fails; stale-record guard removed → stale case fails.

rigor: standard (default_rigor) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1. Challenge: 3 rounds (r1 clean+P2 fixed, r2 P1+P2 fixed, r3 capped clean). Review: 3 rounds (r1 P1 fixed, r2/r3 consecutive clean). Tier/method: defaults (standard/plan) — no off-default resolution.

## Deferred findings

- [x] scripts/worktree-rm.sh:230 — stale-autostash message presents 'git stash store' and --force as alternatives, but storing leaves MERGE_AUTOSTASH in the admin record so a plain rerun refuses again; the completing sequence is store-then---force (or delete the marker). Reword to a sequence. (review r3 P2) — fixed in 57816bc
- [x] scripts/test-worktree.sh:766 — the emitted-recipe execution runs only under an alphanumeric mktemp path, so printf %q's quote/metacharacter handling is untested; run the stale-autostash case from a path containing a single quote so simplified escaping fails the suite. (review r3 P2) — fixed in 57816bc

## Adjudication record

<details><summary>Per-round ledger (challenge 3 rounds, review 3 rounds)</summary>

```text
challenge r1 | 1 finding, adjudicated zero P0/P1
scripts/worktree-rm.sh:482 | marker-only autostash refusal advertises impossible recovery (--continue/--abort need MERGE_HEAD) | confirmed P2, fixed in place: message names git merge --quit + stash pop | challenge r1
challenge r2 | 2 findings, both confirmed and fixed; adjudicated: 1 P1, 1 P2
scripts/worktree-rm.sh:218 | stale-record prune drops sole MERGE_AUTOSTASH reference (tree_exists==0 path bypasses new guard) | confirmed P1, fixed: stale-record guard + case + mutant; subject pre-existing, in scope (same refusal, directory gone) | challenge r2
scripts/worktree-rm.sh:488 | recovery advice pops newest stash, refs/stash repo-wide | confirmed P2, fixed in place: message points at git stash list | challenge r2
challenge r3 | 1 finding, adjudicated zero P0/P1 — capped final round clean, stage exits
scripts/worktree-rm.sh:226 | stale-autostash recovery command unusable for paths with whitespace (unquoted cat arg) | confirmed P2, fixed in place: path quoted inside substitution | challenge r3
review r1 | 1 finding, adjudicated: 1 P1
scripts/worktree-rm.sh:226 | stale-autostash recovery recipe malformed (escaped quotes emitted literally), unusable on any path | confirmed P1, fixed: single-quoted path; suite now executes the emitted recipe against a real stash OID | review r1
review r2 | 1 finding, adjudicated zero P0/P1 — first consecutive clean round
scripts/worktree-rm.sh:228 | single quote in repo path breaks recovery-recipe parse | confirmed P2, fixed in place via printf %q (closes the quoting class); provenance checkpoint: restructured to invariant instead of another corner patch | review r2
review r3 | 2 findings, adjudicated zero P0/P1 — second consecutive clean round + capped final; stage exits
scripts/worktree-rm.sh:230 | store-then-rerun still refuses (marker survives stash store); message implies alternatives | confirmed P2, deferred to PR | review r3
scripts/test-worktree.sh:766 | recipe execution not exercised under quote-bearing path | confirmed P2, deferred to PR | review r3
```

</details>

Closes #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)

