### PR TITLE
fix: report only what clean:branches will act on, and flag stale inputs

### DIFF
--- a/scripts/audit-session-artifacts.sh
+++ b/scripts/audit-session-artifacts.sh
@@ -191,15 +191,41 @@ else
         if [ "$merged_seen" -ge "$pr_limit" ]; then
             echo "  (note: merged-PR listing hit its $pr_limit cap — 'no merged PR' below may be incomplete)"
         fi
+        # A branch checked out in a linked worktree is one `clean:branches`
+        # will refuse — `git branch -d` declines it, and that task guards the
+        # update-ref path explicitly. Counting it as prunable made this report
+        # hand the operator a number and name the very task that would decline
+        # part of it (harmon-init#958). Same derivation clean-branches.sh uses,
+        # so the two cannot disagree about what is checked out.
+        #
+        # A worktree PATH may contain a newline, which this line-delimited form
+        # truncates; a branch NAME cannot (git refnames forbid control
+        # characters), so the classification below is unaffected and only a
+        # displayed path could be short.
+        git worktree list --porcelain | awk '
+            /^worktree /            { path = substr($0, 10) }
+            /^branch refs\/heads\// { printf "%s\t%s\n", substr($0, 19), path }
+        ' >"$tmp/checked-out"
+
         prunable=0
+        held=0
         tip_differs=0
         no_pr=0
         while IFS=$'\t' read -r branch tip; do
             match="$(awk -F'\t' -v b="$branch" -v tip="$tip" -v base="$default_branch" \
                 '$1 == b && $2 == tip && $4 == base { print $3; exit }' "$tmp/merged-prs")"
             if [ -n "$match" ]; then
-                printf '  prunable      %s — merged PR #%s into %s (head == tip %s)\n' "$branch" "$match" "$default_branch" "${tip:0:12}"
-                prunable=$((prunable + 1))
+                held_path="$(awk -F'\t' -v b="$branch" '$1 == b { print $2; exit }' "$tmp/checked-out")"
+                if [ -n "$held_path" ]; then
+                    # Still shown — the evidence is real and the operator
+                    # should see it — but not counted toward a total
+                    # attributed to a task that will decline it.
+                    printf '  held          %s — merged PR #%s, but checked out in worktree %s\n' "$branch" "$match" "$held_path"
+                    held=$((held + 1))
+                else
+                    printf '  prunable      %s — merged PR #%s into %s (head == tip %s)\n' "$branch" "$match" "$default_branch" "${tip:0:12}"
+                    prunable=$((prunable + 1))
+                fi
             elif awk -F'\t' -v b="$branch" '$1 == b { found = 1; exit } END { exit !found }' "$tmp/merged-prs"; then
                 printf '  tip differs   %s — a merged PR matches by name but not tip/base (a human decides)\n' "$branch"
                 tip_differs=$((tip_differs + 1))
@@ -208,8 +234,16 @@ else
                 no_pr=$((no_pr + 1))
             fi
         done <"$tmp/gone"
-        printf '  -> %s prunable (task clean:branches), %s tip-differs, %s without a merged PR\n' \
-            "$prunable" "$tip_differs" "$no_pr"
+        # The invariant this line now keeps: the figure attributed to
+        # `clean:branches` equals what that task reports as deletable on the
+        # same tree.
+        if [ "$held" -gt 0 ]; then
+            printf '  -> %s prunable (task clean:branches), %s held by a worktree, %s tip-differs, %s without a merged PR\n' \
+                "$prunable" "$held" "$tip_differs" "$no_pr"
+        else
+            printf '  -> %s prunable (task clean:branches), %s tip-differs, %s without a merged PR\n' \
+                "$prunable" "$tip_differs" "$no_pr"
+        fi
     else
         echo "  UNVERIFIED — gh unavailable or the merged-PR read failed; $gone_count gone branch(es) unclassified:"
         awk -F'\t' '{ print "    " $1 }' "$tmp/gone"

--- a/scripts/audit-session-artifacts.sh
+++ b/scripts/audit-session-artifacts.sh
@@ -136,24 +136,38 @@ elif net_probe git ls-remote --symref "$remote" HEAD "refs/heads/*" >"$tmp/remot
         default_branch="$live_default"
     fi
     awk '$1 != "ref:" && $2 != "HEAD"' "$tmp/remote-heads-raw" >"$tmp/remote-heads"
-    # Full refname with a dynamic strip, not %(refname:lstrip=3): a remote
-    # name may itself contain slashes, and a fixed strip depth would mangle
-    # every tracking ref into a false "deleted upstream" (review r2).
-    git for-each-ref "refs/remotes/$remote" \
-        --format='%(refname)%09%(objectname)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)' \
-        >"$tmp/tracking"
-    while IFS=$'\t' read -r tref toid tsymref; do
-        [ "$tsymref" = "-" ] || continue
-        tname="${tref#refs/remotes/$remote/}"
-        live_oid="$(awk -v r="refs/heads/$tname" '$2 == r { print $1; exit }' "$tmp/remote-heads")"
-        if [ -z "$live_oid" ]; then
-            printf '  stale  %s — deleted upstream; local tracking ref survives until a prune\n' "$tname"
-            stale=$((stale + 1))
-        elif [ "$live_oid" != "$toid" ]; then
-            printf '  stale  %s — moved upstream (local tracking is behind or diverged)\n' "$tname"
-            stale=$((stale + 1))
-        fi
-    done <"$tmp/tracking"
+    # A tracking ref names `refs/heads/<same name>` only under the identity
+    # fetch refspec. Under `refs/heads/*:refs/remotes/origin/upstream/*`, or
+    # with extra refspecs pulling in e.g. pull refs, the local name is a
+    # DESTINATION — comparing it marks fresh refs stale and recommends a prune
+    # that can never clear the report. Say nothing rather than something false
+    # (found in clean:branches by challenge r1 on #958; the same expression was
+    # copied from here, so both are corrected together).
+    audit_fetch_specs="$(git config --get-all "remote.$remote.fetch" 2>/dev/null || true)"
+    if [ "$audit_fetch_specs" != "+refs/heads/*:refs/remotes/$remote/*" ] &&
+        [ "$audit_fetch_specs" != "refs/heads/*:refs/remotes/$remote/*" ]; then
+        echo "  n/a — $remote is fetched under a non-identity refspec, so a tracking name does not identify a remote branch"
+        : >"$tmp/tracking"
+    else
+        # Full refname with a dynamic strip, not %(refname:lstrip=3): a remote
+        # name may itself contain slashes, and a fixed strip depth would mangle
+        # every tracking ref into a false "deleted upstream" (review r2).
+        git for-each-ref "refs/remotes/$remote" \
+            --format='%(refname)%09%(objectname)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)' \
+            >"$tmp/tracking"
+        while IFS=$'\t' read -r tref toid tsymref; do
+            [ "$tsymref" = "-" ] || continue
+            tname="${tref#refs/remotes/$remote/}"
+            live_oid="$(awk -v r="refs/heads/$tname" '$2 == r { print $1; exit }' "$tmp/remote-heads")"
+            if [ -z "$live_oid" ]; then
+                printf '  stale  %s — deleted upstream; local tracking ref survives until a prune\n' "$tname"
+                stale=$((stale + 1))
+            elif [ "$live_oid" != "$toid" ]; then
+                printf '  stale  %s — moved upstream (local tracking is behind or diverged)\n' "$tname"
+                stale=$((stale + 1))
+            fi
+        done <"$tmp/tracking"
+    fi
     if [ "$stale" -eq 0 ]; then
         echo "  fresh — local tracking refs match the remote's advertised heads"
     else

