### PR TITLE
fix: document area, tier, and method label families

### DIFF
--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -996,6 +996,14 @@ full) # project_management=github; github_org=test-org (an org repo)
 minimal) # project_management=github on a PERSONAL account, use_foreman=false
     [ -f docs/project-management.md ] || err "GitHub project-management.md missing from docs/"
     grep -q 'Not planned' docs/project-management.md || err "GitHub project-management.md missing expected content"
+    grep -qF '**Area** — which codebase subsystem the work lives in (the *solution*' docs/project-management.md ||
+        err "project-management.md omits the area: solution-space label-family guidance"
+    grep -qF 'At most one each of `area:`/`domain:`/`layer:` per issue' docs/project-management.md ||
+        err "project-management.md omits the area/domain/layer cardinality guidance"
+    grep -qF '**Tier** — which model-routing stratum should work the issue' docs/project-management.md ||
+        err "project-management.md omits the tier: label-family guidance"
+    grep -qF '**Method** — the execution topology to work the issue under' docs/project-management.md ||
+        err "project-management.md omits the method: label-family guidance"
     [ -f scripts/setup-github-project.sh ] || err "scripts/setup-github-project.sh did not render for project_management=github"
     [ -f scripts/setup-github-labels.sh ] || err "scripts/setup-github-labels.sh did not render for project_management=github"
     # Personal account -> the org-only scripts must stay out.

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -574,6 +574,13 @@ the taxonomy table below is generated from) and the starter set is created by
 - **Work type** — what kind of work the issue is, on personal-account repos
   where native issue Type is unavailable; the issue forms apply it, and org
   repos use native Type with no work-type label
+- **Area** — which codebase subsystem the work lives in (the *solution*
+  space). At most one each of `area:`/`domain:`/`layer:` per issue
+- **Tier** — which model-routing stratum should work the issue — advisory,
+  human-written, and inert until a consumer resolves it under its own trust
+  model
+- **Method** — the execution topology to work the issue under — advisory,
+  like `tier:`
 - **Rigor** — which round-cap level in [`.devflow.toml`](../.devflow.toml) an
   agent works the issue under (AGENTS.md, "Round caps are resolved, not stated
   here"). An agent reads it and never self-applies one. It is advisory rather


### PR DESCRIPTION
## Description

Bring the generated GitHub project-management guide back into sync with its
dogfood counterpart by documenting the `area:`, `tier:`, and `method:` label
families. Add focused render assertions so each family remains present in the
consumer-facing document.

The structure gate deliberately remains one-way: root-only prose is allowed
because harmon-init can carry repository-specific context, and `AGENTS.md`
already records that limitation. This change therefore tests the exact
consumer contract instead of making the structural comparison symmetric.

Closes #957

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## How Has This Been Tested?

- [x] `task verify`
- [x] `task challenge` — converged in round 1 with no findings
- [x] `task review` — converged in round 1 with no findings
- [x] `task ci`
- [x] Focused minimal and full template renders

## Execution strategy

- Rigor: `standard` (config default) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1
- Tier: `standard` (config default), implemented by Terra subagent
- Method: `orchestrate` (explicit session instruction; off-default)
- The local reviewer was `gpt-5.6-sol`, in the same GPT model family as the Terra implementer.

## Deferred findings

None.

## Adjudication record

<details>
<summary>Local second-model review rounds</summary>

- `challenge r1 | no findings`
- `review r1 | no findings`

</details>

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes
