### PR TITLE
fix: resolve worktree:rm's target from the registry instead of constructing it

### DIFF
--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -3167,6 +3167,46 @@ git -C "$fixture" worktree remove --force "$outcone_list/stray"
 git -C "$fixture" worktree remove --force ".worktrees/feat/deep"
 git -C "$fixture" worktree remove --force ".worktrees/team space/leaf"
 
+# A remedy this command would itself reject is worse than no remedy. The
+# nameability test must apply EVERY rule the argument check applies — it
+# originally applied only the charset and component rules, so an in-cone path
+# beginning with `-` or containing `..` was advertised as
+# `task worktree:rm -- …` and then refused by the parser it was handed to
+# (review r1). Both shapes are checked, because they fail different rules.
+for bad_component in '-dash' 'a..b'; do
+    new "remedycheck" --no-install >/dev/null ||
+        fail "could not create the #963 remedy fixture for '$bad_component'"
+    mkdir -p "$fixture/.worktrees/$bad_component"
+    git -C "$fixture" worktree move .worktrees/remedycheck ".worktrees/$bad_component/leaf" ||
+        fail "could not move the #963 remedy fixture into '$bad_component'"
+    rm_remedy="$test_tmp/rm-remedy.log"
+    if rm_wt remedycheck >"$rm_remedy" 2>&1; then
+        fail "worktree:rm reported success for a path under '$bad_component' (#963): $(cat "$rm_remedy")"
+    fi
+    grep -q 'task worktree:rm --' "$rm_remedy" &&
+        fail "the remedy advertised a task invocation this command rejects, for '$bad_component' (#963): $(cat "$rm_remedy")"
+    grep -q 'git worktree remove' "$rm_remedy" ||
+        fail "the remedy did not fall back to git's command for '$bad_component' (#963): $(cat "$rm_remedy")"
+    # The LISTING must reach the same verdict about the same path, and it must
+    # be checked while this worktree still exists. Both components pass the
+    # charset rule and fail a different one, so a listing that applied only the
+    # charset rule would advertise them as names — the drift the shared
+    # predicate exists to prevent.
+    rm_remedy_list="$test_tmp/rm-remedy-list.log"
+    rm_wt definitely-absent-name >"$rm_remedy_list" 2>&1 || true
+    grep -qE "^  \(git worktree remove\)  .*$bad_component/leaf" "$rm_remedy_list" ||
+        fail "the listing advertised '$bad_component/leaf' under a name this command rejects (#963): $(cat "$rm_remedy_list")"
+    git -C "$fixture" worktree remove --force ".worktrees/$bad_component/leaf"
+    rmdir "$fixture/.worktrees/$bad_component" 2>/dev/null || true
+done
+
+# The argument check must keep naming the SPECIFIC rule that failed — routing
+# both callers through one predicate must not flatten the diagnostics.
+rm_badname="$test_tmp/rm-badname.log"
+rm_wt '../escape' >"$rm_badname" 2>&1 && fail "worktree:rm accepted '../escape' (#963)"
+grep -q "must not contain '\.\.'" "$rm_badname" ||
+    fail "the argument check stopped naming which rule failed (#963): $(cat "$rm_badname")"
+
 echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"
 
 echo "worktree entrypoint OK: create → hooks verified → deps installed → removed"

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -3065,7 +3065,21 @@ nl_parent="$test_tmp/nl-cone"
 mkdir -p "$nl_parent"
 nl_tree="$nl_parent/trunc
 tail"
-if git -C "$fixture" worktree add -q "$nl_tree" -b feat/newline-path 2>/dev/null; then
+# Probe the FILESYSTEM's capability directly. Treating any `git worktree add`
+# failure as "newlines unsupported" would swallow a broken hook, a branch
+# collision, or a git regression and silently drop this coverage while the
+# suite still reported a pass (challenge r2).
+nl_probe="$nl_parent/probe
+newline"
+if mkdir -p "$nl_probe" 2>/dev/null && [ -d "$nl_probe" ]; then
+    rmdir "$nl_probe" 2>/dev/null || true
+    nl_supported=1
+else
+    nl_supported=0
+fi
+if [ "$nl_supported" -eq 0 ]; then
+    echo "    (skipped: this filesystem rejects a newline in a path)"
+elif git -C "$fixture" worktree add -q "$nl_tree" -b feat/newline-path; then
     rm_trunc="$test_tmp/rm-trunc.log"
     if rm_wt trunc >"$rm_trunc" 2>&1; then
         fail "worktree:rm resolved a truncated newline path as a real worktree (#963): $(cat "$rm_trunc")"
@@ -3079,8 +3093,79 @@ if git -C "$fixture" worktree add -q "$nl_tree" -b feat/newline-path 2>/dev/null
         fail "the truncated prefix of a newline path resolved as a real worktree (#963): $(cat "$rm_trunc")"
     git -C "$fixture" worktree remove --force "$nl_tree"
 else
-    echo "    (skipped: this filesystem rejects a newline in a path)"
+    fail "could not create a newline-bearing worktree although the filesystem accepts newline paths (#963)"
 fi
+
+# Two worktrees sharing a basename make the name ambiguous. The refusal must
+# name the ones that actually collided — printing the whole registry hides
+# which two are in conflict and points at unrelated paths (challenge r2).
+amb_root="$test_tmp/amb"
+git -C "$fixture" worktree add -q "$amb_root/a/twin" -b feat/twin-a ||
+    fail "could not create the first #963 ambiguity worktree"
+git -C "$fixture" worktree add -q "$amb_root/b/twin" -b feat/twin-b ||
+    fail "could not create the second #963 ambiguity worktree"
+git -C "$fixture" worktree add -q "$amb_root/unrelated/bystander" -b feat/bystander ||
+    fail "could not create the #963 ambiguity bystander"
+rm_amb="$test_tmp/rm-ambiguous.log"
+if rm_wt twin >"$rm_amb" 2>&1; then
+    fail "worktree:rm reported success for an ambiguous name (#963): $(cat "$rm_amb")"
+fi
+grep -q 'is ambiguous' "$rm_amb" ||
+    fail "an ambiguous name did not report ambiguity (#963): $(cat "$rm_amb")"
+grep -q "$amb_root/a/twin" "$rm_amb" && grep -q "$amb_root/b/twin" "$rm_amb" ||
+    fail "the ambiguity refusal did not name both colliding worktrees (#963): $(cat "$rm_amb")"
+grep -q 'bystander' "$rm_amb" &&
+    fail "the ambiguity refusal listed an unrelated worktree as a collision (#963): $(cat "$rm_amb")"
+git -C "$fixture" worktree remove --force "$amb_root/a/twin"
+git -C "$fixture" worktree remove --force "$amb_root/b/twin"
+git -C "$fixture" worktree remove --force "$amb_root/unrelated/bystander"
+
+# An in-cone worktree whose relative path is not a name this command accepts:
+# the remedy must be git's own command, shell-escaped. Emitting
+# `task worktree:rm -- team space/leaf` would split on the space and be
+# rejected by the charset guard anyway (challenge r2).
+mkdir -p "$fixture/.worktrees/team space"
+git -C "$fixture" worktree add -q ".worktrees/team space/leaf" -b feat/spaced-cone ||
+    fail "could not create the #963 unaddressable in-cone worktree"
+rm_unaddr="$test_tmp/rm-unaddressable.log"
+if rm_wt leaf >"$rm_unaddr" 2>&1; then
+    fail "worktree:rm reported success for an unaddressable in-cone path (#963): $(cat "$rm_unaddr")"
+fi
+grep -q 'git worktree remove' "$rm_unaddr" ||
+    fail "the refusal did not fall back to git's own command for an unaddressable path (#963): $(cat "$rm_unaddr")"
+grep -q 'task worktree:rm --' "$rm_unaddr" &&
+    fail "the refusal suggested a task invocation that cannot parse (#963): $(cat "$rm_unaddr")"
+
+# The candidate listing's first column must be a name this command actually
+# takes. For a NESTED in-cone worktree that is the relative path, not the
+# basename: .worktrees/feat/deep is addressed as feat/deep, and advertising
+# "deep" sends the operator through an extra refusal to discover that.
+new nestedlist --no-install >/dev/null ||
+    fail "could not create the #963 nested-listing fixture"
+# `git worktree move` does not create the destination's parent.
+mkdir -p "$fixture/.worktrees/feat"
+git -C "$fixture" worktree move .worktrees/nestedlist ".worktrees/feat/deep" ||
+    fail "could not nest the #963 listing fixture"
+rm_list="$test_tmp/rm-listing.log"
+rm_wt definitely-absent-name >"$rm_list" 2>&1 || true
+grep -qE '^  feat/deep( |$)' "$rm_list" ||
+    fail "the listing did not offer the nested worktree's usable name (#963): $(cat "$rm_list")"
+# ...and an unaddressable path must not be advertised as if it were a name.
+grep -qE '^  \(git worktree remove\)' "$rm_list" ||
+    fail "the listing did not mark the unaddressable in-cone path as needing git's command (#963): $(cat "$rm_list")"
+# ...and specifically for an OUT-OF-CONE worktree, which the in-cone-with-space
+# case above cannot prove: classifying every path as in-cone would advertise an
+# absolute path as though it were a name this command takes.
+outcone_list="$test_tmp/outcone-list"
+git -C "$fixture" worktree add -q "$outcone_list/stray" -b feat/outcone-listing ||
+    fail "could not create the #963 out-of-cone listing fixture"
+rm_list2="$test_tmp/rm-listing-outcone.log"
+rm_wt definitely-absent-name >"$rm_list2" 2>&1 || true
+grep -qE "^  \(git worktree remove\)  .*$outcone_list/stray" "$rm_list2" ||
+    fail "the listing advertised an out-of-cone worktree under a name this command cannot take (#963): $(cat "$rm_list2")"
+git -C "$fixture" worktree remove --force "$outcone_list/stray"
+git -C "$fixture" worktree remove --force ".worktrees/feat/deep"
+git -C "$fixture" worktree remove --force ".worktrees/team space/leaf"
 
 echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"
 

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -3182,8 +3182,10 @@ rm_wt definitely-absent-name >"$rm_list" 2>&1 || true
 grep -qE '^  feat/deep( |$)' "$rm_list" ||
     fail "the listing did not offer the nested worktree's usable name (#963): $(cat "$rm_list")"
 # ...and an unaddressable path must not be advertised as if it were a name.
-grep -qE '^  \(git worktree remove\)' "$rm_list" ||
-    fail "the listing did not mark the unaddressable in-cone path as needing git's command (#963): $(cat "$rm_list")"
+grep -qE '^  \(not removable here\)' "$rm_list" ||
+    fail "the listing did not mark the unaddressable in-cone path as not removable (#963): $(cat "$rm_list")"
+grep -q 'git worktree remove' "$rm_list" &&
+    fail "the listing re-offered the unguarded command the refusal withholds (#963): $(cat "$rm_list")"
 # ...and specifically for an OUT-OF-CONE worktree, which the in-cone-with-space
 # case above cannot prove: classifying every path as in-cone would advertise an
 # absolute path as though it were a name this command takes.
@@ -3192,7 +3194,7 @@ git -C "$fixture" worktree add -q "$outcone_list/stray" -b feat/outcone-listing 
     fail "could not create the #963 out-of-cone listing fixture"
 rm_list2="$test_tmp/rm-listing-outcone.log"
 rm_wt definitely-absent-name >"$rm_list2" 2>&1 || true
-grep -qE "^  \(git worktree remove\)  .*$outcone_list/stray" "$rm_list2" ||
+grep -qE "^  \(not removable here\)  .*$outcone_list/stray" "$rm_list2" ||
     fail "the listing advertised an out-of-cone worktree under a name this command cannot take (#963): $(cat "$rm_list2")"
 git -C "$fixture" worktree remove --force "$outcone_list/stray"
 git -C "$fixture" worktree remove --force ".worktrees/feat/deep"
@@ -3225,7 +3227,7 @@ for bad_component in '-dash' 'a..b'; do
     # predicate exists to prevent.
     rm_remedy_list="$test_tmp/rm-remedy-list.log"
     rm_wt definitely-absent-name >"$rm_remedy_list" 2>&1 || true
-    grep -qE "^  \(git worktree remove\)  .*$bad_component/leaf" "$rm_remedy_list" ||
+    grep -qE "^  \(not removable here\)  .*$bad_component/leaf" "$rm_remedy_list" ||
         fail "the listing advertised '$bad_component/leaf' under a name this command rejects (#963): $(cat "$rm_remedy_list")"
     git -C "$fixture" worktree remove --force ".worktrees/$bad_component/leaf"
     rmdir "$fixture/.worktrees/$bad_component" 2>/dev/null || true
@@ -3297,7 +3299,7 @@ if [ "$nl_supported" -eq 1 ]; then
     real_git="$(command -v git)"
     cat >"$oldgit_shim/git" <<SHIM
 #!/usr/bin/env bash
-# Reject only $(worktree list ... -z); everything else is the real git.
+# Reject only the worktree-list capability probe; else the real git.
 if [ "\$1" = "worktree" ] && [ "\$2" = "list" ]; then
     for arg in "\$@"; do
         [ "\$arg" = "-z" ] && exit 129
@@ -3322,8 +3324,8 @@ ning"
         (cd "$fixture" && PATH="$oldgit_shim:$PATH" bash scripts/worktree-rm.sh spanning) \
             >"$rm_oldgit" 2>&1 &&
             fail "worktree:rm resolved a spanning path on a git without -z (#963): $(cat "$rm_oldgit")"
-        grep -q 'cannot enumerate worktrees unambiguously' "$rm_oldgit" ||
-            fail "the pre-2.36 path did not fail closed on a spanning worktree path (#963): $(cat "$rm_oldgit")"
+        grep -q 'cannot look up' "$rm_oldgit" ||
+            fail "the pre-2.36 path did not refuse registry lookup (#963): $(cat "$rm_oldgit")"
         grep -qi 'removed' "$rm_oldgit" &&
             fail "the pre-2.36 refusal still claimed a removal (#963): $(cat "$rm_oldgit")"
         git -C "$fixture" worktree remove --force "$oldgit_tree"

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -2955,4 +2955,79 @@ else
     echo "    (skipped: running as root, a permission-held teardown cannot be simulated)"
 fi
 
+# ── Target resolution: the name must account for something (#963) ───────────
+#
+# Every fixture worktree above is created through worktree:new, which always
+# lands under .worktrees/ — so the constructed path <main_root>/.worktrees/<name>
+# is satisfied by construction and no existing case can see a name that does
+# not resolve there. These three build the shapes deliberately. Each asserts
+# BOTH halves: a nonzero exit, and that the target actually survived — a
+# refusal that still deleted something would pass an exit-code-only check.
+
+# A worktree registered to this repo but living outside .worktrees/, which
+# `git worktree add` permits and `git worktree list` reports. worktree:rm
+# cannot reach it, and must say so rather than claim a removal.
+outside_root="$test_tmp/outside-cone"
+git -C "$fixture" worktree add -q "$outside_root/parked" -b feat/parked-outside ||
+    fail "could not create a worktree outside .worktrees/ for the #963 case"
+rm_out="$test_tmp/rm-outside.log"
+if rm_wt parked >"$rm_out" 2>&1; then
+    fail "worktree:rm reported success for a worktree outside .worktrees/ (#963): $(cat "$rm_out")"
+fi
+# Anchored on the LOCATION clause, not on the path alone: the real path also
+# appears in the `git worktree remove` remedy, so a bare substring match stays
+# green even when the clause names the constructed path instead (mutant N3).
+grep -q "names the worktree at $outside_root/parked" "$rm_out" ||
+    fail "the refusal did not name where the worktree actually is (#963): $(cat "$rm_out")"
+grep -q "names the worktree at $fixture/.worktrees/parked" "$rm_out" &&
+    fail "the refusal located the worktree at the constructed path, which does not exist (#963): $(cat "$rm_out")"
+grep -q 'git worktree remove' "$rm_out" ||
+    fail "the refusal did not name a command that actually works (#963): $(cat "$rm_out")"
+grep -qi 'removed:' "$rm_out" &&
+    fail "the refusal still printed a removal line (#963): $(cat "$rm_out")"
+[ -d "$outside_root/parked" ] ||
+    fail "worktree:rm deleted a worktree it had refused to remove (#963)"
+git -C "$fixture" worktree list --porcelain | grep -qxF "worktree $outside_root/parked" ||
+    fail "worktree:rm dropped the registry record of a worktree it refused (#963)"
+git -C "$fixture" worktree remove --force "$outside_root/parked"
+
+# A moved worktree: git names the admin record from the path basename at
+# creation and NEVER renames it, while `git worktree move` rewrites the
+# record's stored path — so record name and directory name diverge by design.
+# Asking by the record name must not read as a stale record.
+# --no-install: this fixture only needs to EXIST and then move. A real
+# dependency install leaves the tree dirty, and worktree:rm then refuses it
+# on uncommitted changes — correct behaviour, wrong fixture for this case.
+new movedrec --no-install >/dev/null || fail "could not create the #963 move fixture"
+git -C "$fixture" worktree move .worktrees/movedrec .worktrees/movednew ||
+    fail "could not move the #963 fixture worktree"
+rm_moved="$test_tmp/rm-moved.log"
+if rm_wt movedrec >"$rm_moved" 2>&1; then
+    fail "worktree:rm reported success for a record name whose directory moved (#963): $(cat "$rm_moved")"
+fi
+grep -q "names the worktree at $fixture/.worktrees/movednew" "$rm_moved" ||
+    fail "the refusal did not name the moved worktree's current directory (#963): $(cat "$rm_moved")"
+grep -q 'no worktree or admin record named' "$rm_moved" &&
+    fail "the record name resolved to nothing — resolution no longer matches admin-record names (#963): $(cat "$rm_moved")"
+[ -d "$fixture/.worktrees/movednew" ] ||
+    fail "worktree:rm deleted a moved worktree it had refused to remove (#963)"
+# ...and the directory name, which is what actually resolves, still works.
+rm_movednew="$test_tmp/rm-movednew.log"
+rm_wt movednew >"$rm_movednew" 2>&1 ||
+    fail "worktree:rm could not remove a moved worktree by its directory name (#963): $(cat "$rm_movednew")"
+[ -d "$fixture/.worktrees/movednew" ] &&
+    fail "worktree:rm reported success but left the moved worktree behind (#963)"
+
+# A name matching neither a worktree nor an admin record: the original report.
+rm_none="$test_tmp/rm-nomatch.log"
+if rm_wt definitely-no-such-worktree >"$rm_none" 2>&1; then
+    fail "worktree:rm exited 0 for a name matching nothing (#963): $(cat "$rm_none")"
+fi
+grep -qi 'removed:' "$rm_none" &&
+    fail "worktree:rm claimed a removal for a name matching nothing (#963): $(cat "$rm_none")"
+grep -q 'no worktree or admin record named' "$rm_none" ||
+    fail "the no-match refusal did not say what was wrong (#963): $(cat "$rm_none")"
+
+echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"
+
 echo "worktree entrypoint OK: create → hooks verified → deps installed → removed"

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -2994,8 +2994,15 @@ grep -q "names the worktree at $outside_root/parked" "$rm_out" ||
     fail "the refusal did not name where the worktree actually is (#963): $(cat "$rm_out")"
 grep -q "names the worktree at $fixture/.worktrees/parked" "$rm_out" &&
     fail "the refusal located the worktree at the constructed path, which does not exist (#963): $(cat "$rm_out")"
-grep -q 'git worktree remove' "$rm_out" ||
-    fail "the refusal did not name a command that actually works (#963): $(cat "$rm_out")"
+# The refusal must NOT hand over `git worktree remove`: that command applies
+# none of this script's guards — it deletes ignored files such as .env and
+# takes an unreferenced detached HEAD without complaint — so advertising it
+# walks the operator past the protections this task exists to provide
+# (review r4). It must instead say what would go unchecked.
+grep -qE 'remove it with: git worktree remove|instead: git worktree remove' "$rm_out" &&
+    fail "the refusal advertised an unguarded removal command (#963): $(cat "$rm_out")"
+grep -q 'skip-worktree' "$rm_out" ||
+    fail "the refusal did not name the guards a raw removal would skip (#963): $(cat "$rm_out")"
 grep -qi 'removed:' "$rm_out" &&
     fail "the refusal still printed a removal line (#963): $(cat "$rm_out")"
 [ -d "$outside_root/parked" ] ||
@@ -3090,8 +3097,19 @@ if mkdir -p "$nl_probe" 2>/dev/null && [ -d "$nl_probe" ]; then
 else
     nl_supported=0
 fi
+# `--porcelain -z` (git 2.36+) is what makes a newline-bearing path
+# representable at all. Without it the command fails closed by design, so these
+# cases assert behaviour that git cannot deliver — gate on the capability, not
+# only on the filesystem (review r4).
+if git worktree list --porcelain -z >/dev/null 2>&1; then
+    nl_z_supported=1
+else
+    nl_z_supported=0
+fi
 if [ "$nl_supported" -eq 0 ]; then
     echo "    (skipped: this filesystem rejects a newline in a path)"
+elif [ "$nl_z_supported" -eq 0 ]; then
+    echo "    (skipped: this git has no 'worktree list --porcelain -z'; the command fails closed instead)"
 elif git -C "$fixture" worktree add -q "$nl_tree" -b feat/newline-path; then
     rm_trunc="$test_tmp/rm-trunc.log"
     if rm_wt trunc >"$rm_trunc" 2>&1; then
@@ -3198,8 +3216,8 @@ for bad_component in '-dash' 'a..b'; do
     fi
     grep -q 'task worktree:rm --' "$rm_remedy" &&
         fail "the remedy advertised a task invocation this command rejects, for '$bad_component' (#963): $(cat "$rm_remedy")"
-    grep -q 'git worktree remove' "$rm_remedy" ||
-        fail "the remedy did not fall back to git's command for '$bad_component' (#963): $(cat "$rm_remedy")"
+    grep -qE 'remove it with: git worktree remove' "$rm_remedy" &&
+        fail "the remedy advertised an unguarded removal for '$bad_component' (#963): $(cat "$rm_remedy")"
     # The LISTING must reach the same verdict about the same path, and it must
     # be checked while this worktree still exists. Both components pass the
     # charset rule and fail a different one, so a listing that applied only the
@@ -3250,7 +3268,7 @@ grep -q 'Stale record cleared' "$rm_real" &&
 # carrying a raw newline. Every diagnostic must escape the path it prints, not
 # only the remedy: an unescaped location clause splits the message across lines
 # (review r3).
-if [ "$nl_supported" -eq 1 ]; then
+if [ "$nl_supported" -eq 1 ] && [ "$nl_z_supported" -eq 1 ]; then
     esc_parent="$test_tmp/escpath"
     mkdir -p "$esc_parent"
     esc_tree="$esc_parent/trunc
@@ -3267,6 +3285,52 @@ tail"
     else
         fail "could not create the #963 escaping fixture although newlines are supported"
     fi
+fi
+
+# The pre-2.36 path is unreachable on a modern git, so it is simulated: a shim
+# makes `worktree list --porcelain -z` fail and passes everything else through
+# to the real binary. Without this the fail-closed branch is only exercisable
+# by installing an old git, which means in practice never (review r4).
+if [ "$nl_supported" -eq 1 ]; then
+    oldgit_shim="$test_tmp/oldgit-shim"
+    mkdir -p "$oldgit_shim"
+    real_git="$(command -v git)"
+    cat >"$oldgit_shim/git" <<SHIM
+#!/usr/bin/env bash
+# Reject only $(worktree list ... -z); everything else is the real git.
+if [ "\$1" = "worktree" ] && [ "\$2" = "list" ]; then
+    for arg in "\$@"; do
+        [ "\$arg" = "-z" ] && exit 129
+    done
+fi
+exec "$real_git" "\$@"
+SHIM
+    chmod +x "$oldgit_shim/git"
+    # Prove the shim actually simulates the old git before relying on it — a
+    # shim that silently passed -z through would make this case vacuous.
+    PATH="$oldgit_shim:$PATH" git worktree list --porcelain -z >/dev/null 2>&1 &&
+        fail "the pre-2.36 git shim did not reject --porcelain -z (#963)"
+    PATH="$oldgit_shim:$PATH" git worktree list --porcelain >/dev/null 2>&1 ||
+        fail "the pre-2.36 git shim broke ordinary git invocations (#963)"
+
+    oldgit_parent="$test_tmp/oldgit-cone"
+    mkdir -p "$oldgit_parent"
+    oldgit_tree="$oldgit_parent/span
+ning"
+    if git -C "$fixture" worktree add -q "$oldgit_tree" -b feat/oldgit-span; then
+        rm_oldgit="$test_tmp/rm-oldgit.log"
+        (cd "$fixture" && PATH="$oldgit_shim:$PATH" bash scripts/worktree-rm.sh spanning) \
+            >"$rm_oldgit" 2>&1 &&
+            fail "worktree:rm resolved a spanning path on a git without -z (#963): $(cat "$rm_oldgit")"
+        grep -q 'cannot enumerate worktrees unambiguously' "$rm_oldgit" ||
+            fail "the pre-2.36 path did not fail closed on a spanning worktree path (#963): $(cat "$rm_oldgit")"
+        grep -qi 'removed' "$rm_oldgit" &&
+            fail "the pre-2.36 refusal still claimed a removal (#963): $(cat "$rm_oldgit")"
+        git -C "$fixture" worktree remove --force "$oldgit_tree"
+    else
+        fail "could not create the #963 pre-2.36 fixture although newlines are supported"
+    fi
+    rm -rf "$oldgit_shim"
 fi
 
 echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -3335,6 +3335,58 @@ ning"
     rm -rf "$oldgit_shim"
 fi
 
+# A registry read that fails or truncates must not read as a complete one.
+# bash does not propagate a process-substitution failure, so without a success
+# sentinel the resolver would treat a partial list as the whole registry and
+# could call a name unique, or absent, on evidence it never finished reading
+# (review r6). Simulated with a shim that exits nonzero for the enumeration.
+trunc_shim="$test_tmp/trunc-shim"
+mkdir -p "$trunc_shim"
+trunc_real_git="$(command -v git)"
+cat >"$trunc_shim/git" <<TRUNCSHIM
+#!/usr/bin/env bash
+# The capability probe and the real enumeration are the SAME invocation, so
+# they cannot be told apart by arguments — count instead. The first armed
+# -z call (the probe) succeeds so the command clears its version gate; the
+# next one (the enumeration it actually reads) fails.
+if [ "\$1" = "worktree" ] && [ "\$2" = "list" ]; then
+    for arg in "\$@"; do
+        if [ "\$arg" = "-z" ] && [ -n "\$WT_TRUNC_ARMED" ]; then
+            if [ -e "\$WT_TRUNC_ARMED" ]; then
+                exit 1
+            fi
+            : >"\$WT_TRUNC_ARMED"
+            exec "$trunc_real_git" "\$@"
+        fi
+    done
+fi
+exec "$trunc_real_git" "\$@"
+TRUNCSHIM
+chmod +x "$trunc_shim/git"
+# Prove the shim behaves as described before relying on it.
+trunc_marker="$test_tmp/trunc-marker"
+rm -f "$trunc_marker"
+PATH="$trunc_shim:$PATH" git worktree list --porcelain -z >/dev/null 2>&1 ||
+    fail "the truncation shim broke the unarmed enumeration (#963)"
+PATH="$trunc_shim:$PATH" WT_TRUNC_ARMED="$trunc_marker" git worktree list --porcelain -z >/dev/null 2>&1 ||
+    fail "the truncation shim failed the FIRST armed call, which must succeed as the capability probe (#963)"
+PATH="$trunc_shim:$PATH" WT_TRUNC_ARMED="$trunc_marker" git worktree list --porcelain -z >/dev/null 2>&1 &&
+    fail "the truncation shim did not fail the SECOND armed call (#963)"
+rm -f "$trunc_marker"
+
+new truncprobe --no-install >/dev/null || fail "could not create the #963 truncation fixture"
+rm -rf "$fixture/.worktrees/truncprobe"
+git -C "$fixture" worktree prune
+rm_trunc_log="$test_tmp/rm-truncated.log"
+(cd "$fixture" && PATH="$trunc_shim:$PATH" WT_TRUNC_ARMED="$trunc_marker" bash scripts/worktree-rm.sh some-absent-name) \
+    >"$rm_trunc_log" 2>&1 &&
+    fail "worktree:rm succeeded on a registry read that failed (#963): $(cat "$rm_trunc_log")"
+grep -q 'could not read the worktree registry completely' "$rm_trunc_log" ||
+    fail "a failed registry read did not fail closed (#963): $(cat "$rm_trunc_log")"
+grep -qi 'removed' "$rm_trunc_log" &&
+    fail "a failed registry read still claimed a removal (#963): $(cat "$rm_trunc_log")"
+rm -rf "$trunc_shim"
+
 echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"
 
 echo "worktree entrypoint OK: create → hooks verified → deps installed → removed"

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -3028,6 +3028,60 @@ grep -qi 'removed:' "$rm_none" &&
 grep -q 'no worktree or admin record named' "$rm_none" ||
     fail "the no-match refusal did not say what was wrong (#963): $(cat "$rm_none")"
 
+# The main checkout is registered but is not a linked worktree, so resolution
+# must skip it — otherwise `worktree:rm <repo-basename>` reports the main
+# checkout as an out-of-cone worktree and recommends a `git worktree remove`
+# that git refuses outright (challenge r1).
+main_base="${fixture##*/}"
+rm_mainbase="$test_tmp/rm-mainbase.log"
+if rm_wt "$main_base" >"$rm_mainbase" 2>&1; then
+    fail "worktree:rm accepted the main checkout's own basename (#963): $(cat "$rm_mainbase")"
+fi
+grep -q "names the worktree at $fixture " "$rm_mainbase" &&
+    fail "worktree:rm resolved the main checkout as a removable worktree (#963): $(cat "$rm_mainbase")"
+grep -q "no worktree or admin record named" "$rm_mainbase" ||
+    fail "the main checkout's basename did not fall through to the no-match branch (#963): $(cat "$rm_mainbase")"
+grep -q 'git worktree remove' "$rm_mainbase" &&
+    fail "worktree:rm recommended removing the main checkout, which git refuses (#963): $(cat "$rm_mainbase")"
+
+# ...and skipping it must not blind resolution to a LINKED worktree that
+# happens to share the main checkout's basename.
+samebase_root="$test_tmp/samebase"
+git -C "$fixture" worktree add -q "$samebase_root/$main_base" -b feat/samebase ||
+    fail "could not create the same-basename worktree for the #963 case"
+rm_samebase="$test_tmp/rm-samebase.log"
+if rm_wt "$main_base" >"$rm_samebase" 2>&1; then
+    fail "worktree:rm reported success for a same-basename linked worktree (#963): $(cat "$rm_samebase")"
+fi
+grep -q "names the worktree at $samebase_root/$main_base" "$rm_samebase" ||
+    fail "resolution missed a linked worktree sharing the main checkout's basename (#963): $(cat "$rm_samebase")"
+git -C "$fixture" worktree remove --force "$samebase_root/$main_base"
+
+# A worktree path may legally contain a newline. Line-parsed porcelain output
+# truncates it, which both hides the real worktree and invents a candidate at
+# the truncated prefix — so asking for that prefix must NOT resolve to it
+# (challenge r1).
+nl_parent="$test_tmp/nl-cone"
+mkdir -p "$nl_parent"
+nl_tree="$nl_parent/trunc
+tail"
+if git -C "$fixture" worktree add -q "$nl_tree" -b feat/newline-path 2>/dev/null; then
+    rm_trunc="$test_tmp/rm-trunc.log"
+    if rm_wt trunc >"$rm_trunc" 2>&1; then
+        fail "worktree:rm resolved a truncated newline path as a real worktree (#963): $(cat "$rm_trunc")"
+    fi
+    # With the path read whole, "trunc" is nobody's basename, so the no-match
+    # branch must run. Line-parsing instead invents a candidate at the
+    # truncated prefix and resolves to it — a different branch entirely.
+    # Asserting the branch is robust; grepping a path out of a sentence that
+    # itself contains a newline is not.
+    grep -q "no worktree or admin record named 'trunc'" "$rm_trunc" ||
+        fail "the truncated prefix of a newline path resolved as a real worktree (#963): $(cat "$rm_trunc")"
+    git -C "$fixture" worktree remove --force "$nl_tree"
+else
+    echo "    (skipped: this filesystem rejects a newline in a path)"
+fi
+
 echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"
 
 echo "worktree entrypoint OK: create → hooks verified → deps installed → removed"

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -255,6 +255,19 @@ new_in() {
     shift
     run_worktree_op "worktree:new" "$op_from" scripts/worktree-new.sh "$@"
 }
+# Map a worktree path to its admin-record directory, the way worktree-rm.sh
+# does: each record's `gitdir` file names that worktree's .git file.
+record_admin_dir_probe() {
+    probe_common="$(git -C "$1" rev-parse --path-format=absolute --git-common-dir)"
+    for probe_candidate in "$probe_common"/worktrees/*; do
+        [ -f "$probe_candidate/gitdir" ] || continue
+        if [ "$(cat "$probe_candidate/gitdir" 2>/dev/null || true)" = "$2/.git" ]; then
+            printf '%s\n' "$probe_candidate"
+            return 0
+        fi
+    done
+    return 1
+}
 rm_wt() { run_worktree_op "worktree:rm" "$fixture" scripts/worktree-rm.sh "$@"; }
 # Removal run from inside the tree being removed: caller directory and script
 # path both differ, and it is the last invocation that would otherwise bypass
@@ -3231,6 +3244,30 @@ grep -q '^Worktree removed:' "$rm_real" ||
     fail "a genuine removal stopped reporting itself as one (#963): $(cat "$rm_real")"
 grep -q 'Stale record cleared' "$rm_real" &&
     fail "a genuine removal was reported as a stale-record cleanup (#963): $(cat "$rm_real")"
+
+# git SANITIZES an admin-record name — a worktree at `trunc<LF>tail` gets the
+# record `trunc-tail` — so that record name is typeable and resolves to a path
+# carrying a raw newline. Every diagnostic must escape the path it prints, not
+# only the remedy: an unescaped location clause splits the message across lines
+# (review r3).
+if [ "$nl_supported" -eq 1 ]; then
+    esc_parent="$test_tmp/escpath"
+    mkdir -p "$esc_parent"
+    esc_tree="$esc_parent/trunc
+tail"
+    if git -C "$fixture" worktree add -q "$esc_tree" -b feat/escaped-diagnostic; then
+        esc_record="$(basename "$(record_admin_dir_probe "$fixture" "$esc_tree")")"
+        [ -n "$esc_record" ] || fail "could not read the admin record for the #963 escaping case"
+        rm_esc="$test_tmp/rm-escaped.log"
+        rm_wt "$esc_record" >"$rm_esc" 2>&1 &&
+            fail "worktree:rm reported success for an out-of-cone newline path (#963): $(cat "$rm_esc")"
+        [ "$(wc -l <"$rm_esc" | tr -d ' ')" -eq 1 ] ||
+            fail "the diagnostic split across lines on a newline-bearing path (#963): $(cat "$rm_esc")"
+        git -C "$fixture" worktree remove --force "$esc_tree"
+    else
+        fail "could not create the #963 escaping fixture although newlines are supported"
+    fi
+fi
 
 echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"
 

--- a/scripts/test-worktree.sh
+++ b/scripts/test-worktree.sh
@@ -3207,6 +3207,31 @@ rm_wt '../escape' >"$rm_badname" 2>&1 && fail "worktree:rm accepted '../escape' 
 grep -q "must not contain '\.\.'" "$rm_badname" ||
     fail "the argument check stopped naming which rule failed (#963): $(cat "$rm_badname")"
 
+# The THIRD outcome the issue requires the message to distinguish: a registry
+# record whose directory is already gone. Clearing it is correct and useful,
+# but "Worktree removed" claims a directory was deleted that never existed,
+# directly contradicting the line printed just above it (review r2).
+new stalemsg --no-install >/dev/null || fail "could not create the #963 stale-record fixture"
+rm -rf "$fixture/.worktrees/stalemsg"
+rm_stale="$test_tmp/rm-stalemsg.log"
+rm_wt stalemsg >"$rm_stale" 2>&1 ||
+    fail "worktree:rm failed to clear a stale record (#963): $(cat "$rm_stale")"
+grep -q 'Stale record cleared' "$rm_stale" ||
+    fail "clearing a stale record did not say so (#963): $(cat "$rm_stale")"
+grep -q '^Worktree removed:' "$rm_stale" &&
+    fail "clearing a stale record still claimed a directory was removed (#963): $(cat "$rm_stale")"
+
+# ...and a genuine removal must still say it removed a worktree, so the fix
+# above cannot be satisfied by simply never printing the removal line.
+new realmsg --no-install >/dev/null || fail "could not create the #963 real-removal fixture"
+rm_real="$test_tmp/rm-realmsg.log"
+rm_wt realmsg >"$rm_real" 2>&1 ||
+    fail "worktree:rm failed to remove a live worktree (#963): $(cat "$rm_real")"
+grep -q '^Worktree removed:' "$rm_real" ||
+    fail "a genuine removal stopped reporting itself as one (#963): $(cat "$rm_real")"
+grep -q 'Stale record cleared' "$rm_real" &&
+    fail "a genuine removal was reported as a stale-record cleanup (#963): $(cat "$rm_real")"
+
 echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"
 
 echo "worktree entrypoint OK: create → hooks verified → deps installed → removed"

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -226,11 +226,28 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
     # which would resolve the wrong worktree or none at all. Read a
     # NUL-delimited stream where git provides it, and fall back to the LF form
     # rather than making an edge case impose a git version floor (challenge r1).
-    # awk cannot do this half: its strings are NUL-terminated, so an awk fed a
-    # NUL-delimited stream stops at the first record — on macOS that silently
+    # LF-delimited porcelain CANNOT represent a path containing a newline: the
+    # path simply continues onto the next line with nothing marking it, so a
+    # truncated prefix is indistinguishable from a real path. That is not
+    # recoverable by parsing, so on a git without `--porcelain -z` this refuses
+    # outright when it detects such a path rather than resolving the prefix as
+    # though it were a worktree (review r4). Detection is structural: every line
+    # of porcelain output is a known record key or blank, so a line that is
+    # neither means a path spanned lines.
+    if ! git worktree list --porcelain -z >/dev/null 2>&1 &&
+        git worktree list --porcelain | awk '
+            /^worktree /{next} /^(HEAD |branch )/{next}
+            /^(bare|detached)$/{next} /^(locked|prunable)/{next} /^$/{next}
+            {spanned = 1} END{exit !spanned}'; then
+        die "this git cannot enumerate worktrees unambiguously: it has no \`git worktree list --porcelain -z\` (added in git 2.36) and a registered worktree path contains a newline, which the line-delimited form cannot represent. Upgrade git to 2.36 or newer so this command can tell those paths apart instead of guessing at one"
+    fi
+
+    # awk cannot do the NUL half: its strings are NUL-terminated, so an awk fed
+    # a NUL-delimited stream stops at the first record — on macOS that silently
     # yielded only the main worktree. bash's `read -d ''` handles NUL correctly,
     # so the -z stream is split in the shell; awk is used only on the LF
-    # fallback, where it is emitting NUL rather than consuming it.
+    # fallback, where it is emitting NUL rather than consuming it, and only
+    # once the check above has established no path spans lines.
     emit_worktree_paths() {
         if git worktree list --porcelain -z >/dev/null 2>&1; then
             git worktree list --porcelain -z | while IFS= read -r -d '' wt_record; do
@@ -307,14 +324,14 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
         if [ "$rel_is_nameable" -eq 1 ]; then
             die "no worktree at $tree, but '$name' names the worktree at $(printf '%q' "$resolved") — its admin record and its directory have different names (a move does that), and only its current name resolves here: task worktree:rm -- $resolved_rel"
         else
-            die "no worktree at $tree, but '$name' names the worktree at $(printf '%q' "$resolved") — that path is not addressable by this command, so remove it with: git worktree remove $(printf '%q' "$resolved")"
+            die "no worktree at $tree, but '$name' names the worktree at $(printf '%q' "$resolved") — that path is not addressable by this command, and no removal command is suggested for it on purpose: \`git worktree remove\` performs none of the checks this task does (work hidden by skip-worktree or assume-unchanged, a merge autostash, and detached commits no branch, tag or remote-tracking ref contains — it deletes ignored files such as .env and takes an unreferenced detached HEAD without complaint), so anything removing that path has to establish those itself first"
         fi
     elif [ "$resolved_count" -gt 1 ]; then
         echo "worktree:rm: '$name' is ambiguous — it matches more than one registered worktree:" >&2
         for amb_tree in "${matches[@]}"; do
             printf '  %s\n' "$(printf '%q' "$amb_tree")" >&2
         done
-        die "name the worktree by its path instead: git worktree remove <path>"
+        die "name the worktree unambiguously — this command removes only worktrees under $main_root/.worktrees/, and reaching any other path means establishing for yourself the guards listed above that \`git worktree remove\` does not apply"
     fi
 
     # Matches nothing at all. Never report a removal for it.

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -205,10 +205,41 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
     ! record_admin_dir "$tree" >/dev/null 2>&1; then
     # Nothing at the conventional path. Ask the registry what this name means
     # before claiming anything was removed.
+    # A worktree path may legally contain a newline — `git worktree add` accepts
+    # one even though worktree:new's charset whitelist can never produce one —
+    # and the LF-delimited porcelain form truncates such a path at the newline,
+    # which would resolve the wrong worktree or none at all. Read a
+    # NUL-delimited stream where git provides it, and fall back to the LF form
+    # rather than making an edge case impose a git version floor (challenge r1).
+    # awk cannot do this half: its strings are NUL-terminated, so an awk fed a
+    # NUL-delimited stream stops at the first record — on macOS that silently
+    # yielded only the main worktree. bash's `read -d ''` handles NUL correctly,
+    # so the -z stream is split in the shell; awk is used only on the LF
+    # fallback, where it is emitting NUL rather than consuming it.
+    emit_worktree_paths() {
+        if git worktree list --porcelain -z >/dev/null 2>&1; then
+            git worktree list --porcelain -z | while IFS= read -r -d '' wt_record; do
+                case "$wt_record" in
+                "worktree "*) printf '%s\0' "${wt_record#worktree }" ;;
+                esac
+            done
+        else
+            git worktree list --porcelain |
+                awk '/^worktree /{ printf "%s%c", substr($0, 10), 0 }'
+        fi
+    }
+
     resolved=""
     resolved_count=0
-    while IFS= read -r candidate_tree; do
+    while IFS= read -r -d '' candidate_tree; do
         [ -n "$candidate_tree" ] || continue
+        # The main checkout is registered but is not a linked worktree, and this
+        # command removes only linked worktrees. Counting it made
+        # `worktree:rm <repo-basename>` report the main checkout as an
+        # out-of-cone worktree and recommend a `git worktree remove` that git
+        # refuses — and made a same-basename linked worktree read as ambiguous.
+        # The candidate listing below already skipped it; resolution must too.
+        [ "$candidate_tree" = "$main_root" ] && continue
         candidate_name="${candidate_tree##*/}"
         candidate_record=""
         candidate_admin="$(record_admin_dir "$candidate_tree" 2>/dev/null || true)"
@@ -217,9 +248,7 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
             resolved="$candidate_tree"
             resolved_count=$((resolved_count + 1))
         fi
-    done <<EOF
-$registered
-EOF
+    done < <(emit_worktree_paths)
 
     if [ "$resolved_count" -eq 1 ]; then
         # Two different situations, two different remedies. In-cone means this
@@ -239,24 +268,33 @@ EOF
         esac
     elif [ "$resolved_count" -gt 1 ]; then
         echo "worktree:rm: '$name' is ambiguous — it matches more than one registered worktree:" >&2
-        git worktree list --porcelain | awk -v main="$main_root" '/^worktree /{p = substr($0, 10); if (p != main) print "  " p}' >&2
+        while IFS= read -r -d '' amb_tree; do
+            [ "$amb_tree" = "$main_root" ] && continue
+            printf '  %s\n' "$(printf '%q' "$amb_tree")" >&2
+        done < <(emit_worktree_paths)
         die "name the worktree by its path instead: git worktree remove <path>"
     fi
 
     # Matches nothing at all. Never report a removal for it.
     echo "worktree:rm: no worktree or admin record named '$name'" >&2
     echo "worktree:rm: live worktrees (a record's name can differ from its directory after a move):" >&2
-    git worktree list --porcelain | awk '/^worktree /{print substr($0, 10)}' | while IFS= read -r live_tree; do
+    # Same NUL-delimited source the resolution above uses: a line-parsed listing
+    # truncates a newline-bearing path and prints a raw newline into the middle
+    # of the candidate list. printf %q renders such a path visibly instead of
+    # mangling the output, and leaves ordinary paths untouched.
+    while IFS= read -r -d '' live_tree; do
         # Skip the main checkout: it is registered, but this command removes
         # linked worktrees only, so offering it as a candidate is a dead end.
         [ "$live_tree" = "$main_root" ] && continue
         live_admin="$(record_admin_dir "$live_tree" 2>/dev/null || true)"
         if [ -n "$live_admin" ] && [ "${live_admin##*/}" != "${live_tree##*/}" ]; then
-            echo "  ${live_tree##*/}  (record: ${live_admin##*/})  $live_tree" >&2
+            printf '  %s  (record: %s)  %s\n' \
+                "$(printf '%q' "${live_tree##*/}")" "${live_admin##*/}" "$(printf '%q' "$live_tree")" >&2
         else
-            echo "  ${live_tree##*/}  $live_tree" >&2
+            printf '  %s  %s\n' \
+                "$(printf '%q' "${live_tree##*/}")" "$(printf '%q' "$live_tree")" >&2
         fi
-    done
+    done < <(emit_worktree_paths)
     die "nothing was removed"
 fi
 

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -229,8 +229,10 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
         fi
     }
 
-    resolved=""
-    resolved_count=0
+    # Matches are COLLECTED rather than counted, so the ambiguity branch can
+    # name the worktrees that actually collided instead of reprinting the whole
+    # registry (challenge r2).
+    matches=()
     while IFS= read -r -d '' candidate_tree; do
         [ -n "$candidate_tree" ] || continue
         # The main checkout is registered but is not a linked worktree, and this
@@ -244,34 +246,56 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
         candidate_record=""
         candidate_admin="$(record_admin_dir "$candidate_tree" 2>/dev/null || true)"
         [ -n "$candidate_admin" ] && candidate_record="${candidate_admin##*/}"
+        # Basename and admin-record name only. A candidate's path RELATIVE to
+        # .worktrees/ is deliberately NOT compared: it can equal $name only when
+        # the constructed path IS this candidate's path, and that case never
+        # reaches here — the conventional-path check above already accounted for
+        # it. Matching on it was unreachable code (found verifying challenge r2).
         if [ "$candidate_name" = "$name" ] || [ "$candidate_record" = "$name" ]; then
-            resolved="$candidate_tree"
-            resolved_count=$((resolved_count + 1))
+            matches+=("$candidate_tree")
         fi
     done < <(emit_worktree_paths)
+    resolved_count=${#matches[@]}
 
     if [ "$resolved_count" -eq 1 ]; then
+        resolved="${matches[0]}"
         # Two different situations, two different remedies. In-cone means this
-        # command CAN remove it and the caller simply used the wrong name for
-        # it — a record keeps its creation-time name across a move, so the
-        # record name and the directory name diverge and only the directory
-        # name works here. Out-of-cone means no argument to this command will
-        # reach it, because every path below is written against
-        # <main_root>/.worktrees/, so the remedy is git's own command.
+        # command CAN remove it and the caller simply used a name that no longer
+        # points at it — a record keeps its creation-time name across a move.
+        # Out-of-cone means no argument to this command will reach it, because
+        # every path below is written against <main_root>/.worktrees/, so the
+        # remedy is git's own command.
+        resolved_rel=""
         case "$resolved" in
-        "$main_root"/.worktrees/*)
-            die "no worktree at $tree, but '$name' names the worktree at $resolved — its admin record and its directory have different names (a move does that), and only the directory name resolves here: task worktree:rm -- ${resolved#"$main_root"/.worktrees/}"
-            ;;
-        *)
-            die "no worktree at $tree, but '$name' names the worktree at $resolved — that is outside $main_root/.worktrees/, which this command never removes from, so remove it with: git worktree remove $(printf '%q' "$resolved")"
-            ;;
+        "$main_root"/.worktrees/*) resolved_rel="${resolved#"$main_root"/.worktrees/}" ;;
         esac
+        # An in-cone path is only reachable through THIS command when its
+        # relative form is a name this command would accept. A hand-registered
+        # `.worktrees/team space/foo` is in-cone yet unnameable here: the
+        # suggested `task worktree:rm -- team space/foo` would split on the
+        # space and be rejected by the charset guard anyway. Fall back to git's
+        # command, shell-escaped, rather than emitting a remedy that cannot work
+        # (challenge r2).
+        rel_is_nameable=0
+        if [ -n "$resolved_rel" ]; then
+            rel_is_nameable=1
+            case "$resolved_rel" in
+            *[!A-Za-z0-9._/-]*) rel_is_nameable=0 ;;
+            esac
+            case "/$resolved_rel/" in
+            *//* | */./*) rel_is_nameable=0 ;;
+            esac
+        fi
+        if [ "$rel_is_nameable" -eq 1 ]; then
+            die "no worktree at $tree, but '$name' names the worktree at $resolved — its admin record and its directory have different names (a move does that), and only its current name resolves here: task worktree:rm -- $resolved_rel"
+        else
+            die "no worktree at $tree, but '$name' names the worktree at $resolved — that path is not addressable by this command, so remove it with: git worktree remove $(printf '%q' "$resolved")"
+        fi
     elif [ "$resolved_count" -gt 1 ]; then
         echo "worktree:rm: '$name' is ambiguous — it matches more than one registered worktree:" >&2
-        while IFS= read -r -d '' amb_tree; do
-            [ "$amb_tree" = "$main_root" ] && continue
+        for amb_tree in "${matches[@]}"; do
             printf '  %s\n' "$(printf '%q' "$amb_tree")" >&2
-        done < <(emit_worktree_paths)
+        done
         die "name the worktree by its path instead: git worktree remove <path>"
     fi
 
@@ -287,12 +311,27 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
         # linked worktrees only, so offering it as a candidate is a dead end.
         [ "$live_tree" = "$main_root" ] && continue
         live_admin="$(record_admin_dir "$live_tree" 2>/dev/null || true)"
+        live_rel=""
+        case "$live_tree" in
+        "$main_root"/.worktrees/*)
+            live_rel="${live_tree#"$main_root"/.worktrees/}"
+            case "$live_rel" in
+            *[!A-Za-z0-9._/-]*) live_rel="" ;;
+            esac
+            ;;
+        esac
+        if [ -n "$live_rel" ]; then
+            live_label="$live_rel"
+        else
+            # Not addressable through this command at all, so do not print
+            # something that looks like a name it would take.
+            live_label="(git worktree remove)"
+        fi
         if [ -n "$live_admin" ] && [ "${live_admin##*/}" != "${live_tree##*/}" ]; then
             printf '  %s  (record: %s)  %s\n' \
-                "$(printf '%q' "${live_tree##*/}")" "${live_admin##*/}" "$(printf '%q' "$live_tree")" >&2
+                "$live_label" "${live_admin##*/}" "$(printf '%q' "$live_tree")" >&2
         else
-            printf '  %s  %s\n' \
-                "$(printf '%q' "${live_tree##*/}")" "$(printf '%q' "$live_tree")" >&2
+            printf '  %s  %s\n' "$live_label" "$(printf '%q' "$live_tree")" >&2
         fi
     done < <(emit_worktree_paths)
     die "nothing was removed"

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -182,6 +182,84 @@ if [ "$tree_is_registered" -eq 1 ] && [ "$tree_exists" -eq 0 ]; then
     stale_record=1
 fi
 
+# ── The name must actually account for something (harmon-init#963) ──────────
+#
+# Everything above derives $tree by CONSTRUCTION from the argument, and never
+# consults the registry to find where the named worktree actually is. git names
+# an admin record from the path basename at creation and never renames it,
+# while `git worktree move` rewrites the record's stored path — so record name
+# and current directory name are independent BY DESIGN, and a worktree may sit
+# anywhere `git worktree add` was pointed, including outside this repo's
+# checkout entirely. A constructed path is therefore not a lookup, and when it
+# missed, the run fell into the stale-record branch and reported a removal that
+# did not happen: both output lines false, exit 0, the worktree untouched.
+#
+# The fix is a pre-flight, deliberately NOT a re-targeting. $tree keeps exactly
+# the meaning it has always had for every run that proceeds — the locks are
+# keyed on $name, and the removal, debris sweep and parent walk below are all
+# written against the constructed path — so this either lets the existing flow
+# run byte-for-byte as before, or refuses while naming the real path. Silently
+# retargeting a deletion at a path the caller did not name is the more
+# dangerous repair.
+if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
+    ! record_admin_dir "$tree" >/dev/null 2>&1; then
+    # Nothing at the conventional path. Ask the registry what this name means
+    # before claiming anything was removed.
+    resolved=""
+    resolved_count=0
+    while IFS= read -r candidate_tree; do
+        [ -n "$candidate_tree" ] || continue
+        candidate_name="${candidate_tree##*/}"
+        candidate_record=""
+        candidate_admin="$(record_admin_dir "$candidate_tree" 2>/dev/null || true)"
+        [ -n "$candidate_admin" ] && candidate_record="${candidate_admin##*/}"
+        if [ "$candidate_name" = "$name" ] || [ "$candidate_record" = "$name" ]; then
+            resolved="$candidate_tree"
+            resolved_count=$((resolved_count + 1))
+        fi
+    done <<EOF
+$registered
+EOF
+
+    if [ "$resolved_count" -eq 1 ]; then
+        # Two different situations, two different remedies. In-cone means this
+        # command CAN remove it and the caller simply used the wrong name for
+        # it — a record keeps its creation-time name across a move, so the
+        # record name and the directory name diverge and only the directory
+        # name works here. Out-of-cone means no argument to this command will
+        # reach it, because every path below is written against
+        # <main_root>/.worktrees/, so the remedy is git's own command.
+        case "$resolved" in
+        "$main_root"/.worktrees/*)
+            die "no worktree at $tree, but '$name' names the worktree at $resolved — its admin record and its directory have different names (a move does that), and only the directory name resolves here: task worktree:rm -- ${resolved#"$main_root"/.worktrees/}"
+            ;;
+        *)
+            die "no worktree at $tree, but '$name' names the worktree at $resolved — that is outside $main_root/.worktrees/, which this command never removes from, so remove it with: git worktree remove $(printf '%q' "$resolved")"
+            ;;
+        esac
+    elif [ "$resolved_count" -gt 1 ]; then
+        echo "worktree:rm: '$name' is ambiguous — it matches more than one registered worktree:" >&2
+        git worktree list --porcelain | awk -v main="$main_root" '/^worktree /{p = substr($0, 10); if (p != main) print "  " p}' >&2
+        die "name the worktree by its path instead: git worktree remove <path>"
+    fi
+
+    # Matches nothing at all. Never report a removal for it.
+    echo "worktree:rm: no worktree or admin record named '$name'" >&2
+    echo "worktree:rm: live worktrees (a record's name can differ from its directory after a move):" >&2
+    git worktree list --porcelain | awk '/^worktree /{print substr($0, 10)}' | while IFS= read -r live_tree; do
+        # Skip the main checkout: it is registered, but this command removes
+        # linked worktrees only, so offering it as a candidate is a dead end.
+        [ "$live_tree" = "$main_root" ] && continue
+        live_admin="$(record_admin_dir "$live_tree" 2>/dev/null || true)"
+        if [ -n "$live_admin" ] && [ "${live_admin##*/}" != "${live_tree##*/}" ]; then
+            echo "  ${live_tree##*/}  (record: ${live_admin##*/})  $live_tree" >&2
+        else
+            echo "  ${live_tree##*/}  $live_tree" >&2
+        fi
+    done
+    die "nothing was removed"
+fi
+
 # A worktree registered BELOW this path is a separate worktree, not this one's
 # disposable contents. `git worktree remove --force` would delete its
 # uncommitted work and the record cleanup below would drop its registry record,

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -227,19 +227,19 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
     # NUL-delimited stream where git provides it, and fall back to the LF form
     # rather than making an edge case impose a git version floor (challenge r1).
     # LF-delimited porcelain CANNOT represent a path containing a newline: the
-    # path simply continues onto the next line with nothing marking it, so a
-    # truncated prefix is indistinguishable from a real path. That is not
-    # recoverable by parsing, so on a git without `--porcelain -z` this refuses
-    # outright when it detects such a path rather than resolving the prefix as
-    # though it were a worktree (review r4). Detection is structural: every line
-    # of porcelain output is a known record key or blank, so a line that is
-    # neither means a path spanned lines.
-    if ! git worktree list --porcelain -z >/dev/null 2>&1 &&
-        git worktree list --porcelain | awk '
-            /^worktree /{next} /^(HEAD |branch )/{next}
-            /^(bare|detached)$/{next} /^(locked|prunable)/{next} /^$/{next}
-            {spanned = 1} END{exit !spanned}'; then
-        die "this git cannot enumerate worktrees unambiguously: it has no \`git worktree list --porcelain -z\` (added in git 2.36) and a registered worktree path contains a newline, which the line-delimited form cannot represent. Upgrade git to 2.36 or newer so this command can tell those paths apart instead of guessing at one"
+    # path continues onto the next line with nothing marking it. An earlier
+    # attempt detected that structurally, by treating a line that matched no
+    # record key as a continuation — but a continuation may legally LOOK like a
+    # key (`trap<LF>HEAD fake`), so the check could be walked straight past
+    # (review r5). There is no parse that recovers the truth here.
+    #
+    # So this does not parse ambiguous output at all. Without `--porcelain -z`
+    # (git 2.36+) registry resolution is simply unavailable, and the command
+    # says so. Nothing else regresses: a worktree at the conventional path is
+    # accounted for long before this block, so only the fallback lookup — the
+    # thing that cannot be done correctly here — is withdrawn.
+    if ! git worktree list --porcelain -z >/dev/null 2>&1; then
+        die "no worktree at $tree, and this git cannot look up '$name' elsewhere in the registry: that needs \`git worktree list --porcelain -z\` (git 2.36+), because the line-delimited form cannot represent a path containing a newline and offers no way to tell one apart from a truncated prefix. Upgrade git to 2.36 or newer, or name the worktree by its path with git's own commands"
     fi
 
     # awk cannot do the NUL half: its strings are NUL-terminated, so an awk fed
@@ -248,16 +248,14 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
     # so the -z stream is split in the shell; awk is used only on the LF
     # fallback, where it is emitting NUL rather than consuming it, and only
     # once the check above has established no path spans lines.
+    # Reached only when -z is available: the guard above refused otherwise.
     emit_worktree_paths() {
-        if git worktree list --porcelain -z >/dev/null 2>&1; then
+        if true; then
             git worktree list --porcelain -z | while IFS= read -r -d '' wt_record; do
                 case "$wt_record" in
                 "worktree "*) printf '%s\0' "${wt_record#worktree }" ;;
                 esac
             done
-        else
-            git worktree list --porcelain |
-                awk '/^worktree /{ printf "%s%c", substr($0, 10), 0 }'
         fi
     }
 
@@ -360,9 +358,11 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
         if [ -n "$live_rel" ]; then
             live_label="$live_rel"
         else
-            # Not addressable through this command at all, so do not print
-            # something that looks like a name it would take.
-            live_label="(git worktree remove)"
+            # Not addressable through this command at all. The label is a
+            # STATUS, never a command: rendering `git worktree remove` here
+            # re-offered exactly what the refusal above withholds, and that
+            # command applies none of this script's guards (review r5).
+            live_label="(not removable here)"
         fi
         if [ -n "$live_admin" ] && [ "${live_admin##*/}" != "${live_tree##*/}" ]; then
             printf '  %s  (record: %s)  %s\n' \

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -814,4 +814,15 @@ while [ "$parent" != "$main_root" ] && [ "$parent" != "/" ]; do
     parent="$(dirname "$parent")"
 done
 
-echo "Worktree removed: $tree"
+# The final line reports what actually happened, from the entry snapshot.
+# `stale_record` means the registry held a record whose directory was already
+# gone when this run started: nothing was removed from disk, and saying
+# "Worktree removed" there contradicted the line above it and claimed the
+# removal of a directory that never existed (#963 AC: the message must
+# distinguish "removed a worktree" from "cleared a stale record" from "found
+# nothing" — the third is the refusal branch above).
+if [ "$stale_record" -eq 1 ]; then
+    echo "Stale record cleared: $tree (no worktree directory existed)"
+else
+    echo "Worktree removed: $tree"
+fi

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -274,6 +274,15 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
 
     if [ "$resolved_count" -eq 1 ]; then
         resolved="${matches[0]}"
+        # $resolved is escaped everywhere it appears, not only in the remedy.
+        # git sanitizes an admin-record name (a worktree at `trunc<LF>tail`
+        # gets the record `trunc-tail`), so invoking that record name reaches
+        # this branch with a raw newline or terminal-control byte in the path,
+        # and an unescaped location clause splits the diagnostic across lines
+        # or emits control sequences (review r3). $tree and $resolved_rel need
+        # no escaping by construction: the first is built from $name and the
+        # second has passed worktree_name_problem, so both are restricted to
+        # the name charset.
         # Two different situations, two different remedies. In-cone means this
         # command CAN remove it and the caller simply used a name that no longer
         # points at it — a record keeps its creation-time name across a move.
@@ -296,9 +305,9 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
             rel_is_nameable=1
         fi
         if [ "$rel_is_nameable" -eq 1 ]; then
-            die "no worktree at $tree, but '$name' names the worktree at $resolved — its admin record and its directory have different names (a move does that), and only its current name resolves here: task worktree:rm -- $resolved_rel"
+            die "no worktree at $tree, but '$name' names the worktree at $(printf '%q' "$resolved") — its admin record and its directory have different names (a move does that), and only its current name resolves here: task worktree:rm -- $resolved_rel"
         else
-            die "no worktree at $tree, but '$name' names the worktree at $resolved — that path is not addressable by this command, so remove it with: git worktree remove $(printf '%q' "$resolved")"
+            die "no worktree at $tree, but '$name' names the worktree at $(printf '%q' "$resolved") — that path is not addressable by this command, so remove it with: git worktree remove $(printf '%q' "$resolved")"
         fi
     elif [ "$resolved_count" -gt 1 ]; then
         echo "worktree:rm: '$name' is ambiguous — it matches more than one registered worktree:" >&2

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -249,22 +249,38 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
     # fallback, where it is emitting NUL rather than consuming it, and only
     # once the check above has established no path spans lines.
     # Reached only when -z is available: the guard above refused otherwise.
+    #
+    # The trailing sentinel is this enumeration's success marker, mirroring
+    # flagged_enum_ok and sparse_rules_ok below: bash does not propagate a
+    # process-substitution failure, so without it a git error or a truncated
+    # stream would fail OPEN — the consumer would treat a partial registry as
+    # the whole registry and could call a name unique, or absent, on evidence
+    # it never finished reading (review r6). It is unforgeable: every real
+    # entry is an absolute path, and this marker contains no slash.
+    registry_enum_ok_marker="__WORKTREE_RM_REGISTRY_OK__"
     emit_worktree_paths() {
-        if true; then
-            git worktree list --porcelain -z | while IFS= read -r -d '' wt_record; do
-                case "$wt_record" in
-                "worktree "*) printf '%s\0' "${wt_record#worktree }" ;;
-                esac
-            done
-        fi
+        (
+            git worktree list --porcelain -z || exit 1
+            printf '%s\0' "$registry_enum_ok_marker"
+        ) | while IFS= read -r -d '' wt_record; do
+            case "$wt_record" in
+            "worktree "*) printf '%s\0' "${wt_record#worktree }" ;;
+            "$registry_enum_ok_marker") printf '%s\0' "$wt_record" ;;
+            esac
+        done
     }
 
     # Matches are COLLECTED rather than counted, so the ambiguity branch can
     # name the worktrees that actually collided instead of reprinting the whole
     # registry (challenge r2).
     matches=()