--- a/scripts/audit-session-artifacts.sh
+++ b/scripts/audit-session-artifacts.sh
@@ -57,8 +57,11 @@ net_probe() {
 # %(refname:lstrip=2), not %(refname:short): when a tag shares a branch's
 # name, :short disambiguates to "heads/<name>" and every "refs/heads/$branch"
 # built from it dereferences nothing (challenge r1).
+# Sentinels on the optionally-empty fields: tab is IFS whitespace, so `read`
+# would COLLAPSE an empty middle field and shift %(symref) into the track
+# column. Same hazard, same fix, as clean-branches.sh.
 git for-each-ref refs/heads \
-    --format='%(refname:lstrip=2)%09%(objectname)%09%(upstream:track)' \
+    --format='%(refname:lstrip=2)%09%(objectname)%09%(if)%(upstream:track)%(then)%(upstream:track)%(else)-%(end)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)' \
     >"$tmp/branches"
 total_branches="$(wc -l <"$tmp/branches" | tr -d ' ')"
 
@@ -94,7 +97,7 @@ if [ "$has_remote" = false ]; then
     echo "No remote configured — every local commit is unpushed by definition; listing skipped."
 else
     unpushed_count=0
-    while IFS=$'\t' read -r branch _tip _track; do
+    while IFS=$'\t' read -r branch _tip _track _symref; do
         n="$(git rev-list --count "refs/heads/$branch" --not --remotes --)"
         if [ "$n" -gt 0 ]; then
             printf '  %s — %s commit(s) on no remote\n' "$branch" "$n"
@@ -186,7 +189,7 @@ fi
 # ── 2. Gone-upstream classification ─────────────────────────────────────────
 
 section "Branches whose upstream is gone"
-awk -F'\t' '$3 == "[gone]" { print $1 "\t" $2 }' "$tmp/branches" >"$tmp/gone"
+awk -F'\t' '$3 == "[gone]" { print $1 "\t" $2 "\t" $4 }' "$tmp/branches" >"$tmp/gone"
 gone_count="$(wc -l <"$tmp/gone" | tr -d ' ')"
 if [ "$gone_count" -eq 0 ]; then
     echo "  none"
@@ -231,10 +234,18 @@ else
         held=0
         tip_differs=0
         no_pr=0
-        while IFS=$'\t' read -r branch tip; do
+        while IFS=$'\t' read -r branch tip symref; do
             match="$(awk -F'\t' -v b="$branch" -v tip="$tip" -v base="$default_branch" \
                 '$1 == b && $2 == tip && $4 == base { print $3; exit }' "$tmp/merged-prs")"
-            if [ -n "$match" ]; then
+            if [ -n "$match" ] && [ "$symref" != "-" ]; then
+                # clean:branches skips every symbolic ref rather than
+                # dereferencing it, so evidence about its TARGET says nothing
+                # about the alias. Counting it prunable named a task that
+                # refuses it — the same defect as the worktree case above, in a
+                # second form (Codex review on PR #991).
+                printf '  held          %s — merged PR #%s, but it is a symbolic ref to %s (never dereferenced)\n' "$branch" "$match" "$symref"
+                held=$((held + 1))
+            elif [ -n "$match" ]; then
                 held_path="$(awk -F'\t' -v b="$branch" '$1 == b { print $2; exit }' "$tmp/checked-out")"
                 if [ -n "$held_path" ]; then
                     # Still shown — the evidence is real and the operator

--- a/scripts/audit-session-artifacts.sh
+++ b/scripts/audit-session-artifacts.sh
@@ -269,7 +269,13 @@ else
         # `clean:branches` equals what that task reports as deletable on the
         # same tree.
         if [ "$held" -gt 0 ]; then
-            printf '  -> %s prunable (task clean:branches), %s held by a worktree, %s tip-differs, %s without a merged PR\n' \
+            # "held" covers two distinct reasons — a worktree checkout and a
+            # symbolic ref — so the bucket is labelled generically. Saying
+            # "held by a worktree" told the operator the wrong reason whenever
+            # a symbolic hold was in the count, or the only thing in it (Codex
+            # review on PR #991). Each entry names its own reason above; the
+            # aggregate does not have to guess at one.
+            printf '  -> %s prunable (task clean:branches), %s held (see above), %s tip-differs, %s without a merged PR\n' \
                 "$prunable" "$held" "$tip_differs" "$no_pr"
         else
             printf '  -> %s prunable (task clean:branches), %s tip-differs, %s without a merged PR\n' \

--- a/scripts/audit-session-artifacts.sh
+++ b/scripts/audit-session-artifacts.sh
@@ -113,6 +113,7 @@ fi
 # here until a fetch --prune — its local branch reads neither [gone] nor
 # unpushed (challenge r2). One bounded read of the remote's advertised heads
 # makes that staleness explicit instead of silent.
+freshness_indeterminate=0
 section "Remote-tracking freshness"
 if [ "$has_remote" = false ]; then
     echo "  n/a — no remote configured"
@@ -148,6 +149,7 @@ elif net_probe git ls-remote --symref "$remote" HEAD "refs/heads/*" >"$tmp/remot
         [ "$audit_fetch_specs" != "refs/heads/*:refs/remotes/$remote/*" ]; then
         echo "  n/a — $remote is fetched under a non-identity refspec, so a tracking name does not identify a remote branch"
         : >"$tmp/tracking"
+        freshness_indeterminate=1
     else
         # Full refname with a dynamic strip, not %(refname:lstrip=3): a remote
         # name may itself contain slashes, and a fixed strip depth would mangle
@@ -168,7 +170,11 @@ elif net_probe git ls-remote --symref "$remote" HEAD "refs/heads/*" >"$tmp/remot
             fi
         done <"$tmp/tracking"
     fi
-    if [ "$stale" -eq 0 ]; then
+    if [ "${freshness_indeterminate:-0}" -eq 1 ]; then
+        # Nothing was compared, so "fresh" would contradict the n/a above and
+        # claim a verification that did not happen (challenge r2).
+        :
+    elif [ "$stale" -eq 0 ]; then
         echo "  fresh — local tracking refs match the remote's advertised heads"
     else
         echo "  -> $stale stale tracking ref(s): run 'task clean:remote-refs' (git fetch --prune), then re-run this audit"

--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -234,7 +234,7 @@ merged_pr_for() {
 # whitespace, so `read` would otherwise COLLAPSE an empty middle field and
 # shift %(symref) into the track column.
 git for-each-ref refs/heads \
-    --format='%(refname:lstrip=2)%09%(objectname)%09%(if)%(upstream:track)%(then)%(upstream:track)%(else)-%(end)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)%09%(if)%(upstream)%(then)u%(else)-%(end)' \
+    --format='%(refname:lstrip=2)%09%(objectname)%09%(if)%(upstream:track)%(then)%(upstream:track)%(else)-%(end)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)%09%(if)%(upstream)%(then)%(upstream)%(else)-%(end)' \
     >"$tmp/branches"
 
 total=0
@@ -243,7 +243,7 @@ refused=0
 active=0
 active_tracked=0
 
-while IFS=$'\t' read -r branch tip track symref has_upstream; do
+while IFS=$'\t' read -r branch tip track symref upstream_ref; do
     total=$((total + 1))
 
     [ "$branch" = "$current_branch" ] && continue
@@ -333,10 +333,19 @@ while IFS=$'\t' read -r branch tip track symref has_upstream; do
     # branches, which no prune can affect — a warning that fires in the common
     # case is one nobody reads (Codex review on PR #991).
     #
-    # Upstream PRESENCE, not %(upstream:track): that is empty for a branch in
-    # sync with its upstream, so it cannot tell "no upstream" from "up to date"
-    # — which is exactly the distinction needed here.
-    [ "$has_upstream" = "-" ] || active_tracked=$((active_tracked + 1))
+    # The upstream REF, not merely its presence, and not %(upstream:track):
+    # track is empty for a branch in sync with its upstream, so it cannot tell
+    # "no upstream" from "up to date"; and presence alone counts a branch that
+    # tracks another LOCAL branch (branch.<name>.remote=.), whose upstream is
+    # under refs/heads/ and which no prune can affect.
+    #
+    # refs/remotes/ is the terminal test rather than another narrowing in a
+    # series: `task clean:remote-refs` is `git fetch --all --prune`, so it
+    # affects exactly the refs under that prefix — every one of them, and
+    # nothing else. Whichever remote they belong to.
+    case "$upstream_ref" in
+    refs/remotes/*) active_tracked=$((active_tracked + 1)) ;;
+    esac
 done <"$tmp/branches"
 
 # ── Act (or report) ─────────────────────────────────────────────────────────

--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -237,71 +237,6 @@ git for-each-ref refs/heads \
     --format='%(refname:lstrip=2)%09%(objectname)%09%(if)%(upstream:track)%(then)%(upstream:track)%(else)-%(end)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)' \
     >"$tmp/branches"
 
-# Remote-tracking freshness, reported the way audit:session-artifacts already
-# reports it (harmon-init#958). Every classification below reads local tracking
-# refs, so a branch whose upstream was deleted on merge reads as neither [gone]
-# nor unpushed until a prune — and lands in `in-flight kept`, a bucket that says
-# "deliberately left alone" rather than "I could not tell". Observed: a merged
-# branch sat there until `task clean:remote-refs`, after which the same run
-# reported it deletable.
-#
-# This is deliberately its own probe rather than a widening of
-# verify_remote_state: that runs ONLY on the delete path, and the misleading
-# figure is the one the DRY RUN prints. Bounded, and skipped entirely when
-# there is no remote.
-tracking_freshness_note=""
-check_tracking_freshness() {
-    # No guard needed: this script exits early when no remote is configured, so
-    # $remote is always resolved by the time this runs.
-    #
-    # A tracking ref only corresponds to `refs/heads/<same name>` when the
-    # remote is fetched under the identity refspec. Under
-    # `refs/heads/*:refs/remotes/origin/upstream/*`, or with extra refspecs
-    # bringing in pull refs, the local name is a destination and not a remote
-    # branch — comparing it would mark fresh refs stale and recommend a prune
-    # that can never clear the warning (challenge r1). Say nothing rather than
-    # say something false.
-    fetch_specs="$(git config --get-all "remote.$remote.fetch" 2>/dev/null || true)"
-    if [ "$fetch_specs" != "+refs/heads/*:refs/remotes/$remote/*" ] &&
-        [ "$fetch_specs" != "refs/heads/*:refs/remotes/$remote/*" ]; then
-        tracking_freshness_note="clean:branches: not checking tracking-ref freshness — $remote is fetched under a non-identity refspec, so a local tracking name does not identify a remote branch"
-        return 0
-    fi
-    # HEAD is requested alongside the heads: `--heads` alone omits it, and a
-    # renamed default branch whose old name still exists would then report
-    # every ref current while the classification above ran against a stale
-    # local default (challenge r1). The audit already probes it this way.
-    if ! heads_raw="$(net_probe git ls-remote --symref "$remote" HEAD "refs/heads/*" 2>/dev/null)"; then
-        tracking_freshness_note="clean:branches: could not read $remote's advertised heads — the classification above trusts possibly-stale tracking refs (run 'task clean:remote-refs', then re-run)"
-        return 0
-    fi
-    printf '%s\n' "$heads_raw" >"$tmp/live-heads"
-    live_default_head="$(awk '$1 == "ref:" && $3 == "HEAD" { sub("^refs/heads/", "", $2); print $2; exit }' "$tmp/live-heads")"
-    if [ -n "$live_default_head" ] && [ "$live_default_head" != "$default_branch" ]; then
-        tracking_freshness_note="clean:branches: the remote's default branch is now '$live_default_head', not '$default_branch' — the classification above used the stale local record (run 'git remote set-head $remote --auto && task clean:remote-refs', then re-run)"
-        return 0
-    fi
-    stale_refs=0
-    while IFS=$'\t' read -r tref toid tsymref; do
-        [ "$tsymref" = "-" ] || continue
-        tname="${tref#refs/remotes/$remote/}"
-        live_oid="$(awk -v r="refs/heads/$tname" '$1 != "ref:" && $2 == r { print $1; exit }' "$tmp/live-heads")"
-        if [ -z "$live_oid" ] || [ "$live_oid" != "$toid" ]; then
-            stale_refs=$((stale_refs + 1))
-        fi
-    done < <(git for-each-ref "refs/remotes/$remote" \
-        --format='%(refname)%09%(objectname)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)')
-    if [ "$stale_refs" -gt 0 ]; then
-        tracking_freshness_note="clean:branches: $stale_refs tracking ref(s) are stale — a branch whose upstream is already gone can read as in-flight until you run 'task clean:remote-refs' and re-run"
-    fi
-}
-
-# Probed against the SAME tracking state the classification below reads. Run at
-# the end instead, a fetch landing mid-run would refresh the refs and silence
-# the caveat while the summary still described the stale ones (challenge r1).
-# The note is printed with the summary; only the measurement happens here.
-check_tracking_freshness
-
 total=0
 candidates=0
 refused=0
@@ -545,17 +480,32 @@ if [ -s "$tmp/candidates" ]; then
     done <"$tmp/candidates"
 fi
 
+# Every classification above reads LOCAL tracking refs, so a branch whose
+# upstream was deleted on merge reads as neither [gone] nor unpushed and lands
+# in `in-flight kept` — a bucket that means "deliberately left alone" rather
+# than "I could not tell". Say so whenever that bucket is non-empty.
+#
+# Deliberately NOT a live probe. An earlier revision asked the remote which
+# refs were stale, and the exactness cost more than it bought: the answer has
+# to be captured atomically with the classification snapshot or a concurrent
+# fetch silences it, it needs the HEAD symref to notice a renamed default, and
+# it is meaningless under a non-identity fetch refspec. Six findings across two
+# review rounds, all in the probe, none in the reporting this issue is about.
+# The issue asks only that the task "performs, or explicitly reports the
+# absence of" the check, and says a one-line note would be enough. This is that
+# note: deterministic, no network, and impossible to race.
+tracking_caveat() {
+    [ "$active" -gt 0 ] || return 0
+    echo "clean:branches: $active branch(es) kept as in-flight are classified from local tracking refs — if you have not pruned recently, run 'task clean:remote-refs' and re-run, since a branch whose upstream is already gone reads as in-flight until then."
+}
+
 echo
 if [ "$do_delete" = true ]; then
     echo "clean:branches: $deleted deleted, $refused skipped, $active in-flight kept, $total local branches scanned."
-    if [ -n "$tracking_freshness_note" ]; then
-        echo "$tracking_freshness_note"
-    fi
+    tracking_caveat
 else
     echo "clean:branches (dry run): $candidates deletable, $refused skipped, $active in-flight kept, $total local branches scanned."
-    if [ -n "$tracking_freshness_note" ]; then
-        echo "$tracking_freshness_note"
-    fi
+    tracking_caveat
     if [ "$candidates" -gt 0 ]; then
         echo "Run 'task clean:branches -- --delete' to delete the branches listed above."
     fi

--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -516,7 +516,14 @@ fi
 # note: deterministic, no network, and impossible to race.
 tracking_caveat() {
     [ "$active_tracked" -gt 0 ] || return 0
-    echo "clean:branches: $active_tracked of the $active branch(es) kept as in-flight have an upstream and were classified from local tracking refs — if you have not pruned recently, run 'task clean:remote-refs' and re-run, since a branch whose upstream is already gone reads as in-flight until then."
+    # No count. The predicate below decides WHETHER this is relevant, and that
+    # is worth getting right; the figure is not. It needed redefining four
+    # times — the aggregate in-flight count, then upstream presence, then
+    # %(upstream:track) versus presence, then local-upstream branches — and a
+    # remote configured `skipFetchAll` would have made it wrong again, since
+    # the remedy below is `fetch --all --prune` and that skips such a remote.
+    # A sentence that names the condition needs none of those distinctions.
+    echo "clean:branches: some branches kept as in-flight were classified from local tracking refs, and a branch whose upstream is already gone reads as in-flight until you prune. If in doubt, run 'task clean:remote-refs' — plus an explicit fetch for any remote set to skipFetchAll, which 'fetch --all' passes over — and re-run."
 }
 
 echo

--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -375,6 +375,42 @@ verify_remote_state() {
     fi
 }
 
+# Remote-tracking freshness, reported the way audit:session-artifacts already
+# reports it (harmon-init#958). Every classification below reads local tracking
+# refs, so a branch whose upstream was deleted on merge reads as neither [gone]
+# nor unpushed until a prune — and lands in `in-flight kept`, a bucket that says
+# "deliberately left alone" rather than "I could not tell". Observed: a merged
+# branch sat there until `task clean:remote-refs`, after which the same run
+# reported it deletable.
+#
+# This is deliberately its own probe rather than a widening of
+# verify_remote_state: that runs ONLY on the delete path, and the misleading
+# figure is the one the DRY RUN prints. Bounded, and skipped entirely when
+# there is no remote.
+tracking_freshness_note=""
+check_tracking_freshness() {
+    # No guard needed: this script exits early when no remote is configured, so
+    # $remote is always resolved by the time this runs.
+    if ! heads_raw="$(net_probe git ls-remote --heads "$remote" 2>/dev/null)"; then
+        tracking_freshness_note="clean:branches: could not read $remote's advertised heads — the classification above trusts possibly-stale tracking refs (run 'task clean:remote-refs', then re-run)"
+        return 0
+    fi
+    printf '%s\n' "$heads_raw" >"$tmp/live-heads"
+    stale_refs=0
+    while IFS=$'\t' read -r tref toid tsymref; do
+        [ "$tsymref" = "-" ] || continue
+        tname="${tref#refs/remotes/$remote/}"
+        live_oid="$(awk -v r="refs/heads/$tname" '$2 == r { print $1; exit }' "$tmp/live-heads")"
+        if [ -z "$live_oid" ] || [ "$live_oid" != "$toid" ]; then
+            stale_refs=$((stale_refs + 1))
+        fi
+    done < <(git for-each-ref "refs/remotes/$remote" \
+        --format='%(refname)%09%(objectname)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)')
+    if [ "$stale_refs" -gt 0 ]; then
+        tracking_freshness_note="clean:branches: $stale_refs tracking ref(s) are stale — a branch whose upstream is already gone can read as in-flight until you run 'task clean:remote-refs' and re-run"
+    fi
+}
+
 # delete_one <branch> <tip> <evidence> <why> — runs in a SUBSHELL so a lock
 # refusal (die) aborts this branch only. The whole check-then-delete sequence
 # holds the per-branch lifecycle lock shared with worktree:new / worktree:rm
@@ -480,11 +516,21 @@ if [ -s "$tmp/candidates" ]; then
     done <"$tmp/candidates"
 fi
 
+# Run once, after classification and before the summary, so the figure and the
+# caveat about it are printed together.
+check_tracking_freshness
+
 echo
 if [ "$do_delete" = true ]; then
     echo "clean:branches: $deleted deleted, $refused skipped, $active in-flight kept, $total local branches scanned."
+    if [ -n "$tracking_freshness_note" ]; then
+        echo "$tracking_freshness_note"
+    fi
 else
     echo "clean:branches (dry run): $candidates deletable, $refused skipped, $active in-flight kept, $total local branches scanned."
+    if [ -n "$tracking_freshness_note" ]; then
+        echo "$tracking_freshness_note"
+    fi
     if [ "$candidates" -gt 0 ]; then
         echo "Run 'task clean:branches -- --delete' to delete the branches listed above."
     fi

--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -237,6 +237,71 @@ git for-each-ref refs/heads \
     --format='%(refname:lstrip=2)%09%(objectname)%09%(if)%(upstream:track)%(then)%(upstream:track)%(else)-%(end)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)' \
     >"$tmp/branches"
 
+# Remote-tracking freshness, reported the way audit:session-artifacts already
+# reports it (harmon-init#958). Every classification below reads local tracking
+# refs, so a branch whose upstream was deleted on merge reads as neither [gone]
+# nor unpushed until a prune — and lands in `in-flight kept`, a bucket that says
+# "deliberately left alone" rather than "I could not tell". Observed: a merged
+# branch sat there until `task clean:remote-refs`, after which the same run
+# reported it deletable.
+#
+# This is deliberately its own probe rather than a widening of
+# verify_remote_state: that runs ONLY on the delete path, and the misleading
+# figure is the one the DRY RUN prints. Bounded, and skipped entirely when
+# there is no remote.
+tracking_freshness_note=""
+check_tracking_freshness() {
+    # No guard needed: this script exits early when no remote is configured, so
+    # $remote is always resolved by the time this runs.
+    #
+    # A tracking ref only corresponds to `refs/heads/<same name>` when the
+    # remote is fetched under the identity refspec. Under
+    # `refs/heads/*:refs/remotes/origin/upstream/*`, or with extra refspecs
+    # bringing in pull refs, the local name is a destination and not a remote
+    # branch — comparing it would mark fresh refs stale and recommend a prune
+    # that can never clear the warning (challenge r1). Say nothing rather than
+    # say something false.
+    fetch_specs="$(git config --get-all "remote.$remote.fetch" 2>/dev/null || true)"
+    if [ "$fetch_specs" != "+refs/heads/*:refs/remotes/$remote/*" ] &&
+        [ "$fetch_specs" != "refs/heads/*:refs/remotes/$remote/*" ]; then
+        tracking_freshness_note="clean:branches: not checking tracking-ref freshness — $remote is fetched under a non-identity refspec, so a local tracking name does not identify a remote branch"
+        return 0
+    fi
+    # HEAD is requested alongside the heads: `--heads` alone omits it, and a
+    # renamed default branch whose old name still exists would then report
+    # every ref current while the classification above ran against a stale
+    # local default (challenge r1). The audit already probes it this way.
+    if ! heads_raw="$(net_probe git ls-remote --symref "$remote" HEAD "refs/heads/*" 2>/dev/null)"; then
+        tracking_freshness_note="clean:branches: could not read $remote's advertised heads — the classification above trusts possibly-stale tracking refs (run 'task clean:remote-refs', then re-run)"
+        return 0
+    fi
+    printf '%s\n' "$heads_raw" >"$tmp/live-heads"
+    live_default_head="$(awk '$1 == "ref:" && $3 == "HEAD" { sub("^refs/heads/", "", $2); print $2; exit }' "$tmp/live-heads")"
+    if [ -n "$live_default_head" ] && [ "$live_default_head" != "$default_branch" ]; then
+        tracking_freshness_note="clean:branches: the remote's default branch is now '$live_default_head', not '$default_branch' — the classification above used the stale local record (run 'git remote set-head $remote --auto && task clean:remote-refs', then re-run)"
+        return 0
+    fi
+    stale_refs=0
+    while IFS=$'\t' read -r tref toid tsymref; do
+        [ "$tsymref" = "-" ] || continue
+        tname="${tref#refs/remotes/$remote/}"
+        live_oid="$(awk -v r="refs/heads/$tname" '$1 != "ref:" && $2 == r { print $1; exit }' "$tmp/live-heads")"
+        if [ -z "$live_oid" ] || [ "$live_oid" != "$toid" ]; then
+            stale_refs=$((stale_refs + 1))
+        fi
+    done < <(git for-each-ref "refs/remotes/$remote" \
+        --format='%(refname)%09%(objectname)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)')
+    if [ "$stale_refs" -gt 0 ]; then
+        tracking_freshness_note="clean:branches: $stale_refs tracking ref(s) are stale — a branch whose upstream is already gone can read as in-flight until you run 'task clean:remote-refs' and re-run"
+    fi
+}
+
+# Probed against the SAME tracking state the classification below reads. Run at
+# the end instead, a fetch landing mid-run would refresh the refs and silence
+# the caveat while the summary still described the stale ones (challenge r1).
+# The note is printed with the summary; only the measurement happens here.
+check_tracking_freshness
+
 total=0
 candidates=0
 refused=0
@@ -375,42 +440,6 @@ verify_remote_state() {
     fi
 }
 
-# Remote-tracking freshness, reported the way audit:session-artifacts already
-# reports it (harmon-init#958). Every classification below reads local tracking
-# refs, so a branch whose upstream was deleted on merge reads as neither [gone]
-# nor unpushed until a prune — and lands in `in-flight kept`, a bucket that says
-# "deliberately left alone" rather than "I could not tell". Observed: a merged
-# branch sat there until `task clean:remote-refs`, after which the same run
-# reported it deletable.
-#
-# This is deliberately its own probe rather than a widening of
-# verify_remote_state: that runs ONLY on the delete path, and the misleading
-# figure is the one the DRY RUN prints. Bounded, and skipped entirely when
-# there is no remote.
-tracking_freshness_note=""
-check_tracking_freshness() {
-    # No guard needed: this script exits early when no remote is configured, so
-    # $remote is always resolved by the time this runs.
-    if ! heads_raw="$(net_probe git ls-remote --heads "$remote" 2>/dev/null)"; then
-        tracking_freshness_note="clean:branches: could not read $remote's advertised heads — the classification above trusts possibly-stale tracking refs (run 'task clean:remote-refs', then re-run)"
-        return 0
-    fi
-    printf '%s\n' "$heads_raw" >"$tmp/live-heads"
-    stale_refs=0
-    while IFS=$'\t' read -r tref toid tsymref; do
-        [ "$tsymref" = "-" ] || continue
-        tname="${tref#refs/remotes/$remote/}"
-        live_oid="$(awk -v r="refs/heads/$tname" '$2 == r { print $1; exit }' "$tmp/live-heads")"
-        if [ -z "$live_oid" ] || [ "$live_oid" != "$toid" ]; then
-            stale_refs=$((stale_refs + 1))
-        fi
-    done < <(git for-each-ref "refs/remotes/$remote" \
-        --format='%(refname)%09%(objectname)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)')
-    if [ "$stale_refs" -gt 0 ]; then
-        tracking_freshness_note="clean:branches: $stale_refs tracking ref(s) are stale — a branch whose upstream is already gone can read as in-flight until you run 'task clean:remote-refs' and re-run"
-    fi
-}
-
 # delete_one <branch> <tip> <evidence> <why> — runs in a SUBSHELL so a lock
 # refusal (die) aborts this branch only. The whole check-then-delete sequence
 # holds the per-branch lifecycle lock shared with worktree:new / worktree:rm
@@ -515,10 +544,6 @@ if [ -s "$tmp/candidates" ]; then
         esac
     done <"$tmp/candidates"
 fi
-
-# Run once, after classification and before the summary, so the figure and the
-# caveat about it are printed together.
-check_tracking_freshness
 
 echo
 if [ "$do_delete" = true ]; then

--- a/scripts/clean-branches.sh
+++ b/scripts/clean-branches.sh
@@ -234,15 +234,16 @@ merged_pr_for() {
 # whitespace, so `read` would otherwise COLLAPSE an empty middle field and
 # shift %(symref) into the track column.
 git for-each-ref refs/heads \
-    --format='%(refname:lstrip=2)%09%(objectname)%09%(if)%(upstream:track)%(then)%(upstream:track)%(else)-%(end)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)' \
+    --format='%(refname:lstrip=2)%09%(objectname)%09%(if)%(upstream:track)%(then)%(upstream:track)%(else)-%(end)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)%09%(if)%(upstream)%(then)u%(else)-%(end)' \
     >"$tmp/branches"
 
 total=0
 candidates=0
 refused=0
 active=0
+active_tracked=0
 
-while IFS=$'\t' read -r branch tip track symref; do
+while IFS=$'\t' read -r branch tip track symref has_upstream; do
     total=$((total + 1))
 
     [ "$branch" = "$current_branch" ] && continue
@@ -326,6 +327,16 @@ while IFS=$'\t' read -r branch tip track symref; do
         continue
     fi
     active=$((active + 1))
+    # Only a branch with an upstream can have been classified from a tracking
+    # ref, so only those make the freshness caveat relevant. Keying the caveat
+    # on the aggregate count instead warned about ordinary local-only feature
+    # branches, which no prune can affect — a warning that fires in the common
+    # case is one nobody reads (Codex review on PR #991).
+    #
+    # Upstream PRESENCE, not %(upstream:track): that is empty for a branch in
+    # sync with its upstream, so it cannot tell "no upstream" from "up to date"
+    # — which is exactly the distinction needed here.
+    [ "$has_upstream" = "-" ] || active_tracked=$((active_tracked + 1))
 done <"$tmp/branches"
 
 # ── Act (or report) ─────────────────────────────────────────────────────────
@@ -495,8 +506,8 @@ fi
 # absence of" the check, and says a one-line note would be enough. This is that
 # note: deterministic, no network, and impossible to race.
 tracking_caveat() {
-    [ "$active" -gt 0 ] || return 0
-    echo "clean:branches: $active branch(es) kept as in-flight are classified from local tracking refs — if you have not pruned recently, run 'task clean:remote-refs' and re-run, since a branch whose upstream is already gone reads as in-flight until then."
+    [ "$active_tracked" -gt 0 ] || return 0
+    echo "clean:branches: $active_tracked of the $active branch(es) kept as in-flight have an upstream and were classified from local tracking refs — if you have not pruned recently, run 'task clean:remote-refs' and re-run, since a branch whose upstream is already gone reads as in-flight until then."
 }
 
 echo

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -395,31 +395,55 @@ echo "ok: every branch the audit calls prunable is one clean:branches would dele
 # kept` — a bucket that says "deliberately left alone", not "I could not tell".
 # The audit has said so since it was written; the task that actually deletes
 # did not (harmon-init#958). The fixture's tf-stale ref is exactly that shape.
-expect_contains "$dry_out" "have an upstream and were classified from local tracking refs" "clean:branches: the in-flight bucket carries its caveat"
+expect_contains "$dry_out" "were classified from local tracking refs" "clean:branches: the in-flight bucket carries its caveat"
+expect_contains "$dry_out" "skipFetchAll" "clean:branches: the remedy names the remote fetch --all passes over"
 expect_contains "$dry_out" "task clean:remote-refs" "clean:branches: the caveat names the remedy"
 # The caveat must count only branches an upstream could have misclassified.
 # The fixture's unpushed-live has none, so it must not be included: keying on
 # the aggregate in-flight count warned about ordinary local-only branches, and
 # a caveat that fires in the common case is one nobody reads (Codex, PR #991).
-caveat_tracked="$(printf '%s\n' "$dry_out" |
-    sed -n 's/^clean:branches: \([0-9][0-9]*\) of the \([0-9][0-9]*\) branch(es).*/\1/p' | head -1)"
-caveat_total="$(printf '%s\n' "$dry_out" |
-    sed -n 's/^clean:branches: \([0-9][0-9]*\) of the \([0-9][0-9]*\) branch(es).*/\2/p' | head -1)"
-[ -n "$caveat_tracked" ] || fail "the in-flight caveat did not report a tracked count (#958)"
-[ "$caveat_tracked" -lt "$caveat_total" ] ||
-    fail "the caveat counted every in-flight branch ($caveat_tracked of $caveat_total) — unpushed-live has no upstream and must be excluded (#958)"
-# local-upstream HAS an upstream, so presence alone would count it — but that
-# upstream is under refs/heads/ and no prune can affect it. Only a
-# remote-tracking upstream belongs in this figure.
-localup_upstream="$(git -C "$fixture" for-each-ref refs/heads/local-upstream --format='%(upstream)')"
-[ -n "$localup_upstream" ] ||
-    fail "the local-upstream fixture lost its upstream — the case cannot distinguish anything (#958)"
-case "$localup_upstream" in
-refs/remotes/*) fail "the local-upstream fixture tracks a REMOTE ref; it must track a local branch (#958)" ;;
-esac
-[ "$caveat_tracked" -le 2 ] ||
-    fail "the caveat counted a locally-tracking branch ($caveat_tracked) — only remote-backed upstreams belong in it (#958)"
+# The caveat no longer prints a count — the figure needed redefining four
+# times and a skipFetchAll remote would have broken it again. What must hold is
+# that it fires only when a remote-backed upstream is in play: unpushed-live
+# and local-upstream must not, on their own, be able to trigger it.
+expect_not_contains "$dry_out" " of the " "clean:branches: the caveat asserts no count (#958)"
 
+# Suppression needs its OWN repository: the main fixture always has a
+# remote-tracking in-flight branch, so it can only ever show the caveat firing.
+# Without this, keying the caveat back on the aggregate in-flight count passes
+# every assertion above (mutant M9).
+untracked_only="$test_tmp/untracked-only"
+untracked_origin="$test_tmp/untracked-only-origin.git"
+git init -q --bare --initial-branch=main "$untracked_origin"
+git init -q --initial-branch=main "$untracked_only"
+(
+    cd "$untracked_only"
+    git config user.name "Session Cleanup Test"
+    git config user.email "session-cleanup@example.invalid"
+    git config commit.gpgsign false
+    git remote add origin "$untracked_origin"
+    echo seed >seed.txt
+    git add seed.txt
+    git commit -qm "chore: seed"
+    git push -q origin main
+    # Its OWN unmerged commit: a branch sitting at main's tip is deletable by
+    # ancestry, not kept in-flight, and would exercise nothing here.
+    git checkout -q -b local-only-work
+    echo local >local.txt
+    git add local.txt
+    git commit -qm "local-only work"
+    git checkout -q main
+)
+mkdir -p "$untracked_only/scripts"
+cp "$repo/scripts/clean-branches.sh" "$untracked_only/scripts/"
+untracked_out="$(cd "$untracked_only" && bash scripts/clean-branches.sh 2>&1)" ||
+    fail "untracked-only dry run exited nonzero: $untracked_out"
+# The summary line prints "N in-flight kept" even when N is zero, so match the
+# count, not the phrase — otherwise this passes against a fixture that keeps
+# nothing and the suppression below proves nothing.
+expect_contains "$untracked_out" "1 in-flight kept" "untracked-only: the local branch is kept in-flight"
+expect_not_contains "$untracked_out" "classified from local tracking refs" \
+    "clean:branches: no caveat when no in-flight branch has a remote-backed upstream (#958)"
 # Degraded mode: a failing gh probe is UNVERIFIED, never silently clean.
 audit_fail_out="$(cd "$fixture" && GH_STUB_FAIL=1 bash scripts/audit-session-artifacts.sh 2>&1)" ||
     fail "degraded audit exited nonzero: $audit_fail_out"

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -375,8 +375,8 @@ echo "ok: every branch the audit calls prunable is one clean:branches would dele
 # kept` — a bucket that says "deliberately left alone", not "I could not tell".
 # The audit has said so since it was written; the task that actually deletes
 # did not (harmon-init#958). The fixture's tf-stale ref is exactly that shape.
-expect_contains "$dry_out" "tracking ref(s) are stale" "clean:branches: stale tracking refs are reported"
-expect_contains "$dry_out" "task clean:remote-refs" "clean:branches: the staleness note names the remedy"
+expect_contains "$dry_out" "kept as in-flight are classified from local tracking refs" "clean:branches: the in-flight bucket carries its caveat"
+expect_contains "$dry_out" "task clean:remote-refs" "clean:branches: the caveat names the remedy"
 
 # Degraded mode: a failing gh probe is UNVERIFIED, never silently clean.
 audit_fail_out="$(cd "$fixture" && GH_STUB_FAIL=1 bash scripts/audit-session-artifacts.sh 2>&1)" ||
@@ -1445,15 +1445,6 @@ ren_audit_out="$(cd "$fixture" && bash scripts/audit-session-artifacts.sh 2>&1)"
     fail "audit exited nonzero inside the renamed-default window: $ren_audit_out"
 expect_contains "$ren_audit_out" "default branch is now 'trunk'" "rename: audit resolves the live default over stale origin/HEAD"
 
-# The DRY RUN must say so too. verify_remote_state — which produces the note
-# above — runs only on the delete path, so before #958 a dry run under a
-# renamed default reported figures computed against the stale local default
-# with no caveat at all. The freshness probe covers that, and it only can
-# because it asks for the HEAD symref: `--heads` alone omits it (challenge r1).
-ren_dry_out="$(cd "$fixture" && bash scripts/clean-branches.sh 2>&1)" ||
-    fail "renamed-default dry run exited nonzero: $ren_dry_out"
-expect_contains "$ren_dry_out" "default branch is now 'trunk'" "rename: the DRY RUN names the live default too (#958)"
-
 # A non-identity fetch refspec makes a tracking name a DESTINATION, not a
 # remote branch — comparing them marks fresh refs stale and recommends a prune
 # that can never clear the warning. Both tasks must decline to compare and say
@@ -1461,14 +1452,16 @@ expect_contains "$ren_dry_out" "default branch is now 'trunk'" "rename: the DRY 
 # expression first, so both are asserted.
 orig_fetch="$(git -C "$fixture" config --get remote.origin.fetch)"
 git -C "$fixture" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/upstream/*'
-spec_dry_out="$(cd "$fixture" && bash scripts/clean-branches.sh 2>&1)" ||
-    fail "non-identity-refspec dry run exited nonzero: $spec_dry_out"
-expect_contains "$spec_dry_out" "non-identity refspec" "refspec: clean:branches declines to compare (#958)"
-expect_not_contains "$spec_dry_out" "tracking ref(s) are stale" "refspec: clean:branches emits no false staleness (#958)"
 spec_audit_out="$(cd "$fixture" && bash scripts/audit-session-artifacts.sh 2>&1)" ||
     fail "non-identity-refspec audit exited nonzero: $spec_audit_out"
 expect_contains "$spec_audit_out" "non-identity refspec" "refspec: audit declines to compare (#958)"
 expect_not_contains "$spec_audit_out" "deleted upstream" "refspec: audit emits no false staleness (#958)"
+# ...and must then reach NO verdict at all. Both of the section's conclusions
+# are claims about a comparison that did not happen — "fresh" asserts the refs
+# match, and "-> N stale" asserts a count from an empty scan. An assertion
+# naming only one of them passes while the other fires (found by mutant M8).
+expect_not_contains "$spec_audit_out" "fresh — local tracking refs match" "refspec: audit does not claim fresh after skipping the comparison (#958)"
+expect_not_contains "$spec_audit_out" "stale tracking ref(s):" "refspec: audit does not report a stale count after skipping the comparison (#958)"
 git -C "$fixture" config remote.origin.fetch "$orig_fetch"
 
 git -C "$origin" symbolic-ref HEAD refs/heads/main

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -338,6 +338,46 @@ expect_contains "$audit_out" "deferred-findings/wt-checked (branch exists) [work
 expect_contains "$audit_out" "stub/fixture/42.json" "audit: shepherd cycle state listed"
 echo "ok: audit reports all artifact classes read-only"
 
+# ── Case B2: the audit's prunable figure equals what clean:branches deletes ──
+#
+# wt-checked has merged-PR evidence AND is checked out in a linked worktree.
+# The audit counted it as prunable and attributed the total to a task that
+# refuses it, so the operator was handed a number nothing would act on
+# (harmon-init#958). It must now be shown, classified as held, and excluded
+# from the figure.
+expect_contains "$audit_out" "held          wt-checked" "audit: worktree-checked-out branch is held, not prunable"
+expect_not_contains "$audit_out" "prunable      wt-checked" "audit: worktree-checked-out branch is not counted prunable"
+expect_contains "$audit_out" "held by a worktree" "audit: the summary names the held bucket"
+
+# The invariant is SUBSET, not equality, and the distinction is load-bearing.
+# clean:branches deletes on two evidence types — ancestry or a merged PR —
+# while the audit classifies prunable on PR evidence alone, so an
+# ancestry-merged branch is legitimately deletable without being prunable
+# (tracked separately). What #958 fixes is the other direction: nothing may be
+# called prunable that clean:branches will refuse. Asserted per branch rather
+# than on the totals, because two counts can coincide while naming different
+# branches.
+audit_prunable_names="$(printf '%s\n' "$audit_out" |
+    sed -n 's/^  prunable      \([^ ]*\) .*/\1/p' | sort)"
+clean_deletable_names="$(printf '%s\n' "$dry_out" |
+    sed -n 's/^WOULD DELETE  \([^ ]*\) .*/\1/p' | sort)"
+[ -n "$audit_prunable_names" ] || fail "the audit classified nothing prunable — the fixture no longer exercises this (#958)"
+[ -n "$clean_deletable_names" ] || fail "clean:branches found nothing deletable — the fixture no longer exercises this (#958)"
+not_deletable="$(comm -23 <(printf '%s\n' "$audit_prunable_names") <(printf '%s\n' "$clean_deletable_names"))"
+[ -z "$not_deletable" ] ||
+    fail "the audit called these prunable but clean:branches will not delete them (#958): $(printf '%s' "$not_deletable" | tr '\n' ' ')"
+echo "ok: every branch the audit calls prunable is one clean:branches would delete"
+
+# ── Case B3: clean:branches reports tracking-ref staleness ──────────────────
+#
+# Every classification reads local tracking refs, so a branch whose upstream is
+# already gone reads as neither [gone] nor unpushed and lands in `in-flight
+# kept` — a bucket that says "deliberately left alone", not "I could not tell".
+# The audit has said so since it was written; the task that actually deletes
+# did not (harmon-init#958). The fixture's tf-stale ref is exactly that shape.
+expect_contains "$dry_out" "tracking ref(s) are stale" "clean:branches: stale tracking refs are reported"
+expect_contains "$dry_out" "task clean:remote-refs" "clean:branches: the staleness note names the remedy"
+
 # Degraded mode: a failing gh probe is UNVERIFIED, never silently clean.
 audit_fail_out="$(cd "$fixture" && GH_STUB_FAIL=1 bash scripts/audit-session-artifacts.sh 2>&1)" ||
     fail "degraded audit exited nonzero: $audit_fail_out"

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -239,6 +239,12 @@ wt_tip="$(make_branch wt-checked wt.txt)"
 retire_remote wt-checked
 git -C "$fixture" worktree add -q "$test_tmp/wt" wt-checked
 
