### PR TITLE
fix: replay captured output when a rendered-repo gate fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
       - run: task test:session-cleanup
       - run: task test:setup-github
       - run: task test:starship-glyphs
+      - run: task test:template-helpers
       # Meaningful only because this job checks out with fetch-depth: 0 above.
       - name: Tag hygiene (no non-release tag where git describe would select it)
         run: task test:tag-hygiene

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -112,6 +112,7 @@ tasks:
       - task: test:image-staleness
       - task: test:open-devcontainer
       - task: test:codex-review
+      - task: test:template-helpers
       - task: test:template
 
   # ── Quality Checks ────────────────────────────────────────────
@@ -519,6 +520,11 @@ tasks:
   # Root-only: a generated repo has no template/ to scan. Makes the Hard Rule in
   # AGENTS.md enforceable — the maintainer's personal dotfiles repo is not
   # readable by a consumer, so shipped output must never name it or chezmoi.
+  test:template-helpers:
+    desc: Unit-test test-template.sh's quiet-command capture helpers (offline; guards seven rendered-repo gates against becoming silent no-ops)
+    cmds:
+      - ./scripts/test-template-helpers.sh
+
   test:template-independence:
     desc: "Guard: consumer-facing output names neither harmon-dotfiles nor chezmoi"
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -517,14 +517,16 @@ tasks:
     cmds:
       - ./scripts/test-starship-glyphs.sh
 
-  # Root-only: a generated repo has no template/ to scan. Makes the Hard Rule in
-  # AGENTS.md enforceable — the maintainer's personal dotfiles repo is not
-  # readable by a consumer, so shipped output must never name it or chezmoi.
+  # Root-only: test-template.sh is the harness that renders the template, so it
+  # has no template/ twin and the helpers under test ship to nobody.
   test:template-helpers:
-    desc: Unit-test test-template.sh's quiet-command capture helpers (offline; guards seven rendered-repo gates against becoming silent no-ops)
+    desc: Unit-test test-template.sh's quiet-command capture helpers (offline; guards the rendered-repo gates against becoming silent no-ops)
     cmds:
       - ./scripts/test-template-helpers.sh
 
+  # Root-only: a generated repo has no template/ to scan. Makes the Hard Rule in
+  # AGENTS.md enforceable — the maintainer's personal dotfiles repo is not
+  # readable by a consumer, so shipped output must never name it or chezmoi.
   test:template-independence:
     desc: "Guard: consumer-facing output names neither harmon-dotfiles nor chezmoi"
     cmds:

--- a/scripts/test-template-helpers.sh
+++ b/scripts/test-template-helpers.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Hermetic unit tests for test-template.sh's quiet-command capture helpers
+# (harmon-init#934).
+#
+# Why this suite exists at all. `run_quiet` replaced seven bare
+# `>/dev/null 2>&1 || err "..."` call sites, so every one of those rendered-repo
+# gates now reaches `err` only if run_quiet propagates a nonzero status. A
+# run_quiet that returned 0 unconditionally would not fail loudly — it would
+# turn all seven gates into silent no-ops while `task verify` stayed green. The
+# exit-status case below is therefore the load-bearing one, and the call-site
+# case guards the wiring those gates depend on.
+set -euo pipefail
+
+repo="$(git rev-parse --show-toplevel)"
+subject="${repo}/scripts/test-template.sh"
+
+fail() {
+    echo "TEST FAIL: $*" >&2
+    exit 1
+}
+
+job_tmp="$(mktemp -d -t harmon-init-tth-XXXXXX)"
+trap 'rm -rf "$job_tmp"' EXIT
+
+# Bind to the REAL helpers rather than a copy: extract them from the subject and
+# source them, so this suite cannot pass against a run_quiet that no longer
+# matches the one test-template.sh actually calls.
+helpers="$job_tmp/helpers.sh"
+sed -n '/^dump_log() {/,/^}/p;/^run_quiet() {/,/^}/p' "$subject" >"$helpers"
+
+# Negative control on the extraction itself. A sed that silently matched
+# nothing would make every assertion below vacuously true — the #889 class of
+# defect, and the reason this is asserted rather than assumed.
+grep -q '^dump_log() {' "$helpers" || fail "extraction found no dump_log() in ${subject}"
+grep -q '^run_quiet() {' "$helpers" || fail "extraction found no run_quiet() in ${subject}"
+
+# shellcheck source=/dev/null
+. "$helpers"
+
+# ── The success path must be exactly as quiet as the >/dev/null it replaced ──
+
+noise="$(run_quiet quiet_ok sh -c 'echo to_stdout; echo to_stderr >&2; exit 0' 2>&1)"
+[ -z "$noise" ] || fail "run_quiet leaked output on the success path: ${noise}"
+
+status=0
+run_quiet status_ok true || status=$?
+[ "$status" -eq 0 ] || fail "run_quiet returned ${status} for a command that succeeded"
+
+# ── The failure path must replay BOTH streams ────────────────────────────────
+
+status=0
+replay="$(run_quiet loud_fail sh -c 'echo marker_out; echo marker_err >&2; exit 1' 2>&1)" || status=$?
+case "$replay" in
+*marker_out*) : ;;
+*) fail "run_quiet lost the failing command's stdout" ;;
+esac
+case "$replay" in
+*marker_err*) : ;;
+*) fail "run_quiet lost the failing command's stderr" ;;
+esac
+case "$replay" in
+*"----- end: loud_fail -----"*) : ;;
+*) fail "run_quiet omitted the closing boundary that delimits captured output" ;;
+esac
+
+# ── Exit-status propagation: the case seven gates depend on ──────────────────
+#
+# Asserted across several distinct nonzero values, not just one, so a helper
+# that collapsed every failure to a constant would still be caught.
+for expected in 1 3 7 42; do
+    status=0
+    run_quiet "status_${expected}" sh -c "exit ${expected}" >/dev/null 2>&1 || status=$?
+    [ "$status" -eq "$expected" ] ||
+        fail "run_quiet reported ${status} for a command that exited ${expected} — the '|| err' call sites would not fire"
+done
+
+# ── --in <dir> runs elsewhere without moving the caller ──────────────────────
+
+mkdir -p "$job_tmp/elsewhere"
+before="$PWD"
+run_quiet --in "$job_tmp/elsewhere" chdir_probe pwd >/dev/null 2>&1 ||
+    fail "run_quiet --in failed on a directory that exists"
+grep -qF "elsewhere" "$job_tmp/chdir_probe.log" ||
+    fail "run_quiet --in did not run the command in the requested directory"
+[ "$PWD" = "$before" ] ||
+    fail "run_quiet --in moved the caller's working directory to ${PWD}"
+
+# A directory that does not exist must fail rather than silently running in the
+# caller's cwd, where the command could pass against the wrong tree.
+status=0
+run_quiet --in "$job_tmp/no-such-dir" absent_dir true >/dev/null 2>&1 || status=$?
+[ "$status" -ne 0 ] || fail "run_quiet --in succeeded against a directory that does not exist"
+
+# ── dump_log replays a log captured by something other than run_quiet ────────
+#
+# The worktree:new call site captures by hand (its failure is legitimate on a
+# profile with no commit) and replays only on the branch that treats it as an
+# error, so dump_log must work standalone.
+printf 'standalone_marker\n' >"$job_tmp/manual.log"
+replay="$(dump_log manual 2>&1)"
+case "$replay" in
+*standalone_marker*) : ;;
+*) fail "dump_log did not replay a hand-captured log" ;;
+esac
+
+# ── The call sites are actually wired to the helper ──────────────────────────
+#
+# Guards the regression this change exists to prevent: a gate reverted to a bare
+# discard fails silently and undiagnosably, which is exactly what #934 reported.
+if grep -nE 'task --color=false [a-z:-]+ >/dev/null 2>&1' "$subject"; then
+    fail "a rendered-repo task gate above still discards its output instead of using run_quiet"
+fi
+if grep -nF 'test:worktree >/dev/null 2>&1' "$subject"; then
+    fail "the test:worktree gate still discards its output (the original #934 report)"
+fi
+
+wired="$(grep -c 'run_quiet ' "$subject" || true)"
+[ "$wired" -ge 6 ] ||
+    fail "expected at least 6 run_quiet call sites in ${subject}, found ${wired}"
+
+echo "test-template.sh capture helpers: PASS"

