### PR TITLE
feat: make action task output colorful and explicit

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -84,6 +84,7 @@ tasks:
       - task: test:label-registry
       - task: test:tasks
       - task: test:ci-results
+      - task: test:output
       - task: test:status
       - task: test:gh-scopes
       - task: test:meta-install
@@ -91,6 +92,7 @@ tasks:
       - task: test:renovate-pins
       - task: test:lint-hygiene
       - task: test:release-title
+      - task: test:setup-github
       - task: test:setup-github-project
       - task: test:sync-devkit-release
       - task: test:devcontainer:image:automation
@@ -398,6 +400,11 @@ tasks:
     cmds:
       - ./scripts/test-ci-results.sh
 
+  test:output:
+    desc: Unit-test shared color/Unicode fallbacks and spinner cleanup
+    cmds:
+      - ./scripts/test-output.sh
+
   test:devflow-config:
     desc: Validate the Dev Loop round-cap levels + tier/method axes in .devflow.toml (both copies)
     cmds:
@@ -438,6 +445,11 @@ tasks:
     desc: Unit-test the release-content title guard (require-release-title.sh)
     cmds:
       - ./scripts/test-release-title.sh
+
+  test:setup-github:
+    desc: Unit-test repository-setting outcomes and failure propagation (stubbed gh, no network)
+    cmds:
+      - ./scripts/test-setup-github.sh
 
   test:setup-github-project:
     desc: Unit-test the GitHub Project field reconciliation (stubbed gh, no network)
@@ -699,16 +711,7 @@ tasks:
     vars:
       REPO: "evanharmon1/harmon-init"
     cmds:
-      - gh api "repos/{{.REPO}}/vulnerability-alerts" --method PUT
-      # Private vulnerability reporting is a public-repo-only feature; harmon-init
-      # creates repos --private, so guard on visibility to avoid a 404 that would
-      # abort the task. Applies cleanly if the repo is later made public.
-      - |
-        if [ "$(gh api "repos/{{.REPO}}" --jq '.private')" = "false" ]; then
-          gh api "repos/{{.REPO}}/private-vulnerability-reporting" --method PUT
-        else
-          echo "Skipping private vulnerability reporting ({{.REPO}} is private; public-repo-only feature)."
-        fi
+      - ./scripts/setup-github.sh --repo "{{.REPO}}"
   setup:github-project:
     desc: Idempotently create/sync the owner's GitHub Project V2 board + Status pipeline (on a personal account also its metadata fields). Requires the Projects scopes — `task setup:gh-scopes`.
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -853,31 +853,37 @@ tasks:
   # ── Status ────────────────────────────────────────────────────
   status:
     desc: Project status dashboard
+    interactive: true
     cmds:
       - ./scripts/status.sh
 
   status:git:
     desc: Git status section
+    interactive: true
     cmds:
       - ./scripts/status.sh git
 
   status:gh:
     desc: GitHub status section
+    interactive: true
     cmds:
       - ./scripts/status.sh gh
 
   status:creds:
     desc: Credential section (gh, Codex, Claude Code logins + gh token scopes — local probes plus one bounded scope check; STATUS_NO_NETWORK=1 skips it)
+    interactive: true
     cmds:
       - ./scripts/status.sh creds
 
   status:code:
     desc: Codebase stats section
+    interactive: true
     cmds:
       - ./scripts/status.sh code
 
   status:env:
     desc: Environment info section
+    interactive: true
     cmds:
       - ./scripts/status.sh env
 
@@ -888,6 +894,7 @@ tasks:
 
   status:setup:
     desc: Setup completeness audit (GitHub, toolchain, devcontainer, dev env)
+    interactive: true
     cmds:
       - ./scripts/status.sh setup
 

--- a/scripts/lib/output.sh
+++ b/scripts/lib/output.sh
@@ -32,10 +32,16 @@ output_write() {
     fi
 }
 
+OUTPUT_UTF8=false
+case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+*[Uu][Tt][Ff]-8* | *[Uu][Tt][Ff]8*) OUTPUT_UTF8=true ;;
+esac
+
 # NO_COLOR disables gum as well as ANSI. Besides respecting the convention,
-# that makes logs and test snapshots plain, greppable text.
+# that makes logs and test snapshots plain, greppable text. Gum's borders are
+# Unicode, so a non-UTF-8 locale also selects the built-in ASCII presentation.
 HAS_GUM=false
-if [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != dumb ] && command -v gum >/dev/null 2>&1; then
+if $OUTPUT_UTF8 && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != dumb ] && command -v gum >/dev/null 2>&1; then
     HAS_GUM=true
 fi
 
@@ -47,11 +53,7 @@ if [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != dumb ]; then
 fi
 
 USE_UNICODE=false
-case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
-*[Uu][Tt][Ff]-8* | *[Uu][Tt][Ff]8*)
-    if $USE_COLOR; then USE_UNICODE=true; fi
-    ;;
-esac
+if $OUTPUT_UTF8 && $USE_COLOR; then USE_UNICODE=true; fi
 
 # Every gum call is piped. This keeps gum from probing the terminal background
 # with OSC 11 and waiting several seconds on terminals that do not answer. Its
@@ -75,6 +77,7 @@ action_banner() {
     sync) icon="↻" && sgr="1;34" && gum_color=75 ;;
     install) icon="⬡" && sgr="1;32" && gum_color=42 ;;
     esac
+    if ! $USE_UNICODE; then icon="*"; fi
 
     if $HAS_GUM && output_is_tty; then
         {
@@ -87,7 +90,11 @@ action_banner() {
         output_emit '\n\033[%sm%s  %s\033[0m  \033[1m%s\033[0m\n' "$sgr" "$icon" \
             "$(printf '%s' "$kind" | tr '[:lower:]' '[:upper:]')" "$title"
         [ -z "$detail" ] || output_emit '\033[2m   %s\033[0m\n' "$detail"
-        output_emit '\033[2;90m%s\033[0m\n' '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+        if $USE_UNICODE; then
+            output_emit '\033[2;90m%s\033[0m\n' '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+        else
+            output_emit '\033[2;90m%s\033[0m\n' '----------------------------------------'
+        fi
     else
         output_emit '\n== %s :: %s ==\n' \
             "$(printf '%s' "$kind" | tr '[:lower:]' '[:upper:]')" "$title"
@@ -265,7 +272,7 @@ output_spinner_loop() {
 # frame, and returns COMMAND's exact status. Redirected/CI output runs COMMAND
 # directly and emits no control sequences.
 output_run() (
-    local label="$1" spinner_pid="" rc
+    local label="$1" spinner_pid="" diagnostics="" rc
     shift
 
     if [ "${OUTPUT_FD}" != 2 ] || { ! output_is_tty && [ "${OUTPUT_TEST_SPINNER:-0}" != 1 ]; } ||
@@ -274,6 +281,7 @@ output_run() (
         return
     fi
 
+    diagnostics="$(mktemp "${TMPDIR:-/tmp}/harmon-output.XXXXXX")" || return 1
     output_spinner_loop "$label" &
     spinner_pid=$!
     output_spinner_cleanup() {
@@ -284,13 +292,20 @@ output_run() (
         fi
         printf '\r\033[2K' >&2
     }
-    trap 'output_spinner_cleanup' EXIT
+    output_run_cleanup() {
+        output_spinner_cleanup
+        [ -z "$diagnostics" ] || rm -f "$diagnostics"
+    }
+    trap 'output_run_cleanup' EXIT
     trap 'exit 129' HUP
     trap 'exit 130' INT
     trap 'exit 143' TERM
 
-    if "$@"; then rc=0; else rc=$?; fi
+    if "$@" 2>"$diagnostics"; then rc=0; else rc=$?; fi
     output_spinner_cleanup
+    if [ -s "$diagnostics" ]; then cat "$diagnostics" >&2; fi
+    rm -f "$diagnostics"
+    diagnostics=""
     trap - EXIT HUP INT TERM
     return "$rc"
 )

--- a/scripts/lib/output.sh
+++ b/scripts/lib/output.sh
@@ -176,6 +176,14 @@ output_done() {
     fi
 }
 
+output_warning() {
+    if $USE_UNICODE; then
+        output_emit '\n%s %s\n' "$(c '1;33' '⚠')" "$(c '1;33' "$1")"
+    else
+        output_emit '\nWARN: %s\n' "$1"
+    fi
+}
+
 output_spinner_loop() {
     local label="$1" i=0 frame
     local unicode_frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')

--- a/scripts/lib/output.sh
+++ b/scripts/lib/output.sh
@@ -60,6 +60,42 @@ gum_style() {
     CLICOLOR_FORCE=1 gum style "$@" | cat
 }
 
+# action_banner KIND TITLE [DETAIL] — a task-family masthead for mutating
+# commands. KIND is deliberately semantic rather than a raw color: a setup,
+# secret, release, cleanup, sync, or install task should be recognizable before
+# the reader reaches its title. The word always remains visible, so color and
+# emoji reinforce meaning without carrying it alone.
+action_banner() {
+    local kind="$1" title="$2" detail="${3:-}" icon="✦" sgr="1;35" gum_color=212
+    case "$kind" in
+    setup) icon="⚙" && sgr="1;36" && gum_color=39 ;;
+    secret) icon="🔐" && sgr="1;35" && gum_color=135 ;;
+    release) icon="🚀" && sgr="1;33" && gum_color=220 ;;
+    clean) icon="◇" && sgr="1;33" && gum_color=214 ;;
+    sync) icon="↻" && sgr="1;34" && gum_color=75 ;;
+    install) icon="⬡" && sgr="1;32" && gum_color=42 ;;
+    esac
+
+    if $HAS_GUM && output_is_tty; then
+        {
+            printf '%s  %s\n' "$icon" "$(printf '%s' "$kind" | tr '[:lower:]' '[:upper:]')"
+            printf '%s\n' "$title"
+            [ -z "$detail" ] || printf '%s\n' "$detail"
+        } | gum_style --bold --foreground "$gum_color" --border double \
+            --border-foreground "$gum_color" --padding "0 2" --margin "0 0 1 0" | output_write
+    elif $USE_COLOR; then
+        output_emit '\n\033[%sm%s  %s\033[0m  \033[1m%s\033[0m\n' "$sgr" "$icon" \
+            "$(printf '%s' "$kind" | tr '[:lower:]' '[:upper:]')" "$title"
+        [ -z "$detail" ] || output_emit '\033[2m   %s\033[0m\n' "$detail"
+        output_emit '\033[2;90m%s\033[0m\n' '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+    else
+        output_emit '\n== %s :: %s ==\n' \
+            "$(printf '%s' "$kind" | tr '[:lower:]' '[:upper:]')" "$title"
+        [ -z "$detail" ] || output_emit '   %s\n' "$detail"
+        output_emit '%s\n' '----------------------------------------'
+    fi
+}
+
 section_header() {
     local title="$1"
     if $HAS_GUM && output_is_tty; then
@@ -170,9 +206,29 @@ checkline() {
     fi
 }
 
+# output_summary [TITLE] — a compact, scan-friendly outcome table. Counts are
+# collected by checkline, so action scripts get a truthful summary without
+# duplicating bookkeeping. The plain form is one stable key/value line for CI,
+# grep, and snapshots; the terminal form is intentionally more visual.
+output_summary() {
+    local title="${1:-Outcome}" total
+    total=$((SETUP_OK + SETUP_NO + SETUP_UNKNOWN + SETUP_NA))
+    if $USE_UNICODE; then
+        output_emit '\n  %s\n' "$(c '1;36' "╭─ $title")"
+        output_emit '  %s  %-12s %s\n' "$(c '1;32' '│ ✓')" "Succeeded" "$SETUP_OK"
+        output_emit '  %s  %-12s %s\n' "$(c '1;31' '│ ✗')" "Failed" "$SETUP_NO"
+        output_emit '  %s  %-12s %s\n' "$(c '1;33' '│ ?')" "Attention" "$SETUP_UNKNOWN"
+        output_emit '  %s  %-12s %s\n' "$(c '2' '│ –')" "Skipped" "$SETUP_NA"
+        output_emit '  %s\n' "$(c '1;36' "╰─ $total checks")"
+    else
+        output_emit '\nSUMMARY: %s - succeeded=%s failed=%s attention=%s skipped=%s total=%s\n' \
+            "$title" "$SETUP_OK" "$SETUP_NO" "$SETUP_UNKNOWN" "$SETUP_NA" "$total"
+    fi
+}
+
 output_done() {
     if $USE_UNICODE; then
-        output_emit '\n%s %s\n' "$(c '1;32' '✨')" "$(c '1' "$1")"
+        output_emit '\n%s %s\n' "$(c '1;32' '╰─ ✨')" "$(c '1;32' "$1")"
     else
         output_emit '\nDONE: %s\n' "$1"
     fi
@@ -180,7 +236,7 @@ output_done() {
 
 output_warning() {
     if $USE_UNICODE; then
-        output_emit '\n%s %s\n' "$(c '1;33' '⚠')" "$(c '1;33' "$1")"
+        output_emit '\n%s %s\n' "$(c '1;33' '╰─ ⚠')" "$(c '1;33' "$1")"
     else
         output_emit '\nWARN: %s\n' "$1"
     fi

--- a/scripts/lib/output.sh
+++ b/scripts/lib/output.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# Shared terminal presentation for status boards and action scripts.
+#
+# Source this file after resolving the repository root. It has no required
+# dependencies: ANSI color and Unicode are used only on a capable terminal,
+# gum is an optional enhancement, and redirected/NO_COLOR/TERM=dumb output is
+# stable ASCII. Action scripts may set OUTPUT_FD=2 before sourcing so Task's
+# grouped stdout does not hide live progress.
+
+OUTPUT_FD="${OUTPUT_FD:-1}"
+
+output_is_tty() {
+    if [ "${OUTPUT_TEST_TTY:-0}" = 1 ]; then
+        return 0
+    fi
+    [ -t "${OUTPUT_FD}" ]
+}
+
+output_emit() {
+    if [ "${OUTPUT_FD}" = 2 ]; then
+        printf "$@" >&2
+    else
+        printf "$@"
+    fi
+}
+
+output_write() {
+    if [ "${OUTPUT_FD}" = 2 ]; then
+        cat >&2
+    else
+        cat
+    fi
+}
+
+# NO_COLOR disables gum as well as ANSI. Besides respecting the convention,
+# that makes logs and test snapshots plain, greppable text.
+HAS_GUM=false
+if [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != dumb ] && command -v gum >/dev/null 2>&1; then
+    HAS_GUM=true
+fi
+
+USE_COLOR=false
+if [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != dumb ]; then
+    if output_is_tty || { [ -n "${CLICOLOR_FORCE:-}" ] && [ "${CLICOLOR_FORCE}" != 0 ]; }; then
+        USE_COLOR=true
+    fi
+fi
+
+USE_UNICODE=false
+case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+*[Uu][Tt][Ff]-8* | *[Uu][Tt][Ff]8*)
+    if $USE_COLOR; then USE_UNICODE=true; fi
+    ;;
+esac
+
+# Every gum call is piped. This keeps gum from probing the terminal background
+# with OSC 11 and waiting several seconds on terminals that do not answer. Its
+# stderr still sees the terminal, while CLICOLOR_FORCE restores styling.
+gum_style() {
+    CLICOLOR_FORCE=1 gum style "$@" | cat
+}
+
+section_header() {
+    local title="$1"
+    if $HAS_GUM && output_is_tty; then
+        gum_style --bold --foreground 212 --border-foreground 240 \
+            --border rounded --padding "0 1" -- "$title" | output_write
+    elif $USE_COLOR; then
+        output_emit '\n\033[1;35m◆ %s\033[0m\n' "$title"
+        output_emit '\033[2;90m────────────────────────────────────────\033[0m\n'
+    else
+        output_emit '\n==> %s\n' "$title"
+        output_emit '%s\n' '----------------------------------------'
+    fi
+}
+
+section_box() {
+    local content
+    content="$(cat)"
+    if $HAS_GUM && output_is_tty; then
+        printf '%s\n' "$content" | gum_style --border rounded \
+            --border-foreground 240 --padding "0 1" --margin "0 0" | output_write
+    else
+        output_emit '%s\n\n' "$content"
+    fi
+}
+
+kv() {
+    local key="$1" val="$2" styled_key
+    if $HAS_GUM && output_is_tty; then
+        styled_key="$(gum_style --bold --foreground 39 "$key:")"
+        output_emit '  %s  %s\n' "$styled_key" "$val"
+    elif $USE_COLOR; then
+        output_emit '  \033[1;36m%-20s\033[0m %s\n' "$key:" "$val"
+    else
+        output_emit '  %-20s %s\n' "$key:" "$val"
+    fi
+}
+
+# c SGR TEXT — emit TEXT wrapped in ANSI when color is active. This writes to
+# stdout deliberately: callers use it inside command substitutions.
+c() {
+    if $USE_COLOR; then printf '\033[%sm%s\033[0m' "$1" "$2"; else printf '%s' "$2"; fi
+}
+
+if $USE_UNICODE; then
+    I_OK="$(c '1;32' '✓')"
+    I_NO="$(c '1;31' '✗')"
+    I_UNKNOWN="$(c '1;33' '?')"
+    I_NA="$(c '2' '–')"
+    I_INFO="$(c '1;36' '•')"
+else
+    I_OK='[x]'
+    I_NO='[ ]'
+    I_UNKNOWN='[?]'
+    I_NA='[-]'
+    I_INFO=' * '
+fi
+
+subhead() {
+    if $USE_UNICODE; then
+        output_emit '\n  %s\n' "$(c '1;36' "▸ $1")"
+    else
+        output_emit '\n  > %s\n' "$1"
+    fi
+}
+
+bar() {
+    local pct="$1" width=20 i=0 fill="" track="" filled
+    filled=$((pct * width / 100))
+    [ "${filled}" -gt "${width}" ] && filled="${width}"
+    [ "${filled}" -lt 0 ] && filled=0
+    while [ "${i}" -lt "${width}" ]; do
+        if [ "${i}" -lt "${filled}" ]; then
+            if $USE_UNICODE; then fill="${fill}█"; else fill="${fill}#"; fi
+        else
+            if $USE_UNICODE; then track="${track}░"; else track="${track}-"; fi
+        fi
+        i=$((i + 1))
+    done
+    printf '%s%s' "$(c '32' "${fill}")" "$(c '2' "${track}")"
+}
+
+SETUP_OK=0
+SETUP_NO=0
+SETUP_UNKNOWN=0
+SETUP_NA=0
+
+# checkline STATUS LABEL [DETAIL]
+# STATUS: ok | no | unknown | na | info
+checkline() {
+    local status="$1" label="$2" detail="${3:-}" icon=""
+    case "$status" in
+    ok) icon="$I_OK" && SETUP_OK=$((SETUP_OK + 1)) ;;
+    no) icon="$I_NO" && SETUP_NO=$((SETUP_NO + 1)) ;;
+    unknown) icon="$I_UNKNOWN" && SETUP_UNKNOWN=$((SETUP_UNKNOWN + 1)) ;;
+    na) icon="$I_NA" && SETUP_NA=$((SETUP_NA + 1)) ;;
+    info) icon="$I_INFO" ;;
+    *)
+        output_emit 'output: unknown check status: %s\n' "$status"
+        return 2
+        ;;
+    esac
+    if [ -n "$detail" ]; then
+        output_emit '  %s %s — %s\n' "$icon" "$label" "$detail"
+    else
+        output_emit '  %s %s\n' "$icon" "$label"
+    fi
+}
+
+output_done() {
+    if $USE_UNICODE; then
+        output_emit '\n%s %s\n' "$(c '1;32' '✨')" "$(c '1' "$1")"
+    else
+        output_emit '\nDONE: %s\n' "$1"
+    fi
+}
+
+output_spinner_loop() {
+    local label="$1" i=0 frame
+    local unicode_frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+    local ascii_frames=('|' '/' '-' '\\')
+    trap 'exit 0' HUP INT TERM
+    while :; do
+        if $USE_UNICODE; then
+            frame="${unicode_frames[$i]}"
+            i=$(((i + 1) % ${#unicode_frames[@]}))
+        else
+            frame="${ascii_frames[$i]}"
+            i=$(((i + 1) % ${#ascii_frames[@]}))
+        fi
+        printf '\r\033[2K%s %s' "$(c '1;35' "$frame")" "$label" >&2
+        sleep "${OUTPUT_SPINNER_DELAY:-0.08}"
+    done
+}
+
+# output_run LABEL COMMAND... — keep COMMAND in the foreground and animate a
+# background-only indicator. The subshell owns every trap, always erases the
+# frame, and returns COMMAND's exact status. Redirected/CI output runs COMMAND
+# directly and emits no control sequences.
+output_run() (
+    local label="$1" spinner_pid="" rc
+    shift
+
+    if [ "${OUTPUT_FD}" != 2 ] || { ! output_is_tty && [ "${OUTPUT_TEST_SPINNER:-0}" != 1 ]; } ||
+        [ "${CI:-}" = true ] || [ -n "${NO_COLOR:-}" ] || [ "${TERM:-}" = dumb ]; then
+        "$@"
+        return
+    fi
+
+    output_spinner_loop "$label" &
+    spinner_pid=$!
+    output_spinner_cleanup() {
+        if [ -n "$spinner_pid" ]; then
+            kill "$spinner_pid" 2>/dev/null || true
+            wait "$spinner_pid" 2>/dev/null || true
+            spinner_pid=""
+        fi
+        printf '\r\033[2K' >&2
+    }
+    trap 'output_spinner_cleanup' EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+
+    if "$@"; then rc=0; else rc=$?; fi
+    output_spinner_cleanup
+    trap - EXIT HUP INT TERM
+    return "$rc"
+)

--- a/scripts/lib/output.sh
+++ b/scripts/lib/output.sh
@@ -109,12 +109,14 @@ if $USE_UNICODE; then
     I_UNKNOWN="$(c '1;33' '?')"
     I_NA="$(c '2' '–')"
     I_INFO="$(c '1;36' '•')"
+    DETAIL_SEPARATOR=' — '
 else
     I_OK='[x]'
     I_NO='[ ]'
     I_UNKNOWN='[?]'
     I_NA='[-]'
     I_INFO=' * '
+    DETAIL_SEPARATOR=' - '
 fi
 
 subhead() {
@@ -162,7 +164,7 @@ checkline() {
         ;;
     esac
     if [ -n "$detail" ]; then
-        output_emit '  %s %s — %s\n' "$icon" "$label" "$detail"
+        output_emit '  %s %s%s%s\n' "$icon" "$label" "$DETAIL_SEPARATOR" "$detail"
     else
         output_emit '  %s %s\n' "$icon" "$label"
     fi

--- a/scripts/lib/output.sh
+++ b/scripts/lib/output.sh
@@ -55,11 +55,16 @@ fi
 USE_UNICODE=false
 if $OUTPUT_UTF8 && $USE_COLOR; then USE_UNICODE=true; fi
 
-# Every gum call is piped. This keeps gum from probing the terminal background
-# with OSC 11 and waiting several seconds on terminals that do not answer. Its
-# stderr still sees the terminal, while CLICOLOR_FORCE restores styling.
+# Gum's stdout is captured, so it cannot probe the terminal background with
+# OSC 11 and wait several seconds on terminals that do not answer. Preserve
+# its status: gum is optional presentation, and callers fall back to the
+# built-in renderer when an installed binary is broken or incompatible.
 gum_style() {
-    CLICOLOR_FORCE=1 gum style "$@" | cat
+    local styled
+    if ! styled="$(CLICOLOR_FORCE=1 gum style "$@")"; then
+        return 1
+    fi
+    printf '%s\n' "$styled"
 }
 
 # action_banner KIND TITLE [DETAIL] — a task-family masthead for mutating
@@ -68,7 +73,7 @@ gum_style() {
 # the reader reaches its title. The word always remains visible, so color and
 # emoji reinforce meaning without carrying it alone.
 action_banner() {
-    local kind="$1" title="$2" detail="${3:-}" icon="✦" sgr="1;35" gum_color=212
+    local kind="$1" title="$2" detail="${3:-}" icon="✦" sgr="1;35" gum_color=212 styled=""
     case "$kind" in
     setup) icon="⚙" && sgr="1;36" && gum_color=39 ;;
     secret) icon="🔐" && sgr="1;35" && gum_color=135 ;;
@@ -79,14 +84,17 @@ action_banner() {
     esac
     if ! $USE_UNICODE; then icon="*"; fi
 
-    if $HAS_GUM && output_is_tty; then
-        {
+    if $HAS_GUM && output_is_tty &&
+        styled="$({
             printf '%s  %s\n' "$icon" "$(printf '%s' "$kind" | tr '[:lower:]' '[:upper:]')"
             printf '%s\n' "$title"
             [ -z "$detail" ] || printf '%s\n' "$detail"
         } | gum_style --bold --foreground "$gum_color" --border double \
-            --border-foreground "$gum_color" --padding "0 2" --margin "0 0 1 0" | output_write
-    elif $USE_COLOR; then
+            --border-foreground "$gum_color" --padding "0 2" --margin "0 0 1 0")"; then
+        output_emit '%s\n' "$styled"
+        return 0
+    fi
+    if $USE_COLOR; then
         output_emit '\n\033[%sm%s  %s\033[0m  \033[1m%s\033[0m\n' "$sgr" "$icon" \
             "$(printf '%s' "$kind" | tr '[:lower:]' '[:upper:]')" "$title"
         [ -z "$detail" ] || output_emit '\033[2m   %s\033[0m\n' "$detail"
@@ -104,11 +112,14 @@ action_banner() {
 }
 
 section_header() {
-    local title="$1"
-    if $HAS_GUM && output_is_tty; then
-        gum_style --bold --foreground 212 --border-foreground 240 \
-            --border rounded --padding "0 1" -- "$title" | output_write
-    elif $USE_COLOR; then
+    local title="$1" styled=""
+    if $HAS_GUM && output_is_tty &&
+        styled="$(gum_style --bold --foreground 212 --border-foreground 240 \
+            --border rounded --padding "0 1" -- "$title")"; then
+        output_emit '%s\n' "$styled"
+        return 0
+    fi
+    if $USE_COLOR; then
         output_emit '\n\033[1;35m◆ %s\033[0m\n' "$title"
         output_emit '\033[2;90m────────────────────────────────────────\033[0m\n'
     else
@@ -118,22 +129,25 @@ section_header() {
 }
 
 section_box() {
-    local content
+    local content styled=""
     content="$(cat)"
-    if $HAS_GUM && output_is_tty; then
-        printf '%s\n' "$content" | gum_style --border rounded \
-            --border-foreground 240 --padding "0 1" --margin "0 0" | output_write
-    else
-        output_emit '%s\n\n' "$content"
+    if $HAS_GUM && output_is_tty &&
+        styled="$(printf '%s\n' "$content" | gum_style --border rounded \
+            --border-foreground 240 --padding "0 1" --margin "0 0")"; then
+        output_emit '%s\n' "$styled"
+        return 0
     fi
+    output_emit '%s\n\n' "$content"
 }
 
 kv() {
     local key="$1" val="$2" styled_key
-    if $HAS_GUM && output_is_tty; then
-        styled_key="$(gum_style --bold --foreground 39 "$key:")"
+    if $HAS_GUM && output_is_tty &&
+        styled_key="$(gum_style --bold --foreground 39 "$key:")"; then
         output_emit '  %s  %s\n' "$styled_key" "$val"
-    elif $USE_COLOR; then
+        return 0
+    fi
+    if $USE_COLOR; then
         output_emit '  \033[1;36m%-20s\033[0m %s\n' "$key:" "$val"
     else
         output_emit '  %-20s %s\n' "$key:" "$val"

--- a/scripts/secret-set-1p.sh
+++ b/scripts/secret-set-1p.sh
@@ -39,6 +39,9 @@ command -v op >/dev/null 2>&1 || fail "op CLI is required"
 command -v jq >/dev/null 2>&1 || fail "jq is required"
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+# Task buffers stdout in grouped mode. Keep legacy progress and the visual
+# outcome on one live stream so their chronology cannot be reversed.
+exec 1>&2
 OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "$script_dir/lib/output.sh"

--- a/scripts/secret-set-1p.sh
+++ b/scripts/secret-set-1p.sh
@@ -38,6 +38,15 @@ fi
 command -v op >/dev/null 2>&1 || fail "op CLI is required"
 command -v jq >/dev/null 2>&1 || fail "jq is required"
 
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_FD=2
+# shellcheck source=scripts/lib/output.sh
+. "$script_dir/lib/output.sh"
+action_banner secret "1Password field" "The secret stays on stdin and is never displayed"
+kv "Vault" "$vault"
+kv "Item" "$item"
+kv "Field" "${section:+$section / }$field"
+
 # Keep the caller's stdin available to jq as a raw file while jq reads the
 # 1Password item JSON from the pipeline.
 exec 3<&0
@@ -97,4 +106,6 @@ printf '%s\n' "$updated_item" |
     op item edit "$item" --vault "$vault" >/dev/null
 unset updated_item
 
-echo "Updated 1Password item '$item' field '$field'."
+checkline ok "Secret field" "$item / ${section:+$section / }$field updated"
+output_summary "Secret write"
+output_done "1Password secret updated"

--- a/scripts/secret-set-gh.sh
+++ b/scripts/secret-set-gh.sh
@@ -34,6 +34,14 @@ fi
 command -v gh >/dev/null 2>&1 || fail "gh CLI is required"
 command -v python3 >/dev/null 2>&1 || fail "python3 is required"
 
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_FD=2
+# shellcheck source=scripts/lib/output.sh
+. "$script_dir/lib/output.sh"
+action_banner secret "GitHub Actions secret" "Encrypted write from stdin; the value is never displayed"
+kv "Repository" "$repo"
+kv "Secret" "$name"
+
 # Read + validate stdin BEFORE gh runs: in a plain pipeline, `gh secret set`
 # starts consuming stdin before the producer's empty-check can fail, so an
 # empty pipe could write an empty secret and only error afterwards. python3 is
@@ -53,5 +61,8 @@ sys.stdout.buffer.write(data)
 ')" || fail "stdin secret is empty"
 
 printf '%s' "$secret" | gh secret set "$name" --repo "$repo" >/dev/null
+unset secret
 
-echo "Updated GitHub secret '$name' in '$repo'."
+checkline ok "Repository secret" "$name updated on $repo"
+output_summary "Secret write"
+output_done "GitHub secret updated"

--- a/scripts/secret-set-gh.sh
+++ b/scripts/secret-set-gh.sh
@@ -35,6 +35,9 @@ command -v gh >/dev/null 2>&1 || fail "gh CLI is required"
 command -v python3 >/dev/null 2>&1 || fail "python3 is required"
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+# Task buffers stdout in grouped mode. Keep legacy progress and the visual
+# outcome on one live stream so their chronology cannot be reversed.
+exec 1>&2
 OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "$script_dir/lib/output.sh"

--- a/scripts/setup-gh-scopes.sh
+++ b/scripts/setup-gh-scopes.sh
@@ -83,6 +83,9 @@ fi
 # the one the warning was about still under-scoped.
 REQUEST_LIST="$(gh_scopes_request_list)"
 
+# shellcheck source=scripts/lib/output.sh
+. "${REPO_ROOT}/scripts/lib/output.sh"
+
 # gh_auth_status_active — `gh auth status` narrowed to the ONE credential this
 # task refreshes. `gh auth refresh` updates only the ACTIVE account, while a
 # bare `--hostname` read reports every account on that host: concatenating
@@ -142,11 +145,11 @@ case "${scopes_before}" in
     ;;
 esac
 
-echo "==> Host:            ${HOSTNAME_ARG}"
-echo "==> Current scopes:  ${scopes_before:-<none reported>}"
-echo "==> Required:        $(gh_scopes_human "${GH_REQUIRED_SCOPES}")"
-echo "==> Requesting:      ${REQUEST_LIST}"
-echo ""
+action_banner setup "GitHub CLI scopes" "Interactive credential upgrade with post-refresh verification"
+kv "Host" "${HOSTNAME_ARG}"
+kv "Current scopes" "${scopes_before:-<none reported>}"
+kv "Required" "$(gh_scopes_human "${GH_REQUIRED_SCOPES}")"
+kv "Requesting" "${REQUEST_LIST}"
 
 # Nothing to do? Say so and stop, WITHOUT opening a browser. `gh auth refresh`
 # is an interactive OAuth flow even when it would change nothing, so an
@@ -155,7 +158,9 @@ echo ""
 # re-run repeats it. The docs promise this requests the MISSING scopes; this is
 # that promise kept.
 if [ -z "$(gh_scopes_missing_requested "${scopes_before}")" ]; then
-    echo "Already complete — no refresh needed."
+    checkline na "OAuth refresh" "already complete; no browser flow needed"
+    output_summary "Scope setup"
+    output_done "GitHub CLI scopes are already ready"
     exit 0
 fi
 
@@ -169,8 +174,7 @@ verify_out="$(gh_auth_status_active)" ||
     die "post-refresh 'gh auth status' failed — the credential may be broken."
 scopes_after="$(printf '%s\n' "${verify_out}" | grep -i 'token scopes:' || true)"
 
-echo ""
-echo "==> New scopes:      ${scopes_after:-<none reported>}"
+kv "New scopes" "${scopes_after:-<none reported>}"
 
 case "${scopes_after}" in
 *"'"*) ;;
@@ -191,5 +195,6 @@ if [ -n "${missing}" ]; then
   them (Settings → Third-party access)."
 fi
 
-echo ""
-echo "All requested scopes present: $(gh_scopes_request_list)"
+checkline ok "OAuth scopes" "$(gh_scopes_request_list)"
+output_summary "Scope setup"
+output_done "All requested GitHub CLI scopes are present"

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -71,6 +71,12 @@ done
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 renderer="$script_dir/label-registry-render.mjs"
+OUTPUT_FD=2
+# shellcheck source=scripts/lib/output.sh
+. "$script_dir/lib/output.sh"
+
+section_header "GitHub labels"
+kv "Repository" "$repo"
 
 render_args=(labels)
 if [ "$foreman" = 1 ]; then
@@ -87,8 +93,13 @@ labels="$(node "$renderer" "${render_args[@]}")"
 
 printf '%s\n' "$labels" | while IFS='|' read -r name color desc; do
     [ -z "$name" ] && continue
-    echo "==> label: $name"
-    gh label create "$name" --repo "$repo" --color "$color" --description "$desc" --force
+    if gh label create "$name" --repo "$repo" --color "$color" --description "$desc" --force; then
+        checkline ok "Label" "$name"
+    else
+        rc=$?
+        checkline no "Label" "$name (exit $rc)"
+        exit "$rc"
+    fi
 done
 
-echo "==> Done — starter labels on $repo (existing labels left as-is)"
+output_done "Starter labels are ready on $repo (existing labels left as-is)"

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -93,7 +93,7 @@ labels="$(node "$renderer" "${render_args[@]}")"
 
 while IFS='|' read -r name color desc; do
     [ -z "$name" ] && continue
-    if gh label create "$name" --repo "$repo" --color "$color" --description "$desc" --force; then
+    if gh label create "$name" --repo "$repo" --color "$color" --description "$desc" --force >/dev/null; then
         checkline ok "Label" "$name"
     else
         rc=$?

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -75,7 +75,7 @@ OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "$script_dir/lib/output.sh"
 
-section_header "GitHub labels"
+action_banner setup "GitHub labels" "Registry-driven taxonomy with non-destructive updates"
 kv "Repository" "$repo"
 
 render_args=(labels)
@@ -91,7 +91,7 @@ fi
 # reaches GitHub, so a bad vocabulary never half-provisions.
 labels="$(node "$renderer" "${render_args[@]}")"
 
-printf '%s\n' "$labels" | while IFS='|' read -r name color desc; do
+while IFS='|' read -r name color desc; do
     [ -z "$name" ] && continue
     if gh label create "$name" --repo "$repo" --color "$color" --description "$desc" --force; then
         checkline ok "Label" "$name"
@@ -100,6 +100,7 @@ printf '%s\n' "$labels" | while IFS='|' read -r name color desc; do
         checkline no "Label" "$name (exit $rc)"
         exit "$rc"
     fi
-done
+done < <(printf '%s\n' "$labels")
 
+output_summary "Label provisioning"
 output_done "Starter labels are ready on $repo (existing labels left as-is)"

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -57,6 +57,15 @@ for tool in gh jq; do
     fi
 done
 
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_FD=2
+# shellcheck source=scripts/lib/output.sh
+. "$script_dir/lib/output.sh"
+
+section_header "GitHub Project"
+kv "Owner" "$owner"
+kv "Project" "$title"
+
 # ── Scope preflight ─────────────────────────────────────────────────────────
 # Every mutation below needs the 'project' scope, which `gh auth login` does not
 # grant by default. Without it the run still fails — `gh api graphql` exits
@@ -485,7 +494,8 @@ create_number "Size"
 if [ "$owner_type" = "Organization" ]; then
     echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product)"
     report_incompatible
-    echo "==> Done — project #$project_number: $title"
+    checkline ok "Project" "#$project_number · $title"
+    output_done "GitHub Project is ready"
     exit 0
 fi
 
@@ -507,4 +517,5 @@ create_text "Product"
 # are the only surface now. See docs/project-management.md, "Label or field?".
 
 report_incompatible
-echo "==> Done — project #$project_number: $title"
+checkline ok "Project" "#$project_number · $title"
+output_done "GitHub Project is ready"

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -320,6 +320,9 @@ incompatible=""
 # Fields that are missing a starter option but have no room left for it.
 at_capacity=""
 
+# Fields that vanished between the discovery snapshot and their guarded write.
+disappeared=""
+
 # GitHub's cap on options in one single-select field.
 max_options=50
 
@@ -356,7 +359,7 @@ report_incompatible() {
 }
 
 finish_project() {
-    if [ -n "$incompatible" ] || [ -n "$at_capacity" ]; then
+    if [ -n "$incompatible" ] || [ -n "$at_capacity" ] || [ -n "$disappeared" ]; then
         checkline unknown "Project" "#$project_number · $title — reconciliation needs attention"
         output_warning "GitHub Project needs attention; resolve the warnings above and re-run"
     else
@@ -382,6 +385,7 @@ append_options() {
     refresh_fields
     if [ -z "$(field_id "$name")" ]; then
         echo "    WARNING: field '$name' disappeared while this script was running — skipping" >&2
+        disappeared="${disappeared}${disappeared:+, }$name"
         return 0
     fi
     existing=$(existing_options "$name")

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -62,7 +62,7 @@ OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "$script_dir/lib/output.sh"
 
-section_header "GitHub Project"
+action_banner setup "GitHub Project" "Board, delivery pipeline, and planning fields"
 kv "Owner" "$owner"
 kv "Project" "$title"
 
@@ -253,14 +253,20 @@ fi
 # at all, and the workflows' title-lookup fallback resolves to that same
 # half-reconciled board. Reconciliation is additive and re-runnable, so the
 # remedy for a partial run is to re-run this script either way.
+org_variable_problem=""
 if [ "$owner_type" = "Organization" ]; then
     echo "==> Recording project id in the ORG_PROJECT_ID org variable"
     if ! gh variable set ORG_PROJECT_ID --org "$owner" --visibility all --body "$project_id"; then
+        org_variable_problem="ORG_PROJECT_ID was not written"
         echo "WARNING: could not set the ORG_PROJECT_ID org variable (needs org admin)." >&2
         echo "         Set it by hand: gh variable set ORG_PROJECT_ID --org \"$owner\" --body \"$project_id\"" >&2
+        checkline unknown "Organization variable" "ORG_PROJECT_ID was not written; set it manually"
+    else
+        checkline ok "Organization variable" "ORG_PROJECT_ID points to project #$project_number"
     fi
 else
     echo "==> Owner is a user account — skipping ORG_PROJECT_ID (no user-level variable scope; personal status automation is a separate follow-up)"
+    checkline na "Organization variable" "not available for personal accounts"
 fi
 
 # ── Snapshot current fields (reused for existence checks; re-read immediately
@@ -359,11 +365,14 @@ report_incompatible() {
 }
 
 finish_project() {
-    if [ -n "$incompatible" ] || [ -n "$at_capacity" ] || [ -n "$disappeared" ]; then
+    if [ -n "$incompatible" ] || [ -n "$at_capacity" ] || [ -n "$disappeared" ] ||
+        [ -n "$org_variable_problem" ]; then
         checkline unknown "Project" "#$project_number / $title: reconciliation needs attention"
+        output_summary "Project reconciliation"
         output_warning "GitHub Project needs attention; resolve the warnings above and re-run"
     else
         checkline ok "Project" "#$project_number / $title"
+        output_summary "Project reconciliation"
         output_done "GitHub Project is ready"
     fi
 }

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -360,10 +360,10 @@ report_incompatible() {
 
 finish_project() {
     if [ -n "$incompatible" ] || [ -n "$at_capacity" ] || [ -n "$disappeared" ]; then
-        checkline unknown "Project" "#$project_number · $title — reconciliation needs attention"
+        checkline unknown "Project" "#$project_number / $title: reconciliation needs attention"
         output_warning "GitHub Project needs attention; resolve the warnings above and re-run"
     else
-        checkline ok "Project" "#$project_number · $title"
+        checkline ok "Project" "#$project_number / $title"
         output_done "GitHub Project is ready"
     fi
 }

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -355,6 +355,16 @@ report_incompatible() {
     fi
 }
 
+finish_project() {
+    if [ -n "$incompatible" ] || [ -n "$at_capacity" ]; then
+        checkline unknown "Project" "#$project_number · $title — reconciliation needs attention"
+        output_warning "GitHub Project needs attention; resolve the warnings above and re-run"
+    else
+        checkline ok "Project" "#$project_number · $title"
+        output_done "GitHub Project is ready"
+    fi
+}
+
 # append_options NAME STARTERS — reconcile one existing single-select field: add
 # whatever starter option it lacks, keep everything else exactly as it is, and
 # write nothing when there is nothing to add. Used for Status and the custom
@@ -494,8 +504,7 @@ create_number "Size"
 if [ "$owner_type" = "Organization" ]; then
     echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product)"
     report_incompatible
-    checkline ok "Project" "#$project_number · $title"
-    output_done "GitHub Project is ready"
+    finish_project
     exit 0
 fi
 
@@ -517,5 +526,4 @@ create_text "Product"
 # are the only surface now. See docs/project-management.md, "Label or field?".
 
 report_incompatible
-checkline ok "Project" "#$project_number · $title"
-output_done "GitHub Project is ready"
+finish_project

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -58,6 +58,9 @@ for tool in gh jq; do
 done
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+# Task buffers stdout in grouped mode. Keep legacy progress and the visual
+# outcome on one live stream so their chronology cannot be reversed.
+exec 1>&2
 OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "$script_dir/lib/output.sh"

--- a/scripts/setup-github.sh
+++ b/scripts/setup-github.sh
@@ -9,6 +9,7 @@ OUTPUT_FD=2
 
 repo=""
 bot_collaborator=""
+bot_pending=false
 while [ "$#" -gt 0 ]; do
     case "$1" in
     --repo)
@@ -83,7 +84,17 @@ fi
 if [ -n "$bot_collaborator" ]; then
     if output_run "Adding bot collaborator" \
         gh api "repos/$repo/collaborators/$bot_collaborator" --method PUT -f permission=push; then
-        checkline ok "Bot collaborator" "$bot_collaborator has push access"
+        permission="$(gh api "repos/$repo/collaborators/$bot_collaborator/permission" \
+            --jq '.permission' 2>/dev/null || true)"
+        case "$permission" in
+        admin | maintain | push | write)
+            checkline ok "Bot collaborator" "$bot_collaborator has push access"
+            ;;
+        *)
+            bot_pending=true
+            checkline unknown "Bot collaborator" "invitation sent to $bot_collaborator; access starts after acceptance"
+            ;;
+        esac
     else
         rc=$?
         fail_step "$rc" "Bot collaborator" "could not grant push access to $bot_collaborator"
@@ -91,4 +102,8 @@ if [ -n "$bot_collaborator" ]; then
     fi
 fi
 
-output_done "GitHub repository settings are ready for $repo"
+if $bot_pending; then
+    output_warning "GitHub repository settings are ready; bot collaborator acceptance is pending"
+else
+    output_done "GitHub repository settings are ready for $repo"
+fi

--- a/scripts/setup-github.sh
+++ b/scripts/setup-github.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Apply the repository-level GitHub settings that are safe to reconcile.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_FD=2
+# shellcheck source=scripts/lib/output.sh
+. "${script_dir}/lib/output.sh"
+
+repo=""
+bot_collaborator=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --repo)
+        repo="${2:-}"
+        shift 2
+        ;;
+    --bot-collaborator)
+        bot_collaborator="${2:-}"
+        shift 2
+        ;;
+    *)
+        echo "Unknown argument: $1" >&2
+        exit 2
+        ;;
+    esac
+done
+
+if [ -z "$repo" ]; then
+    echo "Usage: $0 --repo <owner/repo> [--bot-collaborator <login>]" >&2
+    exit 2
+fi
+if ! command -v gh >/dev/null 2>&1; then
+    echo "Required tool not found: gh" >&2
+    exit 1
+fi
+
+fail_step() {
+    local rc="$1" label="$2" detail="$3"
+    checkline no "$label" "$detail (exit $rc)"
+}
+
+section_header "GitHub repository setup"
+kv "Repository" "$repo"
+
+if output_run "Enabling Dependabot alerts" \
+    gh api "repos/$repo/vulnerability-alerts" --method PUT; then
+    checkline ok "Dependabot alerts" "enabled"
+else
+    rc=$?
+    fail_step "$rc" "Dependabot alerts" "GitHub API request failed"
+    exit "$rc"
+fi
+
+if repo_private="$(gh api "repos/$repo" --jq '.private')"; then
+    :
+else
+    rc=$?
+    fail_step "$rc" "Repository visibility" "could not determine public/private state"
+    exit "$rc"
+fi
+case "$repo_private" in
+true | false) ;;
+*)
+    fail_step 1 "Repository visibility" "unexpected '.private' value: ${repo_private:-<empty>}"
+    exit 1
+    ;;
+esac
+
+if [ "$repo_private" = false ]; then
+    if output_run "Enabling private vulnerability reporting" \
+        gh api "repos/$repo/private-vulnerability-reporting" --method PUT; then
+        checkline ok "Private vulnerability reporting" "enabled"
+    else
+        rc=$?
+        fail_step "$rc" "Private vulnerability reporting" "GitHub API request failed"
+        exit "$rc"
+    fi
+else
+    checkline na "Private vulnerability reporting" "skipped — private repository; feature is public-repo-only"
+fi
+
+if [ -n "$bot_collaborator" ]; then
+    if output_run "Adding bot collaborator" \
+        gh api "repos/$repo/collaborators/$bot_collaborator" --method PUT -f permission=push; then
+        checkline ok "Bot collaborator" "$bot_collaborator has push access"
+    else
+        rc=$?
+        fail_step "$rc" "Bot collaborator" "could not grant push access to $bot_collaborator"
+        exit "$rc"
+    fi
+fi
+
+output_done "GitHub repository settings are ready for $repo"

--- a/scripts/setup-github.sh
+++ b/scripts/setup-github.sh
@@ -77,7 +77,7 @@ if [ "$repo_private" = false ]; then
         exit "$rc"
     fi
 else
-    checkline na "Private vulnerability reporting" "skipped — private repository; feature is public-repo-only"
+    checkline na "Private vulnerability reporting" "skipped: private repository; feature is public-repo-only"
 fi
 
 if [ -n "$bot_collaborator" ]; then

--- a/scripts/setup-github.sh
+++ b/scripts/setup-github.sh
@@ -10,6 +10,7 @@ OUTPUT_FD=2
 repo=""
 bot_collaborator=""
 bot_pending=false
+bot_unverified=false
 while [ "$#" -gt 0 ]; do
     case "$1" in
     --repo)
@@ -41,7 +42,7 @@ fail_step() {
     checkline no "$label" "$detail (exit $rc)"
 }
 
-section_header "GitHub repository setup"
+action_banner setup "GitHub repository" "Safety, vulnerability reporting, and automation access"
 kv "Repository" "$repo"
 
 if output_run "Enabling Dependabot alerts" \
@@ -82,19 +83,30 @@ else
 fi
 
 if [ -n "$bot_collaborator" ]; then
-    if output_run "Adding bot collaborator" \
-        gh api "repos/$repo/collaborators/$bot_collaborator" --method PUT -f permission=push; then
-        permission="$(gh api "repos/$repo/collaborators/$bot_collaborator/permission" \
-            --jq '.permission' 2>/dev/null || true)"
-        case "$permission" in
-        admin | maintain | push | write)
-            checkline ok "Bot collaborator" "$bot_collaborator has push access"
-            ;;
-        *)
+    # GitHub's response itself is authoritative here: 201 + an invitation body
+    # means acceptance is pending; 204 + no body means access is already active.
+    # A follow-up permission lookup cannot distinguish a pending invite from a
+    # lookup failure, which was the old implementation's misleading fallback.
+    if collaborator_response="$(output_run "Adding bot collaborator" \
+        gh api "repos/$repo/collaborators/$bot_collaborator" --method PUT -f permission=push)"; then
+        if [ -n "$collaborator_response" ]; then
             bot_pending=true
             checkline unknown "Bot collaborator" "invitation sent to $bot_collaborator; access starts after acceptance"
