### PR TITLE
fix: pin and preinstall copier, and fail loudly when it is missing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,15 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Dogfood structure (template sections/tasks exist in the root layer)
         run: task test:dogfood-structure
+      # Listed here for the same reason as the category/parity guards above:
+      # this job enumerates its steps by hand, so a check that lives only in
+      # `verify` never runs in CI. It renders the template, so it has to follow
+      # the copier install. It carries the copier pin-agreement gate, whose
+      # whole purpose is to catch a Renovate bump that moves one pin and not
+      # the other — precisely the case that arrives as a PR and must not pass
+      # required checks while drifted (#921).
+      - name: Copier answer validators (+ copier version pin agreement)
+        run: task test:copier-validators
       - name: Skills drift check (vendored skills vs pinned harmon-devkit ref)
         run: task verify:skills
       - run: task test:hooks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,13 +87,7 @@ jobs:
           # overwrites a foreign same-named entry point (e.g. a stale pipx shim)
           # instead of aborting, keeping reruns idempotent on a persistent
           # self-hosted CI_RUNS_ON runner.
-          # Pinned to the same release the devcontainer image bakes in and
-          # scripts/install-copier.sh installs, so the gate exercises the
-          # copier the fleet actually runs rather than whatever is latest that
-          # day. scripts/test-copier-validators.sh fails if the three drift.
-          # renovate: datasource=pypi depName=copier
-          COPIER_VERSION=9.17.1
-          uv tool install --force "copier==${COPIER_VERSION}"
+          uv tool install --force copier
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Dogfood structure (template sections/tasks exist in the root layer)
         run: task test:dogfood-structure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,13 @@ jobs:
           # overwrites a foreign same-named entry point (e.g. a stale pipx shim)
           # instead of aborting, keeping reruns idempotent on a persistent
           # self-hosted CI_RUNS_ON runner.
-          uv tool install --force copier
+          # Pinned to the same release the devcontainer image bakes in and
+          # scripts/install-copier.sh installs, so the gate exercises the
+          # copier the fleet actually runs rather than whatever is latest that
+          # day. scripts/test-copier-validators.sh fails if the three drift.
+          # renovate: datasource=pypi depName=copier
+          COPIER_VERSION=9.17.1
+          uv tool install --force "copier==${COPIER_VERSION}"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Dogfood structure (template sections/tasks exist in the root layer)
         run: task test:dogfood-structure

--- a/images/devcontainer/Dockerfile
+++ b/images/devcontainer/Dockerfile
@@ -45,6 +45,8 @@ ARG HERDR_VERSION=0.8.0
 ARG DMUX_VERSION=5.10.0
 # renovate: datasource=pypi depName=semgrep
 ARG SEMGREP_VERSION=1.172.0
+# renovate: datasource=pypi depName=copier
+ARG COPIER_VERSION=9.17.1
 # renovate: datasource=npm depName=@playwright/test
 ARG PLAYWRIGHT_VERSION=1.62.1
 # renovate: datasource=npm depName=@playwright/cli
@@ -355,8 +357,14 @@ RUN npm install -g \
     && npm cache clean --force
 
 RUN uv pip install --system --break-system-packages --no-cache toml aiogram
-RUN UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/opt/uv-tools \
-    uv tool install "semgrep==${SEMGREP_VERSION}" \
+# `export` rather than a command-prefix assignment: a `VAR=x cmd1 && cmd2`
+# prefix applies to cmd1 ONLY, so every tool after the first would silently
+# install under root's ~/.local instead of the system paths — invisible to the
+# `vscode` runtime user. Exporting covers the whole chain and keeps the next
+# tool added here correct by default.
+RUN export UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/opt/uv-tools \
+    && uv tool install "semgrep==${SEMGREP_VERSION}" \
+    && uv tool install "copier==${COPIER_VERSION}" \
     && rm -rf /root/.cache/uv
 
 # Keep frequently updated agent CLIs in the final expensive-tool layer.
@@ -410,6 +418,7 @@ RUN chmod 0755 \
         "herdr=${HERDR_VERSION}" \
         "dmux=${DMUX_VERSION}" \
         "semgrep=${SEMGREP_VERSION}" \
+        "copier=${COPIER_VERSION}" \
         "playwright=${PLAYWRIGHT_VERSION}" \
         "playwright-cli=${PLAYWRIGHT_CLI_VERSION}" \
         "sops=${SOPS_VERSION}" \