--- a/scripts/test-template-helpers.sh
+++ b/scripts/test-template-helpers.sh
@@ -2,13 +2,17 @@
 # Hermetic unit tests for test-template.sh's quiet-command capture helpers
 # (harmon-init#934).
 #
-# Why this suite exists at all. `run_quiet` replaced seven bare
+# Why this suite exists at all. `run_quiet` replaced the bare
 # `>/dev/null 2>&1 || err "..."` call sites, so every one of those rendered-repo
 # gates now reaches `err` only if run_quiet propagates a nonzero status. A
 # run_quiet that returned 0 unconditionally would not fail loudly — it would
-# turn all seven gates into silent no-ops while `task verify` stayed green. The
-# exit-status case below is therefore the load-bearing one, and the call-site
-# case guards the wiring those gates depend on.
+# turn every one of them into a silent no-op while `task verify` stayed green.
+# The exit-status case below is therefore the load-bearing one, and the
+# call-site case guards the wiring those gates depend on.
+#
+# Counts are deliberately absent from this prose: the number of converted
+# gates is asserted mechanically below, and a figure repeated in comments
+# goes stale the moment one is added (review r2 found exactly that).
 set -euo pipefail
 
 repo="$(git rev-parse --show-toplevel)"
@@ -63,7 +67,7 @@ case "$replay" in
 *) fail "run_quiet omitted the closing boundary that delimits captured output" ;;
 esac
 
-# ── Exit-status propagation: the case seven gates depend on ──────────────────
+# ── Exit-status propagation: the case every converted gate depends on ───────
 #
 # Asserted across several distinct nonzero values, not just one, so a helper
 # that collapsed every failure to a constant would still be caught.

--- a/scripts/test-template-helpers.sh
+++ b/scripts/test-template-helpers.sh
@@ -113,22 +113,28 @@ esac
 # gates could be reverted with the suite still green. Quantifying over the
 # file leaves no seam to slip through.
 #
-# The discriminator is the command's KIND, not its formatting. A gate runs
-# `task` or one of the repo's own scripts and has diagnostic output worth
-# replaying; a probe (`git rev-parse HEAD`, `command -v`) answers a question
-# and has none, so discarding its output is correct. Anchoring on the command
-# instead of on the end of the line is what lets this match a gate written on
-# one line as readily as one split across two — an earlier form required `||`
-# to close the line, which excluded the probe at test-template.sh:266 only by
-# accident of where the line broke (challenge r2).
+# Trigger on the SILENCING PRIMITIVE, not on control flow. Three rounds in a
+# row found one more shell shape the previous pattern missed — `|| err` on a
+# continuation line, then the same on one line, then `if ! … ; then` — because
+# each pattern enumerated the syntax that *surrounds* the discard. Enumerating
+# control flow has no fixed point. Matching `>/dev/null 2>&1` on any line that
+# invokes a gate is shape-independent: it holds for `||`, for `if`, for `if !`,
+# and for forms nobody has written yet.
 #
-# Two shapes are correctly NOT matched, and both are load-bearing:
-#   * `if <gate> >/dev/null 2>&1; then err ...` — a NONZERO exit is the
-#     asserted outcome, so a replay would fire on the expected path.
-#   * `<non-gate> >/dev/null 2>&1 || …` — a probe or a best-effort
-#     `|| true`, neither of which produces output an operator needs.
-if grep -nE '(task |\./scripts/[A-Za-z0-9_.-]+\.sh).*>/dev/null 2>&1\)? *\|\|' "$subject"; then
-    fail "a rendered-repo gate above discards its output and then branches — route it through run_quiet (#934)"
+# It needs no exemptions, which is the property worth protecting. The two
+# inverse-shape sites (a nonzero exit is the asserted outcome) were converted
+# to capture rather than exempted — an unexpectedly PASSING negative control is
+# precisely when you want its output — so nothing here is a special case.
+#
+# What it does NOT cover, stated plainly rather than implied away:
+#   * a redirection split onto a continuation line (no `\` continuations exist
+#     in the subject today);
+#   * `>/dev/null` WITHOUT `2>&1` — stdout only. Five gate lines do this; they
+#     are not silent, because err() and the suites write failures to stderr.
+# Both, and the structural-inspection approach that would settle them, are
+# tracked as follow-up work rather than grown onto this change.
+if grep -nE '(task |\./scripts/[A-Za-z0-9_.-]+\.sh).*>/dev/null 2>&1' "$subject" | grep -v run_quiet; then
+    fail "a rendered-repo gate above silences its output — capture it (run_quiet, or a log + dump_log) so a failure is diagnosable (#934)"
 fi
 
 # Counted on EXECUTABLE call sites only. Counting bare occurrences let the

