### PR TITLE
feat: extend the Codex severity scale with a non-gating P3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -801,14 +801,15 @@ that has become empty is abandoned, not reviewed clean.
 an existing contract), `P1` (a real defect or materially wrong design
 decision with a plausible trigger), `P2` (worth knowing, not
 merge-blocking: hardening, unlikely edge cases, maintainability, non-critical
-test gaps), or `P3` (cosmetic or informational — reported and adjudicated,
-never gating and never deferred to the PR body). The scale is defined in
+test gaps), or `P3` (cosmetic or informational — reported and adjudicated, never
+gating). The scale is defined in
 `scripts/codex-review.sh`, not inherited from the Codex CLI's own labels, so
 the gate keeps its meaning if Codex changes its output; a finding badged off
-that scale, or not badged at all, is adjudicated as **at least a P2**. That
-floor is keyed to **provenance, not spelling**: only a P3 produced under that
-prompt is cosmetic by construction, so a cloud-review badge — which never read
-it — keeps the at-least-P2 floor until evidence says otherwise.
+that scale, or not badged at all, is adjudicated as **at least a P2**. A label
+is a hypothesis and the **adjudicated** severity is the verdict — P3 included,
+whatever reviewer produced it. So a P3 earns no sidecar entry only once
+adjudication has established it is genuinely cosmetic; the badge is grounds to
+suspect that, never grounds to skip the check.
 **Only P0 and P1 gate the local loops.** Adjudicate P2s too — never suppress
 or ignore one — but carry them to the PR-shepherd stage rather than spending
 a local round on them. A P2 you judge worth fixing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -805,7 +805,10 @@ test gaps), or `P3` (cosmetic or informational — reported and adjudicated,
 never gating and never deferred to the PR body). The scale is defined in
 `scripts/codex-review.sh`, not inherited from the Codex CLI's own labels, so
 the gate keeps its meaning if Codex changes its output; a finding badged off
-that scale, or not badged at all, is adjudicated as **at least a P2**.
+that scale, or not badged at all, is adjudicated as **at least a P2**. That
+floor is keyed to **provenance, not spelling**: only a P3 produced under that
+prompt is cosmetic by construction, so a cloud-review badge — which never read
+it — keeps the at-least-P2 floor until evidence says otherwise.
 **Only P0 and P1 gate the local loops.** Adjudicate P2s too — never suppress
 or ignore one — but carry them to the PR-shepherd stage rather than spending
 a local round on them. A P2 you judge worth fixing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -807,9 +807,10 @@ gating). The scale is defined in
 the gate keeps its meaning if Codex changes its output; a finding badged off
 that scale, or not badged at all, is adjudicated as **at least a P2**. A label
 is a hypothesis and the **adjudicated** severity is the verdict — P3 included,
-whatever reviewer produced it. So a P3 earns no sidecar entry only once
-adjudication has established it is genuinely cosmetic; the badge is grounds to
-suspect that, never grounds to skip the check.
+whatever reviewer produced it. The sidecar records what is *deferred*, so an entry is
+owed only for a finding left unresolved and carried forward — one fixed in
+place, or adjudicated genuinely cosmetic, leaves nothing to defer. What the
+badge may never do is skip the adjudication that decides which it is.
 **Only P0 and P1 gate the local loops.** Adjudicate P2s too — never suppress
 or ignore one — but carry them to the PR-shepherd stage rather than spending
 a local round on them. A P2 you judge worth fixing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -799,13 +799,16 @@ that has become empty is abandoned, not reviewed clean.
 **Severity gating.** Both tasks ask Codex to label every finding `P0`
 (breaks correctness, security, or data integrity in ordinary use, or breaks
 an existing contract), `P1` (a real defect or materially wrong design
-decision with a plausible trigger), or `P2` (worth knowing, not
+decision with a plausible trigger), `P2` (worth knowing, not
 merge-blocking: hardening, unlikely edge cases, maintainability, non-critical
-test gaps). The scale is defined in `scripts/codex-review.sh`, not inherited
-from the Codex CLI's own labels, so the gate keeps its meaning if Codex
-changes its output. **Only P0 and P1 gate the local loops.** Adjudicate P2s
-too — never suppress or ignore one — but carry them to the PR-shepherd stage
-rather than spending a local round on them. A P2 you judge worth fixing
+test gaps), or `P3` (cosmetic or informational — reported and adjudicated,
+never gating and never deferred to the PR body). The scale is defined in
+`scripts/codex-review.sh`, not inherited from the Codex CLI's own labels, so
+the gate keeps its meaning if Codex changes its output; a finding badged off
+that scale, or not badged at all, is adjudicated as **at least a P2**.
+**Only P0 and P1 gate the local loops.** Adjudicate P2s too — never suppress
+or ignore one — but carry them to the PR-shepherd stage rather than spending
+a local round on them. A P2 you judge worth fixing
 immediately may of course be fixed in place; it just does not hold the stage
 open.
 

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -374,9 +374,11 @@ holds for every finding from every reviewer, and P3 is not an exception to it:
 - The severity that counts is the one **you** adjudicate on evidence, never
   the one the reviewer wrote. That is already how P0 and P1 are handled; the
   scale just makes it explicit at the bottom too.
-- **Adjudication alone decides deferral.** A finding leaves no sidecar entry
-  only once adjudication has established it is genuinely cosmetic. A `P3`
-  badge is grounds to suspect that, never grounds to skip the check — and the
+- **Adjudication alone decides deferral.** The sidecar records what is
+  *deferred*, so an entry is owed only for a finding that is both unresolved
+  and carried forward: one fixed in place leaves nothing to defer, and one
+  adjudicated genuinely cosmetic leaves nothing to carry. What the badge may
+  never do is skip the adjudication that decides which of those it is — the
   `P3` on harmon-init#918 was a real parsing defect, so this is an observed
   failure mode, not a hypothetical one.
 - A badge **off** the scale, or absent entirely, starts at **at least a P2**.

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -162,7 +162,7 @@ Two things not to change when backgrounding:
   like when each one ran.
 - **The runner.** Background `task challenge` itself, not
   `/codex:adversarial-review --background`: the slash command calls Codex
-  directly, so it never receives the P0/P1/P2 scale that
+  directly, so it never receives the P0/P1/P2/P3 scale that
   `scripts/codex-review.sh` writes into the prompt. Fine for an interactive
   spot-check; it cannot establish the adjudicated-clean rounds this loop gates
   on.
@@ -356,11 +356,23 @@ silently drop one:
 | `P0` | Breaks correctness, security, or data integrity in ordinary use, or breaks an existing contract | Yes |
 | `P1` | A real defect or materially wrong design decision with a plausible trigger | Yes |
 | `P2` | Worth knowing, not merge-blocking: hardening, unlikely edge cases, maintainability, non-critical test gaps | No |
+| `P3` | Cosmetic or purely informational: wording, naming, formatting, an observation with no defect behind it | No |
 
 The scale lives in the prompt that `scripts/codex-review.sh` builds — not in
 the Codex CLI's own priority labels, which are an undocumented convention
 that can change. Keeping the definition local means the gate still means what
 it says when Codex's output format moves.
+
+That prompt reaches the **local** tasks only. Codex **cloud** review runs on
+its own instructions and has been seen badging a finding off this scale (a
+real `P3` on `harmon-init#918`, before P3 was defined here). So the scale
+closes with an invariant rather than a list: **a finding badged off this
+scale, or not badged at all, is adjudicated as at least a P2** — a future
+`P4` is triaged, never dropped for being unrecognized.
+
+P3s are adjudicated in the round they arrive and go no further: they are
+cosmetic by definition, so they neither gate a stage nor earn a sidecar
+entry. Fix one in place if it is worth the keystrokes, or say why not.
 
 P2s are **reported, adjudicated, and deferred**, never suppressed: they carry
 to the PR-shepherd stage, where they are fixed, declined with reasoning, or

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -374,6 +374,14 @@ P3s are adjudicated in the round they arrive and go no further: they are
 cosmetic by definition, so they neither gate a stage nor earn a sidecar
 entry. Fix one in place if it is worth the keystrokes, or say why not.
 