--- a/images/devcontainer/smoke.sh
+++ b/images/devcontainer/smoke.sh
@@ -25,7 +25,7 @@ if [ -n "${EXPECTED_ARCHITECTURE:-}" ]; then
         fail "manifest architecture does not match $EXPECTED_ARCHITECTURE"
 fi
 
-for tool in task shfmt hadolint actionlint terraform-docs yq lefthook gitleaks sops act uv semgrep \
+for tool in task shfmt hadolint actionlint terraform-docs yq lefthook gitleaks sops act uv semgrep copier \
     claude codex gemini agy agent-deck playwright playwright-cli zellij workmux aoe sesh herdr dmux starship \
     dive fx glow lazygit tokei xh gum gh-dash wtfutil lychee tv; do
     command -v "$tool" >/dev/null 2>&1 || fail "$tool is not on PATH"
@@ -53,6 +53,7 @@ run_version sops sops --version
 run_version act act --version
 run_version uv uv --version
 run_version semgrep semgrep --help
+run_version copier copier --version
 run_version claude claude --version
 run_version codex codex --version
 run_version gemini gemini --version

--- a/scripts/install-copier.sh
+++ b/scripts/install-copier.sh
@@ -14,10 +14,18 @@
 #
 # --force overwrites any foreign same-named entry point (e.g. a stale pipx shim)
 # instead of aborting, and keeps reruns idempotent.
+#
+# Pinned to the same version images/devcontainer/Dockerfile installs, so a
+# brew-less host (this repo's devcontainer, or a bare Linux box) lands on the
+# identical, tested copier release rather than whatever uv resolves that day.
+# scripts/test-copier-validators.sh cross-checks that the two pins agree.
 set -euo pipefail
+
+# renovate: datasource=pypi depName=copier
+COPIER_VERSION=9.17.1
 
 if command -v brew >/dev/null 2>&1; then
     exit 0
 fi
 
-uv tool install --force copier
+uv tool install --force "copier==${COPIER_VERSION}"

--- a/scripts/test-copier-validators.sh
+++ b/scripts/test-copier-validators.sh
@@ -18,6 +18,17 @@ set -euo pipefail
 repo="$(git rev-parse --show-toplevel)"
 cd "$repo"
 
+# copier itself is not optional here: this script IS one of the primary
+# template-render gates, so a local skip would report `task verify` green
+# while validating nothing. copier is now preinstalled in the devcontainer
+# image and installed by `task install` on every other host
+# (scripts/install-copier.sh), so there is no supported environment where it
+# is legitimately absent — fail loudly instead of silently skipping. See #921.
+if ! command -v copier >/dev/null 2>&1; then
+    echo "FAIL: copier not found — run 'task install' (or: uv tool install copier)" >&2
+    exit 1
+fi
+
 work="$(mktemp -d -t harmon-init-validators-XXXXXX)"
 trap 'rm -rf "$work"' EXIT
 
@@ -83,6 +94,44 @@ else
     fail "rejected a valid path containing a space"
     sed 's/^/      /' "$work/render.log" >&2
     hint_stale_worktree