--- a/scripts/test-template-helpers.sh
+++ b/scripts/test-template-helpers.sh
@@ -107,15 +107,23 @@ esac
 #
 # Guards the regression this change exists to prevent: a gate reverted to a bare
 # discard fails silently and undiagnosably, which is exactly what #934 reported.
-if grep -nE 'task --color=false [a-z:-]+ >/dev/null 2>&1' "$subject"; then
-    fail "a rendered-repo task gate above still discards its output instead of using run_quiet"
-fi
-if grep -nF 'test:worktree >/dev/null 2>&1' "$subject"; then
-    fail "the test:worktree gate still discards its output (the original #934 report)"
+# Stated as a PROPERTY over the whole file, not as a list of per-gate greps.
+# An enumeration is exactly what the challenge round defeated: `--dry check`
+# and `./scripts/foo.sh` forms evade any set of task-name patterns, so three
+# gates could be reverted with the suite still green. Quantifying over the
+# file leaves no seam to slip through.
+#
+# The INVERSE shape is deliberately not matched: `if cmd >/dev/null 2>&1; then
+# err ...` asserts that a nonzero exit is the failure, so there the discard is
+# correct and a replay would fire on the expected path.
+if grep -nE '>/dev/null 2>&1\)? *\|\|$' "$subject"; then
+    fail "a rendered-repo gate above discards its output and then calls err — route it through run_quiet (#934)"
 fi
 
-wired="$(grep -c 'run_quiet ' "$subject" || true)"
-[ "$wired" -ge 6 ] ||
-    fail "expected at least 6 run_quiet call sites in ${subject}, found ${wired}"
+# Counted on EXECUTABLE call sites only. Counting bare occurrences let the
+# three prose mentions of run_quiet satisfy the assertion on their own.
+wired="$(grep -cE '^[[:space:]]+run_quiet ' "$subject" || true)"
+[ "$wired" -ge 11 ] ||
+    fail "expected at least 11 run_quiet call sites in ${subject}, found ${wired}"
 
 echo "test-template.sh capture helpers: PASS"

--- a/scripts/test-template-helpers.sh
+++ b/scripts/test-template-helpers.sh
@@ -113,11 +113,22 @@ esac
 # gates could be reverted with the suite still green. Quantifying over the
 # file leaves no seam to slip through.
 #
-# The INVERSE shape is deliberately not matched: `if cmd >/dev/null 2>&1; then
-# err ...` asserts that a nonzero exit is the failure, so there the discard is
-# correct and a replay would fire on the expected path.
-if grep -nE '>/dev/null 2>&1\)? *\|\|$' "$subject"; then
-    fail "a rendered-repo gate above discards its output and then calls err — route it through run_quiet (#934)"
+# The discriminator is the command's KIND, not its formatting. A gate runs
+# `task` or one of the repo's own scripts and has diagnostic output worth
+# replaying; a probe (`git rev-parse HEAD`, `command -v`) answers a question
+# and has none, so discarding its output is correct. Anchoring on the command
+# instead of on the end of the line is what lets this match a gate written on
+# one line as readily as one split across two — an earlier form required `||`
+# to close the line, which excluded the probe at test-template.sh:266 only by
+# accident of where the line broke (challenge r2).
+#
+# Two shapes are correctly NOT matched, and both are load-bearing:
+#   * `if <gate> >/dev/null 2>&1; then err ...` — a NONZERO exit is the
+#     asserted outcome, so a replay would fire on the expected path.
+#   * `<non-gate> >/dev/null 2>&1 || …` — a probe or a best-effort
+#     `|| true`, neither of which produces output an operator needs.
+if grep -nE '(task |\./scripts/[A-Za-z0-9_.-]+\.sh).*>/dev/null 2>&1\)? *\|\|' "$subject"; then
+    fail "a rendered-repo gate above discards its output and then branches — route it through run_quiet (#934)"
 fi
 
 # Counted on EXECUTABLE call sites only. Counting bare occurrences let the

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -1868,7 +1868,7 @@ if grep -Eq '^include_terraform:[[:space:]]+(true|yes)$' .copier-answers.yml; th
         grep -qF -- "$lock_contract" scripts/terraform-provider-locks.sh ||
             err "scripts/terraform-provider-locks.sh does not establish '$lock_contract'"
     done