+    registry_enum_ok=0
     while IFS= read -r -d '' candidate_tree; do
         [ -n "$candidate_tree" ] || continue
+        if [ "$candidate_tree" = "$registry_enum_ok_marker" ]; then
+            registry_enum_ok=1
+            continue
+        fi
         # The main checkout is registered but is not a linked worktree, and this
         # command removes only linked worktrees. Counting it made
         # `worktree:rm <repo-basename>` report the main checkout as an
@@ -285,6 +301,8 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
             matches+=("$candidate_tree")
         fi
     done < <(emit_worktree_paths)
+    [ "$registry_enum_ok" -eq 1 ] ||
+        die "could not read the worktree registry completely, so '$name' cannot be resolved against it — refusing rather than acting on a partial list"
     resolved_count=${#matches[@]}
 
     if [ "$resolved_count" -eq 1 ]; then
@@ -339,7 +357,12 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
     # truncates a newline-bearing path and prints a raw newline into the middle
     # of the candidate list. printf %q renders such a path visibly instead of
     # mangling the output, and leaves ordinary paths untouched.
+    listing_enum_ok=0
     while IFS= read -r -d '' live_tree; do
+        if [ "$live_tree" = "$registry_enum_ok_marker" ]; then
+            listing_enum_ok=1
+            continue
+        fi
         # Skip the main checkout: it is registered, but this command removes
         # linked worktrees only, so offering it as a candidate is a dead end.
         [ "$live_tree" = "$main_root" ] && continue
@@ -371,6 +394,8 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
             printf '  %s  %s\n' "$live_label" "$(printf '%q' "$live_tree")" >&2
         fi
     done < <(emit_worktree_paths)
+    [ "$listing_enum_ok" -eq 1 ] ||
+        echo "worktree:rm: (the registry could not be read completely — this list may be partial)" >&2
     die "nothing was removed"
 fi
 

--- a/scripts/worktree-rm.sh
+++ b/scripts/worktree-rm.sh
@@ -78,6 +78,27 @@ record_admin_dir() {
     return 1
 }
 
+# The SINGLE definition of "a name this command accepts". Two places need that
+# answer — the argument validation below, and the decision about whether a
+# resolved path can be advertised as a name — and they must never disagree.
+# They did: the advertised remedy applied only the charset and component rules,
+# so an in-cone path like `-dash/leaf` or `x..y` was offered as
+# `task worktree:rm -- …` and then rejected by the very parser it was offered
+# to (review r1). Echoes the problem and returns 1 when the name is not
+# acceptable; silent and 0 when it is.
+worktree_name_problem() {
+    case "$1" in
+    "") echo "must not be empty" && return 1 ;;
+    /* | -*) echo "must not start with '/' or '-'" && return 1 ;;
+    *..*) echo "must not contain '..'" && return 1 ;;
+    *[!A-Za-z0-9._/-]*) echo "use only A-Z a-z 0-9 . _ - /" && return 1 ;;
+    esac
+    case "/$1/" in
+    *//* | */./*) echo "path components must not be empty or '.'" && return 1 ;;
+    esac
+    return 0
+}
+
 name=""
 force=0
 
@@ -108,26 +129,20 @@ done
     die "a worktree name is required"
 }
 
-case "$name" in
-/* | -*) die "invalid name '$name': must not start with '/' or '-'" ;;
-*..*) die "invalid name '$name': must not contain '..'" ;;
-esac
-# The same character whitelist creation enforces. Removal used to get away
-# without it, but lock entries are derived from the name, and a name
-# carrying whitespace, glob characters, or the encoding characters would
-# corrupt the lock bookkeeping (harmon-init#784) — and no conforming
-# creation can have produced such a worktree anyway.
-case "$name" in
-*[!A-Za-z0-9._/-]*) die "invalid name '$name': use only A-Z a-z 0-9 . _ - /" ;;
-esac
-# The same component rule creation enforces, and for the same reason: every
-# decision below compares `$tree` against git's CANONICAL registry paths as
-# text. `./live` would miss the record for the live worktree at `live`, and the
-# script would then classify a checked-out tree as debris and delete its
-# gitlink. Equivalent spellings must not reach the comparisons at all.
-case "/$name/" in
-*//* | */./*) die "invalid name '$name': path components must not be empty or '.'" ;;
-esac
+if ! name_problem="$(worktree_name_problem "$name")"; then
+    die "invalid name '$name': $name_problem"
+fi
+# The character whitelist and the component rule that creation enforces both
+# live in worktree_name_problem above. Removal used to get away without them,
+# but lock entries are derived from the name, and a name carrying whitespace,
+# glob characters, or the encoding characters would corrupt the lock
+# bookkeeping (harmon-init#784) — and no conforming creation can have produced
+# such a worktree anyway.
+# The component rule matters for the same reason: every decision below compares
+# `$tree` against git's CANONICAL registry paths as text. `./live` would miss
+# the record for the live worktree at `live`, and the script would then classify
+# a checked-out tree as debris and delete its gitlink. Equivalent spellings must
+# not reach the comparisons at all.
 
 git rev-parse --git-dir >/dev/null 2>&1 || die "not inside a git repository"
 
@@ -277,14 +292,8 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
         # command, shell-escaped, rather than emitting a remedy that cannot work
         # (challenge r2).
         rel_is_nameable=0
-        if [ -n "$resolved_rel" ]; then
+        if [ -n "$resolved_rel" ] && worktree_name_problem "$resolved_rel" >/dev/null; then
             rel_is_nameable=1
-            case "$resolved_rel" in
-            *[!A-Za-z0-9._/-]*) rel_is_nameable=0 ;;
-            esac
-            case "/$resolved_rel/" in
-            *//* | */./*) rel_is_nameable=0 ;;
-            esac
         fi
         if [ "$rel_is_nameable" -eq 1 ]; then
             die "no worktree at $tree, but '$name' names the worktree at $resolved — its admin record and its directory have different names (a move does that), and only its current name resolves here: task worktree:rm -- $resolved_rel"
@@ -315,9 +324,11 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
         case "$live_tree" in
         "$main_root"/.worktrees/*)
             live_rel="${live_tree#"$main_root"/.worktrees/}"
-            case "$live_rel" in
-            *[!A-Za-z0-9._/-]*) live_rel="" ;;
-            esac
+            # Same single definition the remedy and the argument check use: a
+            # path is only advertised under a name when that name would
+            # actually be accepted. This was a third partial copy of the rule
+            # (charset only), found while fixing the second one (review r1).
+            worktree_name_problem "$live_rel" >/dev/null || live_rel=""
             ;;
         esac
         if [ -n "$live_rel" ]; then

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -3167,6 +3167,46 @@ git -C "$fixture" worktree remove --force "$outcone_list/stray"
 git -C "$fixture" worktree remove --force ".worktrees/feat/deep"
 git -C "$fixture" worktree remove --force ".worktrees/team space/leaf"
 
+# A remedy this command would itself reject is worse than no remedy. The
+# nameability test must apply EVERY rule the argument check applies — it
+# originally applied only the charset and component rules, so an in-cone path
+# beginning with `-` or containing `..` was advertised as
+# `task worktree:rm -- …` and then refused by the parser it was handed to
+# (review r1). Both shapes are checked, because they fail different rules.
+for bad_component in '-dash' 'a..b'; do
+    new "remedycheck" --no-install >/dev/null ||
+        fail "could not create the #963 remedy fixture for '$bad_component'"
+    mkdir -p "$fixture/.worktrees/$bad_component"
+    git -C "$fixture" worktree move .worktrees/remedycheck ".worktrees/$bad_component/leaf" ||
+        fail "could not move the #963 remedy fixture into '$bad_component'"
+    rm_remedy="$test_tmp/rm-remedy.log"
+    if rm_wt remedycheck >"$rm_remedy" 2>&1; then
+        fail "worktree:rm reported success for a path under '$bad_component' (#963): $(cat "$rm_remedy")"
+    fi
+    grep -q 'task worktree:rm --' "$rm_remedy" &&
+        fail "the remedy advertised a task invocation this command rejects, for '$bad_component' (#963): $(cat "$rm_remedy")"
+    grep -q 'git worktree remove' "$rm_remedy" ||
+        fail "the remedy did not fall back to git's command for '$bad_component' (#963): $(cat "$rm_remedy")"
+    # The LISTING must reach the same verdict about the same path, and it must
+    # be checked while this worktree still exists. Both components pass the
+    # charset rule and fail a different one, so a listing that applied only the
+    # charset rule would advertise them as names — the drift the shared
+    # predicate exists to prevent.
+    rm_remedy_list="$test_tmp/rm-remedy-list.log"
+    rm_wt definitely-absent-name >"$rm_remedy_list" 2>&1 || true
+    grep -qE "^  \(git worktree remove\)  .*$bad_component/leaf" "$rm_remedy_list" ||
+        fail "the listing advertised '$bad_component/leaf' under a name this command rejects (#963): $(cat "$rm_remedy_list")"
+    git -C "$fixture" worktree remove --force ".worktrees/$bad_component/leaf"
+    rmdir "$fixture/.worktrees/$bad_component" 2>/dev/null || true
+done
+
+# The argument check must keep naming the SPECIFIC rule that failed — routing
+# both callers through one predicate must not flatten the diagnostics.
+rm_badname="$test_tmp/rm-badname.log"
+rm_wt '../escape' >"$rm_badname" 2>&1 && fail "worktree:rm accepted '../escape' (#963)"
+grep -q "must not contain '\.\.'" "$rm_badname" ||
+    fail "the argument check stopped naming which rule failed (#963): $(cat "$rm_badname")"
+
 echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"
 
 echo "worktree entrypoint OK: create → hooks verified → deps installed → removed"

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -3065,7 +3065,21 @@ nl_parent="$test_tmp/nl-cone"
 mkdir -p "$nl_parent"
 nl_tree="$nl_parent/trunc
 tail"
-if git -C "$fixture" worktree add -q "$nl_tree" -b feat/newline-path 2>/dev/null; then
+# Probe the FILESYSTEM's capability directly. Treating any `git worktree add`
+# failure as "newlines unsupported" would swallow a broken hook, a branch
+# collision, or a git regression and silently drop this coverage while the
+# suite still reported a pass (challenge r2).
+nl_probe="$nl_parent/probe
+newline"
+if mkdir -p "$nl_probe" 2>/dev/null && [ -d "$nl_probe" ]; then
+    rmdir "$nl_probe" 2>/dev/null || true
+    nl_supported=1
+else
+    nl_supported=0
+fi
+if [ "$nl_supported" -eq 0 ]; then
+    echo "    (skipped: this filesystem rejects a newline in a path)"
+elif git -C "$fixture" worktree add -q "$nl_tree" -b feat/newline-path; then
     rm_trunc="$test_tmp/rm-trunc.log"
     if rm_wt trunc >"$rm_trunc" 2>&1; then
         fail "worktree:rm resolved a truncated newline path as a real worktree (#963): $(cat "$rm_trunc")"
@@ -3079,8 +3093,79 @@ if git -C "$fixture" worktree add -q "$nl_tree" -b feat/newline-path 2>/dev/null
         fail "the truncated prefix of a newline path resolved as a real worktree (#963): $(cat "$rm_trunc")"
     git -C "$fixture" worktree remove --force "$nl_tree"
 else
-    echo "    (skipped: this filesystem rejects a newline in a path)"
+    fail "could not create a newline-bearing worktree although the filesystem accepts newline paths (#963)"
 fi
+
+# Two worktrees sharing a basename make the name ambiguous. The refusal must
+# name the ones that actually collided — printing the whole registry hides
+# which two are in conflict and points at unrelated paths (challenge r2).
+amb_root="$test_tmp/amb"
+git -C "$fixture" worktree add -q "$amb_root/a/twin" -b feat/twin-a ||
+    fail "could not create the first #963 ambiguity worktree"
+git -C "$fixture" worktree add -q "$amb_root/b/twin" -b feat/twin-b ||
+    fail "could not create the second #963 ambiguity worktree"
+git -C "$fixture" worktree add -q "$amb_root/unrelated/bystander" -b feat/bystander ||
+    fail "could not create the #963 ambiguity bystander"
+rm_amb="$test_tmp/rm-ambiguous.log"
+if rm_wt twin >"$rm_amb" 2>&1; then
+    fail "worktree:rm reported success for an ambiguous name (#963): $(cat "$rm_amb")"
+fi
+grep -q 'is ambiguous' "$rm_amb" ||
+    fail "an ambiguous name did not report ambiguity (#963): $(cat "$rm_amb")"
+grep -q "$amb_root/a/twin" "$rm_amb" && grep -q "$amb_root/b/twin" "$rm_amb" ||
+    fail "the ambiguity refusal did not name both colliding worktrees (#963): $(cat "$rm_amb")"
+grep -q 'bystander' "$rm_amb" &&
+    fail "the ambiguity refusal listed an unrelated worktree as a collision (#963): $(cat "$rm_amb")"
+git -C "$fixture" worktree remove --force "$amb_root/a/twin"
+git -C "$fixture" worktree remove --force "$amb_root/b/twin"
+git -C "$fixture" worktree remove --force "$amb_root/unrelated/bystander"
+
+# An in-cone worktree whose relative path is not a name this command accepts:
+# the remedy must be git's own command, shell-escaped. Emitting
+# `task worktree:rm -- team space/leaf` would split on the space and be
+# rejected by the charset guard anyway (challenge r2).
+mkdir -p "$fixture/.worktrees/team space"
+git -C "$fixture" worktree add -q ".worktrees/team space/leaf" -b feat/spaced-cone ||
+    fail "could not create the #963 unaddressable in-cone worktree"
+rm_unaddr="$test_tmp/rm-unaddressable.log"
+if rm_wt leaf >"$rm_unaddr" 2>&1; then
+    fail "worktree:rm reported success for an unaddressable in-cone path (#963): $(cat "$rm_unaddr")"
+fi
+grep -q 'git worktree remove' "$rm_unaddr" ||
+    fail "the refusal did not fall back to git's own command for an unaddressable path (#963): $(cat "$rm_unaddr")"
+grep -q 'task worktree:rm --' "$rm_unaddr" &&
+    fail "the refusal suggested a task invocation that cannot parse (#963): $(cat "$rm_unaddr")"
+
+# The candidate listing's first column must be a name this command actually
+# takes. For a NESTED in-cone worktree that is the relative path, not the
+# basename: .worktrees/feat/deep is addressed as feat/deep, and advertising
+# "deep" sends the operator through an extra refusal to discover that.
+new nestedlist --no-install >/dev/null ||
+    fail "could not create the #963 nested-listing fixture"
+# `git worktree move` does not create the destination's parent.
+mkdir -p "$fixture/.worktrees/feat"
+git -C "$fixture" worktree move .worktrees/nestedlist ".worktrees/feat/deep" ||
+    fail "could not nest the #963 listing fixture"
+rm_list="$test_tmp/rm-listing.log"
+rm_wt definitely-absent-name >"$rm_list" 2>&1 || true
+grep -qE '^  feat/deep( |$)' "$rm_list" ||
+    fail "the listing did not offer the nested worktree's usable name (#963): $(cat "$rm_list")"
+# ...and an unaddressable path must not be advertised as if it were a name.
+grep -qE '^  \(git worktree remove\)' "$rm_list" ||
+    fail "the listing did not mark the unaddressable in-cone path as needing git's command (#963): $(cat "$rm_list")"
+# ...and specifically for an OUT-OF-CONE worktree, which the in-cone-with-space
+# case above cannot prove: classifying every path as in-cone would advertise an
+# absolute path as though it were a name this command takes.
+outcone_list="$test_tmp/outcone-list"
+git -C "$fixture" worktree add -q "$outcone_list/stray" -b feat/outcone-listing ||
+    fail "could not create the #963 out-of-cone listing fixture"
+rm_list2="$test_tmp/rm-listing-outcone.log"
+rm_wt definitely-absent-name >"$rm_list2" 2>&1 || true
+grep -qE "^  \(git worktree remove\)  .*$outcone_list/stray" "$rm_list2" ||
+    fail "the listing advertised an out-of-cone worktree under a name this command cannot take (#963): $(cat "$rm_list2")"
+git -C "$fixture" worktree remove --force "$outcone_list/stray"
+git -C "$fixture" worktree remove --force ".worktrees/feat/deep"
+git -C "$fixture" worktree remove --force ".worktrees/team space/leaf"
 
 echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"
 

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -3182,8 +3182,10 @@ rm_wt definitely-absent-name >"$rm_list" 2>&1 || true
 grep -qE '^  feat/deep( |$)' "$rm_list" ||
     fail "the listing did not offer the nested worktree's usable name (#963): $(cat "$rm_list")"
 # ...and an unaddressable path must not be advertised as if it were a name.
-grep -qE '^  \(git worktree remove\)' "$rm_list" ||
-    fail "the listing did not mark the unaddressable in-cone path as needing git's command (#963): $(cat "$rm_list")"
+grep -qE '^  \(not removable here\)' "$rm_list" ||
+    fail "the listing did not mark the unaddressable in-cone path as not removable (#963): $(cat "$rm_list")"
+grep -q 'git worktree remove' "$rm_list" &&
+    fail "the listing re-offered the unguarded command the refusal withholds (#963): $(cat "$rm_list")"
 # ...and specifically for an OUT-OF-CONE worktree, which the in-cone-with-space
 # case above cannot prove: classifying every path as in-cone would advertise an
 # absolute path as though it were a name this command takes.
@@ -3192,7 +3194,7 @@ git -C "$fixture" worktree add -q "$outcone_list/stray" -b feat/outcone-listing 
     fail "could not create the #963 out-of-cone listing fixture"
 rm_list2="$test_tmp/rm-listing-outcone.log"
 rm_wt definitely-absent-name >"$rm_list2" 2>&1 || true
-grep -qE "^  \(git worktree remove\)  .*$outcone_list/stray" "$rm_list2" ||
+grep -qE "^  \(not removable here\)  .*$outcone_list/stray" "$rm_list2" ||
     fail "the listing advertised an out-of-cone worktree under a name this command cannot take (#963): $(cat "$rm_list2")"
 git -C "$fixture" worktree remove --force "$outcone_list/stray"
 git -C "$fixture" worktree remove --force ".worktrees/feat/deep"
@@ -3225,7 +3227,7 @@ for bad_component in '-dash' 'a..b'; do
     # predicate exists to prevent.
     rm_remedy_list="$test_tmp/rm-remedy-list.log"
     rm_wt definitely-absent-name >"$rm_remedy_list" 2>&1 || true
-    grep -qE "^  \(git worktree remove\)  .*$bad_component/leaf" "$rm_remedy_list" ||
+    grep -qE "^  \(not removable here\)  .*$bad_component/leaf" "$rm_remedy_list" ||
         fail "the listing advertised '$bad_component/leaf' under a name this command rejects (#963): $(cat "$rm_remedy_list")"
     git -C "$fixture" worktree remove --force ".worktrees/$bad_component/leaf"
     rmdir "$fixture/.worktrees/$bad_component" 2>/dev/null || true
@@ -3297,7 +3299,7 @@ if [ "$nl_supported" -eq 1 ]; then
     real_git="$(command -v git)"
     cat >"$oldgit_shim/git" <<SHIM
 #!/usr/bin/env bash
-# Reject only $(worktree list ... -z); everything else is the real git.
+# Reject only the worktree-list capability probe; else the real git.
 if [ "\$1" = "worktree" ] && [ "\$2" = "list" ]; then
     for arg in "\$@"; do
         [ "\$arg" = "-z" ] && exit 129
@@ -3322,8 +3324,8 @@ ning"
         (cd "$fixture" && PATH="$oldgit_shim:$PATH" bash scripts/worktree-rm.sh spanning) \
             >"$rm_oldgit" 2>&1 &&
             fail "worktree:rm resolved a spanning path on a git without -z (#963): $(cat "$rm_oldgit")"
-        grep -q 'cannot enumerate worktrees unambiguously' "$rm_oldgit" ||
-            fail "the pre-2.36 path did not fail closed on a spanning worktree path (#963): $(cat "$rm_oldgit")"
+        grep -q 'cannot look up' "$rm_oldgit" ||
+            fail "the pre-2.36 path did not refuse registry lookup (#963): $(cat "$rm_oldgit")"
         grep -qi 'removed' "$rm_oldgit" &&
             fail "the pre-2.36 refusal still claimed a removal (#963): $(cat "$rm_oldgit")"
         git -C "$fixture" worktree remove --force "$oldgit_tree"

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -2955,4 +2955,79 @@ else
     echo "    (skipped: running as root, a permission-held teardown cannot be simulated)"
 fi
 
+# ── Target resolution: the name must account for something (#963) ───────────
+#
+# Every fixture worktree above is created through worktree:new, which always
+# lands under .worktrees/ — so the constructed path <main_root>/.worktrees/<name>
+# is satisfied by construction and no existing case can see a name that does
+# not resolve there. These three build the shapes deliberately. Each asserts
+# BOTH halves: a nonzero exit, and that the target actually survived — a
+# refusal that still deleted something would pass an exit-code-only check.
+
+# A worktree registered to this repo but living outside .worktrees/, which
+# `git worktree add` permits and `git worktree list` reports. worktree:rm
+# cannot reach it, and must say so rather than claim a removal.
+outside_root="$test_tmp/outside-cone"
+git -C "$fixture" worktree add -q "$outside_root/parked" -b feat/parked-outside ||
+    fail "could not create a worktree outside .worktrees/ for the #963 case"
+rm_out="$test_tmp/rm-outside.log"
+if rm_wt parked >"$rm_out" 2>&1; then
+    fail "worktree:rm reported success for a worktree outside .worktrees/ (#963): $(cat "$rm_out")"
+fi
+# Anchored on the LOCATION clause, not on the path alone: the real path also
+# appears in the `git worktree remove` remedy, so a bare substring match stays
+# green even when the clause names the constructed path instead (mutant N3).
+grep -q "names the worktree at $outside_root/parked" "$rm_out" ||
+    fail "the refusal did not name where the worktree actually is (#963): $(cat "$rm_out")"
+grep -q "names the worktree at $fixture/.worktrees/parked" "$rm_out" &&
+    fail "the refusal located the worktree at the constructed path, which does not exist (#963): $(cat "$rm_out")"
+grep -q 'git worktree remove' "$rm_out" ||
+    fail "the refusal did not name a command that actually works (#963): $(cat "$rm_out")"
+grep -qi 'removed:' "$rm_out" &&
+    fail "the refusal still printed a removal line (#963): $(cat "$rm_out")"
+[ -d "$outside_root/parked" ] ||
+    fail "worktree:rm deleted a worktree it had refused to remove (#963)"
+git -C "$fixture" worktree list --porcelain | grep -qxF "worktree $outside_root/parked" ||
+    fail "worktree:rm dropped the registry record of a worktree it refused (#963)"
+git -C "$fixture" worktree remove --force "$outside_root/parked"
+
+# A moved worktree: git names the admin record from the path basename at
+# creation and NEVER renames it, while `git worktree move` rewrites the
+# record's stored path — so record name and directory name diverge by design.
+# Asking by the record name must not read as a stale record.
+# --no-install: this fixture only needs to EXIST and then move. A real
+# dependency install leaves the tree dirty, and worktree:rm then refuses it
+# on uncommitted changes — correct behaviour, wrong fixture for this case.
+new movedrec --no-install >/dev/null || fail "could not create the #963 move fixture"
+git -C "$fixture" worktree move .worktrees/movedrec .worktrees/movednew ||
+    fail "could not move the #963 fixture worktree"
+rm_moved="$test_tmp/rm-moved.log"
+if rm_wt movedrec >"$rm_moved" 2>&1; then
+    fail "worktree:rm reported success for a record name whose directory moved (#963): $(cat "$rm_moved")"
+fi
+grep -q "names the worktree at $fixture/.worktrees/movednew" "$rm_moved" ||
+    fail "the refusal did not name the moved worktree's current directory (#963): $(cat "$rm_moved")"
+grep -q 'no worktree or admin record named' "$rm_moved" &&
+    fail "the record name resolved to nothing — resolution no longer matches admin-record names (#963): $(cat "$rm_moved")"
+[ -d "$fixture/.worktrees/movednew" ] ||
+    fail "worktree:rm deleted a moved worktree it had refused to remove (#963)"
+# ...and the directory name, which is what actually resolves, still works.
+rm_movednew="$test_tmp/rm-movednew.log"
+rm_wt movednew >"$rm_movednew" 2>&1 ||
+    fail "worktree:rm could not remove a moved worktree by its directory name (#963): $(cat "$rm_movednew")"
+[ -d "$fixture/.worktrees/movednew" ] &&
+    fail "worktree:rm reported success but left the moved worktree behind (#963)"
+
+# A name matching neither a worktree nor an admin record: the original report.
+rm_none="$test_tmp/rm-nomatch.log"
+if rm_wt definitely-no-such-worktree >"$rm_none" 2>&1; then
+    fail "worktree:rm exited 0 for a name matching nothing (#963): $(cat "$rm_none")"
+fi
+grep -qi 'removed:' "$rm_none" &&
+    fail "worktree:rm claimed a removal for a name matching nothing (#963): $(cat "$rm_none")"
+grep -q 'no worktree or admin record named' "$rm_none" ||
+    fail "the no-match refusal did not say what was wrong (#963): $(cat "$rm_none")"
+
+echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"
+
 echo "worktree entrypoint OK: create → hooks verified → deps installed → removed"

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -2994,8 +2994,15 @@ grep -q "names the worktree at $outside_root/parked" "$rm_out" ||
     fail "the refusal did not name where the worktree actually is (#963): $(cat "$rm_out")"
 grep -q "names the worktree at $fixture/.worktrees/parked" "$rm_out" &&
     fail "the refusal located the worktree at the constructed path, which does not exist (#963): $(cat "$rm_out")"
-grep -q 'git worktree remove' "$rm_out" ||
-    fail "the refusal did not name a command that actually works (#963): $(cat "$rm_out")"
+# The refusal must NOT hand over `git worktree remove`: that command applies
+# none of this script's guards — it deletes ignored files such as .env and
+# takes an unreferenced detached HEAD without complaint — so advertising it
+# walks the operator past the protections this task exists to provide
+# (review r4). It must instead say what would go unchecked.
+grep -qE 'remove it with: git worktree remove|instead: git worktree remove' "$rm_out" &&
+    fail "the refusal advertised an unguarded removal command (#963): $(cat "$rm_out")"
+grep -q 'skip-worktree' "$rm_out" ||
+    fail "the refusal did not name the guards a raw removal would skip (#963): $(cat "$rm_out")"
 grep -qi 'removed:' "$rm_out" &&
     fail "the refusal still printed a removal line (#963): $(cat "$rm_out")"
 [ -d "$outside_root/parked" ] ||
@@ -3090,8 +3097,19 @@ if mkdir -p "$nl_probe" 2>/dev/null && [ -d "$nl_probe" ]; then
 else
     nl_supported=0
 fi
+# `--porcelain -z` (git 2.36+) is what makes a newline-bearing path
+# representable at all. Without it the command fails closed by design, so these
+# cases assert behaviour that git cannot deliver — gate on the capability, not
+# only on the filesystem (review r4).
+if git worktree list --porcelain -z >/dev/null 2>&1; then
+    nl_z_supported=1
+else
+    nl_z_supported=0
+fi
 if [ "$nl_supported" -eq 0 ]; then
     echo "    (skipped: this filesystem rejects a newline in a path)"
+elif [ "$nl_z_supported" -eq 0 ]; then
+    echo "    (skipped: this git has no 'worktree list --porcelain -z'; the command fails closed instead)"
 elif git -C "$fixture" worktree add -q "$nl_tree" -b feat/newline-path; then
     rm_trunc="$test_tmp/rm-trunc.log"
     if rm_wt trunc >"$rm_trunc" 2>&1; then
@@ -3198,8 +3216,8 @@ for bad_component in '-dash' 'a..b'; do
     fi
     grep -q 'task worktree:rm --' "$rm_remedy" &&
         fail "the remedy advertised a task invocation this command rejects, for '$bad_component' (#963): $(cat "$rm_remedy")"
-    grep -q 'git worktree remove' "$rm_remedy" ||
-        fail "the remedy did not fall back to git's command for '$bad_component' (#963): $(cat "$rm_remedy")"
+    grep -qE 'remove it with: git worktree remove' "$rm_remedy" &&
+        fail "the remedy advertised an unguarded removal for '$bad_component' (#963): $(cat "$rm_remedy")"
     # The LISTING must reach the same verdict about the same path, and it must
     # be checked while this worktree still exists. Both components pass the
     # charset rule and fail a different one, so a listing that applied only the
@@ -3250,7 +3268,7 @@ grep -q 'Stale record cleared' "$rm_real" &&
 # carrying a raw newline. Every diagnostic must escape the path it prints, not
 # only the remedy: an unescaped location clause splits the message across lines
 # (review r3).
-if [ "$nl_supported" -eq 1 ]; then
+if [ "$nl_supported" -eq 1 ] && [ "$nl_z_supported" -eq 1 ]; then
     esc_parent="$test_tmp/escpath"
     mkdir -p "$esc_parent"
     esc_tree="$esc_parent/trunc
@@ -3267,6 +3285,52 @@ tail"
     else
         fail "could not create the #963 escaping fixture although newlines are supported"
     fi
+fi
+
+# The pre-2.36 path is unreachable on a modern git, so it is simulated: a shim
+# makes `worktree list --porcelain -z` fail and passes everything else through
+# to the real binary. Without this the fail-closed branch is only exercisable
+# by installing an old git, which means in practice never (review r4).
+if [ "$nl_supported" -eq 1 ]; then
+    oldgit_shim="$test_tmp/oldgit-shim"
+    mkdir -p "$oldgit_shim"
+    real_git="$(command -v git)"
+    cat >"$oldgit_shim/git" <<SHIM
+#!/usr/bin/env bash
+# Reject only $(worktree list ... -z); everything else is the real git.
+if [ "\$1" = "worktree" ] && [ "\$2" = "list" ]; then
+    for arg in "\$@"; do
+        [ "\$arg" = "-z" ] && exit 129
+    done
+fi
+exec "$real_git" "\$@"
+SHIM
+    chmod +x "$oldgit_shim/git"
+    # Prove the shim actually simulates the old git before relying on it — a
+    # shim that silently passed -z through would make this case vacuous.
+    PATH="$oldgit_shim:$PATH" git worktree list --porcelain -z >/dev/null 2>&1 &&
+        fail "the pre-2.36 git shim did not reject --porcelain -z (#963)"
+    PATH="$oldgit_shim:$PATH" git worktree list --porcelain >/dev/null 2>&1 ||
+        fail "the pre-2.36 git shim broke ordinary git invocations (#963)"
+
+    oldgit_parent="$test_tmp/oldgit-cone"
+    mkdir -p "$oldgit_parent"
+    oldgit_tree="$oldgit_parent/span
+ning"
+    if git -C "$fixture" worktree add -q "$oldgit_tree" -b feat/oldgit-span; then
+        rm_oldgit="$test_tmp/rm-oldgit.log"
+        (cd "$fixture" && PATH="$oldgit_shim:$PATH" bash scripts/worktree-rm.sh spanning) \
+            >"$rm_oldgit" 2>&1 &&
+            fail "worktree:rm resolved a spanning path on a git without -z (#963): $(cat "$rm_oldgit")"
+        grep -q 'cannot enumerate worktrees unambiguously' "$rm_oldgit" ||
+            fail "the pre-2.36 path did not fail closed on a spanning worktree path (#963): $(cat "$rm_oldgit")"
+        grep -qi 'removed' "$rm_oldgit" &&
+            fail "the pre-2.36 refusal still claimed a removal (#963): $(cat "$rm_oldgit")"
+        git -C "$fixture" worktree remove --force "$oldgit_tree"
+    else
+        fail "could not create the #963 pre-2.36 fixture although newlines are supported"
+    fi
+    rm -rf "$oldgit_shim"
 fi
 
 echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -3335,6 +3335,58 @@ ning"
     rm -rf "$oldgit_shim"
 fi
 
+# A registry read that fails or truncates must not read as a complete one.
+# bash does not propagate a process-substitution failure, so without a success
+# sentinel the resolver would treat a partial list as the whole registry and
+# could call a name unique, or absent, on evidence it never finished reading
+# (review r6). Simulated with a shim that exits nonzero for the enumeration.
+trunc_shim="$test_tmp/trunc-shim"
+mkdir -p "$trunc_shim"
+trunc_real_git="$(command -v git)"
+cat >"$trunc_shim/git" <<TRUNCSHIM
+#!/usr/bin/env bash
+# The capability probe and the real enumeration are the SAME invocation, so
+# they cannot be told apart by arguments — count instead. The first armed
+# -z call (the probe) succeeds so the command clears its version gate; the
+# next one (the enumeration it actually reads) fails.
+if [ "\$1" = "worktree" ] && [ "\$2" = "list" ]; then
+    for arg in "\$@"; do
+        if [ "\$arg" = "-z" ] && [ -n "\$WT_TRUNC_ARMED" ]; then
+            if [ -e "\$WT_TRUNC_ARMED" ]; then
+                exit 1
+            fi
+            : >"\$WT_TRUNC_ARMED"
+            exec "$trunc_real_git" "\$@"
+        fi
+    done
+fi
+exec "$trunc_real_git" "\$@"
+TRUNCSHIM
+chmod +x "$trunc_shim/git"
+# Prove the shim behaves as described before relying on it.
+trunc_marker="$test_tmp/trunc-marker"
+rm -f "$trunc_marker"
+PATH="$trunc_shim:$PATH" git worktree list --porcelain -z >/dev/null 2>&1 ||
+    fail "the truncation shim broke the unarmed enumeration (#963)"
+PATH="$trunc_shim:$PATH" WT_TRUNC_ARMED="$trunc_marker" git worktree list --porcelain -z >/dev/null 2>&1 ||
+    fail "the truncation shim failed the FIRST armed call, which must succeed as the capability probe (#963)"
+PATH="$trunc_shim:$PATH" WT_TRUNC_ARMED="$trunc_marker" git worktree list --porcelain -z >/dev/null 2>&1 &&
+    fail "the truncation shim did not fail the SECOND armed call (#963)"
+rm -f "$trunc_marker"
+
+new truncprobe --no-install >/dev/null || fail "could not create the #963 truncation fixture"
+rm -rf "$fixture/.worktrees/truncprobe"
+git -C "$fixture" worktree prune
+rm_trunc_log="$test_tmp/rm-truncated.log"
+(cd "$fixture" && PATH="$trunc_shim:$PATH" WT_TRUNC_ARMED="$trunc_marker" bash scripts/worktree-rm.sh some-absent-name) \
+    >"$rm_trunc_log" 2>&1 &&
+    fail "worktree:rm succeeded on a registry read that failed (#963): $(cat "$rm_trunc_log")"
+grep -q 'could not read the worktree registry completely' "$rm_trunc_log" ||
+    fail "a failed registry read did not fail closed (#963): $(cat "$rm_trunc_log")"
+grep -qi 'removed' "$rm_trunc_log" &&
+    fail "a failed registry read still claimed a removal (#963): $(cat "$rm_trunc_log")"
+rm -rf "$trunc_shim"
+
 echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"
 
 echo "worktree entrypoint OK: create → hooks verified → deps installed → removed"

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -3028,6 +3028,60 @@ grep -qi 'removed:' "$rm_none" &&
 grep -q 'no worktree or admin record named' "$rm_none" ||
     fail "the no-match refusal did not say what was wrong (#963): $(cat "$rm_none")"
 
+# The main checkout is registered but is not a linked worktree, so resolution
+# must skip it — otherwise `worktree:rm <repo-basename>` reports the main
+# checkout as an out-of-cone worktree and recommends a `git worktree remove`
+# that git refuses outright (challenge r1).
+main_base="${fixture##*/}"
+rm_mainbase="$test_tmp/rm-mainbase.log"
+if rm_wt "$main_base" >"$rm_mainbase" 2>&1; then
+    fail "worktree:rm accepted the main checkout's own basename (#963): $(cat "$rm_mainbase")"
+fi
+grep -q "names the worktree at $fixture " "$rm_mainbase" &&
+    fail "worktree:rm resolved the main checkout as a removable worktree (#963): $(cat "$rm_mainbase")"
+grep -q "no worktree or admin record named" "$rm_mainbase" ||
+    fail "the main checkout's basename did not fall through to the no-match branch (#963): $(cat "$rm_mainbase")"
+grep -q 'git worktree remove' "$rm_mainbase" &&
+    fail "worktree:rm recommended removing the main checkout, which git refuses (#963): $(cat "$rm_mainbase")"
+
+# ...and skipping it must not blind resolution to a LINKED worktree that
+# happens to share the main checkout's basename.
+samebase_root="$test_tmp/samebase"
+git -C "$fixture" worktree add -q "$samebase_root/$main_base" -b feat/samebase ||
+    fail "could not create the same-basename worktree for the #963 case"
+rm_samebase="$test_tmp/rm-samebase.log"
+if rm_wt "$main_base" >"$rm_samebase" 2>&1; then
+    fail "worktree:rm reported success for a same-basename linked worktree (#963): $(cat "$rm_samebase")"
+fi
+grep -q "names the worktree at $samebase_root/$main_base" "$rm_samebase" ||
+    fail "resolution missed a linked worktree sharing the main checkout's basename (#963): $(cat "$rm_samebase")"
+git -C "$fixture" worktree remove --force "$samebase_root/$main_base"
+
+# A worktree path may legally contain a newline. Line-parsed porcelain output
+# truncates it, which both hides the real worktree and invents a candidate at
+# the truncated prefix — so asking for that prefix must NOT resolve to it
+# (challenge r1).
+nl_parent="$test_tmp/nl-cone"
+mkdir -p "$nl_parent"
+nl_tree="$nl_parent/trunc
+tail"
+if git -C "$fixture" worktree add -q "$nl_tree" -b feat/newline-path 2>/dev/null; then
+    rm_trunc="$test_tmp/rm-trunc.log"
+    if rm_wt trunc >"$rm_trunc" 2>&1; then
+        fail "worktree:rm resolved a truncated newline path as a real worktree (#963): $(cat "$rm_trunc")"
+    fi
+    # With the path read whole, "trunc" is nobody's basename, so the no-match
+    # branch must run. Line-parsing instead invents a candidate at the
+    # truncated prefix and resolves to it — a different branch entirely.
+    # Asserting the branch is robust; grepping a path out of a sentence that
+    # itself contains a newline is not.
+    grep -q "no worktree or admin record named 'trunc'" "$rm_trunc" ||
+        fail "the truncated prefix of a newline path resolved as a real worktree (#963): $(cat "$rm_trunc")"
+    git -C "$fixture" worktree remove --force "$nl_tree"
+else
+    echo "    (skipped: this filesystem rejects a newline in a path)"
+fi
+
 echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"
 
 echo "worktree entrypoint OK: create → hooks verified → deps installed → removed"

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -255,6 +255,19 @@ new_in() {
     shift
     run_worktree_op "worktree:new" "$op_from" scripts/worktree-new.sh "$@"
 }