+That invariant is **adjudication guidance, not a tooling contract**. The
+pinned shepherd checker still matches severities as `p[0-2]`, so a P3 the
+*cloud* reviewer posts is invisible to it in both directions: posted as its
+own comment it classifies as findings that `settle` then refuses to record a
+disposition for, and appended to a clean verdict it passes unnoticed. Until
+that is fixed upstream and re-pinned (evanharmon1/harmon-devkit#530), settle a
+cloud P3 by hand and say so on the pull request.
+
 P2s are **reported, adjudicated, and deferred**, never suppressed: they carry
 to the PR-shepherd stage, where they are fixed, declined with reasoning, or
 filed as follow-up issues. That keeps the expensive local loops focused on

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -356,7 +356,7 @@ silently drop one:
 | `P0` | Breaks correctness, security, or data integrity in ordinary use, or breaks an existing contract | Yes |
 | `P1` | A real defect or materially wrong design decision with a plausible trigger | Yes |
 | `P2` | Worth knowing, not merge-blocking: hardening, unlikely edge cases, maintainability, non-critical test gaps | No |
-| `P3` | Cosmetic or purely informational: wording, naming, formatting, an observation with no defect behind it | No |
+| `P3` | Cosmetic or purely informational: a naming or wording choice that will mislead a reader, an observation with no defect behind it. The no-style-nits rule still binds — P3 is the floor for findings worth stating, not a licence to report nits | No |
 
 The scale lives in the prompt that `scripts/codex-review.sh` builds — not in
 the Codex CLI's own priority labels, which are an undocumented convention

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -388,11 +388,16 @@ Nothing in that depends on which reviewer produced the badge, so no
 provenance rule is needed: an under-labelled finding is caught by adjudicating
 it, wherever it came from.
 
-**The mechanism belongs to the checker, not to this prose.** How a cloud
-finding is answered depends on the surface it landed on, and
-`.claude/skills/shepherd/assets/check-codex-cloud-review.sh` is the authority
-on that — its exit codes are the contract, and the shepherd stage acts on
-them. Two things about it are worth knowing here because they are not
+**The mechanism belongs to the shepherd stage, not to this prose.** How a
+cloud finding is answered depends on the surface it landed on, and `AGENTS.md`
+is the authority — it carries both procedures, because a repository can answer
+`use_codex_review` yes and `use_skills_sync` no, which renders this guide with
+no vendored checker at all. Follow whichever of the two applies to your
+checkout; nothing below overrides it.
+
+**Where the pinned checker is vendored**
+(`.claude/skills/shepherd/assets/check-codex-cloud-review.sh`), its exit codes
+are the contract. Two things about it are worth knowing because they are not
 symmetric:
 
 - An **inline** finding is classified independently of its badge and is
@@ -400,11 +405,19 @@ symmetric:
   ordinary reply path with everything else.
 - A badged finding stated **outside** an inline thread has no reply linkage,
   and `settle` currently refuses a badge it does not recognize as `p[0-2]`.
-  So an unfixed, non-inline cloud P3 has no way to be recorded as settled:
-  fix it and push (which starts a fresh-head cycle and resolves it), or if it
-  genuinely needs no change, report the blocker and leave the PR draft. That
-  gap is being fixed upstream in evanharmon1/harmon-devkit#530 and re-pinned
-  here; it is a limitation of the current pin, not a rule.
+  So an unfixed, non-inline cloud P3 has no way to be recorded as settled
+  *by that checker*: fix it and push (which starts a fresh-head cycle and
+  resolves it), or if it genuinely needs no change, report the blocker and
+  leave the PR draft. That gap is being fixed upstream in
+  evanharmon1/harmon-devkit#530 and re-pinned here; it is a limitation of the
+  current pin, not a rule.
+
+**Where it is not vendored**, that limitation does not exist to work around:
+`AGENTS.md`'s checker-absent procedure governs, and a non-inline finding is
+answered and its disposition recorded on the pull request in the ordinary way.
+Do not import the paragraph above into that configuration — leaving a PR draft
+indefinitely over a `settle` call your checkout has no way to make would be
+the wrong reading.
 
 P2s are **reported, adjudicated, and deferred**, never suppressed: they carry
 to the PR-shepherd stage, where they are fixed, declined with reasoning, or

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -379,8 +379,12 @@ pinned shepherd checker still matches severities as `p[0-2]`, so a P3 the
 *cloud* reviewer posts is invisible to it in both directions: posted as its
 own comment it classifies as findings that `settle` then refuses to record a
 disposition for, and appended to a clean verdict it passes unnoticed. Until
-that is fixed upstream and re-pinned (evanharmon1/harmon-devkit#530), settle a
-cloud P3 by hand and say so on the pull request.
+that is fixed upstream and re-pinned (evanharmon1/harmon-devkit#530), a
+standalone cloud P3 has **no settlement path at all**: `settle` is the only
+sanctioned mechanism and it refuses the badge, so the cycle cannot reach a
+terminal-clean result for that head. Treat it as a blocker — report it on the
+pull request and leave the PR draft. A comment is not a disposition the
+checker can read, and promoting past it would defeat the readiness gate.
 
 P2s are **reported, adjudicated, and deferred**, never suppressed: they carry
 to the PR-shepherd stage, where they are fixed, declined with reasoning, or

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -366,34 +366,43 @@ it says when Codex's output format moves.
 That prompt reaches the **local** tasks only. Codex **cloud** review runs on
 its own instructions and has been seen badging a finding off this scale (a
 real `P3` on `harmon-init#918`, before P3 was defined here). So the scale
-closes with an invariant rather than a list: **a finding badged off this
-scale, or not badged at all, is adjudicated as at least a P2** — a future
-`P4` is triaged, never dropped for being unrecognized.
+closes with a property rather than a list.
 
-That invariant is about **provenance, not spelling**. A P3 produced under the
-prompt above inherits the definition: adjudicated in the round it arrives and
-going no further, since it is cosmetic by construction — it neither gates a
-stage nor earns a sidecar entry. Fix one in place if it is worth the
-keystrokes, or say why not.
+**A label is a hypothesis; the adjudicated severity is the verdict.** This
+holds for every finding from every reviewer, and P3 is not an exception to it:
 
-A P3 from **cloud** review inherits nothing, because cloud never read that
-prompt. Defining P3 locally must not silently reclassify it: the `P3` on
-harmon-init#918 was a real parsing defect, and the floor is what caught it.
-So a cloud badge keeps the at-least-P2 floor — deferred like a P2 — until
-adjudication on evidence establishes it is genuinely cosmetic. Matching a
-level this repo happens to define is not that evidence.
+- The severity that counts is the one **you** adjudicate on evidence, never
+  the one the reviewer wrote. That is already how P0 and P1 are handled; the
+  scale just makes it explicit at the bottom too.
+- **Adjudication alone decides deferral.** A finding leaves no sidecar entry
+  only once adjudication has established it is genuinely cosmetic. A `P3`
+  badge is grounds to suspect that, never grounds to skip the check — and the
+  `P3` on harmon-init#918 was a real parsing defect, so this is an observed
+  failure mode, not a hypothetical one.
+- A badge **off** the scale, or absent entirely, starts at **at least a P2**.
+  A future `P4` is triaged, never dropped for being unrecognized.
 
-That invariant is **adjudication guidance, not a tooling contract**. The
-pinned shepherd checker still matches severities as `p[0-2]`, so a P3 the
-*cloud* reviewer posts is invisible to it in both directions: posted as its
-own comment it classifies as findings that `settle` then refuses to record a
-disposition for, and appended to a clean verdict it passes unnoticed. Until
-that is fixed upstream and re-pinned (evanharmon1/harmon-devkit#530), a
-standalone cloud P3 has **no settlement path at all**: `settle` is the only
-sanctioned mechanism and it refuses the badge, so the cycle cannot reach a
-terminal-clean result for that head. Treat it as a blocker — report it on the
-pull request and leave the PR draft. A comment is not a disposition the
-checker can read, and promoting past it would defeat the readiness gate.
+Nothing in that depends on which reviewer produced the badge, so no
+provenance rule is needed: an under-labelled finding is caught by adjudicating
+it, wherever it came from.
+
+**The mechanism belongs to the checker, not to this prose.** How a cloud
+finding is answered depends on the surface it landed on, and
+`.claude/skills/shepherd/assets/check-codex-cloud-review.sh` is the authority
+on that — its exit codes are the contract, and the shepherd stage acts on
+them. Two things about it are worth knowing here because they are not
+symmetric:
+
+- An **inline** finding is classified independently of its badge and is
+  answered by a trusted in-thread reply, so an inline cloud P3 is on the
+  ordinary reply path with everything else.
+- A badged finding stated **outside** an inline thread has no reply linkage,
+  and `settle` currently refuses a badge it does not recognize as `p[0-2]`.
+  So an unfixed, non-inline cloud P3 has no way to be recorded as settled:
+  fix it and push (which starts a fresh-head cycle and resolves it), or if it
+  genuinely needs no change, report the blocker and leave the PR draft. That
+  gap is being fixed upstream in evanharmon1/harmon-devkit#530 and re-pinned
+  here; it is a limitation of the current pin, not a rule.
 
 P2s are **reported, adjudicated, and deferred**, never suppressed: they carry
 to the PR-shepherd stage, where they are fixed, declined with reasoning, or

--- a/docs/guides/codex-review.md
+++ b/docs/guides/codex-review.md
@@ -370,9 +370,18 @@ closes with an invariant rather than a list: **a finding badged off this
 scale, or not badged at all, is adjudicated as at least a P2** — a future
 `P4` is triaged, never dropped for being unrecognized.
 
-P3s are adjudicated in the round they arrive and go no further: they are
-cosmetic by definition, so they neither gate a stage nor earn a sidecar
-entry. Fix one in place if it is worth the keystrokes, or say why not.
+That invariant is about **provenance, not spelling**. A P3 produced under the
+prompt above inherits the definition: adjudicated in the round it arrives and
+going no further, since it is cosmetic by construction — it neither gates a
+stage nor earns a sidecar entry. Fix one in place if it is worth the
+keystrokes, or say why not.
+
+A P3 from **cloud** review inherits nothing, because cloud never read that
+prompt. Defining P3 locally must not silently reclassify it: the `P3` on
+harmon-init#918 was a real parsing defect, and the floor is what caught it.
+So a cloud badge keeps the at-least-P2 floor — deferred like a P2 — until
+adjudication on evidence establishes it is genuinely cosmetic. Matching a
+level this repo happens to define is not that evidence.
 
 That invariant is **adjudication guidance, not a tooling contract**. The
 pinned shepherd checker still matches severities as `p[0-2]`, so a P3 the

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -445,9 +445,11 @@ Label EVERY finding with a priority, as the first token of the finding:
        trigger. Merge-blocking unless argued down with evidence.
   P2 — worth knowing, but not merge-blocking: hardening, edge cases behind
        unlikely preconditions, maintainability, non-critical test gaps.
-  P3 — cosmetic or purely informational: wording, naming, formatting, an
-       observation with no defect behind it. Never gating, and not carried
-       into the pull request description the way a P2 is.
+  P3 — cosmetic or purely informational: a naming or wording choice that
+       will mislead a reader, an observation with no defect behind it.
+       Never gating, and not carried into the pull request description the
+       way a P2 is. The no-style-nits rule above still binds — P3 is the
+       floor for findings worth stating, not a licence to report nits.
 
 Only P0 and P1 decide whether this review passes. Still report P2s in full —
 they are triaged later, once the pull request is open — but do not let them

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -447,8 +447,7 @@ Label EVERY finding with a priority, as the first token of the finding:
        unlikely preconditions, maintainability, non-critical test gaps.
   P3 — cosmetic or purely informational: a naming or wording choice that
        will mislead a reader, an observation with no defect behind it.
-       Never gating, and not carried into the pull request description the
-       way a P2 is. The no-style-nits rule above still binds — P3 is the
+       Never gating. The no-style-nits rule above still binds — P3 is the
        floor for findings worth stating, not a licence to report nits.
 
 Only P0 and P1 decide whether this review passes. Still report P2s in full —
@@ -459,7 +458,9 @@ carried into the pull request description, so an unreported one is lost
 outright. The same holds one level down: report a P3 as a P3 rather than
 inflating it to P2 or dropping it for being small. Use these four labels and
 no others — a finding that arrives off this scale, or with no label at all,
-is adjudicated as at least a P2. If there are no P0 or P1 findings, say so
+is adjudicated as at least a P2. Every label you apply is a hypothesis the
+reader adjudicates on evidence, P3 included; none of them decides its own
+disposition. If there are no P0 or P1 findings, say so
 explicitly and in those terms."
 
 if [ -n "$focus" ]; then

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -21,8 +21,10 @@
 # Codex reviews read-only; findings are advisory hypotheses for the primary
 # agent/human to adjudicate (AGENTS.md "Second-Model Review") — this is never
 # part of `verify`/`ci`. Both modes ask for P0/P1/P2/P3-labelled findings;
-# only P0/P1 gate the local loop, P2s are reported and deferred to the PR
-# stage, and P3s are cosmetic — reported and adjudicated, never deferred.
+# only P0/P1 gate the local loop and P2s are reported and deferred to the PR
+# stage. A label is a hypothesis and the ADJUDICATED severity is the verdict,
+# P3 included: a P3 skips the sidecar only once adjudication establishes it is
+# genuinely cosmetic, and one adjudicated up to P2 is deferred like any other.
 # A finding badged off that scale, or not badged at all, is adjudicated as at
 # least a P2, never dropped for being unrecognized.
 # No target path may invoke Codex with an empty scope; every one of them

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -20,8 +20,11 @@
 # so the resolved scope is written INTO the instructions instead.
 # Codex reviews read-only; findings are advisory hypotheses for the primary
 # agent/human to adjudicate (AGENTS.md "Second-Model Review") — this is never
-# part of `verify`/`ci`. Both modes ask for P0/P1/P2-labelled findings; only
-# P0/P1 gate the local loop, P2s are reported and deferred to the PR stage.
+# part of `verify`/`ci`. Both modes ask for P0/P1/P2/P3-labelled findings;
+# only P0/P1 gate the local loop, P2s are reported and deferred to the PR
+# stage, and P3s are cosmetic — reported and adjudicated, never deferred.
+# A finding badged off that scale, or not badged at all, is adjudicated as at
+# least a P2, never dropped for being unrecognized.
 # No target path may invoke Codex with an empty scope; every one of them
 # refuses and exits non-zero instead (see refuse_empty_scope).
 # Requires an authenticated Codex CLI (`codex login`);
@@ -427,6 +430,11 @@ fi
 # review output: its priority labels are an undocumented convention that can
 # change under us, and the local dev loop gates on this scale (AGENTS.md
 # "Second-Model Review"). Stating it in the prompt keeps the gate meaningful.
+# The scale is closed at four levels, but the CLOUD reviewer is not driven by
+# this prompt and has been seen emitting off-scale badges (a P3 on #918, back
+# when the scale stopped at P2), so the unrecognized-badge invariant below is
+# written for both audiences: an unknown or missing badge is worth at least a
+# P2 of adjudication.
 instructions="${instructions}
 
 Label EVERY finding with a priority, as the first token of the finding:
@@ -437,14 +445,20 @@ Label EVERY finding with a priority, as the first token of the finding:
        trigger. Merge-blocking unless argued down with evidence.
   P2 — worth knowing, but not merge-blocking: hardening, edge cases behind
        unlikely preconditions, maintainability, non-critical test gaps.
+  P3 — cosmetic or purely informational: wording, naming, formatting, an
+       observation with no defect behind it. Never gating, and not carried
+       into the pull request description the way a P2 is.
 
 Only P0 and P1 decide whether this review passes. Still report P2s in full —
 they are triaged later, once the pull request is open — but do not let them
 hold the stage open. Do not inflate a P2 to P1 to make it heard, and do not
 withhold or soften a P2 because it is non-gating: a P2 reported here is
 carried into the pull request description, so an unreported one is lost
-outright. If there are no P0 or P1 findings, say so explicitly and in those
-terms."
+outright. The same holds one level down: report a P3 as a P3 rather than
+inflating it to P2 or dropping it for being small. Use these four labels and
+no others — a finding that arrives off this scale, or with no label at all,
+is adjudicated as at least a P2. If there are no P0 or P1 findings, say so
+explicitly and in those terms."
 
 if [ -n "$focus" ]; then
     instructions="${instructions}

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -23,8 +23,8 @@
 # part of `verify`/`ci`. Both modes ask for P0/P1/P2/P3-labelled findings;
 # only P0/P1 gate the local loop and P2s are reported and deferred to the PR
 # stage. A label is a hypothesis and the ADJUDICATED severity is the verdict,
-# P3 included: a P3 skips the sidecar only once adjudication establishes it is
-# genuinely cosmetic, and one adjudicated up to P2 is deferred like any other.
+# P3 included; the sidecar records only what is left unresolved AND carried
+# forward, so fixing one in place defers nothing and owes no entry.
 # A finding badged off that scale, or not badged at all, is adjudicated as at
 # least a P2, never dropped for being unrecognized.
 # No target path may invoke Codex with an empty scope; every one of them

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -107,6 +107,15 @@ echo "$out" | grep -q "Still report P2s" || fail "challenge prompt missing the r
 echo "$out" | grep -q "carried into the pull request description" || fail "challenge prompt missing the P2 handoff clause: $out"
 # P3 is cosmetic and the cloud reviewer emits badges this prompt never sent,
 # so both the fourth level and the off-scale floor have to survive edits.
+# The prompt assertions below read the RENDERED instructions, so they cannot
+# see a stale claim in the script's own header comment — which is exactly how
+# one survived the P3 rewording (harmon-init#923 shepherd r3). Assert against
+# the SOURCE too, so a summary that contradicts the prompt fails here rather
+# than in review.
+if grep -q "never deferred" "${repo}/scripts/codex-review.sh"; then
+    fail "codex-review.sh's header still claims a P3 is never deferred — deferral is decided by adjudication, not by the badge"
+fi
+
 echo "$out" | grep -q "P3 — cosmetic" || fail "challenge prompt missing the P3 level: $out"
 echo "$out" | grep -q "adjudicated as at least a P2" || fail "challenge prompt missing the off-scale badge floor: $out"
 echo "$out" | grep -q "hypothesis the" ||

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -109,6 +109,10 @@ echo "$out" | grep -q "carried into the pull request description" || fail "chall
 # so both the fourth level and the off-scale floor have to survive edits.
 echo "$out" | grep -q "P3 — cosmetic" || fail "challenge prompt missing the P3 level: $out"
 echo "$out" | grep -q "adjudicated as at least a P2" || fail "challenge prompt missing the off-scale badge floor: $out"
+echo "$out" | grep -q "hypothesis the" ||
+    fail "challenge prompt missing the label-is-a-hypothesis rule — an under-labelled P3 could be dropped without adjudication (harmon-init#923 shepherd r2): $out"
+! echo "$out" | grep -q "not carried into the pull request description" ||
+    fail "challenge prompt still claims a P3 is never deferred — deferral is decided by adjudication, not by the badge: $out"
 
 echo "==> origin/HEAD outranks a stray local main"
 git branch -q main "$(git rev-list --max-parents=0 HEAD)"
@@ -133,6 +137,10 @@ echo "$out" | grep -q "Only P0 and P1 decide" || fail "review prompt missing the
 echo "$out" | grep -q "carried into the pull request description" || fail "review prompt missing the P2 handoff clause: $out"
 echo "$out" | grep -q "P3 — cosmetic" || fail "review prompt missing the P3 level: $out"
 echo "$out" | grep -q "adjudicated as at least a P2" || fail "review prompt missing the off-scale badge floor: $out"
+echo "$out" | grep -q "hypothesis the" ||
+    fail "review prompt missing the label-is-a-hypothesis rule — an under-labelled P3 could be dropped without adjudication (harmon-init#923 shepherd r2): $out"
+! echo "$out" | grep -q "not carried into the pull request description" ||
+    fail "review prompt still claims a P3 is never deferred — deferral is decided by adjudication, not by the badge: $out"
 
 echo "==> --base warns when the ref lags an upstream HEAD already contains"
 # The reported bug: `--base main` on a checkout whose local main trails

--- a/scripts/test-codex-review.sh
+++ b/scripts/test-codex-review.sh
@@ -105,6 +105,10 @@ echo "$out" | grep -q "Still report P2s" || fail "challenge prompt missing the r
 # An unreported P2 never reaches the PR body, so the handoff clause is what
 # makes "reported but non-gating" different from "ignored".
 echo "$out" | grep -q "carried into the pull request description" || fail "challenge prompt missing the P2 handoff clause: $out"
+# P3 is cosmetic and the cloud reviewer emits badges this prompt never sent,
+# so both the fourth level and the off-scale floor have to survive edits.
+echo "$out" | grep -q "P3 — cosmetic" || fail "challenge prompt missing the P3 level: $out"
+echo "$out" | grep -q "adjudicated as at least a P2" || fail "challenge prompt missing the off-scale badge floor: $out"
 
 echo "==> origin/HEAD outranks a stray local main"
 git branch -q main "$(git rev-list --max-parents=0 HEAD)"
@@ -127,6 +131,8 @@ echo "$out" | grep -q "VERIFICATION-CHECKPOINT" || fail "review mode instruction
 echo "$out" | grep -q "watch the hooks" || fail "focus text missing from prompt: $out"
 echo "$out" | grep -q "Only P0 and P1 decide" || fail "review prompt missing the P0/P1 gating rule: $out"
 echo "$out" | grep -q "carried into the pull request description" || fail "review prompt missing the P2 handoff clause: $out"
+echo "$out" | grep -q "P3 — cosmetic" || fail "review prompt missing the P3 level: $out"
+echo "$out" | grep -q "adjudicated as at least a P2" || fail "review prompt missing the off-scale badge floor: $out"
 
 echo "==> --base warns when the ref lags an upstream HEAD already contains"
 # The reported bug: `--base main` on a checkout whose local main trails

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -697,14 +697,15 @@ that has become empty is abandoned, not reviewed clean.
 an existing contract), `P1` (a real defect or materially wrong design
 decision with a plausible trigger), `P2` (worth knowing, not
 merge-blocking: hardening, unlikely edge cases, maintainability, non-critical
-test gaps), or `P3` (cosmetic or informational — reported and adjudicated,
-never gating and never deferred to the PR body). The scale is defined in
+test gaps), or `P3` (cosmetic or informational — reported and adjudicated, never
+gating). The scale is defined in
 `scripts/codex-review.sh`, not inherited from the Codex CLI's own labels, so
 the gate keeps its meaning if Codex changes its output; a finding badged off
-that scale, or not badged at all, is adjudicated as **at least a P2**. That
-floor is keyed to **provenance, not spelling**: only a P3 produced under that
-prompt is cosmetic by construction, so a cloud-review badge — which never read
-it — keeps the at-least-P2 floor until evidence says otherwise.
+that scale, or not badged at all, is adjudicated as **at least a P2**. A label
+is a hypothesis and the **adjudicated** severity is the verdict — P3 included,
+whatever reviewer produced it. So a P3 earns no sidecar entry only once
+adjudication has established it is genuinely cosmetic; the badge is grounds to
+suspect that, never grounds to skip the check.
 **Only P0 and P1 gate the local loops.** Adjudicate P2s too — never suppress
 or ignore one — but carry them to the PR-shepherd stage rather than spending
 a local round on them. A P2 you judge worth fixing

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -701,7 +701,10 @@ test gaps), or `P3` (cosmetic or informational — reported and adjudicated,
 never gating and never deferred to the PR body). The scale is defined in
 `scripts/codex-review.sh`, not inherited from the Codex CLI's own labels, so
 the gate keeps its meaning if Codex changes its output; a finding badged off
-that scale, or not badged at all, is adjudicated as **at least a P2**.
+that scale, or not badged at all, is adjudicated as **at least a P2**. That
+floor is keyed to **provenance, not spelling**: only a P3 produced under that
+prompt is cosmetic by construction, so a cloud-review badge — which never read
+it — keeps the at-least-P2 floor until evidence says otherwise.
 **Only P0 and P1 gate the local loops.** Adjudicate P2s too — never suppress
 or ignore one — but carry them to the PR-shepherd stage rather than spending
 a local round on them. A P2 you judge worth fixing

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -703,9 +703,10 @@ gating). The scale is defined in
 the gate keeps its meaning if Codex changes its output; a finding badged off
 that scale, or not badged at all, is adjudicated as **at least a P2**. A label
 is a hypothesis and the **adjudicated** severity is the verdict — P3 included,