-    ./scripts/test-terraform-provider-locks.sh >/dev/null 2>&1 ||
+    run_quiet tf-provider-locks ./scripts/test-terraform-provider-locks.sh ||
         err "scripts/test-terraform-provider-locks.sh fails its hermetic lock-process checks"
     grep -q 'test-terraform-provider-locks.sh' scripts/test-tasks.sh ||
         err "test-tasks.sh does not run the provider-lock regression"
@@ -2012,7 +2012,7 @@ PY
         [ -f "$changed_script" ] || err "$changed_script missing (include_terraform=true)"
         [ -x "$changed_script" ] || err "$changed_script is not executable"
     done
-    ./scripts/test-terraform-changed.sh >/dev/null 2>&1 ||
+    run_quiet tf-changed ./scripts/test-terraform-changed.sh ||
         err "scripts/test-terraform-changed.sh fails its own change-detection checks"
     grep -q 'test-terraform-changed.sh' scripts/test-tasks.sh ||
         err "test-tasks.sh does not run the change-detection regression"
@@ -2146,7 +2146,7 @@ if [ -f prettier.config.cjs ]; then # use_node profiles (web-astro / web-app)
         grep -q -- '--pass-with-no-tests' scripts/e2e-run.sh ||
             err "e2e-run.sh filters out @a11y without --pass-with-no-tests — an a11y-only repo would fail the blocking e2e check"
     fi
-    ./scripts/e2e-run.sh >/dev/null 2>&1 ||
+    run_quiet e2e-skip ./scripts/e2e-run.sh ||
         err "e2e-run.sh does not skip cleanly on a fresh render (no playwright.config.*)"
     # A config with the guard still unconfigured must FAIL, not skip.
     touch playwright.config.ts
@@ -2214,9 +2214,9 @@ fi
 # directions are asserted.
 if grep -Eq '^project_type:[[:space:]]+web-app$' .copier-answers.yml; then
     [ -x scripts/codegen.sh ] || err "scripts/codegen.sh missing or not executable (project_type=web-app)"
-    ./scripts/codegen.sh >/dev/null 2>&1 ||
+    run_quiet codegen-skip ./scripts/codegen.sh ||
         err "codegen.sh does not skip cleanly on a fresh render (no app/deps yet)"
-    ./scripts/codegen.sh --guard >/dev/null 2>&1 ||
+    run_quiet codegen-guard-skip ./scripts/codegen.sh --guard ||
         err "codegen.sh --guard does not skip cleanly on a fresh render (no app/deps yet)"
     grep -q 'convex codegen' scripts/codegen.sh || err "codegen.sh does not run Convex codegen"
     if have task; then

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -85,6 +85,48 @@ err() {
     fail=1
 }
 