+# Map a worktree path to its admin-record directory, the way worktree-rm.sh
+# does: each record's `gitdir` file names that worktree's .git file.
+record_admin_dir_probe() {
+    probe_common="$(git -C "$1" rev-parse --path-format=absolute --git-common-dir)"
+    for probe_candidate in "$probe_common"/worktrees/*; do
+        [ -f "$probe_candidate/gitdir" ] || continue
+        if [ "$(cat "$probe_candidate/gitdir" 2>/dev/null || true)" = "$2/.git" ]; then
+            printf '%s\n' "$probe_candidate"
+            return 0
+        fi
+    done
+    return 1
+}
 rm_wt() { run_worktree_op "worktree:rm" "$fixture" scripts/worktree-rm.sh "$@"; }
 # Removal run from inside the tree being removed: caller directory and script
 # path both differ, and it is the last invocation that would otherwise bypass
@@ -3231,6 +3244,30 @@ grep -q '^Worktree removed:' "$rm_real" ||
     fail "a genuine removal stopped reporting itself as one (#963): $(cat "$rm_real")"
 grep -q 'Stale record cleared' "$rm_real" &&
     fail "a genuine removal was reported as a stale-record cleanup (#963): $(cat "$rm_real")"
+
+# git SANITIZES an admin-record name — a worktree at `trunc<LF>tail` gets the
+# record `trunc-tail` — so that record name is typeable and resolves to a path
+# carrying a raw newline. Every diagnostic must escape the path it prints, not
+# only the remedy: an unescaped location clause splits the message across lines
+# (review r3).
+if [ "$nl_supported" -eq 1 ]; then
+    esc_parent="$test_tmp/escpath"
+    mkdir -p "$esc_parent"
+    esc_tree="$esc_parent/trunc
+tail"
+    if git -C "$fixture" worktree add -q "$esc_tree" -b feat/escaped-diagnostic; then
+        esc_record="$(basename "$(record_admin_dir_probe "$fixture" "$esc_tree")")"
+        [ -n "$esc_record" ] || fail "could not read the admin record for the #963 escaping case"
+        rm_esc="$test_tmp/rm-escaped.log"
+        rm_wt "$esc_record" >"$rm_esc" 2>&1 &&
+            fail "worktree:rm reported success for an out-of-cone newline path (#963): $(cat "$rm_esc")"
+        [ "$(wc -l <"$rm_esc" | tr -d ' ')" -eq 1 ] ||
+            fail "the diagnostic split across lines on a newline-bearing path (#963): $(cat "$rm_esc")"
+        git -C "$fixture" worktree remove --force "$esc_tree"
+    else
+        fail "could not create the #963 escaping fixture although newlines are supported"
+    fi
+fi
 
 echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"
 

--- a/template/scripts/test-worktree.sh
+++ b/template/scripts/test-worktree.sh
@@ -3207,6 +3207,31 @@ rm_wt '../escape' >"$rm_badname" 2>&1 && fail "worktree:rm accepted '../escape' 
 grep -q "must not contain '\.\.'" "$rm_badname" ||
     fail "the argument check stopped naming which rule failed (#963): $(cat "$rm_badname")"
 
+# The THIRD outcome the issue requires the message to distinguish: a registry
+# record whose directory is already gone. Clearing it is correct and useful,
+# but "Worktree removed" claims a directory was deleted that never existed,
+# directly contradicting the line printed just above it (review r2).
+new stalemsg --no-install >/dev/null || fail "could not create the #963 stale-record fixture"
+rm -rf "$fixture/.worktrees/stalemsg"
+rm_stale="$test_tmp/rm-stalemsg.log"
+rm_wt stalemsg >"$rm_stale" 2>&1 ||
+    fail "worktree:rm failed to clear a stale record (#963): $(cat "$rm_stale")"
+grep -q 'Stale record cleared' "$rm_stale" ||
+    fail "clearing a stale record did not say so (#963): $(cat "$rm_stale")"
+grep -q '^Worktree removed:' "$rm_stale" &&
+    fail "clearing a stale record still claimed a directory was removed (#963): $(cat "$rm_stale")"
+
+# ...and a genuine removal must still say it removed a worktree, so the fix
+# above cannot be satisfied by simply never printing the removal line.
+new realmsg --no-install >/dev/null || fail "could not create the #963 real-removal fixture"
+rm_real="$test_tmp/rm-realmsg.log"
+rm_wt realmsg >"$rm_real" 2>&1 ||
+    fail "worktree:rm failed to remove a live worktree (#963): $(cat "$rm_real")"
+grep -q '^Worktree removed:' "$rm_real" ||
+    fail "a genuine removal stopped reporting itself as one (#963): $(cat "$rm_real")"
+grep -q 'Stale record cleared' "$rm_real" &&
+    fail "a genuine removal was reported as a stale-record cleanup (#963): $(cat "$rm_real")"
+
 echo "    worktree:rm target resolution: outside-cone, moved-record, and no-match all refuse without claiming a removal (#963)"
 
 echo "worktree entrypoint OK: create → hooks verified → deps installed → removed"

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -226,11 +226,28 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
     # which would resolve the wrong worktree or none at all. Read a
     # NUL-delimited stream where git provides it, and fall back to the LF form
     # rather than making an edge case impose a git version floor (challenge r1).
-    # awk cannot do this half: its strings are NUL-terminated, so an awk fed a
-    # NUL-delimited stream stops at the first record — on macOS that silently
+    # LF-delimited porcelain CANNOT represent a path containing a newline: the
+    # path simply continues onto the next line with nothing marking it, so a
+    # truncated prefix is indistinguishable from a real path. That is not
+    # recoverable by parsing, so on a git without `--porcelain -z` this refuses
+    # outright when it detects such a path rather than resolving the prefix as
+    # though it were a worktree (review r4). Detection is structural: every line
+    # of porcelain output is a known record key or blank, so a line that is
+    # neither means a path spanned lines.
+    if ! git worktree list --porcelain -z >/dev/null 2>&1 &&
+        git worktree list --porcelain | awk '
+            /^worktree /{next} /^(HEAD |branch )/{next}
+            /^(bare|detached)$/{next} /^(locked|prunable)/{next} /^$/{next}
+            {spanned = 1} END{exit !spanned}'; then
+        die "this git cannot enumerate worktrees unambiguously: it has no \`git worktree list --porcelain -z\` (added in git 2.36) and a registered worktree path contains a newline, which the line-delimited form cannot represent. Upgrade git to 2.36 or newer so this command can tell those paths apart instead of guessing at one"
+    fi
+
+    # awk cannot do the NUL half: its strings are NUL-terminated, so an awk fed
+    # a NUL-delimited stream stops at the first record — on macOS that silently
     # yielded only the main worktree. bash's `read -d ''` handles NUL correctly,
     # so the -z stream is split in the shell; awk is used only on the LF
-    # fallback, where it is emitting NUL rather than consuming it.
+    # fallback, where it is emitting NUL rather than consuming it, and only
+    # once the check above has established no path spans lines.
     emit_worktree_paths() {
         if git worktree list --porcelain -z >/dev/null 2>&1; then
             git worktree list --porcelain -z | while IFS= read -r -d '' wt_record; do
@@ -307,14 +324,14 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
         if [ "$rel_is_nameable" -eq 1 ]; then
             die "no worktree at $tree, but '$name' names the worktree at $(printf '%q' "$resolved") — its admin record and its directory have different names (a move does that), and only its current name resolves here: task worktree:rm -- $resolved_rel"
         else
-            die "no worktree at $tree, but '$name' names the worktree at $(printf '%q' "$resolved") — that path is not addressable by this command, so remove it with: git worktree remove $(printf '%q' "$resolved")"
+            die "no worktree at $tree, but '$name' names the worktree at $(printf '%q' "$resolved") — that path is not addressable by this command, and no removal command is suggested for it on purpose: \`git worktree remove\` performs none of the checks this task does (work hidden by skip-worktree or assume-unchanged, a merge autostash, and detached commits no branch, tag or remote-tracking ref contains — it deletes ignored files such as .env and takes an unreferenced detached HEAD without complaint), so anything removing that path has to establish those itself first"
         fi
     elif [ "$resolved_count" -gt 1 ]; then
         echo "worktree:rm: '$name' is ambiguous — it matches more than one registered worktree:" >&2
         for amb_tree in "${matches[@]}"; do
             printf '  %s\n' "$(printf '%q' "$amb_tree")" >&2
         done
-        die "name the worktree by its path instead: git worktree remove <path>"
+        die "name the worktree unambiguously — this command removes only worktrees under $main_root/.worktrees/, and reaching any other path means establishing for yourself the guards listed above that \`git worktree remove\` does not apply"
     fi
 
     # Matches nothing at all. Never report a removal for it.

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -205,10 +205,41 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
     ! record_admin_dir "$tree" >/dev/null 2>&1; then
     # Nothing at the conventional path. Ask the registry what this name means
     # before claiming anything was removed.
+    # A worktree path may legally contain a newline — `git worktree add` accepts
+    # one even though worktree:new's charset whitelist can never produce one —
+    # and the LF-delimited porcelain form truncates such a path at the newline,
+    # which would resolve the wrong worktree or none at all. Read a
+    # NUL-delimited stream where git provides it, and fall back to the LF form
+    # rather than making an edge case impose a git version floor (challenge r1).
+    # awk cannot do this half: its strings are NUL-terminated, so an awk fed a
+    # NUL-delimited stream stops at the first record — on macOS that silently
+    # yielded only the main worktree. bash's `read -d ''` handles NUL correctly,
+    # so the -z stream is split in the shell; awk is used only on the LF
+    # fallback, where it is emitting NUL rather than consuming it.
+    emit_worktree_paths() {
+        if git worktree list --porcelain -z >/dev/null 2>&1; then
+            git worktree list --porcelain -z | while IFS= read -r -d '' wt_record; do
+                case "$wt_record" in
+                "worktree "*) printf '%s\0' "${wt_record#worktree }" ;;
+                esac
+            done
+        else
+            git worktree list --porcelain |
+                awk '/^worktree /{ printf "%s%c", substr($0, 10), 0 }'
+        fi
+    }
+
     resolved=""
     resolved_count=0
-    while IFS= read -r candidate_tree; do
+    while IFS= read -r -d '' candidate_tree; do
         [ -n "$candidate_tree" ] || continue
+        # The main checkout is registered but is not a linked worktree, and this
+        # command removes only linked worktrees. Counting it made
+        # `worktree:rm <repo-basename>` report the main checkout as an
+        # out-of-cone worktree and recommend a `git worktree remove` that git
+        # refuses — and made a same-basename linked worktree read as ambiguous.
+        # The candidate listing below already skipped it; resolution must too.
+        [ "$candidate_tree" = "$main_root" ] && continue
         candidate_name="${candidate_tree##*/}"
         candidate_record=""
         candidate_admin="$(record_admin_dir "$candidate_tree" 2>/dev/null || true)"
