### PR TITLE
fix: validate worktree:new --branch early with git's own ref grammar

### DIFF
--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -2231,6 +2231,23 @@ for badbr in 'rollcfg$x' '../evil' '/abs' '-lead' 'a b' 'a//b' 'a/./b'; do
         fail "worktree-new.sh accepted the invalid --branch '$badbr'"
     case "$badbr_out" in *"invalid --branch"*) : ;; *) fail "the invalid --branch '$badbr' was refused for the wrong reason: $badbr_out" ;; esac
 done
+# Charset-clean values git's ref grammar still rejects (leading-dot
+# component, trailing dot, .lock suffix) must fail the check-ref-format
+# guard, early, not `git worktree add` (#929 challenge r1).
+for badbr in '.topic' 'topic.' 'topic.lock' 'topic/.child'; do
+    badbr_out="$(new brcheck --branch "$badbr" 2>&1)" &&
+        fail "worktree-new.sh accepted the grammar-invalid --branch '$badbr'"
+    # The distinctive prefix matters: git's own LATE failure ("fatal: ...
+    # not a valid branch name / hint: See 'git help check-ref-format'")
+    # also mentions check-ref-format, and a loose match let a mutant with
+    # the early guard deleted pass this very case.
+    case "$badbr_out" in *"rejected by git check-ref-format --branch"*) : ;; *) fail "the grammar-invalid --branch '$badbr' was not refused by the early guard: $badbr_out" ;; esac
+done
+# An explicitly EMPTY --branch must be refused, not silently defaulted to
+# the worktree name (#929 challenge r1).
+empty_out="$(new brcheck --branch '' 2>&1)" &&
+    fail "worktree-new.sh accepted an explicitly empty --branch"
+case "$empty_out" in *"non-empty"*) : ;; *) fail "the empty --branch was refused for the wrong reason: $empty_out" ;; esac
 refute_exists "$fixture/.worktrees/brcheck" "an invalid --branch refusal left a tree behind"
 if git -C "$fixture" show-ref --verify --quiet refs/heads/brcheck; then
     fail "an invalid --branch refusal left the name branch behind"

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -2216,32 +2216,21 @@ fi
 [ "$(git -C "$fixture" config --get branch.rollcfg.pushRemote || true)" = "myfork" ] ||
     fail "the stale-config refusal modified an unrelated branch config key"
 
-echo "==> an explicit --branch gets the same validation as the name, before any side effects"
+echo "==> an invalid --branch is refused early, before any lock or side effect"
 # The front door of the creation path: an explicit --branch used to bypass
-# every check the name gets and fail late, inside git, with locks already
-# held — and metacharacter branch names reached genuinely bad paths before
-# the #916 review hardened them (#929). The charset refusal removes the
-# whole class, which is also why the former metacharacter-branch
-# stale-config case (PR #932 cloud review) is superseded: 'rollcfg$x' can
-# no longer reach the stale-config guard at all — it is refused here, with
-# nothing created and nothing locked.
-git -C "$fixture" config 'branch.rollcfg$x.remote' oldrem
-for badbr in 'rollcfg$x' '../evil' '/abs' '-lead' 'a b' 'a//b' 'a/./b'; do
+# validation entirely and fail late, inside git, with the path reserved and
+# locks held (#929). The validator is git's own branch grammar
+# (check-ref-format), deliberately NOT the worktree-name charset: branch
+# names legally carry metacharacters, and create-or-attach must keep
+# accepting an existing 'feature+flag' (challenge r2).
+for badbr in '../evil' '/abs' '-lead' 'a b' 'a//b' 'a/./b' '.topic' 'topic.' 'topic.lock' 'topic/.child'; do
     badbr_out="$(new brcheck --branch "$badbr" 2>&1)" &&
         fail "worktree-new.sh accepted the invalid --branch '$badbr'"
-    case "$badbr_out" in *"invalid --branch"*) : ;; *) fail "the invalid --branch '$badbr' was refused for the wrong reason: $badbr_out" ;; esac
-done
-# Charset-clean values git's ref grammar still rejects (leading-dot
-# component, trailing dot, .lock suffix) must fail the check-ref-format
-# guard, early, not `git worktree add` (#929 challenge r1).
-for badbr in '.topic' 'topic.' 'topic.lock' 'topic/.child'; do
-    badbr_out="$(new brcheck --branch "$badbr" 2>&1)" &&
-        fail "worktree-new.sh accepted the grammar-invalid --branch '$badbr'"
     # The distinctive prefix matters: git's own LATE failure ("fatal: ...
     # not a valid branch name / hint: See 'git help check-ref-format'")
     # also mentions check-ref-format, and a loose match let a mutant with
     # the early guard deleted pass this very case.
-    case "$badbr_out" in *"rejected by git check-ref-format --branch"*) : ;; *) fail "the grammar-invalid --branch '$badbr' was not refused by the early guard: $badbr_out" ;; esac
+    case "$badbr_out" in *"rejected by git check-ref-format --branch"*) : ;; *) fail "the invalid --branch '$badbr' was not refused by the early guard: $badbr_out" ;; esac
 done
 # An explicitly EMPTY --branch must be refused, not silently defaulted to
 # the worktree name (#929 challenge r1).