-whatever reviewer produced it. So a P3 earns no sidecar entry only once
-adjudication has established it is genuinely cosmetic; the badge is grounds to
-suspect that, never grounds to skip the check.
+whatever reviewer produced it. The sidecar records what is *deferred*, so an entry is
+owed only for a finding left unresolved and carried forward — one fixed in
+place, or adjudicated genuinely cosmetic, leaves nothing to defer. What the
+badge may never do is skip the adjudication that decides which it is.
 **Only P0 and P1 gate the local loops.** Adjudicate P2s too — never suppress
 or ignore one — but carry them to the PR-shepherd stage rather than spending
 a local round on them. A P2 you judge worth fixing

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -695,13 +695,16 @@ that has become empty is abandoned, not reviewed clean.
 **Severity gating.** Both tasks ask Codex to label every finding `P0`
 (breaks correctness, security, or data integrity in ordinary use, or breaks
 an existing contract), `P1` (a real defect or materially wrong design
-decision with a plausible trigger), or `P2` (worth knowing, not
+decision with a plausible trigger), `P2` (worth knowing, not
 merge-blocking: hardening, unlikely edge cases, maintainability, non-critical
-test gaps). The scale is defined in `scripts/codex-review.sh`, not inherited
-from the Codex CLI's own labels, so the gate keeps its meaning if Codex
-changes its output. **Only P0 and P1 gate the local loops.** Adjudicate P2s
-too — never suppress or ignore one — but carry them to the PR-shepherd stage
-rather than spending a local round on them. A P2 you judge worth fixing
+test gaps), or `P3` (cosmetic or informational — reported and adjudicated,
+never gating and never deferred to the PR body). The scale is defined in
+`scripts/codex-review.sh`, not inherited from the Codex CLI's own labels, so
+the gate keeps its meaning if Codex changes its output; a finding badged off
+that scale, or not badged at all, is adjudicated as **at least a P2**.
+**Only P0 and P1 gate the local loops.** Adjudicate P2s too — never suppress
+or ignore one — but carry them to the PR-shepherd stage rather than spending
+a local round on them. A P2 you judge worth fixing
 immediately may of course be fixed in place; it just does not hold the stage
 open.
 

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -374,9 +374,11 @@ holds for every finding from every reviewer, and P3 is not an exception to it:
 - The severity that counts is the one **you** adjudicate on evidence, never
   the one the reviewer wrote. That is already how P0 and P1 are handled; the
   scale just makes it explicit at the bottom too.