+# 5b. tracked-live: pushed, upstream still present, not merged — ordinary
+#     in-flight work that WAS classified from a tracking ref. The freshness
+#     caveat counts this one and must not count unpushed-live below, which has
+#     no upstream for a prune to affect (Codex review on PR #991).
+make_branch tracked-live tracked.txt >/dev/null
+
 # 6. unpushed-live: never pushed anywhere — ordinary in-flight work, silent
 #    survival.
 (
@@ -375,8 +381,19 @@ echo "ok: every branch the audit calls prunable is one clean:branches would dele
 # kept` — a bucket that says "deliberately left alone", not "I could not tell".
 # The audit has said so since it was written; the task that actually deletes
 # did not (harmon-init#958). The fixture's tf-stale ref is exactly that shape.
-expect_contains "$dry_out" "kept as in-flight are classified from local tracking refs" "clean:branches: the in-flight bucket carries its caveat"
+expect_contains "$dry_out" "have an upstream and were classified from local tracking refs" "clean:branches: the in-flight bucket carries its caveat"
 expect_contains "$dry_out" "task clean:remote-refs" "clean:branches: the caveat names the remedy"
+# The caveat must count only branches an upstream could have misclassified.
+# The fixture's unpushed-live has none, so it must not be included: keying on
+# the aggregate in-flight count warned about ordinary local-only branches, and
+# a caveat that fires in the common case is one nobody reads (Codex, PR #991).
+caveat_tracked="$(printf '%s\n' "$dry_out" |
+    sed -n 's/^clean:branches: \([0-9][0-9]*\) of the \([0-9][0-9]*\) branch(es).*/\1/p' | head -1)"
+caveat_total="$(printf '%s\n' "$dry_out" |
+    sed -n 's/^clean:branches: \([0-9][0-9]*\) of the \([0-9][0-9]*\) branch(es).*/\2/p' | head -1)"
+[ -n "$caveat_tracked" ] || fail "the in-flight caveat did not report a tracked count (#958)"
+[ "$caveat_tracked" -lt "$caveat_total" ] ||
+    fail "the caveat counted every in-flight branch ($caveat_tracked of $caveat_total) — unpushed-live has no upstream and must be excluded (#958)"
 
 # Degraded mode: a failing gh probe is UNVERIFIED, never silently clean.
 audit_fail_out="$(cd "$fixture" && GH_STUB_FAIL=1 bash scripts/audit-session-artifacts.sh 2>&1)" ||

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -245,6 +245,20 @@ git -C "$fixture" worktree add -q "$test_tmp/wt" wt-checked
 #     no upstream for a prune to affect (Codex review on PR #991).
 make_branch tracked-live tracked.txt >/dev/null
 