-            ;;
-        esac
+        elif permission="$(gh api "repos/$repo/collaborators/$bot_collaborator/permission" \
+            --jq '.permission' 2>/dev/null)"; then
+            case "$permission" in
+            admin | maintain | push | write)
+                checkline ok "Bot collaborator" "$bot_collaborator has $permission access"
+                ;;
+            *)
+                bot_unverified=true
+                checkline unknown "Bot collaborator" "access response was '$permission'; verify $bot_collaborator manually"
+                ;;
+            esac
+        else
+            bot_unverified=true
+            checkline unknown "Bot collaborator" "GitHub accepted the request, but permission verification failed"
+        fi
     else
         rc=$?
         fail_step "$rc" "Bot collaborator" "could not grant push access to $bot_collaborator"
@@ -102,8 +114,11 @@ if [ -n "$bot_collaborator" ]; then
     fi
 fi
 
+output_summary "Repository setup"
 if $bot_pending; then
     output_warning "GitHub repository settings are ready; bot collaborator acceptance is pending"
+elif $bot_unverified; then
+    output_warning "GitHub repository settings changed, but collaborator access needs verification"
 else
     output_done "GitHub repository settings are ready for $repo"
 fi

--- a/scripts/setup-github.sh
+++ b/scripts/setup-github.sh
@@ -3,6 +3,9 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+# Task buffers stdout in grouped mode. Keep legacy progress and the visual
+# outcome on one live stream so their chronology cannot be reversed.
+exec 1>&2
 OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "${script_dir}/lib/output.sh"

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -21,14 +21,12 @@ NETWORK_TIMEOUT="${NETWORK_TIMEOUT:-5}"
 # shellcheck source=scripts/gh-scopes.sh
 . "${REPO_ROOT}/scripts/gh-scopes.sh"
 
-# ── Tool detection ──────────────────────────────────────────────────────────
+# Shared presentation primitives. NO_COLOR turns off gum and ANSI, making the
+# board plain, stable text for logs and scripts/test-status.sh.
+# shellcheck source=scripts/lib/output.sh
+. "${REPO_ROOT}/scripts/lib/output.sh"
 
-# NO_COLOR (https://no-color.org/) turns off gum styling as well as ANSI, which
-# makes the board's output plain, stable text — greppable, diffable, and
-# assertable by scripts/test-status.sh without matching around escape sequences
-# or box drawing.
-HAS_GUM=false
-[[ -z "${NO_COLOR:-}" ]] && command -v gum &>/dev/null && HAS_GUM=true
+# ── Tool detection ──────────────────────────────────────────────────────────
 
 # Network probes below are bounded so a hung `gh` call cannot wedge the board.
 # Stock macOS ships no `timeout` — it comes from coreutils, which also provides
@@ -79,133 +77,8 @@ run_timeout() {
     fi
 }
 
-# ── Formatting helpers ──────────────────────────────────────────────────────
-
-# Every `gum` call goes through here, because gum asks the TERMINAL for its
-# background colour (OSC 11) whenever its own stdout is one — and waits 5s for
-# an answer. A terminal that replies to neither that nor the cursor-position
-# probe gum falls back on pays the full 5s, EVERY invocation; a board renders
-# a dozen of them, which is the minutes-long hang of harmon-init#865 on a
-# devcontainer terminal. (Terminals that answer either probe were always fast,
-# which is why this never reproduced on a Mac.)
-#
-# Piping stdout removes the terminal from gum's view, so it does not ask.
-# `CLICOLOR_FORCE` then restores the colour gum drops for a non-terminal
-# stdout: with stderr still on the terminal the output is BYTE-IDENTICAL to
-# what an answering terminal produced before this change, 256-colour included.
-# Where stderr is redirected too, gum cannot read the depth and falls back to
-# 16 colours — not a regression, since gum emitted no colour at all into that
-# case before.
-gum_style() {
-    CLICOLOR_FORCE=1 gum style "$@" | cat
-}
-
-section_header() {
-    local title="$1"
-    if $HAS_GUM; then
-        gum_style --bold --foreground 212 --border-foreground 240 \
-            --border rounded --padding "0 1" -- "$title"
-    else
-        echo ""
-        echo "==> ${title}"
-        echo "────────────────────────────────────────"
-    fi
-}
-
-section_box() {
-    local content
-    content="$(cat)"
-    if $HAS_GUM; then
-        echo "$content" | gum_style --border rounded \
-            --border-foreground 240 --padding "0 1" --margin "0 0"
-    else
-        echo "$content"
-        echo ""
-    fi
-}
-
-kv() {
-    local key="$1" val="$2"
-    if $HAS_GUM; then
-        printf "  %s  %s\n" "$(gum_style --bold --foreground 39 "$key:")" "$val"
-    else
-        printf "  %-20s %s\n" "$key:" "$val"
-    fi
-}
-
 should_show() {
     [[ -z "${SECTION}" || "${SECTION}" == "$1" ]]
-}
-
-# ── Setup-check helpers ─────────────────────────────────────────────────────
-
-# Color is on when stdout is a TTY or gum is present (gum forces color anyway).
-# ANSI only — no extra dependency. Detected here at top level because inside the
-# section's `| section_box` pipe, stdout reads as a non-TTY.
-USE_COLOR=false
-[[ -z "${NO_COLOR:-}" ]] && { [ -t 1 ] || $HAS_GUM; } && USE_COLOR=true
-
-# c SGR TEXT — wrap TEXT in an ANSI SGR sequence when color is enabled.
-c() {
-    if $USE_COLOR; then printf '\033[%sm%s\033[0m' "$1" "$2"; else printf '%s' "$2"; fi
-}
-
-# Status glyphs: colored Unicode when color is on, plain ASCII otherwise.
-if $USE_COLOR; then
-    I_OK="$(c '1;32' '✓')"
-    I_NO="$(c '1;31' '✗')"
-    I_UNKNOWN="$(c '1;33' '?')"
-    I_NA="$(c '2' '–')"
-    I_INFO="$(c '1;36' '•')"
-else
-    I_OK='[x]'
-    I_NO='[ ]'
-    I_UNKNOWN='[?]'
-    I_NA='[-]'
-    I_INFO=' * '
-fi
-
-# subhead TEXT — a colored group header inside a section.
-subhead() {
-    printf '\n  %s\n' "$(c '1;36' "▸ $1")"
-}
-
-# bar PERCENT — a 20-cell Unicode progress bar (green fill on a dim track).
-bar() {
-    local pct="$1" width=20 i=0 fill="" track=""
-    local filled=$((pct * width / 100))
-    [ "${filled}" -gt "${width}" ] && filled="${width}"
-    [ "${filled}" -lt 0 ] && filled=0
-    while [ "${i}" -lt "${width}" ]; do
-        if [ "${i}" -lt "${filled}" ]; then fill="${fill}█"; else track="${track}░"; fi
-        i=$((i + 1))
-    done
-    printf '%s%s' "$(c '32' "${fill}")" "$(c '2' "${track}")"
-}
-
-SETUP_OK=0
-SETUP_NO=0
-SETUP_UNKNOWN=0
-SETUP_NA=0
-
-# checkline STATUS LABEL [DETAIL]
-#   STATUS in: ok | no | unknown | na | info
-# Counters mutate in the caller's subshell, so the summary line MUST be emitted
-# from the same { ... } group as the checks (see the Setup section).
-checkline() {
-    local status="$1" label="$2" detail="${3:-}" icon=""
-    case "$status" in
-    ok) icon="$I_OK" && SETUP_OK=$((SETUP_OK + 1)) ;;
-    no) icon="$I_NO" && SETUP_NO=$((SETUP_NO + 1)) ;;
-    unknown) icon="$I_UNKNOWN" && SETUP_UNKNOWN=$((SETUP_UNKNOWN + 1)) ;;
-    na) icon="$I_NA" && SETUP_NA=$((SETUP_NA + 1)) ;;
-    info) icon="$I_INFO" ;;
-    esac
-    if [ -n "$detail" ]; then
-        printf '  %s %s — %s\n' "$icon" "$label" "$detail"
-    else
-        printf '  %s %s\n' "$icon" "$label"
-    fi
 }
 
 # has_cred FILE NAME — true if NAME appears in FILE, where FILE is the output of
@@ -393,7 +266,7 @@ done
 # ── Header ──────────────────────────────────────────────────────────────────
 
 if [[ -z "${SECTION}" ]]; then
-    if $HAS_GUM; then
+    if $HAS_GUM && output_is_tty; then
         gum_style --bold --foreground 212 --border double \
             --border-foreground 99 --padding "0 2" --margin "1 0" \
             -- "${PROJECT_NAME}"

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -266,10 +266,12 @@ done
 # ── Header ──────────────────────────────────────────────────────────────────
 
 if [[ -z "${SECTION}" ]]; then
-    if $HAS_GUM && output_is_tty; then
-        gum_style --bold --foreground 212 --border double \
+    styled_header=""
+    if $HAS_GUM && output_is_tty &&
+        styled_header="$(gum_style --bold --foreground 212 --border double \
             --border-foreground 99 --padding "0 2" --margin "1 0" \
-            -- "${PROJECT_NAME}"
+            -- "${PROJECT_NAME}")"; then
+        printf '%s\n' "${styled_header}"
     else
         echo ""
         echo "=== ${PROJECT_NAME} ==="

--- a/scripts/test-label-registry.sh
+++ b/scripts/test-label-registry.sh
@@ -323,7 +323,7 @@ else
 fi
 
 # ── 4. provisioning-script binding ─────────────────────────────────────────
-# Run the provisioning script with `gh` stubbed to echo the label name and
+# Run the provisioning script with `gh` stubbed to record the label name and
 # confirm it provisions exactly the renderer's set — both directions, so
 # neither a dropped delegation nor a re-added hand-list can fork.
 if [ -f scripts/setup-github-labels.sh ]; then