+fi
+
+# copier is installed from three places that cannot see each other: the shared
+# devcontainer image (images/devcontainer/Dockerfile, baked in), the CI lint
+# job (.github/workflows/build.yml, which cannot use install-copier.sh because
+# GitHub's ubuntu images ship linuxbrew and that script no-ops under brew), and
+# scripts/install-copier.sh (`task install` on every other brew-less host).
+# Renovate bumps each independently, so nothing else catches them drifting
+# apart — and a CI pin that lags the image pin is the worst case, because the
+# gate would then green-light a copier the fleet never runs. This check lives
+# here (root-only, no template/ twin) rather than in scripts/test-tasks.sh,
+# which IS a byte-identical twin shipped to generated repos that have none of
+# these files. See #921.
+echo "==> copier version pins agree across the image, CI, and install-copier.sh"
+pin_from() {
+    # $1 = file, $2 = ERE capturing the whole `NAME=<version>` assignment.
+    # `|| true` on the pipeline so a no-match returns EMPTY rather than killing
+    # the script: under `set -euo pipefail` a failing grep inside a command
+    # substitution aborts silently, with a non-zero exit and no diagnostic —
+    # fail-closed, but unexplained. Emptiness is the signal the explicit
+    # `[ -n ... ] || fail` checks below turn into a named failure. grep's own
+    # stderr is deliberately NOT redirected, so a missing file still says so.
+    grep -oE "$2" "$1" | head -n1 | cut -d= -f2 | tr -d '"' || true
+}
+image_pin="$(pin_from "$repo/images/devcontainer/Dockerfile" '^ARG COPIER_VERSION=[^[:space:]]+')"
+ci_pin="$(pin_from "$repo/.github/workflows/build.yml" 'COPIER_VERSION=[^[:space:]"]+')"
+install_pin="$(pin_from "$repo/scripts/install-copier.sh" '^COPIER_VERSION=[^[:space:]]+')"
+
+[ -n "$image_pin" ] || fail "images/devcontainer/Dockerfile: no 'ARG COPIER_VERSION=' found"
+[ -n "$ci_pin" ] || fail ".github/workflows/build.yml: no 'COPIER_VERSION=' found"
+[ -n "$install_pin" ] || fail "scripts/install-copier.sh: no 'COPIER_VERSION=' found"
+
+if [ -n "$image_pin" ] && [ -n "$ci_pin" ] && [ -n "$install_pin" ]; then
+    if [ "$image_pin" != "$ci_pin" ] || [ "$image_pin" != "$install_pin" ]; then
+        fail "copier version pins disagree: image=${image_pin}, ci=${ci_pin}, install-copier.sh=${install_pin}"
+    else
+        echo "  ok — all three pin ${image_pin}"
+    fi
 fi
 
 if [ "$failures" -gt 0 ]; then

--- a/scripts/test-copier-validators.sh
+++ b/scripts/test-copier-validators.sh
@@ -105,11 +105,13 @@ fi
 # "Devcontainer" group (images/devcontainer/** and scripts/**), so a release
 # bumps both in ONE PR and this check passes or fails as a unit.
 #
-# Scope note: CI installs copier unpinned, here and in the template-test
-# matrix, and this guard is not wired into required CI (`test:copier-validators`
-# is in local `task verify` only). Both are deliberate — pinning every copier
-# execution across the CI workflows, and binding verify's target list to the
-# workflow's, are their own units of work. See the follow-up issue and #962.
+# This runs in required CI too (build.yml's lint job lists it explicitly, after
+# the copier install) — a guard that only runs locally would miss the case it
+# exists for: a Renovate bump that moves one pin and not the other arrives as a
+# PR. Scope note: CI still installs copier UNPINNED, here and in the
+# template-test matrix, so the version CI renders with is not the pinned one.
+# Pinning every copier execution across the workflows is its own unit of work
+# (#966), as is binding verify's target list to the workflow's (#962).
 #
 # This check lives here (root-only, no template/ twin) rather than in
 # scripts/test-tasks.sh, which IS a byte-identical twin shipped to generated

--- a/scripts/test-copier-validators.sh
+++ b/scripts/test-copier-validators.sh
@@ -25,7 +25,14 @@ cd "$repo"
 # (scripts/install-copier.sh), so there is no supported environment where it
 # is legitimately absent — fail loudly instead of silently skipping. See #921.
 if ! command -v copier >/dev/null 2>&1; then
-    echo "FAIL: copier not found — run 'task install' (or: uv tool install copier)" >&2
+    # `task install` is the only remedy correct on every host: it installs the
+    # Brewfile's copier under Homebrew and the pinned uv one otherwise
+    # (scripts/install-copier.sh no-ops under brew by design, so naming it
+    # directly would silently do nothing on a Mac). Deliberately NOT a bare
+    # `uv tool install copier`: that resolves to whatever is latest, so
+    # following the advice would satisfy this check and then run the render
+    # gates on an unreviewed version, defeating the pin this repo just added.
+    echo "FAIL: copier not found — run 'task install'" >&2
     exit 1
 fi
 

--- a/scripts/test-copier-validators.sh
+++ b/scripts/test-copier-validators.sh
@@ -96,18 +96,25 @@ else
     hint_stale_worktree
 fi
 