@@ -217,9 +248,7 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
             resolved="$candidate_tree"
             resolved_count=$((resolved_count + 1))
         fi
-    done <<EOF
-$registered
-EOF
+    done < <(emit_worktree_paths)
 
     if [ "$resolved_count" -eq 1 ]; then
         # Two different situations, two different remedies. In-cone means this
@@ -239,24 +268,33 @@ EOF
         esac
     elif [ "$resolved_count" -gt 1 ]; then
         echo "worktree:rm: '$name' is ambiguous — it matches more than one registered worktree:" >&2
-        git worktree list --porcelain | awk -v main="$main_root" '/^worktree /{p = substr($0, 10); if (p != main) print "  " p}' >&2
+        while IFS= read -r -d '' amb_tree; do
+            [ "$amb_tree" = "$main_root" ] && continue
+            printf '  %s\n' "$(printf '%q' "$amb_tree")" >&2
+        done < <(emit_worktree_paths)
         die "name the worktree by its path instead: git worktree remove <path>"
     fi
 
     # Matches nothing at all. Never report a removal for it.
     echo "worktree:rm: no worktree or admin record named '$name'" >&2
     echo "worktree:rm: live worktrees (a record's name can differ from its directory after a move):" >&2
-    git worktree list --porcelain | awk '/^worktree /{print substr($0, 10)}' | while IFS= read -r live_tree; do
+    # Same NUL-delimited source the resolution above uses: a line-parsed listing
+    # truncates a newline-bearing path and prints a raw newline into the middle
+    # of the candidate list. printf %q renders such a path visibly instead of
+    # mangling the output, and leaves ordinary paths untouched.
+    while IFS= read -r -d '' live_tree; do
         # Skip the main checkout: it is registered, but this command removes
         # linked worktrees only, so offering it as a candidate is a dead end.
         [ "$live_tree" = "$main_root" ] && continue
         live_admin="$(record_admin_dir "$live_tree" 2>/dev/null || true)"
         if [ -n "$live_admin" ] && [ "${live_admin##*/}" != "${live_tree##*/}" ]; then