+# ── Quiet-but-not-silent command capture (#934) ─────────────────────────────
+#
+# A rendered-repo gate that can fail with no evidence turns an intermittent
+# failure into an unexplainable event: the render lives under $job_tmp and the
+# EXIT trap above reaps it, so once this script returns there is nothing left
+# to inspect. One local `task ci` run failed inside the rendered repo's
+# worktree suite while shepherding PR #932; every re-run passed and the cause
+# could not be recovered, because the inner output had gone to /dev/null and
+# the render was already gone.
+#
+# dump_log replays one captured log; run_quiet captures a command and replays
+# it only when the command failed, so the success path stays exactly as quiet
+# as the bare `>/dev/null 2>&1` it replaces.
+dump_log() {
+    dl_name="$1"
+    dl_status="${2:-}"
+    if [ -n "$dl_status" ]; then
+        echo "----- captured output: $dl_name (exit $dl_status) -----" >&2
+    else
+        echo "----- captured output: $dl_name -----" >&2
+    fi
+    cat "$job_tmp/$dl_name.log" >&2 || true
+    echo "----- end: $dl_name -----" >&2
+}
+
+# Usage: run_quiet [--in <dir>] <log-name> <cmd>...
+# Returns the command's own exit status, so every call site keeps the
+# `|| err "..."` shape it had when it discarded the output instead.
+run_quiet() {
+    rq_dir="."
+    if [ "${1:-}" = "--in" ]; then
+        rq_dir="$2"
+        shift 2
+    fi
+    rq_name="$1"
+    shift
+    rq_status=0
+    (cd "$rq_dir" && "$@") >"$job_tmp/$rq_name.log" 2>&1 || rq_status=$?
+    [ "$rq_status" -eq 0 ] || dump_log "$rq_name" "$rq_status"
+    return "$rq_status"
+}
+
 # copier itself is not optional here, unlike the tools gated behind
 # required() above: this script IS the template-render gate, so a local skip
 # would report `task verify` green while rendering nothing. copier is now
@@ -352,7 +394,7 @@ if have task; then
         err "task verify does not reach test:registry-docs"
     # End-to-end: run the task itself, so the env plumbing is exercised rather
     # than just asserted.
-    task --color=false test:registry-docs >/dev/null 2>&1 ||
+    run_quiet registry-docs task --color=false test:registry-docs ||
         err "task test:registry-docs fails in the rendered repo"
 else
     required task "registry-docs verify reachability" || fail=1
@@ -376,7 +418,7 @@ if have task; then
     verify_dry="$(task --color=false --dry verify 2>&1 || true)"
     grep -qF './scripts/test-worktree.sh' <<<"$verify_dry" ||
         err "task verify does not reach test:worktree"
-    task --color=false test:worktree >/dev/null 2>&1 ||
+    run_quiet worktree task --color=false test:worktree ||
         err "task test:worktree fails in the rendered repo"
 
     # ...and the issue's own acceptance path, against THIS rendered repo rather
@@ -386,19 +428,24 @@ if have task; then
     # where `.git` is a file and the working directory is not the repo root.
     # --no-install keeps it offline; lint:hygiene is the gate that needs only
     # bash, git and `file`, which this job already has.
-    if ./scripts/worktree-new.sh smoke --no-install >/dev/null 2>&1; then
-        (cd .worktrees/smoke && task --color=false --dry check >/dev/null 2>&1) ||
+    if ./scripts/worktree-new.sh smoke --no-install >"$job_tmp/smoke-new.log" 2>&1; then
+        run_quiet --in .worktrees/smoke smoke-check task --color=false --dry check ||
             err "task check does not resolve inside a worktree of the rendered repo"
-        (cd .worktrees/smoke && task --color=false lint:hygiene >/dev/null 2>&1) ||
+        run_quiet --in .worktrees/smoke smoke-hygiene task --color=false lint:hygiene ||
             err "task lint:hygiene fails inside a worktree of the rendered repo"
-        ./scripts/worktree-rm.sh smoke >/dev/null 2>&1 ||
+        run_quiet smoke-rm ./scripts/worktree-rm.sh smoke ||
             err "worktree:rm failed to remove the smoke worktree in the rendered repo"
         [ -e .worktrees/smoke ] && err "worktree:rm left the smoke worktree behind"
     else
         # A render whose _tasks were skipped has no commit for the worktree to
-        # check out; that is a property of the profile, not a failure.
-        git rev-parse HEAD >/dev/null 2>&1 &&
+        # check out; that is a property of the profile, not a failure — so the
+        # capture above is replayed only where HEAD exists and the failure is
+        # therefore real. run_quiet cannot be used here: it replays on every
+        # nonzero exit, which would make the legitimate no-commit path noisy.
+        if git rev-parse HEAD >/dev/null 2>&1; then
+            dump_log smoke-new
             err "worktree:new failed in the rendered repo"
+        fi
     fi
 else
     required task "worktree entrypoint reachability" || fail=1