@@ -333,13 +333,16 @@ if [ -f scripts/setup-github-labels.sh ]; then
         fail "setup-github-labels.sh hard-lists a name|color|description label line — the vocabulary lives in label-registry.json"
     fi
     stub_dir="$(mktemp -d)"
+    emitted_file="$stub_dir/emitted"
     cat >"$stub_dir/gh" <<'STUB'
 #!/usr/bin/env bash
-[ "$1" = label ] && { shift 2; printf '%s\n' "$1"; exit 0; }
+[ "$1" = label ] && { shift 2; printf '%s\n' "$1" >>"$STUB_EMITTED"; exit 0; }
 exit 0
 STUB
     chmod +x "$stub_dir/gh"
-    emitted="$(PATH="$stub_dir:$PATH" bash scripts/setup-github-labels.sh --repo drift/check --foreman 2>/dev/null | grep -v '^==>' | sort)"
+    STUB_EMITTED="$emitted_file" PATH="$stub_dir:$PATH" \
+        bash scripts/setup-github-labels.sh --repo drift/check --foreman >/dev/null 2>&1
+    emitted="$(sort "$emitted_file")"
     rm -rf "$stub_dir"
     want_names="$(node scripts/label-registry-render.mjs labels --foreman | sed 's/|.*//' | sort)"
     [ "$emitted" = "$want_names" ] || {

--- a/scripts/test-output.sh
+++ b/scripts/test-output.sh
@@ -39,6 +39,14 @@ secret_color="$(env -u NO_COLOR PATH=/usr/bin:/bin LANG=C.UTF-8 TERM=xterm-256co
 case "$setup_color" in *$'\033[1;36m'*) ;; *) fail "setup banner lost its cyan accent" ;; esac
 case "$secret_color" in *$'\033[1;35m'*) ;; *) fail "secret banner lost its magenta accent" ;; esac
 
+echo "==> a non-UTF-8 locale disables gum and Unicode presentation"
+non_utf8="$(env -u NO_COLOR LC_ALL=C TERM=xterm-256color CLICOLOR_FORCE=1 OUTPUT_TEST_TTY=1 \
+    bash -c '. "$1"; printf "capabilities=%s/%s\n" "$HAS_GUM" "$USE_UNICODE"; action_banner setup "Repository"' _ "$lib")"
+case "$non_utf8" in *'capabilities=false/false'*'*  SETUP'*) ;; *) fail "non-UTF-8 terminal did not select the ASCII presentation" ;; esac
+printf '%s\n' "$non_utf8" | LC_ALL=C od -An -tu1 -v | awk '
+    { for (i = 1; i <= NF; i++) if ($i > 127) exit 1 }
+' || fail "non-UTF-8 presentation contains Unicode bytes"
+
 echo "==> TERM=dumb wins over forced color"
 dumb="$(TERM=dumb CLICOLOR_FORCE=1 LANG=C.UTF-8 \
     bash -c '. "$1"; checkline ok "Step"' _ "$lib")"
@@ -80,6 +88,21 @@ esac
 case "$spinner" in
 *$'\r\033[2K') ;;
 *) fail "spinner did not erase its final frame" ;;
+esac
+
+echo "==> command diagnostics render only after the spinner is erased"
+set +e
+diagnostic="$(env -u CI -u NO_COLOR OUTPUT_FD=2 OUTPUT_TEST_TTY=1 OUTPUT_TEST_SPINNER=1 OUTPUT_SPINNER_DELAY=0.01 \
+    LANG=C.UTF-8 TERM=xterm-256color bash -c '
+        . "$1"
+        output_run "Working" bash -c "sleep 0.04; echo API-failed >&2; exit 29"
+    ' _ "$lib" 2>&1)"
+diagnostic_rc=$?
+set -e
+[ "$diagnostic_rc" -eq 29 ] || fail "diagnostic spinner path returned $diagnostic_rc instead of 29"
+case "$diagnostic" in
+*$'\r\033[2KAPI-failed') ;;
+*) fail "command diagnostic was not serialized after spinner cleanup" ;;
 esac
 
 echo "==> NO_COLOR disables animation even on a terminal"

--- a/scripts/test-output.sh
+++ b/scripts/test-output.sh
@@ -15,9 +15,12 @@ case "$plain" in
 *$'\033'*) fail "NO_COLOR output contains ANSI escapes" ;;
 esac
 case "$plain" in
-*'==> Action'*'[x] Step — complete'*'DONE: finished'*) ;;
+*'==> Action'*'[x] Step - complete'*'DONE: finished'*) ;;
 *) fail "plain output omitted the stable heading, outcome, or summary" ;;
 esac
+printf '%s\n' "$plain" | LC_ALL=C od -An -tu1 -v | awk '
+    { for (i = 1; i <= NF; i++) if ($i != 9 && $i != 10 && $i != 13 && ($i < 32 || $i > 126)) exit 1 }
+' || fail "plain output contains non-ASCII bytes"
 
 echo "==> a capable terminal gets ANSI color and Unicode"
 color="$(env -u NO_COLOR PATH=/usr/bin:/bin LANG=C.UTF-8 TERM=xterm-256color OUTPUT_TEST_TTY=1 \

--- a/scripts/test-output.sh
+++ b/scripts/test-output.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Unit-test the shared output library without requiring a terminal or gum.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+lib="$PWD/scripts/lib/output.sh"
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+echo "==> redirected output is stable ASCII"
+plain="$(NO_COLOR=1 bash -c '. "$1"; section_header "Action"; checkline ok "Step" "complete"; output_done "finished"' _ "$lib")"
+case "$plain" in
+*$'\033'*) fail "NO_COLOR output contains ANSI escapes" ;;
+esac
+case "$plain" in
+*'==> Action'*'[x] Step — complete'*'DONE: finished'*) ;;
+*) fail "plain output omitted the stable heading, outcome, or summary" ;;
+esac
+
+echo "==> a capable terminal gets ANSI color and Unicode"
+color="$(env -u NO_COLOR PATH=/usr/bin:/bin LANG=C.UTF-8 TERM=xterm-256color OUTPUT_TEST_TTY=1 \
+    bash -c '. "$1"; section_header "Action"; checkline ok "Step" "complete"' _ "$lib")"
+case "$color" in *$'\033['*) ;; *) fail "terminal output did not include ANSI color" ;; esac
+case "$color" in *'◆ Action'*'✓'*'Step — complete'*) ;;
+*) fail "terminal output did not include the Unicode presentation" ;;
+esac
+
+echo "==> TERM=dumb wins over forced color"
+dumb="$(TERM=dumb CLICOLOR_FORCE=1 LANG=C.UTF-8 \
+    bash -c '. "$1"; checkline ok "Step"' _ "$lib")"
+case "$dumb" in
+*$'\033'*) fail "TERM=dumb output contains ANSI escapes" ;;
+esac
+case "$dumb" in
+*'[x] Step'*) ;;
+*) fail "TERM=dumb output did not fall back to ASCII" ;;
+esac
+
+echo "==> non-terminal commands preserve status without control sequences"
+set +e
+non_tty="$(OUTPUT_FD=2 bash -c '. "$1"; output_run "Working" bash -c "exit 37"' _ "$lib" 2>&1)"
+non_tty_rc=$?
+set -e
+[ "$non_tty_rc" -eq 37 ] || fail "output_run changed exit 37 to $non_tty_rc"
+case "$non_tty" in
+*$'\033'*) fail "non-terminal output_run emitted control sequences" ;;
+esac
+
+echo "==> spinner cleanup leaves no job and preserves command status"
+set +e
+spinner="$(env -u CI -u NO_COLOR OUTPUT_FD=2 OUTPUT_TEST_TTY=1 OUTPUT_TEST_SPINNER=1 OUTPUT_SPINNER_DELAY=0.01 \
+    LANG=C.UTF-8 TERM=xterm-256color bash -c '
+        . "$1"
+        output_run "Working" bash -c "sleep 0.04; exit 23"
+        rc=$?
+        [ -z "$(jobs -pr)" ] || exit 91
+        exit "$rc"
+    ' _ "$lib" 2>&1)"
+spinner_rc=$?
+set -e
+[ "$spinner_rc" -eq 23 ] || fail "spinner path returned $spinner_rc instead of 23"
+case "$spinner" in
+*$'\033[2K'*'Working'*) ;;
+*) fail "forced terminal path did not animate" ;;
+esac
+case "$spinner" in
+*$'\r\033[2K') ;;
+*) fail "spinner did not erase its final frame" ;;
+esac
+
+echo "==> NO_COLOR disables animation even on a terminal"
+no_color_spinner="$(env -u CI NO_COLOR=1 OUTPUT_FD=2 OUTPUT_TEST_TTY=1 OUTPUT_TEST_SPINNER=1 \
+    bash -c '. "$1"; output_run "Working" true' _ "$lib" 2>&1)"
+case "$no_color_spinner" in
+*$'\033'*) fail "NO_COLOR spinner path emitted terminal controls" ;;
+esac
+
+echo "PASS: shared output fallbacks and spinner lifecycle"

--- a/scripts/test-output.sh
+++ b/scripts/test-output.sh
@@ -10,12 +10,12 @@ fail() {
 }
 
 echo "==> redirected output is stable ASCII"
-plain="$(NO_COLOR=1 bash -c '. "$1"; section_header "Action"; checkline ok "Step" "complete"; output_done "finished"' _ "$lib")"
+plain="$(NO_COLOR=1 bash -c '. "$1"; action_banner secret "Credential" "stdin only"; checkline ok "Step" "complete"; checkline na "Optional" "skipped"; output_summary "Write"; output_done "finished"' _ "$lib")"
 case "$plain" in
 *$'\033'*) fail "NO_COLOR output contains ANSI escapes" ;;
 esac
 case "$plain" in
-*'==> Action'*'[x] Step - complete'*'DONE: finished'*) ;;
+*'== SECRET :: Credential =='*'[x] Step - complete'*'SUMMARY: Write - succeeded=1 failed=0 attention=0 skipped=1 total=2'*'DONE: finished'*) ;;
 *) fail "plain output omitted the stable heading, outcome, or summary" ;;
 esac
 printf '%s\n' "$plain" | LC_ALL=C od -An -tu1 -v | awk '
@@ -24,11 +24,20 @@ printf '%s\n' "$plain" | LC_ALL=C od -An -tu1 -v | awk '
 
 echo "==> a capable terminal gets ANSI color and Unicode"
 color="$(env -u NO_COLOR PATH=/usr/bin:/bin LANG=C.UTF-8 TERM=xterm-256color OUTPUT_TEST_TTY=1 \
-    bash -c '. "$1"; section_header "Action"; checkline ok "Step" "complete"' _ "$lib")"
+    bash -c '. "$1"; action_banner setup "Repository" "configure"; checkline ok "Step" "complete"; checkline unknown "Review" "pending"; output_summary "Setup"; output_done "ready"' _ "$lib")"
 case "$color" in *$'\033['*) ;; *) fail "terminal output did not include ANSI color" ;; esac
-case "$color" in *'◆ Action'*'✓'*'Step — complete'*) ;;
+case "$color" in *'⚙  SETUP'*'✓'*'Step — complete'*'╭─ Setup'*'Attention'*'╰─ ✨'*'ready'*) ;;
 *) fail "terminal output did not include the Unicode presentation" ;;
 esac
+
+echo "==> task families have visually distinct semantic accents"
+setup_color="$(env -u NO_COLOR PATH=/usr/bin:/bin LANG=C.UTF-8 TERM=xterm-256color OUTPUT_TEST_TTY=1 \
+    bash -c '. "$1"; action_banner setup "One"' _ "$lib")"
+secret_color="$(env -u NO_COLOR PATH=/usr/bin:/bin LANG=C.UTF-8 TERM=xterm-256color OUTPUT_TEST_TTY=1 \
+    bash -c '. "$1"; action_banner secret "Two"' _ "$lib")"
+[ "$setup_color" != "$secret_color" ] || fail "setup and secret banners rendered identically"
+case "$setup_color" in *$'\033[1;36m'*) ;; *) fail "setup banner lost its cyan accent" ;; esac
+case "$secret_color" in *$'\033[1;35m'*) ;; *) fail "secret banner lost its magenta accent" ;; esac
 
 echo "==> TERM=dumb wins over forced color"
 dumb="$(TERM=dumb CLICOLOR_FORCE=1 LANG=C.UTF-8 \

--- a/scripts/test-output.sh
+++ b/scripts/test-output.sh
@@ -47,6 +47,28 @@ printf '%s\n' "$non_utf8" | LC_ALL=C od -An -tu1 -v | awk '
     { for (i = 1; i <= NF; i++) if ($i > 127) exit 1 }
 ' || fail "non-UTF-8 presentation contains Unicode bytes"
 
+echo "==> a broken optional gum falls back without aborting the task"
+fake_bin="$(mktemp -d)"
+trap 'rm -rf "$fake_bin"' EXIT
+cat >"${fake_bin}/gum" <<'EOF'
+#!/bin/sh
+exit 42
+EOF
+chmod +x "${fake_bin}/gum"
+gum_fallback="$(env -u NO_COLOR PATH="${fake_bin}:/usr/bin:/bin" LANG=C.UTF-8 \
+    TERM=xterm-256color OUTPUT_TEST_TTY=1 bash -euo pipefail -c '
+        . "$1"
+        action_banner setup "Repository" "configure"
+        section_header "Details"
+        printf "inside\n" | section_box
+        kv "State" "ready"
+        printf "REACHED-END\n"
+    ' _ "$lib")"
+case "$gum_fallback" in
+*$'\033[1;36m'*'Repository'*'Details'*'inside'*'State:'*'ready'*'REACHED-END'*) ;;
+*) fail "broken gum did not fall back to the complete built-in presentation" ;;
+esac
+
 echo "==> TERM=dumb wins over forced color"
 dumb="$(TERM=dumb CLICOLOR_FORCE=1 LANG=C.UTF-8 \
     bash -c '. "$1"; checkline ok "Step"' _ "$lib")"

--- a/scripts/test-registry-drift.sh
+++ b/scripts/test-registry-drift.sh
@@ -124,13 +124,16 @@ if [ -f "$labels_script" ]; then
     # running it observes what would really be provisioned. --foreman exercises
     # both renderer modes regardless of whether this profile arms Foreman.
     stub_dir="$(mktemp -d)"
+    emitted_file="$stub_dir/emitted"
     cat >"$stub_dir/gh" <<'STUB'
 #!/usr/bin/env bash
-[ "$1" = label ] && { shift 2; printf '%s\n' "$1"; exit 0; }
+[ "$1" = label ] && { shift 2; printf '%s\n' "$1" >>"$STUB_EMITTED"; exit 0; }
 exit 0
 STUB
     chmod +x "$stub_dir/gh"
-    emitted="$(PATH="$stub_dir:$PATH" bash "$labels_script" --repo drift/check --foreman 2>/dev/null | sort -u)"
+    STUB_EMITTED="$emitted_file" PATH="$stub_dir:$PATH" \
+        bash "$labels_script" --repo drift/check --foreman >/dev/null 2>&1
+    emitted="$(sort -u "$emitted_file")"
     rm -rf "$stub_dir"
     missing="$(comm -23 <(printf '%s\n' "$names" | sort -u) <(printf '%s\n' "$emitted"))"
     if [ -n "$missing" ]; then

--- a/scripts/test-setup-gh-scopes.sh
+++ b/scripts/test-setup-gh-scopes.sh
@@ -31,14 +31,17 @@ unset GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN GH_HOST
 
 script="./scripts/setup-gh-scopes.sh"
 scopes_lib="./scripts/gh-scopes.sh"
+output_lib="./scripts/lib/output.sh"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "${TMP}"' EXIT
 
 # A board-carrying fixture, so the required list includes the Projects scopes.
 mkdir -p "${TMP}/repo/scripts"
+mkdir -p "${TMP}/repo/scripts/lib"
 cp "${script}" "${TMP}/repo/scripts/setup-gh-scopes.sh"
 cp "${scopes_lib}" "${TMP}/repo/scripts/gh-scopes.sh"
+cp "${output_lib}" "${TMP}/repo/scripts/lib/output.sh"
 : >"${TMP}/repo/scripts/setup-github-project.sh"
 SUT="${TMP}/repo/scripts/setup-gh-scopes.sh"
 
@@ -281,7 +284,7 @@ if [ "${PTY_OK}" = true ]; then
     echo "==> succeeds when the refresh lands, naming the scopes"
     out="$(run_sut_pty lands-after-refresh GH_HOST=github.com)"
     case "$out" in
-    *"All requested scopes present"*) ;;
+    *"All requested GitHub CLI scopes are present"*) ;;
     *) fail "expected success after a landed refresh, got: ${out}" ;;
     esac
 
@@ -302,7 +305,7 @@ if [ "${PTY_OK}" = true ]; then
     # host would let an unrelated login satisfy the requirement.
     out="$(run_sut_pty inactive-has-scope GH_HOST=github.com)"
     case "$out" in
-    *"All requested scopes present"*) fail "an inactive account's scopes verified the active one: ${out}" ;;
+    *"All requested GitHub CLI scopes are present"*) fail "an inactive account's scopes verified the active one: ${out}" ;;
     *"did not grant"*) ;;
     *) fail "expected the active account's missing scopes to be reported, got: ${out}" ;;
     esac
@@ -314,7 +317,7 @@ if [ "${PTY_OK}" = true ]; then
     # read grant leaves board writes broken while satisfying the alternation.
     out="$(run_sut_pty read-only-grant GH_HOST=github.com)"
     case "$out" in
-    *"All requested scopes present"*) fail "a read-only grant was reported as success: ${out}" ;;
+    *"All requested GitHub CLI scopes are present"*) fail "a read-only grant was reported as success: ${out}" ;;
     *"did not grant"*"project"*) ;;
     *) fail "expected the missing write scope to be reported, got: ${out}" ;;
     esac
@@ -342,7 +345,7 @@ if [ "${PTY_OK}" = true ]; then
     fi
     unset STUB_CALLS
     case "$out" in
-    *"Already complete"*) ;;
+    *"GitHub CLI scopes are already ready"*) ;;
     *) fail "expected the no-op path to say so, got: ${out}" ;;
     esac
     [ "$(rc_pty_of lands GH_HOST=github.com)" = 0 ] ||

--- a/scripts/test-setup-github-project.sh
+++ b/scripts/test-setup-github-project.sh
@@ -37,6 +37,9 @@ if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
     [ -n "${STUB_SCOPES:-}" ] && echo "  - Token scopes: ${STUB_SCOPES}"
     exit 0
 fi
+if [ "$1" = "variable" ] && [ "$2" = "set" ]; then
+    exit "${STUB_VARIABLE_RC:-0}"
+fi
 q=""
 for a in "$@"; do case "$a" in query=*) q="${a#query=}" ;; esac; done
 case "$q" in
@@ -48,7 +51,7 @@ case "$q" in
         cat "$STUB_FIELDS_FILE"
     fi
     ;;
-*repositoryOwner*__typename*) echo '{"data":{"repositoryOwner":{"__typename":"User","id":"U_1"}}}' ;;
+*repositoryOwner*__typename*) printf '{"data":{"repositoryOwner":{"__typename":"%s","id":"U_1"}}}\n' "${STUB_OWNER_TYPE:-User}" ;;
 *projectsV2*) echo '{"data":{"repositoryOwner":{"projectsV2":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"P_1","number":7,"title":"Test Project"}]}}}}' ;;
 *ProjectV2Field*) printf '%s\n' "$q" >>"$MUTATIONS"; echo '{"data":{}}' ;;
 *) echo "fake gh: unexpected query: $q" >&2; exit 1 ;;
@@ -64,6 +67,7 @@ MUTATIONS="$tmp/mutations"
 STUB_FIELDS_FILE="$tmp/fields.json"
 STUB_FIELDS_FILE2="$tmp/fields2.json"
 export MUTATIONS STUB_FIELDS_FILE STUB_FIELDS_FILE2
+export STUB_OWNER_TYPE STUB_VARIABLE_RC
 
 # run_with FIELDS_JSON — run the script against that project snapshot.
 run_with() {
@@ -108,6 +112,19 @@ run_with "$complete"
 [ "$(updates)" = 0 ] || fail "expected no mutations on an unchanged project, got $(updates)"
 grep -q "leaving it as-is" "$tmp/out" || fail "expected 'leaving it as-is' output"
 grep -q "DONE: GitHub Project is ready" "$tmp/out" || fail "expected an explicit ready outcome"
+
+echo "==> a failed ORG_PROJECT_ID write degrades the final outcome"
+STUB_OWNER_TYPE=Organization
+STUB_VARIABLE_RC=19
+run_with "$complete"
+grep -q "ORG_PROJECT_ID was not written" "$tmp/out" ||
+    fail "expected the failed org-variable write in the outcome rows"
+grep -q "WARN: GitHub Project needs attention" "$tmp/out" ||
+    fail "expected a warning final outcome after the org-variable write failed"
+! grep -q "DONE: GitHub Project is ready" "$tmp/out" ||
+    fail "failed org-variable write claimed the project was ready"
+STUB_OWNER_TYPE=User
+STUB_VARIABLE_RC=0
 
 echo "==> the retired Agent field is never created"
 # The fixture above deliberately has no Agent field, so any mutation naming one

--- a/scripts/test-setup-github-project.sh
+++ b/scripts/test-setup-github-project.sh
@@ -113,6 +113,21 @@ run_with "$complete"
 grep -q "leaving it as-is" "$tmp/out" || fail "expected 'leaving it as-is' output"
 grep -q "DONE: GitHub Project is ready" "$tmp/out" || fail "expected an explicit ready outcome"
 
+echo "==> visual progress stays on one ordered stream under Task grouping"
+printf '%s' "$complete" >"$STUB_FIELDS_FILE"
+rm -f "$tmp_seen"
+: >"$MUTATIONS"
+NO_COLOR=1 "$script" --owner someuser --title "Test Project" \
+    >"$tmp/stdout" 2>"$tmp/stderr" || fail "ordered-stream run exited non-zero"
+[ ! -s "$tmp/stdout" ] || fail "action progress leaked onto Task's buffered stdout"
+banner_line="$(grep -n '== SETUP :: GitHub Project ==' "$tmp/stderr" | cut -d: -f1 || true)"
+progress_line="$(grep -n "Resolving owner 'someuser'" "$tmp/stderr" | cut -d: -f1 || true)"
+done_line="$(grep -n 'DONE: GitHub Project is ready' "$tmp/stderr" | cut -d: -f1 || true)"
+[ -n "$banner_line" ] && [ -n "$progress_line" ] && [ -n "$done_line" ] ||
+    fail "ordered stream is missing its banner, progress, or final outcome"
+[ "$banner_line" -lt "$progress_line" ] && [ "$progress_line" -lt "$done_line" ] ||
+    fail "action stream did not preserve banner -> progress -> outcome chronology"
+
 echo "==> a failed ORG_PROJECT_ID write degrades the final outcome"
 STUB_OWNER_TYPE=Organization
 STUB_VARIABLE_RC=19

--- a/scripts/test-setup-github-project.sh
+++ b/scripts/test-setup-github-project.sh
@@ -107,6 +107,7 @@ echo "==> a re-run against an already-synced project writes nothing"
 run_with "$complete"
 [ "$(updates)" = 0 ] || fail "expected no mutations on an unchanged project, got $(updates)"
 grep -q "leaving it as-is" "$tmp/out" || fail "expected 'leaving it as-is' output"
+grep -q "DONE: GitHub Project is ready" "$tmp/out" || fail "expected an explicit ready outcome"
 
 echo "==> the retired Agent field is never created"
 # The fixture above deliberately has no Agent field, so any mutation naming one
@@ -171,6 +172,10 @@ grep -q "field 'Status' already exists as TEXT" "$tmp/out" ||
     fail "expected a data-type warning naming Status and its actual type"
 grep -q "Status (is TEXT, wanted SINGLE_SELECT)" "$tmp/out" ||
     fail "expected Status in the end-of-run incompatible summary"
+grep -q "WARN: GitHub Project needs attention" "$tmp/out" ||
+    fail "expected a warning final outcome for incomplete reconciliation"
+! grep -q "DONE: GitHub Project is ready" "$tmp/out" ||
+    fail "incomplete reconciliation claimed the project was ready"
 
 echo "==> a field at the option cap warns instead of attempting an oversized write"
 capped=$(printf '%s' "$complete" | jq -c '
@@ -182,6 +187,8 @@ capped=$(printf '%s' "$complete" | jq -c '
 run_with "$capped"
 [ "$(updates)" = 0 ] || fail "an over-capacity append must be skipped, not attempted"
 grep -q "cannot fit Low" "$tmp/out" || fail "expected a capacity warning naming the missing option"
+grep -q "WARN: GitHub Project needs attention" "$tmp/out" ||
+    fail "expected a warning final outcome at the option cap"
 
 echo "==> an option added after the startup snapshot survives the append"
 # The re-read immediately before the write is what saves it: the replacement is

--- a/scripts/test-setup-github-project.sh
+++ b/scripts/test-setup-github-project.sh
@@ -190,6 +190,16 @@ grep -q "cannot fit Low" "$tmp/out" || fail "expected a capacity warning naming 
 grep -q "WARN: GitHub Project needs attention" "$tmp/out" ||
     fail "expected a warning final outcome at the option cap"
 
+echo "==> a field deleted during reconciliation cannot produce a ready outcome"
+without_status=$(printf '%s' "$complete" | jq -c '
+    .data.node.fields.nodes |= map(select(.name != "Status"))')
+run_with "$complete" "$without_status"
+grep -q "field 'Status' disappeared" "$tmp/out" || fail "expected a concurrent-disappearance warning"
+grep -q "WARN: GitHub Project needs attention" "$tmp/out" ||
+    fail "expected a warning final outcome after a field disappeared"
+! grep -q "DONE: GitHub Project is ready" "$tmp/out" ||
+    fail "a skipped field reconciliation claimed the project was ready"
+
 echo "==> an option added after the startup snapshot survives the append"
 # The re-read immediately before the write is what saves it: the replacement is
 # built from the fresh list, not the stale one.

--- a/scripts/test-setup-github.sh
+++ b/scripts/test-setup-github.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Unit-test setup-github.sh against a stubbed gh; never touches GitHub.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+script="$PWD/scripts/setup-github.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    [ -f "$tmp/out" ] && sed 's/^/    /' "$tmp/out" >&2
+    exit 1
+}
+
+mkdir -p "$tmp/bin"
+stub_calls="$tmp/calls"
+cat >"$tmp/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${STUB_CALLS:?}"
+case "$*" in
+*"${GH_FAIL_MATCH:-__never__}"*) exit "${GH_FAIL_RC:-1}" ;;
+esac
+case "$*" in
+*" --jq .private") printf '%s\n' "${GH_PRIVATE:-true}" ;;
+esac
+STUB
+chmod +x "$tmp/bin/gh"
+
+run_case() {
+    : >"$stub_calls"
+    set +e
+    PATH="$tmp/bin:$PATH" STUB_CALLS="$stub_calls" NO_COLOR=1 \
+        "$script" "$@" >"$tmp/out" 2>&1
+    run_rc=$?
+    set -e
+}
+
+echo "==> private repositories report success plus the reason for a skip"
+GH_PRIVATE=true run_case --repo owner/private
+[ "$run_rc" -eq 0 ] || fail "private path exited $run_rc"
+grep -Fq '[x] Dependabot alerts — enabled' "$tmp/out" || fail "missing Dependabot success"
+grep -Fq '[-] Private vulnerability reporting — skipped — private repository' "$tmp/out" || fail "missing private-repo skip reason"
+grep -Fq 'DONE: GitHub repository settings are ready for owner/private' "$tmp/out" || fail "missing final outcome"
+if grep -q 'private-vulnerability-reporting' "$stub_calls"; then
+    fail "private repository attempted to enable public-only reporting"
+fi
+
+echo "==> public repositories enable every requested setting and collaborator"
+GH_PRIVATE=false run_case --repo owner/public --bot-collaborator owner-bot
+[ "$run_rc" -eq 0 ] || fail "public path exited $run_rc"
+grep -Fq '[x] Private vulnerability reporting — enabled' "$tmp/out" || fail "missing reporting success"
+grep -Fq '[x] Bot collaborator — owner-bot has push access' "$tmp/out" || fail "missing collaborator success"
+grep -q 'private-vulnerability-reporting --method PUT' "$stub_calls" || fail "reporting API was not called"
+grep -q 'collaborators/owner-bot --method PUT -f permission=push' "$stub_calls" || fail "collaborator API was not called"
+
+echo "==> failures are formatted, preserve status, and never claim completion"
+GH_PRIVATE=false GH_FAIL_MATCH=vulnerability-alerts GH_FAIL_RC=23 \
+    run_case --repo owner/failing
+[ "$run_rc" -eq 23 ] || fail "API exit 23 became $run_rc"
+grep -Fq '[ ] Dependabot alerts — GitHub API request failed (exit 23)' "$tmp/out" || fail "missing formatted failure"
+if grep -q 'DONE:' "$tmp/out"; then fail "failed run printed a completion summary"; fi
+if grep -q 'private-vulnerability-reporting' "$stub_calls"; then
+    fail "script continued mutating after the first failure"
+fi
+
+echo "PASS: setup-github outcomes and failure propagation"

--- a/scripts/test-setup-github.sh
+++ b/scripts/test-setup-github.sh
@@ -40,8 +40,11 @@ echo "==> private repositories report success plus the reason for a skip"
 GH_PRIVATE=true run_case --repo owner/private
 [ "$run_rc" -eq 0 ] || fail "private path exited $run_rc"
 grep -Fq '[x] Dependabot alerts - enabled' "$tmp/out" || fail "missing Dependabot success"
-grep -Fq '[-] Private vulnerability reporting - skipped — private repository' "$tmp/out" || fail "missing private-repo skip reason"
+grep -Fq '[-] Private vulnerability reporting - skipped: private repository' "$tmp/out" || fail "missing private-repo skip reason"
 grep -Fq 'DONE: GitHub repository settings are ready for owner/private' "$tmp/out" || fail "missing final outcome"
+LC_ALL=C od -An -tu1 -v "$tmp/out" | awk '
+    { for (i = 1; i <= NF; i++) if ($i != 9 && $i != 10 && $i != 13 && ($i < 32 || $i > 126)) exit 1 }
+' || fail "plain setup output contains non-ASCII presentation bytes"
 if grep -q 'private-vulnerability-reporting' "$stub_calls"; then
     fail "private repository attempted to enable public-only reporting"
 fi

--- a/scripts/test-setup-github.sh
+++ b/scripts/test-setup-github.sh
@@ -22,6 +22,10 @@ case "$*" in
 *"${GH_FAIL_MATCH:-__never__}"*) exit "${GH_FAIL_RC:-1}" ;;
 esac
 case "$*" in