-- **Adjudication alone decides deferral.** A finding leaves no sidecar entry
-  only once adjudication has established it is genuinely cosmetic. A `P3`
-  badge is grounds to suspect that, never grounds to skip the check — and the
+- **Adjudication alone decides deferral.** The sidecar records what is
+  *deferred*, so an entry is owed only for a finding that is both unresolved
+  and carried forward: one fixed in place leaves nothing to defer, and one
+  adjudicated genuinely cosmetic leaves nothing to carry. What the badge may
+  never do is skip the adjudication that decides which of those it is — the
   `P3` on harmon-init#918 was a real parsing defect, so this is an observed
   failure mode, not a hypothetical one.
 - A badge **off** the scale, or absent entirely, starts at **at least a P2**.

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -162,7 +162,7 @@ Two things not to change when backgrounding:
   like when each one ran.
 - **The runner.** Background `task challenge` itself, not
   `/codex:adversarial-review --background`: the slash command calls Codex
-  directly, so it never receives the P0/P1/P2 scale that
+  directly, so it never receives the P0/P1/P2/P3 scale that
   `scripts/codex-review.sh` writes into the prompt. Fine for an interactive
   spot-check; it cannot establish the adjudicated-clean rounds this loop gates
   on.
@@ -356,11 +356,23 @@ silently drop one:
 | `P0` | Breaks correctness, security, or data integrity in ordinary use, or breaks an existing contract | Yes |
 | `P1` | A real defect or materially wrong design decision with a plausible trigger | Yes |
 | `P2` | Worth knowing, not merge-blocking: hardening, unlikely edge cases, maintainability, non-critical test gaps | No |