@@ -2256,7 +2245,25 @@ echo "==> the default branch = name path is unchanged"
 new brcheck >/dev/null || fail "worktree-new.sh failed with the default branch after --branch refusals"
 rm_wt brcheck >/dev/null || fail "cleanup of the default-branch tree failed"
 git -C "$fixture" branch -D brcheck >/dev/null 2>&1 || true
+
+echo "==> the stale-config remedy is shell-quoted for a metacharacter branch name"
+# Branch names — unlike whitelisted worktree names — legally carry \$, ;,
+# and quotes, so the pasted remedy must quote the key: unquoted,
+# branch.rollcfg\$x.remote expands \$x away in the user's shell and clears
+# the wrong key, or worse (PR #932 cloud review). This also pins the
+# create-or-attach contract: a git-valid metacharacter branch passes the
+# early --branch validation and reaches the deeper guards (#929
+# challenge r2).
+git -C "$fixture" config 'branch.rollcfg$x.remote' oldrem
+git -C "$fixture" push -q origin 'HEAD:refs/heads/rollcfg$x'
+git -C "$fixture" update-ref -d 'refs/remotes/origin/rollcfg$x' 2>/dev/null || true
+metacfg_out="$(new rollcfg-meta --branch 'rollcfg$x' 2>&1)" &&
+    fail "worktree-new.sh accepted a metacharacter branch with stale config"
+case "$metacfg_out" in *"stale config from a deleted branch"*) : ;; *) fail "the metacharacter branch was refused for the wrong reason: $metacfg_out" ;; esac
+case "$metacfg_out" in *"--unset-all 'branch.rollcfg\$x.remote'"*) : ;; *) fail "the stale-config remedy was not shell-quoted: $metacfg_out" ;; esac
+refute_exists "$fixture/.worktrees/rollcfg-meta" "the metacharacter refusal left a tree behind"
 git -C "$fixture" config --unset 'branch.rollcfg$x.remote'
+git -C "$fixture" push -q origin ':refs/heads/rollcfg$x'
 
 echo "==> a non-local stale branch config value does not refuse creation"
 # PR #932 cloud review: the stale-debris guard exists for LOCAL config this

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -2216,21 +2216,30 @@ fi
 [ "$(git -C "$fixture" config --get branch.rollcfg.pushRemote || true)" = "myfork" ] ||
     fail "the stale-config refusal modified an unrelated branch config key"
 
-echo "==> the stale-config remedy is shell-quoted for a metacharacter branch name"
-# Branch names — unlike whitelisted worktree names — legally carry \$, ;,
-# and quotes, so the pasted remedy must quote the key: unquoted,
-# branch.rollcfg\$x.remote expands \$x away in the user's shell and clears
-# the wrong key, or worse (PR #932 cloud review).
+echo "==> an explicit --branch gets the same validation as the name, before any side effects"
+# The front door of the creation path: an explicit --branch used to bypass
+# every check the name gets and fail late, inside git, with locks already
+# held — and metacharacter branch names reached genuinely bad paths before
+# the #916 review hardened them (#929). The charset refusal removes the
+# whole class, which is also why the former metacharacter-branch
+# stale-config case (PR #932 cloud review) is superseded: 'rollcfg$x' can
+# no longer reach the stale-config guard at all — it is refused here, with
+# nothing created and nothing locked.
 git -C "$fixture" config 'branch.rollcfg$x.remote' oldrem
-git -C "$fixture" push -q origin 'HEAD:refs/heads/rollcfg$x'
-git -C "$fixture" update-ref -d 'refs/remotes/origin/rollcfg$x' 2>/dev/null || true
-metacfg_out="$(new rollcfg-meta --branch 'rollcfg$x' 2>&1)" &&
-    fail "worktree-new.sh accepted a metacharacter branch with stale config"
-case "$metacfg_out" in *"stale config from a deleted branch"*) : ;; *) fail "the metacharacter branch was refused for the wrong reason: $metacfg_out" ;; esac
-case "$metacfg_out" in *"--unset-all 'branch.rollcfg\$x.remote'"*) : ;; *) fail "the stale-config remedy was not shell-quoted: $metacfg_out" ;; esac
-refute_exists "$fixture/.worktrees/rollcfg-meta" "the metacharacter refusal left a tree behind"
+for badbr in 'rollcfg$x' '../evil' '/abs' '-lead' 'a b' 'a//b' 'a/./b'; do
+    badbr_out="$(new brcheck --branch "$badbr" 2>&1)" &&
+        fail "worktree-new.sh accepted the invalid --branch '$badbr'"
+    case "$badbr_out" in *"invalid --branch"*) : ;; *) fail "the invalid --branch '$badbr' was refused for the wrong reason: $badbr_out" ;; esac
+done
+refute_exists "$fixture/.worktrees/brcheck" "an invalid --branch refusal left a tree behind"
+if git -C "$fixture" show-ref --verify --quiet refs/heads/brcheck; then
+    fail "an invalid --branch refusal left the name branch behind"
+fi
+echo "==> the default branch = name path is unchanged"
+new brcheck >/dev/null || fail "worktree-new.sh failed with the default branch after --branch refusals"
+rm_wt brcheck >/dev/null || fail "cleanup of the default-branch tree failed"
+git -C "$fixture" branch -D brcheck >/dev/null 2>&1 || true
 git -C "$fixture" config --unset 'branch.rollcfg$x.remote'