+*"/permission --jq .permission")
+    [ -n "${GH_PERMISSION:-}" ] || exit 1
+    printf '%s\n' "$GH_PERMISSION"
+    ;;
 *" --jq .private") printf '%s\n' "${GH_PRIVATE:-true}" ;;
 esac
 STUB
@@ -50,12 +54,24 @@ if grep -q 'private-vulnerability-reporting' "$stub_calls"; then
 fi
 
 echo "==> public repositories enable every requested setting and collaborator"
-GH_PRIVATE=false run_case --repo owner/public --bot-collaborator owner-bot
+GH_PRIVATE=false GH_PERMISSION=write run_case --repo owner/public --bot-collaborator owner-bot
 [ "$run_rc" -eq 0 ] || fail "public path exited $run_rc"
 grep -Fq '[x] Private vulnerability reporting - enabled' "$tmp/out" || fail "missing reporting success"
 grep -Fq '[x] Bot collaborator - owner-bot has push access' "$tmp/out" || fail "missing collaborator success"
 grep -q 'private-vulnerability-reporting --method PUT' "$stub_calls" || fail "reporting API was not called"
 grep -q 'collaborators/owner-bot --method PUT -f permission=push' "$stub_calls" || fail "collaborator API was not called"
+grep -q 'collaborators/owner-bot/permission --jq .permission' "$stub_calls" || fail "collaborator access was not verified"
+
+echo "==> a new collaborator invitation is reported as pending until accepted"
+GH_PRIVATE=false GH_PERMISSION= run_case --repo owner/public --bot-collaborator owner-bot
+[ "$run_rc" -eq 0 ] || fail "pending invitation path exited $run_rc"
+grep -Fq '[?] Bot collaborator - invitation sent to owner-bot; access starts after acceptance' "$tmp/out" ||
+    fail "missing pending-invitation outcome"
+grep -Fq 'WARN: GitHub repository settings are ready; bot collaborator acceptance is pending' "$tmp/out" ||
+    fail "missing pending-invitation summary"
+if grep -q 'owner-bot has push access' "$tmp/out"; then
+    fail "pending invitation falsely claimed active push access"
+fi
 
 echo "==> failures are formatted, preserve status, and never claim completion"
 GH_PRIVATE=false GH_FAIL_MATCH=vulnerability-alerts GH_FAIL_RC=23 \

--- a/scripts/test-setup-github.sh
+++ b/scripts/test-setup-github.sh
@@ -39,8 +39,8 @@ run_case() {
 echo "==> private repositories report success plus the reason for a skip"
 GH_PRIVATE=true run_case --repo owner/private
 [ "$run_rc" -eq 0 ] || fail "private path exited $run_rc"
-grep -Fq '[x] Dependabot alerts — enabled' "$tmp/out" || fail "missing Dependabot success"
-grep -Fq '[-] Private vulnerability reporting — skipped — private repository' "$tmp/out" || fail "missing private-repo skip reason"
+grep -Fq '[x] Dependabot alerts - enabled' "$tmp/out" || fail "missing Dependabot success"
+grep -Fq '[-] Private vulnerability reporting - skipped — private repository' "$tmp/out" || fail "missing private-repo skip reason"
 grep -Fq 'DONE: GitHub repository settings are ready for owner/private' "$tmp/out" || fail "missing final outcome"
 if grep -q 'private-vulnerability-reporting' "$stub_calls"; then
     fail "private repository attempted to enable public-only reporting"
@@ -49,8 +49,8 @@ fi
 echo "==> public repositories enable every requested setting and collaborator"
 GH_PRIVATE=false run_case --repo owner/public --bot-collaborator owner-bot
 [ "$run_rc" -eq 0 ] || fail "public path exited $run_rc"
-grep -Fq '[x] Private vulnerability reporting — enabled' "$tmp/out" || fail "missing reporting success"
-grep -Fq '[x] Bot collaborator — owner-bot has push access' "$tmp/out" || fail "missing collaborator success"
+grep -Fq '[x] Private vulnerability reporting - enabled' "$tmp/out" || fail "missing reporting success"
+grep -Fq '[x] Bot collaborator - owner-bot has push access' "$tmp/out" || fail "missing collaborator success"
 grep -q 'private-vulnerability-reporting --method PUT' "$stub_calls" || fail "reporting API was not called"
 grep -q 'collaborators/owner-bot --method PUT -f permission=push' "$stub_calls" || fail "collaborator API was not called"
 
@@ -58,7 +58,7 @@ echo "==> failures are formatted, preserve status, and never claim completion"
 GH_PRIVATE=false GH_FAIL_MATCH=vulnerability-alerts GH_FAIL_RC=23 \
     run_case --repo owner/failing
 [ "$run_rc" -eq 23 ] || fail "API exit 23 became $run_rc"
-grep -Fq '[ ] Dependabot alerts — GitHub API request failed (exit 23)' "$tmp/out" || fail "missing formatted failure"
+grep -Fq '[ ] Dependabot alerts - GitHub API request failed (exit 23)' "$tmp/out" || fail "missing formatted failure"
 if grep -q 'DONE:' "$tmp/out"; then fail "failed run printed a completion summary"; fi
 if grep -q 'private-vulnerability-reporting' "$stub_calls"; then
     fail "script continued mutating after the first failure"

--- a/scripts/test-setup-github.sh
+++ b/scripts/test-setup-github.sh
@@ -22,6 +22,7 @@ case "$*" in
 *"${GH_FAIL_MATCH:-__never__}"*) exit "${GH_FAIL_RC:-1}" ;;
 esac
 case "$*" in
+*"collaborators/"*" --method PUT"*) printf '%s' "${GH_COLLAB_RESPONSE:-}" ;;
 *"/permission --jq .permission")
     [ -n "${GH_PERMISSION:-}" ] || exit 1
     printf '%s\n' "$GH_PERMISSION"
@@ -57,21 +58,37 @@ echo "==> public repositories enable every requested setting and collaborator"
 GH_PRIVATE=false GH_PERMISSION=write run_case --repo owner/public --bot-collaborator owner-bot
 [ "$run_rc" -eq 0 ] || fail "public path exited $run_rc"
 grep -Fq '[x] Private vulnerability reporting - enabled' "$tmp/out" || fail "missing reporting success"
-grep -Fq '[x] Bot collaborator - owner-bot has push access' "$tmp/out" || fail "missing collaborator success"
+grep -Fq '[x] Bot collaborator - owner-bot has write access' "$tmp/out" || fail "missing collaborator success"
 grep -q 'private-vulnerability-reporting --method PUT' "$stub_calls" || fail "reporting API was not called"
 grep -q 'collaborators/owner-bot --method PUT -f permission=push' "$stub_calls" || fail "collaborator API was not called"
 grep -q 'collaborators/owner-bot/permission --jq .permission' "$stub_calls" || fail "collaborator access was not verified"
 
 echo "==> a new collaborator invitation is reported as pending until accepted"
-GH_PRIVATE=false GH_PERMISSION= run_case --repo owner/public --bot-collaborator owner-bot
+GH_PRIVATE=false GH_COLLAB_RESPONSE='{"id":42,"invitee":{"login":"owner-bot"}}' \
+    run_case --repo owner/public --bot-collaborator owner-bot
 [ "$run_rc" -eq 0 ] || fail "pending invitation path exited $run_rc"
 grep -Fq '[?] Bot collaborator - invitation sent to owner-bot; access starts after acceptance' "$tmp/out" ||
     fail "missing pending-invitation outcome"
 grep -Fq 'WARN: GitHub repository settings are ready; bot collaborator acceptance is pending' "$tmp/out" ||
     fail "missing pending-invitation summary"
-if grep -q 'owner-bot has push access' "$tmp/out"; then
+if grep -q 'owner-bot has write access' "$tmp/out"; then
     fail "pending invitation falsely claimed active push access"
 fi
+
+echo "==> a failed permission lookup is unknown, never mislabeled as an invitation"
+GH_PRIVATE=false GH_COLLAB_RESPONSE= GH_PERMISSION= \
+    run_case --repo owner/public --bot-collaborator owner-bot
+[ "$run_rc" -eq 0 ] || fail "unverified collaborator path exited $run_rc"
+grep -Fq '[?] Bot collaborator - GitHub accepted the request, but permission verification failed' "$tmp/out" ||
+    fail "missing unverified-permission outcome"
+grep -Fq 'WARN: GitHub repository settings changed, but collaborator access needs verification' "$tmp/out" ||
+    fail "missing unverified-permission summary"
+if grep -q 'invitation sent' "$tmp/out"; then
+    fail "permission lookup failure was mislabeled as a confirmed invitation"
+fi
+
+grep -Fq 'SUMMARY: Repository setup - succeeded=' "$tmp/out" ||
+    fail "missing compact repository outcome summary"
 
 echo "==> failures are formatted, preserve status, and never claim completion"
 GH_PRIVATE=false GH_FAIL_MATCH=vulnerability-alerts GH_FAIL_RC=23 \

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -752,7 +752,7 @@ echo "==> gh's own credential line reports the state the section already probed"
 # From the one bounded probe at the top of the script — no second `gh auth
 # status` call, which is why this line survives a logged-out gh at all.
 case "$out" in
-*"[ ] GitHub CLI (gh) — gh auth login"*) ;;
+*"[ ] GitHub CLI (gh) - gh auth login"*) ;;
 *) fail "expected the gh credential line to name its remedy, got: ${out}" ;;
 esac
 
@@ -769,7 +769,7 @@ make_codex_stub out
 out="$(run_setup_section unauthenticated)"
 case "$out" in
 *"[x] Codex CLI"*) fail "a logged-out codex must not read as ok: ${out}" ;;
-*"[ ] Codex CLI — codex login"*) ;;
+*"[ ] Codex CLI - codex login"*) ;;
 *) fail "expected a logged-out codex to name its remedy, got: ${out}" ;;
 esac
 
@@ -822,8 +822,8 @@ make_stub unauthenticated
 make_codex_stub in
 out="$(run_setup_without gh)"
 case "$out" in
-*"GitHub CLI (gh) — gh auth login"*) fail "an absent gh must not be told to log in: ${out}" ;;
-*"[ ] GitHub CLI (gh) — brew install gh"*) ;;
+*"GitHub CLI (gh) - gh auth login"*) fail "an absent gh must not be told to log in: ${out}" ;;
+*"[ ] GitHub CLI (gh) - brew install gh"*) ;;
 *) fail "expected an install remedy for a missing gh, got: ${out}" ;;
 esac
 # The rest of the run must still behave: an absent gh is not an authenticated
@@ -1069,7 +1069,7 @@ echo "==> status:creds reports a logged-out gh with the login remedy"
 make_codex_stub in
 out="$(run_creds_section unauthenticated)"
 case "$out" in
-*"[ ] GitHub CLI (gh) — gh auth login"*) ;;
+*"[ ] GitHub CLI (gh) - gh auth login"*) ;;
 *) fail "expected a missing-login line from status:creds, got: ${out}" ;;
 esac
 
@@ -1107,7 +1107,7 @@ make_codex_stub out
 out="$(run_creds_section project)"
 case "$out" in
 *"[x] Codex CLI"*) fail "a logged-out codex must not read as ok: ${out}" ;;
-*"[ ] Codex CLI — codex login"*) ;;
+*"[ ] Codex CLI - codex login"*) ;;
 *) fail "expected a logged-out codex line from status:creds, got: ${out}" ;;
 esac
 
@@ -1119,7 +1119,7 @@ make_claude_stub out
 out="$(run_creds_section project)"
 case "$out" in
 *"[x] Claude Code CLI"*) fail "a logged-out claude must not read as ok: ${out}" ;;
-*"[ ] Claude Code CLI — claude auth login"*) ;;
+*"[ ] Claude Code CLI - claude auth login"*) ;;
 *) fail "expected a logged-out claude line, got: ${out}" ;;
 esac
 
@@ -1166,8 +1166,8 @@ make_codex_stub in
 make_isolated_bin gh
 out="$(PATH="${TMP}/bin-iso" NO_COLOR=1 "${WITH_CODEX}" creds 2>&1)"
 case "$out" in
-*"GitHub CLI (gh) — gh auth login"*) fail "an absent gh must not be told to log in: ${out}" ;;
-*"[ ] GitHub CLI (gh) — brew install gh"*) ;;
+*"GitHub CLI (gh) - gh auth login"*) fail "an absent gh must not be told to log in: ${out}" ;;
+*"[ ] GitHub CLI (gh) - brew install gh"*) ;;
 *) fail "expected an install remedy for a missing gh, got: ${out}" ;;
 esac
 

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -31,6 +31,7 @@ status="./scripts/status.sh"
 # status.sh sources the required-scope list from its sibling; every fixture root
 # below therefore needs both files, not just the script under test.
 scopes_lib="./scripts/gh-scopes.sh"
+output_lib="./scripts/lib/output.sh"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "${TMP}"' EXIT
@@ -50,9 +51,10 @@ trap 'rm -rf "${TMP}"' EXIT
 #   org-repo    — an ORG repo (github_org != the author's account), which
 #                 renders the issue-types setup and therefore needs admin:org.
 for fixture in with-board no-board skills-only with-codex creds-board org-repo; do
-    mkdir -p "${TMP}/${fixture}/scripts"
+    mkdir -p "${TMP}/${fixture}/scripts/lib"
     cp "${status}" "${TMP}/${fixture}/scripts/status.sh"
     cp "${scopes_lib}" "${TMP}/${fixture}/scripts/gh-scopes.sh"
+    cp "${output_lib}" "${TMP}/${fixture}/scripts/lib/output.sh"
 done
 # The markers status.sh feature-detects on. Contents are never read.
 : >"${TMP}/with-board/scripts/setup-github-project.sh"
@@ -66,9 +68,10 @@ mkdir -p "${TMP}/skills-only/.claude/skills/track-work/assets"
 
 # A board repo whose remote is a GitHub Enterprise host, and which exports no
 # GH_HOST — the case where forcing github.com disowns a valid login.
-mkdir -p "${TMP}/enterprise/scripts"
+mkdir -p "${TMP}/enterprise/scripts/lib"
 cp "${status}" "${TMP}/enterprise/scripts/status.sh"
 cp "${scopes_lib}" "${TMP}/enterprise/scripts/gh-scopes.sh"
+cp "${output_lib}" "${TMP}/enterprise/scripts/lib/output.sh"
 : >"${TMP}/enterprise/scripts/setup-github-project.sh"
 git -C "${TMP}/enterprise" init -q
 git -C "${TMP}/enterprise" remote add origin git@ghe.example.com:owner/repo.git
@@ -1272,11 +1275,14 @@ echo "==> every gum call keeps its stdout off the terminal"
 # all. gum_style is the single place that keeps stdout off the terminal; a call
 # site that bypasses it reintroduces the stall on exactly the terminals that
 # cannot answer, which are the ones nobody develops on.
-grep -qF 'CLICOLOR_FORCE=1 gum style "$@" | cat' "${status}" ||
+grep -qF 'CLICOLOR_FORCE=1 gum style "$@" | cat' "${output_lib}" ||
     fail "gum_style no longer pipes gum's stdout with CLICOLOR_FORCE — the terminal probe and the colour both depend on it"
 grep -q 'gum_style ' "${status}" ||
     fail "nothing calls gum_style — the check below would pass vacuously"
-stray="$(grep -nE '(^|[^_[:alnum:]])gum[[:space:]]+style' "${status}" |
+stray="$({
+    grep -nE '(^|[^_[:alnum:]])gum[[:space:]]+style' "${status}"
+    grep -nE '(^|[^_[:alnum:]])gum[[:space:]]+style' "${output_lib}"
+} |
     grep -vF 'CLICOLOR_FORCE=1 gum style' |
     grep -vE '^[0-9]+:[[:space:]]*#' || true)"
 [ -z "${stray}" ] ||

--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -1274,9 +1274,10 @@ echo "==> every gum call keeps its stdout off the terminal"
 # in every test above because they all run under NO_COLOR with no terminal at
 # all. gum_style is the single place that keeps stdout off the terminal; a call
 # site that bypasses it reintroduces the stall on exactly the terminals that
-# cannot answer, which are the ones nobody develops on.
-grep -qF 'CLICOLOR_FORCE=1 gum style "$@" | cat' "${output_lib}" ||
-    fail "gum_style no longer pipes gum's stdout with CLICOLOR_FORCE — the terminal probe and the colour both depend on it"
+# cannot answer, which are the ones nobody develops on. Command substitution
+# also preserves gum's failure status so this optional renderer can fall back.
+grep -qF 'styled="$(CLICOLOR_FORCE=1 gum style "$@")"' "${output_lib}" ||
+    fail "gum_style no longer captures gum's stdout with CLICOLOR_FORCE — the terminal probe, colour, and fallback depend on it"
 grep -q 'gum_style ' "${status}" ||
     fail "nothing calls gum_style — the check below would pass vacuously"
 stray="$({

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -307,7 +307,7 @@ case "$out" in
 *"$secret_value"*) fail "secret:set:gh printed the secret value" ;;
 esac
 
-echo "==> tasks whose script demands a TTY are marked interactive, in both twins"
+echo "==> terminal-aware tasks stay interactive through Task grouping, in both twins"
 # A run-time-only regression, and a total one: this Taskfile sets `output:
 # group` GLOBALLY, so Task pipes each task's stdout. A script guarding on
 # `[ -t 1 ]` then sees a pipe and refuses even in a real terminal, which made
@@ -323,12 +323,14 @@ echo "==> tasks whose script demands a TTY are marked interactive, in both twins
 #
 # Keyed to a fatal `-t 1` check specifically. A `-t 0` guard (secret:set:*,
 # codex:gate:disable) is untouched by output grouping, which redirects stdout
-# only, and status.sh's `-t 1` merely selects colour and never refuses.
+# only. The status tasks do not refuse without a TTY, but their intentionally
+# visual dashboard would otherwise lose color, Unicode, and gum through its
+# documented Task entrypoints.
 # Both layers where they exist. A GENERATED repo has only the first — it is the
 # rendered output, with no template/ of its own — so a missing file is skipped
 # rather than failed, and the counter below keeps "skipped everything" from
 # passing silently.
-tty_gated_tasks="setup:gh-scopes"
+tty_gated_tasks="setup:gh-scopes status status:git status:gh status:creds status:code status:env status:setup"
 checked_taskfiles=0
 for taskfile in Taskfile.yml template/Taskfile.yml.jinja; do
     [ -f "$taskfile" ] || continue
@@ -347,7 +349,7 @@ for taskfile in Taskfile.yml template/Taskfile.yml.jinja; do
         printf '%s\n' "$block" |
             grep -vE '^[[:space:]]*#' |
             grep -qE '^[[:space:]]*interactive:[[:space:]]*true[[:space:]]*$' ||
-            fail "${taskfile}: ${t} lacks 'interactive: true' — global 'output: group' pipes its stdout, so its TTY guard refuses in a real terminal"
+            fail "${taskfile}: ${t} lacks 'interactive: true' — global 'output: group' hides its terminal from the script"
     done
 done
 

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -267,6 +267,46 @@ for category in SSH_KEY SSHKEY; do
     fi
 done
 
+echo "==> secret helpers print styled outcomes without echoing secret values"
+secret_value='sensitive-value-must-not-appear'
+rm -f "$op_edit_called"
+out=$(printf '%s' "$secret_value" |
+    PATH="${op_bin}:${PATH}" OP_FIXTURE_CATEGORY=LOGIN \
+        OP_EDIT_CALLED="$op_edit_called" VAULT=test ITEM=test FIELD=password \
+        ./scripts/secret-set-1p.sh 2>&1) || fail "secret:set:1p success fixture failed: $out"
+[ -e "$op_edit_called" ] || fail "secret:set:1p success fixture never edited the item"
+case "$out" in
+*'DONE: 1Password secret updated'*) ;;
+*) fail "secret:set:1p omitted its final outcome: $out" ;;
+esac
+case "$out" in
+*"$secret_value"*) fail "secret:set:1p printed the secret value" ;;
+esac
+
+gh_bin="${test_tmp}/gh-bin"
+gh_secret_capture="${test_tmp}/gh-secret"
+mkdir -p "$gh_bin"
+cat >"${gh_bin}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-} ${2:-}" = "secret set" ] || exit 1
+cat >"${GH_SECRET_CAPTURE:?}"
+EOF
+chmod +x "${gh_bin}/gh"
+out=$(printf '%s' "$secret_value" |
+    PATH="${gh_bin}:${PATH}" GH_SECRET_CAPTURE="$gh_secret_capture" \
+        NAME=DEPLOY_TOKEN REPO=owner/repo ./scripts/secret-set-gh.sh 2>&1) ||
+    fail "secret:set:gh success fixture failed: $out"
+[ "$(cat "$gh_secret_capture")" = "$secret_value" ] ||
+    fail "secret:set:gh changed the secret value sent to gh"
+case "$out" in
+*'DONE: GitHub secret updated'*) ;;
+*) fail "secret:set:gh omitted its final outcome: $out" ;;
+esac
+case "$out" in
+*"$secret_value"*) fail "secret:set:gh printed the secret value" ;;
+esac
+
 echo "==> tasks whose script demands a TTY are marked interactive, in both twins"
 # A run-time-only regression, and a total one: this Taskfile sets `output:
 # group` GLOBALLY, so Task pipes each task's stdout. A script guarding on

--- a/scripts/test-tasks.sh
+++ b/scripts/test-tasks.sh
@@ -328,6 +328,25 @@ awk '
 ' Taskfile.yml ||
     fail "Taskfile.yml no longer selects 'output: group' — re-derive whether the interactive: true assertion above still describes a real hazard"
 
+echo "==> setup:github delegates action logic to the tested script in both twins"
+checked_setup_tasks=0
+for taskfile in Taskfile.yml template/Taskfile.yml.jinja; do
+    [ -f "$taskfile" ] || continue
+    checked_setup_tasks=$((checked_setup_tasks + 1))
+    block="$(awk '
+        $0 == "  setup:github:" { inblock = 1; next }
+        inblock && /^  [a-zA-Z0-9]/ { inblock = 0 }
+        inblock { print }
+    ' "$taskfile")"
+    [ -n "$block" ] || fail "${taskfile}: setup:github task not found"
+    printf '%s\n' "$block" | grep -Fq './scripts/setup-github.sh --repo "{{.REPO}}"' ||
+        fail "${taskfile}: setup:github does not delegate to scripts/setup-github.sh"
+    if printf '%s\n' "$block" | grep -Eq 'gh api|^[[:space:]]*-[[:space:]]*\|'; then
+        fail "${taskfile}: setup:github contains inline action logic instead of a trivial script command"
+    fi
+done
+[ "$checked_setup_tasks" -gt 0 ] || fail "no Taskfile setup:github wiring was checked"
+
 if [ -x ./scripts/test-terraform-provider-locks.sh ]; then
     echo "==> Terraform provider locks cover developer and CI platforms"
     ./scripts/test-terraform-provider-locks.sh

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -112,6 +112,7 @@ tasks:
       - task: test:label-registry
       - task: test:tasks
       - task: test:ci-results
+      - task: test:output
       - task: test:status
       - task: test:gh-scopes
       - task: test:meta-install
@@ -122,6 +123,7 @@ tasks:
 [% if use_release_please %]
       - task: test:release-title
 [% endif %]
+      - task: test:setup-github
 [% if project_management == 'github' %]
       - task: test:setup-github-project
 [% endif %]
@@ -721,6 +723,11 @@ tasks:
     cmds:
       - ./scripts/test-ci-results.sh
 
+  test:output:
+    desc: Unit-test shared color/Unicode fallbacks and spinner cleanup
+    cmds:
+      - ./scripts/test-output.sh
+
   test:status:
     desc: Unit-test the status board-writes + local-credential checks (stubbed CLIs, no network)
     cmds:
@@ -754,6 +761,11 @@ tasks:
     cmds:
       - ./scripts/test-release-title.sh
 [% endif %]
+
+  test:setup-github:
+    desc: Unit-test repository-setting outcomes and failure propagation (stubbed gh, no network)
+    cmds:
+      - ./scripts/test-setup-github.sh
 [% if project_management == 'github' %]
 
   test:setup-github-project:
@@ -1035,19 +1047,7 @@ tasks:
     vars:
       REPO: "[[ github_org ]]/[[ project_slug ]]"
     cmds:
-      - gh api "repos/{{.REPO}}/vulnerability-alerts" --method PUT
-      # Private vulnerability reporting is a public-repo-only feature; harmon-init
-      # creates repos --private, so guard on visibility to avoid a 404 that would
-      # abort the task. Applies cleanly if the repo is later made public.
-      - |
-        if [ "$(gh api "repos/{{.REPO}}" --jq '.private')" = "false" ]; then
-          gh api "repos/{{.REPO}}/private-vulnerability-reporting" --method PUT
-        else
-          echo "Skipping private vulnerability reporting ({{.REPO}} is private; public-repo-only feature)."
-        fi
-[% if github_org != author_git_provider_username %]
-      - gh api "repos/{{.REPO}}/collaborators/[[ author_git_provider_username ]]-bot" --method PUT -f permission=push
-[% endif %]
+      - ./scripts/setup-github.sh --repo "{{.REPO}}"[% if github_org != author_git_provider_username %] --bot-collaborator "[[ author_git_provider_username ]]-bot"[% endif %]
 [% if project_management == 'github' %]
 
   setup:github-project:

--- a/template/Taskfile.yml.jinja
+++ b/template/Taskfile.yml.jinja
@@ -1234,31 +1234,37 @@ tasks:
   # ── Status ─────────────────────────────────────────────────────
   status:
     desc: Project status dashboard
+    interactive: true
     cmds:
       - ./scripts/status.sh
 
   status:git:
     desc: Git status section
+    interactive: true
     cmds:
       - ./scripts/status.sh git
 
   status:gh:
     desc: GitHub status section
+    interactive: true
     cmds:
       - ./scripts/status.sh gh
 
   status:creds:
     desc: Credential section (gh, Codex, Claude Code logins + gh token scopes — local probes plus one bounded scope check; STATUS_NO_NETWORK=1 skips it)
+    interactive: true
     cmds:
       - ./scripts/status.sh creds
 
   status:code:
     desc: Codebase stats section
+    interactive: true
     cmds:
       - ./scripts/status.sh code
 
   status:env:
     desc: Environment info section
+    interactive: true
     cmds:
       - ./scripts/status.sh env
 
@@ -1271,6 +1277,7 @@ tasks:
 
   status:setup:
     desc: Setup completeness audit (GitHub, toolchain, devcontainer, dev env)
+    interactive: true
     cmds:
       - ./scripts/status.sh setup
 [% if project_type == 'web-astro' %]

--- a/template/scripts/[% if github_org != author_git_provider_username %]setup-github-issue-types.sh[% endif %]
+++ b/template/scripts/[% if github_org != author_git_provider_username %]setup-github-issue-types.sh[% endif %]
@@ -45,6 +45,9 @@ for tool in gh jq; do
 done
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+# Task buffers stdout in grouped mode. Keep legacy progress and the visual
+# outcome on one live stream so their chronology cannot be reversed.
+exec 1>&2
 OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "$script_dir/lib/output.sh"

--- a/template/scripts/[% if github_org != author_git_provider_username %]setup-github-issue-types.sh[% endif %]
+++ b/template/scripts/[% if github_org != author_git_provider_username %]setup-github-issue-types.sh[% endif %]
@@ -49,7 +49,7 @@ OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "$script_dir/lib/output.sh"
 
-section_header "GitHub issue types"
+action_banner setup "GitHub issue types" "Organization-wide work classification"
 kv "Organization" "$org"
 
 # Desired issue types — mirror the issue forms. Colors are GitHub's issue-type
@@ -90,4 +90,5 @@ printf '%s' "$desired" | jq -c '.[]' | while IFS= read -r t; do
 done
 
 checkline ok "Issue types" "Bug, Feature, Task, Research"
+output_summary "Issue type provisioning"
 output_done "GitHub issue types are ready on $org"

--- a/template/scripts/[% if github_org != author_git_provider_username %]setup-github-issue-types.sh[% endif %]
+++ b/template/scripts/[% if github_org != author_git_provider_username %]setup-github-issue-types.sh[% endif %]
@@ -44,6 +44,14 @@ for tool in gh jq; do
     fi
 done
 
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_FD=2
+# shellcheck source=scripts/lib/output.sh
+. "$script_dir/lib/output.sh"
+
+section_header "GitHub issue types"
+kv "Organization" "$org"
+
 # Desired issue types — mirror the issue forms. Colors are GitHub's issue-type
 # palette: gray, blue, green, yellow, orange, red, pink, purple.
 desired='[