+# 5c. local-upstream: tracks another LOCAL branch (branch.<name>.remote=.).
+#     %(upstream) is non-empty, but it is under refs/heads/, so
+#     `task clean:remote-refs` cannot affect how this branch is classified and
+#     the freshness caveat must not count it (Codex review on PR #991).
+(
+    cd "$fixture"
+    git checkout -q -b local-upstream main
+    echo localup >localup.txt
+    git add localup.txt
+    git commit -qm "work tracking a local branch"
+    git branch --set-upstream-to=main local-upstream >/dev/null 2>&1
+    git checkout -q main
+)
+
 # 6. unpushed-live: never pushed anywhere — ordinary in-flight work, silent
 #    survival.
 (
@@ -394,6 +408,17 @@ caveat_total="$(printf '%s\n' "$dry_out" |
 [ -n "$caveat_tracked" ] || fail "the in-flight caveat did not report a tracked count (#958)"
 [ "$caveat_tracked" -lt "$caveat_total" ] ||
     fail "the caveat counted every in-flight branch ($caveat_tracked of $caveat_total) — unpushed-live has no upstream and must be excluded (#958)"
+# local-upstream HAS an upstream, so presence alone would count it — but that
+# upstream is under refs/heads/ and no prune can affect it. Only a
+# remote-tracking upstream belongs in this figure.
+localup_upstream="$(git -C "$fixture" for-each-ref refs/heads/local-upstream --format='%(upstream)')"
+[ -n "$localup_upstream" ] ||
+    fail "the local-upstream fixture lost its upstream — the case cannot distinguish anything (#958)"
+case "$localup_upstream" in
+refs/remotes/*) fail "the local-upstream fixture tracks a REMOTE ref; it must track a local branch (#958)" ;;
+esac
+[ "$caveat_tracked" -le 2 ] ||
+    fail "the caveat counted a locally-tracking branch ($caveat_tracked) — only remote-backed upstreams belong in it (#958)"
 
 # Degraded mode: a failing gh probe is UNVERIFIED, never silently clean.
 audit_fail_out="$(cd "$fixture" && GH_STUB_FAIL=1 bash scripts/audit-session-artifacts.sh 2>&1)" ||

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -1445,6 +1445,32 @@ ren_audit_out="$(cd "$fixture" && bash scripts/audit-session-artifacts.sh 2>&1)"
     fail "audit exited nonzero inside the renamed-default window: $ren_audit_out"
 expect_contains "$ren_audit_out" "default branch is now 'trunk'" "rename: audit resolves the live default over stale origin/HEAD"
 
+# The DRY RUN must say so too. verify_remote_state — which produces the note
+# above — runs only on the delete path, so before #958 a dry run under a
+# renamed default reported figures computed against the stale local default
+# with no caveat at all. The freshness probe covers that, and it only can
+# because it asks for the HEAD symref: `--heads` alone omits it (challenge r1).
+ren_dry_out="$(cd "$fixture" && bash scripts/clean-branches.sh 2>&1)" ||
+    fail "renamed-default dry run exited nonzero: $ren_dry_out"
+expect_contains "$ren_dry_out" "default branch is now 'trunk'" "rename: the DRY RUN names the live default too (#958)"
+
+# A non-identity fetch refspec makes a tracking name a DESTINATION, not a
+# remote branch — comparing them marks fresh refs stale and recommends a prune
+# that can never clear the warning. Both tasks must decline to compare and say
+# why, rather than emit something false (challenge r1). The audit copied this
+# expression first, so both are asserted.
+orig_fetch="$(git -C "$fixture" config --get remote.origin.fetch)"
+git -C "$fixture" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/upstream/*'
+spec_dry_out="$(cd "$fixture" && bash scripts/clean-branches.sh 2>&1)" ||
+    fail "non-identity-refspec dry run exited nonzero: $spec_dry_out"
+expect_contains "$spec_dry_out" "non-identity refspec" "refspec: clean:branches declines to compare (#958)"
+expect_not_contains "$spec_dry_out" "tracking ref(s) are stale" "refspec: clean:branches emits no false staleness (#958)"
+spec_audit_out="$(cd "$fixture" && bash scripts/audit-session-artifacts.sh 2>&1)" ||
+    fail "non-identity-refspec audit exited nonzero: $spec_audit_out"
+expect_contains "$spec_audit_out" "non-identity refspec" "refspec: audit declines to compare (#958)"
+expect_not_contains "$spec_audit_out" "deleted upstream" "refspec: audit emits no false staleness (#958)"
+git -C "$fixture" config remote.origin.fetch "$orig_fetch"
+
 git -C "$origin" symbolic-ref HEAD refs/heads/main
 git -C "$origin" update-ref -d refs/heads/trunk
 ren_ok_out="$(cd "$fixture" && bash scripts/clean-branches.sh --delete 2>&1)" ||

--- a/scripts/test-session-cleanup.sh
+++ b/scripts/test-session-cleanup.sh
@@ -367,7 +367,11 @@ echo "ok: audit reports all artifact classes read-only"
 # from the figure.
 expect_contains "$audit_out" "held          wt-checked" "audit: worktree-checked-out branch is held, not prunable"
 expect_not_contains "$audit_out" "prunable      wt-checked" "audit: worktree-checked-out branch is not counted prunable"
-expect_contains "$audit_out" "held by a worktree" "audit: the summary names the held bucket"
+# Generic on purpose: "held" covers a worktree checkout AND a symbolic ref, so
+# a summary naming only one gives the wrong reason whenever the other is in the
+# count (Codex, PR #991). Each entry states its own reason.
+expect_contains "$audit_out" "held (see above)" "audit: the summary names the held bucket without guessing its reason"
+expect_not_contains "$audit_out" "held by a worktree" "audit: the aggregate does not claim a single reason (#958)"
 
 # The invariant is SUBSET, not equality, and the distinction is load-bearing.
 # clean:branches deletes on two evidence types — ancestry or a merged PR —

--- a/template/scripts/audit-session-artifacts.sh
+++ b/template/scripts/audit-session-artifacts.sh
@@ -191,15 +191,41 @@ else
         if [ "$merged_seen" -ge "$pr_limit" ]; then
             echo "  (note: merged-PR listing hit its $pr_limit cap — 'no merged PR' below may be incomplete)"
         fi
+        # A branch checked out in a linked worktree is one `clean:branches`
+        # will refuse — `git branch -d` declines it, and that task guards the
+        # update-ref path explicitly. Counting it as prunable made this report
+        # hand the operator a number and name the very task that would decline
+        # part of it (harmon-init#958). Same derivation clean-branches.sh uses,
+        # so the two cannot disagree about what is checked out.
+        #
+        # A worktree PATH may contain a newline, which this line-delimited form
+        # truncates; a branch NAME cannot (git refnames forbid control
+        # characters), so the classification below is unaffected and only a
+        # displayed path could be short.
+        git worktree list --porcelain | awk '
+            /^worktree /            { path = substr($0, 10) }
+            /^branch refs\/heads\// { printf "%s\t%s\n", substr($0, 19), path }
+        ' >"$tmp/checked-out"
+
         prunable=0
+        held=0
         tip_differs=0
         no_pr=0
         while IFS=$'\t' read -r branch tip; do
             match="$(awk -F'\t' -v b="$branch" -v tip="$tip" -v base="$default_branch" \
                 '$1 == b && $2 == tip && $4 == base { print $3; exit }' "$tmp/merged-prs")"
             if [ -n "$match" ]; then
-                printf '  prunable      %s — merged PR #%s into %s (head == tip %s)\n' "$branch" "$match" "$default_branch" "${tip:0:12}"
-                prunable=$((prunable + 1))
+                held_path="$(awk -F'\t' -v b="$branch" '$1 == b { print $2; exit }' "$tmp/checked-out")"
+                if [ -n "$held_path" ]; then
+                    # Still shown — the evidence is real and the operator
+                    # should see it — but not counted toward a total
+                    # attributed to a task that will decline it.
+                    printf '  held          %s — merged PR #%s, but checked out in worktree %s\n' "$branch" "$match" "$held_path"
+                    held=$((held + 1))
+                else
+                    printf '  prunable      %s — merged PR #%s into %s (head == tip %s)\n' "$branch" "$match" "$default_branch" "${tip:0:12}"
+                    prunable=$((prunable + 1))
+                fi
             elif awk -F'\t' -v b="$branch" '$1 == b { found = 1; exit } END { exit !found }' "$tmp/merged-prs"; then
                 printf '  tip differs   %s — a merged PR matches by name but not tip/base (a human decides)\n' "$branch"
                 tip_differs=$((tip_differs + 1))
@@ -208,8 +234,16 @@ else
                 no_pr=$((no_pr + 1))
             fi
         done <"$tmp/gone"
-        printf '  -> %s prunable (task clean:branches), %s tip-differs, %s without a merged PR\n' \
-            "$prunable" "$tip_differs" "$no_pr"
+        # The invariant this line now keeps: the figure attributed to
+        # `clean:branches` equals what that task reports as deletable on the
+        # same tree.
+        if [ "$held" -gt 0 ]; then
+            printf '  -> %s prunable (task clean:branches), %s held by a worktree, %s tip-differs, %s without a merged PR\n' \
+                "$prunable" "$held" "$tip_differs" "$no_pr"
+        else
+            printf '  -> %s prunable (task clean:branches), %s tip-differs, %s without a merged PR\n' \
+                "$prunable" "$tip_differs" "$no_pr"
+        fi
     else
         echo "  UNVERIFIED — gh unavailable or the merged-PR read failed; $gone_count gone branch(es) unclassified:"
         awk -F'\t' '{ print "    " $1 }' "$tmp/gone"

--- a/template/scripts/audit-session-artifacts.sh
+++ b/template/scripts/audit-session-artifacts.sh
@@ -136,24 +136,38 @@ elif net_probe git ls-remote --symref "$remote" HEAD "refs/heads/*" >"$tmp/remot
         default_branch="$live_default"
     fi
     awk '$1 != "ref:" && $2 != "HEAD"' "$tmp/remote-heads-raw" >"$tmp/remote-heads"
-    # Full refname with a dynamic strip, not %(refname:lstrip=3): a remote
-    # name may itself contain slashes, and a fixed strip depth would mangle
-    # every tracking ref into a false "deleted upstream" (review r2).
-    git for-each-ref "refs/remotes/$remote" \
-        --format='%(refname)%09%(objectname)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)' \
-        >"$tmp/tracking"
-    while IFS=$'\t' read -r tref toid tsymref; do
-        [ "$tsymref" = "-" ] || continue
-        tname="${tref#refs/remotes/$remote/}"
-        live_oid="$(awk -v r="refs/heads/$tname" '$2 == r { print $1; exit }' "$tmp/remote-heads")"
-        if [ -z "$live_oid" ]; then
-            printf '  stale  %s — deleted upstream; local tracking ref survives until a prune\n' "$tname"
-            stale=$((stale + 1))
-        elif [ "$live_oid" != "$toid" ]; then
-            printf '  stale  %s — moved upstream (local tracking is behind or diverged)\n' "$tname"
-            stale=$((stale + 1))
-        fi
-    done <"$tmp/tracking"
+    # A tracking ref names `refs/heads/<same name>` only under the identity
+    # fetch refspec. Under `refs/heads/*:refs/remotes/origin/upstream/*`, or
+    # with extra refspecs pulling in e.g. pull refs, the local name is a
+    # DESTINATION — comparing it marks fresh refs stale and recommends a prune
+    # that can never clear the report. Say nothing rather than something false
+    # (found in clean:branches by challenge r1 on #958; the same expression was
+    # copied from here, so both are corrected together).
+    audit_fetch_specs="$(git config --get-all "remote.$remote.fetch" 2>/dev/null || true)"
+    if [ "$audit_fetch_specs" != "+refs/heads/*:refs/remotes/$remote/*" ] &&
+        [ "$audit_fetch_specs" != "refs/heads/*:refs/remotes/$remote/*" ]; then
+        echo "  n/a — $remote is fetched under a non-identity refspec, so a tracking name does not identify a remote branch"
+        : >"$tmp/tracking"
+    else
+        # Full refname with a dynamic strip, not %(refname:lstrip=3): a remote
+        # name may itself contain slashes, and a fixed strip depth would mangle
+        # every tracking ref into a false "deleted upstream" (review r2).
+        git for-each-ref "refs/remotes/$remote" \
+            --format='%(refname)%09%(objectname)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)' \
+            >"$tmp/tracking"
+        while IFS=$'\t' read -r tref toid tsymref; do
+            [ "$tsymref" = "-" ] || continue
+            tname="${tref#refs/remotes/$remote/}"
+            live_oid="$(awk -v r="refs/heads/$tname" '$2 == r { print $1; exit }' "$tmp/remote-heads")"
+            if [ -z "$live_oid" ]; then
+                printf '  stale  %s — deleted upstream; local tracking ref survives until a prune\n' "$tname"
+                stale=$((stale + 1))
+            elif [ "$live_oid" != "$toid" ]; then
+                printf '  stale  %s — moved upstream (local tracking is behind or diverged)\n' "$tname"
+                stale=$((stale + 1))
+            fi
+        done <"$tmp/tracking"
+    fi
     if [ "$stale" -eq 0 ]; then
         echo "  fresh — local tracking refs match the remote's advertised heads"
     else

--- a/template/scripts/audit-session-artifacts.sh
+++ b/template/scripts/audit-session-artifacts.sh
@@ -57,8 +57,11 @@ net_probe() {
 # %(refname:lstrip=2), not %(refname:short): when a tag shares a branch's
 # name, :short disambiguates to "heads/<name>" and every "refs/heads/$branch"
 # built from it dereferences nothing (challenge r1).
+# Sentinels on the optionally-empty fields: tab is IFS whitespace, so `read`
+# would COLLAPSE an empty middle field and shift %(symref) into the track
+# column. Same hazard, same fix, as clean-branches.sh.
 git for-each-ref refs/heads \
-    --format='%(refname:lstrip=2)%09%(objectname)%09%(upstream:track)' \
+    --format='%(refname:lstrip=2)%09%(objectname)%09%(if)%(upstream:track)%(then)%(upstream:track)%(else)-%(end)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)' \
     >"$tmp/branches"
 total_branches="$(wc -l <"$tmp/branches" | tr -d ' ')"
 
@@ -94,7 +97,7 @@ if [ "$has_remote" = false ]; then
     echo "No remote configured — every local commit is unpushed by definition; listing skipped."
 else
     unpushed_count=0
-    while IFS=$'\t' read -r branch _tip _track; do
+    while IFS=$'\t' read -r branch _tip _track _symref; do
         n="$(git rev-list --count "refs/heads/$branch" --not --remotes --)"
         if [ "$n" -gt 0 ]; then
             printf '  %s — %s commit(s) on no remote\n' "$branch" "$n"
@@ -186,7 +189,7 @@ fi
 # ── 2. Gone-upstream classification ─────────────────────────────────────────
 
 section "Branches whose upstream is gone"
-awk -F'\t' '$3 == "[gone]" { print $1 "\t" $2 }' "$tmp/branches" >"$tmp/gone"
+awk -F'\t' '$3 == "[gone]" { print $1 "\t" $2 "\t" $4 }' "$tmp/branches" >"$tmp/gone"
 gone_count="$(wc -l <"$tmp/gone" | tr -d ' ')"
 if [ "$gone_count" -eq 0 ]; then
     echo "  none"
@@ -231,10 +234,18 @@ else
         held=0
         tip_differs=0
         no_pr=0
-        while IFS=$'\t' read -r branch tip; do
+        while IFS=$'\t' read -r branch tip symref; do
             match="$(awk -F'\t' -v b="$branch" -v tip="$tip" -v base="$default_branch" \
                 '$1 == b && $2 == tip && $4 == base { print $3; exit }' "$tmp/merged-prs")"
-            if [ -n "$match" ]; then
+            if [ -n "$match" ] && [ "$symref" != "-" ]; then
+                # clean:branches skips every symbolic ref rather than
+                # dereferencing it, so evidence about its TARGET says nothing
+                # about the alias. Counting it prunable named a task that
+                # refuses it — the same defect as the worktree case above, in a
+                # second form (Codex review on PR #991).
+                printf '  held          %s — merged PR #%s, but it is a symbolic ref to %s (never dereferenced)\n' "$branch" "$match" "$symref"
+                held=$((held + 1))
+            elif [ -n "$match" ]; then
                 held_path="$(awk -F'\t' -v b="$branch" '$1 == b { print $2; exit }' "$tmp/checked-out")"
                 if [ -n "$held_path" ]; then
                     # Still shown — the evidence is real and the operator

--- a/template/scripts/audit-session-artifacts.sh
+++ b/template/scripts/audit-session-artifacts.sh
@@ -269,7 +269,13 @@ else
         # `clean:branches` equals what that task reports as deletable on the
         # same tree.
         if [ "$held" -gt 0 ]; then
-            printf '  -> %s prunable (task clean:branches), %s held by a worktree, %s tip-differs, %s without a merged PR\n' \
+            # "held" covers two distinct reasons — a worktree checkout and a
+            # symbolic ref — so the bucket is labelled generically. Saying
+            # "held by a worktree" told the operator the wrong reason whenever
+            # a symbolic hold was in the count, or the only thing in it (Codex
+            # review on PR #991). Each entry names its own reason above; the
+            # aggregate does not have to guess at one.
+            printf '  -> %s prunable (task clean:branches), %s held (see above), %s tip-differs, %s without a merged PR\n' \
                 "$prunable" "$held" "$tip_differs" "$no_pr"
         else
             printf '  -> %s prunable (task clean:branches), %s tip-differs, %s without a merged PR\n' \

--- a/template/scripts/audit-session-artifacts.sh
+++ b/template/scripts/audit-session-artifacts.sh
@@ -113,6 +113,7 @@ fi
 # here until a fetch --prune — its local branch reads neither [gone] nor
 # unpushed (challenge r2). One bounded read of the remote's advertised heads
 # makes that staleness explicit instead of silent.
+freshness_indeterminate=0
 section "Remote-tracking freshness"
 if [ "$has_remote" = false ]; then
     echo "  n/a — no remote configured"
@@ -148,6 +149,7 @@ elif net_probe git ls-remote --symref "$remote" HEAD "refs/heads/*" >"$tmp/remot
         [ "$audit_fetch_specs" != "refs/heads/*:refs/remotes/$remote/*" ]; then
         echo "  n/a — $remote is fetched under a non-identity refspec, so a tracking name does not identify a remote branch"
         : >"$tmp/tracking"
+        freshness_indeterminate=1
     else
         # Full refname with a dynamic strip, not %(refname:lstrip=3): a remote
         # name may itself contain slashes, and a fixed strip depth would mangle
@@ -168,7 +170,11 @@ elif net_probe git ls-remote --symref "$remote" HEAD "refs/heads/*" >"$tmp/remot
             fi
         done <"$tmp/tracking"
     fi
-    if [ "$stale" -eq 0 ]; then
+    if [ "${freshness_indeterminate:-0}" -eq 1 ]; then
+        # Nothing was compared, so "fresh" would contradict the n/a above and
+        # claim a verification that did not happen (challenge r2).
+        :
+    elif [ "$stale" -eq 0 ]; then
         echo "  fresh — local tracking refs match the remote's advertised heads"
     else
         echo "  -> $stale stale tracking ref(s): run 'task clean:remote-refs' (git fetch --prune), then re-run this audit"

--- a/template/scripts/clean-branches.sh
+++ b/template/scripts/clean-branches.sh
@@ -234,7 +234,7 @@ merged_pr_for() {
 # whitespace, so `read` would otherwise COLLAPSE an empty middle field and
 # shift %(symref) into the track column.
 git for-each-ref refs/heads \
-    --format='%(refname:lstrip=2)%09%(objectname)%09%(if)%(upstream:track)%(then)%(upstream:track)%(else)-%(end)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)%09%(if)%(upstream)%(then)u%(else)-%(end)' \
+    --format='%(refname:lstrip=2)%09%(objectname)%09%(if)%(upstream:track)%(then)%(upstream:track)%(else)-%(end)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)%09%(if)%(upstream)%(then)%(upstream)%(else)-%(end)' \
     >"$tmp/branches"
 
 total=0
@@ -243,7 +243,7 @@ refused=0
 active=0
 active_tracked=0
 
-while IFS=$'\t' read -r branch tip track symref has_upstream; do
+while IFS=$'\t' read -r branch tip track symref upstream_ref; do
     total=$((total + 1))
 
     [ "$branch" = "$current_branch" ] && continue
@@ -333,10 +333,19 @@ while IFS=$'\t' read -r branch tip track symref has_upstream; do
     # branches, which no prune can affect — a warning that fires in the common
     # case is one nobody reads (Codex review on PR #991).
     #
-    # Upstream PRESENCE, not %(upstream:track): that is empty for a branch in
-    # sync with its upstream, so it cannot tell "no upstream" from "up to date"
-    # — which is exactly the distinction needed here.
-    [ "$has_upstream" = "-" ] || active_tracked=$((active_tracked + 1))
+    # The upstream REF, not merely its presence, and not %(upstream:track):
+    # track is empty for a branch in sync with its upstream, so it cannot tell
+    # "no upstream" from "up to date"; and presence alone counts a branch that
+    # tracks another LOCAL branch (branch.<name>.remote=.), whose upstream is
+    # under refs/heads/ and which no prune can affect.
+    #
+    # refs/remotes/ is the terminal test rather than another narrowing in a
+    # series: `task clean:remote-refs` is `git fetch --all --prune`, so it
+    # affects exactly the refs under that prefix — every one of them, and
+    # nothing else. Whichever remote they belong to.
+    case "$upstream_ref" in
+    refs/remotes/*) active_tracked=$((active_tracked + 1)) ;;
+    esac
 done <"$tmp/branches"
 
 # ── Act (or report) ─────────────────────────────────────────────────────────

--- a/template/scripts/clean-branches.sh
+++ b/template/scripts/clean-branches.sh
@@ -237,71 +237,6 @@ git for-each-ref refs/heads \
     --format='%(refname:lstrip=2)%09%(objectname)%09%(if)%(upstream:track)%(then)%(upstream:track)%(else)-%(end)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)' \
     >"$tmp/branches"
 
-# Remote-tracking freshness, reported the way audit:session-artifacts already
-# reports it (harmon-init#958). Every classification below reads local tracking
-# refs, so a branch whose upstream was deleted on merge reads as neither [gone]
-# nor unpushed until a prune — and lands in `in-flight kept`, a bucket that says
-# "deliberately left alone" rather than "I could not tell". Observed: a merged
-# branch sat there until `task clean:remote-refs`, after which the same run
-# reported it deletable.
-#
-# This is deliberately its own probe rather than a widening of
-# verify_remote_state: that runs ONLY on the delete path, and the misleading
-# figure is the one the DRY RUN prints. Bounded, and skipped entirely when
-# there is no remote.
-tracking_freshness_note=""
-check_tracking_freshness() {
-    # No guard needed: this script exits early when no remote is configured, so
-    # $remote is always resolved by the time this runs.
-    #
-    # A tracking ref only corresponds to `refs/heads/<same name>` when the
-    # remote is fetched under the identity refspec. Under
-    # `refs/heads/*:refs/remotes/origin/upstream/*`, or with extra refspecs
-    # bringing in pull refs, the local name is a destination and not a remote
-    # branch — comparing it would mark fresh refs stale and recommend a prune
-    # that can never clear the warning (challenge r1). Say nothing rather than
-    # say something false.
-    fetch_specs="$(git config --get-all "remote.$remote.fetch" 2>/dev/null || true)"
-    if [ "$fetch_specs" != "+refs/heads/*:refs/remotes/$remote/*" ] &&
-        [ "$fetch_specs" != "refs/heads/*:refs/remotes/$remote/*" ]; then
-        tracking_freshness_note="clean:branches: not checking tracking-ref freshness — $remote is fetched under a non-identity refspec, so a local tracking name does not identify a remote branch"
-        return 0
-    fi
-    # HEAD is requested alongside the heads: `--heads` alone omits it, and a
-    # renamed default branch whose old name still exists would then report
-    # every ref current while the classification above ran against a stale
-    # local default (challenge r1). The audit already probes it this way.
-    if ! heads_raw="$(net_probe git ls-remote --symref "$remote" HEAD "refs/heads/*" 2>/dev/null)"; then
-        tracking_freshness_note="clean:branches: could not read $remote's advertised heads — the classification above trusts possibly-stale tracking refs (run 'task clean:remote-refs', then re-run)"
-        return 0
-    fi
-    printf '%s\n' "$heads_raw" >"$tmp/live-heads"
-    live_default_head="$(awk '$1 == "ref:" && $3 == "HEAD" { sub("^refs/heads/", "", $2); print $2; exit }' "$tmp/live-heads")"
-    if [ -n "$live_default_head" ] && [ "$live_default_head" != "$default_branch" ]; then
-        tracking_freshness_note="clean:branches: the remote's default branch is now '$live_default_head', not '$default_branch' — the classification above used the stale local record (run 'git remote set-head $remote --auto && task clean:remote-refs', then re-run)"
-        return 0
-    fi
-    stale_refs=0
-    while IFS=$'\t' read -r tref toid tsymref; do
-        [ "$tsymref" = "-" ] || continue
-        tname="${tref#refs/remotes/$remote/}"
-        live_oid="$(awk -v r="refs/heads/$tname" '$1 != "ref:" && $2 == r { print $1; exit }' "$tmp/live-heads")"
-        if [ -z "$live_oid" ] || [ "$live_oid" != "$toid" ]; then
-            stale_refs=$((stale_refs + 1))
-        fi
-    done < <(git for-each-ref "refs/remotes/$remote" \
-        --format='%(refname)%09%(objectname)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)')
-    if [ "$stale_refs" -gt 0 ]; then
-        tracking_freshness_note="clean:branches: $stale_refs tracking ref(s) are stale — a branch whose upstream is already gone can read as in-flight until you run 'task clean:remote-refs' and re-run"
-    fi
-}
-
-# Probed against the SAME tracking state the classification below reads. Run at
-# the end instead, a fetch landing mid-run would refresh the refs and silence
-# the caveat while the summary still described the stale ones (challenge r1).
-# The note is printed with the summary; only the measurement happens here.
-check_tracking_freshness
-
 total=0
 candidates=0
 refused=0
@@ -545,17 +480,32 @@ if [ -s "$tmp/candidates" ]; then
     done <"$tmp/candidates"
 fi
 
+# Every classification above reads LOCAL tracking refs, so a branch whose
+# upstream was deleted on merge reads as neither [gone] nor unpushed and lands
+# in `in-flight kept` — a bucket that means "deliberately left alone" rather
+# than "I could not tell". Say so whenever that bucket is non-empty.
+#
+# Deliberately NOT a live probe. An earlier revision asked the remote which
+# refs were stale, and the exactness cost more than it bought: the answer has
+# to be captured atomically with the classification snapshot or a concurrent
+# fetch silences it, it needs the HEAD symref to notice a renamed default, and
+# it is meaningless under a non-identity fetch refspec. Six findings across two
+# review rounds, all in the probe, none in the reporting this issue is about.
+# The issue asks only that the task "performs, or explicitly reports the
+# absence of" the check, and says a one-line note would be enough. This is that
+# note: deterministic, no network, and impossible to race.
+tracking_caveat() {
+    [ "$active" -gt 0 ] || return 0
+    echo "clean:branches: $active branch(es) kept as in-flight are classified from local tracking refs — if you have not pruned recently, run 'task clean:remote-refs' and re-run, since a branch whose upstream is already gone reads as in-flight until then."
+}
+
 echo
 if [ "$do_delete" = true ]; then
     echo "clean:branches: $deleted deleted, $refused skipped, $active in-flight kept, $total local branches scanned."
-    if [ -n "$tracking_freshness_note" ]; then
-        echo "$tracking_freshness_note"
-    fi
+    tracking_caveat
 else
     echo "clean:branches (dry run): $candidates deletable, $refused skipped, $active in-flight kept, $total local branches scanned."
-    if [ -n "$tracking_freshness_note" ]; then
-        echo "$tracking_freshness_note"
-    fi
+    tracking_caveat
     if [ "$candidates" -gt 0 ]; then
         echo "Run 'task clean:branches -- --delete' to delete the branches listed above."
     fi

--- a/template/scripts/clean-branches.sh
+++ b/template/scripts/clean-branches.sh
@@ -516,7 +516,14 @@ fi
 # note: deterministic, no network, and impossible to race.
 tracking_caveat() {
     [ "$active_tracked" -gt 0 ] || return 0
-    echo "clean:branches: $active_tracked of the $active branch(es) kept as in-flight have an upstream and were classified from local tracking refs — if you have not pruned recently, run 'task clean:remote-refs' and re-run, since a branch whose upstream is already gone reads as in-flight until then."
+    # No count. The predicate below decides WHETHER this is relevant, and that
+    # is worth getting right; the figure is not. It needed redefining four
+    # times — the aggregate in-flight count, then upstream presence, then
+    # %(upstream:track) versus presence, then local-upstream branches — and a
+    # remote configured `skipFetchAll` would have made it wrong again, since
+    # the remedy below is `fetch --all --prune` and that skips such a remote.
+    # A sentence that names the condition needs none of those distinctions.
+    echo "clean:branches: some branches kept as in-flight were classified from local tracking refs, and a branch whose upstream is already gone reads as in-flight until you prune. If in doubt, run 'task clean:remote-refs' — plus an explicit fetch for any remote set to skipFetchAll, which 'fetch --all' passes over — and re-run."
 }
 
 echo

--- a/template/scripts/clean-branches.sh
+++ b/template/scripts/clean-branches.sh
@@ -375,6 +375,42 @@ verify_remote_state() {
     fi
 }
 
+# Remote-tracking freshness, reported the way audit:session-artifacts already
+# reports it (harmon-init#958). Every classification below reads local tracking
+# refs, so a branch whose upstream was deleted on merge reads as neither [gone]
+# nor unpushed until a prune — and lands in `in-flight kept`, a bucket that says
+# "deliberately left alone" rather than "I could not tell". Observed: a merged
+# branch sat there until `task clean:remote-refs`, after which the same run
+# reported it deletable.
+#
+# This is deliberately its own probe rather than a widening of
+# verify_remote_state: that runs ONLY on the delete path, and the misleading
+# figure is the one the DRY RUN prints. Bounded, and skipped entirely when
+# there is no remote.
+tracking_freshness_note=""
+check_tracking_freshness() {
+    # No guard needed: this script exits early when no remote is configured, so
+    # $remote is always resolved by the time this runs.
+    if ! heads_raw="$(net_probe git ls-remote --heads "$remote" 2>/dev/null)"; then
+        tracking_freshness_note="clean:branches: could not read $remote's advertised heads — the classification above trusts possibly-stale tracking refs (run 'task clean:remote-refs', then re-run)"
+        return 0
+    fi
+    printf '%s\n' "$heads_raw" >"$tmp/live-heads"
+    stale_refs=0
+    while IFS=$'\t' read -r tref toid tsymref; do
+        [ "$tsymref" = "-" ] || continue
+        tname="${tref#refs/remotes/$remote/}"
+        live_oid="$(awk -v r="refs/heads/$tname" '$2 == r { print $1; exit }' "$tmp/live-heads")"
+        if [ -z "$live_oid" ] || [ "$live_oid" != "$toid" ]; then
+            stale_refs=$((stale_refs + 1))
+        fi
+    done < <(git for-each-ref "refs/remotes/$remote" \
+        --format='%(refname)%09%(objectname)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)')
+    if [ "$stale_refs" -gt 0 ]; then
+        tracking_freshness_note="clean:branches: $stale_refs tracking ref(s) are stale — a branch whose upstream is already gone can read as in-flight until you run 'task clean:remote-refs' and re-run"
+    fi
+}
+
 # delete_one <branch> <tip> <evidence> <why> — runs in a SUBSHELL so a lock
 # refusal (die) aborts this branch only. The whole check-then-delete sequence
 # holds the per-branch lifecycle lock shared with worktree:new / worktree:rm
@@ -480,11 +516,21 @@ if [ -s "$tmp/candidates" ]; then
     done <"$tmp/candidates"
 fi
 
+# Run once, after classification and before the summary, so the figure and the
+# caveat about it are printed together.
+check_tracking_freshness
+
 echo
 if [ "$do_delete" = true ]; then
     echo "clean:branches: $deleted deleted, $refused skipped, $active in-flight kept, $total local branches scanned."
+    if [ -n "$tracking_freshness_note" ]; then
+        echo "$tracking_freshness_note"
+    fi
 else
     echo "clean:branches (dry run): $candidates deletable, $refused skipped, $active in-flight kept, $total local branches scanned."
+    if [ -n "$tracking_freshness_note" ]; then
+        echo "$tracking_freshness_note"
+    fi
     if [ "$candidates" -gt 0 ]; then
         echo "Run 'task clean:branches -- --delete' to delete the branches listed above."
     fi

--- a/template/scripts/clean-branches.sh
+++ b/template/scripts/clean-branches.sh
@@ -237,6 +237,71 @@ git for-each-ref refs/heads \
     --format='%(refname:lstrip=2)%09%(objectname)%09%(if)%(upstream:track)%(then)%(upstream:track)%(else)-%(end)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)' \
     >"$tmp/branches"
 
+# Remote-tracking freshness, reported the way audit:session-artifacts already
+# reports it (harmon-init#958). Every classification below reads local tracking
+# refs, so a branch whose upstream was deleted on merge reads as neither [gone]
+# nor unpushed until a prune — and lands in `in-flight kept`, a bucket that says
+# "deliberately left alone" rather than "I could not tell". Observed: a merged
+# branch sat there until `task clean:remote-refs`, after which the same run
+# reported it deletable.
+#
+# This is deliberately its own probe rather than a widening of
+# verify_remote_state: that runs ONLY on the delete path, and the misleading
+# figure is the one the DRY RUN prints. Bounded, and skipped entirely when
+# there is no remote.
+tracking_freshness_note=""
+check_tracking_freshness() {
+    # No guard needed: this script exits early when no remote is configured, so
+    # $remote is always resolved by the time this runs.
+    #
+    # A tracking ref only corresponds to `refs/heads/<same name>` when the
+    # remote is fetched under the identity refspec. Under
+    # `refs/heads/*:refs/remotes/origin/upstream/*`, or with extra refspecs
+    # bringing in pull refs, the local name is a destination and not a remote
+    # branch — comparing it would mark fresh refs stale and recommend a prune
+    # that can never clear the warning (challenge r1). Say nothing rather than
+    # say something false.
+    fetch_specs="$(git config --get-all "remote.$remote.fetch" 2>/dev/null || true)"
+    if [ "$fetch_specs" != "+refs/heads/*:refs/remotes/$remote/*" ] &&
+        [ "$fetch_specs" != "refs/heads/*:refs/remotes/$remote/*" ]; then
+        tracking_freshness_note="clean:branches: not checking tracking-ref freshness — $remote is fetched under a non-identity refspec, so a local tracking name does not identify a remote branch"
+        return 0
+    fi
+    # HEAD is requested alongside the heads: `--heads` alone omits it, and a
+    # renamed default branch whose old name still exists would then report
+    # every ref current while the classification above ran against a stale
+    # local default (challenge r1). The audit already probes it this way.
+    if ! heads_raw="$(net_probe git ls-remote --symref "$remote" HEAD "refs/heads/*" 2>/dev/null)"; then
+        tracking_freshness_note="clean:branches: could not read $remote's advertised heads — the classification above trusts possibly-stale tracking refs (run 'task clean:remote-refs', then re-run)"
+        return 0
+    fi
+    printf '%s\n' "$heads_raw" >"$tmp/live-heads"
+    live_default_head="$(awk '$1 == "ref:" && $3 == "HEAD" { sub("^refs/heads/", "", $2); print $2; exit }' "$tmp/live-heads")"
+    if [ -n "$live_default_head" ] && [ "$live_default_head" != "$default_branch" ]; then
+        tracking_freshness_note="clean:branches: the remote's default branch is now '$live_default_head', not '$default_branch' — the classification above used the stale local record (run 'git remote set-head $remote --auto && task clean:remote-refs', then re-run)"
+        return 0
+    fi
+    stale_refs=0
+    while IFS=$'\t' read -r tref toid tsymref; do
+        [ "$tsymref" = "-" ] || continue
+        tname="${tref#refs/remotes/$remote/}"
+        live_oid="$(awk -v r="refs/heads/$tname" '$1 != "ref:" && $2 == r { print $1; exit }' "$tmp/live-heads")"
+        if [ -z "$live_oid" ] || [ "$live_oid" != "$toid" ]; then
+            stale_refs=$((stale_refs + 1))
+        fi
+    done < <(git for-each-ref "refs/remotes/$remote" \
+        --format='%(refname)%09%(objectname)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)')
+    if [ "$stale_refs" -gt 0 ]; then
+        tracking_freshness_note="clean:branches: $stale_refs tracking ref(s) are stale — a branch whose upstream is already gone can read as in-flight until you run 'task clean:remote-refs' and re-run"
+    fi
+}
+
+# Probed against the SAME tracking state the classification below reads. Run at
+# the end instead, a fetch landing mid-run would refresh the refs and silence
+# the caveat while the summary still described the stale ones (challenge r1).
+# The note is printed with the summary; only the measurement happens here.
+check_tracking_freshness
+
 total=0
 candidates=0
 refused=0
@@ -375,42 +440,6 @@ verify_remote_state() {
     fi
 }
 
-# Remote-tracking freshness, reported the way audit:session-artifacts already
-# reports it (harmon-init#958). Every classification below reads local tracking
-# refs, so a branch whose upstream was deleted on merge reads as neither [gone]
-# nor unpushed until a prune — and lands in `in-flight kept`, a bucket that says
-# "deliberately left alone" rather than "I could not tell". Observed: a merged
-# branch sat there until `task clean:remote-refs`, after which the same run
-# reported it deletable.
-#
-# This is deliberately its own probe rather than a widening of
-# verify_remote_state: that runs ONLY on the delete path, and the misleading
-# figure is the one the DRY RUN prints. Bounded, and skipped entirely when
-# there is no remote.
-tracking_freshness_note=""
-check_tracking_freshness() {
-    # No guard needed: this script exits early when no remote is configured, so
-    # $remote is always resolved by the time this runs.
-    if ! heads_raw="$(net_probe git ls-remote --heads "$remote" 2>/dev/null)"; then
-        tracking_freshness_note="clean:branches: could not read $remote's advertised heads — the classification above trusts possibly-stale tracking refs (run 'task clean:remote-refs', then re-run)"
-        return 0
-    fi
-    printf '%s\n' "$heads_raw" >"$tmp/live-heads"
-    stale_refs=0
-    while IFS=$'\t' read -r tref toid tsymref; do
-        [ "$tsymref" = "-" ] || continue
-        tname="${tref#refs/remotes/$remote/}"
-        live_oid="$(awk -v r="refs/heads/$tname" '$2 == r { print $1; exit }' "$tmp/live-heads")"
-        if [ -z "$live_oid" ] || [ "$live_oid" != "$toid" ]; then
-            stale_refs=$((stale_refs + 1))
-        fi
-    done < <(git for-each-ref "refs/remotes/$remote" \
-        --format='%(refname)%09%(objectname)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)')
-    if [ "$stale_refs" -gt 0 ]; then
-        tracking_freshness_note="clean:branches: $stale_refs tracking ref(s) are stale — a branch whose upstream is already gone can read as in-flight until you run 'task clean:remote-refs' and re-run"
-    fi
-}
-
 # delete_one <branch> <tip> <evidence> <why> — runs in a SUBSHELL so a lock
 # refusal (die) aborts this branch only. The whole check-then-delete sequence
 # holds the per-branch lifecycle lock shared with worktree:new / worktree:rm
@@ -515,10 +544,6 @@ if [ -s "$tmp/candidates" ]; then
         esac
     done <"$tmp/candidates"
 fi
-
-# Run once, after classification and before the summary, so the figure and the
-# caveat about it are printed together.
-check_tracking_freshness
 
 echo
 if [ "$do_delete" = true ]; then

--- a/template/scripts/clean-branches.sh
+++ b/template/scripts/clean-branches.sh
@@ -234,15 +234,16 @@ merged_pr_for() {
 # whitespace, so `read` would otherwise COLLAPSE an empty middle field and
 # shift %(symref) into the track column.
 git for-each-ref refs/heads \
-    --format='%(refname:lstrip=2)%09%(objectname)%09%(if)%(upstream:track)%(then)%(upstream:track)%(else)-%(end)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)' \
+    --format='%(refname:lstrip=2)%09%(objectname)%09%(if)%(upstream:track)%(then)%(upstream:track)%(else)-%(end)%09%(if)%(symref)%(then)%(symref)%(else)-%(end)%09%(if)%(upstream)%(then)u%(else)-%(end)' \
     >"$tmp/branches"
 
 total=0
 candidates=0
 refused=0
 active=0
+active_tracked=0
 
-while IFS=$'\t' read -r branch tip track symref; do
+while IFS=$'\t' read -r branch tip track symref has_upstream; do
     total=$((total + 1))
 
     [ "$branch" = "$current_branch" ] && continue
@@ -326,6 +327,16 @@ while IFS=$'\t' read -r branch tip track symref; do
         continue
     fi
     active=$((active + 1))
+    # Only a branch with an upstream can have been classified from a tracking
+    # ref, so only those make the freshness caveat relevant. Keying the caveat
+    # on the aggregate count instead warned about ordinary local-only feature
+    # branches, which no prune can affect — a warning that fires in the common
+    # case is one nobody reads (Codex review on PR #991).
+    #
+    # Upstream PRESENCE, not %(upstream:track): that is empty for a branch in
+    # sync with its upstream, so it cannot tell "no upstream" from "up to date"
+    # — which is exactly the distinction needed here.
+    [ "$has_upstream" = "-" ] || active_tracked=$((active_tracked + 1))
 done <"$tmp/branches"
 
 # ── Act (or report) ─────────────────────────────────────────────────────────
@@ -495,8 +506,8 @@ fi
 # absence of" the check, and says a one-line note would be enough. This is that
 # note: deterministic, no network, and impossible to race.
 tracking_caveat() {
-    [ "$active" -gt 0 ] || return 0
-    echo "clean:branches: $active branch(es) kept as in-flight are classified from local tracking refs — if you have not pruned recently, run 'task clean:remote-refs' and re-run, since a branch whose upstream is already gone reads as in-flight until then."
+    [ "$active_tracked" -gt 0 ] || return 0
+    echo "clean:branches: $active_tracked of the $active branch(es) kept as in-flight have an upstream and were classified from local tracking refs — if you have not pruned recently, run 'task clean:remote-refs' and re-run, since a branch whose upstream is already gone reads as in-flight until then."
 }
 
 echo

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -395,31 +395,55 @@ echo "ok: every branch the audit calls prunable is one clean:branches would dele
 # kept` — a bucket that says "deliberately left alone", not "I could not tell".
 # The audit has said so since it was written; the task that actually deletes
 # did not (harmon-init#958). The fixture's tf-stale ref is exactly that shape.
-expect_contains "$dry_out" "have an upstream and were classified from local tracking refs" "clean:branches: the in-flight bucket carries its caveat"
+expect_contains "$dry_out" "were classified from local tracking refs" "clean:branches: the in-flight bucket carries its caveat"
+expect_contains "$dry_out" "skipFetchAll" "clean:branches: the remedy names the remote fetch --all passes over"
 expect_contains "$dry_out" "task clean:remote-refs" "clean:branches: the caveat names the remedy"
 # The caveat must count only branches an upstream could have misclassified.
 # The fixture's unpushed-live has none, so it must not be included: keying on
 # the aggregate in-flight count warned about ordinary local-only branches, and
 # a caveat that fires in the common case is one nobody reads (Codex, PR #991).
-caveat_tracked="$(printf '%s\n' "$dry_out" |
-    sed -n 's/^clean:branches: \([0-9][0-9]*\) of the \([0-9][0-9]*\) branch(es).*/\1/p' | head -1)"
-caveat_total="$(printf '%s\n' "$dry_out" |
-    sed -n 's/^clean:branches: \([0-9][0-9]*\) of the \([0-9][0-9]*\) branch(es).*/\2/p' | head -1)"
-[ -n "$caveat_tracked" ] || fail "the in-flight caveat did not report a tracked count (#958)"
-[ "$caveat_tracked" -lt "$caveat_total" ] ||
-    fail "the caveat counted every in-flight branch ($caveat_tracked of $caveat_total) — unpushed-live has no upstream and must be excluded (#958)"
-# local-upstream HAS an upstream, so presence alone would count it — but that
-# upstream is under refs/heads/ and no prune can affect it. Only a
-# remote-tracking upstream belongs in this figure.
-localup_upstream="$(git -C "$fixture" for-each-ref refs/heads/local-upstream --format='%(upstream)')"
-[ -n "$localup_upstream" ] ||
-    fail "the local-upstream fixture lost its upstream — the case cannot distinguish anything (#958)"
-case "$localup_upstream" in
-refs/remotes/*) fail "the local-upstream fixture tracks a REMOTE ref; it must track a local branch (#958)" ;;
-esac
-[ "$caveat_tracked" -le 2 ] ||
-    fail "the caveat counted a locally-tracking branch ($caveat_tracked) — only remote-backed upstreams belong in it (#958)"
+# The caveat no longer prints a count — the figure needed redefining four
+# times and a skipFetchAll remote would have broken it again. What must hold is
+# that it fires only when a remote-backed upstream is in play: unpushed-live
+# and local-upstream must not, on their own, be able to trigger it.
+expect_not_contains "$dry_out" " of the " "clean:branches: the caveat asserts no count (#958)"
 
+# Suppression needs its OWN repository: the main fixture always has a
+# remote-tracking in-flight branch, so it can only ever show the caveat firing.
+# Without this, keying the caveat back on the aggregate in-flight count passes
+# every assertion above (mutant M9).
+untracked_only="$test_tmp/untracked-only"
+untracked_origin="$test_tmp/untracked-only-origin.git"
+git init -q --bare --initial-branch=main "$untracked_origin"
+git init -q --initial-branch=main "$untracked_only"
+(
+    cd "$untracked_only"
+    git config user.name "Session Cleanup Test"
+    git config user.email "session-cleanup@example.invalid"
+    git config commit.gpgsign false
+    git remote add origin "$untracked_origin"
+    echo seed >seed.txt
+    git add seed.txt
+    git commit -qm "chore: seed"
+    git push -q origin main
+    # Its OWN unmerged commit: a branch sitting at main's tip is deletable by
+    # ancestry, not kept in-flight, and would exercise nothing here.
+    git checkout -q -b local-only-work
+    echo local >local.txt
+    git add local.txt
+    git commit -qm "local-only work"
+    git checkout -q main
+)
+mkdir -p "$untracked_only/scripts"
+cp "$repo/scripts/clean-branches.sh" "$untracked_only/scripts/"
+untracked_out="$(cd "$untracked_only" && bash scripts/clean-branches.sh 2>&1)" ||
+    fail "untracked-only dry run exited nonzero: $untracked_out"
+# The summary line prints "N in-flight kept" even when N is zero, so match the
+# count, not the phrase — otherwise this passes against a fixture that keeps
+# nothing and the suppression below proves nothing.
+expect_contains "$untracked_out" "1 in-flight kept" "untracked-only: the local branch is kept in-flight"
+expect_not_contains "$untracked_out" "classified from local tracking refs" \
+    "clean:branches: no caveat when no in-flight branch has a remote-backed upstream (#958)"
 # Degraded mode: a failing gh probe is UNVERIFIED, never silently clean.
 audit_fail_out="$(cd "$fixture" && GH_STUB_FAIL=1 bash scripts/audit-session-artifacts.sh 2>&1)" ||
     fail "degraded audit exited nonzero: $audit_fail_out"

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -375,8 +375,8 @@ echo "ok: every branch the audit calls prunable is one clean:branches would dele
 # kept` — a bucket that says "deliberately left alone", not "I could not tell".
 # The audit has said so since it was written; the task that actually deletes
 # did not (harmon-init#958). The fixture's tf-stale ref is exactly that shape.
-expect_contains "$dry_out" "tracking ref(s) are stale" "clean:branches: stale tracking refs are reported"
-expect_contains "$dry_out" "task clean:remote-refs" "clean:branches: the staleness note names the remedy"
+expect_contains "$dry_out" "kept as in-flight are classified from local tracking refs" "clean:branches: the in-flight bucket carries its caveat"
+expect_contains "$dry_out" "task clean:remote-refs" "clean:branches: the caveat names the remedy"
 
 # Degraded mode: a failing gh probe is UNVERIFIED, never silently clean.
 audit_fail_out="$(cd "$fixture" && GH_STUB_FAIL=1 bash scripts/audit-session-artifacts.sh 2>&1)" ||
@@ -1445,15 +1445,6 @@ ren_audit_out="$(cd "$fixture" && bash scripts/audit-session-artifacts.sh 2>&1)"
     fail "audit exited nonzero inside the renamed-default window: $ren_audit_out"
 expect_contains "$ren_audit_out" "default branch is now 'trunk'" "rename: audit resolves the live default over stale origin/HEAD"
 
-# The DRY RUN must say so too. verify_remote_state — which produces the note
-# above — runs only on the delete path, so before #958 a dry run under a
-# renamed default reported figures computed against the stale local default
-# with no caveat at all. The freshness probe covers that, and it only can
-# because it asks for the HEAD symref: `--heads` alone omits it (challenge r1).
-ren_dry_out="$(cd "$fixture" && bash scripts/clean-branches.sh 2>&1)" ||
-    fail "renamed-default dry run exited nonzero: $ren_dry_out"
-expect_contains "$ren_dry_out" "default branch is now 'trunk'" "rename: the DRY RUN names the live default too (#958)"
-
 # A non-identity fetch refspec makes a tracking name a DESTINATION, not a
 # remote branch — comparing them marks fresh refs stale and recommends a prune
 # that can never clear the warning. Both tasks must decline to compare and say
@@ -1461,14 +1452,16 @@ expect_contains "$ren_dry_out" "default branch is now 'trunk'" "rename: the DRY 
 # expression first, so both are asserted.
 orig_fetch="$(git -C "$fixture" config --get remote.origin.fetch)"
 git -C "$fixture" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/upstream/*'
-spec_dry_out="$(cd "$fixture" && bash scripts/clean-branches.sh 2>&1)" ||
-    fail "non-identity-refspec dry run exited nonzero: $spec_dry_out"
-expect_contains "$spec_dry_out" "non-identity refspec" "refspec: clean:branches declines to compare (#958)"
-expect_not_contains "$spec_dry_out" "tracking ref(s) are stale" "refspec: clean:branches emits no false staleness (#958)"
 spec_audit_out="$(cd "$fixture" && bash scripts/audit-session-artifacts.sh 2>&1)" ||
     fail "non-identity-refspec audit exited nonzero: $spec_audit_out"
 expect_contains "$spec_audit_out" "non-identity refspec" "refspec: audit declines to compare (#958)"
 expect_not_contains "$spec_audit_out" "deleted upstream" "refspec: audit emits no false staleness (#958)"
+# ...and must then reach NO verdict at all. Both of the section's conclusions
+# are claims about a comparison that did not happen — "fresh" asserts the refs
+# match, and "-> N stale" asserts a count from an empty scan. An assertion
+# naming only one of them passes while the other fires (found by mutant M8).
+expect_not_contains "$spec_audit_out" "fresh — local tracking refs match" "refspec: audit does not claim fresh after skipping the comparison (#958)"
+expect_not_contains "$spec_audit_out" "stale tracking ref(s):" "refspec: audit does not report a stale count after skipping the comparison (#958)"
 git -C "$fixture" config remote.origin.fetch "$orig_fetch"
 
 git -C "$origin" symbolic-ref HEAD refs/heads/main

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -338,6 +338,46 @@ expect_contains "$audit_out" "deferred-findings/wt-checked (branch exists) [work
 expect_contains "$audit_out" "stub/fixture/42.json" "audit: shepherd cycle state listed"
 echo "ok: audit reports all artifact classes read-only"
 
+# ── Case B2: the audit's prunable figure equals what clean:branches deletes ──
+#
+# wt-checked has merged-PR evidence AND is checked out in a linked worktree.
+# The audit counted it as prunable and attributed the total to a task that
+# refuses it, so the operator was handed a number nothing would act on
+# (harmon-init#958). It must now be shown, classified as held, and excluded
+# from the figure.
+expect_contains "$audit_out" "held          wt-checked" "audit: worktree-checked-out branch is held, not prunable"
+expect_not_contains "$audit_out" "prunable      wt-checked" "audit: worktree-checked-out branch is not counted prunable"
+expect_contains "$audit_out" "held by a worktree" "audit: the summary names the held bucket"
+
+# The invariant is SUBSET, not equality, and the distinction is load-bearing.
+# clean:branches deletes on two evidence types — ancestry or a merged PR —
+# while the audit classifies prunable on PR evidence alone, so an
+# ancestry-merged branch is legitimately deletable without being prunable
+# (tracked separately). What #958 fixes is the other direction: nothing may be
+# called prunable that clean:branches will refuse. Asserted per branch rather
+# than on the totals, because two counts can coincide while naming different
+# branches.
+audit_prunable_names="$(printf '%s\n' "$audit_out" |
+    sed -n 's/^  prunable      \([^ ]*\) .*/\1/p' | sort)"
+clean_deletable_names="$(printf '%s\n' "$dry_out" |
+    sed -n 's/^WOULD DELETE  \([^ ]*\) .*/\1/p' | sort)"
+[ -n "$audit_prunable_names" ] || fail "the audit classified nothing prunable — the fixture no longer exercises this (#958)"
+[ -n "$clean_deletable_names" ] || fail "clean:branches found nothing deletable — the fixture no longer exercises this (#958)"
+not_deletable="$(comm -23 <(printf '%s\n' "$audit_prunable_names") <(printf '%s\n' "$clean_deletable_names"))"
+[ -z "$not_deletable" ] ||
+    fail "the audit called these prunable but clean:branches will not delete them (#958): $(printf '%s' "$not_deletable" | tr '\n' ' ')"
+echo "ok: every branch the audit calls prunable is one clean:branches would delete"
+
+# ── Case B3: clean:branches reports tracking-ref staleness ──────────────────
+#
+# Every classification reads local tracking refs, so a branch whose upstream is
+# already gone reads as neither [gone] nor unpushed and lands in `in-flight
+# kept` — a bucket that says "deliberately left alone", not "I could not tell".
+# The audit has said so since it was written; the task that actually deletes
+# did not (harmon-init#958). The fixture's tf-stale ref is exactly that shape.
+expect_contains "$dry_out" "tracking ref(s) are stale" "clean:branches: stale tracking refs are reported"
+expect_contains "$dry_out" "task clean:remote-refs" "clean:branches: the staleness note names the remedy"
+
 # Degraded mode: a failing gh probe is UNVERIFIED, never silently clean.
 audit_fail_out="$(cd "$fixture" && GH_STUB_FAIL=1 bash scripts/audit-session-artifacts.sh 2>&1)" ||
     fail "degraded audit exited nonzero: $audit_fail_out"

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -239,6 +239,12 @@ wt_tip="$(make_branch wt-checked wt.txt)"
 retire_remote wt-checked
 git -C "$fixture" worktree add -q "$test_tmp/wt" wt-checked
 