+| `P3` | Cosmetic or purely informational: wording, naming, formatting, an observation with no defect behind it | No |
 
 The scale lives in the prompt that `scripts/codex-review.sh` builds — not in
 the Codex CLI's own priority labels, which are an undocumented convention
 that can change. Keeping the definition local means the gate still means what
 it says when Codex's output format moves.
+
+That prompt reaches the **local** tasks only. Codex **cloud** review runs on
+its own instructions and has been seen badging a finding off this scale (a
+real `P3` on `harmon-init#918`, before P3 was defined here). So the scale
+closes with an invariant rather than a list: **a finding badged off this
+scale, or not badged at all, is adjudicated as at least a P2** — a future
+`P4` is triaged, never dropped for being unrecognized.
+
+P3s are adjudicated in the round they arrive and go no further: they are
+cosmetic by definition, so they neither gate a stage nor earn a sidecar
+entry. Fix one in place if it is worth the keystrokes, or say why not.
 
 P2s are **reported, adjudicated, and deferred**, never suppressed: they carry
 to the PR-shepherd stage, where they are fixed, declined with reasoning, or

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -374,6 +374,14 @@ P3s are adjudicated in the round they arrive and go no further: they are
 cosmetic by definition, so they neither gate a stage nor earn a sidecar
 entry. Fix one in place if it is worth the keystrokes, or say why not.
 