@@ -450,7 +497,7 @@ if have task; then
     verify_dry="$(task --color=false --dry verify 2>&1 || true)"
     grep -qF './scripts/test-label-registry.sh' <<<"$verify_dry" ||
         err "task verify does not reach test:label-registry"
-    task --color=false test:label-registry >/dev/null 2>&1 ||
+    run_quiet label-registry task --color=false test:label-registry ||
         err "task test:label-registry fails in the rendered repo (the #873/#883 class of regression: a docs-presence check misfiring on the rendered project_management variant)"
 else
     required task "label-registry verify reachability + execution" || fail=1

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -576,7 +576,8 @@ grep -q 'task test:ci-results' .github/workflows/build.yml ||
 [ -x scripts/verify-ci-results.sh ] || err "fail-closed CI result helper missing or not executable"
 EXPECTED_RESULT=success ./scripts/verify-ci-results.sh lint=success security=success >/dev/null ||
     err "rendered CI result helper rejected successful trusted jobs"
-if EXPECTED_RESULT=success ./scripts/verify-ci-results.sh lint=success security=skipped >/dev/null 2>&1; then
+if EXPECTED_RESULT=success ./scripts/verify-ci-results.sh lint=success security=skipped >"$job_tmp/ci-results-negative.log" 2>&1; then
+    dump_log ci-results-negative
     err "rendered CI result helper accepted an unexpectedly skipped trusted job"
 fi
 for aggregate_workflow in .github/workflows/build.yml .github/workflows/devcontainer-build.yml; do
@@ -2150,7 +2151,8 @@ if [ -f prettier.config.cjs ]; then # use_node profiles (web-astro / web-app)
         err "e2e-run.sh does not skip cleanly on a fresh render (no playwright.config.*)"
     # A config with the guard still unconfigured must FAIL, not skip.
     touch playwright.config.ts
-    if ./scripts/e2e-run.sh >/dev/null 2>&1; then
+    if ./scripts/e2e-run.sh >"$job_tmp/e2e-guard-negative.log" 2>&1; then
+        dump_log e2e-guard-negative
         err "e2e-run.sh passed with an unconfigured e2e-env-guard.sh — the guard must fail closed"
     fi
     rm -f playwright.config.ts


### PR DESCRIPTION
## What

`scripts/test-template.sh` ran its rendered-repo gates as
`cmd >/dev/null 2>&1 || err "..."`, and the script's `EXIT` trap removes the
whole job temp dir. A failing gate therefore produced a one-line `FAIL` with no
evidence, and nothing left on disk to inspect.

Adds two helpers — `dump_log` (replay one captured log) and `run_quiet`
(capture a command, replay it only on failure) — and routes every rendered-repo
gate through them. The success path stays exactly as quiet as the bare discard
it replaces; only a failure prints, delimited by explicit boundary lines.

## Why it is 14 gates, not the one the issue names

The issue reports the `test:worktree` gate. The same shape covered
`test:registry-docs`, both in-worktree smoke probes, the smoke worktree
removal, `test:label-registry`, and — found during the challenge stage — five
more in the iac and web-app profile blocks (`test-terraform-provider-locks.sh`,
`test-terraform-changed.sh`, `e2e-run.sh`, `codegen.sh` twice). All were
equally undiagnosable on failure.

Two sites are handled deliberately differently, because a nonzero exit is their
**asserted** outcome rather than a failure: the `worktree:new` smoke probe
(legitimately fails on a profile whose `_tasks` were skipped) and two
fail-closed negative controls. They capture by hand and replay only on the
branch that treats the result as an error — `run_quiet` would have printed a
diagnostic dump on the expected path. Converting the negative controls from
discard to capture is a strict improvement: an unexpectedly *passing* negative
control previously showed nothing about why.

## The regression guard, and why it looks the way it does

`scripts/test-template-helpers.sh` is the negative control. Routing 14 gates
through one helper makes its exit status load-bearing: a `run_quiet` that
returned 0 unconditionally would not fail loudly — it would turn every gate
into a silent no-op while `task verify` stayed green. Mutant M1 is exactly that
case.

The suite extracts the helpers from the subject rather than copying them, and
asserts the extraction matched something, so it cannot pass vacuously.