-            echo "  ${live_tree##*/}  (record: ${live_admin##*/})  $live_tree" >&2
+            printf '  %s  (record: %s)  %s\n' \
+                "$(printf '%q' "${live_tree##*/}")" "${live_admin##*/}" "$(printf '%q' "$live_tree")" >&2
         else
-            echo "  ${live_tree##*/}  $live_tree" >&2
+            printf '  %s  %s\n' \
+                "$(printf '%q' "${live_tree##*/}")" "$(printf '%q' "$live_tree")" >&2
         fi
-    done
+    done < <(emit_worktree_paths)
     die "nothing was removed"
 fi
 

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -229,8 +229,10 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
         fi
     }
 
-    resolved=""
-    resolved_count=0
+    # Matches are COLLECTED rather than counted, so the ambiguity branch can
+    # name the worktrees that actually collided instead of reprinting the whole
+    # registry (challenge r2).
+    matches=()
     while IFS= read -r -d '' candidate_tree; do
         [ -n "$candidate_tree" ] || continue
         # The main checkout is registered but is not a linked worktree, and this
@@ -244,34 +246,56 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
         candidate_record=""
         candidate_admin="$(record_admin_dir "$candidate_tree" 2>/dev/null || true)"
         [ -n "$candidate_admin" ] && candidate_record="${candidate_admin##*/}"
+        # Basename and admin-record name only. A candidate's path RELATIVE to
+        # .worktrees/ is deliberately NOT compared: it can equal $name only when
+        # the constructed path IS this candidate's path, and that case never
+        # reaches here — the conventional-path check above already accounted for
+        # it. Matching on it was unreachable code (found verifying challenge r2).
         if [ "$candidate_name" = "$name" ] || [ "$candidate_record" = "$name" ]; then
-            resolved="$candidate_tree"
-            resolved_count=$((resolved_count + 1))
+            matches+=("$candidate_tree")
         fi
     done < <(emit_worktree_paths)
+    resolved_count=${#matches[@]}
 
     if [ "$resolved_count" -eq 1 ]; then
+        resolved="${matches[0]}"
         # Two different situations, two different remedies. In-cone means this
-        # command CAN remove it and the caller simply used the wrong name for
-        # it — a record keeps its creation-time name across a move, so the
-        # record name and the directory name diverge and only the directory
-        # name works here. Out-of-cone means no argument to this command will
-        # reach it, because every path below is written against
-        # <main_root>/.worktrees/, so the remedy is git's own command.
+        # command CAN remove it and the caller simply used a name that no longer
+        # points at it — a record keeps its creation-time name across a move.
+        # Out-of-cone means no argument to this command will reach it, because
+        # every path below is written against <main_root>/.worktrees/, so the
+        # remedy is git's own command.
+        resolved_rel=""
         case "$resolved" in
-        "$main_root"/.worktrees/*)
-            die "no worktree at $tree, but '$name' names the worktree at $resolved — its admin record and its directory have different names (a move does that), and only the directory name resolves here: task worktree:rm -- ${resolved#"$main_root"/.worktrees/}"
-            ;;
-        *)
-            die "no worktree at $tree, but '$name' names the worktree at $resolved — that is outside $main_root/.worktrees/, which this command never removes from, so remove it with: git worktree remove $(printf '%q' "$resolved")"
-            ;;
+        "$main_root"/.worktrees/*) resolved_rel="${resolved#"$main_root"/.worktrees/}" ;;
         esac
+        # An in-cone path is only reachable through THIS command when its
+        # relative form is a name this command would accept. A hand-registered
+        # `.worktrees/team space/foo` is in-cone yet unnameable here: the
+        # suggested `task worktree:rm -- team space/foo` would split on the
+        # space and be rejected by the charset guard anyway. Fall back to git's
+        # command, shell-escaped, rather than emitting a remedy that cannot work
+        # (challenge r2).
+        rel_is_nameable=0
+        if [ -n "$resolved_rel" ]; then
+            rel_is_nameable=1
+            case "$resolved_rel" in
+            *[!A-Za-z0-9._/-]*) rel_is_nameable=0 ;;
+            esac
+            case "/$resolved_rel/" in
+            *//* | */./*) rel_is_nameable=0 ;;
+            esac
+        fi
+        if [ "$rel_is_nameable" -eq 1 ]; then
+            die "no worktree at $tree, but '$name' names the worktree at $resolved — its admin record and its directory have different names (a move does that), and only its current name resolves here: task worktree:rm -- $resolved_rel"
+        else
+            die "no worktree at $tree, but '$name' names the worktree at $resolved — that path is not addressable by this command, so remove it with: git worktree remove $(printf '%q' "$resolved")"
+        fi
     elif [ "$resolved_count" -gt 1 ]; then
         echo "worktree:rm: '$name' is ambiguous — it matches more than one registered worktree:" >&2
-        while IFS= read -r -d '' amb_tree; do
-            [ "$amb_tree" = "$main_root" ] && continue
+        for amb_tree in "${matches[@]}"; do
             printf '  %s\n' "$(printf '%q' "$amb_tree")" >&2
-        done < <(emit_worktree_paths)
+        done
         die "name the worktree by its path instead: git worktree remove <path>"
     fi
 
@@ -287,12 +311,27 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
         # linked worktrees only, so offering it as a candidate is a dead end.
         [ "$live_tree" = "$main_root" ] && continue
         live_admin="$(record_admin_dir "$live_tree" 2>/dev/null || true)"
+        live_rel=""
+        case "$live_tree" in
+        "$main_root"/.worktrees/*)
+            live_rel="${live_tree#"$main_root"/.worktrees/}"
+            case "$live_rel" in
+            *[!A-Za-z0-9._/-]*) live_rel="" ;;
+            esac
+            ;;
+        esac
+        if [ -n "$live_rel" ]; then
+            live_label="$live_rel"
+        else
+            # Not addressable through this command at all, so do not print
+            # something that looks like a name it would take.
+            live_label="(git worktree remove)"
+        fi
         if [ -n "$live_admin" ] && [ "${live_admin##*/}" != "${live_tree##*/}" ]; then
             printf '  %s  (record: %s)  %s\n' \
-                "$(printf '%q' "${live_tree##*/}")" "${live_admin##*/}" "$(printf '%q' "$live_tree")" >&2
+                "$live_label" "${live_admin##*/}" "$(printf '%q' "$live_tree")" >&2
         else
-            printf '  %s  %s\n' \
-                "$(printf '%q' "${live_tree##*/}")" "$(printf '%q' "$live_tree")" >&2
+            printf '  %s  %s\n' "$live_label" "$(printf '%q' "$live_tree")" >&2
         fi
     done < <(emit_worktree_paths)
     die "nothing was removed"

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -182,6 +182,84 @@ if [ "$tree_is_registered" -eq 1 ] && [ "$tree_exists" -eq 0 ]; then
     stale_record=1
 fi
 
+# ── The name must actually account for something (harmon-init#963) ──────────
+#
+# Everything above derives $tree by CONSTRUCTION from the argument, and never
+# consults the registry to find where the named worktree actually is. git names
+# an admin record from the path basename at creation and never renames it,
+# while `git worktree move` rewrites the record's stored path — so record name
+# and current directory name are independent BY DESIGN, and a worktree may sit
+# anywhere `git worktree add` was pointed, including outside this repo's
+# checkout entirely. A constructed path is therefore not a lookup, and when it
+# missed, the run fell into the stale-record branch and reported a removal that
+# did not happen: both output lines false, exit 0, the worktree untouched.
+#
+# The fix is a pre-flight, deliberately NOT a re-targeting. $tree keeps exactly
+# the meaning it has always had for every run that proceeds — the locks are
+# keyed on $name, and the removal, debris sweep and parent walk below are all
+# written against the constructed path — so this either lets the existing flow
+# run byte-for-byte as before, or refuses while naming the real path. Silently
+# retargeting a deletion at a path the caller did not name is the more
+# dangerous repair.
+if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
+    ! record_admin_dir "$tree" >/dev/null 2>&1; then
+    # Nothing at the conventional path. Ask the registry what this name means
+    # before claiming anything was removed.
+    resolved=""
+    resolved_count=0
+    while IFS= read -r candidate_tree; do
+        [ -n "$candidate_tree" ] || continue
+        candidate_name="${candidate_tree##*/}"
+        candidate_record=""
+        candidate_admin="$(record_admin_dir "$candidate_tree" 2>/dev/null || true)"
+        [ -n "$candidate_admin" ] && candidate_record="${candidate_admin##*/}"
+        if [ "$candidate_name" = "$name" ] || [ "$candidate_record" = "$name" ]; then
+            resolved="$candidate_tree"
+            resolved_count=$((resolved_count + 1))
+        fi
+    done <<EOF
+$registered
+EOF
+
+    if [ "$resolved_count" -eq 1 ]; then
+        # Two different situations, two different remedies. In-cone means this
+        # command CAN remove it and the caller simply used the wrong name for
+        # it — a record keeps its creation-time name across a move, so the
+        # record name and the directory name diverge and only the directory
+        # name works here. Out-of-cone means no argument to this command will
+        # reach it, because every path below is written against
+        # <main_root>/.worktrees/, so the remedy is git's own command.
+        case "$resolved" in
+        "$main_root"/.worktrees/*)
+            die "no worktree at $tree, but '$name' names the worktree at $resolved — its admin record and its directory have different names (a move does that), and only the directory name resolves here: task worktree:rm -- ${resolved#"$main_root"/.worktrees/}"
+            ;;
+        *)
+            die "no worktree at $tree, but '$name' names the worktree at $resolved — that is outside $main_root/.worktrees/, which this command never removes from, so remove it with: git worktree remove $(printf '%q' "$resolved")"
+            ;;
+        esac
+    elif [ "$resolved_count" -gt 1 ]; then
+        echo "worktree:rm: '$name' is ambiguous — it matches more than one registered worktree:" >&2
+        git worktree list --porcelain | awk -v main="$main_root" '/^worktree /{p = substr($0, 10); if (p != main) print "  " p}' >&2
+        die "name the worktree by its path instead: git worktree remove <path>"
+    fi
+
+    # Matches nothing at all. Never report a removal for it.
+    echo "worktree:rm: no worktree or admin record named '$name'" >&2
+    echo "worktree:rm: live worktrees (a record's name can differ from its directory after a move):" >&2
+    git worktree list --porcelain | awk '/^worktree /{print substr($0, 10)}' | while IFS= read -r live_tree; do
+        # Skip the main checkout: it is registered, but this command removes
+        # linked worktrees only, so offering it as a candidate is a dead end.
+        [ "$live_tree" = "$main_root" ] && continue
+        live_admin="$(record_admin_dir "$live_tree" 2>/dev/null || true)"
+        if [ -n "$live_admin" ] && [ "${live_admin##*/}" != "${live_tree##*/}" ]; then
+            echo "  ${live_tree##*/}  (record: ${live_admin##*/})  $live_tree" >&2
+        else
+            echo "  ${live_tree##*/}  $live_tree" >&2
+        fi
+    done
+    die "nothing was removed"
+fi
+
 # A worktree registered BELOW this path is a separate worktree, not this one's
 # disposable contents. `git worktree remove --force` would delete its
 # uncommitted work and the record cleanup below would drop its registry record,

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -227,19 +227,19 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
     # NUL-delimited stream where git provides it, and fall back to the LF form
     # rather than making an edge case impose a git version floor (challenge r1).
     # LF-delimited porcelain CANNOT represent a path containing a newline: the
-    # path simply continues onto the next line with nothing marking it, so a
-    # truncated prefix is indistinguishable from a real path. That is not
-    # recoverable by parsing, so on a git without `--porcelain -z` this refuses
-    # outright when it detects such a path rather than resolving the prefix as
-    # though it were a worktree (review r4). Detection is structural: every line
-    # of porcelain output is a known record key or blank, so a line that is
-    # neither means a path spanned lines.
-    if ! git worktree list --porcelain -z >/dev/null 2>&1 &&
-        git worktree list --porcelain | awk '
-            /^worktree /{next} /^(HEAD |branch )/{next}
-            /^(bare|detached)$/{next} /^(locked|prunable)/{next} /^$/{next}
-            {spanned = 1} END{exit !spanned}'; then
-        die "this git cannot enumerate worktrees unambiguously: it has no \`git worktree list --porcelain -z\` (added in git 2.36) and a registered worktree path contains a newline, which the line-delimited form cannot represent. Upgrade git to 2.36 or newer so this command can tell those paths apart instead of guessing at one"
+    # path continues onto the next line with nothing marking it. An earlier
+    # attempt detected that structurally, by treating a line that matched no
+    # record key as a continuation — but a continuation may legally LOOK like a
+    # key (`trap<LF>HEAD fake`), so the check could be walked straight past
+    # (review r5). There is no parse that recovers the truth here.
+    #
+    # So this does not parse ambiguous output at all. Without `--porcelain -z`
+    # (git 2.36+) registry resolution is simply unavailable, and the command
+    # says so. Nothing else regresses: a worktree at the conventional path is
+    # accounted for long before this block, so only the fallback lookup — the
+    # thing that cannot be done correctly here — is withdrawn.
+    if ! git worktree list --porcelain -z >/dev/null 2>&1; then
+        die "no worktree at $tree, and this git cannot look up '$name' elsewhere in the registry: that needs \`git worktree list --porcelain -z\` (git 2.36+), because the line-delimited form cannot represent a path containing a newline and offers no way to tell one apart from a truncated prefix. Upgrade git to 2.36 or newer, or name the worktree by its path with git's own commands"
     fi
 
     # awk cannot do the NUL half: its strings are NUL-terminated, so an awk fed
@@ -248,16 +248,14 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
     # so the -z stream is split in the shell; awk is used only on the LF
     # fallback, where it is emitting NUL rather than consuming it, and only
     # once the check above has established no path spans lines.
+    # Reached only when -z is available: the guard above refused otherwise.
     emit_worktree_paths() {
-        if git worktree list --porcelain -z >/dev/null 2>&1; then
+        if true; then
             git worktree list --porcelain -z | while IFS= read -r -d '' wt_record; do
                 case "$wt_record" in
                 "worktree "*) printf '%s\0' "${wt_record#worktree }" ;;
                 esac
             done
-        else
-            git worktree list --porcelain |
-                awk '/^worktree /{ printf "%s%c", substr($0, 10), 0 }'
         fi
     }
 
@@ -360,9 +358,11 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
         if [ -n "$live_rel" ]; then
             live_label="$live_rel"
         else
-            # Not addressable through this command at all, so do not print
-            # something that looks like a name it would take.
-            live_label="(git worktree remove)"
+            # Not addressable through this command at all. The label is a
+            # STATUS, never a command: rendering `git worktree remove` here
+            # re-offered exactly what the refusal above withholds, and that
+            # command applies none of this script's guards (review r5).
+            live_label="(not removable here)"
         fi
         if [ -n "$live_admin" ] && [ "${live_admin##*/}" != "${live_tree##*/}" ]; then
             printf '  %s  (record: %s)  %s\n' \

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -814,4 +814,15 @@ while [ "$parent" != "$main_root" ] && [ "$parent" != "/" ]; do
     parent="$(dirname "$parent")"
 done
 
-echo "Worktree removed: $tree"
+# The final line reports what actually happened, from the entry snapshot.
+# `stale_record` means the registry held a record whose directory was already
+# gone when this run started: nothing was removed from disk, and saying
+# "Worktree removed" there contradicted the line above it and claimed the
+# removal of a directory that never existed (#963 AC: the message must
+# distinguish "removed a worktree" from "cleared a stale record" from "found
+# nothing" — the third is the refusal branch above).
+if [ "$stale_record" -eq 1 ]; then
+    echo "Stale record cleared: $tree (no worktree directory existed)"
+else
+    echo "Worktree removed: $tree"
+fi

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -274,6 +274,15 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
 
     if [ "$resolved_count" -eq 1 ]; then
         resolved="${matches[0]}"
+        # $resolved is escaped everywhere it appears, not only in the remedy.
+        # git sanitizes an admin-record name (a worktree at `trunc<LF>tail`
+        # gets the record `trunc-tail`), so invoking that record name reaches
+        # this branch with a raw newline or terminal-control byte in the path,
+        # and an unescaped location clause splits the diagnostic across lines
+        # or emits control sequences (review r3). $tree and $resolved_rel need
+        # no escaping by construction: the first is built from $name and the
+        # second has passed worktree_name_problem, so both are restricted to
+        # the name charset.
         # Two different situations, two different remedies. In-cone means this
         # command CAN remove it and the caller simply used a name that no longer
         # points at it — a record keeps its creation-time name across a move.
@@ -296,9 +305,9 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
             rel_is_nameable=1
         fi
         if [ "$rel_is_nameable" -eq 1 ]; then
-            die "no worktree at $tree, but '$name' names the worktree at $resolved — its admin record and its directory have different names (a move does that), and only its current name resolves here: task worktree:rm -- $resolved_rel"
+            die "no worktree at $tree, but '$name' names the worktree at $(printf '%q' "$resolved") — its admin record and its directory have different names (a move does that), and only its current name resolves here: task worktree:rm -- $resolved_rel"
         else
-            die "no worktree at $tree, but '$name' names the worktree at $resolved — that path is not addressable by this command, so remove it with: git worktree remove $(printf '%q' "$resolved")"
+            die "no worktree at $tree, but '$name' names the worktree at $(printf '%q' "$resolved") — that path is not addressable by this command, so remove it with: git worktree remove $(printf '%q' "$resolved")"
         fi
     elif [ "$resolved_count" -gt 1 ]; then
         echo "worktree:rm: '$name' is ambiguous — it matches more than one registered worktree:" >&2

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -249,22 +249,38 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
     # fallback, where it is emitting NUL rather than consuming it, and only
     # once the check above has established no path spans lines.
     # Reached only when -z is available: the guard above refused otherwise.
+    #
+    # The trailing sentinel is this enumeration's success marker, mirroring
+    # flagged_enum_ok and sparse_rules_ok below: bash does not propagate a
+    # process-substitution failure, so without it a git error or a truncated
+    # stream would fail OPEN — the consumer would treat a partial registry as
+    # the whole registry and could call a name unique, or absent, on evidence
+    # it never finished reading (review r6). It is unforgeable: every real
+    # entry is an absolute path, and this marker contains no slash.
+    registry_enum_ok_marker="__WORKTREE_RM_REGISTRY_OK__"
     emit_worktree_paths() {
-        if true; then
-            git worktree list --porcelain -z | while IFS= read -r -d '' wt_record; do
-                case "$wt_record" in
-                "worktree "*) printf '%s\0' "${wt_record#worktree }" ;;
-                esac
-            done
-        fi
+        (
+            git worktree list --porcelain -z || exit 1
+            printf '%s\0' "$registry_enum_ok_marker"
+        ) | while IFS= read -r -d '' wt_record; do
+            case "$wt_record" in
+            "worktree "*) printf '%s\0' "${wt_record#worktree }" ;;
+            "$registry_enum_ok_marker") printf '%s\0' "$wt_record" ;;
+            esac
+        done
     }
 
     # Matches are COLLECTED rather than counted, so the ambiguity branch can
     # name the worktrees that actually collided instead of reprinting the whole
     # registry (challenge r2).
     matches=()