-git -C "$fixture" push -q origin ':refs/heads/rollcfg$x'
 
 echo "==> a non-local stale branch config value does not refuse creation"
 # PR #932 cloud review: the stale-debris guard exists for LOCAL config this

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -2232,6 +2232,17 @@ for badbr in '../evil' '/abs' '-lead' 'a b' 'a//b' 'a/./b' '.topic' 'topic.' 'to
     # the early guard deleted pass this very case.
     case "$badbr_out" in *"rejected by git check-ref-format --branch"*) : ;; *) fail "the invalid --branch '$badbr' was not refused by the early guard: $badbr_out" ;; esac
 done
+# Checkout SHORTHAND must be refused even though check-ref-format accepts
+# it: with checkout history, `--branch '@{-1}'` exits 0 there while
+# expanding to the previous branch — the literal value would then feed the
+# branch lock and worktree add (#929 challenge r3). Needs real history, or
+# the shorthand fails the validator for the wrong reason.
+git -C "$fixture" switch -qc shorthand-prev
+git -C "$fixture" switch -q - >/dev/null 2>&1
+short_out="$(new brcheck --branch '@{-1}' 2>&1)" &&
+    fail "worktree-new.sh accepted the checkout shorthand @{-1} as a branch"
+case "$short_out" in *"checkout shorthand is not accepted"*) : ;; *) fail "the @{-1} shorthand was refused for the wrong reason: $short_out" ;; esac
+git -C "$fixture" branch -qD shorthand-prev
 # An explicitly EMPTY --branch must be refused, not silently defaulted to
 # the worktree name (#929 challenge r1).
 empty_out="$(new brcheck --branch '' 2>&1)" &&

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -51,7 +51,10 @@ do_install=1
 while [ "$#" -gt 0 ]; do
     case "$1" in
     --branch)
-        [ "$#" -ge 2 ] || die "--branch needs a value"
+        # Non-empty is checked HERE, not by the later default: an empty
+        # supplied value would otherwise fall through `branch=name` and
+        # silently create a branch the caller never asked for (#929).
+        [ "$#" -ge 2 ] && [ -n "$2" ] || die "--branch needs a non-empty value"
         branch="$2"
         shift 2
         ;;
@@ -127,6 +130,13 @@ esac
 case "/$branch/" in
 *//* | */./*) die "invalid --branch '$branch': path components must not be empty or '.'" ;;
 esac
+# The charset is policy; git's ref grammar is stricter still in corners the
+# charset cannot see (a component starting with '.', a trailing '.', a
+# '.lock' suffix). check-ref-format is local and side-effect-free, so the
+# full grammar is settled here too — before any lock, reservation, or ref
+# write — instead of failing late inside `git worktree add`.
+git check-ref-format --branch "$branch" >/dev/null 2>&1 ||
+    die "invalid branch name '$branch' (from --branch, or the worktree name it defaults to): rejected by git check-ref-format --branch"
 
 # Anchor .worktrees/ to the MAIN worktree, never to whichever linked tree the
 # caller happens to be standing in — otherwise running this from inside a

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -113,28 +113,15 @@ git rev-parse --git-dir >/dev/null 2>&1 || die "not inside a git repository"
 
 [ -n "$branch" ] || branch="$name"
 
