### PR TITLE
fix: run test:gh-scopes in the required CI lint job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
       - run: task test:codex-review
       - run: task test:ci-results
       - run: task test:status
+      - run: task test:gh-scopes
       - run: task test:worktree
       - run: task test:renovate-pins
       - run: task test:lint-hygiene

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -58,6 +58,7 @@ jobs:
 [% endif %]
       - run: task test:ci-results
       - run: task test:status
+      - run: task test:gh-scopes
       - run: task test:worktree
       - run: task test:lint-hygiene
 [% if use_release_please %]


### PR DESCRIPTION
## What

`task test:gh-scopes` now runs in the required CI `lint` job, in both dogfood layers:

- `.github/workflows/build.yml`
- `template/.github/workflows/build.yml.jinja`

One line each, placed immediately after `test:status` — which is also where `verify` runs it (`Taskfile.yml:88`, `template/Taskfile.yml.jinja:116`), so the workflow order now mirrors the gate it had diverged from. Unconditional in the jinja layer, matching the target's unconditional presence in the template Taskfile and its `verify`.

## Why

`AGENTS.md` states the CI-mirror contract directly, and the converse has to hold too: a target in `verify` that is absent from the required check means CI is *weaker* than the local gate, so a PR can go green on GitHub while the behaviour that target covers is broken.

What that target covers is why it matters. `setup-gh-scopes.sh` is the one script here that **mutates the operator's stored credential**, and its tests are the safety story — the env-token refusal, the TTY refusal, the credential-class guard (#903), and the post-refresh verification that the grant actually landed. None of it ran in the required check.

## CI safety

`test:gh-scopes` runs `scripts/test-setup-gh-scopes.sh`, which builds a hermetic fixture in a temp dir and stubs `gh`. It needs no runner credential and makes no API call. Line 30 `unset`s `GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN GH_HOST` before anything runs — deliberately, because the BOT devcontainer profile supplies `GH_TOKEN` by design — so an Actions `GITHUB_TOKEN` cannot leak in or change the result.

No dependency on any earlier step beyond what the job already provides: `task`, `bash` and `git` come from the `./.github/actions/setup` composite. The TTY-refusal cases allocate a pty via `python3`, falling back to `script(1)`, and skip cleanly if neither is available — so on an exotic runner they cover less rather than failing.

## Scope

The issue's AC-3 — a drift guard binding the workflow's target list to `verify`'s — is deliberately **not** in this PR. It must land after it: a guard binding the two lists fails on arrival against a workflow still missing the target. Tracked as the deferred finding below.

## Verification

- `task check` — green (yamllint + actionlint over the edited workflow)
- `task test:gh-scopes` — green
- `task test:dogfood-structure` / `test:dogfood-parity` — green
- `task verify` — green

rigor: standard (config default) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1

## Deferred findings

- [x] `template/.github/workflows/build.yml.jinja:61` — no regression check binds the hand-maintained CI step list to `verify`'s target list, so a later removal of `task test:gh-scopes` would silently recreate this gap (review r1, reviewer P2, adjudicated P2). **filed as #962** — this is #909's own AC-3, deliberately sequenced after this PR because a guard binding the two lists would fail on arrival against a workflow still missing the target.

Refs #909