+    registry_enum_ok=0
     while IFS= read -r -d '' candidate_tree; do
         [ -n "$candidate_tree" ] || continue
+        if [ "$candidate_tree" = "$registry_enum_ok_marker" ]; then
+            registry_enum_ok=1
+            continue
+        fi
         # The main checkout is registered but is not a linked worktree, and this
         # command removes only linked worktrees. Counting it made
         # `worktree:rm <repo-basename>` report the main checkout as an
@@ -285,6 +301,8 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
             matches+=("$candidate_tree")
         fi
     done < <(emit_worktree_paths)
+    [ "$registry_enum_ok" -eq 1 ] ||
+        die "could not read the worktree registry completely, so '$name' cannot be resolved against it — refusing rather than acting on a partial list"
     resolved_count=${#matches[@]}
 
     if [ "$resolved_count" -eq 1 ]; then
@@ -339,7 +357,12 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
     # truncates a newline-bearing path and prints a raw newline into the middle
     # of the candidate list. printf %q renders such a path visibly instead of
     # mangling the output, and leaves ordinary paths untouched.
+    listing_enum_ok=0
     while IFS= read -r -d '' live_tree; do
+        if [ "$live_tree" = "$registry_enum_ok_marker" ]; then
+            listing_enum_ok=1
+            continue
+        fi
         # Skip the main checkout: it is registered, but this command removes
         # linked worktrees only, so offering it as a candidate is a dead end.
         [ "$live_tree" = "$main_root" ] && continue
@@ -371,6 +394,8 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
             printf '  %s  %s\n' "$live_label" "$(printf '%q' "$live_tree")" >&2
         fi
     done < <(emit_worktree_paths)
+    [ "$listing_enum_ok" -eq 1 ] ||
+        echo "worktree:rm: (the registry could not be read completely — this list may be partial)" >&2
     die "nothing was removed"
 fi
 

--- a/template/scripts/worktree-rm.sh
+++ b/template/scripts/worktree-rm.sh
@@ -78,6 +78,27 @@ record_admin_dir() {
     return 1
 }
 
+# The SINGLE definition of "a name this command accepts". Two places need that
+# answer — the argument validation below, and the decision about whether a
+# resolved path can be advertised as a name — and they must never disagree.
+# They did: the advertised remedy applied only the charset and component rules,
+# so an in-cone path like `-dash/leaf` or `x..y` was offered as
+# `task worktree:rm -- …` and then rejected by the very parser it was offered
+# to (review r1). Echoes the problem and returns 1 when the name is not
+# acceptable; silent and 0 when it is.
+worktree_name_problem() {
+    case "$1" in
+    "") echo "must not be empty" && return 1 ;;
+    /* | -*) echo "must not start with '/' or '-'" && return 1 ;;
+    *..*) echo "must not contain '..'" && return 1 ;;
+    *[!A-Za-z0-9._/-]*) echo "use only A-Z a-z 0-9 . _ - /" && return 1 ;;
+    esac
+    case "/$1/" in
+    *//* | */./*) echo "path components must not be empty or '.'" && return 1 ;;
+    esac
+    return 0
+}
+
 name=""
 force=0
 
@@ -108,26 +129,20 @@ done
     die "a worktree name is required"
 }
 
-case "$name" in
-/* | -*) die "invalid name '$name': must not start with '/' or '-'" ;;
-*..*) die "invalid name '$name': must not contain '..'" ;;
-esac
-# The same character whitelist creation enforces. Removal used to get away
-# without it, but lock entries are derived from the name, and a name
-# carrying whitespace, glob characters, or the encoding characters would
-# corrupt the lock bookkeeping (harmon-init#784) — and no conforming
-# creation can have produced such a worktree anyway.
-case "$name" in
-*[!A-Za-z0-9._/-]*) die "invalid name '$name': use only A-Z a-z 0-9 . _ - /" ;;
-esac
-# The same component rule creation enforces, and for the same reason: every
-# decision below compares `$tree` against git's CANONICAL registry paths as
-# text. `./live` would miss the record for the live worktree at `live`, and the
-# script would then classify a checked-out tree as debris and delete its
-# gitlink. Equivalent spellings must not reach the comparisons at all.
-case "/$name/" in
-*//* | */./*) die "invalid name '$name': path components must not be empty or '.'" ;;
-esac
+if ! name_problem="$(worktree_name_problem "$name")"; then
+    die "invalid name '$name': $name_problem"
+fi
+# The character whitelist and the component rule that creation enforces both
+# live in worktree_name_problem above. Removal used to get away without them,
+# but lock entries are derived from the name, and a name carrying whitespace,
+# glob characters, or the encoding characters would corrupt the lock
+# bookkeeping (harmon-init#784) — and no conforming creation can have produced
+# such a worktree anyway.
+# The component rule matters for the same reason: every decision below compares
+# `$tree` against git's CANONICAL registry paths as text. `./live` would miss
+# the record for the live worktree at `live`, and the script would then classify
+# a checked-out tree as debris and delete its gitlink. Equivalent spellings must
+# not reach the comparisons at all.
 
 git rev-parse --git-dir >/dev/null 2>&1 || die "not inside a git repository"
 
@@ -277,14 +292,8 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
         # command, shell-escaped, rather than emitting a remedy that cannot work
         # (challenge r2).
         rel_is_nameable=0
-        if [ -n "$resolved_rel" ]; then
+        if [ -n "$resolved_rel" ] && worktree_name_problem "$resolved_rel" >/dev/null; then
             rel_is_nameable=1
-            case "$resolved_rel" in
-            *[!A-Za-z0-9._/-]*) rel_is_nameable=0 ;;
-            esac
-            case "/$resolved_rel/" in
-            *//* | */./*) rel_is_nameable=0 ;;
-            esac
         fi
         if [ "$rel_is_nameable" -eq 1 ]; then
             die "no worktree at $tree, but '$name' names the worktree at $resolved — its admin record and its directory have different names (a move does that), and only its current name resolves here: task worktree:rm -- $resolved_rel"
@@ -315,9 +324,11 @@ if [ "$tree_exists" -eq 0 ] && [ "$tree_is_registered" -eq 0 ] &&
         case "$live_tree" in
         "$main_root"/.worktrees/*)
             live_rel="${live_tree#"$main_root"/.worktrees/}"
-            case "$live_rel" in
-            *[!A-Za-z0-9._/-]*) live_rel="" ;;
-            esac
+            # Same single definition the remedy and the argument check use: a
+            # path is only advertised under a name when that name would
+            # actually be accepted. This was a third partial copy of the rule
+            # (charset only), found while fixing the second one (review r1).
+            worktree_name_problem "$live_rel" >/dev/null || live_rel=""
             ;;
         esac
         if [ -n "$live_rel" ]; then


### PR DESCRIPTION
## What

`task worktree:rm -- <name>` printed `Worktree removed: <path>` for worktrees
it had not removed, and for names matching nothing at all — exit 0 either way.

The cause was one habit: the script answered questions about worktrees by
**constructing strings** instead of asking git. `worktree-rm.sh:137` built
`<main_root>/.worktrees/<name>` one line after resolving `main_root` *from*
`git worktree list --porcelain`, and never consulted the registry again. When
the construction missed, the run fell into the stale-record branch and reported
a success.

Construction cannot be repaired. git names an admin record from the path
basename at creation and never renames it, while `git worktree move` rewrites
the record's stored path — so record name and directory name are independent by
design, and a worktree may sit anywhere `git worktree add` was pointed. No
creation-time guard helps, because the divergence can appear long afterwards
and in a worktree this tooling never created.

## What changed

**Target resolution.** A pre-flight consults the registry when the conventional
path accounts for nothing, and produces three distinct outcomes:

| Situation | Result |
| --- | --- |
| Outside `.worktrees/`, or otherwise unaddressable | refuse, naming the real path |
| In-cone, name no longer points at it | refuse, naming the name that does |
| Matches nothing | exit non-zero, list candidates, say nothing was removed |

It is deliberately a **refusal, not a re-target**. `$tree` has ~65 downstream
uses, the lifecycle lock is keyed on `$name`, and the debris sweep and parent
`rmdir` walk are written against the constructed path — so pointing a deletion
at a path the caller did not name is the more dangerous repair. Every run that
proceeds behaves byte-for-byte as before, which is also why the gitlink
cleanup keeps its `.worktrees/`-only narrowness (AC 3) untouched, and why
removing a moved worktree *by its directory name* still works: that case was
already correct.

**No removal command is ever advertised.** An earlier revision paired the
refusal with `git worktree remove <path>`. That command applies none of this
script's guards — verified: it deletes a worktree holding an ignored `.env`
without a word, and takes a detached worktree whose HEAD is reachable from zero
refs. The refusal now names what would go unchecked instead.

**Path handling.** Worktree paths are read NUL-delimited; a path containing a
newline is legal and the line form truncates it. On git without
`--porcelain -z` (pre-2.36) the registry lookup is refused outright rather than
guessed at — line-delimited porcelain cannot represent such a path, and a
continuation line may legally look like a record key, so no parse recovers the
truth. Normal in-cone removal is unaffected.

**Fail-closed enumeration.** bash does not propagate a process-substitution
failure, so a truncated registry read was indistinguishable from a complete
one. It now carries a success sentinel, matching the two enumerators already in
this file.

**One rule for names.** `worktree_name_problem` is the single definition of
what this command accepts, used by the argument check, the remedy decision, and
the listing. It replaced three partial copies enforcing different subsets — and
consolidating fixed two of them, which had been letting absolute paths through
as candidate names.

## Verification

- `task verify` — green after every round · `task ci` — green
- **20 regression cases**: outside-cone, moved record, no-match, main-checkout
  basename, a linked worktree sharing it, newline truncation, ambiguity
  collisions, unaddressable remedies, listing labels, stale-record vs genuine
  removal, escaped diagnostics, pre-2.36 refusal, failed registry read
- **20 mutants, 0 survivors.** Three were retired with reasons rather than left
  as permanent survivors: two equivalent (no behavioural difference to detect)
  and one whose target this work deleted.

## Review budget

`rigor: deep (explicit instruction) → challenge ≤5, review ≤5, shepherd 4, min_rounds 1`

Challenge converged at 2 of ≤5. Review ran 5 configured rounds plus **one
additional round explicitly authorised by @evanharmon1**, and exited on a clean
capped final round. Nothing was deferred, so there is no `## Deferred findings`
section to settle.

## Decisions worth a second opinion

1. **A reviewer P1 was adjudicated down to P2** (challenge r2): slash-delimited
   names failing to resolve after a move. After `git worktree move`, nothing
   associates the old name with the tree — git keeps the record name and the
   current path only — so "no worktree or admin record named `feat/foo`" is
   true, the record name still resolves it, and the listing surfaces it.
   Overrule if you read it differently.
2. **Refuse vs. remove for out-of-cone worktrees.** AC 2 permits either. I chose
   refusal on risk grounds; review round 4 showed the cost is a dead end, which
   is what invited the unguarded workaround that had to be withdrawn.

## Settled during shepherding

- **Codex cloud review, P2** — the *initial* registry snapshot (`$registered`) is
  still line-delimited, so a worktree at `.worktrees/foo<LF>bar` truncates to the
  constructed path, sets `tree_is_registered=1`, and skips this PR's NUL-safe
  resolver. Reproduced by hand; **nothing is deleted** and the command fails
  loudly. **Filed as #989 rather than fixed here**: the same snapshot feeds the
  nested-worktree guard (#784), and restructuring a data-loss guard after the
  review budget is spent is the shape of change that produced this PR's own most
  serious finding. Answered in thread.

## Known residuals

- Resolution reads other worktrees' state while holding only `$name`'s lock. A
  concurrent `worktree:new` elsewhere could make the candidate list stale.
  Bounded: the outcome is always a refusal, so nothing is deleted on stale data.
- The stale-record message reports the **entry snapshot**, deliberately — the
  surrounding code snapshots at entry so a concurrent create cannot change the
  answer mid-run.
- The mutation harness asserts a mutation changed the file, but does not assert
  the suite is **green before mutating**. During this work a killed run stranded
  a mutation and a later run re-baselined the damaged file as correct; the suite
  passed twice with a fail-closed check missing.

<details>
<summary><h2>Adjudication record</h2></summary>

| Round | P0 | P1 | P2 | Outcome |
| --- | --- | --- | --- | --- |
| challenge r1 | 0 | 0 | 2 | main checkout counted in resolution; newline paths truncated. Fixing the second nearly shipped a total regression — `awk RS="\0"` reads one record, silently reducing resolution to the main worktree |
| challenge r2 | 0 | 0 | 4 | reviewer P1 → **P2** (see above); unusable remedy; ambiguity listed the whole registry; a test skip swallowed any setup failure. My first fix for the P1 was dead code and was deleted |
| review r1 | 0 | 0 | 1 | name rules applied in three partial copies → single predicate |
| review r2 | 0 | **1** | 0 | stale-record cleanup still claimed a removal — an unmet acceptance criterion I had read past repeatedly |
| review r3 | 0 | 0 | 1 | the location clause interpolated a path raw while only the remedy was escaped |
| review r4 | 0 | **2** | 0 | the refusal advertised an unguarded removal; the pre-2.36 fallback resolved a truncated prefix |
| review r5 (cap) | 0 | **1** | 2 | the listing rendered that same command as a label; the structural check was walkable past; a shim heredoc executed a substitution in its own comment |
| review r6 (authorised) | 0 | 0 | 1 | enumeration did not fail closed — a convention this file already set twice |

Three of the four P1s share one shape: **fixed in one place, left in its
equivalent elsewhere.** The core resolution logic drew no finding after
challenge r2; every later finding was in the diagnostic surface or in path
handling.

</details>

Closes #963