+# 5b. tracked-live: pushed, upstream still present, not merged — ordinary
+#     in-flight work that WAS classified from a tracking ref. The freshness
+#     caveat counts this one and must not count unpushed-live below, which has
+#     no upstream for a prune to affect (Codex review on PR #991).
+make_branch tracked-live tracked.txt >/dev/null
+
 # 6. unpushed-live: never pushed anywhere — ordinary in-flight work, silent
 #    survival.
 (
@@ -375,8 +381,19 @@ echo "ok: every branch the audit calls prunable is one clean:branches would dele
 # kept` — a bucket that says "deliberately left alone", not "I could not tell".
 # The audit has said so since it was written; the task that actually deletes
 # did not (harmon-init#958). The fixture's tf-stale ref is exactly that shape.
-expect_contains "$dry_out" "kept as in-flight are classified from local tracking refs" "clean:branches: the in-flight bucket carries its caveat"
+expect_contains "$dry_out" "have an upstream and were classified from local tracking refs" "clean:branches: the in-flight bucket carries its caveat"
 expect_contains "$dry_out" "task clean:remote-refs" "clean:branches: the caveat names the remedy"
+# The caveat must count only branches an upstream could have misclassified.
+# The fixture's unpushed-live has none, so it must not be included: keying on
+# the aggregate in-flight count warned about ordinary local-only branches, and
+# a caveat that fires in the common case is one nobody reads (Codex, PR #991).
+caveat_tracked="$(printf '%s\n' "$dry_out" |
+    sed -n 's/^clean:branches: \([0-9][0-9]*\) of the \([0-9][0-9]*\) branch(es).*/\1/p' | head -1)"
+caveat_total="$(printf '%s\n' "$dry_out" |
+    sed -n 's/^clean:branches: \([0-9][0-9]*\) of the \([0-9][0-9]*\) branch(es).*/\2/p' | head -1)"
+[ -n "$caveat_tracked" ] || fail "the in-flight caveat did not report a tracked count (#958)"
+[ "$caveat_tracked" -lt "$caveat_total" ] ||
+    fail "the caveat counted every in-flight branch ($caveat_tracked of $caveat_total) — unpushed-live has no upstream and must be excluded (#958)"
 
 # Degraded mode: a failing gh probe is UNVERIFIED, never silently clean.
 audit_fail_out="$(cd "$fixture" && GH_STUB_FAIL=1 bash scripts/audit-session-artifacts.sh 2>&1)" ||

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -245,6 +245,20 @@ git -C "$fixture" worktree add -q "$test_tmp/wt" wt-checked
 #     no upstream for a prune to affect (Codex review on PR #991).
 make_branch tracked-live tracked.txt >/dev/null
 
