### PR TITLE
fix: execute the rendered label-registry gate in the render matrix

### DIFF
--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -388,6 +388,58 @@ if [ -f .github/workflows/build.yml ]; then
         err "required CI does not run test:worktree"
 fi
 
+# ── 1a-ter. Every profile RUNS its docs-presence gate, not just proves
+#            it's wired ──────────────────────────────────────────────
+# harmon-init#883 AC-2: the reachability checks above only prove a target is
+# reachable from `task verify` via a `--dry` grep — never that it PASSES.
+# That gap is exactly how #873 shipped: test:label-registry's docs-presence
+# check misfired on every linear-profile render (it assumed
+# docs/project-management.md always carries the GitHub taxonomy markers,
+# which the Linear variant never renders), and the render matrix plus five
+# local CI mirrors stayed green because nothing here ever EXECUTED the gate
+# against a rendered repo — only cloud review caught it.
+#
+# Reachability and execution catch different regressions, so keep both: the
+# `--dry` grep proves `verify` calls the target, the run proves the target
+# passes. There was no reachability grep for test:label-registry either, so
+# this adds one.
+#
+# Unconditional, like every sibling check in this section:
+# scripts/test-label-registry.sh and the `test:label-registry` task render in
+# every profile with no copier conditional, so there is nothing to gate on.
+# The `meta` profile is what makes this catch #873 specifically — it is the
+# only one rendering project_management=linear — but a github-variant
+# regression is worth catching just as much, and running everywhere is cheap
+# (measured under 1s: `time` on the dry-run grep plus the execution, against
+# a real --skip-tasks render).
+#
+# Deliberately NOT the whole of `task verify`. Measured directly (`time task
+# --color=false verify`) against a real --skip-tasks meta render: 2:45
+# (165.73s) wall-clock, offline, with no `task install` run. Every other
+# target in a full `verify` (lint:*, test:hooks, test:statusline,
+# test:session-cleanup, test:codex-review, etc.) is profile-INDEPENDENT — it
+# would pass or fail identically whatever project_management renders — so
+# running it here would quietly make this script the template's only
+# end-to-end regression suite for code unrelated to #883, roughly doubling
+# each profile's runtime for coverage the issue never asked for.
+# test:label-registry is the opposite: its PASS/FAIL depends on the rendered
+# project-management variant, and it needs only node+jq+python3 against
+# already-rendered JSON/Markdown (no `task install`, no git history beyond
+# `git init`, no network).
+if have task; then
+    verify_dry="$(task --color=false --dry verify 2>&1 || true)"
+    grep -qF './scripts/test-label-registry.sh' <<<"$verify_dry" ||
+        err "task verify does not reach test:label-registry"
+    task --color=false test:label-registry >/dev/null 2>&1 ||
+        err "task test:label-registry fails in the rendered repo (the #873/#883 class of regression: a docs-presence check misfiring on the rendered project_management variant)"
+else
+    required task "label-registry verify reachability + execution" || fail=1
+fi
+if [ -f .github/workflows/build.yml ]; then
+    grep -qF 'task test:label-registry' .github/workflows/build.yml ||
+        err "required CI does not run test:label-registry"
+fi
+
 # ── 1b. Free security policy renders as a coherent stack ───────────
 [ -x scripts/run-semgrep.sh ] || err "pinned Semgrep CE runner missing or not executable"
 grep -q 'brew "uv"' Brewfile || err "Brewfile must install uv for the Semgrep runner"


### PR DESCRIPTION
## What

The render matrix now **executes** the rendered repo's `test:label-registry`
gate, on every profile, instead of only proving it is reachable from `task
verify`.

Adds three things to `scripts/test-template.sh`, unconditionally:

- a `--dry` reachability grep for `test:label-registry` (it had none at all),
- an end-to-end run of the gate inside the rendered repo,
- a check that required CI runs it.

## Why

Every `verify` reference in this script was a `task --color=false --dry verify`
**reachability grep** (lines 276, 297, 330, 356, 2085). That proves a target is
wired into `verify`; it never proves the target passes. Only four targets were
ever actually run in a render (`test:registry-docs`, `test:worktree`,
`lint:hygiene`, `test:tasks`).

That is exactly how #873 shipped: `test:label-registry`'s docs-presence check
misfired on **every** linear-profile render (it assumed
`docs/project-management.md` carries the GitHub taxonomy markers, which the
Linear variant never renders). The full matrix and five local CI-mirror runs
stayed green because nothing executed the gate against a rendered repo — only
cloud review caught it.