-# copier is installed from three places that cannot see each other: the shared
-# devcontainer image (images/devcontainer/Dockerfile, baked in), the CI lint
-# job (.github/workflows/build.yml, which cannot use install-copier.sh because
-# GitHub's ubuntu images ship linuxbrew and that script no-ops under brew), and
+# copier is installed from two places that cannot see each other: the shared
+# devcontainer image (images/devcontainer/Dockerfile, baked in) and
 # scripts/install-copier.sh (`task install` on every other brew-less host).
 # Renovate bumps each independently, so nothing else catches them drifting
-# apart — and a CI pin that lags the image pin is the worst case, because the
-# gate would then green-light a copier the fleet never runs. This check lives
-# here (root-only, no template/ twin) rather than in scripts/test-tasks.sh,
-# which IS a byte-identical twin shipped to generated repos that have none of
-# these files. See #921.
-echo "==> copier version pins agree across the image, CI, and install-copier.sh"
+# apart — a stale image pin would silently ship every devcontainer an older
+# copier than every other host installs. Both files sit in Renovate's
+# "Devcontainer" group (images/devcontainer/** and scripts/**), so a release
+# bumps both in ONE PR and this check passes or fails as a unit.
+#
+# Scope note: CI installs copier unpinned, here and in the template-test
+# matrix, and this guard is not wired into required CI (`test:copier-validators`
+# is in local `task verify` only). Both are deliberate — pinning every copier
+# execution across the CI workflows, and binding verify's target list to the
+# workflow's, are their own units of work. See the follow-up issue and #962.
+#
+# This check lives here (root-only, no template/ twin) rather than in
+# scripts/test-tasks.sh, which IS a byte-identical twin shipped to generated
+# repos that have neither file. See #921.
+echo "==> copier version pins agree between the devcontainer image and install-copier.sh"
 pin_from() {
     # $1 = file, $2 = ERE capturing the whole `NAME=<version>` assignment.
     # `|| true` on the pipeline so a no-match returns EMPTY rather than killing
@@ -119,18 +126,16 @@ pin_from() {
     grep -oE "$2" "$1" | head -n1 | cut -d= -f2 | tr -d '"' || true
 }
 image_pin="$(pin_from "$repo/images/devcontainer/Dockerfile" '^ARG COPIER_VERSION=[^[:space:]]+')"
-ci_pin="$(pin_from "$repo/.github/workflows/build.yml" 'COPIER_VERSION=[^[:space:]"]+')"
 install_pin="$(pin_from "$repo/scripts/install-copier.sh" '^COPIER_VERSION=[^[:space:]]+')"
 
 [ -n "$image_pin" ] || fail "images/devcontainer/Dockerfile: no 'ARG COPIER_VERSION=' found"
-[ -n "$ci_pin" ] || fail ".github/workflows/build.yml: no 'COPIER_VERSION=' found"
 [ -n "$install_pin" ] || fail "scripts/install-copier.sh: no 'COPIER_VERSION=' found"
 
-if [ -n "$image_pin" ] && [ -n "$ci_pin" ] && [ -n "$install_pin" ]; then
-    if [ "$image_pin" != "$ci_pin" ] || [ "$image_pin" != "$install_pin" ]; then
-        fail "copier version pins disagree: image=${image_pin}, ci=${ci_pin}, install-copier.sh=${install_pin}"
+if [ -n "$image_pin" ] && [ -n "$install_pin" ]; then
+    if [ "$image_pin" != "$install_pin" ]; then
+        fail "copier version pins disagree: image=${image_pin}, install-copier.sh=${install_pin}"
     else