+That invariant is **adjudication guidance, not a tooling contract**. The
+pinned shepherd checker still matches severities as `p[0-2]`, so a P3 the
+*cloud* reviewer posts is invisible to it in both directions: posted as its
+own comment it classifies as findings that `settle` then refuses to record a
+disposition for, and appended to a clean verdict it passes unnoticed. Until
+that is fixed upstream and re-pinned (evanharmon1/harmon-devkit#530), settle a
+cloud P3 by hand and say so on the pull request.
+
 P2s are **reported, adjudicated, and deferred**, never suppressed: they carry
 to the PR-shepherd stage, where they are fixed, declined with reasoning, or
 filed as follow-up issues. That keeps the expensive local loops focused on

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -356,7 +356,7 @@ silently drop one:
 | `P0` | Breaks correctness, security, or data integrity in ordinary use, or breaks an existing contract | Yes |
 | `P1` | A real defect or materially wrong design decision with a plausible trigger | Yes |
 | `P2` | Worth knowing, not merge-blocking: hardening, unlikely edge cases, maintainability, non-critical test gaps | No |
-| `P3` | Cosmetic or purely informational: wording, naming, formatting, an observation with no defect behind it | No |
+| `P3` | Cosmetic or purely informational: a naming or wording choice that will mislead a reader, an observation with no defect behind it. The no-style-nits rule still binds — P3 is the floor for findings worth stating, not a licence to report nits | No |
 
 The scale lives in the prompt that `scripts/codex-review.sh` builds — not in
 the Codex CLI's own priority labels, which are an undocumented convention

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -388,11 +388,16 @@ Nothing in that depends on which reviewer produced the badge, so no
 provenance rule is needed: an under-labelled finding is caught by adjudicating
 it, wherever it came from.
 
-**The mechanism belongs to the checker, not to this prose.** How a cloud
-finding is answered depends on the surface it landed on, and
-`.claude/skills/shepherd/assets/check-codex-cloud-review.sh` is the authority
-on that — its exit codes are the contract, and the shepherd stage acts on
-them. Two things about it are worth knowing here because they are not
+**The mechanism belongs to the shepherd stage, not to this prose.** How a
+cloud finding is answered depends on the surface it landed on, and `AGENTS.md`
+is the authority — it carries both procedures, because a repository can answer
+`use_codex_review` yes and `use_skills_sync` no, which renders this guide with
+no vendored checker at all. Follow whichever of the two applies to your
+checkout; nothing below overrides it.
+
+**Where the pinned checker is vendored**
+(`.claude/skills/shepherd/assets/check-codex-cloud-review.sh`), its exit codes
+are the contract. Two things about it are worth knowing because they are not
 symmetric:
 
 - An **inline** finding is classified independently of its badge and is
@@ -400,11 +405,19 @@ symmetric:
   ordinary reply path with everything else.
 - A badged finding stated **outside** an inline thread has no reply linkage,
   and `settle` currently refuses a badge it does not recognize as `p[0-2]`.
-  So an unfixed, non-inline cloud P3 has no way to be recorded as settled:
-  fix it and push (which starts a fresh-head cycle and resolves it), or if it
-  genuinely needs no change, report the blocker and leave the PR draft. That
-  gap is being fixed upstream in evanharmon1/harmon-devkit#530 and re-pinned
-  here; it is a limitation of the current pin, not a rule.
+  So an unfixed, non-inline cloud P3 has no way to be recorded as settled
+  *by that checker*: fix it and push (which starts a fresh-head cycle and
+  resolves it), or if it genuinely needs no change, report the blocker and
+  leave the PR draft. That gap is being fixed upstream in
+  evanharmon1/harmon-devkit#530 and re-pinned here; it is a limitation of the
+  current pin, not a rule.
+
+**Where it is not vendored**, that limitation does not exist to work around:
+`AGENTS.md`'s checker-absent procedure governs, and a non-inline finding is
+answered and its disposition recorded on the pull request in the ordinary way.
+Do not import the paragraph above into that configuration — leaving a PR draft
+indefinitely over a `settle` call your checkout has no way to make would be
+the wrong reading.
 
 P2s are **reported, adjudicated, and deferred**, never suppressed: they carry
 to the PR-shepherd stage, where they are fixed, declined with reasoning, or

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -379,8 +379,12 @@ pinned shepherd checker still matches severities as `p[0-2]`, so a P3 the
 *cloud* reviewer posts is invisible to it in both directions: posted as its
 own comment it classifies as findings that `settle` then refuses to record a
 disposition for, and appended to a clean verdict it passes unnoticed. Until
-that is fixed upstream and re-pinned (evanharmon1/harmon-devkit#530), settle a
-cloud P3 by hand and say so on the pull request.
+that is fixed upstream and re-pinned (evanharmon1/harmon-devkit#530), a
+standalone cloud P3 has **no settlement path at all**: `settle` is the only
+sanctioned mechanism and it refuses the badge, so the cycle cannot reach a
+terminal-clean result for that head. Treat it as a blocker — report it on the
+pull request and leave the PR draft. A comment is not a disposition the
+checker can read, and promoting past it would defeat the readiness gate.
 
 P2s are **reported, adjudicated, and deferred**, never suppressed: they carry
 to the PR-shepherd stage, where they are fixed, declined with reasoning, or

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -366,34 +366,43 @@ it says when Codex's output format moves.
 That prompt reaches the **local** tasks only. Codex **cloud** review runs on
 its own instructions and has been seen badging a finding off this scale (a
 real `P3` on `harmon-init#918`, before P3 was defined here). So the scale
-closes with an invariant rather than a list: **a finding badged off this
-scale, or not badged at all, is adjudicated as at least a P2** — a future
-`P4` is triaged, never dropped for being unrecognized.
+closes with a property rather than a list.
 
-That invariant is about **provenance, not spelling**. A P3 produced under the
-prompt above inherits the definition: adjudicated in the round it arrives and
-going no further, since it is cosmetic by construction — it neither gates a
-stage nor earns a sidecar entry. Fix one in place if it is worth the
-keystrokes, or say why not.
+**A label is a hypothesis; the adjudicated severity is the verdict.** This
+holds for every finding from every reviewer, and P3 is not an exception to it:
 
-A P3 from **cloud** review inherits nothing, because cloud never read that
-prompt. Defining P3 locally must not silently reclassify it: the `P3` on
-harmon-init#918 was a real parsing defect, and the floor is what caught it.
-So a cloud badge keeps the at-least-P2 floor — deferred like a P2 — until
-adjudication on evidence establishes it is genuinely cosmetic. Matching a
-level this repo happens to define is not that evidence.
+- The severity that counts is the one **you** adjudicate on evidence, never
+  the one the reviewer wrote. That is already how P0 and P1 are handled; the
+  scale just makes it explicit at the bottom too.
+- **Adjudication alone decides deferral.** A finding leaves no sidecar entry
+  only once adjudication has established it is genuinely cosmetic. A `P3`
+  badge is grounds to suspect that, never grounds to skip the check — and the
+  `P3` on harmon-init#918 was a real parsing defect, so this is an observed
+  failure mode, not a hypothetical one.
+- A badge **off** the scale, or absent entirely, starts at **at least a P2**.
+  A future `P4` is triaged, never dropped for being unrecognized.
 
-That invariant is **adjudication guidance, not a tooling contract**. The
-pinned shepherd checker still matches severities as `p[0-2]`, so a P3 the
-*cloud* reviewer posts is invisible to it in both directions: posted as its
-own comment it classifies as findings that `settle` then refuses to record a
-disposition for, and appended to a clean verdict it passes unnoticed. Until
-that is fixed upstream and re-pinned (evanharmon1/harmon-devkit#530), a
-standalone cloud P3 has **no settlement path at all**: `settle` is the only
-sanctioned mechanism and it refuses the badge, so the cycle cannot reach a
-terminal-clean result for that head. Treat it as a blocker — report it on the
-pull request and leave the PR draft. A comment is not a disposition the
-checker can read, and promoting past it would defeat the readiness gate.
+Nothing in that depends on which reviewer produced the badge, so no
+provenance rule is needed: an under-labelled finding is caught by adjudicating
+it, wherever it came from.
+
+**The mechanism belongs to the checker, not to this prose.** How a cloud
+finding is answered depends on the surface it landed on, and
+`.claude/skills/shepherd/assets/check-codex-cloud-review.sh` is the authority
+on that — its exit codes are the contract, and the shepherd stage acts on
+them. Two things about it are worth knowing here because they are not
+symmetric:
+
+- An **inline** finding is classified independently of its badge and is
+  answered by a trusted in-thread reply, so an inline cloud P3 is on the
+  ordinary reply path with everything else.
+- A badged finding stated **outside** an inline thread has no reply linkage,
+  and `settle` currently refuses a badge it does not recognize as `p[0-2]`.
+  So an unfixed, non-inline cloud P3 has no way to be recorded as settled:
+  fix it and push (which starts a fresh-head cycle and resolves it), or if it
+  genuinely needs no change, report the blocker and leave the PR draft. That
+  gap is being fixed upstream in evanharmon1/harmon-devkit#530 and re-pinned
+  here; it is a limitation of the current pin, not a rule.
 
 P2s are **reported, adjudicated, and deferred**, never suppressed: they carry
 to the PR-shepherd stage, where they are fixed, declined with reasoning, or

--- a/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
+++ b/template/docs/guides/[% if use_codex_review %]codex-review.md[% endif %]
@@ -370,9 +370,18 @@ closes with an invariant rather than a list: **a finding badged off this
 scale, or not badged at all, is adjudicated as at least a P2** — a future
 `P4` is triaged, never dropped for being unrecognized.
 
-P3s are adjudicated in the round they arrive and go no further: they are
-cosmetic by definition, so they neither gate a stage nor earn a sidecar
-entry. Fix one in place if it is worth the keystrokes, or say why not.
+That invariant is about **provenance, not spelling**. A P3 produced under the
+prompt above inherits the definition: adjudicated in the round it arrives and
+going no further, since it is cosmetic by construction — it neither gates a
+stage nor earns a sidecar entry. Fix one in place if it is worth the
+keystrokes, or say why not.
+
+A P3 from **cloud** review inherits nothing, because cloud never read that
+prompt. Defining P3 locally must not silently reclassify it: the `P3` on
+harmon-init#918 was a real parsing defect, and the floor is what caught it.
+So a cloud badge keeps the at-least-P2 floor — deferred like a P2 — until
+adjudication on evidence establishes it is genuinely cosmetic. Matching a
+level this repo happens to define is not that evidence.
 
 That invariant is **adjudication guidance, not a tooling contract**. The
 pinned shepherd checker still matches severities as `p[0-2]`, so a P3 the

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -445,9 +445,11 @@ Label EVERY finding with a priority, as the first token of the finding:
        trigger. Merge-blocking unless argued down with evidence.
   P2 — worth knowing, but not merge-blocking: hardening, edge cases behind
        unlikely preconditions, maintainability, non-critical test gaps.
-  P3 — cosmetic or purely informational: wording, naming, formatting, an
-       observation with no defect behind it. Never gating, and not carried
-       into the pull request description the way a P2 is.
+  P3 — cosmetic or purely informational: a naming or wording choice that
+       will mislead a reader, an observation with no defect behind it.
+       Never gating, and not carried into the pull request description the
+       way a P2 is. The no-style-nits rule above still binds — P3 is the
+       floor for findings worth stating, not a licence to report nits.
 
 Only P0 and P1 decide whether this review passes. Still report P2s in full —
 they are triaged later, once the pull request is open — but do not let them

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -447,8 +447,7 @@ Label EVERY finding with a priority, as the first token of the finding:
        unlikely preconditions, maintainability, non-critical test gaps.
   P3 — cosmetic or purely informational: a naming or wording choice that
        will mislead a reader, an observation with no defect behind it.
-       Never gating, and not carried into the pull request description the
-       way a P2 is. The no-style-nits rule above still binds — P3 is the
+       Never gating. The no-style-nits rule above still binds — P3 is the
        floor for findings worth stating, not a licence to report nits.
 
 Only P0 and P1 decide whether this review passes. Still report P2s in full —
@@ -459,7 +458,9 @@ carried into the pull request description, so an unreported one is lost
 outright. The same holds one level down: report a P3 as a P3 rather than
 inflating it to P2 or dropping it for being small. Use these four labels and
 no others — a finding that arrives off this scale, or with no label at all,
-is adjudicated as at least a P2. If there are no P0 or P1 findings, say so
+is adjudicated as at least a P2. Every label you apply is a hypothesis the
+reader adjudicates on evidence, P3 included; none of them decides its own
+disposition. If there are no P0 or P1 findings, say so
 explicitly and in those terms."
 
 if [ -n "$focus" ]; then

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -21,8 +21,10 @@
 # Codex reviews read-only; findings are advisory hypotheses for the primary
 # agent/human to adjudicate (AGENTS.md "Second-Model Review") — this is never
 # part of `verify`/`ci`. Both modes ask for P0/P1/P2/P3-labelled findings;
-# only P0/P1 gate the local loop, P2s are reported and deferred to the PR
-# stage, and P3s are cosmetic — reported and adjudicated, never deferred.
+# only P0/P1 gate the local loop and P2s are reported and deferred to the PR
+# stage. A label is a hypothesis and the ADJUDICATED severity is the verdict,
+# P3 included: a P3 skips the sidecar only once adjudication establishes it is
+# genuinely cosmetic, and one adjudicated up to P2 is deferred like any other.
 # A finding badged off that scale, or not badged at all, is adjudicated as at
 # least a P2, never dropped for being unrecognized.
 # No target path may invoke Codex with an empty scope; every one of them

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -20,8 +20,11 @@
 # so the resolved scope is written INTO the instructions instead.
 # Codex reviews read-only; findings are advisory hypotheses for the primary
 # agent/human to adjudicate (AGENTS.md "Second-Model Review") — this is never
-# part of `verify`/`ci`. Both modes ask for P0/P1/P2-labelled findings; only
-# P0/P1 gate the local loop, P2s are reported and deferred to the PR stage.
+# part of `verify`/`ci`. Both modes ask for P0/P1/P2/P3-labelled findings;
+# only P0/P1 gate the local loop, P2s are reported and deferred to the PR
+# stage, and P3s are cosmetic — reported and adjudicated, never deferred.
+# A finding badged off that scale, or not badged at all, is adjudicated as at
+# least a P2, never dropped for being unrecognized.
 # No target path may invoke Codex with an empty scope; every one of them
 # refuses and exits non-zero instead (see refuse_empty_scope).
 # Requires an authenticated Codex CLI (`codex login`);
@@ -427,6 +430,11 @@ fi
 # review output: its priority labels are an undocumented convention that can
 # change under us, and the local dev loop gates on this scale (AGENTS.md
 # "Second-Model Review"). Stating it in the prompt keeps the gate meaningful.
+# The scale is closed at four levels, but the CLOUD reviewer is not driven by
+# this prompt and has been seen emitting off-scale badges (a P3 on #918, back
+# when the scale stopped at P2), so the unrecognized-badge invariant below is
+# written for both audiences: an unknown or missing badge is worth at least a
+# P2 of adjudication.
 instructions="${instructions}
 
 Label EVERY finding with a priority, as the first token of the finding:
@@ -437,14 +445,20 @@ Label EVERY finding with a priority, as the first token of the finding:
        trigger. Merge-blocking unless argued down with evidence.
   P2 — worth knowing, but not merge-blocking: hardening, edge cases behind
        unlikely preconditions, maintainability, non-critical test gaps.
+  P3 — cosmetic or purely informational: wording, naming, formatting, an
+       observation with no defect behind it. Never gating, and not carried
+       into the pull request description the way a P2 is.
 
 Only P0 and P1 decide whether this review passes. Still report P2s in full —
 they are triaged later, once the pull request is open — but do not let them
 hold the stage open. Do not inflate a P2 to P1 to make it heard, and do not
 withhold or soften a P2 because it is non-gating: a P2 reported here is
 carried into the pull request description, so an unreported one is lost
-outright. If there are no P0 or P1 findings, say so explicitly and in those
-terms."
+outright. The same holds one level down: report a P3 as a P3 rather than
+inflating it to P2 or dropping it for being small. Use these four labels and
+no others — a finding that arrives off this scale, or with no label at all,
+is adjudicated as at least a P2. If there are no P0 or P1 findings, say so
+explicitly and in those terms."
 
 if [ -n "$focus" ]; then
     instructions="${instructions}

--- a/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]codex-review.sh[% endif %]
@@ -23,8 +23,8 @@
 # part of `verify`/`ci`. Both modes ask for P0/P1/P2/P3-labelled findings;
 # only P0/P1 gate the local loop and P2s are reported and deferred to the PR
 # stage. A label is a hypothesis and the ADJUDICATED severity is the verdict,
-# P3 included: a P3 skips the sidecar only once adjudication establishes it is
-# genuinely cosmetic, and one adjudicated up to P2 is deferred like any other.
+# P3 included; the sidecar records only what is left unresolved AND carried
+# forward, so fixing one in place defers nothing and owes no entry.
 # A finding badged off that scale, or not badged at all, is adjudicated as at
 # least a P2, never dropped for being unrecognized.
 # No target path may invoke Codex with an empty scope; every one of them

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -107,6 +107,15 @@ echo "$out" | grep -q "Still report P2s" || fail "challenge prompt missing the r
 echo "$out" | grep -q "carried into the pull request description" || fail "challenge prompt missing the P2 handoff clause: $out"
 # P3 is cosmetic and the cloud reviewer emits badges this prompt never sent,
 # so both the fourth level and the off-scale floor have to survive edits.
+# The prompt assertions below read the RENDERED instructions, so they cannot
+# see a stale claim in the script's own header comment — which is exactly how
+# one survived the P3 rewording (harmon-init#923 shepherd r3). Assert against
+# the SOURCE too, so a summary that contradicts the prompt fails here rather
+# than in review.
+if grep -q "never deferred" "${repo}/scripts/codex-review.sh"; then
+    fail "codex-review.sh's header still claims a P3 is never deferred — deferral is decided by adjudication, not by the badge"
+fi
+
 echo "$out" | grep -q "P3 — cosmetic" || fail "challenge prompt missing the P3 level: $out"
 echo "$out" | grep -q "adjudicated as at least a P2" || fail "challenge prompt missing the off-scale badge floor: $out"
 echo "$out" | grep -q "hypothesis the" ||

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -109,6 +109,10 @@ echo "$out" | grep -q "carried into the pull request description" || fail "chall
 # so both the fourth level and the off-scale floor have to survive edits.
 echo "$out" | grep -q "P3 — cosmetic" || fail "challenge prompt missing the P3 level: $out"
 echo "$out" | grep -q "adjudicated as at least a P2" || fail "challenge prompt missing the off-scale badge floor: $out"
+echo "$out" | grep -q "hypothesis the" ||
+    fail "challenge prompt missing the label-is-a-hypothesis rule — an under-labelled P3 could be dropped without adjudication (harmon-init#923 shepherd r2): $out"
+! echo "$out" | grep -q "not carried into the pull request description" ||
+    fail "challenge prompt still claims a P3 is never deferred — deferral is decided by adjudication, not by the badge: $out"
 
 echo "==> origin/HEAD outranks a stray local main"
 git branch -q main "$(git rev-list --max-parents=0 HEAD)"
@@ -133,6 +137,10 @@ echo "$out" | grep -q "Only P0 and P1 decide" || fail "review prompt missing the
 echo "$out" | grep -q "carried into the pull request description" || fail "review prompt missing the P2 handoff clause: $out"
 echo "$out" | grep -q "P3 — cosmetic" || fail "review prompt missing the P3 level: $out"
 echo "$out" | grep -q "adjudicated as at least a P2" || fail "review prompt missing the off-scale badge floor: $out"
+echo "$out" | grep -q "hypothesis the" ||
+    fail "review prompt missing the label-is-a-hypothesis rule — an under-labelled P3 could be dropped without adjudication (harmon-init#923 shepherd r2): $out"
+! echo "$out" | grep -q "not carried into the pull request description" ||
+    fail "review prompt still claims a P3 is never deferred — deferral is decided by adjudication, not by the badge: $out"
 
 echo "==> --base warns when the ref lags an upstream HEAD already contains"
 # The reported bug: `--base main` on a checkout whose local main trails

--- a/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
+++ b/template/scripts/[% if use_codex_review %]test-codex-review.sh[% endif %]
@@ -105,6 +105,10 @@ echo "$out" | grep -q "Still report P2s" || fail "challenge prompt missing the r
 # An unreported P2 never reaches the PR body, so the handoff clause is what
 # makes "reported but non-gating" different from "ignored".
 echo "$out" | grep -q "carried into the pull request description" || fail "challenge prompt missing the P2 handoff clause: $out"
+# P3 is cosmetic and the cloud reviewer emits badges this prompt never sent,
+# so both the fourth level and the off-scale floor have to survive edits.
+echo "$out" | grep -q "P3 — cosmetic" || fail "challenge prompt missing the P3 level: $out"
+echo "$out" | grep -q "adjudicated as at least a P2" || fail "challenge prompt missing the off-scale badge floor: $out"
 
 echo "==> origin/HEAD outranks a stray local main"
 git branch -q main "$(git rev-list --max-parents=0 HEAD)"
@@ -127,6 +131,8 @@ echo "$out" | grep -q "VERIFICATION-CHECKPOINT" || fail "review mode instruction
 echo "$out" | grep -q "watch the hooks" || fail "focus text missing from prompt: $out"
 echo "$out" | grep -q "Only P0 and P1 decide" || fail "review prompt missing the P0/P1 gating rule: $out"
 echo "$out" | grep -q "carried into the pull request description" || fail "review prompt missing the P2 handoff clause: $out"
+echo "$out" | grep -q "P3 — cosmetic" || fail "review prompt missing the P3 level: $out"
+echo "$out" | grep -q "adjudicated as at least a P2" || fail "review prompt missing the off-scale badge floor: $out"
 
 echo "==> --base warns when the ref lags an upstream HEAD already contains"
 # The reported bug: `--base main` on a checkout whose local main trails


### PR DESCRIPTION
## What

Extends the Codex severity scale with an explicit, never-gating **P3**, and pins the invariant that matters more than the level itself: **a finding badged off the scale, or not badged at all, is adjudicated as at least a P2** — a future `P4` is triaged, never dropped for being unrecognized.

- `scripts/codex-review.sh` — the normative definition, in the prompt text
- `scripts/test-codex-review.sh` — assertions on both review modes
- `docs/guides/codex-review.md` — the scale table and the cloud-vs-local distinction
- `AGENTS.md` — the minimum restatement in the severity-gating paragraph
- the four template twins

## Why

The scale was defined as exactly P0/P1/P2, but Codex **cloud** review is not driven by that prompt and posted a **P3** badge on #918 (2026-08-16) — a real finding (newline-filename parsing), fixed in `ac682df`. Nothing broke, because the shepherd checker treats any P-badge as a finding, but the scale and reality disagreed, and two consumers read the scale: humans adjudicating against `AGENTS.md`, and any tooling matching specific badge values.

Per the issue, this takes **option 2** (extend the scale) rather than option 1 (clamp P3 → P2).

## Where the normative text lives, and why

The full definition is in `scripts/codex-review.sh`'s prompt, not in `AGENTS.md`. `AGENTS.md` is 61 KiB and Codex reads 32 KiB by default, and the severity-gating paragraph sits around line 799 of ~1000 — well past the cut. Text added there may never reach the reviewer it configures. `AGENTS.md` therefore gains **+203 bytes**: P3 in the label list, and one clause carrying the off-scale invariant. That also keeps this change compatible with #924, which asks to *streamline* that very section.

## What this does and does not change

This aligns the documented contract with observed reality. It does **not** change what cloud review emits — cloud review runs on its own instructions, so it will keep badging as it likes regardless of this prompt.

## Verification

- `task check` — green
- `task test:codex-review` — green (38 cases)
- `task test:dogfood-parity` — green (132 verbatim twins identical; all four template twins byte-verified with `diff`)
- `task test:dogfood-structure` — green (223 sections)
- `task verify` — green
- size advisory: `AGENTS.md is 61223 bytes; Codex reads 32 KiB by default` — advisory, non-blocking, +203 bytes

rigor: standard (config default) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1

Challenge converged at round 2 of 3 (two consecutive rounds adjudicated to zero P0/P1). Three findings, all adjudicated and all resolved:

| # | Finding | Reviewer | Adjudicated | Disposition |
|---|---|---|---|---|
| 1 | Cloud checker cannot settle a P3 | P1 | P2 | Real but not introduced here; filed upstream, guide caveat added |
| 2 | P3 band contradicted the no-style-nits rule | P2 | P2 | Fixed — P3 re-scoped, prohibition restated as binding |
| 3 | Guide advertised an unavailable settlement path | P2 | P2 | Fixed — round 1's own text corrected |

Finding 3 was caught by the round-2 provenance checkpoint: its subject existed only because round 1's fix created it. Round 1 had said to "settle a cloud P3 by hand", which policy forbids — `settle` is helper-only and a PR comment is not a disposition the checker can read. Deletion was weighed and rejected (without the caveat the guide still implies the checker honors the invariant, which was finding 1 and remains true), so it was corrected in place: a standalone cloud P3 has **no** settlement path, and is a blocker to report rather than something to wave through.

## Deferred findings

None — every P2 raised was fixed in place rather than deferred.

## Follow-up filed

**evanharmon1/harmon-devkit#530** — the pinned shepherd checker matches severities as `p[0-2]` in three places (`has_severity_marker` at l.511, both `settle` fingerprint counters at l.2030/2032), so a cloud P3 fails in **both** directions: posted as its own comment it classifies as findings that `settle` refuses to record a disposition for (deadlock), and appended to a clean verdict it lands in the documented residual and passes (false clean). That gap predates this change and exists whether or not any repo defines P3 — but it means the P3 scale is not fully coherent until the checker is fixed upstream and re-pinned here.

Closes #923


<details>
<summary>Adjudication ledger (challenge 2 rounds, review 2 rounds)</summary>

```text
challenge r1 | 1 finding
  #1 docs/guides/codex-review.md:369-371 "Teach the cloud checker to settle P3 findings"
     reviewer P1 | adjudicated P2 | confirmed-but-not-introduced-here
     evidence: check-codex-cloud-review.sh l.511 has_severity_marker=\bp[0-2]\b;
               l.2003 settle dies on no-P0/P1/P2 badge; l.1441-1443 verdict_class
               routes a non-verdict-opening body to `findings`. Both directions
               confirmed: own-comment P3 -> findings + unsettleable (deadlock);
               appended-to-clean P3 -> residual pass (false clean).
     not introduced by this change: cloud review is not driven by scripts/codex-review.sh's
               prompt; the observed P3 on #918 (2026-08-16) predates this branch.
               Filed upstream as evanharmon1/harmon-devkit#530 (+ correction comment
               adding the deadlock direction I had omitted).
     action: guide gains an explicit "adjudication guidance, not a tooling contract"
             caveat naming both directions and pointing at devkit#530; twin re-synced
             byte-identical. Upstream fix + pin bump tracked there, not here.
challenge r2 | 2 findings, both P2/P2 -> zero adjudicated P0/P1
  #2 scripts/codex-review.sh:448-450 "Reconcile P3 reporting with the no-style-nits rule"
     reviewer P2 | adjudicated P2 | CONFIRMED, introduced by this change
     new in this stage? NO - subject is the original change (r0), not scaffolding.
     evidence: both prompt modes prohibit "style nits" (l.414-426) while the new
               P3 band named "wording, naming, formatting" - i.e. exactly nits.
               Genuinely mutually exclusive instructions.
     action: FIXED IN PLACE. P3 re-scoped to misleading naming/wording and
             defect-free observations, with the no-style-nits rule restated as
             still binding. P2 does not gate; fixed because it is our own defect
             and cheap.
  #3 docs/guides/codex-review.md:382-383 "Do not advertise an unavailable P3 settlement path"
     reviewer P2 | adjudicated P2 | CONFIRMED
     new in this stage? YES - subject exists ONLY because challenge r1's fix added it.
     PROVENANCE CHECKPOINT (damper 3) disposition: IN SCOPE, corrected in place.
       Not deletion: without the caveat the guide implies the checker honours the
       invariant, which is the r1 finding and still true. Not restructure: the
       problem was a wrong instruction, not attackable procedure-prose.
       My r1 text said "settle a cloud P3 by hand", which AGENTS.md forbids -
       settle is helper-only and a PR comment is not a disposition the checker
       reads. Corrected to: no settlement path exists; treat as a blocker,
       report and leave the PR draft.
  EXIT: r1 and r2 both adjudicated to zero P0/P1 -> two-consecutive -> CHALLENGE CONVERGED (2 of cap 3)
review r1 | 1 finding, P2/P2 -> zero adjudicated P0/P1 (clean round 1 of 2)
  #4 docs/guides/codex-review.md:359 "Align the guide's P3 row with the no-style-nits rule"
     reviewer P2 | adjudicated P2 | CONFIRMED
     new in this stage? n/a (review r1) - but subject IS challenge r2's fix:
       that fix changed the PROMPT's P3 wording and left the GUIDE's table row
       with the original "wording, naming, formatting" text. An incomplete fix,
       not new scaffolding. Same stale text shipped in the template twin.
     action: FIXED IN PLACE. Guide row now matches the prompt verbatim in intent
             (misleading naming/wording + defect-free observations, no-style-nits
             still binding); twin re-synced byte-identical.
review r2 | no findings | exit: empty-round (min_rounds 1 met) + two-consecutive. REVIEW CONVERGED (2 of cap 3)
```

</details>
