### PR TITLE
fix: close the known verify/CI target-list gaps in both layers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,10 +107,6 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Dogfood structure (template sections/tasks exist in the root layer)
         run: task test:dogfood-structure
-      # Needs copier for the same reason as the structure check above: it
-      # renders template/ (with .dogfood-answers.yml) to check the template
-      # layer's own verify<->CI reachability, since template/*.jinja source
-      # cannot be parsed as YAML directly (see the script's header comment).
       # Listed here for the same reason as the category/parity guards above:
       # this job enumerates its steps by hand, so a check that lives only in
       # `verify` never runs in CI. It renders the template, so it has to follow

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,22 @@ jobs:
       - run: task test:sync-devkit-release
       - run: task test:devcontainer:image:automation
       - run: task test:skills-pin-parity
+      # Added under #962: each of these ran in local `verify` but in no CI
+      # job, so CI was strictly weaker than the local gate. This job
+      # enumerates its steps by hand, so a check added to `verify` alone never
+      # runs here and the drift is invisible (#614, same class). Every one is
+      # a unit test needing no container, network, or credential, each ~1-2s.
+      - run: task audit:agent-instructions
+      - run: task test:agent-instructions-size
+      - run: task test:agent-skill-links
+      - run: task test:image-staleness
+      - run: task test:link-claude-json
+      - run: task test:meta-install
+      - run: task test:open-devcontainer
+      - run: task test:output
+      - run: task test:session-cleanup
+      - run: task test:setup-github
+      - run: task test:starship-glyphs
       # Meaningful only because this job checks out with fetch-depth: 0 above.
       - name: Tag hygiene (no non-release tag where git describe would select it)
         run: task test:tag-hygiene
@@ -91,6 +107,10 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Dogfood structure (template sections/tasks exist in the root layer)
         run: task test:dogfood-structure
+      # Needs copier for the same reason as the structure check above: it
+      # renders template/ (with .dogfood-answers.yml) to check the template
+      # layer's own verify<->CI reachability, since template/*.jinja source
+      # cannot be parsed as YAML directly (see the script's header comment).
       # Listed here for the same reason as the category/parity guards above:
       # this job enumerates its steps by hand, so a check that lives only in
       # `verify` never runs in CI. It renders the template, so it has to follow

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -52,6 +52,15 @@ jobs:
       # These run in local `verify` and must run here too, or CI is strictly
       # weaker than the local gate (harmon-init#962). Each is a unit test
       # needing no container, network, or credential.
+      #
+      # NOT here, deliberately: `validate` and `test`. Both are in `verify`
+      # unconditionally, but CI only invokes them from the build-test job,
+      # which is gated on use_node. So a repo with
+      # `(include_terraform or include_ansible) and not use_node` runs real
+      # terraform/ansible checks locally and none in CI. Adding them here is
+      # not a one-liner — `terraform validate` needs an init step CI does not
+      # have — so it is tracked as harmon-init#978 rather than fixed in the
+      # same breath as these.
       - run: task audit:agent-instructions
       - run: task test:agent-instructions-size
       - run: task test:agent-skill-links

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -49,6 +49,16 @@ jobs:
         run: task guard:codegen
 [% endif %]
       - run: task test:tasks
+      # These run in local `verify` and must run here too, or CI is strictly
+      # weaker than the local gate (harmon-init#962). Each is a unit test
+      # needing no container, network, or credential.
+      - run: task audit:agent-instructions
+      - run: task test:agent-instructions-size
+      - run: task test:agent-skill-links
+      - run: task test:output
+      - run: task test:meta-install
+      - run: task test:session-cleanup
+      - run: task test:setup-github
       - run: task test:agent-registry
       - run: task test:registry-drift
       - run: task test:registry-docs
@@ -71,6 +81,7 @@ jobs:
       - run: task test:setup-github-issue-fields
 [% endif %]
 [% if use_skills_sync %]
+      - run: task test:sync-devkit-release
       - name: Skills drift check (vendored skills vs pinned harmon-devkit ref)
         run: task verify:skills
 [% endif %]
@@ -78,6 +89,10 @@ jobs:
       - run: task test:hooks
       - run: task test:statusline
       - run: task test:devcontainer:permissions
+      # Same devcontainer gate their `verify` entries carry (#962).
+      - run: task test:link-claude-json
+      - run: task test:image-staleness
+      - run: task test:open-devcontainer
 [% endif %]
 [% if use_node %]
 


### PR DESCRIPTION
## What

21 targets ran in local `verify` but in **no CI job**, in both dogfood layers —
so required CI was silently weaker than the local gate. This closes those gaps.

**Root (11):** `audit:agent-instructions`, `test:agent-instructions-size`,
`test:agent-skill-links`, `test:image-staleness`, `test:link-claude-json`,
`test:meta-install`, `test:open-devcontainer`, `test:output`,
`test:session-cleanup`, `test:setup-github`, `test:starship-glyphs`.

**Template (10 + 1):** the seven that apply ungated, three more under the same
`devcontainer` gate their `verify` entries carry, and `test:sync-devkit-release`.