-# An explicit --branch gets the SAME validation as the name, for the same
-# reasons: git rejects an invalid ref name only after the path is reserved
-# and locks are held (fail-late, with git's error instead of this early,
-# remedy-carrying one), and the branch-namespace lock key is derived from
-# this value, so its key space should match the name's by construction
-# rather than by clamping (#929). On the default path branch == name and
-# every check below already passed, so this cannot fire there.
-case "$branch" in
-/* | -*) die "invalid --branch '$branch': must not start with '/' or '-'" ;;
-*..*) die "invalid --branch '$branch': must not contain '..'" ;;
-esac
-case "$branch" in
-*[!A-Za-z0-9._/-]*) die "invalid --branch '$branch': use only A-Z a-z 0-9 . _ - /" ;;
-esac
-case "/$branch/" in
-*//* | */./*) die "invalid --branch '$branch': path components must not be empty or '.'" ;;
-esac
-# The charset is policy; git's ref grammar is stricter still in corners the
-# charset cannot see (a component starting with '.', a trailing '.', a
-# '.lock' suffix). check-ref-format is local and side-effect-free, so the
-# full grammar is settled here too — before any lock, reservation, or ref
-# write — instead of failing late inside `git worktree add`.
+# Validate the branch EARLY — git itself rejects an invalid ref name only
+# after the path is reserved and locks are held, with its own error instead
+# of this remedy-carrying one (#929). The validator is git's own branch
+# grammar, deliberately NOT the worktree-name charset: branch names are not
+# charset-restricted (create-or-attach must accept an existing
+# `feature+flag` or `release@2026` — docs/conventions.md § Worktrees), and
+# the branch-namespace lock key already byte-clamps arbitrary names safely
+# (#916). check-ref-format is local and side-effect-free, so the full
+# grammar is settled before any lock, reservation, or ref write.
 git check-ref-format --branch "$branch" >/dev/null 2>&1 ||
     die "invalid branch name '$branch' (from --branch, or the worktree name it defaults to): rejected by git check-ref-format --branch"
 

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -110,6 +110,24 @@ git rev-parse --git-dir >/dev/null 2>&1 || die "not inside a git repository"
 
 [ -n "$branch" ] || branch="$name"
 
+# An explicit --branch gets the SAME validation as the name, for the same
+# reasons: git rejects an invalid ref name only after the path is reserved
+# and locks are held (fail-late, with git's error instead of this early,
+# remedy-carrying one), and the branch-namespace lock key is derived from
+# this value, so its key space should match the name's by construction
+# rather than by clamping (#929). On the default path branch == name and
+# every check below already passed, so this cannot fire there.
+case "$branch" in
+/* | -*) die "invalid --branch '$branch': must not start with '/' or '-'" ;;
+*..*) die "invalid --branch '$branch': must not contain '..'" ;;
+esac
+case "$branch" in
+*[!A-Za-z0-9._/-]*) die "invalid --branch '$branch': use only A-Z a-z 0-9 . _ - /" ;;
+esac
+case "/$branch/" in
+*//* | */./*) die "invalid --branch '$branch': path components must not be empty or '.'" ;;
+esac
+
 # Anchor .worktrees/ to the MAIN worktree, never to whichever linked tree the
 # caller happens to be standing in — otherwise running this from inside a
 # worktree nests .worktrees/a/.worktrees/b and every tool's assumption about

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -122,8 +122,16 @@ git rev-parse --git-dir >/dev/null 2>&1 || die "not inside a git repository"
 # the branch-namespace lock key already byte-clamps arbitrary names safely
 # (#916). check-ref-format is local and side-effect-free, so the full
 # grammar is settled before any lock, reservation, or ref write.
-git check-ref-format --branch "$branch" >/dev/null 2>&1 ||
+branch_canon="$(git check-ref-format --branch "$branch" 2>/dev/null)" ||
     die "invalid branch name '$branch' (from --branch, or the worktree name it defaults to): rejected by git check-ref-format --branch"
+# check-ref-format --branch also EXPANDS checkout shorthand (`@{-1}` exits 0
+# and prints the previous branch), while everything downstream — the branch
+# lock, worktree add -b, the report — would keep the literal value: wrong
+# lock identity, and a deleted previous branch silently recreated under a
+# name the caller never wrote (challenge r3). Requiring the canonical output
+# to equal the input closes that whole class.
+[ "$branch_canon" = "$branch" ] ||
+    die "invalid branch name '$branch': checkout shorthand is not accepted here — name the branch explicitly (this resolves to '$branch_canon')"
 
 # Anchor .worktrees/ to the MAIN worktree, never to whichever linked tree the
 # caller happens to be standing in — otherwise running this from inside a

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -2231,6 +2231,23 @@ for badbr in 'rollcfg$x' '../evil' '/abs' '-lead' 'a b' 'a//b' 'a/./b'; do
         fail "worktree-new.sh accepted the invalid --branch '$badbr'"
     case "$badbr_out" in *"invalid --branch"*) : ;; *) fail "the invalid --branch '$badbr' was refused for the wrong reason: $badbr_out" ;; esac
 done
+# Charset-clean values git's ref grammar still rejects (leading-dot
+# component, trailing dot, .lock suffix) must fail the check-ref-format
+# guard, early, not `git worktree add` (#929 challenge r1).
+for badbr in '.topic' 'topic.' 'topic.lock' 'topic/.child'; do
+    badbr_out="$(new brcheck --branch "$badbr" 2>&1)" &&
+        fail "worktree-new.sh accepted the grammar-invalid --branch '$badbr'"
+    # The distinctive prefix matters: git's own LATE failure ("fatal: ...
+    # not a valid branch name / hint: See 'git help check-ref-format'")
+    # also mentions check-ref-format, and a loose match let a mutant with
+    # the early guard deleted pass this very case.
+    case "$badbr_out" in *"rejected by git check-ref-format --branch"*) : ;; *) fail "the grammar-invalid --branch '$badbr' was not refused by the early guard: $badbr_out" ;; esac
+done
+# An explicitly EMPTY --branch must be refused, not silently defaulted to
+# the worktree name (#929 challenge r1).
+empty_out="$(new brcheck --branch '' 2>&1)" &&
+    fail "worktree-new.sh accepted an explicitly empty --branch"
+case "$empty_out" in *"non-empty"*) : ;; *) fail "the empty --branch was refused for the wrong reason: $empty_out" ;; esac
 refute_exists "$fixture/.worktrees/brcheck" "an invalid --branch refusal left a tree behind"
 if git -C "$fixture" show-ref --verify --quiet refs/heads/brcheck; then
     fail "an invalid --branch refusal left the name branch behind"

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -2216,32 +2216,21 @@ fi
 [ "$(git -C "$fixture" config --get branch.rollcfg.pushRemote || true)" = "myfork" ] ||
     fail "the stale-config refusal modified an unrelated branch config key"
 
-echo "==> an explicit --branch gets the same validation as the name, before any side effects"
+echo "==> an invalid --branch is refused early, before any lock or side effect"
 # The front door of the creation path: an explicit --branch used to bypass
-# every check the name gets and fail late, inside git, with locks already
-# held — and metacharacter branch names reached genuinely bad paths before
-# the #916 review hardened them (#929). The charset refusal removes the
-# whole class, which is also why the former metacharacter-branch
-# stale-config case (PR #932 cloud review) is superseded: 'rollcfg$x' can
-# no longer reach the stale-config guard at all — it is refused here, with
-# nothing created and nothing locked.
-git -C "$fixture" config 'branch.rollcfg$x.remote' oldrem
-for badbr in 'rollcfg$x' '../evil' '/abs' '-lead' 'a b' 'a//b' 'a/./b'; do
+# validation entirely and fail late, inside git, with the path reserved and
+# locks held (#929). The validator is git's own branch grammar
+# (check-ref-format), deliberately NOT the worktree-name charset: branch
+# names legally carry metacharacters, and create-or-attach must keep
+# accepting an existing 'feature+flag' (challenge r2).
+for badbr in '../evil' '/abs' '-lead' 'a b' 'a//b' 'a/./b' '.topic' 'topic.' 'topic.lock' 'topic/.child'; do
     badbr_out="$(new brcheck --branch "$badbr" 2>&1)" &&
         fail "worktree-new.sh accepted the invalid --branch '$badbr'"
-    case "$badbr_out" in *"invalid --branch"*) : ;; *) fail "the invalid --branch '$badbr' was refused for the wrong reason: $badbr_out" ;; esac
-done
-# Charset-clean values git's ref grammar still rejects (leading-dot
-# component, trailing dot, .lock suffix) must fail the check-ref-format
-# guard, early, not `git worktree add` (#929 challenge r1).
-for badbr in '.topic' 'topic.' 'topic.lock' 'topic/.child'; do
-    badbr_out="$(new brcheck --branch "$badbr" 2>&1)" &&
-        fail "worktree-new.sh accepted the grammar-invalid --branch '$badbr'"
     # The distinctive prefix matters: git's own LATE failure ("fatal: ...
     # not a valid branch name / hint: See 'git help check-ref-format'")
     # also mentions check-ref-format, and a loose match let a mutant with
     # the early guard deleted pass this very case.
-    case "$badbr_out" in *"rejected by git check-ref-format --branch"*) : ;; *) fail "the grammar-invalid --branch '$badbr' was not refused by the early guard: $badbr_out" ;; esac
+    case "$badbr_out" in *"rejected by git check-ref-format --branch"*) : ;; *) fail "the invalid --branch '$badbr' was not refused by the early guard: $badbr_out" ;; esac
 done
 # An explicitly EMPTY --branch must be refused, not silently defaulted to
 # the worktree name (#929 challenge r1).
@@ -2256,7 +2245,25 @@ echo "==> the default branch = name path is unchanged"
 new brcheck >/dev/null || fail "worktree-new.sh failed with the default branch after --branch refusals"
 rm_wt brcheck >/dev/null || fail "cleanup of the default-branch tree failed"
 git -C "$fixture" branch -D brcheck >/dev/null 2>&1 || true
+
+echo "==> the stale-config remedy is shell-quoted for a metacharacter branch name"
+# Branch names — unlike whitelisted worktree names — legally carry \$, ;,
+# and quotes, so the pasted remedy must quote the key: unquoted,
+# branch.rollcfg\$x.remote expands \$x away in the user's shell and clears
+# the wrong key, or worse (PR #932 cloud review). This also pins the
+# create-or-attach contract: a git-valid metacharacter branch passes the
+# early --branch validation and reaches the deeper guards (#929
+# challenge r2).
+git -C "$fixture" config 'branch.rollcfg$x.remote' oldrem
+git -C "$fixture" push -q origin 'HEAD:refs/heads/rollcfg$x'
+git -C "$fixture" update-ref -d 'refs/remotes/origin/rollcfg$x' 2>/dev/null || true
+metacfg_out="$(new rollcfg-meta --branch 'rollcfg$x' 2>&1)" &&
+    fail "worktree-new.sh accepted a metacharacter branch with stale config"
+case "$metacfg_out" in *"stale config from a deleted branch"*) : ;; *) fail "the metacharacter branch was refused for the wrong reason: $metacfg_out" ;; esac
+case "$metacfg_out" in *"--unset-all 'branch.rollcfg\$x.remote'"*) : ;; *) fail "the stale-config remedy was not shell-quoted: $metacfg_out" ;; esac
+refute_exists "$fixture/.worktrees/rollcfg-meta" "the metacharacter refusal left a tree behind"
 git -C "$fixture" config --unset 'branch.rollcfg$x.remote'
+git -C "$fixture" push -q origin ':refs/heads/rollcfg$x'
 
 echo "==> a non-local stale branch config value does not refuse creation"
 # PR #932 cloud review: the stale-debris guard exists for LOCAL config this

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -2216,21 +2216,30 @@ fi
 [ "$(git -C "$fixture" config --get branch.rollcfg.pushRemote || true)" = "myfork" ] ||
     fail "the stale-config refusal modified an unrelated branch config key"
 
-echo "==> the stale-config remedy is shell-quoted for a metacharacter branch name"
-# Branch names — unlike whitelisted worktree names — legally carry \$, ;,
-# and quotes, so the pasted remedy must quote the key: unquoted,
-# branch.rollcfg\$x.remote expands \$x away in the user's shell and clears
-# the wrong key, or worse (PR #932 cloud review).
+echo "==> an explicit --branch gets the same validation as the name, before any side effects"
+# The front door of the creation path: an explicit --branch used to bypass
+# every check the name gets and fail late, inside git, with locks already
+# held — and metacharacter branch names reached genuinely bad paths before
+# the #916 review hardened them (#929). The charset refusal removes the
+# whole class, which is also why the former metacharacter-branch
+# stale-config case (PR #932 cloud review) is superseded: 'rollcfg$x' can
+# no longer reach the stale-config guard at all — it is refused here, with
+# nothing created and nothing locked.
 git -C "$fixture" config 'branch.rollcfg$x.remote' oldrem
-git -C "$fixture" push -q origin 'HEAD:refs/heads/rollcfg$x'
-git -C "$fixture" update-ref -d 'refs/remotes/origin/rollcfg$x' 2>/dev/null || true
-metacfg_out="$(new rollcfg-meta --branch 'rollcfg$x' 2>&1)" &&
-    fail "worktree-new.sh accepted a metacharacter branch with stale config"
-case "$metacfg_out" in *"stale config from a deleted branch"*) : ;; *) fail "the metacharacter branch was refused for the wrong reason: $metacfg_out" ;; esac
-case "$metacfg_out" in *"--unset-all 'branch.rollcfg\$x.remote'"*) : ;; *) fail "the stale-config remedy was not shell-quoted: $metacfg_out" ;; esac
-refute_exists "$fixture/.worktrees/rollcfg-meta" "the metacharacter refusal left a tree behind"
+for badbr in 'rollcfg$x' '../evil' '/abs' '-lead' 'a b' 'a//b' 'a/./b'; do
+    badbr_out="$(new brcheck --branch "$badbr" 2>&1)" &&
+        fail "worktree-new.sh accepted the invalid --branch '$badbr'"
+    case "$badbr_out" in *"invalid --branch"*) : ;; *) fail "the invalid --branch '$badbr' was refused for the wrong reason: $badbr_out" ;; esac
+done
+refute_exists "$fixture/.worktrees/brcheck" "an invalid --branch refusal left a tree behind"
+if git -C "$fixture" show-ref --verify --quiet refs/heads/brcheck; then
+    fail "an invalid --branch refusal left the name branch behind"
+fi
+echo "==> the default branch = name path is unchanged"
+new brcheck >/dev/null || fail "worktree-new.sh failed with the default branch after --branch refusals"
+rm_wt brcheck >/dev/null || fail "cleanup of the default-branch tree failed"
+git -C "$fixture" branch -D brcheck >/dev/null 2>&1 || true
 git -C "$fixture" config --unset 'branch.rollcfg$x.remote'
-git -C "$fixture" push -q origin ':refs/heads/rollcfg$x'
 
 echo "==> a non-local stale branch config value does not refuse creation"
 # PR #932 cloud review: the stale-debris guard exists for LOCAL config this

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -2232,6 +2232,17 @@ for badbr in '../evil' '/abs' '-lead' 'a b' 'a//b' 'a/./b' '.topic' 'topic.' 'to
     # the early guard deleted pass this very case.
     case "$badbr_out" in *"rejected by git check-ref-format --branch"*) : ;; *) fail "the invalid --branch '$badbr' was not refused by the early guard: $badbr_out" ;; esac
 done
+# Checkout SHORTHAND must be refused even though check-ref-format accepts
+# it: with checkout history, `--branch '@{-1}'` exits 0 there while
+# expanding to the previous branch — the literal value would then feed the
+# branch lock and worktree add (#929 challenge r3). Needs real history, or
+# the shorthand fails the validator for the wrong reason.
+git -C "$fixture" switch -qc shorthand-prev
+git -C "$fixture" switch -q - >/dev/null 2>&1
+short_out="$(new brcheck --branch '@{-1}' 2>&1)" &&
+    fail "worktree-new.sh accepted the checkout shorthand @{-1} as a branch"
+case "$short_out" in *"checkout shorthand is not accepted"*) : ;; *) fail "the @{-1} shorthand was refused for the wrong reason: $short_out" ;; esac
+git -C "$fixture" branch -qD shorthand-prev
 # An explicitly EMPTY --branch must be refused, not silently defaulted to
 # the worktree name (#929 challenge r1).
 empty_out="$(new brcheck --branch '' 2>&1)" &&

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -51,7 +51,10 @@ do_install=1
 while [ "$#" -gt 0 ]; do
     case "$1" in
     --branch)
-        [ "$#" -ge 2 ] || die "--branch needs a value"
+        # Non-empty is checked HERE, not by the later default: an empty
+        # supplied value would otherwise fall through `branch=name` and
+        # silently create a branch the caller never asked for (#929).
+        [ "$#" -ge 2 ] && [ -n "$2" ] || die "--branch needs a non-empty value"
         branch="$2"
         shift 2
         ;;
@@ -127,6 +130,13 @@ esac
 case "/$branch/" in
 *//* | */./*) die "invalid --branch '$branch': path components must not be empty or '.'" ;;
 esac
+# The charset is policy; git's ref grammar is stricter still in corners the
+# charset cannot see (a component starting with '.', a trailing '.', a
+# '.lock' suffix). check-ref-format is local and side-effect-free, so the
+# full grammar is settled here too — before any lock, reservation, or ref
+# write — instead of failing late inside `git worktree add`.
+git check-ref-format --branch "$branch" >/dev/null 2>&1 ||
+    die "invalid branch name '$branch' (from --branch, or the worktree name it defaults to): rejected by git check-ref-format --branch"
 
 # Anchor .worktrees/ to the MAIN worktree, never to whichever linked tree the
 # caller happens to be standing in — otherwise running this from inside a

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -113,28 +113,15 @@ git rev-parse --git-dir >/dev/null 2>&1 || die "not inside a git repository"
 
 [ -n "$branch" ] || branch="$name"
 
-# An explicit --branch gets the SAME validation as the name, for the same
-# reasons: git rejects an invalid ref name only after the path is reserved
-# and locks are held (fail-late, with git's error instead of this early,
-# remedy-carrying one), and the branch-namespace lock key is derived from
-# this value, so its key space should match the name's by construction
-# rather than by clamping (#929). On the default path branch == name and
-# every check below already passed, so this cannot fire there.
-case "$branch" in
-/* | -*) die "invalid --branch '$branch': must not start with '/' or '-'" ;;
-*..*) die "invalid --branch '$branch': must not contain '..'" ;;
-esac
-case "$branch" in
-*[!A-Za-z0-9._/-]*) die "invalid --branch '$branch': use only A-Z a-z 0-9 . _ - /" ;;
-esac
-case "/$branch/" in
-*//* | */./*) die "invalid --branch '$branch': path components must not be empty or '.'" ;;
-esac
-# The charset is policy; git's ref grammar is stricter still in corners the
-# charset cannot see (a component starting with '.', a trailing '.', a
-# '.lock' suffix). check-ref-format is local and side-effect-free, so the
-# full grammar is settled here too — before any lock, reservation, or ref
-# write — instead of failing late inside `git worktree add`.
+# Validate the branch EARLY — git itself rejects an invalid ref name only
+# after the path is reserved and locks are held, with its own error instead
+# of this remedy-carrying one (#929). The validator is git's own branch
+# grammar, deliberately NOT the worktree-name charset: branch names are not
+# charset-restricted (create-or-attach must accept an existing
+# `feature+flag` or `release@2026` — docs/conventions.md § Worktrees), and
+# the branch-namespace lock key already byte-clamps arbitrary names safely
+# (#916). check-ref-format is local and side-effect-free, so the full
+# grammar is settled before any lock, reservation, or ref write.
 git check-ref-format --branch "$branch" >/dev/null 2>&1 ||
     die "invalid branch name '$branch' (from --branch, or the worktree name it defaults to): rejected by git check-ref-format --branch"
 

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -110,6 +110,24 @@ git rev-parse --git-dir >/dev/null 2>&1 || die "not inside a git repository"
 
 [ -n "$branch" ] || branch="$name"
 
+# An explicit --branch gets the SAME validation as the name, for the same
+# reasons: git rejects an invalid ref name only after the path is reserved
+# and locks are held (fail-late, with git's error instead of this early,
+# remedy-carrying one), and the branch-namespace lock key is derived from
+# this value, so its key space should match the name's by construction
+# rather than by clamping (#929). On the default path branch == name and
+# every check below already passed, so this cannot fire there.
+case "$branch" in
+/* | -*) die "invalid --branch '$branch': must not start with '/' or '-'" ;;
+*..*) die "invalid --branch '$branch': must not contain '..'" ;;
+esac
+case "$branch" in
+*[!A-Za-z0-9._/-]*) die "invalid --branch '$branch': use only A-Z a-z 0-9 . _ - /" ;;
+esac
+case "/$branch/" in
+*//* | */./*) die "invalid --branch '$branch': path components must not be empty or '.'" ;;
+esac
+
 # Anchor .worktrees/ to the MAIN worktree, never to whichever linked tree the
 # caller happens to be standing in — otherwise running this from inside a
 # worktree nests .worktrees/a/.worktrees/b and every tool's assumption about

--- a/template/scripts/worktree-new.sh
+++ b/template/scripts/worktree-new.sh
@@ -122,8 +122,16 @@ git rev-parse --git-dir >/dev/null 2>&1 || die "not inside a git repository"
 # the branch-namespace lock key already byte-clamps arbitrary names safely
 # (#916). check-ref-format is local and side-effect-free, so the full
 # grammar is settled before any lock, reservation, or ref write.
-git check-ref-format --branch "$branch" >/dev/null 2>&1 ||
+branch_canon="$(git check-ref-format --branch "$branch" 2>/dev/null)" ||
     die "invalid branch name '$branch' (from --branch, or the worktree name it defaults to): rejected by git check-ref-format --branch"
+# check-ref-format --branch also EXPANDS checkout shorthand (`@{-1}` exits 0
+# and prints the previous branch), while everything downstream — the branch
+# lock, worktree add -b, the report — would keep the literal value: wrong
+# lock identity, and a deleted previous branch silently recreated under a
+# name the caller never wrote (challenge r3). Requiring the canonical output
+# to equal the input closes that whole class.
+[ "$branch_canon" = "$branch" ] ||
+    die "invalid branch name '$branch': checkout shorthand is not accepted here — name the branch explicitly (this resolves to '$branch_canon')"
 
 # Anchor .worktrees/ to the MAIN worktree, never to whichever linked tree the
 # caller happens to be standing in — otherwise running this from inside a


### PR DESCRIPTION
## What

An explicit `--branch` bypassed all the validation the worktree name gets and failed late — inside git, with the path reserved and locks held. `worktree-new.sh` now settles the branch early, before any lock, reservation, or ref write:

- `git check-ref-format --branch` validates the full ref grammar (deliberately **not** the name charset — branch names legally carry metacharacters, and create-or-attach must keep accepting an existing `feature+flag`; the #916 lock clamp already handles arbitrary names).
- Its canonical output must equal the input, refusing checkout shorthand (`@{-1}` exits 0 there while expanding to the previous branch — the literal would feed the branch lock and `worktree add -b` under the wrong identity).
- An explicitly empty `--branch` is refused at parse time instead of silently defaulting to the worktree name.
- The default `branch = name` path is unchanged; both files' `template/scripts/` byte twins updated in lockstep. The PR #932 quoted-remedy stale-config case is restored and now also pins the create-or-attach contract for metacharacter branches.

## Why

The front door of the creation path (#929, noticed during the #916 gauntlet): fail-late leaves git's error where an early, remedy-carrying refusal belongs, and the #916 review showed metacharacter branch names reaching genuinely bad paths.

## Verification

- `task verify` green after every round; `task ci` green.
- Regression cases in `test:worktree`: ten grammar-invalid values refused with the early guard's distinctive message (loose matching is called out in-test — git's late failure also mentions check-ref-format and let a mutant survive until tightened); `@{-1}` refused under real checkout history; empty `--branch` refused; default path exercised after the refusals; metacfg case restored.
- Mutants killed (cp-backup protocol): grammar guard deleted; empty-value check reverted; canonical-equality check deleted.

rigor: standard (default_rigor) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1. Challenge ran 4 rounds — the cap was reached with a confirmed P1 (checkout shorthand) and Evan explicitly granted round 4, which came back empty. Review: 1 round, empty. Tier/method: defaults (standard/plan) — no off-default resolution.

## Deferred findings

None — no P2s were deferred during either stage.

## Adjudication record

<details><summary>Per-round ledger (challenge 4 rounds, review 1 round)</summary>

```text
challenge r1 | 2 findings, adjudicated: 2 P1, both confirmed and fixed
scripts/worktree-new.sh:54 | explicitly empty --branch silently defaults to the worktree name | confirmed P1, fixed: non-empty required at parse; case + killed mutant | challenge r1
scripts/worktree-new.sh:124 | charset passes git-grammar-invalid names (.topic, topic., .lock) — still fail-late | confirmed P1, fixed: git check-ref-format --branch before any lock; cases + killed mutant (assertion tightened — git's late hint also says check-ref-format) | challenge r1
challenge r2 | 1 finding, adjudicated: 1 P1, confirmed and fixed
scripts/worktree-new.sh:120 | charset gate rejects git-valid branches previously accepted for attach (feature+flag, rollcfg$x); docs + lock clamp prove the contract | confirmed P1, fixed: check-ref-format --branch is the sole validator; #932 metacfg case restored; provenance: scaffolding restructured to git's own invariant | challenge r2
challenge r3 | 1 finding, adjudicated: 1 P1 (confirmed) — capped final round not clean; stage escalated to Evan
scripts/worktree-new.sh:125 | check-ref-format --branch expands checkout shorthand (@{-1} -> prior branch) while the script keeps the literal — wrong lock identity, wrong branch created/reported | confirmed P1 empirically; Evan granted round 4; fixed: canonical-output equality check, case + killed mutant | challenge r3
challenge r4 (granted by Evan) | no findings — empty round, stage exits
review r1 | no findings — empty round, stage exits
```

</details>

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)