@@ -81,4 +89,5 @@ printf '%s' "$desired" | jq -c '.[]' | while IFS= read -r t; do
         -f description="$(printf '%s' "$t" | jq -r '.description')" >/dev/null
 done
 
-echo "==> Done — issue types on '$org': Bug, Feature, Task, Research"
+checkline ok "Issue types" "Bug, Feature, Task, Research"
+output_done "GitHub issue types are ready on $org"

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -57,6 +57,15 @@ for tool in gh jq; do
     fi
 done
 
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_FD=2
+# shellcheck source=scripts/lib/output.sh
+. "$script_dir/lib/output.sh"
+
+section_header "GitHub Project"
+kv "Owner" "$owner"
+kv "Project" "$title"
+
 # ── Scope preflight ─────────────────────────────────────────────────────────
 # Every mutation below needs the 'project' scope, which `gh auth login` does not
 # grant by default. Without it the run still fails — `gh api graphql` exits
@@ -485,7 +494,8 @@ create_number "Size"
 if [ "$owner_type" = "Organization" ]; then
     echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product)"
     report_incompatible
-    echo "==> Done — project #$project_number: $title"
+    checkline ok "Project" "#$project_number · $title"
+    output_done "GitHub Project is ready"
     exit 0
 fi
 
@@ -507,4 +517,5 @@ create_text "Product"
 # are the only surface now. See docs/project-management.md, "Label or field?".
 
 report_incompatible
-echo "==> Done — project #$project_number: $title"
+checkline ok "Project" "#$project_number · $title"
+output_done "GitHub Project is ready"

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -320,6 +320,9 @@ incompatible=""
 # Fields that are missing a starter option but have no room left for it.
 at_capacity=""
 
+# Fields that vanished between the discovery snapshot and their guarded write.
+disappeared=""
+
 # GitHub's cap on options in one single-select field.
 max_options=50
 
@@ -356,7 +359,7 @@ report_incompatible() {
 }
 
 finish_project() {
-    if [ -n "$incompatible" ] || [ -n "$at_capacity" ]; then
+    if [ -n "$incompatible" ] || [ -n "$at_capacity" ] || [ -n "$disappeared" ]; then
         checkline unknown "Project" "#$project_number · $title — reconciliation needs attention"
         output_warning "GitHub Project needs attention; resolve the warnings above and re-run"
     else
@@ -382,6 +385,7 @@ append_options() {
     refresh_fields
     if [ -z "$(field_id "$name")" ]; then
         echo "    WARNING: field '$name' disappeared while this script was running — skipping" >&2
+        disappeared="${disappeared}${disappeared:+, }$name"
         return 0
     fi
     existing=$(existing_options "$name")

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -62,7 +62,7 @@ OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "$script_dir/lib/output.sh"
 
-section_header "GitHub Project"
+action_banner setup "GitHub Project" "Board, delivery pipeline, and planning fields"
 kv "Owner" "$owner"
 kv "Project" "$title"
 
@@ -253,14 +253,20 @@ fi
 # at all, and the workflows' title-lookup fallback resolves to that same
 # half-reconciled board. Reconciliation is additive and re-runnable, so the
 # remedy for a partial run is to re-run this script either way.
+org_variable_problem=""
 if [ "$owner_type" = "Organization" ]; then
     echo "==> Recording project id in the ORG_PROJECT_ID org variable"
     if ! gh variable set ORG_PROJECT_ID --org "$owner" --visibility all --body "$project_id"; then
+        org_variable_problem="ORG_PROJECT_ID was not written"
         echo "WARNING: could not set the ORG_PROJECT_ID org variable (needs org admin)." >&2
         echo "         Set it by hand: gh variable set ORG_PROJECT_ID --org \"$owner\" --body \"$project_id\"" >&2
+        checkline unknown "Organization variable" "ORG_PROJECT_ID was not written; set it manually"
+    else
+        checkline ok "Organization variable" "ORG_PROJECT_ID points to project #$project_number"
     fi
 else
     echo "==> Owner is a user account — skipping ORG_PROJECT_ID (no user-level variable scope; personal status automation is a separate follow-up)"
+    checkline na "Organization variable" "not available for personal accounts"
 fi
 
 # ── Snapshot current fields (reused for existence checks; re-read immediately
@@ -359,11 +365,14 @@ report_incompatible() {
 }
 
 finish_project() {
-    if [ -n "$incompatible" ] || [ -n "$at_capacity" ] || [ -n "$disappeared" ]; then
+    if [ -n "$incompatible" ] || [ -n "$at_capacity" ] || [ -n "$disappeared" ] ||
+        [ -n "$org_variable_problem" ]; then
         checkline unknown "Project" "#$project_number / $title: reconciliation needs attention"
+        output_summary "Project reconciliation"
         output_warning "GitHub Project needs attention; resolve the warnings above and re-run"
     else
         checkline ok "Project" "#$project_number / $title"
+        output_summary "Project reconciliation"
         output_done "GitHub Project is ready"
     fi
 }

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -360,10 +360,10 @@ report_incompatible() {
 
 finish_project() {
     if [ -n "$incompatible" ] || [ -n "$at_capacity" ] || [ -n "$disappeared" ]; then
-        checkline unknown "Project" "#$project_number · $title — reconciliation needs attention"
+        checkline unknown "Project" "#$project_number / $title: reconciliation needs attention"
         output_warning "GitHub Project needs attention; resolve the warnings above and re-run"
     else
-        checkline ok "Project" "#$project_number · $title"
+        checkline ok "Project" "#$project_number / $title"
         output_done "GitHub Project is ready"
     fi
 }

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -355,6 +355,16 @@ report_incompatible() {
     fi
 }
 
+finish_project() {
+    if [ -n "$incompatible" ] || [ -n "$at_capacity" ]; then
+        checkline unknown "Project" "#$project_number · $title — reconciliation needs attention"
+        output_warning "GitHub Project needs attention; resolve the warnings above and re-run"
+    else
+        checkline ok "Project" "#$project_number · $title"
+        output_done "GitHub Project is ready"
+    fi
+}
+
 # append_options NAME STARTERS — reconcile one existing single-select field: add
 # whatever starter option it lacks, keep everything else exactly as it is, and
 # write nothing when there is nothing to add. Used for Status and the custom
@@ -494,8 +504,7 @@ create_number "Size"
 if [ "$owner_type" = "Organization" ]; then
     echo "==> Other metadata are org issue fields (Priority/Effort built-ins, left at their defaults; run setup-github-issue-fields.sh for Product)"
     report_incompatible
-    checkline ok "Project" "#$project_number · $title"
-    output_done "GitHub Project is ready"
+    finish_project
     exit 0
 fi
 
@@ -517,5 +526,4 @@ create_text "Product"
 # are the only surface now. See docs/project-management.md, "Label or field?".
 
 report_incompatible
-checkline ok "Project" "#$project_number · $title"
-output_done "GitHub Project is ready"
+finish_project

--- a/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]setup-github-project.sh[% endif %]
@@ -58,6 +58,9 @@ for tool in gh jq; do
 done
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+# Task buffers stdout in grouped mode. Keep legacy progress and the visual
+# outcome on one live stream so their chronology cannot be reversed.
+exec 1>&2
 OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "$script_dir/lib/output.sh"

--- a/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
@@ -37,6 +37,9 @@ if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
     [ -n "${STUB_SCOPES:-}" ] && echo "  - Token scopes: ${STUB_SCOPES}"
     exit 0
 fi
+if [ "$1" = "variable" ] && [ "$2" = "set" ]; then
+    exit "${STUB_VARIABLE_RC:-0}"
+fi
 q=""
 for a in "$@"; do case "$a" in query=*) q="${a#query=}" ;; esac; done
 case "$q" in
@@ -48,7 +51,7 @@ case "$q" in
         cat "$STUB_FIELDS_FILE"
     fi
     ;;
-*repositoryOwner*__typename*) echo '{"data":{"repositoryOwner":{"__typename":"User","id":"U_1"}}}' ;;
+*repositoryOwner*__typename*) printf '{"data":{"repositoryOwner":{"__typename":"%s","id":"U_1"}}}\n' "${STUB_OWNER_TYPE:-User}" ;;
 *projectsV2*) echo '{"data":{"repositoryOwner":{"projectsV2":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"P_1","number":7,"title":"Test Project"}]}}}}' ;;
 *ProjectV2Field*) printf '%s\n' "$q" >>"$MUTATIONS"; echo '{"data":{}}' ;;
 *) echo "fake gh: unexpected query: $q" >&2; exit 1 ;;
@@ -64,6 +67,7 @@ MUTATIONS="$tmp/mutations"
 STUB_FIELDS_FILE="$tmp/fields.json"
 STUB_FIELDS_FILE2="$tmp/fields2.json"
 export MUTATIONS STUB_FIELDS_FILE STUB_FIELDS_FILE2
+export STUB_OWNER_TYPE STUB_VARIABLE_RC
 
 # run_with FIELDS_JSON — run the script against that project snapshot.
 run_with() {
@@ -108,6 +112,19 @@ run_with "$complete"
 [ "$(updates)" = 0 ] || fail "expected no mutations on an unchanged project, got $(updates)"
 grep -q "leaving it as-is" "$tmp/out" || fail "expected 'leaving it as-is' output"
 grep -q "DONE: GitHub Project is ready" "$tmp/out" || fail "expected an explicit ready outcome"
+
+echo "==> a failed ORG_PROJECT_ID write degrades the final outcome"
+STUB_OWNER_TYPE=Organization
+STUB_VARIABLE_RC=19
+run_with "$complete"
+grep -q "ORG_PROJECT_ID was not written" "$tmp/out" ||
+    fail "expected the failed org-variable write in the outcome rows"
+grep -q "WARN: GitHub Project needs attention" "$tmp/out" ||
+    fail "expected a warning final outcome after the org-variable write failed"
+! grep -q "DONE: GitHub Project is ready" "$tmp/out" ||
+    fail "failed org-variable write claimed the project was ready"
+STUB_OWNER_TYPE=User
+STUB_VARIABLE_RC=0
 
 echo "==> the retired Agent field is never created"
 # The fixture above deliberately has no Agent field, so any mutation naming one

--- a/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
@@ -113,6 +113,21 @@ run_with "$complete"
 grep -q "leaving it as-is" "$tmp/out" || fail "expected 'leaving it as-is' output"
 grep -q "DONE: GitHub Project is ready" "$tmp/out" || fail "expected an explicit ready outcome"
 
+echo "==> visual progress stays on one ordered stream under Task grouping"
+printf '%s' "$complete" >"$STUB_FIELDS_FILE"
+rm -f "$tmp_seen"
+: >"$MUTATIONS"
+NO_COLOR=1 "$script" --owner someuser --title "Test Project" \
+    >"$tmp/stdout" 2>"$tmp/stderr" || fail "ordered-stream run exited non-zero"
+[ ! -s "$tmp/stdout" ] || fail "action progress leaked onto Task's buffered stdout"
+banner_line="$(grep -n '== SETUP :: GitHub Project ==' "$tmp/stderr" | cut -d: -f1 || true)"
+progress_line="$(grep -n "Resolving owner 'someuser'" "$tmp/stderr" | cut -d: -f1 || true)"
+done_line="$(grep -n 'DONE: GitHub Project is ready' "$tmp/stderr" | cut -d: -f1 || true)"
+[ -n "$banner_line" ] && [ -n "$progress_line" ] && [ -n "$done_line" ] ||
+    fail "ordered stream is missing its banner, progress, or final outcome"
+[ "$banner_line" -lt "$progress_line" ] && [ "$progress_line" -lt "$done_line" ] ||
+    fail "action stream did not preserve banner -> progress -> outcome chronology"
+
 echo "==> a failed ORG_PROJECT_ID write degrades the final outcome"
 STUB_OWNER_TYPE=Organization
 STUB_VARIABLE_RC=19

--- a/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
@@ -107,6 +107,7 @@ echo "==> a re-run against an already-synced project writes nothing"
 run_with "$complete"
 [ "$(updates)" = 0 ] || fail "expected no mutations on an unchanged project, got $(updates)"
 grep -q "leaving it as-is" "$tmp/out" || fail "expected 'leaving it as-is' output"
+grep -q "DONE: GitHub Project is ready" "$tmp/out" || fail "expected an explicit ready outcome"
 
 echo "==> the retired Agent field is never created"
 # The fixture above deliberately has no Agent field, so any mutation naming one
@@ -171,6 +172,10 @@ grep -q "field 'Status' already exists as TEXT" "$tmp/out" ||
     fail "expected a data-type warning naming Status and its actual type"
 grep -q "Status (is TEXT, wanted SINGLE_SELECT)" "$tmp/out" ||
     fail "expected Status in the end-of-run incompatible summary"
+grep -q "WARN: GitHub Project needs attention" "$tmp/out" ||
+    fail "expected a warning final outcome for incomplete reconciliation"
+! grep -q "DONE: GitHub Project is ready" "$tmp/out" ||
+    fail "incomplete reconciliation claimed the project was ready"
 
 echo "==> a field at the option cap warns instead of attempting an oversized write"
 capped=$(printf '%s' "$complete" | jq -c '
@@ -182,6 +187,8 @@ capped=$(printf '%s' "$complete" | jq -c '
 run_with "$capped"
 [ "$(updates)" = 0 ] || fail "an over-capacity append must be skipped, not attempted"
 grep -q "cannot fit Low" "$tmp/out" || fail "expected a capacity warning naming the missing option"
+grep -q "WARN: GitHub Project needs attention" "$tmp/out" ||
+    fail "expected a warning final outcome at the option cap"
 
 echo "==> an option added after the startup snapshot survives the append"
 # The re-read immediately before the write is what saves it: the replacement is

--- a/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' %]test-setup-github-project.sh[% endif %]
@@ -190,6 +190,16 @@ grep -q "cannot fit Low" "$tmp/out" || fail "expected a capacity warning naming 
 grep -q "WARN: GitHub Project needs attention" "$tmp/out" ||
     fail "expected a warning final outcome at the option cap"
 
+echo "==> a field deleted during reconciliation cannot produce a ready outcome"
+without_status=$(printf '%s' "$complete" | jq -c '
+    .data.node.fields.nodes |= map(select(.name != "Status"))')
+run_with "$complete" "$without_status"
+grep -q "field 'Status' disappeared" "$tmp/out" || fail "expected a concurrent-disappearance warning"
+grep -q "WARN: GitHub Project needs attention" "$tmp/out" ||
+    fail "expected a warning final outcome after a field disappeared"
+! grep -q "DONE: GitHub Project is ready" "$tmp/out" ||
+    fail "a skipped field reconciliation claimed the project was ready"
+
 echo "==> an option added after the startup snapshot survives the append"
 # The re-read immediately before the write is what saves it: the replacement is
 # built from the fresh list, not the stale one.

--- a/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
@@ -64,7 +64,7 @@ OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "$script_dir/lib/output.sh"
 
-section_header "GitHub issue fields"
+action_banner setup "GitHub issue fields" "Durable organization metadata"
 kv "Organization" "$org"
 
 # Preview REST API version for issue fields; bump if GitHub moves the endpoint.
@@ -140,8 +140,10 @@ if [ -n "$incompatible" ]; then
     echo "    These fields already exist with a different data type: $incompatible" >&2
     echo "    GitHub cannot change an issue field's data type in place. Rename or delete each one in the org's" >&2
     echo "    issue-field settings and re-run this script to get the intended options." >&2
+    output_summary "Issue field provisioning"
     output_warning "GitHub issue fields need attention; resolve the warnings above and re-run"
 else
     checkline ok "Issue fields" "Product (Priority/Effort/dates are GitHub built-ins)"
+    output_summary "Issue field provisioning"
     output_done "GitHub issue fields are ready on $org"
 fi

--- a/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
@@ -60,6 +60,9 @@ for tool in gh jq; do
 done
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+# Task buffers stdout in grouped mode. Keep legacy progress and the visual
+# outcome on one live stream so their chronology cannot be reversed.
+exec 1>&2
 OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "$script_dir/lib/output.sh"

--- a/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
@@ -140,7 +140,8 @@ if [ -n "$incompatible" ]; then
     echo "    These fields already exist with a different data type: $incompatible" >&2
     echo "    GitHub cannot change an issue field's data type in place. Rename or delete each one in the org's" >&2
     echo "    issue-field settings and re-run this script to get the intended options." >&2
+    output_warning "GitHub issue fields need attention; resolve the warnings above and re-run"
 else
     checkline ok "Issue fields" "Product (Priority/Effort/dates are GitHub built-ins)"
+    output_done "GitHub issue fields are ready on $org"
 fi
-output_done "GitHub issue fields are ready on $org"

--- a/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]setup-github-issue-fields.sh[% endif %]
@@ -59,6 +59,14 @@ for tool in gh jq; do
     fi
 done
 
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_FD=2
+# shellcheck source=scripts/lib/output.sh
+. "$script_dir/lib/output.sh"
+
+section_header "GitHub issue fields"
+kv "Organization" "$org"
+
 # Preview REST API version for issue fields; bump if GitHub moves the endpoint.
 api_version="2026-03-10"
 
@@ -128,10 +136,11 @@ create_field() {
 create_field "Product" "text" "Which product/area it belongs to"
 
 if [ -n "$incompatible" ]; then
-    echo "==> Done, WITH WARNINGS" >&2
+    checkline unknown "Done, WITH WARNINGS" "issue fields have incompatible existing types"
     echo "    These fields already exist with a different data type: $incompatible" >&2
     echo "    GitHub cannot change an issue field's data type in place. Rename or delete each one in the org's" >&2
     echo "    issue-field settings and re-run this script to get the intended options." >&2
 else
-    echo "==> Done — added issue fields on '$org': Product (Priority/Effort/dates are GitHub built-ins)"
+    checkline ok "Issue fields" "Product (Priority/Effort/dates are GitHub built-ins)"
 fi
+output_done "GitHub issue fields are ready on $org"

--- a/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]test-setup-github-issue-fields.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' and github_org != author_git_provider_username %]test-setup-github-issue-fields.sh[% endif %]
@@ -69,6 +69,7 @@ echo "==> a re-run against an already-synced org writes nothing"
 run_with "$complete"
 [ ! -s "$POSTS" ] || fail "expected no field creation on an unchanged org"
 grep -q "already exists — leaving it as-is" "$tmp/out" || fail "expected 'leaving it as-is' output for Product"
+grep -q "DONE: GitHub issue fields are ready" "$tmp/out" || fail "expected an explicit ready outcome"
 
 echo "==> the retired Agent field is never created"
 grep -q '"name":"Agent"' "$POSTS" &&
@@ -94,5 +95,7 @@ run_with "$wrong"
 grep -q "already exists as 'single_select', not 'text'" "$tmp/out" ||
     fail "expected a data-type warning for Product"
 grep -q "Done, WITH WARNINGS" "$tmp/out" || fail "expected the run to end with warnings"
+grep -q "WARN: GitHub issue fields need attention" "$tmp/out" || fail "expected a warning final outcome"
+! grep -q "DONE: GitHub issue fields are ready" "$tmp/out" || fail "incompatible fields claimed readiness"
 
 echo "PASS: setup-github-issue-fields.sh field creation"

--- a/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
@@ -71,6 +71,12 @@ done
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 renderer="$script_dir/label-registry-render.mjs"
+OUTPUT_FD=2
+# shellcheck source=scripts/lib/output.sh
+. "$script_dir/lib/output.sh"
+
+section_header "GitHub labels"
+kv "Repository" "$repo"
 
 render_args=(labels)
 if [ "$foreman" = 1 ]; then
@@ -87,8 +93,13 @@ labels="$(node "$renderer" "${render_args[@]}")"
 
 printf '%s\n' "$labels" | while IFS='|' read -r name color desc; do
     [ -z "$name" ] && continue
-    echo "==> label: $name"
-    gh label create "$name" --repo "$repo" --color "$color" --description "$desc" --force
+    if gh label create "$name" --repo "$repo" --color "$color" --description "$desc" --force; then
+        checkline ok "Label" "$name"
+    else
+        rc=$?
+        checkline no "Label" "$name (exit $rc)"
+        exit "$rc"
+    fi
 done
 
-echo "==> Done — starter labels on $repo (existing labels left as-is)"
+output_done "Starter labels are ready on $repo (existing labels left as-is)"

--- a/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
@@ -93,7 +93,7 @@ labels="$(node "$renderer" "${render_args[@]}")"
 
 while IFS='|' read -r name color desc; do
     [ -z "$name" ] && continue
-    if gh label create "$name" --repo "$repo" --color "$color" --description "$desc" --force; then
+    if gh label create "$name" --repo "$repo" --color "$color" --description "$desc" --force >/dev/null; then
         checkline ok "Label" "$name"
     else
         rc=$?

--- a/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
+++ b/template/scripts/[% if project_management == 'github' or use_foreman %]setup-github-labels.sh[% endif %]
@@ -75,7 +75,7 @@ OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "$script_dir/lib/output.sh"
 
-section_header "GitHub labels"
+action_banner setup "GitHub labels" "Registry-driven taxonomy with non-destructive updates"
 kv "Repository" "$repo"
 
 render_args=(labels)
@@ -91,7 +91,7 @@ fi
 # reaches GitHub, so a bad vocabulary never half-provisions.
 labels="$(node "$renderer" "${render_args[@]}")"
 
-printf '%s\n' "$labels" | while IFS='|' read -r name color desc; do
+while IFS='|' read -r name color desc; do
     [ -z "$name" ] && continue
     if gh label create "$name" --repo "$repo" --color "$color" --description "$desc" --force; then
         checkline ok "Label" "$name"
@@ -100,6 +100,7 @@ printf '%s\n' "$labels" | while IFS='|' read -r name color desc; do
         checkline no "Label" "$name (exit $rc)"
         exit "$rc"
     fi
-done
+done < <(printf '%s\n' "$labels")
 
+output_summary "Label provisioning"
 output_done "Starter labels are ready on $repo (existing labels left as-is)"

--- a/template/scripts/lib/output.sh
+++ b/template/scripts/lib/output.sh
@@ -32,10 +32,16 @@ output_write() {
     fi
 }
 
+OUTPUT_UTF8=false
+case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+*[Uu][Tt][Ff]-8* | *[Uu][Tt][Ff]8*) OUTPUT_UTF8=true ;;
+esac
+
 # NO_COLOR disables gum as well as ANSI. Besides respecting the convention,
-# that makes logs and test snapshots plain, greppable text.
+# that makes logs and test snapshots plain, greppable text. Gum's borders are
+# Unicode, so a non-UTF-8 locale also selects the built-in ASCII presentation.
 HAS_GUM=false
-if [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != dumb ] && command -v gum >/dev/null 2>&1; then
+if $OUTPUT_UTF8 && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != dumb ] && command -v gum >/dev/null 2>&1; then
     HAS_GUM=true
 fi
 
@@ -47,11 +53,7 @@ if [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != dumb ]; then
 fi
 
 USE_UNICODE=false
-case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
-*[Uu][Tt][Ff]-8* | *[Uu][Tt][Ff]8*)
-    if $USE_COLOR; then USE_UNICODE=true; fi
-    ;;
-esac
+if $OUTPUT_UTF8 && $USE_COLOR; then USE_UNICODE=true; fi
 
 # Every gum call is piped. This keeps gum from probing the terminal background
 # with OSC 11 and waiting several seconds on terminals that do not answer. Its
@@ -75,6 +77,7 @@ action_banner() {
     sync) icon="↻" && sgr="1;34" && gum_color=75 ;;
     install) icon="⬡" && sgr="1;32" && gum_color=42 ;;
     esac