+# 5c. local-upstream: tracks another LOCAL branch (branch.<name>.remote=.).
+#     %(upstream) is non-empty, but it is under refs/heads/, so
+#     `task clean:remote-refs` cannot affect how this branch is classified and
+#     the freshness caveat must not count it (Codex review on PR #991).
+(
+    cd "$fixture"
+    git checkout -q -b local-upstream main
+    echo localup >localup.txt
+    git add localup.txt
+    git commit -qm "work tracking a local branch"
+    git branch --set-upstream-to=main local-upstream >/dev/null 2>&1
+    git checkout -q main
+)
+
 # 6. unpushed-live: never pushed anywhere — ordinary in-flight work, silent
 #    survival.
 (
@@ -394,6 +408,17 @@ caveat_total="$(printf '%s\n' "$dry_out" |
 [ -n "$caveat_tracked" ] || fail "the in-flight caveat did not report a tracked count (#958)"
 [ "$caveat_tracked" -lt "$caveat_total" ] ||
     fail "the caveat counted every in-flight branch ($caveat_tracked of $caveat_total) — unpushed-live has no upstream and must be excluded (#958)"
+# local-upstream HAS an upstream, so presence alone would count it — but that
+# upstream is under refs/heads/ and no prune can affect it. Only a
+# remote-tracking upstream belongs in this figure.
+localup_upstream="$(git -C "$fixture" for-each-ref refs/heads/local-upstream --format='%(upstream)')"
+[ -n "$localup_upstream" ] ||
+    fail "the local-upstream fixture lost its upstream — the case cannot distinguish anything (#958)"
+case "$localup_upstream" in
+refs/remotes/*) fail "the local-upstream fixture tracks a REMOTE ref; it must track a local branch (#958)" ;;
+esac
+[ "$caveat_tracked" -le 2 ] ||
+    fail "the caveat counted a locally-tracking branch ($caveat_tracked) — only remote-backed upstreams belong in it (#958)"
 
 # Degraded mode: a failing gh probe is UNVERIFIED, never silently clean.
 audit_fail_out="$(cd "$fixture" && GH_STUB_FAIL=1 bash scripts/audit-session-artifacts.sh 2>&1)" ||

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -1445,6 +1445,32 @@ ren_audit_out="$(cd "$fixture" && bash scripts/audit-session-artifacts.sh 2>&1)"
     fail "audit exited nonzero inside the renamed-default window: $ren_audit_out"
 expect_contains "$ren_audit_out" "default branch is now 'trunk'" "rename: audit resolves the live default over stale origin/HEAD"
 
+# The DRY RUN must say so too. verify_remote_state — which produces the note
+# above — runs only on the delete path, so before #958 a dry run under a
+# renamed default reported figures computed against the stale local default
+# with no caveat at all. The freshness probe covers that, and it only can
+# because it asks for the HEAD symref: `--heads` alone omits it (challenge r1).
+ren_dry_out="$(cd "$fixture" && bash scripts/clean-branches.sh 2>&1)" ||
+    fail "renamed-default dry run exited nonzero: $ren_dry_out"
+expect_contains "$ren_dry_out" "default branch is now 'trunk'" "rename: the DRY RUN names the live default too (#958)"
+
+# A non-identity fetch refspec makes a tracking name a DESTINATION, not a
+# remote branch — comparing them marks fresh refs stale and recommends a prune
+# that can never clear the warning. Both tasks must decline to compare and say
+# why, rather than emit something false (challenge r1). The audit copied this
+# expression first, so both are asserted.
+orig_fetch="$(git -C "$fixture" config --get remote.origin.fetch)"
+git -C "$fixture" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/upstream/*'
+spec_dry_out="$(cd "$fixture" && bash scripts/clean-branches.sh 2>&1)" ||
+    fail "non-identity-refspec dry run exited nonzero: $spec_dry_out"
+expect_contains "$spec_dry_out" "non-identity refspec" "refspec: clean:branches declines to compare (#958)"
+expect_not_contains "$spec_dry_out" "tracking ref(s) are stale" "refspec: clean:branches emits no false staleness (#958)"
+spec_audit_out="$(cd "$fixture" && bash scripts/audit-session-artifacts.sh 2>&1)" ||
+    fail "non-identity-refspec audit exited nonzero: $spec_audit_out"
+expect_contains "$spec_audit_out" "non-identity refspec" "refspec: audit declines to compare (#958)"
+expect_not_contains "$spec_audit_out" "deleted upstream" "refspec: audit emits no false staleness (#958)"
+git -C "$fixture" config remote.origin.fetch "$orig_fetch"
+
 git -C "$origin" symbolic-ref HEAD refs/heads/main
 git -C "$origin" update-ref -d refs/heads/trunk
 ren_ok_out="$(cd "$fixture" && bash scripts/clean-branches.sh --delete 2>&1)" ||

--- a/template/scripts/test-session-cleanup.sh
+++ b/template/scripts/test-session-cleanup.sh
@@ -367,7 +367,11 @@ echo "ok: audit reports all artifact classes read-only"
 # from the figure.
 expect_contains "$audit_out" "held          wt-checked" "audit: worktree-checked-out branch is held, not prunable"
 expect_not_contains "$audit_out" "prunable      wt-checked" "audit: worktree-checked-out branch is not counted prunable"
-expect_contains "$audit_out" "held by a worktree" "audit: the summary names the held bucket"
+# Generic on purpose: "held" covers a worktree checkout AND a symbolic ref, so
+# a summary naming only one gives the wrong reason whenever the other is in the
+# count (Codex, PR #991). Each entry states its own reason.
+expect_contains "$audit_out" "held (see above)" "audit: the summary names the held bucket without guessing its reason"
+expect_not_contains "$audit_out" "held by a worktree" "audit: the aggregate does not claim a single reason (#958)"
 
 # The invariant is SUBSET, not equality, and the distinction is load-bearing.
 # clean:branches deletes on two evidence types — ancestry or a merged PR —


### PR DESCRIPTION
## What

Two ways the session-cleanup pair reported numbers the operator could not act on.

**The audit counted branches `clean:branches` refuses.** A branch with merged-PR
evidence that is checked out in a linked worktree was classified `prunable`, and
the total was labelled `(task clean:branches)` — naming the very task that
declines it. Observed as `-> 3 prunable` against `1 deletable`.

**`clean:branches` never said when its own inputs were stale.** Every
classification reads local tracking refs, so a branch whose upstream was deleted
on merge reads as neither `[gone]` nor unpushed and lands in `in-flight kept` —
a bucket that means "deliberately left alone", not "I could not tell".

## What changed

The audit applies the same worktree test, derived by the **same awk** as
`clean-branches.sh` so the two cannot disagree about what is checked out. Such a
branch is shown as `held` with its worktree path and excluded from the figure
attributed to the other task.

`clean:branches` states the caveat whenever anything is kept as in-flight:
that bucket is classified from local tracking refs, and a prune may change it.

A non-identity fetch refspec now stops the audit comparing at all, rather than
marking fresh refs stale and recommending a prune that can never clear the
report. That expression was pre-existing and had been copied into the new code;
both copies are corrected, since leaving them divergent is the failure this
issue removes.

## The invariant is subset, not equality

This issue proposed that the audit's figure **equal** what `clean:branches`
deletes. That was asserted first and **failed on the fixture** — `clean:branches`
also deletes on ancestry evidence the audit does not classify, so an
ancestry-merged branch is legitimately deletable without being prunable. Filed
as #990.

What ships is the direction this issue establishes: **every branch the audit
calls prunable is one `clean:branches` would delete**, asserted per branch rather
than on totals, since two counts can agree while naming different branches.

## What was deleted, and why

Case 3 was first built as a live freshness probe. Two challenge rounds produced
six findings against it — snapshot atomicity versus a concurrent fetch, a missing
HEAD symref, non-identity refspecs — **every one inside the probe, none in the
reporting this issue is about**, and all of round 2's were against round 1's own
fixes.

This issue asks only that the task "performs, or explicitly reports the absence
of" the check, and says a one-line note would be enough. So the probe is gone and
the note is deterministic: no network call, nothing to race, no configuration in
which it can be wrong. Two of the findings are **mooted** rather than fixed.
`clean-branches.sh` is 50 lines lighter.

## Verification

- `task verify` green after every round · `task ci` green
- Cases: worktree-held branch classified and excluded; the subset invariant per
  branch; the in-flight caveat and its remedy; a non-identity refspec declining
  in the audit **without then reaching either verdict**
- **6 mutants, 0 survivors**, measured against a suite proven green first

Verified by hand against a genuinely stale tracking ref — deleted in the bare
repo, since `git push --delete` also drops the local tracking ref and cannot
reproduce the condition.

## Review budget

`rigor: deep → challenge ≤5, review ≤5, shepherd 4, min_rounds 1`

Challenge ran 2 rounds (r1: 3×P2; r2: 1×P1 + 2×P2, all against r1's fixes,
resolved by deletion). **Challenge round 3 and the review stage were skipped on
@evanharmon1's explicit instruction** — the change is small, both cases are
verified empirically, and the deletion removed the surface generating findings.
Codex cloud review still runs against the final head during shepherding.

Nothing was deferred, so there is no `## Deferred findings` section.

## This will close #958 with one criterion unticked

Stating it rather than letting it happen quietly. The first commit's message
carries `Closes #958`, this repo squashes with `COMMIT_MESSAGES`, and amending a
pushed commit is not permitted here — so the close is unavoidable at merge.

Three of four acceptance criteria are ticked. The fourth asks the suite to assert
that **"the two tasks' counts agree"**, and they cannot: `clean:branches` also
deletes on ancestry evidence the audit does not classify, so equality is
unreachable until **#990**, which carries that half in full with a reproduction.

The half belonging to this issue — a worktree-held branch no longer inflating the
audit's figure — is implemented and asserted per branch.

Refs #990