Reachability and execution catch different regressions, so both are kept. The
existing `--dry` greps are untouched.

## The issue's premise is stale — AC-1 needed no work

Recorded here because the issue text will mislead the next reader:

- **AC-1 is already satisfied.** "renders no profile with `project_management:
  linear`" has not been true since #182. The **meta** profile sets `--data
  project_management=linear` (`scripts/test-template.sh:175`), with
  linear-specific assertions at lines 944-949 (Linear doc present, titled
  `# Linear`, TODO marker, GitHub-only PM scripts absent).
- **The issue's own Verify recipe resolves the opposite way.** `grep -n "linear"
  scripts/test-template.sh | head` *does* hit, so "no profile hits means the gap
  stands" reads backwards.
- **AC-2 was the live gap**, and this PR closes it.

## Why unconditional, and why not the whole of `verify`

**Unconditional** because `scripts/test-label-registry.sh` and the
`test:label-registry` task render in every profile with no copier conditional —
there is nothing to gate on, and every sibling check in that section is
unconditional too. `meta` is what makes this catch #873 specifically (it is the
only profile rendering linear), but a github-variant regression is worth catching
just as much. Measured under 1s per profile.

**Not the whole of `verify`**, even though a full run was measured to pass
offline in a real `--skip-tasks` meta render (`time task --color=false verify` →
**165.73s**, no network, no `task install`). Every other target in `verify`
(`lint:*`, `test:hooks`, `test:statusline`, `test:session-cleanup`,
`test:codex-review`, …) is profile-**independent** — it would pass or fail
identically whatever `project_management` renders. Running it here would quietly
make this script the template's only end-to-end regression suite for code
unrelated to #883, roughly doubling each profile's runtime for coverage the issue
never asked for. `test:label-registry` is the opposite: its result depends on the
rendered project-management variant, and it needs only node+jq+python3 against
already-rendered JSON/Markdown.

## Verification

- `task verify` — **GREEN**, all 7 render profiles. This is what proves the
  unconditional block passes on every profile, not just `meta`.
- `task ci` — **GREEN** (Semgrep 89 rules / 281 files, 0 findings; gitleaks
  clean).
- `shellcheck --severity=error` + `shfmt -d` — clean.
- `task test:dogfood-parity` (132 verbatim twins) and `task
  test:dogfood-structure` (223 sections/tasks) — confirm
  `scripts/test-template.sh` is root-only with no `template/` twin.

**Mutation test — the guard has been watched fail.** Reverted
`template/scripts/test-label-registry.sh`'s tracker-aware skip to the naive
presence-only check that #873 shipped (the fault reproduces the real one), then
ran `./scripts/test-template.sh meta`: **FAILED, exit 1**, with

```
FAIL: task test:label-registry fails in the rendered repo (the #873/#883 class
of regression: a docs-presence check misfiring on project_management=linear)
```

Restored from a `cp` backup (never `git checkout`) and confirmed byte-identical.

## Review

rigor: `standard` (`default_rigor`; no `rigor:*` label on #883) → challenge ≤3,
review ≤3, shepherd 4, min_rounds 1. tier `standard`, method `plan` — both
defaults, no off-default resolution to disclose.

**Challenge stage — converged at round 1.** Round 1 returned **no findings at
all**, which ends the stage on its own once `min_rounds` (1) has run. Codex's
summary: *"No P0 or P1 findings. The added check executes the rendered
label-registry gate for every profile while preserving existing
tool-availability and CI wiring behavior."*

**Review stage — converged at round 1**, counted separately from challenge.
Round 1 also returned no findings: *"No P0 or P1 findings. The change executes
the rendered label-registry gate for every profile while separately verifying
Taskfile and CI reachability, and the Linear meta-profile path passed the new
check."*

One change was made after the implementer's work and before review, by the
session rather than by a reviewer: the block was originally gated on `if [
"$profile" = "meta" ]`. That was wrong for two of its three checks — the `--dry`
reachability grep and the "required CI runs it" grep are not linear-specific, and
gating them meant 6 of 7 profiles never verified `test:label-registry` was wired
into `verify` or CI at all. Lifting the gate is what the full-matrix `verify` run
above then proved safe.

## Deferred findings

None. Neither stage produced a P2 to carry forward.

Closes #883