+    if ! $USE_UNICODE; then icon="*"; fi
 
     if $HAS_GUM && output_is_tty; then
         {
@@ -87,7 +90,11 @@ action_banner() {
         output_emit '\n\033[%sm%s  %s\033[0m  \033[1m%s\033[0m\n' "$sgr" "$icon" \
             "$(printf '%s' "$kind" | tr '[:lower:]' '[:upper:]')" "$title"
         [ -z "$detail" ] || output_emit '\033[2m   %s\033[0m\n' "$detail"
-        output_emit '\033[2;90m%s\033[0m\n' '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+        if $USE_UNICODE; then
+            output_emit '\033[2;90m%s\033[0m\n' '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+        else
+            output_emit '\033[2;90m%s\033[0m\n' '----------------------------------------'
+        fi
     else
         output_emit '\n== %s :: %s ==\n' \
             "$(printf '%s' "$kind" | tr '[:lower:]' '[:upper:]')" "$title"
@@ -265,7 +272,7 @@ output_spinner_loop() {
 # frame, and returns COMMAND's exact status. Redirected/CI output runs COMMAND
 # directly and emits no control sequences.
 output_run() (
-    local label="$1" spinner_pid="" rc
+    local label="$1" spinner_pid="" diagnostics="" rc
     shift
 
     if [ "${OUTPUT_FD}" != 2 ] || { ! output_is_tty && [ "${OUTPUT_TEST_SPINNER:-0}" != 1 ]; } ||
@@ -274,6 +281,7 @@ output_run() (
         return
     fi
 
+    diagnostics="$(mktemp "${TMPDIR:-/tmp}/harmon-output.XXXXXX")" || return 1
     output_spinner_loop "$label" &
     spinner_pid=$!
     output_spinner_cleanup() {
@@ -284,13 +292,20 @@ output_run() (
         fi
         printf '\r\033[2K' >&2
     }
-    trap 'output_spinner_cleanup' EXIT
+    output_run_cleanup() {
+        output_spinner_cleanup
+        [ -z "$diagnostics" ] || rm -f "$diagnostics"
+    }
+    trap 'output_run_cleanup' EXIT
     trap 'exit 129' HUP
     trap 'exit 130' INT
     trap 'exit 143' TERM
 
-    if "$@"; then rc=0; else rc=$?; fi
+    if "$@" 2>"$diagnostics"; then rc=0; else rc=$?; fi
     output_spinner_cleanup
+    if [ -s "$diagnostics" ]; then cat "$diagnostics" >&2; fi
+    rm -f "$diagnostics"
+    diagnostics=""
     trap - EXIT HUP INT TERM
     return "$rc"
 )

--- a/template/scripts/lib/output.sh
+++ b/template/scripts/lib/output.sh
@@ -176,6 +176,14 @@ output_done() {
     fi
 }
 
+output_warning() {
+    if $USE_UNICODE; then
+        output_emit '\n%s %s\n' "$(c '1;33' '⚠')" "$(c '1;33' "$1")"
+    else
+        output_emit '\nWARN: %s\n' "$1"
+    fi
+}
+
 output_spinner_loop() {
     local label="$1" i=0 frame
     local unicode_frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')

--- a/template/scripts/lib/output.sh
+++ b/template/scripts/lib/output.sh
@@ -60,6 +60,42 @@ gum_style() {
     CLICOLOR_FORCE=1 gum style "$@" | cat
 }
 
+# action_banner KIND TITLE [DETAIL] — a task-family masthead for mutating
+# commands. KIND is deliberately semantic rather than a raw color: a setup,
+# secret, release, cleanup, sync, or install task should be recognizable before
+# the reader reaches its title. The word always remains visible, so color and
+# emoji reinforce meaning without carrying it alone.
+action_banner() {
+    local kind="$1" title="$2" detail="${3:-}" icon="✦" sgr="1;35" gum_color=212
+    case "$kind" in
+    setup) icon="⚙" && sgr="1;36" && gum_color=39 ;;
+    secret) icon="🔐" && sgr="1;35" && gum_color=135 ;;
+    release) icon="🚀" && sgr="1;33" && gum_color=220 ;;
+    clean) icon="◇" && sgr="1;33" && gum_color=214 ;;
+    sync) icon="↻" && sgr="1;34" && gum_color=75 ;;
+    install) icon="⬡" && sgr="1;32" && gum_color=42 ;;
+    esac
+
+    if $HAS_GUM && output_is_tty; then
+        {
+            printf '%s  %s\n' "$icon" "$(printf '%s' "$kind" | tr '[:lower:]' '[:upper:]')"
+            printf '%s\n' "$title"
+            [ -z "$detail" ] || printf '%s\n' "$detail"
+        } | gum_style --bold --foreground "$gum_color" --border double \
+            --border-foreground "$gum_color" --padding "0 2" --margin "0 0 1 0" | output_write
+    elif $USE_COLOR; then
+        output_emit '\n\033[%sm%s  %s\033[0m  \033[1m%s\033[0m\n' "$sgr" "$icon" \
+            "$(printf '%s' "$kind" | tr '[:lower:]' '[:upper:]')" "$title"
+        [ -z "$detail" ] || output_emit '\033[2m   %s\033[0m\n' "$detail"
+        output_emit '\033[2;90m%s\033[0m\n' '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+    else
+        output_emit '\n== %s :: %s ==\n' \
+            "$(printf '%s' "$kind" | tr '[:lower:]' '[:upper:]')" "$title"
+        [ -z "$detail" ] || output_emit '   %s\n' "$detail"
+        output_emit '%s\n' '----------------------------------------'
+    fi
+}
+
 section_header() {
     local title="$1"
     if $HAS_GUM && output_is_tty; then
@@ -170,9 +206,29 @@ checkline() {
     fi
 }
 
+# output_summary [TITLE] — a compact, scan-friendly outcome table. Counts are
+# collected by checkline, so action scripts get a truthful summary without
+# duplicating bookkeeping. The plain form is one stable key/value line for CI,
+# grep, and snapshots; the terminal form is intentionally more visual.
+output_summary() {
+    local title="${1:-Outcome}" total
+    total=$((SETUP_OK + SETUP_NO + SETUP_UNKNOWN + SETUP_NA))
+    if $USE_UNICODE; then
+        output_emit '\n  %s\n' "$(c '1;36' "╭─ $title")"
+        output_emit '  %s  %-12s %s\n' "$(c '1;32' '│ ✓')" "Succeeded" "$SETUP_OK"
+        output_emit '  %s  %-12s %s\n' "$(c '1;31' '│ ✗')" "Failed" "$SETUP_NO"
+        output_emit '  %s  %-12s %s\n' "$(c '1;33' '│ ?')" "Attention" "$SETUP_UNKNOWN"
+        output_emit '  %s  %-12s %s\n' "$(c '2' '│ –')" "Skipped" "$SETUP_NA"
+        output_emit '  %s\n' "$(c '1;36' "╰─ $total checks")"
+    else
+        output_emit '\nSUMMARY: %s - succeeded=%s failed=%s attention=%s skipped=%s total=%s\n' \
+            "$title" "$SETUP_OK" "$SETUP_NO" "$SETUP_UNKNOWN" "$SETUP_NA" "$total"
+    fi
+}
+
 output_done() {
     if $USE_UNICODE; then
-        output_emit '\n%s %s\n' "$(c '1;32' '✨')" "$(c '1' "$1")"
+        output_emit '\n%s %s\n' "$(c '1;32' '╰─ ✨')" "$(c '1;32' "$1")"
     else
         output_emit '\nDONE: %s\n' "$1"
     fi
@@ -180,7 +236,7 @@ output_done() {
 
 output_warning() {
     if $USE_UNICODE; then
-        output_emit '\n%s %s\n' "$(c '1;33' '⚠')" "$(c '1;33' "$1")"
+        output_emit '\n%s %s\n' "$(c '1;33' '╰─ ⚠')" "$(c '1;33' "$1")"
     else
         output_emit '\nWARN: %s\n' "$1"
     fi

--- a/template/scripts/lib/output.sh
+++ b/template/scripts/lib/output.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# Shared terminal presentation for status boards and action scripts.
+#
+# Source this file after resolving the repository root. It has no required
+# dependencies: ANSI color and Unicode are used only on a capable terminal,
+# gum is an optional enhancement, and redirected/NO_COLOR/TERM=dumb output is
+# stable ASCII. Action scripts may set OUTPUT_FD=2 before sourcing so Task's
+# grouped stdout does not hide live progress.
+
+OUTPUT_FD="${OUTPUT_FD:-1}"
+
+output_is_tty() {
+    if [ "${OUTPUT_TEST_TTY:-0}" = 1 ]; then
+        return 0
+    fi
+    [ -t "${OUTPUT_FD}" ]
+}
+
+output_emit() {
+    if [ "${OUTPUT_FD}" = 2 ]; then
+        printf "$@" >&2
+    else
+        printf "$@"
+    fi
+}
+
+output_write() {
+    if [ "${OUTPUT_FD}" = 2 ]; then
+        cat >&2
+    else
+        cat
+    fi
+}
+
+# NO_COLOR disables gum as well as ANSI. Besides respecting the convention,
+# that makes logs and test snapshots plain, greppable text.
+HAS_GUM=false
+if [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != dumb ] && command -v gum >/dev/null 2>&1; then
+    HAS_GUM=true
+fi
+
+USE_COLOR=false
+if [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != dumb ]; then
+    if output_is_tty || { [ -n "${CLICOLOR_FORCE:-}" ] && [ "${CLICOLOR_FORCE}" != 0 ]; }; then
+        USE_COLOR=true
+    fi
+fi
+
+USE_UNICODE=false
+case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+*[Uu][Tt][Ff]-8* | *[Uu][Tt][Ff]8*)
+    if $USE_COLOR; then USE_UNICODE=true; fi
+    ;;
+esac
+
+# Every gum call is piped. This keeps gum from probing the terminal background
+# with OSC 11 and waiting several seconds on terminals that do not answer. Its
+# stderr still sees the terminal, while CLICOLOR_FORCE restores styling.
+gum_style() {
+    CLICOLOR_FORCE=1 gum style "$@" | cat
+}
+
+section_header() {
+    local title="$1"
+    if $HAS_GUM && output_is_tty; then
+        gum_style --bold --foreground 212 --border-foreground 240 \
+            --border rounded --padding "0 1" -- "$title" | output_write
+    elif $USE_COLOR; then
+        output_emit '\n\033[1;35m◆ %s\033[0m\n' "$title"
+        output_emit '\033[2;90m────────────────────────────────────────\033[0m\n'
+    else
+        output_emit '\n==> %s\n' "$title"
+        output_emit '%s\n' '----------------------------------------'
+    fi
+}
+
+section_box() {
+    local content
+    content="$(cat)"
+    if $HAS_GUM && output_is_tty; then
+        printf '%s\n' "$content" | gum_style --border rounded \
+            --border-foreground 240 --padding "0 1" --margin "0 0" | output_write
+    else
+        output_emit '%s\n\n' "$content"
+    fi
+}
+
+kv() {
+    local key="$1" val="$2" styled_key
+    if $HAS_GUM && output_is_tty; then
+        styled_key="$(gum_style --bold --foreground 39 "$key:")"
+        output_emit '  %s  %s\n' "$styled_key" "$val"
+    elif $USE_COLOR; then
+        output_emit '  \033[1;36m%-20s\033[0m %s\n' "$key:" "$val"
+    else
+        output_emit '  %-20s %s\n' "$key:" "$val"
+    fi
+}
+
+# c SGR TEXT — emit TEXT wrapped in ANSI when color is active. This writes to
+# stdout deliberately: callers use it inside command substitutions.
+c() {
+    if $USE_COLOR; then printf '\033[%sm%s\033[0m' "$1" "$2"; else printf '%s' "$2"; fi
+}
+
+if $USE_UNICODE; then
+    I_OK="$(c '1;32' '✓')"
+    I_NO="$(c '1;31' '✗')"
+    I_UNKNOWN="$(c '1;33' '?')"
+    I_NA="$(c '2' '–')"
+    I_INFO="$(c '1;36' '•')"
+else
+    I_OK='[x]'
+    I_NO='[ ]'
+    I_UNKNOWN='[?]'
+    I_NA='[-]'
+    I_INFO=' * '
+fi
+
+subhead() {
+    if $USE_UNICODE; then
+        output_emit '\n  %s\n' "$(c '1;36' "▸ $1")"
+    else
+        output_emit '\n  > %s\n' "$1"
+    fi
+}
+
+bar() {
+    local pct="$1" width=20 i=0 fill="" track="" filled
+    filled=$((pct * width / 100))
+    [ "${filled}" -gt "${width}" ] && filled="${width}"
+    [ "${filled}" -lt 0 ] && filled=0
+    while [ "${i}" -lt "${width}" ]; do
+        if [ "${i}" -lt "${filled}" ]; then
+            if $USE_UNICODE; then fill="${fill}█"; else fill="${fill}#"; fi
+        else
+            if $USE_UNICODE; then track="${track}░"; else track="${track}-"; fi
+        fi
+        i=$((i + 1))
+    done
+    printf '%s%s' "$(c '32' "${fill}")" "$(c '2' "${track}")"
+}
+
+SETUP_OK=0
+SETUP_NO=0
+SETUP_UNKNOWN=0
+SETUP_NA=0
+
+# checkline STATUS LABEL [DETAIL]
+# STATUS: ok | no | unknown | na | info
+checkline() {
+    local status="$1" label="$2" detail="${3:-}" icon=""
+    case "$status" in
+    ok) icon="$I_OK" && SETUP_OK=$((SETUP_OK + 1)) ;;
+    no) icon="$I_NO" && SETUP_NO=$((SETUP_NO + 1)) ;;
+    unknown) icon="$I_UNKNOWN" && SETUP_UNKNOWN=$((SETUP_UNKNOWN + 1)) ;;
+    na) icon="$I_NA" && SETUP_NA=$((SETUP_NA + 1)) ;;
+    info) icon="$I_INFO" ;;
+    *)
+        output_emit 'output: unknown check status: %s\n' "$status"
+        return 2
+        ;;
+    esac
+    if [ -n "$detail" ]; then
+        output_emit '  %s %s — %s\n' "$icon" "$label" "$detail"
+    else
+        output_emit '  %s %s\n' "$icon" "$label"
+    fi
+}
+
+output_done() {
+    if $USE_UNICODE; then
+        output_emit '\n%s %s\n' "$(c '1;32' '✨')" "$(c '1' "$1")"
+    else
+        output_emit '\nDONE: %s\n' "$1"
+    fi
+}
+
+output_spinner_loop() {
+    local label="$1" i=0 frame
+    local unicode_frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+    local ascii_frames=('|' '/' '-' '\\')
+    trap 'exit 0' HUP INT TERM
+    while :; do
+        if $USE_UNICODE; then
+            frame="${unicode_frames[$i]}"
+            i=$(((i + 1) % ${#unicode_frames[@]}))
+        else
+            frame="${ascii_frames[$i]}"
+            i=$(((i + 1) % ${#ascii_frames[@]}))
+        fi
+        printf '\r\033[2K%s %s' "$(c '1;35' "$frame")" "$label" >&2
+        sleep "${OUTPUT_SPINNER_DELAY:-0.08}"
+    done
+}
+
+# output_run LABEL COMMAND... — keep COMMAND in the foreground and animate a
+# background-only indicator. The subshell owns every trap, always erases the
+# frame, and returns COMMAND's exact status. Redirected/CI output runs COMMAND
+# directly and emits no control sequences.
+output_run() (
+    local label="$1" spinner_pid="" rc
+    shift
+
+    if [ "${OUTPUT_FD}" != 2 ] || { ! output_is_tty && [ "${OUTPUT_TEST_SPINNER:-0}" != 1 ]; } ||
+        [ "${CI:-}" = true ] || [ -n "${NO_COLOR:-}" ] || [ "${TERM:-}" = dumb ]; then
+        "$@"
+        return
+    fi
+
+    output_spinner_loop "$label" &
+    spinner_pid=$!
+    output_spinner_cleanup() {
+        if [ -n "$spinner_pid" ]; then
+            kill "$spinner_pid" 2>/dev/null || true
+            wait "$spinner_pid" 2>/dev/null || true
+            spinner_pid=""
+        fi
+        printf '\r\033[2K' >&2
+    }
+    trap 'output_spinner_cleanup' EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+
+    if "$@"; then rc=0; else rc=$?; fi
+    output_spinner_cleanup
+    trap - EXIT HUP INT TERM
+    return "$rc"
+)

--- a/template/scripts/lib/output.sh
+++ b/template/scripts/lib/output.sh
@@ -109,12 +109,14 @@ if $USE_UNICODE; then
     I_UNKNOWN="$(c '1;33' '?')"
     I_NA="$(c '2' '–')"
     I_INFO="$(c '1;36' '•')"
+    DETAIL_SEPARATOR=' — '
 else
     I_OK='[x]'
     I_NO='[ ]'
     I_UNKNOWN='[?]'
     I_NA='[-]'
     I_INFO=' * '
+    DETAIL_SEPARATOR=' - '
 fi
 
 subhead() {
@@ -162,7 +164,7 @@ checkline() {
         ;;
     esac
     if [ -n "$detail" ]; then
-        output_emit '  %s %s — %s\n' "$icon" "$label" "$detail"
+        output_emit '  %s %s%s%s\n' "$icon" "$label" "$DETAIL_SEPARATOR" "$detail"
     else
         output_emit '  %s %s\n' "$icon" "$label"
     fi

--- a/template/scripts/lib/output.sh
+++ b/template/scripts/lib/output.sh
@@ -55,11 +55,16 @@ fi
 USE_UNICODE=false
 if $OUTPUT_UTF8 && $USE_COLOR; then USE_UNICODE=true; fi
 
-# Every gum call is piped. This keeps gum from probing the terminal background
-# with OSC 11 and waiting several seconds on terminals that do not answer. Its
-# stderr still sees the terminal, while CLICOLOR_FORCE restores styling.
+# Gum's stdout is captured, so it cannot probe the terminal background with
+# OSC 11 and wait several seconds on terminals that do not answer. Preserve
+# its status: gum is optional presentation, and callers fall back to the
+# built-in renderer when an installed binary is broken or incompatible.
 gum_style() {
-    CLICOLOR_FORCE=1 gum style "$@" | cat
+    local styled
+    if ! styled="$(CLICOLOR_FORCE=1 gum style "$@")"; then
+        return 1
+    fi
+    printf '%s\n' "$styled"
 }
 
 # action_banner KIND TITLE [DETAIL] — a task-family masthead for mutating
@@ -68,7 +73,7 @@ gum_style() {
 # the reader reaches its title. The word always remains visible, so color and
 # emoji reinforce meaning without carrying it alone.
 action_banner() {
-    local kind="$1" title="$2" detail="${3:-}" icon="✦" sgr="1;35" gum_color=212
+    local kind="$1" title="$2" detail="${3:-}" icon="✦" sgr="1;35" gum_color=212 styled=""
     case "$kind" in
     setup) icon="⚙" && sgr="1;36" && gum_color=39 ;;
     secret) icon="🔐" && sgr="1;35" && gum_color=135 ;;
@@ -79,14 +84,17 @@ action_banner() {
     esac
     if ! $USE_UNICODE; then icon="*"; fi
 
-    if $HAS_GUM && output_is_tty; then
-        {
+    if $HAS_GUM && output_is_tty &&
+        styled="$({
             printf '%s  %s\n' "$icon" "$(printf '%s' "$kind" | tr '[:lower:]' '[:upper:]')"
             printf '%s\n' "$title"
             [ -z "$detail" ] || printf '%s\n' "$detail"
         } | gum_style --bold --foreground "$gum_color" --border double \
-            --border-foreground "$gum_color" --padding "0 2" --margin "0 0 1 0" | output_write
-    elif $USE_COLOR; then
+            --border-foreground "$gum_color" --padding "0 2" --margin "0 0 1 0")"; then
+        output_emit '%s\n' "$styled"
+        return 0
+    fi
+    if $USE_COLOR; then
         output_emit '\n\033[%sm%s  %s\033[0m  \033[1m%s\033[0m\n' "$sgr" "$icon" \
             "$(printf '%s' "$kind" | tr '[:lower:]' '[:upper:]')" "$title"
         [ -z "$detail" ] || output_emit '\033[2m   %s\033[0m\n' "$detail"
@@ -104,11 +112,14 @@ action_banner() {
 }
 
 section_header() {
-    local title="$1"
-    if $HAS_GUM && output_is_tty; then
-        gum_style --bold --foreground 212 --border-foreground 240 \
-            --border rounded --padding "0 1" -- "$title" | output_write
-    elif $USE_COLOR; then
+    local title="$1" styled=""
+    if $HAS_GUM && output_is_tty &&
+        styled="$(gum_style --bold --foreground 212 --border-foreground 240 \
+            --border rounded --padding "0 1" -- "$title")"; then
+        output_emit '%s\n' "$styled"
+        return 0
+    fi
+    if $USE_COLOR; then
         output_emit '\n\033[1;35m◆ %s\033[0m\n' "$title"
         output_emit '\033[2;90m────────────────────────────────────────\033[0m\n'
     else
@@ -118,22 +129,25 @@ section_header() {
 }
 
 section_box() {
-    local content
+    local content styled=""
     content="$(cat)"
-    if $HAS_GUM && output_is_tty; then
-        printf '%s\n' "$content" | gum_style --border rounded \
-            --border-foreground 240 --padding "0 1" --margin "0 0" | output_write
-    else
-        output_emit '%s\n\n' "$content"
+    if $HAS_GUM && output_is_tty &&
+        styled="$(printf '%s\n' "$content" | gum_style --border rounded \
+            --border-foreground 240 --padding "0 1" --margin "0 0")"; then
+        output_emit '%s\n' "$styled"
+        return 0
     fi
+    output_emit '%s\n\n' "$content"
 }
 
 kv() {
     local key="$1" val="$2" styled_key
-    if $HAS_GUM && output_is_tty; then
-        styled_key="$(gum_style --bold --foreground 39 "$key:")"
+    if $HAS_GUM && output_is_tty &&
+        styled_key="$(gum_style --bold --foreground 39 "$key:")"; then
         output_emit '  %s  %s\n' "$styled_key" "$val"
-    elif $USE_COLOR; then
+        return 0
+    fi
+    if $USE_COLOR; then
         output_emit '  \033[1;36m%-20s\033[0m %s\n' "$key:" "$val"
     else
         output_emit '  %-20s %s\n' "$key:" "$val"

--- a/template/scripts/secret-set-1p.sh
+++ b/template/scripts/secret-set-1p.sh
@@ -39,6 +39,9 @@ command -v op >/dev/null 2>&1 || fail "op CLI is required"
 command -v jq >/dev/null 2>&1 || fail "jq is required"
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+# Task buffers stdout in grouped mode. Keep legacy progress and the visual
+# outcome on one live stream so their chronology cannot be reversed.
+exec 1>&2
 OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "$script_dir/lib/output.sh"

--- a/template/scripts/secret-set-1p.sh
+++ b/template/scripts/secret-set-1p.sh
@@ -38,6 +38,15 @@ fi
 command -v op >/dev/null 2>&1 || fail "op CLI is required"
 command -v jq >/dev/null 2>&1 || fail "jq is required"
 
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_FD=2
+# shellcheck source=scripts/lib/output.sh
+. "$script_dir/lib/output.sh"
+action_banner secret "1Password field" "The secret stays on stdin and is never displayed"
+kv "Vault" "$vault"
+kv "Item" "$item"
+kv "Field" "${section:+$section / }$field"
+
 # Keep the caller's stdin available to jq as a raw file while jq reads the
 # 1Password item JSON from the pipeline.
 exec 3<&0
@@ -97,4 +106,6 @@ printf '%s\n' "$updated_item" |
     op item edit "$item" --vault "$vault" >/dev/null
 unset updated_item
 
-echo "Updated 1Password item '$item' field '$field'."
+checkline ok "Secret field" "$item / ${section:+$section / }$field updated"
+output_summary "Secret write"
+output_done "1Password secret updated"

--- a/template/scripts/secret-set-gh.sh
+++ b/template/scripts/secret-set-gh.sh
@@ -34,6 +34,14 @@ fi
 command -v gh >/dev/null 2>&1 || fail "gh CLI is required"
 command -v python3 >/dev/null 2>&1 || fail "python3 is required"
 
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_FD=2
+# shellcheck source=scripts/lib/output.sh
+. "$script_dir/lib/output.sh"
+action_banner secret "GitHub Actions secret" "Encrypted write from stdin; the value is never displayed"
+kv "Repository" "$repo"
+kv "Secret" "$name"
+
 # Read + validate stdin BEFORE gh runs: in a plain pipeline, `gh secret set`
 # starts consuming stdin before the producer's empty-check can fail, so an
 # empty pipe could write an empty secret and only error afterwards. python3 is
@@ -53,5 +61,8 @@ sys.stdout.buffer.write(data)
 ')" || fail "stdin secret is empty"
 
 printf '%s' "$secret" | gh secret set "$name" --repo "$repo" >/dev/null
+unset secret
 
-echo "Updated GitHub secret '$name' in '$repo'."
+checkline ok "Repository secret" "$name updated on $repo"
+output_summary "Secret write"
+output_done "GitHub secret updated"

--- a/template/scripts/secret-set-gh.sh
+++ b/template/scripts/secret-set-gh.sh
@@ -35,6 +35,9 @@ command -v gh >/dev/null 2>&1 || fail "gh CLI is required"
 command -v python3 >/dev/null 2>&1 || fail "python3 is required"
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+# Task buffers stdout in grouped mode. Keep legacy progress and the visual
+# outcome on one live stream so their chronology cannot be reversed.
+exec 1>&2
 OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "$script_dir/lib/output.sh"

--- a/template/scripts/setup-gh-scopes.sh
+++ b/template/scripts/setup-gh-scopes.sh
@@ -83,6 +83,9 @@ fi
 # the one the warning was about still under-scoped.
 REQUEST_LIST="$(gh_scopes_request_list)"
 
+# shellcheck source=scripts/lib/output.sh
+. "${REPO_ROOT}/scripts/lib/output.sh"
+
 # gh_auth_status_active — `gh auth status` narrowed to the ONE credential this
 # task refreshes. `gh auth refresh` updates only the ACTIVE account, while a
 # bare `--hostname` read reports every account on that host: concatenating
@@ -142,11 +145,11 @@ case "${scopes_before}" in
     ;;
 esac
 
-echo "==> Host:            ${HOSTNAME_ARG}"
-echo "==> Current scopes:  ${scopes_before:-<none reported>}"
-echo "==> Required:        $(gh_scopes_human "${GH_REQUIRED_SCOPES}")"
-echo "==> Requesting:      ${REQUEST_LIST}"
-echo ""
+action_banner setup "GitHub CLI scopes" "Interactive credential upgrade with post-refresh verification"
+kv "Host" "${HOSTNAME_ARG}"
+kv "Current scopes" "${scopes_before:-<none reported>}"
+kv "Required" "$(gh_scopes_human "${GH_REQUIRED_SCOPES}")"
+kv "Requesting" "${REQUEST_LIST}"
 
 # Nothing to do? Say so and stop, WITHOUT opening a browser. `gh auth refresh`
 # is an interactive OAuth flow even when it would change nothing, so an
@@ -155,7 +158,9 @@ echo ""
 # re-run repeats it. The docs promise this requests the MISSING scopes; this is
 # that promise kept.
 if [ -z "$(gh_scopes_missing_requested "${scopes_before}")" ]; then
-    echo "Already complete — no refresh needed."
+    checkline na "OAuth refresh" "already complete; no browser flow needed"
+    output_summary "Scope setup"
+    output_done "GitHub CLI scopes are already ready"
     exit 0
 fi
 
@@ -169,8 +174,7 @@ verify_out="$(gh_auth_status_active)" ||
     die "post-refresh 'gh auth status' failed — the credential may be broken."
 scopes_after="$(printf '%s\n' "${verify_out}" | grep -i 'token scopes:' || true)"
 
-echo ""
-echo "==> New scopes:      ${scopes_after:-<none reported>}"
+kv "New scopes" "${scopes_after:-<none reported>}"
 
 case "${scopes_after}" in
 *"'"*) ;;
@@ -191,5 +195,6 @@ if [ -n "${missing}" ]; then
   them (Settings → Third-party access)."
 fi
 
-echo ""
-echo "All requested scopes present: $(gh_scopes_request_list)"
+checkline ok "OAuth scopes" "$(gh_scopes_request_list)"
+output_summary "Scope setup"
+output_done "All requested GitHub CLI scopes are present"

--- a/template/scripts/setup-github.sh
+++ b/template/scripts/setup-github.sh
@@ -9,6 +9,7 @@ OUTPUT_FD=2
 
 repo=""
 bot_collaborator=""
+bot_pending=false
 while [ "$#" -gt 0 ]; do
     case "$1" in
     --repo)
@@ -83,7 +84,17 @@ fi
 if [ -n "$bot_collaborator" ]; then
     if output_run "Adding bot collaborator" \
         gh api "repos/$repo/collaborators/$bot_collaborator" --method PUT -f permission=push; then
-        checkline ok "Bot collaborator" "$bot_collaborator has push access"
+        permission="$(gh api "repos/$repo/collaborators/$bot_collaborator/permission" \
+            --jq '.permission' 2>/dev/null || true)"
+        case "$permission" in
+        admin | maintain | push | write)
+            checkline ok "Bot collaborator" "$bot_collaborator has push access"
+            ;;
+        *)
+            bot_pending=true
+            checkline unknown "Bot collaborator" "invitation sent to $bot_collaborator; access starts after acceptance"
+            ;;
+        esac
     else
         rc=$?
         fail_step "$rc" "Bot collaborator" "could not grant push access to $bot_collaborator"
@@ -91,4 +102,8 @@ if [ -n "$bot_collaborator" ]; then
     fi
 fi
 
-output_done "GitHub repository settings are ready for $repo"
+if $bot_pending; then
+    output_warning "GitHub repository settings are ready; bot collaborator acceptance is pending"
+else
+    output_done "GitHub repository settings are ready for $repo"
+fi

--- a/template/scripts/setup-github.sh
+++ b/template/scripts/setup-github.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Apply the repository-level GitHub settings that are safe to reconcile.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_FD=2
+# shellcheck source=scripts/lib/output.sh
+. "${script_dir}/lib/output.sh"
+
+repo=""
+bot_collaborator=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --repo)
+        repo="${2:-}"
+        shift 2
+        ;;
+    --bot-collaborator)
+        bot_collaborator="${2:-}"
+        shift 2
+        ;;
+    *)
+        echo "Unknown argument: $1" >&2
+        exit 2
+        ;;
+    esac
+done
+
+if [ -z "$repo" ]; then
+    echo "Usage: $0 --repo <owner/repo> [--bot-collaborator <login>]" >&2
+    exit 2
+fi
+if ! command -v gh >/dev/null 2>&1; then
+    echo "Required tool not found: gh" >&2
+    exit 1
+fi
+
+fail_step() {
+    local rc="$1" label="$2" detail="$3"
+    checkline no "$label" "$detail (exit $rc)"
+}
+
+section_header "GitHub repository setup"
+kv "Repository" "$repo"
+
+if output_run "Enabling Dependabot alerts" \
+    gh api "repos/$repo/vulnerability-alerts" --method PUT; then
+    checkline ok "Dependabot alerts" "enabled"
+else
+    rc=$?
+    fail_step "$rc" "Dependabot alerts" "GitHub API request failed"
+    exit "$rc"
+fi
+
+if repo_private="$(gh api "repos/$repo" --jq '.private')"; then
+    :
+else
+    rc=$?
+    fail_step "$rc" "Repository visibility" "could not determine public/private state"
+    exit "$rc"
+fi
+case "$repo_private" in
+true | false) ;;
+*)
+    fail_step 1 "Repository visibility" "unexpected '.private' value: ${repo_private:-<empty>}"
+    exit 1
+    ;;
+esac
+
+if [ "$repo_private" = false ]; then
+    if output_run "Enabling private vulnerability reporting" \
+        gh api "repos/$repo/private-vulnerability-reporting" --method PUT; then
+        checkline ok "Private vulnerability reporting" "enabled"
+    else
+        rc=$?
+        fail_step "$rc" "Private vulnerability reporting" "GitHub API request failed"
+        exit "$rc"
+    fi
+else
+    checkline na "Private vulnerability reporting" "skipped — private repository; feature is public-repo-only"
+fi
+
+if [ -n "$bot_collaborator" ]; then
+    if output_run "Adding bot collaborator" \
+        gh api "repos/$repo/collaborators/$bot_collaborator" --method PUT -f permission=push; then
+        checkline ok "Bot collaborator" "$bot_collaborator has push access"
+    else
+        rc=$?
+        fail_step "$rc" "Bot collaborator" "could not grant push access to $bot_collaborator"
+        exit "$rc"
+    fi
+fi
+
+output_done "GitHub repository settings are ready for $repo"

--- a/template/scripts/setup-github.sh
+++ b/template/scripts/setup-github.sh
@@ -77,7 +77,7 @@ if [ "$repo_private" = false ]; then
         exit "$rc"
     fi
 else
-    checkline na "Private vulnerability reporting" "skipped — private repository; feature is public-repo-only"
+    checkline na "Private vulnerability reporting" "skipped: private repository; feature is public-repo-only"
 fi
 
 if [ -n "$bot_collaborator" ]; then

--- a/template/scripts/setup-github.sh
+++ b/template/scripts/setup-github.sh
@@ -10,6 +10,7 @@ OUTPUT_FD=2
 repo=""
 bot_collaborator=""
 bot_pending=false
+bot_unverified=false
 while [ "$#" -gt 0 ]; do
     case "$1" in
     --repo)
@@ -41,7 +42,7 @@ fail_step() {
     checkline no "$label" "$detail (exit $rc)"
 }
 
-section_header "GitHub repository setup"
+action_banner setup "GitHub repository" "Safety, vulnerability reporting, and automation access"
 kv "Repository" "$repo"
 
 if output_run "Enabling Dependabot alerts" \
@@ -82,19 +83,30 @@ else
 fi
 
 if [ -n "$bot_collaborator" ]; then
-    if output_run "Adding bot collaborator" \
-        gh api "repos/$repo/collaborators/$bot_collaborator" --method PUT -f permission=push; then
-        permission="$(gh api "repos/$repo/collaborators/$bot_collaborator/permission" \
-            --jq '.permission' 2>/dev/null || true)"
-        case "$permission" in
-        admin | maintain | push | write)
-            checkline ok "Bot collaborator" "$bot_collaborator has push access"
-            ;;
-        *)
+    # GitHub's response itself is authoritative here: 201 + an invitation body
+    # means acceptance is pending; 204 + no body means access is already active.
+    # A follow-up permission lookup cannot distinguish a pending invite from a
+    # lookup failure, which was the old implementation's misleading fallback.
+    if collaborator_response="$(output_run "Adding bot collaborator" \
+        gh api "repos/$repo/collaborators/$bot_collaborator" --method PUT -f permission=push)"; then
+        if [ -n "$collaborator_response" ]; then
             bot_pending=true
             checkline unknown "Bot collaborator" "invitation sent to $bot_collaborator; access starts after acceptance"
-            ;;
-        esac
+        elif permission="$(gh api "repos/$repo/collaborators/$bot_collaborator/permission" \
+            --jq '.permission' 2>/dev/null)"; then
+            case "$permission" in
+            admin | maintain | push | write)
+                checkline ok "Bot collaborator" "$bot_collaborator has $permission access"
+                ;;
+            *)
+                bot_unverified=true
+                checkline unknown "Bot collaborator" "access response was '$permission'; verify $bot_collaborator manually"
+                ;;
+            esac
+        else
+            bot_unverified=true
+            checkline unknown "Bot collaborator" "GitHub accepted the request, but permission verification failed"
+        fi
     else
         rc=$?
         fail_step "$rc" "Bot collaborator" "could not grant push access to $bot_collaborator"
