### PR TITLE
fix: disambiguate generic area label buckets

### DIFF
--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -510,7 +510,10 @@ the taxonomy table below is generated from) and the starter set is created by
   where native issue Type is unavailable; the issue forms apply it, and org
   repos use native Type with no work-type label
 - **Area** — which codebase subsystem the work lives in (the *solution*
-  space). At most one each of `area:`/`domain:`/`layer:` per issue
+  space). At most one each of `area:`/`domain:`/`layer:` per issue. On these
+  exclusive axes, a generic bucket defers to the most specific matching value;
+  write that single-owner boundary into the value's registry description
+  rather than leaving it implicit
 - **Tier** — which model-routing stratum should work the issue — advisory,
   human-written, and inert until a consumer resolves it under its own trust
   model

--- a/label-registry.json
+++ b/label-registry.json
@@ -314,7 +314,7 @@
         },
         {
           "value": "skills",
-          "description": "Vendored/authored agent skills and the skills sync"
+          "description": "Shared agent skills and skills sync; subsystem workflow skills belong to that subsystem's area"
         },
         {
           "value": "foreman",

--- a/label-registry.json
+++ b/label-registry.json
@@ -298,7 +298,7 @@
         },
         {
           "value": "ci",
-          "description": "GitHub Actions workflows and CI plumbing"
+          "description": "Repository-wide CI workflows and plumbing; subsystem workflows belong to that subsystem's area"
         },
         {
           "value": "tasks",
@@ -310,7 +310,7 @@
         },
         {
           "value": "deps",
-          "description": "Renovate, version pins, dependency bumps"
+          "description": "Cross-cutting dependency automation and bumps; subsystem dependencies belong to its area"
         },
         {
           "value": "skills",

--- a/label-registry.json
+++ b/label-registry.json
@@ -302,11 +302,11 @@
         },
         {
           "value": "tasks",
-          "description": "Taskfile targets and scripts/ glue"
+          "description": "Taskfile targets and scripts/ glue without a more specific area; security targets are area:security"
         },
         {
           "value": "tests",
-          "description": "The test-*.sh suite and gate assertions"
+          "description": "The shared test-*.sh suite and gates; a subsystem's own tests belong to its area"
         },
         {
           "value": "deps",
@@ -342,7 +342,7 @@
         },
         {
           "value": "docs",
-          "description": "Documentation content and structure"
+          "description": "Documentation content and structure; a subsystem's own docs belong to that subsystem's area"
         },
         {
           "value": "template",

--- a/scripts/test-label-registry.sh
+++ b/scripts/test-label-registry.sh
@@ -248,10 +248,10 @@ domain:delivery|FBCA04|Releases and versioning: release-please, tags, release gu
 domain:environment|FBCA04|The ready-to-code environment: devcontainer, images, codespaces, editor setup
 area:copier|0E8A16|The templating engine: copier.yml, answers, validators, jinja, render matrix
 area:devcontainer|0E8A16|Dev containers, images, features
-area:ci|0E8A16|GitHub Actions workflows and CI plumbing
+area:ci|0E8A16|Repository-wide CI workflows and plumbing; subsystem workflows belong to that subsystem's area
 area:tasks|0E8A16|Taskfile targets and scripts/ glue without a more specific area; security targets are area:security
 area:tests|0E8A16|The shared test-*.sh suite and gates; a subsystem's own tests belong to its area
-area:deps|0E8A16|Renovate, version pins, dependency bumps
+area:deps|0E8A16|Cross-cutting dependency automation and bumps; subsystem dependencies belong to its area
 area:skills|0E8A16|Vendored/authored agent skills and the skills sync
 area:foreman|0E8A16|Foreman config, wrapper tasks, adapters
 area:gauntlet|0E8A16|The challenge/review second-model stage: scripts, gates, and skill wiring
@@ -291,10 +291,10 @@ $root_only_inline" "root layer"
     template_only_inline="domain:auth|FBCA04|Authentication and authorization
 domain:billing|FBCA04|Billing and payments
 domain:platform|FBCA04|CI, build, test infra, and tooling in this repo
-area:ci|0E8A16|GitHub Actions workflows and CI plumbing
+area:ci|0E8A16|Repository-wide CI workflows and plumbing; subsystem workflows belong to that subsystem's area
 area:docs|0E8A16|Documentation content and structure; a subsystem's own docs belong to that subsystem's area
-area:deps|0E8A16|Renovate, version pins, dependency bumps
-area:build|0E8A16|Build system and artifacts
+area:deps|0E8A16|Cross-cutting dependency automation and bumps; subsystem dependencies belong to its area
+area:build|0E8A16|Shared build system and artifacts; subsystem builds belong to that subsystem's area
 area:tests|0E8A16|The shared test suite and gates; a subsystem's own tests belong to its area
 area:tasks|0E8A16|Taskfile targets and scripts/ glue without a more specific area
 area:release|0E8A16|release-please, tags, release guards

--- a/scripts/test-label-registry.sh
+++ b/scripts/test-label-registry.sh
@@ -249,8 +249,8 @@ domain:environment|FBCA04|The ready-to-code environment: devcontainer, images, c
 area:copier|0E8A16|The templating engine: copier.yml, answers, validators, jinja, render matrix
 area:devcontainer|0E8A16|Dev containers, images, features
 area:ci|0E8A16|GitHub Actions workflows and CI plumbing
-area:tasks|0E8A16|Taskfile targets and scripts/ glue
-area:tests|0E8A16|The test-*.sh suite and gate assertions
+area:tasks|0E8A16|Taskfile targets and scripts/ glue without a more specific area; security targets are area:security
+area:tests|0E8A16|The shared test-*.sh suite and gates; a subsystem's own tests belong to its area
 area:deps|0E8A16|Renovate, version pins, dependency bumps
 area:skills|0E8A16|Vendored/authored agent skills and the skills sync
 area:foreman|0E8A16|Foreman config, wrapper tasks, adapters
@@ -259,7 +259,7 @@ area:worktree|0E8A16|Worktree lifecycle tooling
 area:release|0E8A16|release-please, tags, release guards
 area:security|0E8A16|Scanners, secret handling, hardening
 area:pm|0E8A16|Labels, projects, issue tooling, PM docs
-area:docs|0E8A16|Documentation content and structure"
+area:docs|0E8A16|Documentation content and structure; a subsystem's own docs belong to that subsystem's area"
 foreman_inline="foreman:approved|1D76DB|Arm with the repo default backend
 foreman:hold|D93F0B|Exclude from foreman dispatch (always wins)
 foreman:satisfied|0E8A16|Human override: treat this dependency as satisfied
@@ -292,11 +292,11 @@ $root_only_inline" "root layer"
 domain:billing|FBCA04|Billing and payments
 domain:platform|FBCA04|CI, build, test infra, and tooling in this repo
 area:ci|0E8A16|GitHub Actions workflows and CI plumbing
-area:docs|0E8A16|Documentation content and structure
+area:docs|0E8A16|Documentation content and structure; a subsystem's own docs belong to that subsystem's area
 area:deps|0E8A16|Renovate, version pins, dependency bumps
 area:build|0E8A16|Build system and artifacts
-area:tests|0E8A16|The test suite and gate assertions
-area:tasks|0E8A16|Taskfile targets and scripts/ glue
+area:tests|0E8A16|The shared test suite and gates; a subsystem's own tests belong to its area
+area:tasks|0E8A16|Taskfile targets and scripts/ glue without a more specific area
 area:release|0E8A16|release-please, tags, release guards
 area:devcontainer|0E8A16|Dev containers, images, features
 area:pm|0E8A16|Labels, projects, issue tooling, PM docs

--- a/scripts/test-label-registry.sh
+++ b/scripts/test-label-registry.sh
@@ -252,7 +252,7 @@ area:ci|0E8A16|Repository-wide CI workflows and plumbing; subsystem workflows be
 area:tasks|0E8A16|Taskfile targets and scripts/ glue without a more specific area; security targets are area:security
 area:tests|0E8A16|The shared test-*.sh suite and gates; a subsystem's own tests belong to its area
 area:deps|0E8A16|Cross-cutting dependency automation and bumps; subsystem dependencies belong to its area
-area:skills|0E8A16|Vendored/authored agent skills and the skills sync
+area:skills|0E8A16|Shared agent skills and skills sync; subsystem workflow skills belong to that subsystem's area
 area:foreman|0E8A16|Foreman config, wrapper tasks, adapters
 area:gauntlet|0E8A16|The challenge/review second-model stage: scripts, gates, and skill wiring
 area:worktree|0E8A16|Worktree lifecycle tooling
@@ -300,7 +300,7 @@ area:tasks|0E8A16|Taskfile targets and scripts/ glue without a more specific are
 area:release|0E8A16|release-please, tags, release guards
 area:devcontainer|0E8A16|Dev containers, images, features
 area:pm|0E8A16|Labels, projects, issue tooling, PM docs
-area:skills|0E8A16|Vendored/authored agent skills and the skills sync
+area:skills|0E8A16|Shared agent skills and skills sync; subsystem workflow skills belong to that subsystem's area
 area:gauntlet|0E8A16|The challenge/review second-model stage: scripts, gates, and skill wiring"
     check_lockfile template/label-registry.json template/agent-registry.json \
         "$shared_inline

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -575,7 +575,10 @@ the taxonomy table below is generated from) and the starter set is created by
   where native issue Type is unavailable; the issue forms apply it, and org
   repos use native Type with no work-type label
 - **Area** — which codebase subsystem the work lives in (the *solution*
-  space). At most one each of `area:`/`domain:`/`layer:` per issue
+  space). At most one each of `area:`/`domain:`/`layer:` per issue. On these
+  exclusive axes, a generic bucket defers to the most specific matching value;
+  write that single-owner boundary into the value's registry description
+  rather than leaving it implicit
 - **Tier** — which model-routing stratum should work the issue — advisory,
   human-written, and inert until a consumer resolves it under its own trust
   model

