### PR TITLE
fix: cover area: values in the per-repo label customization guidance

### DIFF
--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -229,9 +229,11 @@ this comment. -->
 - [ ] Labels: run `task setup:github-labels` to seed this repo's starter label
       families from `label-registry.json` (see the generated taxonomy table in
       [project-management.md](project-management.md)) — grow `domain:` values
-      there as the product's own vocabulary. Labels are per-repo, so run it in
-      each repo; org default labels (org Settings → Repository, UI-only) only
-      seed new repos.
+      there as the product's own problem-space vocabulary and `area:` values as
+      its solution-space subsystems; both starter lists are a floor. `layer:`
+      is product-independent and normally needs no edits. Labels are per-repo,
+      so run it in each repo; org default labels (org Settings → Repository,
+      UI-only) only seed new repos.
 - [ ] **After a `copier update` that adds label families** (e.g. `tier:*` /
       `method:*`), re-run `task setup:github-labels` to provision the new
       labels here — it is additive and never deletes, so existing labels and

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -557,9 +557,12 @@ so provisioning and documentation cannot fork from each other.
 > carries. Do not seed `agent:*` into new repos; a repo carrying neither
 > family tracks a claim by assignee and claim comment alone.
 
-The `layer:` and `domain:` families are the *only* surface for this
+The `layer:`, `domain:`, and `area:` families are the *only* surface for this
 taxonomy (see Fields) — there is no more paired project/issue field to keep
-in step with, so extend the label lists alone as the product grows.
+in step with, so extend the label lists alone as the product grows. `domain:`
+(problem space) and `area:` (solution space) are both per-repository
+vocabulary whose starter values are a floor; `layer:` is product-independent
+and normally needs no edits.
 
 The `claim:` and `suggest:` families share a vocabulary and *nothing else*.
 `suggest:` is the planned implementer, `claim:` is the active one — see

--- a/template/docs/CHECKLIST.md.jinja
+++ b/template/docs/CHECKLIST.md.jinja
@@ -281,10 +281,11 @@ environment — against the items below
       families from `label-registry.json`[% if project_management == 'github' %]
       (see the generated taxonomy table in
       [project-management.md](project-management.md))[% endif %] — grow `domain:` values
-      there as the product's own vocabulary; `layer:` is product-independent
-      and normally needs no edits. Labels are per-repo, so run it in each repo;
-      org default labels (org Settings → Repository, UI-only) only seed new
-      repos.
+      there as the product's own problem-space vocabulary and `area:` values as
+      its solution-space subsystems; both starter lists are a floor. `layer:`
+      is product-independent and normally needs no edits. Labels are per-repo,
+      so run it in each repo; org default labels (org Settings → Repository,
+      UI-only) only seed new repos.
 - [ ] **After a `copier update` that adds label families** (e.g. `tier:*` /
       `method:*`), re-run `task setup:github-labels` to provision the new
       labels here — it is additive and never deletes, so existing labels and

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -614,9 +614,12 @@ so provisioning and documentation cannot fork from each other.
 > into new repos; a repo carrying neither family tracks a claim by assignee
 > and claim comment alone.
 
-The `layer:` and `domain:` families are the *only* surface for this
+The `layer:`, `domain:`, and `area:` families are the *only* surface for this
 taxonomy (see Fields) — there is no more paired project/issue field to keep
-in step with, so extend the label lists alone as the product grows.
+in step with, so extend the label lists alone as the product grows. `domain:`
+(problem space) and `area:` (solution space) are both per-repository
+vocabulary whose starter values are a floor; `layer:` is product-independent
+and normally needs no edits.
 
 The `claim:` and `suggest:` families share a vocabulary and *nothing else*.
 `suggest:` is the planned implementer, `claim:` is the active one — see


### PR DESCRIPTION
## What

The per-repo label customization guidance now names `area:` alongside `domain:` as a family consumers are expected to grow. `layer:`'s "product-independent, normally needs no edits" note is unchanged.

Four files, both dogfood layers:

- `docs/CHECKLIST.md` + `template/docs/CHECKLIST.md.jinja` — the Labels item
- `docs/project-management.md` + the `project_management == 'github'` template twin — the taxonomy prose

## Why

The checklist told consumers to grow `domain:` and said nothing about `area:`, so a consumer following it to the letter ends up with a mis-fitting taxonomy. In practice `area:` needs as much customization: harmon-devkit's taxonomy pass (evanharmon1/harmon-devkit#505) added 10 area values and re-described 5 starters, and harmon-init itself renamed `area:template` → `area:copier` and `area:codex` → `area:gauntlet` and added `area:foreman`, `area:worktree`, and others. The starter `area:` list is a floor exactly like the starter `domain:` list.

The wording reuses the distinction the repo already states at `docs/project-management.md:659` — area = solution space, domain = problem space, layer = stack slice — rather than inventing new framing.

## Scope note

The `project_management == 'linear'` template variant is deliberately untouched: it carries no `domain:` taxonomy prose (zero matches), so it has nothing to reconcile.

One divergence was closed as a side effect: root `docs/CHECKLIST.md` was missing the `layer:` clause its template twin carried. The twins now say the same thing, which is what the dogfood contract asks for.

## Verification

- `task check` — green
- `task test:dogfood-structure` — green (223 rendered sections/tasks present in the root layer)
- `task test:dogfood-parity` — green (132 verbatim twins identical)
- `task verify` — green
- `task ci` — green

rigor: standard (config default) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1

Second-model review: challenge converged at round 1 (no findings), review converged at round 1 (no findings). Both took the empty-round exit with `min_rounds 1` satisfied.

## Deferred findings

None — no P2s were raised in either stage.

## Follow-up filed

#957 — the template's `project-management.md` twin lacks the `Area`, `Tier` and `Method` label-family bullets the root copy has, despite the template shipping the `area` family in `label-registry.json`. Out of scope here (a document expansion); `test:dogfood-structure` cannot see it because it only checks rendered → root.

Closes #943