@@ -102,8 +114,11 @@ if [ -n "$bot_collaborator" ]; then
     fi
 fi
 
+output_summary "Repository setup"
 if $bot_pending; then
     output_warning "GitHub repository settings are ready; bot collaborator acceptance is pending"
+elif $bot_unverified; then
+    output_warning "GitHub repository settings changed, but collaborator access needs verification"
 else
     output_done "GitHub repository settings are ready for $repo"
 fi

--- a/template/scripts/setup-github.sh
+++ b/template/scripts/setup-github.sh
@@ -3,6 +3,9 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+# Task buffers stdout in grouped mode. Keep legacy progress and the visual
+# outcome on one live stream so their chronology cannot be reversed.
+exec 1>&2
 OUTPUT_FD=2
 # shellcheck source=scripts/lib/output.sh
 . "${script_dir}/lib/output.sh"

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -21,14 +21,12 @@ NETWORK_TIMEOUT="${NETWORK_TIMEOUT:-5}"
 # shellcheck source=scripts/gh-scopes.sh
 . "${REPO_ROOT}/scripts/gh-scopes.sh"
 
-# ── Tool detection ──────────────────────────────────────────────────────────
+# Shared presentation primitives. NO_COLOR turns off gum and ANSI, making the
+# board plain, stable text for logs and scripts/test-status.sh.
+# shellcheck source=scripts/lib/output.sh
+. "${REPO_ROOT}/scripts/lib/output.sh"
 
-# NO_COLOR (https://no-color.org/) turns off gum styling as well as ANSI, which
-# makes the board's output plain, stable text — greppable, diffable, and
-# assertable by scripts/test-status.sh without matching around escape sequences
-# or box drawing.
-HAS_GUM=false
-[[ -z "${NO_COLOR:-}" ]] && command -v gum &>/dev/null && HAS_GUM=true
+# ── Tool detection ──────────────────────────────────────────────────────────
 
 # Network probes below are bounded so a hung `gh` call cannot wedge the board.
 # Stock macOS ships no `timeout` — it comes from coreutils, which also provides
@@ -79,133 +77,8 @@ run_timeout() {
     fi
 }
 
-# ── Formatting helpers ──────────────────────────────────────────────────────
-
-# Every `gum` call goes through here, because gum asks the TERMINAL for its
-# background colour (OSC 11) whenever its own stdout is one — and waits 5s for
-# an answer. A terminal that replies to neither that nor the cursor-position
-# probe gum falls back on pays the full 5s, EVERY invocation; a board renders
-# a dozen of them, which is the minutes-long hang of harmon-init#865 on a
-# devcontainer terminal. (Terminals that answer either probe were always fast,
-# which is why this never reproduced on a Mac.)
-#
-# Piping stdout removes the terminal from gum's view, so it does not ask.
-# `CLICOLOR_FORCE` then restores the colour gum drops for a non-terminal
-# stdout: with stderr still on the terminal the output is BYTE-IDENTICAL to
-# what an answering terminal produced before this change, 256-colour included.
-# Where stderr is redirected too, gum cannot read the depth and falls back to
-# 16 colours — not a regression, since gum emitted no colour at all into that
-# case before.
-gum_style() {
-    CLICOLOR_FORCE=1 gum style "$@" | cat
-}
-
-section_header() {
-    local title="$1"
-    if $HAS_GUM; then
-        gum_style --bold --foreground 212 --border-foreground 240 \
-            --border rounded --padding "0 1" -- "$title"
-    else
-        echo ""
-        echo "==> ${title}"
-        echo "────────────────────────────────────────"
-    fi
-}
-
-section_box() {
-    local content
-    content="$(cat)"
-    if $HAS_GUM; then
-        echo "$content" | gum_style --border rounded \
-            --border-foreground 240 --padding "0 1" --margin "0 0"
-    else
-        echo "$content"
-        echo ""
-    fi
-}
-
-kv() {
-    local key="$1" val="$2"
-    if $HAS_GUM; then
-        printf "  %s  %s\n" "$(gum_style --bold --foreground 39 "$key:")" "$val"
-    else
-        printf "  %-20s %s\n" "$key:" "$val"
-    fi
-}
-
 should_show() {
     [[ -z "${SECTION}" || "${SECTION}" == "$1" ]]
-}
-
-# ── Setup-check helpers ─────────────────────────────────────────────────────
-
-# Color is on when stdout is a TTY or gum is present (gum forces color anyway).
-# ANSI only — no extra dependency. Detected here at top level because inside the
-# section's `| section_box` pipe, stdout reads as a non-TTY.
-USE_COLOR=false
-[[ -z "${NO_COLOR:-}" ]] && { [ -t 1 ] || $HAS_GUM; } && USE_COLOR=true
-
-# c SGR TEXT — wrap TEXT in an ANSI SGR sequence when color is enabled.
-c() {
-    if $USE_COLOR; then printf '\033[%sm%s\033[0m' "$1" "$2"; else printf '%s' "$2"; fi
-}
-
-# Status glyphs: colored Unicode when color is on, plain ASCII otherwise.
-if $USE_COLOR; then
-    I_OK="$(c '1;32' '✓')"
-    I_NO="$(c '1;31' '✗')"
-    I_UNKNOWN="$(c '1;33' '?')"
-    I_NA="$(c '2' '–')"
-    I_INFO="$(c '1;36' '•')"
-else
-    I_OK='[x]'
-    I_NO='[ ]'
-    I_UNKNOWN='[?]'
-    I_NA='[-]'
-    I_INFO=' * '
-fi
-
-# subhead TEXT — a colored group header inside a section.
-subhead() {
-    printf '\n  %s\n' "$(c '1;36' "▸ $1")"
-}
-
-# bar PERCENT — a 20-cell Unicode progress bar (green fill on a dim track).
-bar() {
-    local pct="$1" width=20 i=0 fill="" track=""
-    local filled=$((pct * width / 100))
-    [ "${filled}" -gt "${width}" ] && filled="${width}"
-    [ "${filled}" -lt 0 ] && filled=0
-    while [ "${i}" -lt "${width}" ]; do
-        if [ "${i}" -lt "${filled}" ]; then fill="${fill}█"; else track="${track}░"; fi
-        i=$((i + 1))
-    done
-    printf '%s%s' "$(c '32' "${fill}")" "$(c '2' "${track}")"
-}
-
-SETUP_OK=0
-SETUP_NO=0
-SETUP_UNKNOWN=0
-SETUP_NA=0
-
-# checkline STATUS LABEL [DETAIL]
-#   STATUS in: ok | no | unknown | na | info
-# Counters mutate in the caller's subshell, so the summary line MUST be emitted
-# from the same { ... } group as the checks (see the Setup section).
-checkline() {
-    local status="$1" label="$2" detail="${3:-}" icon=""
-    case "$status" in
-    ok) icon="$I_OK" && SETUP_OK=$((SETUP_OK + 1)) ;;
-    no) icon="$I_NO" && SETUP_NO=$((SETUP_NO + 1)) ;;
-    unknown) icon="$I_UNKNOWN" && SETUP_UNKNOWN=$((SETUP_UNKNOWN + 1)) ;;
-    na) icon="$I_NA" && SETUP_NA=$((SETUP_NA + 1)) ;;
-    info) icon="$I_INFO" ;;
-    esac
-    if [ -n "$detail" ]; then
-        printf '  %s %s — %s\n' "$icon" "$label" "$detail"
-    else
-        printf '  %s %s\n' "$icon" "$label"
-    fi
 }
 
 # has_cred FILE NAME — true if NAME appears in FILE, where FILE is the output of
@@ -393,7 +266,7 @@ done
 # ── Header ──────────────────────────────────────────────────────────────────
 
 if [[ -z "${SECTION}" ]]; then
-    if $HAS_GUM; then
+    if $HAS_GUM && output_is_tty; then
         gum_style --bold --foreground 212 --border double \
             --border-foreground 99 --padding "0 2" --margin "1 0" \
             -- "${PROJECT_NAME}"

--- a/template/scripts/status.sh
+++ b/template/scripts/status.sh
@@ -266,10 +266,12 @@ done
 # ── Header ──────────────────────────────────────────────────────────────────
 
 if [[ -z "${SECTION}" ]]; then
-    if $HAS_GUM && output_is_tty; then
-        gum_style --bold --foreground 212 --border double \
+    styled_header=""
+    if $HAS_GUM && output_is_tty &&
+        styled_header="$(gum_style --bold --foreground 212 --border double \
             --border-foreground 99 --padding "0 2" --margin "1 0" \
-            -- "${PROJECT_NAME}"
+            -- "${PROJECT_NAME}")"; then
+        printf '%s\n' "${styled_header}"
     else
         echo ""
         echo "=== ${PROJECT_NAME} ==="

--- a/template/scripts/test-label-registry.sh
+++ b/template/scripts/test-label-registry.sh
@@ -323,7 +323,7 @@ else
 fi
 
 # ── 4. provisioning-script binding ─────────────────────────────────────────
-# Run the provisioning script with `gh` stubbed to echo the label name and
+# Run the provisioning script with `gh` stubbed to record the label name and
 # confirm it provisions exactly the renderer's set — both directions, so
 # neither a dropped delegation nor a re-added hand-list can fork.
 if [ -f scripts/setup-github-labels.sh ]; then
@@ -333,13 +333,16 @@ if [ -f scripts/setup-github-labels.sh ]; then
         fail "setup-github-labels.sh hard-lists a name|color|description label line — the vocabulary lives in label-registry.json"
     fi
     stub_dir="$(mktemp -d)"
+    emitted_file="$stub_dir/emitted"
     cat >"$stub_dir/gh" <<'STUB'
 #!/usr/bin/env bash
-[ "$1" = label ] && { shift 2; printf '%s\n' "$1"; exit 0; }
+[ "$1" = label ] && { shift 2; printf '%s\n' "$1" >>"$STUB_EMITTED"; exit 0; }
 exit 0
 STUB
     chmod +x "$stub_dir/gh"
-    emitted="$(PATH="$stub_dir:$PATH" bash scripts/setup-github-labels.sh --repo drift/check --foreman 2>/dev/null | grep -v '^==>' | sort)"
+    STUB_EMITTED="$emitted_file" PATH="$stub_dir:$PATH" \
+        bash scripts/setup-github-labels.sh --repo drift/check --foreman >/dev/null 2>&1
+    emitted="$(sort "$emitted_file")"
     rm -rf "$stub_dir"
     want_names="$(node scripts/label-registry-render.mjs labels --foreman | sed 's/|.*//' | sort)"
     [ "$emitted" = "$want_names" ] || {

--- a/template/scripts/test-output.sh
+++ b/template/scripts/test-output.sh
@@ -39,6 +39,14 @@ secret_color="$(env -u NO_COLOR PATH=/usr/bin:/bin LANG=C.UTF-8 TERM=xterm-256co
 case "$setup_color" in *$'\033[1;36m'*) ;; *) fail "setup banner lost its cyan accent" ;; esac
 case "$secret_color" in *$'\033[1;35m'*) ;; *) fail "secret banner lost its magenta accent" ;; esac
 
+echo "==> a non-UTF-8 locale disables gum and Unicode presentation"
+non_utf8="$(env -u NO_COLOR LC_ALL=C TERM=xterm-256color CLICOLOR_FORCE=1 OUTPUT_TEST_TTY=1 \
+    bash -c '. "$1"; printf "capabilities=%s/%s\n" "$HAS_GUM" "$USE_UNICODE"; action_banner setup "Repository"' _ "$lib")"
+case "$non_utf8" in *'capabilities=false/false'*'*  SETUP'*) ;; *) fail "non-UTF-8 terminal did not select the ASCII presentation" ;; esac
+printf '%s\n' "$non_utf8" | LC_ALL=C od -An -tu1 -v | awk '
+    { for (i = 1; i <= NF; i++) if ($i > 127) exit 1 }
+' || fail "non-UTF-8 presentation contains Unicode bytes"
+
 echo "==> TERM=dumb wins over forced color"
 dumb="$(TERM=dumb CLICOLOR_FORCE=1 LANG=C.UTF-8 \
     bash -c '. "$1"; checkline ok "Step"' _ "$lib")"
@@ -80,6 +88,21 @@ esac
 case "$spinner" in
 *$'\r\033[2K') ;;
 *) fail "spinner did not erase its final frame" ;;
+esac
+
+echo "==> command diagnostics render only after the spinner is erased"
+set +e
+diagnostic="$(env -u CI -u NO_COLOR OUTPUT_FD=2 OUTPUT_TEST_TTY=1 OUTPUT_TEST_SPINNER=1 OUTPUT_SPINNER_DELAY=0.01 \
+    LANG=C.UTF-8 TERM=xterm-256color bash -c '
+        . "$1"
+        output_run "Working" bash -c "sleep 0.04; echo API-failed >&2; exit 29"
+    ' _ "$lib" 2>&1)"
+diagnostic_rc=$?
+set -e
+[ "$diagnostic_rc" -eq 29 ] || fail "diagnostic spinner path returned $diagnostic_rc instead of 29"
+case "$diagnostic" in
+*$'\r\033[2KAPI-failed') ;;
+*) fail "command diagnostic was not serialized after spinner cleanup" ;;
 esac
 
 echo "==> NO_COLOR disables animation even on a terminal"

--- a/template/scripts/test-output.sh
+++ b/template/scripts/test-output.sh
@@ -15,9 +15,12 @@ case "$plain" in
 *$'\033'*) fail "NO_COLOR output contains ANSI escapes" ;;
 esac
 case "$plain" in
-*'==> Action'*'[x] Step — complete'*'DONE: finished'*) ;;
+*'==> Action'*'[x] Step - complete'*'DONE: finished'*) ;;
 *) fail "plain output omitted the stable heading, outcome, or summary" ;;
 esac
+printf '%s\n' "$plain" | LC_ALL=C od -An -tu1 -v | awk '
+    { for (i = 1; i <= NF; i++) if ($i != 9 && $i != 10 && $i != 13 && ($i < 32 || $i > 126)) exit 1 }
+' || fail "plain output contains non-ASCII bytes"
 
 echo "==> a capable terminal gets ANSI color and Unicode"
 color="$(env -u NO_COLOR PATH=/usr/bin:/bin LANG=C.UTF-8 TERM=xterm-256color OUTPUT_TEST_TTY=1 \

--- a/template/scripts/test-output.sh
+++ b/template/scripts/test-output.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Unit-test the shared output library without requiring a terminal or gum.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+lib="$PWD/scripts/lib/output.sh"
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+echo "==> redirected output is stable ASCII"
+plain="$(NO_COLOR=1 bash -c '. "$1"; section_header "Action"; checkline ok "Step" "complete"; output_done "finished"' _ "$lib")"
+case "$plain" in
+*$'\033'*) fail "NO_COLOR output contains ANSI escapes" ;;
+esac
+case "$plain" in
+*'==> Action'*'[x] Step — complete'*'DONE: finished'*) ;;
+*) fail "plain output omitted the stable heading, outcome, or summary" ;;
+esac
+
+echo "==> a capable terminal gets ANSI color and Unicode"
+color="$(env -u NO_COLOR PATH=/usr/bin:/bin LANG=C.UTF-8 TERM=xterm-256color OUTPUT_TEST_TTY=1 \
+    bash -c '. "$1"; section_header "Action"; checkline ok "Step" "complete"' _ "$lib")"
+case "$color" in *$'\033['*) ;; *) fail "terminal output did not include ANSI color" ;; esac
+case "$color" in *'◆ Action'*'✓'*'Step — complete'*) ;;
+*) fail "terminal output did not include the Unicode presentation" ;;
+esac
+
+echo "==> TERM=dumb wins over forced color"
+dumb="$(TERM=dumb CLICOLOR_FORCE=1 LANG=C.UTF-8 \
+    bash -c '. "$1"; checkline ok "Step"' _ "$lib")"
+case "$dumb" in
+*$'\033'*) fail "TERM=dumb output contains ANSI escapes" ;;
+esac
+case "$dumb" in
+*'[x] Step'*) ;;
+*) fail "TERM=dumb output did not fall back to ASCII" ;;
+esac
+
+echo "==> non-terminal commands preserve status without control sequences"
+set +e
+non_tty="$(OUTPUT_FD=2 bash -c '. "$1"; output_run "Working" bash -c "exit 37"' _ "$lib" 2>&1)"
+non_tty_rc=$?
+set -e
+[ "$non_tty_rc" -eq 37 ] || fail "output_run changed exit 37 to $non_tty_rc"
+case "$non_tty" in
+*$'\033'*) fail "non-terminal output_run emitted control sequences" ;;
+esac
+
+echo "==> spinner cleanup leaves no job and preserves command status"
+set +e
+spinner="$(env -u CI -u NO_COLOR OUTPUT_FD=2 OUTPUT_TEST_TTY=1 OUTPUT_TEST_SPINNER=1 OUTPUT_SPINNER_DELAY=0.01 \
+    LANG=C.UTF-8 TERM=xterm-256color bash -c '
+        . "$1"
+        output_run "Working" bash -c "sleep 0.04; exit 23"
+        rc=$?
+        [ -z "$(jobs -pr)" ] || exit 91
+        exit "$rc"
+    ' _ "$lib" 2>&1)"
+spinner_rc=$?
+set -e
+[ "$spinner_rc" -eq 23 ] || fail "spinner path returned $spinner_rc instead of 23"
+case "$spinner" in
+*$'\033[2K'*'Working'*) ;;
+*) fail "forced terminal path did not animate" ;;
+esac
+case "$spinner" in
+*$'\r\033[2K') ;;
+*) fail "spinner did not erase its final frame" ;;
+esac
+
+echo "==> NO_COLOR disables animation even on a terminal"
+no_color_spinner="$(env -u CI NO_COLOR=1 OUTPUT_FD=2 OUTPUT_TEST_TTY=1 OUTPUT_TEST_SPINNER=1 \
+    bash -c '. "$1"; output_run "Working" true' _ "$lib" 2>&1)"
+case "$no_color_spinner" in
+*$'\033'*) fail "NO_COLOR spinner path emitted terminal controls" ;;
+esac
+
+echo "PASS: shared output fallbacks and spinner lifecycle"

--- a/template/scripts/test-output.sh
+++ b/template/scripts/test-output.sh
@@ -10,12 +10,12 @@ fail() {
 }
 
 echo "==> redirected output is stable ASCII"
-plain="$(NO_COLOR=1 bash -c '. "$1"; section_header "Action"; checkline ok "Step" "complete"; output_done "finished"' _ "$lib")"
+plain="$(NO_COLOR=1 bash -c '. "$1"; action_banner secret "Credential" "stdin only"; checkline ok "Step" "complete"; checkline na "Optional" "skipped"; output_summary "Write"; output_done "finished"' _ "$lib")"
 case "$plain" in
 *$'\033'*) fail "NO_COLOR output contains ANSI escapes" ;;
 esac
 case "$plain" in
-*'==> Action'*'[x] Step - complete'*'DONE: finished'*) ;;
+*'== SECRET :: Credential =='*'[x] Step - complete'*'SUMMARY: Write - succeeded=1 failed=0 attention=0 skipped=1 total=2'*'DONE: finished'*) ;;
 *) fail "plain output omitted the stable heading, outcome, or summary" ;;
 esac
 printf '%s\n' "$plain" | LC_ALL=C od -An -tu1 -v | awk '
@@ -24,11 +24,20 @@ printf '%s\n' "$plain" | LC_ALL=C od -An -tu1 -v | awk '
 
 echo "==> a capable terminal gets ANSI color and Unicode"
 color="$(env -u NO_COLOR PATH=/usr/bin:/bin LANG=C.UTF-8 TERM=xterm-256color OUTPUT_TEST_TTY=1 \
-    bash -c '. "$1"; section_header "Action"; checkline ok "Step" "complete"' _ "$lib")"
+    bash -c '. "$1"; action_banner setup "Repository" "configure"; checkline ok "Step" "complete"; checkline unknown "Review" "pending"; output_summary "Setup"; output_done "ready"' _ "$lib")"
 case "$color" in *$'\033['*) ;; *) fail "terminal output did not include ANSI color" ;; esac
-case "$color" in *'◆ Action'*'✓'*'Step — complete'*) ;;
+case "$color" in *'⚙  SETUP'*'✓'*'Step — complete'*'╭─ Setup'*'Attention'*'╰─ ✨'*'ready'*) ;;
 *) fail "terminal output did not include the Unicode presentation" ;;
 esac
+
+echo "==> task families have visually distinct semantic accents"
+setup_color="$(env -u NO_COLOR PATH=/usr/bin:/bin LANG=C.UTF-8 TERM=xterm-256color OUTPUT_TEST_TTY=1 \
+    bash -c '. "$1"; action_banner setup "One"' _ "$lib")"
+secret_color="$(env -u NO_COLOR PATH=/usr/bin:/bin LANG=C.UTF-8 TERM=xterm-256color OUTPUT_TEST_TTY=1 \
+    bash -c '. "$1"; action_banner secret "Two"' _ "$lib")"
+[ "$setup_color" != "$secret_color" ] || fail "setup and secret banners rendered identically"
+case "$setup_color" in *$'\033[1;36m'*) ;; *) fail "setup banner lost its cyan accent" ;; esac
+case "$secret_color" in *$'\033[1;35m'*) ;; *) fail "secret banner lost its magenta accent" ;; esac
 
 echo "==> TERM=dumb wins over forced color"
 dumb="$(TERM=dumb CLICOLOR_FORCE=1 LANG=C.UTF-8 \

--- a/template/scripts/test-output.sh
+++ b/template/scripts/test-output.sh
@@ -47,6 +47,28 @@ printf '%s\n' "$non_utf8" | LC_ALL=C od -An -tu1 -v | awk '
     { for (i = 1; i <= NF; i++) if ($i > 127) exit 1 }
 ' || fail "non-UTF-8 presentation contains Unicode bytes"
 
+echo "==> a broken optional gum falls back without aborting the task"
+fake_bin="$(mktemp -d)"
+trap 'rm -rf "$fake_bin"' EXIT
+cat >"${fake_bin}/gum" <<'EOF'
+#!/bin/sh
+exit 42
+EOF
+chmod +x "${fake_bin}/gum"
+gum_fallback="$(env -u NO_COLOR PATH="${fake_bin}:/usr/bin:/bin" LANG=C.UTF-8 \
+    TERM=xterm-256color OUTPUT_TEST_TTY=1 bash -euo pipefail -c '
+        . "$1"
+        action_banner setup "Repository" "configure"
+        section_header "Details"
+        printf "inside\n" | section_box
+        kv "State" "ready"
+        printf "REACHED-END\n"
+    ' _ "$lib")"
+case "$gum_fallback" in
+*$'\033[1;36m'*'Repository'*'Details'*'inside'*'State:'*'ready'*'REACHED-END'*) ;;
+*) fail "broken gum did not fall back to the complete built-in presentation" ;;
+esac
+
 echo "==> TERM=dumb wins over forced color"
 dumb="$(TERM=dumb CLICOLOR_FORCE=1 LANG=C.UTF-8 \
     bash -c '. "$1"; checkline ok "Step"' _ "$lib")"

--- a/template/scripts/test-registry-drift.sh
+++ b/template/scripts/test-registry-drift.sh
@@ -124,13 +124,16 @@ if [ -f "$labels_script" ]; then
     # running it observes what would really be provisioned. --foreman exercises
     # both renderer modes regardless of whether this profile arms Foreman.
     stub_dir="$(mktemp -d)"
+    emitted_file="$stub_dir/emitted"
     cat >"$stub_dir/gh" <<'STUB'
 #!/usr/bin/env bash
-[ "$1" = label ] && { shift 2; printf '%s\n' "$1"; exit 0; }
+[ "$1" = label ] && { shift 2; printf '%s\n' "$1" >>"$STUB_EMITTED"; exit 0; }
 exit 0
 STUB
     chmod +x "$stub_dir/gh"
-    emitted="$(PATH="$stub_dir:$PATH" bash "$labels_script" --repo drift/check --foreman 2>/dev/null | sort -u)"
+    STUB_EMITTED="$emitted_file" PATH="$stub_dir:$PATH" \
+        bash "$labels_script" --repo drift/check --foreman >/dev/null 2>&1
+    emitted="$(sort -u "$emitted_file")"
     rm -rf "$stub_dir"
     missing="$(comm -23 <(printf '%s\n' "$names" | sort -u) <(printf '%s\n' "$emitted"))"
     if [ -n "$missing" ]; then

--- a/template/scripts/test-setup-gh-scopes.sh
+++ b/template/scripts/test-setup-gh-scopes.sh
@@ -31,14 +31,17 @@ unset GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN GH_HOST
 
 script="./scripts/setup-gh-scopes.sh"
 scopes_lib="./scripts/gh-scopes.sh"
+output_lib="./scripts/lib/output.sh"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "${TMP}"' EXIT
 
 # A board-carrying fixture, so the required list includes the Projects scopes.
 mkdir -p "${TMP}/repo/scripts"
+mkdir -p "${TMP}/repo/scripts/lib"
 cp "${script}" "${TMP}/repo/scripts/setup-gh-scopes.sh"
 cp "${scopes_lib}" "${TMP}/repo/scripts/gh-scopes.sh"
+cp "${output_lib}" "${TMP}/repo/scripts/lib/output.sh"
 : >"${TMP}/repo/scripts/setup-github-project.sh"
 SUT="${TMP}/repo/scripts/setup-gh-scopes.sh"
 
@@ -281,7 +284,7 @@ if [ "${PTY_OK}" = true ]; then
     echo "==> succeeds when the refresh lands, naming the scopes"
     out="$(run_sut_pty lands-after-refresh GH_HOST=github.com)"
     case "$out" in
-    *"All requested scopes present"*) ;;
+    *"All requested GitHub CLI scopes are present"*) ;;
     *) fail "expected success after a landed refresh, got: ${out}" ;;
     esac
 
@@ -302,7 +305,7 @@ if [ "${PTY_OK}" = true ]; then
     # host would let an unrelated login satisfy the requirement.
     out="$(run_sut_pty inactive-has-scope GH_HOST=github.com)"
     case "$out" in
-    *"All requested scopes present"*) fail "an inactive account's scopes verified the active one: ${out}" ;;
+    *"All requested GitHub CLI scopes are present"*) fail "an inactive account's scopes verified the active one: ${out}" ;;
     *"did not grant"*) ;;
     *) fail "expected the active account's missing scopes to be reported, got: ${out}" ;;
     esac
@@ -314,7 +317,7 @@ if [ "${PTY_OK}" = true ]; then
     # read grant leaves board writes broken while satisfying the alternation.
     out="$(run_sut_pty read-only-grant GH_HOST=github.com)"
     case "$out" in
-    *"All requested scopes present"*) fail "a read-only grant was reported as success: ${out}" ;;
+    *"All requested GitHub CLI scopes are present"*) fail "a read-only grant was reported as success: ${out}" ;;
     *"did not grant"*"project"*) ;;
     *) fail "expected the missing write scope to be reported, got: ${out}" ;;
     esac
@@ -342,7 +345,7 @@ if [ "${PTY_OK}" = true ]; then
     fi
     unset STUB_CALLS
     case "$out" in
-    *"Already complete"*) ;;
+    *"GitHub CLI scopes are already ready"*) ;;
     *) fail "expected the no-op path to say so, got: ${out}" ;;
     esac
     [ "$(rc_pty_of lands GH_HOST=github.com)" = 0 ] ||

--- a/template/scripts/test-setup-github.sh
+++ b/template/scripts/test-setup-github.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Unit-test setup-github.sh against a stubbed gh; never touches GitHub.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+script="$PWD/scripts/setup-github.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    [ -f "$tmp/out" ] && sed 's/^/    /' "$tmp/out" >&2
+    exit 1
+}
+
+mkdir -p "$tmp/bin"
+stub_calls="$tmp/calls"
+cat >"$tmp/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${STUB_CALLS:?}"
+case "$*" in
+*"${GH_FAIL_MATCH:-__never__}"*) exit "${GH_FAIL_RC:-1}" ;;
+esac
+case "$*" in
+*" --jq .private") printf '%s\n' "${GH_PRIVATE:-true}" ;;
+esac
+STUB
+chmod +x "$tmp/bin/gh"
+
+run_case() {
+    : >"$stub_calls"
+    set +e
+    PATH="$tmp/bin:$PATH" STUB_CALLS="$stub_calls" NO_COLOR=1 \
+        "$script" "$@" >"$tmp/out" 2>&1
+    run_rc=$?
+    set -e
+}
+
+echo "==> private repositories report success plus the reason for a skip"
+GH_PRIVATE=true run_case --repo owner/private
+[ "$run_rc" -eq 0 ] || fail "private path exited $run_rc"
+grep -Fq '[x] Dependabot alerts — enabled' "$tmp/out" || fail "missing Dependabot success"
+grep -Fq '[-] Private vulnerability reporting — skipped — private repository' "$tmp/out" || fail "missing private-repo skip reason"
+grep -Fq 'DONE: GitHub repository settings are ready for owner/private' "$tmp/out" || fail "missing final outcome"
+if grep -q 'private-vulnerability-reporting' "$stub_calls"; then
+    fail "private repository attempted to enable public-only reporting"
+fi
+
+echo "==> public repositories enable every requested setting and collaborator"
+GH_PRIVATE=false run_case --repo owner/public --bot-collaborator owner-bot
+[ "$run_rc" -eq 0 ] || fail "public path exited $run_rc"
+grep -Fq '[x] Private vulnerability reporting — enabled' "$tmp/out" || fail "missing reporting success"
+grep -Fq '[x] Bot collaborator — owner-bot has push access' "$tmp/out" || fail "missing collaborator success"
+grep -q 'private-vulnerability-reporting --method PUT' "$stub_calls" || fail "reporting API was not called"
+grep -q 'collaborators/owner-bot --method PUT -f permission=push' "$stub_calls" || fail "collaborator API was not called"
+
+echo "==> failures are formatted, preserve status, and never claim completion"
+GH_PRIVATE=false GH_FAIL_MATCH=vulnerability-alerts GH_FAIL_RC=23 \
+    run_case --repo owner/failing
+[ "$run_rc" -eq 23 ] || fail "API exit 23 became $run_rc"
+grep -Fq '[ ] Dependabot alerts — GitHub API request failed (exit 23)' "$tmp/out" || fail "missing formatted failure"
+if grep -q 'DONE:' "$tmp/out"; then fail "failed run printed a completion summary"; fi
+if grep -q 'private-vulnerability-reporting' "$stub_calls"; then
+    fail "script continued mutating after the first failure"
+fi
+
+echo "PASS: setup-github outcomes and failure propagation"