Each added target was **empirically confirmed** to need no container, network, or
credential and to run in ~1-2s — not assumed. Three of them (`test:image-staleness`,
`test:link-claude-json`, `test:open-devcontainer`) were expected to require Docker
and do not.

## Two things worth a reviewer's attention

**A bug consumers already have.** `template/.github/workflows/build.yml.jinja`
never gained `task test:sync-devkit-release`. #909's fix landed on the **root**
`build.yml` and never reached the repos generated from the template, so every
generated repo with `use_skills_sync` has that gate in `verify` and not in CI.

**`audit:agent-instructions` had dead code.** Its `::warning::` annotation path
only executes under `GITHUB_ACTIONS`, and it had never run in CI — so that branch
had never once executed.

## What this does NOT do

**It adds no gate**, so the class can recur the next time a target is added to
`verify` alone. That is deliberate, and it is the whole reason this PR exists
separately.

#962 originally carried both the fixes and a parity guard. Adversarial review put
the guard through three rounds and it did not converge: 2 → 5 → 5 confirmed P1s,
every round's findings against the previous round's additions, the checker growing
163 → 458 lines while acquiring demands to understand shell control flow, step
`if:` conditions, matrix `exclude:` rules, and delegated work inside "inert" tasks.
That is a parity checker turning into a workflow interpreter.

@evanharmon1 adjudicated the split: ship the verified fixes, take the guard back to
design. **#962 stays open** for it; the guard branch is preserved. The standing
recommendation there is to delete the second hand-maintained list rather than
police it — define the target list once in the Taskfile and have the workflow call
it — which makes drift structurally impossible instead of detectable.

**`validate` and `test` are deliberately excluded** from the template additions.
Both are in `verify` unconditionally, but CI invokes them only from the
`use_node`-gated `build-test` job, so a repo with
`(include_terraform or include_ansible) and not use_node` runs real
Terraform/Ansible checks locally and none in CI. Adding them is not a one-liner —
`terraform validate` needs an init step CI does not have — so it is **#978**, and
the exclusion is now documented at the exact spot a reader would ask.

## Verification

- `task verify` — GREEN (7 render profiles), on the tree with `origin/main` merged.
- `task ci` — GREEN. Re-run after the merge because it brought a 58-line change to
  `scripts/test-link-claude-json.sh`, one of the tasks this PR wires into CI.
- `actionlint`, `yamllint`, `task check`, `test:dogfood-parity`,
  `test:dogfood-structure` — all clean.
- Every added target executed standalone to confirm its dependencies.

## Review

rigor: `standard` (`default_rigor`; no `rigor:*` label on #962) → challenge ≤3,
review ≤3, shepherd 4, min_rounds 1. tier `standard`, method `plan` — both
defaults, nothing off-default to disclose.

### Challenge — converged in 2 rounds

| Round | Finding | Reviewer | Adjudicated | Action |
|---|---|---|---|---|
| 1 | No verify→CI parity gate; the class can recur | P1 | **P2** | Confirmed as fact, out of scope by the maintainer's split decision. Tracked in #962 |
| 2 | Same finding | P2 | **P2** | Reviewer self-downgraded P1 → P2. Carried below |

Two consecutive rounds adjudicated to zero P0/P1 → stage exits.

### Review — converged in 2 rounds

| Round | Finding | Reviewer | Adjudicated | Action |
|---|---|---|---|---|
| 1 | A comment claims `test:copier-validators` checks verify↔CI reachability | P1 | **P1 confirmed** | **Self-inflicted by the split**: removing the guard step left its four-line explanation behind, where it reattached to the copier-validators step and advertised a check no longer present. Removed |
| 1 | `validate`/`test` not run for non-Node profiles | P1 | **P1 confirmed → tracked** | Real; it is #978, deferred by the maintainer because `terraform validate` needs a CI init step. The code now states the exclusion rather than being silently short |
| 1 | No parity gate | P2 | **P2** | Same as challenge |
| 2 | — | — | **none** | Empty round → stage exits |

## Deferred findings

- [x] **declined: out of scope, tracked as #962** — `.github/workflows/build.yml`
      — P2 (challenge r1 as P1, r2 self-downgraded): this PR fixes the current
      snapshot of verify↔CI drift but adds no gate, so the class can recur.
      #962 stays open for the parity guard, and the guard branch is preserved.
      Recorded so the omission is visible rather than assumed.
- [x] **declined with evidence, filed as #980** — `template/.github/workflows/build.yml.jinja`
      — P1 (Codex cloud review, shepherd r1): CI depends on `jq` but never
      provisions it, so `test:link-claude-json` would fail on a self-hosted
      runner without it. Confirmed real but **pre-existing in both layers**:
      `test:status`, `test:label-registry` and `test:registry-drift` already run
      in root *and* template CI and all use `jq`, so such a runner already fails
      required CI today. This change affects legibility, not likelihood — the
      new task fails with an explicit `jq is required` message where the
      incumbents fail obscurely. Answered in-thread; #980 carries the evidence
      and the `ensure-file.sh` precedent.

Refs #962
Refs #978