--- a/template/label-registry.json
+++ b/template/label-registry.json
@@ -292,7 +292,7 @@
         },
         {
           "value": "skills",
-          "description": "Vendored/authored agent skills and the skills sync"
+          "description": "Shared agent skills and skills sync; subsystem workflow skills belong to that subsystem's area"
         },
         {
           "value": "gauntlet",

--- a/template/label-registry.json
+++ b/template/label-registry.json
@@ -260,7 +260,7 @@
         },
         {
           "value": "docs",
-          "description": "Documentation content and structure"
+          "description": "Documentation content and structure; a subsystem's own docs belong to that subsystem's area"
         },
         {
           "value": "deps",
@@ -272,11 +272,11 @@
         },
         {
           "value": "tests",
-          "description": "The test suite and gate assertions"
+          "description": "The shared test suite and gates; a subsystem's own tests belong to its area"
         },
         {
           "value": "tasks",
-          "description": "Taskfile targets and scripts/ glue"
+          "description": "Taskfile targets and scripts/ glue without a more specific area"
         },
         {
           "value": "release",

--- a/template/label-registry.json
+++ b/template/label-registry.json
@@ -256,7 +256,7 @@
       "values": [
         {
           "value": "ci",
-          "description": "GitHub Actions workflows and CI plumbing"
+          "description": "Repository-wide CI workflows and plumbing; subsystem workflows belong to that subsystem's area"
         },
         {
           "value": "docs",
@@ -264,11 +264,11 @@
         },
         {
           "value": "deps",
-          "description": "Renovate, version pins, dependency bumps"
+          "description": "Cross-cutting dependency automation and bumps; subsystem dependencies belong to its area"
         },
         {
           "value": "build",
-          "description": "Build system and artifacts"
+          "description": "Shared build system and artifacts; subsystem builds belong to that subsystem's area"
         },
         {
           "value": "tests",

--- a/template/scripts/test-label-registry.sh
+++ b/template/scripts/test-label-registry.sh
@@ -248,10 +248,10 @@ domain:delivery|FBCA04|Releases and versioning: release-please, tags, release gu
 domain:environment|FBCA04|The ready-to-code environment: devcontainer, images, codespaces, editor setup
 area:copier|0E8A16|The templating engine: copier.yml, answers, validators, jinja, render matrix
 area:devcontainer|0E8A16|Dev containers, images, features
-area:ci|0E8A16|GitHub Actions workflows and CI plumbing
+area:ci|0E8A16|Repository-wide CI workflows and plumbing; subsystem workflows belong to that subsystem's area
 area:tasks|0E8A16|Taskfile targets and scripts/ glue without a more specific area; security targets are area:security
 area:tests|0E8A16|The shared test-*.sh suite and gates; a subsystem's own tests belong to its area
-area:deps|0E8A16|Renovate, version pins, dependency bumps
+area:deps|0E8A16|Cross-cutting dependency automation and bumps; subsystem dependencies belong to its area
 area:skills|0E8A16|Vendored/authored agent skills and the skills sync
 area:foreman|0E8A16|Foreman config, wrapper tasks, adapters
 area:gauntlet|0E8A16|The challenge/review second-model stage: scripts, gates, and skill wiring
@@ -291,10 +291,10 @@ $root_only_inline" "root layer"
     template_only_inline="domain:auth|FBCA04|Authentication and authorization
 domain:billing|FBCA04|Billing and payments
 domain:platform|FBCA04|CI, build, test infra, and tooling in this repo
-area:ci|0E8A16|GitHub Actions workflows and CI plumbing
+area:ci|0E8A16|Repository-wide CI workflows and plumbing; subsystem workflows belong to that subsystem's area
 area:docs|0E8A16|Documentation content and structure; a subsystem's own docs belong to that subsystem's area
-area:deps|0E8A16|Renovate, version pins, dependency bumps
-area:build|0E8A16|Build system and artifacts
+area:deps|0E8A16|Cross-cutting dependency automation and bumps; subsystem dependencies belong to its area
+area:build|0E8A16|Shared build system and artifacts; subsystem builds belong to that subsystem's area
 area:tests|0E8A16|The shared test suite and gates; a subsystem's own tests belong to its area
 area:tasks|0E8A16|Taskfile targets and scripts/ glue without a more specific area
 area:release|0E8A16|release-please, tags, release guards

--- a/template/scripts/test-label-registry.sh
+++ b/template/scripts/test-label-registry.sh
@@ -249,8 +249,8 @@ domain:environment|FBCA04|The ready-to-code environment: devcontainer, images, c
 area:copier|0E8A16|The templating engine: copier.yml, answers, validators, jinja, render matrix
 area:devcontainer|0E8A16|Dev containers, images, features
 area:ci|0E8A16|GitHub Actions workflows and CI plumbing
-area:tasks|0E8A16|Taskfile targets and scripts/ glue
-area:tests|0E8A16|The test-*.sh suite and gate assertions
+area:tasks|0E8A16|Taskfile targets and scripts/ glue without a more specific area; security targets are area:security
+area:tests|0E8A16|The shared test-*.sh suite and gates; a subsystem's own tests belong to its area
 area:deps|0E8A16|Renovate, version pins, dependency bumps
 area:skills|0E8A16|Vendored/authored agent skills and the skills sync
 area:foreman|0E8A16|Foreman config, wrapper tasks, adapters
@@ -259,7 +259,7 @@ area:worktree|0E8A16|Worktree lifecycle tooling
 area:release|0E8A16|release-please, tags, release guards
 area:security|0E8A16|Scanners, secret handling, hardening
 area:pm|0E8A16|Labels, projects, issue tooling, PM docs
-area:docs|0E8A16|Documentation content and structure"
+area:docs|0E8A16|Documentation content and structure; a subsystem's own docs belong to that subsystem's area"
 foreman_inline="foreman:approved|1D76DB|Arm with the repo default backend
 foreman:hold|D93F0B|Exclude from foreman dispatch (always wins)
 foreman:satisfied|0E8A16|Human override: treat this dependency as satisfied
@@ -292,11 +292,11 @@ $root_only_inline" "root layer"
 domain:billing|FBCA04|Billing and payments
 domain:platform|FBCA04|CI, build, test infra, and tooling in this repo
 area:ci|0E8A16|GitHub Actions workflows and CI plumbing
-area:docs|0E8A16|Documentation content and structure
+area:docs|0E8A16|Documentation content and structure; a subsystem's own docs belong to that subsystem's area
 area:deps|0E8A16|Renovate, version pins, dependency bumps
 area:build|0E8A16|Build system and artifacts
-area:tests|0E8A16|The test suite and gate assertions
-area:tasks|0E8A16|Taskfile targets and scripts/ glue
+area:tests|0E8A16|The shared test suite and gates; a subsystem's own tests belong to its area
+area:tasks|0E8A16|Taskfile targets and scripts/ glue without a more specific area
 area:release|0E8A16|release-please, tags, release guards
 area:devcontainer|0E8A16|Dev containers, images, features
 area:pm|0E8A16|Labels, projects, issue tooling, PM docs

--- a/template/scripts/test-label-registry.sh
+++ b/template/scripts/test-label-registry.sh
@@ -252,7 +252,7 @@ area:ci|0E8A16|Repository-wide CI workflows and plumbing; subsystem workflows be
 area:tasks|0E8A16|Taskfile targets and scripts/ glue without a more specific area; security targets are area:security
 area:tests|0E8A16|The shared test-*.sh suite and gates; a subsystem's own tests belong to its area
 area:deps|0E8A16|Cross-cutting dependency automation and bumps; subsystem dependencies belong to its area
-area:skills|0E8A16|Vendored/authored agent skills and the skills sync
+area:skills|0E8A16|Shared agent skills and skills sync; subsystem workflow skills belong to that subsystem's area
 area:foreman|0E8A16|Foreman config, wrapper tasks, adapters
 area:gauntlet|0E8A16|The challenge/review second-model stage: scripts, gates, and skill wiring
 area:worktree|0E8A16|Worktree lifecycle tooling
@@ -300,7 +300,7 @@ area:tasks|0E8A16|Taskfile targets and scripts/ glue without a more specific are
 area:release|0E8A16|release-please, tags, release guards
 area:devcontainer|0E8A16|Dev containers, images, features
 area:pm|0E8A16|Labels, projects, issue tooling, PM docs
-area:skills|0E8A16|Vendored/authored agent skills and the skills sync
+area:skills|0E8A16|Shared agent skills and skills sync; subsystem workflow skills belong to that subsystem's area
 area:gauntlet|0E8A16|The challenge/review second-model stage: scripts, gates, and skill wiring"
     check_lockfile template/label-registry.json template/agent-registry.json \
         "$shared_inline


### PR DESCRIPTION
## What

- add explicit single-owner deferral boundaries to generic `area:` label descriptions
- keep root and Copier template registries, reviewed lock expectations, and taxonomy docs aligned
- extend the boundary to other overlapping fallback buckets found during adversarial review (`ci`, `deps`, `build`, and `skills`)

## Why

Exclusive classification axes must resolve to one plausible value. Unqualified generic buckets overlap subsystem-specific values and leave triage unable to select a label.

Closes #942

## Verification

- `task verify`
- `task challenge` — converged in 3 rounds
- `task review` — converged in 1 round
- `task ci`
- `task test:label-registry`
- `task test:dogfood-parity`
- `task test:dogfood-structure`

Rigor: `standard` (`default_rigor`) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1. Tier: `standard`; method: `plan` (configuration defaults).

Local implementation and second-model review were both performed by Codex-family models; the required current-head Codex cloud review remains an independent final-head check during shepherding.

## Deferred findings

None.

## Adjudication record

<details>
<summary>Local review rounds</summary>

- Challenge round 1: confirmed P1 — remaining generic `ci`, `deps`, and `build` buckets lacked deferral boundaries; fixed.
- Challenge round 2: confirmed P1 — `area:skills` overlapped `area:gauntlet` skill wiring; original-scope, not round-1 scaffolding; fixed by making `skills` a shared fallback that defers subsystem workflow skills.
- Challenge round 3: no P0/P1/P2/P3 findings; capped final round clean; challenge converged.
- Review round 1: no P0/P1/P2/P3 findings; empty round at `min_rounds = 1`; review converged.
- Shepherd round 1: GitHub reported the branch behind `main`; merged current `origin/main`, reran `task ci`, and pushed `6323504`.

</details>