-        echo "  ok — all three pin ${image_pin}"
+        echo "  ok — both pin ${image_pin}"
     fi
 fi
 

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -93,7 +93,14 @@ err() {
 # environment where it is legitimately absent — fail loudly instead of
 # silently skipping the thing the rest of this script depends on. See #921.
 if ! have copier; then
-    echo "FAIL: copier not found — run 'task install' (or: uv tool install copier)" >&2
+    # `task install` is the only remedy correct on every host: it installs the
+    # Brewfile's copier under Homebrew and the pinned uv one otherwise
+    # (scripts/install-copier.sh no-ops under brew by design, so naming it
+    # directly would silently do nothing on a Mac). Deliberately NOT a bare
+    # `uv tool install copier`: that resolves to whatever is latest, so
+    # following the advice would satisfy this check and then run the render
+    # gates on an unreviewed version, defeating the pin this repo just added.
+    echo "FAIL: copier not found — run 'task install'" >&2
     exit 1
 fi
 

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -85,6 +85,18 @@ err() {
     fail=1
 }
 
+# copier itself is not optional here, unlike the tools gated behind
+# required() above: this script IS the template-render gate, so a local skip
+# would report `task verify` green while rendering nothing. copier is now
+# preinstalled in the devcontainer image and installed by `task install` on
+# every other host (scripts/install-copier.sh), so there is no supported
+# environment where it is legitimately absent — fail loudly instead of
+# silently skipping the thing the rest of this script depends on. See #921.
+if ! have copier; then
+    echo "FAIL: copier not found — run 'task install' (or: uv tool install copier)" >&2
+    exit 1
+fi
+
 # Answers shared by every profile. Side-effectful answers are forced off so
 # this is safe to run anywhere (no gh repo create, no iCloud moves). The meta
 # profile re-enables bunch/obsidian but renders with --skip-tasks.


### PR DESCRIPTION
## What

A fresh devcontainer had **no copier at all**, and the install that did exist was
unpinned. Both halves are fixed, per the maintainer's decision to do both:

- **Preinstall, pinned.** `images/devcontainer/Dockerfile` pins
  `COPIER_VERSION=9.17.1` (Renovate, `datasource=pypi`) and bakes copier into the
  shared image beside semgrep, recorded in the image manifest and asserted by
  `smoke.sh`. `scripts/install-copier.sh` pins the same release for brew-less
  hosts.
- **Fail loudly.** `scripts/test-copier-validators.sh` and
  `scripts/test-template.sh` — the two primary render gates — now fail with
  `copier not found — run 'task install'` instead of a bare
  `copier: command not found`.
- **Drift gated.** The two pins must agree, checked in `task verify` **and** in
  required CI.

## Delivery is two-step — worth knowing before merging

Merging this does **not** put copier in the root devcontainer. It changes the
shared image *source*; `publish-harmon-devcontainer.yml` builds a candidate on
this PR (no registry creds), publishes on push to `main`, and then opens the
rolling pin-bump PR. copier reaches devcontainers when **that** PR merges. That
is the designed mechanism, not a gap — but it means #921's first acceptance
criterion completes in two merges, so I have not ticked it.

## Premise check

The issue is partly stale: `scripts/install-copier.sh` already existed and
already ran from `task install`. What was still true, and is what this fixes:
`post-create.sh` never runs `task install`, so a fresh container had nothing; the
install was unpinned (AC-2 unmet); and 2 of the 5 copier-invoking scripts had no
guard at all.

## Verification

- `task verify` — **GREEN** (7 render profiles), on the tree with `origin/main`
  merged in.
- `task ci` — **GREEN**.
- `shellcheck --severity=error`, `shfmt -d`, `hadolint`, `actionlint`, `yamllint`
  — clean.
- `task test:dogfood-parity` (132 twins) / `test:dogfood-structure` (223) — the
  touched files are root-only, no `template/` twins. Nothing in this PR's diff is
  under `template/`.

**Mutations — every new guard has been watched fail:**

| Mutation | Observed |
|---|---|
| copier hidden from `PATH` | both gates exit 1 with `copier not found — run 'task install'` |
| image pin ≠ installer pin | `FAIL — copier version pins disagree: image=9.16.0, install-copier.sh=9.17.1` |
| `ARG COPIER_VERSION` deleted | `FAIL — images/devcontainer/Dockerfile: no 'ARG COPIER_VERSION=' found` |
| the `RUN` env-scope bug (below) | `uv` stub showed the 2nd install receiving empty `UV_TOOL_BIN_DIR`/`UV_TOOL_DIR`; after the fix both receive the system paths |

All restores used `cp` backups and were confirmed byte-identical.

## Review

rigor: `standard` (`default_rigor`; no `rigor:*` label on #921) → challenge ≤3,
review ≤3, shepherd 4, min_rounds 1. tier `standard`, method `plan` — both
defaults.

**Deviation from the config, disclosed:** the challenge stage ran **4** rounds,
one more than `standard` allows. Round 3 was the capped final round and returned
a confirmed P1; I fixed it but the cap forbade the confirming round, so I stopped
and asked. @evanharmon1 granted round 4 in-session — an explicit human
instruction, which outranks the config. Round 4 came back empty.

### Challenge stage

**Round 1** — 1 P0, 1 P2:

| Finding | Reviewer | Adjudicated | Evidence / action |
|---|---|---|---|
| copier installs outside the system tool dirs — the `VAR=x cmd1 && cmd2` prefix applies to `cmd1` only | P0 | **P0 confirmed** | Reproduced independently with a `uv` stub: the copier install received empty `UV_TOOL_BIN_DIR`/`UV_TOOL_DIR`, so it would land in root's `~/.local`, invisible to the `vscode` runtime user, failing the new smoke check. **Fixed** — the layer now `export`s both, covering the whole chain and keeping the next tool added correct by default |
| pin check compares source text, not the pinned binary | P2 | **split** | *Remedy declined*: asserting the **active** binary matches the pin would fail on every macOS box, since Homebrew's `copier` is deliberately unpinned (this checkout runs 9.16.0). *Underlying defect confirmed*: CI installed copier unpinned, so the pin protected nothing — addressed in round 1, then reconsidered in round 2 (below) |

**Round 2** — 3 P1. **Scaffolding checkpoint: all three findings' subjects existed
only because round 1 added them.** Disposition: delete the scaffolding rather than
harden it.

| Finding | Reviewer | Adjudicated | Provenance | Action |
|---|---|---|---|---|
| pin *every* copier execution used by CI | P1 | **P1 confirmed** | round-1 scaffolding | `pipx install copier` at `build.yml:157` (the primary render gate) is unpinned, as are sync/publish. Round 1 pinned only the lint job — a partial claim. **Descoped**: CI pin reverted, `build.yml` restored byte-identical to `main`. Filed **#966** |
| Renovate splits the pins across update groups | P1 | **P1 confirmed** | round-1 scaffolding | `.github/workflows/**` → *GitHub Actions* group; `images/devcontainer/**` + `scripts/**` → *Devcontainer*. No single Renovate PR could satisfy a cross-group agreement guard. **Mooted by the revert** — the two survivors share one group and move together |
| the pin guard never executes in required CI | P1 | **P1 confirmed** | pre-existing, surfaced by round 1 | Deferred here to #962/#966 — then re-raised in round 3 and fixed; see below |

**Round 3 (capped final round)** — 1 P1:

| Finding | Reviewer | Adjudicated | Evidence / action |
|---|---|---|---|
| add the pin-agreement guard to required CI | P1 | **P1 confirmed** | Verified pre-existing: `test:copier-validators` is in `verify` and absent from `build.yml` on `main` too. But the *pin it protects* is new, so without the CI step the guard would never fire on the Renovate bump it exists for. Rather than argue it down to P2 and exit at the cap, **fixed**: the step is listed in `build.yml`'s lint job after the copier install. That file already warns about exactly this drift (#614) |

**Round 4 (granted)** — **no findings**. Stage converged. Codex: *"No P0 or P1
findings were identified… The pin agreement is enforced in required CI, and the
image and shell changes preserve runtime visibility and portability."*

### Review stage (counted separately)

**Round 1** — 1 P2, zero P0/P1:

| Finding | Reviewer | Adjudicated | Evidence / action |
|---|---|---|---|
| the advertised recovery command is unpinned | P2 | **P2 confirmed → fixed in place** | The message said `uv tool install copier`, which resolves to latest — following it would satisfy the availability check and then run the render gates on an unreviewed version, defeating the pin. Now `run 'task install'`, the only remedy correct on every host. `scripts/install-copier.sh` is deliberately **not** advertised: it no-ops under brew by design, so naming it would silently do nothing on a Mac |

**Round 2** — **no findings**. Stage converged. Codex: *"No P0 or P1 findings. The
implementation is internally consistent, follows the repository's
root-only/shared-image conventions, adds appropriate CI and smoke coverage, and
handles missing Copier and pin drift clearly."*

## Known inconsistency, left deliberately

Two copier guards now fail everywhere (`test-template.sh`,
`test-copier-validators.sh` — the primary render gates, where a local skip would
report `verify` green while rendering nothing); three keep their existing
skip-locally/fail-in-CI behaviour (`audit-dogfood.sh`,
`test-dogfood-structure.sh`, `test-template-update.sh`). Changing those is not
this issue's scope, but the asymmetry is intentional and worth a reviewer's eye.

## Deferred findings

None. Every P2 raised was either fixed in place or declined with evidence, and
the descoped P1s are tracked in #966 rather than carried.

Closes #921
Refs #966