Its wiring assertion was rewritten three times across the review rounds, and
the final shape is the point: it keys on the **silencing primitive**
(`>/dev/null 2>&1` on a line invoking a gate) rather than on the control flow
surrounding it. Every earlier version enumerated syntax — `||` at line end,
then `||` anywhere, then `if ! … ; then` — and an enumeration of shell forms
has no fixed point. Keying on the primitive is shape-independent and needs
**zero exemptions**, which is why the two inverse-shape sites were converted
rather than exempted.

What it does not cover is stated in the code rather than implied away: a
redirection split onto a continuation line, and `>/dev/null` without `2>&1`
(stdout only — not silent, since `err()` and the rendered suites write to
stderr). Both, and the shell-parsing approach that would settle them, are
tracked in #986.

## Verification

- `task verify` — green, re-run after every round; the new `test:template-helpers` runs inside it
- `task ci` — green (full mirror: verify + skills drift + devcontainer assert + security)
- **AC 1** — a staged rendered-repo failure replays the suite's own output:
  ```
  ----- captured output: worktree (exit 201) -----
  STAGED_FAILURE_MARKER_934 — deliberate, see harmon-init#934
  and a second line on stderr
  task: Failed to run task "test:worktree": exit status 3
  ----- end: worktree -----
  FAIL: task test:worktree fails in the rendered repo
  ```
  Staged with a `cp` backup against the template twin; twin restored byte-identical.
- **AC 2** — that staging *is* the demonstration, run end-to-end through `test-template.sh minimal`.
- **16 mutants, 0 survivors**, plus 2 false-positive controls asserting the guard does *not* fire on a state probe with `|| err` or a best-effort `|| true`. Mutants cover: run_quiet always returning 0, output not replayed, exit status collapsed, `--in` ignored, success-path leakage, `dump_log` emptied, the extraction going vacuous, a call site dropped without reintroducing the discard, and gate reverts in five distinct shell shapes.

`scripts/test-template.sh` is root-only — it is the harness that renders the
template — so there is no `template/` twin and no dogfood-parity obligation.
The new task is wired into **both** `verify` and `build.yml`, since CI
enumerating its own target list by hand is the drift #962/#981 address.

## Review budget

`rigor: standard (default_rigor) → challenge ≤3, review ≤3, shepherd 4, min_rounds 1`

Not a reduced budget. Challenge converged at 2 of ≤3, review at 2 of ≤3, both
on the two-consecutive-clean exit. Zero P0 and zero P1 in all four rounds.
Nothing was deferred — every P2 and P3 was fixed in place or spun out to #986 —
so there is no `## Deferred findings` section to settle.

<details>
<summary><h2>Adjudication record</h2></summary>

| Stage | P0 | P1 | P2 | P3 | Finding → disposition |
|---|---|---|---|---|---|
| challenge r1 | 0 | 0 | 1 | 0 | Wiring assertion counted prose mentions (9 raw vs 6 real) and its per-gate greps were evaded by the `--dry check` and script-path forms → **confirmed**; restructured to a file-wide invariant, which then exposed 5 unconverted gates |
| challenge r2 | 0 | 0 | 1 | 0 | Property required `\|\|` to end the line, so a same-line gate evaded it → **confirmed**. *Provenance: subject added by r1.* Re-anchored on command kind rather than exempting the `git rev-parse` probe a naive broadening would have false-flagged |
| review r1 | 0 | 0 | 1 | 0 | Line-based regex missed `if ! <gate> >/dev/null 2>&1; then` → **confirmed**. *Provenance: 3rd consecutive round on the same artifact.* Restructured to key on the silencing primitive; residual spun out to #986 rather than hardened a 4th time |
| review r2 | 0 | 0 | 0 | 2 | New task block orphaned the dotfiles/chezmoi rationale above `test:template-independence` → **confirmed**, moved. Prose claimed "seven" gates against an assertion requiring ≥11 → **confirmed**, count removed from prose rather than corrected (it re-rots on the next added gate) |

No finding on the guard's completeness in review r2, after three consecutive
rounds attacking it — the restructure held rather than relocating the seam.

</details>

Closes #934