--- a/template/scripts/test-setup-github.sh
+++ b/template/scripts/test-setup-github.sh
@@ -40,8 +40,11 @@ echo "==> private repositories report success plus the reason for a skip"
 GH_PRIVATE=true run_case --repo owner/private
 [ "$run_rc" -eq 0 ] || fail "private path exited $run_rc"
 grep -Fq '[x] Dependabot alerts - enabled' "$tmp/out" || fail "missing Dependabot success"
-grep -Fq '[-] Private vulnerability reporting - skipped — private repository' "$tmp/out" || fail "missing private-repo skip reason"
+grep -Fq '[-] Private vulnerability reporting - skipped: private repository' "$tmp/out" || fail "missing private-repo skip reason"
 grep -Fq 'DONE: GitHub repository settings are ready for owner/private' "$tmp/out" || fail "missing final outcome"
+LC_ALL=C od -An -tu1 -v "$tmp/out" | awk '
+    { for (i = 1; i <= NF; i++) if ($i != 9 && $i != 10 && $i != 13 && ($i < 32 || $i > 126)) exit 1 }
+' || fail "plain setup output contains non-ASCII presentation bytes"
 if grep -q 'private-vulnerability-reporting' "$stub_calls"; then
     fail "private repository attempted to enable public-only reporting"
 fi

--- a/template/scripts/test-setup-github.sh
+++ b/template/scripts/test-setup-github.sh
@@ -22,6 +22,10 @@ case "$*" in
 *"${GH_FAIL_MATCH:-__never__}"*) exit "${GH_FAIL_RC:-1}" ;;
 esac
 case "$*" in
+*"/permission --jq .permission")
+    [ -n "${GH_PERMISSION:-}" ] || exit 1
+    printf '%s\n' "$GH_PERMISSION"
+    ;;
 *" --jq .private") printf '%s\n' "${GH_PRIVATE:-true}" ;;
 esac
 STUB
@@ -50,12 +54,24 @@ if grep -q 'private-vulnerability-reporting' "$stub_calls"; then
 fi
 
 echo "==> public repositories enable every requested setting and collaborator"
-GH_PRIVATE=false run_case --repo owner/public --bot-collaborator owner-bot
+GH_PRIVATE=false GH_PERMISSION=write run_case --repo owner/public --bot-collaborator owner-bot
 [ "$run_rc" -eq 0 ] || fail "public path exited $run_rc"
 grep -Fq '[x] Private vulnerability reporting - enabled' "$tmp/out" || fail "missing reporting success"
 grep -Fq '[x] Bot collaborator - owner-bot has push access' "$tmp/out" || fail "missing collaborator success"
 grep -q 'private-vulnerability-reporting --method PUT' "$stub_calls" || fail "reporting API was not called"
 grep -q 'collaborators/owner-bot --method PUT -f permission=push' "$stub_calls" || fail "collaborator API was not called"
+grep -q 'collaborators/owner-bot/permission --jq .permission' "$stub_calls" || fail "collaborator access was not verified"
+
+echo "==> a new collaborator invitation is reported as pending until accepted"
+GH_PRIVATE=false GH_PERMISSION= run_case --repo owner/public --bot-collaborator owner-bot
+[ "$run_rc" -eq 0 ] || fail "pending invitation path exited $run_rc"
+grep -Fq '[?] Bot collaborator - invitation sent to owner-bot; access starts after acceptance' "$tmp/out" ||
+    fail "missing pending-invitation outcome"
+grep -Fq 'WARN: GitHub repository settings are ready; bot collaborator acceptance is pending' "$tmp/out" ||
+    fail "missing pending-invitation summary"
+if grep -q 'owner-bot has push access' "$tmp/out"; then
+    fail "pending invitation falsely claimed active push access"
+fi
 
 echo "==> failures are formatted, preserve status, and never claim completion"
 GH_PRIVATE=false GH_FAIL_MATCH=vulnerability-alerts GH_FAIL_RC=23 \

--- a/template/scripts/test-setup-github.sh
+++ b/template/scripts/test-setup-github.sh
@@ -39,8 +39,8 @@ run_case() {
 echo "==> private repositories report success plus the reason for a skip"
 GH_PRIVATE=true run_case --repo owner/private
 [ "$run_rc" -eq 0 ] || fail "private path exited $run_rc"
-grep -Fq '[x] Dependabot alerts — enabled' "$tmp/out" || fail "missing Dependabot success"
-grep -Fq '[-] Private vulnerability reporting — skipped — private repository' "$tmp/out" || fail "missing private-repo skip reason"
+grep -Fq '[x] Dependabot alerts - enabled' "$tmp/out" || fail "missing Dependabot success"
+grep -Fq '[-] Private vulnerability reporting - skipped — private repository' "$tmp/out" || fail "missing private-repo skip reason"
 grep -Fq 'DONE: GitHub repository settings are ready for owner/private' "$tmp/out" || fail "missing final outcome"
 if grep -q 'private-vulnerability-reporting' "$stub_calls"; then
     fail "private repository attempted to enable public-only reporting"
@@ -49,8 +49,8 @@ fi
 echo "==> public repositories enable every requested setting and collaborator"
 GH_PRIVATE=false run_case --repo owner/public --bot-collaborator owner-bot
 [ "$run_rc" -eq 0 ] || fail "public path exited $run_rc"
-grep -Fq '[x] Private vulnerability reporting — enabled' "$tmp/out" || fail "missing reporting success"
-grep -Fq '[x] Bot collaborator — owner-bot has push access' "$tmp/out" || fail "missing collaborator success"
+grep -Fq '[x] Private vulnerability reporting - enabled' "$tmp/out" || fail "missing reporting success"
+grep -Fq '[x] Bot collaborator - owner-bot has push access' "$tmp/out" || fail "missing collaborator success"
 grep -q 'private-vulnerability-reporting --method PUT' "$stub_calls" || fail "reporting API was not called"
 grep -q 'collaborators/owner-bot --method PUT -f permission=push' "$stub_calls" || fail "collaborator API was not called"
 
@@ -58,7 +58,7 @@ echo "==> failures are formatted, preserve status, and never claim completion"
 GH_PRIVATE=false GH_FAIL_MATCH=vulnerability-alerts GH_FAIL_RC=23 \
     run_case --repo owner/failing
 [ "$run_rc" -eq 23 ] || fail "API exit 23 became $run_rc"
-grep -Fq '[ ] Dependabot alerts — GitHub API request failed (exit 23)' "$tmp/out" || fail "missing formatted failure"
+grep -Fq '[ ] Dependabot alerts - GitHub API request failed (exit 23)' "$tmp/out" || fail "missing formatted failure"
 if grep -q 'DONE:' "$tmp/out"; then fail "failed run printed a completion summary"; fi
 if grep -q 'private-vulnerability-reporting' "$stub_calls"; then
     fail "script continued mutating after the first failure"

--- a/template/scripts/test-setup-github.sh
+++ b/template/scripts/test-setup-github.sh
@@ -22,6 +22,7 @@ case "$*" in
 *"${GH_FAIL_MATCH:-__never__}"*) exit "${GH_FAIL_RC:-1}" ;;
 esac
 case "$*" in
+*"collaborators/"*" --method PUT"*) printf '%s' "${GH_COLLAB_RESPONSE:-}" ;;
 *"/permission --jq .permission")
     [ -n "${GH_PERMISSION:-}" ] || exit 1
     printf '%s\n' "$GH_PERMISSION"
@@ -57,21 +58,37 @@ echo "==> public repositories enable every requested setting and collaborator"
 GH_PRIVATE=false GH_PERMISSION=write run_case --repo owner/public --bot-collaborator owner-bot
 [ "$run_rc" -eq 0 ] || fail "public path exited $run_rc"
 grep -Fq '[x] Private vulnerability reporting - enabled' "$tmp/out" || fail "missing reporting success"
-grep -Fq '[x] Bot collaborator - owner-bot has push access' "$tmp/out" || fail "missing collaborator success"
+grep -Fq '[x] Bot collaborator - owner-bot has write access' "$tmp/out" || fail "missing collaborator success"
 grep -q 'private-vulnerability-reporting --method PUT' "$stub_calls" || fail "reporting API was not called"
 grep -q 'collaborators/owner-bot --method PUT -f permission=push' "$stub_calls" || fail "collaborator API was not called"
 grep -q 'collaborators/owner-bot/permission --jq .permission' "$stub_calls" || fail "collaborator access was not verified"
 
 echo "==> a new collaborator invitation is reported as pending until accepted"
-GH_PRIVATE=false GH_PERMISSION= run_case --repo owner/public --bot-collaborator owner-bot
+GH_PRIVATE=false GH_COLLAB_RESPONSE='{"id":42,"invitee":{"login":"owner-bot"}}' \
+    run_case --repo owner/public --bot-collaborator owner-bot
 [ "$run_rc" -eq 0 ] || fail "pending invitation path exited $run_rc"
 grep -Fq '[?] Bot collaborator - invitation sent to owner-bot; access starts after acceptance' "$tmp/out" ||
     fail "missing pending-invitation outcome"
 grep -Fq 'WARN: GitHub repository settings are ready; bot collaborator acceptance is pending' "$tmp/out" ||
     fail "missing pending-invitation summary"
-if grep -q 'owner-bot has push access' "$tmp/out"; then
+if grep -q 'owner-bot has write access' "$tmp/out"; then
     fail "pending invitation falsely claimed active push access"
 fi
+
+echo "==> a failed permission lookup is unknown, never mislabeled as an invitation"
+GH_PRIVATE=false GH_COLLAB_RESPONSE= GH_PERMISSION= \
+    run_case --repo owner/public --bot-collaborator owner-bot
+[ "$run_rc" -eq 0 ] || fail "unverified collaborator path exited $run_rc"
+grep -Fq '[?] Bot collaborator - GitHub accepted the request, but permission verification failed' "$tmp/out" ||
+    fail "missing unverified-permission outcome"
+grep -Fq 'WARN: GitHub repository settings changed, but collaborator access needs verification' "$tmp/out" ||
+    fail "missing unverified-permission summary"
+if grep -q 'invitation sent' "$tmp/out"; then
+    fail "permission lookup failure was mislabeled as a confirmed invitation"
+fi
+
+grep -Fq 'SUMMARY: Repository setup - succeeded=' "$tmp/out" ||
+    fail "missing compact repository outcome summary"
 
 echo "==> failures are formatted, preserve status, and never claim completion"
 GH_PRIVATE=false GH_FAIL_MATCH=vulnerability-alerts GH_FAIL_RC=23 \

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -752,7 +752,7 @@ echo "==> gh's own credential line reports the state the section already probed"
 # From the one bounded probe at the top of the script — no second `gh auth
 # status` call, which is why this line survives a logged-out gh at all.
 case "$out" in
-*"[ ] GitHub CLI (gh) — gh auth login"*) ;;
+*"[ ] GitHub CLI (gh) - gh auth login"*) ;;
 *) fail "expected the gh credential line to name its remedy, got: ${out}" ;;
 esac
 
@@ -769,7 +769,7 @@ make_codex_stub out
 out="$(run_setup_section unauthenticated)"
 case "$out" in
 *"[x] Codex CLI"*) fail "a logged-out codex must not read as ok: ${out}" ;;
-*"[ ] Codex CLI — codex login"*) ;;
+*"[ ] Codex CLI - codex login"*) ;;
 *) fail "expected a logged-out codex to name its remedy, got: ${out}" ;;
 esac
 
@@ -822,8 +822,8 @@ make_stub unauthenticated
 make_codex_stub in
 out="$(run_setup_without gh)"
 case "$out" in
-*"GitHub CLI (gh) — gh auth login"*) fail "an absent gh must not be told to log in: ${out}" ;;
-*"[ ] GitHub CLI (gh) — brew install gh"*) ;;
+*"GitHub CLI (gh) - gh auth login"*) fail "an absent gh must not be told to log in: ${out}" ;;
+*"[ ] GitHub CLI (gh) - brew install gh"*) ;;
 *) fail "expected an install remedy for a missing gh, got: ${out}" ;;
 esac
 # The rest of the run must still behave: an absent gh is not an authenticated
@@ -1069,7 +1069,7 @@ echo "==> status:creds reports a logged-out gh with the login remedy"
 make_codex_stub in
 out="$(run_creds_section unauthenticated)"
 case "$out" in
-*"[ ] GitHub CLI (gh) — gh auth login"*) ;;
+*"[ ] GitHub CLI (gh) - gh auth login"*) ;;
 *) fail "expected a missing-login line from status:creds, got: ${out}" ;;
 esac
 
@@ -1107,7 +1107,7 @@ make_codex_stub out
 out="$(run_creds_section project)"
 case "$out" in
 *"[x] Codex CLI"*) fail "a logged-out codex must not read as ok: ${out}" ;;
-*"[ ] Codex CLI — codex login"*) ;;
+*"[ ] Codex CLI - codex login"*) ;;
 *) fail "expected a logged-out codex line from status:creds, got: ${out}" ;;
 esac
 
@@ -1119,7 +1119,7 @@ make_claude_stub out
 out="$(run_creds_section project)"
 case "$out" in
 *"[x] Claude Code CLI"*) fail "a logged-out claude must not read as ok: ${out}" ;;
-*"[ ] Claude Code CLI — claude auth login"*) ;;
+*"[ ] Claude Code CLI - claude auth login"*) ;;
 *) fail "expected a logged-out claude line, got: ${out}" ;;
 esac
 
@@ -1166,8 +1166,8 @@ make_codex_stub in
 make_isolated_bin gh
 out="$(PATH="${TMP}/bin-iso" NO_COLOR=1 "${WITH_CODEX}" creds 2>&1)"
 case "$out" in
-*"GitHub CLI (gh) — gh auth login"*) fail "an absent gh must not be told to log in: ${out}" ;;
-*"[ ] GitHub CLI (gh) — brew install gh"*) ;;
+*"GitHub CLI (gh) - gh auth login"*) fail "an absent gh must not be told to log in: ${out}" ;;
+*"[ ] GitHub CLI (gh) - brew install gh"*) ;;
 *) fail "expected an install remedy for a missing gh, got: ${out}" ;;
 esac
 

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -31,6 +31,7 @@ status="./scripts/status.sh"
 # status.sh sources the required-scope list from its sibling; every fixture root
 # below therefore needs both files, not just the script under test.
 scopes_lib="./scripts/gh-scopes.sh"
+output_lib="./scripts/lib/output.sh"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "${TMP}"' EXIT
@@ -50,9 +51,10 @@ trap 'rm -rf "${TMP}"' EXIT
 #   org-repo    — an ORG repo (github_org != the author's account), which
 #                 renders the issue-types setup and therefore needs admin:org.
 for fixture in with-board no-board skills-only with-codex creds-board org-repo; do
-    mkdir -p "${TMP}/${fixture}/scripts"
+    mkdir -p "${TMP}/${fixture}/scripts/lib"
     cp "${status}" "${TMP}/${fixture}/scripts/status.sh"
     cp "${scopes_lib}" "${TMP}/${fixture}/scripts/gh-scopes.sh"
+    cp "${output_lib}" "${TMP}/${fixture}/scripts/lib/output.sh"
 done
 # The markers status.sh feature-detects on. Contents are never read.
 : >"${TMP}/with-board/scripts/setup-github-project.sh"
@@ -66,9 +68,10 @@ mkdir -p "${TMP}/skills-only/.claude/skills/track-work/assets"
 
 # A board repo whose remote is a GitHub Enterprise host, and which exports no
 # GH_HOST — the case where forcing github.com disowns a valid login.
-mkdir -p "${TMP}/enterprise/scripts"
+mkdir -p "${TMP}/enterprise/scripts/lib"
 cp "${status}" "${TMP}/enterprise/scripts/status.sh"
 cp "${scopes_lib}" "${TMP}/enterprise/scripts/gh-scopes.sh"
+cp "${output_lib}" "${TMP}/enterprise/scripts/lib/output.sh"
 : >"${TMP}/enterprise/scripts/setup-github-project.sh"
 git -C "${TMP}/enterprise" init -q
 git -C "${TMP}/enterprise" remote add origin git@ghe.example.com:owner/repo.git
@@ -1272,11 +1275,14 @@ echo "==> every gum call keeps its stdout off the terminal"
 # all. gum_style is the single place that keeps stdout off the terminal; a call
 # site that bypasses it reintroduces the stall on exactly the terminals that
 # cannot answer, which are the ones nobody develops on.
-grep -qF 'CLICOLOR_FORCE=1 gum style "$@" | cat' "${status}" ||
+grep -qF 'CLICOLOR_FORCE=1 gum style "$@" | cat' "${output_lib}" ||
     fail "gum_style no longer pipes gum's stdout with CLICOLOR_FORCE — the terminal probe and the colour both depend on it"
 grep -q 'gum_style ' "${status}" ||
     fail "nothing calls gum_style — the check below would pass vacuously"
-stray="$(grep -nE '(^|[^_[:alnum:]])gum[[:space:]]+style' "${status}" |
+stray="$({
+    grep -nE '(^|[^_[:alnum:]])gum[[:space:]]+style' "${status}"
+    grep -nE '(^|[^_[:alnum:]])gum[[:space:]]+style' "${output_lib}"
+} |
     grep -vF 'CLICOLOR_FORCE=1 gum style' |
     grep -vE '^[0-9]+:[[:space:]]*#' || true)"
 [ -z "${stray}" ] ||

--- a/template/scripts/test-status.sh
+++ b/template/scripts/test-status.sh
@@ -1274,9 +1274,10 @@ echo "==> every gum call keeps its stdout off the terminal"
 # in every test above because they all run under NO_COLOR with no terminal at
 # all. gum_style is the single place that keeps stdout off the terminal; a call
 # site that bypasses it reintroduces the stall on exactly the terminals that
-# cannot answer, which are the ones nobody develops on.
-grep -qF 'CLICOLOR_FORCE=1 gum style "$@" | cat' "${output_lib}" ||
-    fail "gum_style no longer pipes gum's stdout with CLICOLOR_FORCE — the terminal probe and the colour both depend on it"
+# cannot answer, which are the ones nobody develops on. Command substitution
+# also preserves gum's failure status so this optional renderer can fall back.
+grep -qF 'styled="$(CLICOLOR_FORCE=1 gum style "$@")"' "${output_lib}" ||
+    fail "gum_style no longer captures gum's stdout with CLICOLOR_FORCE — the terminal probe, colour, and fallback depend on it"
 grep -q 'gum_style ' "${status}" ||
     fail "nothing calls gum_style — the check below would pass vacuously"
 stray="$({

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -307,7 +307,7 @@ case "$out" in
 *"$secret_value"*) fail "secret:set:gh printed the secret value" ;;
 esac
 
-echo "==> tasks whose script demands a TTY are marked interactive, in both twins"
+echo "==> terminal-aware tasks stay interactive through Task grouping, in both twins"
 # A run-time-only regression, and a total one: this Taskfile sets `output:
 # group` GLOBALLY, so Task pipes each task's stdout. A script guarding on
 # `[ -t 1 ]` then sees a pipe and refuses even in a real terminal, which made
@@ -323,12 +323,14 @@ echo "==> tasks whose script demands a TTY are marked interactive, in both twins
 #
 # Keyed to a fatal `-t 1` check specifically. A `-t 0` guard (secret:set:*,
 # codex:gate:disable) is untouched by output grouping, which redirects stdout
-# only, and status.sh's `-t 1` merely selects colour and never refuses.
+# only. The status tasks do not refuse without a TTY, but their intentionally
+# visual dashboard would otherwise lose color, Unicode, and gum through its
+# documented Task entrypoints.
 # Both layers where they exist. A GENERATED repo has only the first — it is the
 # rendered output, with no template/ of its own — so a missing file is skipped
 # rather than failed, and the counter below keeps "skipped everything" from
 # passing silently.
-tty_gated_tasks="setup:gh-scopes"
+tty_gated_tasks="setup:gh-scopes status status:git status:gh status:creds status:code status:env status:setup"
 checked_taskfiles=0
 for taskfile in Taskfile.yml template/Taskfile.yml.jinja; do
     [ -f "$taskfile" ] || continue
@@ -347,7 +349,7 @@ for taskfile in Taskfile.yml template/Taskfile.yml.jinja; do
         printf '%s\n' "$block" |
             grep -vE '^[[:space:]]*#' |
             grep -qE '^[[:space:]]*interactive:[[:space:]]*true[[:space:]]*$' ||
-            fail "${taskfile}: ${t} lacks 'interactive: true' — global 'output: group' pipes its stdout, so its TTY guard refuses in a real terminal"
+            fail "${taskfile}: ${t} lacks 'interactive: true' — global 'output: group' hides its terminal from the script"
     done
 done
 

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -267,6 +267,46 @@ for category in SSH_KEY SSHKEY; do
     fi
 done
 
+echo "==> secret helpers print styled outcomes without echoing secret values"
+secret_value='sensitive-value-must-not-appear'
+rm -f "$op_edit_called"
+out=$(printf '%s' "$secret_value" |
+    PATH="${op_bin}:${PATH}" OP_FIXTURE_CATEGORY=LOGIN \
+        OP_EDIT_CALLED="$op_edit_called" VAULT=test ITEM=test FIELD=password \
+        ./scripts/secret-set-1p.sh 2>&1) || fail "secret:set:1p success fixture failed: $out"
+[ -e "$op_edit_called" ] || fail "secret:set:1p success fixture never edited the item"
+case "$out" in
+*'DONE: 1Password secret updated'*) ;;
+*) fail "secret:set:1p omitted its final outcome: $out" ;;
+esac
+case "$out" in
+*"$secret_value"*) fail "secret:set:1p printed the secret value" ;;
+esac
+
+gh_bin="${test_tmp}/gh-bin"
+gh_secret_capture="${test_tmp}/gh-secret"
+mkdir -p "$gh_bin"
+cat >"${gh_bin}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-} ${2:-}" = "secret set" ] || exit 1
+cat >"${GH_SECRET_CAPTURE:?}"
+EOF
+chmod +x "${gh_bin}/gh"
+out=$(printf '%s' "$secret_value" |
+    PATH="${gh_bin}:${PATH}" GH_SECRET_CAPTURE="$gh_secret_capture" \
+        NAME=DEPLOY_TOKEN REPO=owner/repo ./scripts/secret-set-gh.sh 2>&1) ||
+    fail "secret:set:gh success fixture failed: $out"
+[ "$(cat "$gh_secret_capture")" = "$secret_value" ] ||
+    fail "secret:set:gh changed the secret value sent to gh"
+case "$out" in
+*'DONE: GitHub secret updated'*) ;;
+*) fail "secret:set:gh omitted its final outcome: $out" ;;
+esac
+case "$out" in
+*"$secret_value"*) fail "secret:set:gh printed the secret value" ;;
+esac
+
 echo "==> tasks whose script demands a TTY are marked interactive, in both twins"
 # A run-time-only regression, and a total one: this Taskfile sets `output:
 # group` GLOBALLY, so Task pipes each task's stdout. A script guarding on

--- a/template/scripts/test-tasks.sh
+++ b/template/scripts/test-tasks.sh
@@ -328,6 +328,25 @@ awk '
 ' Taskfile.yml ||
     fail "Taskfile.yml no longer selects 'output: group' — re-derive whether the interactive: true assertion above still describes a real hazard"
 
+echo "==> setup:github delegates action logic to the tested script in both twins"
+checked_setup_tasks=0
+for taskfile in Taskfile.yml template/Taskfile.yml.jinja; do
+    [ -f "$taskfile" ] || continue
+    checked_setup_tasks=$((checked_setup_tasks + 1))
+    block="$(awk '
+        $0 == "  setup:github:" { inblock = 1; next }
+        inblock && /^  [a-zA-Z0-9]/ { inblock = 0 }
+        inblock { print }
+    ' "$taskfile")"
+    [ -n "$block" ] || fail "${taskfile}: setup:github task not found"
+    printf '%s\n' "$block" | grep -Fq './scripts/setup-github.sh --repo "{{.REPO}}"' ||
+        fail "${taskfile}: setup:github does not delegate to scripts/setup-github.sh"
+    if printf '%s\n' "$block" | grep -Eq 'gh api|^[[:space:]]*-[[:space:]]*\|'; then
+        fail "${taskfile}: setup:github contains inline action logic instead of a trivial script command"
+    fi
+done
+[ "$checked_setup_tasks" -gt 0 ] || fail "no Taskfile setup:github wiring was checked"
+
 if [ -x ./scripts/test-terraform-provider-locks.sh ]; then
     echo "==> Terraform provider locks cover developer and CI platforms"
     ./scripts/test-terraform-provider-locks.sh


### PR DESCRIPTION
## Description

Give harmon-init's status and mutating Task targets a shared terminal design language that is colorful and unmistakable in an interactive terminal, while remaining stable, accessible, dependency-free plain text in logs.

- extract the status presentation primitives into `scripts/lib/output.sh` and ship the same library from the template
- add semantic action mastheads, check rows, summaries, warnings/completion lines, compact tables, and bounded spinners for setup and secret actions
- make `setup:github` report each API outcome truthfully, including skips, pending invitations, unknown permission reads, and write failures
- keep Task-grouped action progress chronological and preserve the styled status dashboard through its normal `task status:*` entrypoints
- gate color, Unicode, animation, and optional `gum` on terminal capabilities, with `NO_COLOR`, `TERM=dumb`, non-UTF-8, redirected-output, CI, missing-gum, and broken-gum fallbacks
- maintain root/template dogfood parity throughout

The design research followed the durable CLI guidance from [Command Line Interface Guidelines](https://clig.dev/), the [NO_COLOR convention](https://no-color.org/), [WCAG's non-color cue requirement](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), [Unicode width guidance](https://www.unicode.org/reports/tr11/), and [gum](https://github.com/charmbracelet/gum) as optional inspiration rather than a dependency. Color and symbols always reinforce visible words; they never carry the outcome alone.

Refs evanharmon1/harmon-devkit#494

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Task / chore (maintenance, tooling, no product change)

## How Has This Been Tested?

- [x] `task check`
- [x] `task verify`
- [x] challenge review: 2 rounds, converged with zero adjudicated P0/P1 in both rounds
- [x] verification review: 2 rounds, converged with zero adjudicated P0/P1 in both rounds
- [x] `task ci`
- [x] `task audit:dogfood -- --summary` reviewed; no newly absent root twins, parity and structure gates green
- [x] real PTY smoke test: `env -u NO_COLOR task status:git` rendered the optional-gum/color/Unicode presentation
- [x] capability regressions cover redirected output, `NO_COLOR`, `TERM=dumb`, non-UTF-8, missing/broken gum, spinner cleanup/status/diagnostic order, and Task stream chronology

## Review budget

rigor: `standard` (config default) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1. Tier: `standard` (config default). Method: `plan` (config default).

## Action-family audit

The shared style is adopted by `setup:github*`, project-board, GitHub-label, GitHub-scope, and `secret:set:*` scripts. Release, install, sync, cleanup, and worktree tasks were audited: their existing purpose-built output remains in scope for future incremental adoption, while this PR provides semantic `release`, `install`, `sync`, and `clean` banner primitives without wrapping unrelated mutation logic merely for decoration.

## Deferred findings

None. Every P2 raised by the local challenge and verification stages was fixed on this branch.

## Adjudication record

<details>
<summary>Challenge and verification findings</summary>

- `scripts/setup-github-project.sh:61` — Task grouped stdout could follow the live stderr outcome. Fixed with one ordered progress stream and a chronology regression test. Challenge round 1: zero adjudicated P0/P1.
- `scripts/lib/output.sh:38` — gum and ANSI banner Unicode could render under a non-UTF-8 locale. Fixed by gating gum and symbols on an explicit UTF-8 capability. Not introduced by challenge round 1.
- `scripts/lib/output.sh:279` — spinner output could race foreground diagnostics. Fixed by buffering diagnostics until spinner cleanup. Not introduced by challenge round 1. Challenge round 2: zero adjudicated P0/P1; provenance checkpoint complete; stage converged.
- `scripts/lib/output.sh:59` — a broken optional gum binary could abort an action under `set -e`. Fixed with checked rendering and complete built-in fallback. Verification round 1: zero adjudicated P0/P1.
- `Taskfile.yml:854` — global grouped output hid dashboard styling through normal `task status:*` entrypoints. Fixed by making visual status tasks interactive in both layers and testing the wiring. Not introduced by verification round 1. Verification round 2: zero adjudicated P0/P1; provenance checkpoint complete; stage converged.

</details>

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to root/template twins
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
