### PR TITLE
feat(devcontainer): configure antigravity statusline in devcontainer

### DIFF
--- a/.devcontainer/config/antigravity-settings.json
+++ b/.devcontainer/config/antigravity-settings.json
@@ -2,5 +2,11 @@
   "toolPermission": "always-proceed",
   "artifactReviewPolicy": "always-proceed",
   "allowNonWorkspaceAccess": true,
-  "enableTerminalSandbox": false
+  "enableTerminalSandbox": false,
+  "statusLine": {
+    "type": "command",
+    "command": "/etc/claude-code/statusline.sh",
+    "enabled": true,
+    "stack_with_default": false
+  }
 }

--- a/.devcontainer/config/apply-antigravity-settings.sh
+++ b/.devcontainer/config/apply-antigravity-settings.sh
@@ -50,7 +50,7 @@ apply)
             . as $settings |
             reduce $keys[] as $key (
                 {
-                    schemaVersion: 3,
+                    schemaVersion: 4,
                     present: [],
                     values: {},
                     introducedWorkspaces: (
@@ -68,8 +68,20 @@ apply)
             )
         ' "$settings_path" >"$backup_tmp"
         atomic_replace "$backup_tmp" "$backup_path"
-    elif ! jq -e --argjson keys "$managed_keys" '
-        type == "object" and .schemaVersion == 3 and
+    elif jq -e '.schemaVersion == 3' "$backup_path" >/dev/null 2>&1; then
+        backup_tmp="$(mktemp "${settings_dir}/settings.backup.tmp.XXXXXX")"
+        trap 'rm -f "${backup_tmp:-}" "${settings_tmp:-}"' EXIT
+        jq --slurpfile settings "$settings_path" '
+            .schemaVersion = 4 |
+            if ($settings[0] | type == "object" and has("statusLine")) and (.present | index("statusLine") == null) then
+                .present += ["statusLine"] | .values.statusLine = $settings[0].statusLine
+            else . end
+        ' "$backup_path" >"$backup_tmp"
+        atomic_replace "$backup_tmp" "$backup_path"
+    fi
+
+    if ! jq -e --argjson keys "$managed_keys" '
+        type == "object" and .schemaVersion == 4 and
         (.present | type == "array") and (.values | type == "object") and
         (.introducedWorkspaces | type == "array") and
         ([.introducedWorkspaces[] | select(type != "string")] | length == 0) and
@@ -124,7 +136,7 @@ restore)
         exit 0
     fi
     if ! jq -e --argjson keys "$managed_keys" '
-        type == "object" and .schemaVersion == 3 and
+        type == "object" and .schemaVersion == 4 and
         (.present | type == "array") and (.values | type == "object") and
         (.introducedWorkspaces | type == "array") and
         ([.introducedWorkspaces[] | select(type != "string")] | length == 0) and

--- a/.devcontainer/config/apply-antigravity-settings.sh
+++ b/.devcontainer/config/apply-antigravity-settings.sh
@@ -136,7 +136,7 @@ restore)
         exit 0
     fi
     if ! jq -e --argjson keys "$managed_keys" '
-        type == "object" and .schemaVersion == 4 and
+        type == "object" and (.schemaVersion == 4 or .schemaVersion == 3) and
         (.present | type == "array") and (.values | type == "object") and
         (.introducedWorkspaces | type == "array") and
         ([.introducedWorkspaces[] | select(type != "string")] | length == 0) and

--- a/.devcontainer/config/apply-antigravity-settings.sh
+++ b/.devcontainer/config/apply-antigravity-settings.sh
@@ -151,7 +151,12 @@ restore)
     trap 'rm -f "${settings_tmp:-}"' EXIT
     jq -s --argjson keys "$managed_keys" '
         .[0] as $current | .[1] as $backup |
-        reduce $keys[] as $key ($current; del(.[$key])) |
+        (if $backup.schemaVersion == 3 then
+            ["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox"]
+         else
+            $keys
+         end) as $active_keys |
+        reduce $active_keys[] as $key ($current; del(.[$key])) |
         reduce $backup.present[] as $key (.; .[$key] = $backup.values[$key]) |
         if ((.trustedWorkspaces | type) == "array") then
             .trustedWorkspaces = [

--- a/.devcontainer/config/apply-antigravity-settings.sh
+++ b/.devcontainer/config/apply-antigravity-settings.sh
@@ -7,7 +7,7 @@ workspace="${3:-$PWD}"
 settings_dir="$HOME/.gemini/antigravity-cli"
 settings_path="$settings_dir/settings.json"
 backup_path="$settings_dir/settings.json.harmon-init-autonomy-backup"
-managed_keys='["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox"]'
+managed_keys='["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox","statusLine"]'
 
 valid_object() {
     jq -s -e 'length == 1 and (.[0] | type == "object")' "$1" >/dev/null

--- a/.devcontainer/config/claude-statusline.sh
+++ b/.devcontainer/config/claude-statusline.sh
@@ -101,16 +101,16 @@ fields=$(jq -r '
   # and folding that to 0 would draw two empty quota bars claiming a fresh
   # allowance the session does not have. Only a real 0 may render as 0.
   def o: if . == null then "" else (. | n) end;
-  [ ((.workspace.current_dir // .cwd // .workspace_path) | s)
-  , (.workspace.project_dir                             | s)
-  , ((.model.display_name // .model.id // .model)       | s)
-  , ((.effort.level // .effort)                         | s)
-  , (((.fast_mode == true) or (.fast == true))          | s)
-  , (((.thinking.enabled == true) or (.thinking == true)) | s)
-  , (.version                                           | s)
-  , ((.output_style.name // .output_style)              | s)
+  [ (((if (.workspace | type) == "object" then .workspace.current_dir else .workspace end) // .cwd // .workspace_path) | s)
+  , ((if (.workspace | type) == "object" then .workspace.project_dir else "" end) | s)
+  , ((if (.model | type) == "object" then (.model.display_name // .model.id) else .model end) | s)
+  , ((if (.effort | type) == "object" then .effort.level else .effort end) | s)
+  , (((.fast_mode == true) or (.fast == true)) | s)
+  , (((if (.thinking | type) == "object" then .thinking.enabled else .thinking end) == true) | s)
+  , (.version | s)
+  , ((if (.output_style | type) == "object" then .output_style.name else .output_style end) | s)
   , ((.session_id // .conversation_id // .conversationId) | s | .[0:8])
-  , (.session_name                                      | s)
+  , (.session_name | s)
   # The context gauge has three states, not two: a percentage, and "unknown".
   # A payload carrying neither field — an early-session refresh, or an agent
   # that reports only token counts — must reach the renderer as absent so
@@ -118,27 +118,25 @@ fields=$(jq -r '
   # `100 - 100 = 0` and paint an empty green bar over a context window that may
   # be nearly full: the one wrong answer worse than no answer. Same rule as `o`
   # above, one field deeper.
-  , (if   (.context_window.used_percentage      | type) == "number"
-     then (.context_window.used_percentage      | floor)
-     elif (.context_window.remaining_percentage | type) == "number"
+  , (if   ((.context_window | type) == "object" and (.context_window.used_percentage | type) == "number")
+     then (.context_window.used_percentage | floor)
+     elif ((.context_window | type) == "object" and (.context_window.remaining_percentage | type) == "number")
      then ((100 - .context_window.remaining_percentage) | floor)
-     elif ((.context_window.total_tokens | type) == "number" and (.context_window.context_window_size | type) == "number" and .context_window.context_window_size > 0)
+     elif ((.context_window | type) == "object" and (.context_window.total_tokens | type) == "number" and (.context_window.context_window_size | type) == "number" and .context_window.context_window_size > 0 and .context_window.total_tokens <= .context_window.context_window_size)
      then ((.context_window.total_tokens * 100 / .context_window.context_window_size) | floor)
-     elif ((.context_window.total_input_tokens | type) == "number" and (.context_window.total_output_tokens | type) == "number" and (.context_window.context_window_size | type) == "number" and .context_window.context_window_size > 0)
-     then (((.context_window.total_input_tokens + .context_window.total_output_tokens) * 100 / .context_window.context_window_size) | floor)
      else "" end)
-  , (.context_window.context_window_size    | n)
-  , ((.cost.total_cost_usd // .cost)        | (. // 0) | tostring)
-  , (.cost.total_lines_added                | n)
-  , (.cost.total_lines_removed              | n)
-  , (.cost.total_duration_ms                | n)
-  , (.pr.number                             | s)
-  , (.pr.url                                | s)
-  , (.pr.review_state                       | s)
-  , ((.rate_limits.five_hour.used_percentage // .quota.five_hour.used_percentage) | o)
-  , ((.rate_limits.five_hour.resets_at       // .quota.five_hour.resets_at)       | o)
-  , ((.rate_limits.seven_day.used_percentage // .quota.seven_day.used_percentage) | o)
-  , ((.rate_limits.seven_day.resets_at       // .quota.seven_day.resets_at)       | o)
+  , ((if (.context_window | type) == "object" then .context_window.context_window_size else 0 end) | n)
+  , ((if (.cost | type) == "object" then .cost.total_cost_usd else .cost end) | (. // 0) | tostring)
+  , ((if (.cost | type) == "object" then .cost.total_lines_added else 0 end) | n)
+  , ((if (.cost | type) == "object" then .cost.total_lines_removed else 0 end) | n)
+  , ((if (.cost | type) == "object" then .cost.total_duration_ms else 0 end) | n)
+  , ((if (.pr | type) == "object" then .pr.number else "" end) | s)
+  , ((if (.pr | type) == "object" then .pr.url else "" end) | s)
+  , ((if (.pr | type) == "object" then .pr.review_state else "" end) | s)
+  , ((if (.rate_limits | type) == "object" then .rate_limits.five_hour.used_percentage elif (.quota | type) == "object" then .quota.five_hour.used_percentage else null end) | o)
+  , ((if (.rate_limits | type) == "object" then .rate_limits.five_hour.resets_at elif (.quota | type) == "object" then .quota.five_hour.resets_at else null end) | o)
+  , ((if (.rate_limits | type) == "object" then .rate_limits.seven_day.used_percentage elif (.quota | type) == "object" then .quota.seven_day.used_percentage else null end) | o)
+  , ((if (.rate_limits | type) == "object" then .rate_limits.seven_day.resets_at elif (.quota | type) == "object" then .quota.seven_day.resets_at else null end) | o)
   ] | map(tostring) | join("\u001f")' <<<"$input" 2>/dev/null)
 
 # Split on U+001F (unit separator), not a tab: TAB is IFS *whitespace*, so

--- a/.devcontainer/config/claude-statusline.sh
+++ b/.devcontainer/config/claude-statusline.sh
@@ -101,19 +101,19 @@ fields=$(jq -r '
   # and folding that to 0 would draw two empty quota bars claiming a fresh
   # allowance the session does not have. Only a real 0 may render as 0.
   def o: if . == null then "" else (. | n) end;
-  [ ((.workspace.current_dir // .cwd)   | s)
-  , (.workspace.project_dir             | s)
-  , (.model.display_name                | s)
-  , (.effort.level                      | s)
-  , ((.fast_mode        == true)        | s)
-  , ((.thinking.enabled == true)        | s)
-  , (.version                           | s)
-  , (.output_style.name                 | s)
-  , (.session_id                        | s | .[0:8])
-  , (.session_name                      | s)
+  [ ((.workspace.current_dir // .cwd // .workspace_path) | s)
+  , (.workspace.project_dir                             | s)
+  , ((.model.display_name // .model.id // .model)       | s)
+  , ((.effort.level // .effort)                         | s)
+  , (((.fast_mode == true) or (.fast == true))          | s)
+  , (((.thinking.enabled == true) or (.thinking == true)) | s)
+  , (.version                                           | s)
+  , ((.output_style.name // .output_style)              | s)
+  , ((.session_id // .conversation_id // .conversationId) | s | .[0:8])
+  , (.session_name                                      | s)
   # The context gauge has three states, not two: a percentage, and "unknown".
-  # A payload carrying neither field — an early-session refresh, or a Claude
-  # Code that reports only token counts — must reach the renderer as absent so
+  # A payload carrying neither field — an early-session refresh, or an agent
+  # that reports only token counts — must reach the renderer as absent so
   # it draws `context n/a`. Defaulting the missing remainder to 100 would make
   # `100 - 100 = 0` and paint an empty green bar over a context window that may
   # be nearly full: the one wrong answer worse than no answer. Same rule as `o`
@@ -122,19 +122,23 @@ fields=$(jq -r '
      then (.context_window.used_percentage      | floor)
      elif (.context_window.remaining_percentage | type) == "number"
      then ((100 - .context_window.remaining_percentage) | floor)
+     elif ((.context_window.total_tokens | type) == "number" and (.context_window.context_window_size | type) == "number" and .context_window.context_window_size > 0)
+     then ((.context_window.total_tokens * 100 / .context_window.context_window_size) | floor)
+     elif ((.context_window.total_input_tokens | type) == "number" and (.context_window.total_output_tokens | type) == "number" and (.context_window.context_window_size | type) == "number" and .context_window.context_window_size > 0)
+     then (((.context_window.total_input_tokens + .context_window.total_output_tokens) * 100 / .context_window.context_window_size) | floor)
      else "" end)
   , (.context_window.context_window_size    | n)
-  , (.cost.total_cost_usd                   | (. // 0) | tostring)
+  , ((.cost.total_cost_usd // .cost)        | (. // 0) | tostring)
   , (.cost.total_lines_added                | n)
   , (.cost.total_lines_removed              | n)
   , (.cost.total_duration_ms                | n)
   , (.pr.number                             | s)
   , (.pr.url                                | s)
   , (.pr.review_state                       | s)
-  , (.rate_limits.five_hour.used_percentage | o)
-  , (.rate_limits.five_hour.resets_at       | o)
-  , (.rate_limits.seven_day.used_percentage | o)
-  , (.rate_limits.seven_day.resets_at       | o)
+  , ((.rate_limits.five_hour.used_percentage // .quota.five_hour.used_percentage) | o)
+  , ((.rate_limits.five_hour.resets_at       // .quota.five_hour.resets_at)       | o)
+  , ((.rate_limits.seven_day.used_percentage // .quota.seven_day.used_percentage) | o)
+  , ((.rate_limits.seven_day.resets_at       // .quota.seven_day.resets_at)       | o)
   ] | map(tostring) | join("\u001f")' <<<"$input" 2>/dev/null)
 
 # Split on U+001F (unit separator), not a tab: TAB is IFS *whitespace*, so

--- a/copier.yml
+++ b/copier.yml
@@ -331,9 +331,9 @@ use_antigravity_cli:
     feature restriction: the CLI operates on the mounted local workspace, so
     review its terms/data handling before using proprietary code. The bot then
     trusts its workspace, always proceeds with tools/artifacts, allows
-    non-workspace access, and disables Antigravity's inner terminal sandbox
-    because the container is the isolation boundary. The human dev profile
-    keeps Antigravity's normal prompts.
+    non-workspace access, disables Antigravity's inner terminal sandbox
+    because the container is the isolation boundary, and configures the
+    statusLine renderer. The human dev profile keeps Antigravity's normal prompts.
   default: no
   when: "[[ devcontainer ]]"
   validator: "[% if use_antigravity_cli and not devcontainer %]Enable DEVCONTAINER before ANTIGRAVITY CLI.[% endif %]"

--- a/docs/guides/devcontainers.md
+++ b/docs/guides/devcontainers.md
@@ -43,15 +43,16 @@ remain the bot's boundaries.
 **Antigravity autonomy is an explicit opt-in.** This repo enables
 `use_antigravity_cli`, so its bot profile applies `always-proceed`, always
 accepts artifact reviews, allows non-workspace access, disables Antigravity's
-inner terminal sandbox, and trusts the current container workspace. The human
-profile keeps Antigravity's normal prompts. Run `agy` interactively once to
-complete Google sign-in; the pinned CLI falls back to file-backed credentials
-when the headless container has no D-Bus keyring, and the `~/.gemini` named
-volume persists that login. A checksum-verified compatibility installer covers
-the interval before the shared-image pin advances, then becomes a network-free
-no-op. The settings helper backs up the four policy keys it owns and tracks its
-workspace-trust entry, so turning the Copier option off restores both while
-preserving unrelated settings.
+inner terminal sandbox, configures the devcontainer status line renderer, and
+trusts the current container workspace. The human profile keeps Antigravity's
+normal prompts. Run `agy` interactively once to complete Google sign-in; the
+pinned CLI falls back to file-backed credentials when the headless container has
+no D-Bus keyring, and the `~/.gemini` named volume persists that login. A
+checksum-verified compatibility installer covers the interval before the
+shared-image pin advances, then becomes a network-free no-op. The settings helper
+backs up the five policy keys it owns and tracks its workspace-trust entry, so
+turning the Copier option off restores all five while preserving unrelated
+settings.
 
 ## Run it locally
 

--- a/images/devcontainer/install-repo-config.sh
+++ b/images/devcontainer/install-repo-config.sh
@@ -48,8 +48,8 @@ EOF
 tic -x "${config_dir}/ghostty.terminfo"
 
 install -d -m 0755 \
+    /etc/antigravity \
     /etc/claude-code/hooks \
-    /etc/codex/hooks \
     /etc/codex/hooks \
     /home/vscode/.agent-deck \
     /home/vscode/.config/git \
@@ -70,6 +70,7 @@ install -m 0644 "${config_dir}/zshrc" /home/vscode/.zshrc
 
 install -m 0644 "${config_dir}/claude-settings.json" /etc/claude-code/managed-settings.json
 install -m 0755 "${config_dir}/claude-statusline.sh" /etc/claude-code/statusline.sh
+install -m 0755 "${config_dir}/claude-statusline.sh" /etc/antigravity/statusline.sh
 install -m 0644 "${config_dir}/codex-managed-config.toml" /etc/codex/managed_config.toml
 install -m 0644 "${config_dir}/codex-managed-config.toml" /etc/codex/managed_config.toml
 for hook in \

--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -474,16 +474,34 @@ assert_unit() {
     ' --arg workspace "$agy_workspace" "$agy_backup" >/dev/null ||
         fail "Antigravity policy rollback state was not recorded correctly"
 
-    # Test migration of a legacy schemaVersion 3 backup
-    printf '%s\n' '{"schemaVersion":3,"present":["toolPermission"],"values":{"toolPermission":"request-review"},"introducedWorkspaces":["/tmp/old"],"trustedWorkspacesKeyWasPresent":false}' >"$agy_backup"
-    printf '%s\n' '{"statusLine":{"type":"command","command":"/custom/statusline.sh"}}' >"$agy_settings"
-    HOME="$agy_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace" >/dev/null
+    local agy_mig_home agy_mig_settings agy_mig_backup
+    agy_mig_home="${work_dir}/agy-mig-home"
+    agy_mig_settings="${agy_mig_home}/.gemini/antigravity-cli/settings.json"
+    agy_mig_backup="${agy_mig_home}/.gemini/antigravity-cli/settings.json.harmon-init-autonomy-backup"
+    mkdir -p "${agy_mig_home}/.gemini/antigravity-cli"
+    printf '%s\n' '{"schemaVersion":3,"present":["toolPermission"],"values":{"toolPermission":"request-review"},"introducedWorkspaces":["/tmp/old"],"trustedWorkspacesKeyWasPresent":false}' >"$agy_mig_backup"
+    printf '%s\n' '{"statusLine":{"type":"command","command":"/custom/statusline.sh"}}' >"$agy_mig_settings"
+    HOME="$agy_mig_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace" >/dev/null
     jq -e '
         .schemaVersion == 4 and
         (.present | index("statusLine") != null) and
         .values.statusLine.command == "/custom/statusline.sh"
-    ' "$agy_backup" >/dev/null ||
+    ' "$agy_mig_backup" >/dev/null ||
         fail "legacy schemaVersion 3 backup was not migrated to schemaVersion 4 with custom statusLine captured"
+
+    # Test that restore also handles legacy schemaVersion 3 rollback state
+    printf '%s\n' '{"schemaVersion":3,"present":["toolPermission"],"values":{"toolPermission":"request-review"},"introducedWorkspaces":["/tmp/old"],"trustedWorkspacesKeyWasPresent":false}' >"$agy_mig_backup"
+    printf '%s\n' '{"toolPermission":"always-proceed","artifactReviewPolicy":"always-proceed","allowNonWorkspaceAccess":true,"enableTerminalSandbox":false,"statusLine":{"type":"command","command":"/etc/claude-code/statusline.sh"},"trustedWorkspaces":["/tmp/old"]}' >"$agy_mig_settings"
+    HOME="$agy_mig_home" bash "$agy_apply" restore >/dev/null
+    jq -e '
+        .toolPermission == "request-review" and
+        has("artifactReviewPolicy") == false and
+        has("allowNonWorkspaceAccess") == false and
+        has("enableTerminalSandbox") == false and
+        has("statusLine") == false and
+        has("trustedWorkspaces") == false
+    ' "$agy_mig_settings" >/dev/null ||
+        fail "Antigravity policy rollback did not handle legacy schemaVersion 3 backup on restore"
 
     HOME="$agy_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace_moved" >/dev/null
     jq -e '.trustedWorkspaces == [$first, $second]' \

--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -458,6 +458,10 @@ assert_unit() {
         .artifactReviewPolicy == "always-proceed" and
         .allowNonWorkspaceAccess == true and
         .enableTerminalSandbox == false and
+        .statusLine.type == "command" and
+        .statusLine.command == "/etc/claude-code/statusline.sh" and
+        .statusLine.enabled == true and
+        .statusLine.stack_with_default == false and
         .trustedWorkspaces == [$workspace]
     ' --arg workspace "$agy_workspace" "$agy_settings" >/dev/null ||
         fail "Antigravity dev container policy was not merged correctly"
@@ -489,6 +493,7 @@ assert_unit() {
         has("artifactReviewPolicy") == false and
         has("allowNonWorkspaceAccess") == false and
         has("enableTerminalSandbox") == false and
+        has("statusLine") == false and
         has("trustedWorkspaces") == false
     ' "$agy_settings" >/dev/null ||
         fail "Antigravity policy rollback did not restore only the managed keys"

--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -466,13 +466,24 @@ assert_unit() {
     ' --arg workspace "$agy_workspace" "$agy_settings" >/dev/null ||
         fail "Antigravity dev container policy was not merged correctly"
     jq -e '
-        .schemaVersion == 3 and
+        .schemaVersion == 4 and
         .present == ["toolPermission"] and
         .values.toolPermission == "request-review" and
         .introducedWorkspaces == [$workspace] and
         .trustedWorkspacesKeyWasPresent == false
     ' --arg workspace "$agy_workspace" "$agy_backup" >/dev/null ||
         fail "Antigravity policy rollback state was not recorded correctly"
+
+    # Test migration of a legacy schemaVersion 3 backup
+    printf '%s\n' '{"schemaVersion":3,"present":["toolPermission"],"values":{"toolPermission":"request-review"},"introducedWorkspaces":["/tmp/old"],"trustedWorkspacesKeyWasPresent":false}' >"$agy_backup"
+    printf '%s\n' '{"statusLine":{"type":"command","command":"/custom/statusline.sh"}}' >"$agy_settings"
+    HOME="$agy_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace" >/dev/null
+    jq -e '
+        .schemaVersion == 4 and
+        (.present | index("statusLine") != null) and
+        .values.statusLine.command == "/custom/statusline.sh"
+    ' "$agy_backup" >/dev/null ||
+        fail "legacy schemaVersion 3 backup was not migrated to schemaVersion 4 with custom statusLine captured"
 
     HOME="$agy_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace_moved" >/dev/null
     jq -e '.trustedWorkspaces == [$first, $second]' \

--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -489,19 +489,19 @@ assert_unit() {
     ' "$agy_mig_backup" >/dev/null ||
         fail "legacy schemaVersion 3 backup was not migrated to schemaVersion 4 with custom statusLine captured"
 
-    # Test that restore also handles legacy schemaVersion 3 rollback state
+    # Test that restore also handles legacy schemaVersion 3 rollback state and preserves user statusLine
     printf '%s\n' '{"schemaVersion":3,"present":["toolPermission"],"values":{"toolPermission":"request-review"},"introducedWorkspaces":["/tmp/old"],"trustedWorkspacesKeyWasPresent":false}' >"$agy_mig_backup"
-    printf '%s\n' '{"toolPermission":"always-proceed","artifactReviewPolicy":"always-proceed","allowNonWorkspaceAccess":true,"enableTerminalSandbox":false,"statusLine":{"type":"command","command":"/etc/claude-code/statusline.sh"},"trustedWorkspaces":["/tmp/old"]}' >"$agy_mig_settings"
+    printf '%s\n' '{"toolPermission":"always-proceed","artifactReviewPolicy":"always-proceed","allowNonWorkspaceAccess":true,"enableTerminalSandbox":false,"statusLine":{"type":"command","command":"/custom/statusline.sh"},"trustedWorkspaces":["/tmp/old"]}' >"$agy_mig_settings"
     HOME="$agy_mig_home" bash "$agy_apply" restore >/dev/null
     jq -e '
         .toolPermission == "request-review" and
         has("artifactReviewPolicy") == false and
         has("allowNonWorkspaceAccess") == false and
         has("enableTerminalSandbox") == false and
-        has("statusLine") == false and
+        .statusLine.command == "/custom/statusline.sh" and
         has("trustedWorkspaces") == false
     ' "$agy_mig_settings" >/dev/null ||
-        fail "Antigravity policy rollback did not handle legacy schemaVersion 3 backup on restore"
+        fail "Antigravity policy rollback did not handle legacy schemaVersion 3 backup on restore while preserving statusLine"
 
     HOME="$agy_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace_moved" >/dev/null
     jq -e '.trustedWorkspaces == [$first, $second]' \

--- a/scripts/test-statusline.sh
+++ b/scripts/test-statusline.sh
@@ -79,4 +79,11 @@ echo "==> an empty payload degrades instead of blanking"
 out=$(render '')
 [ -n "$out" ] || fail "an empty payload produced no output at all"
 
+echo "==> Antigravity payload (conversation_id, model, headroom)"
+out=$(render '{"workspace":{"current_dir":"/"},"context_window":{"used_percentage":25,"context_window_size":1000000},"model":{"display_name":"Gemini 3.1 Pro (High)"},"conversation_id":"34ee01b6-2f37-4fe7"}')
+case "$out" in *' 25%'*) ;; *) fail "expected 25%, got: $out" ;; esac
+case "$out" in *'750k left'*) ;; *) fail "expected '750k left', got: $out" ;; esac
+case "$out" in *'Gemini 3.1 Pro (High)'*) ;; *) fail "expected model name, got: $out" ;; esac
+case "$out" in *'34ee01b6'*) ;; *) fail "expected session id, got: $out" ;; esac
+
 echo "statusline: all cases passed"

--- a/scripts/test-statusline.sh
+++ b/scripts/test-statusline.sh
@@ -86,4 +86,9 @@ case "$out" in *'750k left'*) ;; *) fail "expected '750k left', got: $out" ;; es
 case "$out" in *'Gemini 3.1 Pro (High)'*) ;; *) fail "expected model name, got: $out" ;; esac
 case "$out" in *'34ee01b6'*) ;; *) fail "expected session id, got: $out" ;; esac
 
+echo "==> scalar-shaped fields (model, effort, cost as string/numbers) do not crash jq"
+out=$(render '{"workspace":"/","model":"gemini-pro","effort":"high","cost":0.12,"thinking":true,"conversation_id":"34ee01b6-2f37-4fe7"}')
+case "$out" in *'gemini-pro'*) ;; *) fail "expected scalar model name, got: $out" ;; esac
+case "$out" in *'34ee01b6'*) ;; *) fail "expected session id, got: $out" ;; esac
+
 echo "statusline: all cases passed"

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/antigravity-settings.json
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/antigravity-settings.json
@@ -2,5 +2,11 @@
   "toolPermission": "always-proceed",
   "artifactReviewPolicy": "always-proceed",
   "allowNonWorkspaceAccess": true,
-  "enableTerminalSandbox": false
+  "enableTerminalSandbox": false,
+  "statusLine": {
+    "type": "command",
+    "command": "/etc/claude-code/statusline.sh",
+    "enabled": true,
+    "stack_with_default": false
+  }
 }

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/apply-antigravity-settings.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/apply-antigravity-settings.sh
@@ -50,7 +50,7 @@ apply)
             . as $settings |
             reduce $keys[] as $key (
                 {
-                    schemaVersion: 3,
+                    schemaVersion: 4,
                     present: [],
                     values: {},
                     introducedWorkspaces: (
@@ -68,8 +68,20 @@ apply)
             )
         ' "$settings_path" >"$backup_tmp"
         atomic_replace "$backup_tmp" "$backup_path"
-    elif ! jq -e --argjson keys "$managed_keys" '
-        type == "object" and .schemaVersion == 3 and
+    elif jq -e '.schemaVersion == 3' "$backup_path" >/dev/null 2>&1; then
+        backup_tmp="$(mktemp "${settings_dir}/settings.backup.tmp.XXXXXX")"
+        trap 'rm -f "${backup_tmp:-}" "${settings_tmp:-}"' EXIT
+        jq --slurpfile settings "$settings_path" '
+            .schemaVersion = 4 |
+            if ($settings[0] | type == "object" and has("statusLine")) and (.present | index("statusLine") == null) then
+                .present += ["statusLine"] | .values.statusLine = $settings[0].statusLine
+            else . end
+        ' "$backup_path" >"$backup_tmp"
+        atomic_replace "$backup_tmp" "$backup_path"
+    fi
+
+    if ! jq -e --argjson keys "$managed_keys" '
+        type == "object" and .schemaVersion == 4 and
         (.present | type == "array") and (.values | type == "object") and
         (.introducedWorkspaces | type == "array") and
         ([.introducedWorkspaces[] | select(type != "string")] | length == 0) and
@@ -124,7 +136,7 @@ restore)
         exit 0
     fi
     if ! jq -e --argjson keys "$managed_keys" '
-        type == "object" and .schemaVersion == 3 and
+        type == "object" and .schemaVersion == 4 and
         (.present | type == "array") and (.values | type == "object") and
         (.introducedWorkspaces | type == "array") and
         ([.introducedWorkspaces[] | select(type != "string")] | length == 0) and

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/apply-antigravity-settings.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/apply-antigravity-settings.sh
@@ -136,7 +136,7 @@ restore)
         exit 0
     fi
     if ! jq -e --argjson keys "$managed_keys" '
-        type == "object" and .schemaVersion == 4 and
+        type == "object" and (.schemaVersion == 4 or .schemaVersion == 3) and
         (.present | type == "array") and (.values | type == "object") and
         (.introducedWorkspaces | type == "array") and
         ([.introducedWorkspaces[] | select(type != "string")] | length == 0) and

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/apply-antigravity-settings.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/apply-antigravity-settings.sh
@@ -151,7 +151,12 @@ restore)
     trap 'rm -f "${settings_tmp:-}"' EXIT
     jq -s --argjson keys "$managed_keys" '
         .[0] as $current | .[1] as $backup |
-        reduce $keys[] as $key ($current; del(.[$key])) |
+        (if $backup.schemaVersion == 3 then
+            ["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox"]
+         else
+            $keys
+         end) as $active_keys |
+        reduce $active_keys[] as $key ($current; del(.[$key])) |
         reduce $backup.present[] as $key (.; .[$key] = $backup.values[$key]) |
         if ((.trustedWorkspaces | type) == "array") then
             .trustedWorkspaces = [

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/apply-antigravity-settings.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/apply-antigravity-settings.sh
@@ -7,7 +7,7 @@ workspace="${3:-$PWD}"
 settings_dir="$HOME/.gemini/antigravity-cli"
 settings_path="$settings_dir/settings.json"
 backup_path="$settings_dir/settings.json.harmon-init-autonomy-backup"
-managed_keys='["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox"]'
+managed_keys='["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox","statusLine"]'
 
 valid_object() {
     jq -s -e 'length == 1 and (.[0] | type == "object")' "$1" >/dev/null

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-statusline.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-statusline.sh
@@ -101,16 +101,16 @@ fields=$(jq -r '
   # and folding that to 0 would draw two empty quota bars claiming a fresh
   # allowance the session does not have. Only a real 0 may render as 0.
   def o: if . == null then "" else (. | n) end;
-  [ ((.workspace.current_dir // .cwd // .workspace_path) | s)
-  , (.workspace.project_dir                             | s)
-  , ((.model.display_name // .model.id // .model)       | s)
-  , ((.effort.level // .effort)                         | s)
-  , (((.fast_mode == true) or (.fast == true))          | s)
-  , (((.thinking.enabled == true) or (.thinking == true)) | s)
-  , (.version                                           | s)
-  , ((.output_style.name // .output_style)              | s)
+  [ (((if (.workspace | type) == "object" then .workspace.current_dir else .workspace end) // .cwd // .workspace_path) | s)
+  , ((if (.workspace | type) == "object" then .workspace.project_dir else "" end) | s)
+  , ((if (.model | type) == "object" then (.model.display_name // .model.id) else .model end) | s)
+  , ((if (.effort | type) == "object" then .effort.level else .effort end) | s)
+  , (((.fast_mode == true) or (.fast == true)) | s)
+  , (((if (.thinking | type) == "object" then .thinking.enabled else .thinking end) == true) | s)
+  , (.version | s)
+  , ((if (.output_style | type) == "object" then .output_style.name else .output_style end) | s)
   , ((.session_id // .conversation_id // .conversationId) | s | .[0:8])
-  , (.session_name                                      | s)
+  , (.session_name | s)
   # The context gauge has three states, not two: a percentage, and "unknown".
   # A payload carrying neither field — an early-session refresh, or an agent
   # that reports only token counts — must reach the renderer as absent so
@@ -118,27 +118,25 @@ fields=$(jq -r '
   # `100 - 100 = 0` and paint an empty green bar over a context window that may
   # be nearly full: the one wrong answer worse than no answer. Same rule as `o`
   # above, one field deeper.
-  , (if   (.context_window.used_percentage      | type) == "number"
-     then (.context_window.used_percentage      | floor)
-     elif (.context_window.remaining_percentage | type) == "number"
+  , (if   ((.context_window | type) == "object" and (.context_window.used_percentage | type) == "number")
+     then (.context_window.used_percentage | floor)
+     elif ((.context_window | type) == "object" and (.context_window.remaining_percentage | type) == "number")
      then ((100 - .context_window.remaining_percentage) | floor)
-     elif ((.context_window.total_tokens | type) == "number" and (.context_window.context_window_size | type) == "number" and .context_window.context_window_size > 0)
+     elif ((.context_window | type) == "object" and (.context_window.total_tokens | type) == "number" and (.context_window.context_window_size | type) == "number" and .context_window.context_window_size > 0 and .context_window.total_tokens <= .context_window.context_window_size)
      then ((.context_window.total_tokens * 100 / .context_window.context_window_size) | floor)
-     elif ((.context_window.total_input_tokens | type) == "number" and (.context_window.total_output_tokens | type) == "number" and (.context_window.context_window_size | type) == "number" and .context_window.context_window_size > 0)
-     then (((.context_window.total_input_tokens + .context_window.total_output_tokens) * 100 / .context_window.context_window_size) | floor)
      else "" end)
-  , (.context_window.context_window_size    | n)
-  , ((.cost.total_cost_usd // .cost)        | (. // 0) | tostring)
-  , (.cost.total_lines_added                | n)
-  , (.cost.total_lines_removed              | n)
-  , (.cost.total_duration_ms                | n)
-  , (.pr.number                             | s)
-  , (.pr.url                                | s)
-  , (.pr.review_state                       | s)
-  , ((.rate_limits.five_hour.used_percentage // .quota.five_hour.used_percentage) | o)
-  , ((.rate_limits.five_hour.resets_at       // .quota.five_hour.resets_at)       | o)
-  , ((.rate_limits.seven_day.used_percentage // .quota.seven_day.used_percentage) | o)
-  , ((.rate_limits.seven_day.resets_at       // .quota.seven_day.resets_at)       | o)
+  , ((if (.context_window | type) == "object" then .context_window.context_window_size else 0 end) | n)
+  , ((if (.cost | type) == "object" then .cost.total_cost_usd else .cost end) | (. // 0) | tostring)
+  , ((if (.cost | type) == "object" then .cost.total_lines_added else 0 end) | n)
+  , ((if (.cost | type) == "object" then .cost.total_lines_removed else 0 end) | n)
+  , ((if (.cost | type) == "object" then .cost.total_duration_ms else 0 end) | n)
+  , ((if (.pr | type) == "object" then .pr.number else "" end) | s)
+  , ((if (.pr | type) == "object" then .pr.url else "" end) | s)
+  , ((if (.pr | type) == "object" then .pr.review_state else "" end) | s)
+  , ((if (.rate_limits | type) == "object" then .rate_limits.five_hour.used_percentage elif (.quota | type) == "object" then .quota.five_hour.used_percentage else null end) | o)
+  , ((if (.rate_limits | type) == "object" then .rate_limits.five_hour.resets_at elif (.quota | type) == "object" then .quota.five_hour.resets_at else null end) | o)
+  , ((if (.rate_limits | type) == "object" then .rate_limits.seven_day.used_percentage elif (.quota | type) == "object" then .quota.seven_day.used_percentage else null end) | o)
+  , ((if (.rate_limits | type) == "object" then .rate_limits.seven_day.resets_at elif (.quota | type) == "object" then .quota.seven_day.resets_at else null end) | o)
   ] | map(tostring) | join("\u001f")' <<<"$input" 2>/dev/null)
 
 # Split on U+001F (unit separator), not a tab: TAB is IFS *whitespace*, so

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-statusline.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/claude-statusline.sh
@@ -101,19 +101,19 @@ fields=$(jq -r '
   # and folding that to 0 would draw two empty quota bars claiming a fresh
   # allowance the session does not have. Only a real 0 may render as 0.
   def o: if . == null then "" else (. | n) end;
-  [ ((.workspace.current_dir // .cwd)   | s)
-  , (.workspace.project_dir             | s)
-  , (.model.display_name                | s)
-  , (.effort.level                      | s)
-  , ((.fast_mode        == true)        | s)
-  , ((.thinking.enabled == true)        | s)
-  , (.version                           | s)
-  , (.output_style.name                 | s)
-  , (.session_id                        | s | .[0:8])
-  , (.session_name                      | s)
+  [ ((.workspace.current_dir // .cwd // .workspace_path) | s)
+  , (.workspace.project_dir                             | s)
+  , ((.model.display_name // .model.id // .model)       | s)
+  , ((.effort.level // .effort)                         | s)
+  , (((.fast_mode == true) or (.fast == true))          | s)
+  , (((.thinking.enabled == true) or (.thinking == true)) | s)
+  , (.version                                           | s)
+  , ((.output_style.name // .output_style)              | s)
+  , ((.session_id // .conversation_id // .conversationId) | s | .[0:8])
+  , (.session_name                                      | s)
   # The context gauge has three states, not two: a percentage, and "unknown".
-  # A payload carrying neither field — an early-session refresh, or a Claude
-  # Code that reports only token counts — must reach the renderer as absent so
+  # A payload carrying neither field — an early-session refresh, or an agent
+  # that reports only token counts — must reach the renderer as absent so
   # it draws `context n/a`. Defaulting the missing remainder to 100 would make
   # `100 - 100 = 0` and paint an empty green bar over a context window that may
   # be nearly full: the one wrong answer worse than no answer. Same rule as `o`
@@ -122,19 +122,23 @@ fields=$(jq -r '
      then (.context_window.used_percentage      | floor)
      elif (.context_window.remaining_percentage | type) == "number"
      then ((100 - .context_window.remaining_percentage) | floor)
+     elif ((.context_window.total_tokens | type) == "number" and (.context_window.context_window_size | type) == "number" and .context_window.context_window_size > 0)
+     then ((.context_window.total_tokens * 100 / .context_window.context_window_size) | floor)
+     elif ((.context_window.total_input_tokens | type) == "number" and (.context_window.total_output_tokens | type) == "number" and (.context_window.context_window_size | type) == "number" and .context_window.context_window_size > 0)
+     then (((.context_window.total_input_tokens + .context_window.total_output_tokens) * 100 / .context_window.context_window_size) | floor)
      else "" end)
   , (.context_window.context_window_size    | n)
-  , (.cost.total_cost_usd                   | (. // 0) | tostring)
+  , ((.cost.total_cost_usd // .cost)        | (. // 0) | tostring)
   , (.cost.total_lines_added                | n)
   , (.cost.total_lines_removed              | n)
   , (.cost.total_duration_ms                | n)
   , (.pr.number                             | s)
   , (.pr.url                                | s)
   , (.pr.review_state                       | s)
-  , (.rate_limits.five_hour.used_percentage | o)
-  , (.rate_limits.five_hour.resets_at       | o)
-  , (.rate_limits.seven_day.used_percentage | o)
-  , (.rate_limits.seven_day.resets_at       | o)
+  , ((.rate_limits.five_hour.used_percentage // .quota.five_hour.used_percentage) | o)
+  , ((.rate_limits.five_hour.resets_at       // .quota.five_hour.resets_at)       | o)
+  , ((.rate_limits.seven_day.used_percentage // .quota.seven_day.used_percentage) | o)
+  , ((.rate_limits.seven_day.resets_at       // .quota.seven_day.resets_at)       | o)
   ] | map(tostring) | join("\u001f")' <<<"$input" 2>/dev/null)
 
 # Split on U+001F (unit separator), not a tab: TAB is IFS *whitespace*, so

--- a/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
+++ b/template/docs/guides/[% if devcontainer %]devcontainers.md[% endif %].jinja
@@ -43,15 +43,16 @@ remain the bot's boundaries.
 [% if use_antigravity_cli %]
 **Antigravity autonomy is enabled for the bot profile.** It applies
 `always-proceed`, always accepts artifact reviews, allows non-workspace access,
-disables Antigravity's inner terminal sandbox, and trusts the current container
-workspace. The human profile keeps Antigravity's normal prompts. Run `agy`
-interactively once to complete Google sign-in; the pinned CLI falls back to
-file-backed credentials when the headless container has no D-Bus keyring, and
-the `~/.gemini` named volume persists that login. A checksum-verified
-compatibility installer covers the interval before the shared-image pin
-advances, then becomes a network-free no-op. The settings helper backs up the
-four policy keys it owns and tracks its workspace-trust entry, so turning the
-Copier option off restores both while preserving unrelated settings.
+disables Antigravity's inner terminal sandbox, configures the devcontainer
+status line renderer, and trusts the current container workspace. The human
+profile keeps Antigravity's normal prompts. Run `agy` interactively once to
+complete Google sign-in; the pinned CLI falls back to file-backed credentials
+when the headless container has no D-Bus keyring, and the `~/.gemini` named
+volume persists that login. A checksum-verified compatibility installer covers
+the interval before the shared-image pin advances, then becomes a network-free
+no-op. The settings helper backs up the five policy keys it owns and tracks its
+workspace-trust entry, so turning the Copier option off restores all five while
+preserving unrelated settings.
 [% else %]
 **Antigravity autonomy is off by default.** The CLI is available in the shared
 image, but this template does not authenticate it or weaken its permission

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -474,16 +474,34 @@ assert_unit() {
     ' --arg workspace "$agy_workspace" "$agy_backup" >/dev/null ||
         fail "Antigravity policy rollback state was not recorded correctly"
 
-    # Test migration of a legacy schemaVersion 3 backup
-    printf '%s\n' '{"schemaVersion":3,"present":["toolPermission"],"values":{"toolPermission":"request-review"},"introducedWorkspaces":["/tmp/old"],"trustedWorkspacesKeyWasPresent":false}' >"$agy_backup"
-    printf '%s\n' '{"statusLine":{"type":"command","command":"/custom/statusline.sh"}}' >"$agy_settings"
-    HOME="$agy_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace" >/dev/null
+    local agy_mig_home agy_mig_settings agy_mig_backup
+    agy_mig_home="${work_dir}/agy-mig-home"
+    agy_mig_settings="${agy_mig_home}/.gemini/antigravity-cli/settings.json"
+    agy_mig_backup="${agy_mig_home}/.gemini/antigravity-cli/settings.json.harmon-init-autonomy-backup"
+    mkdir -p "${agy_mig_home}/.gemini/antigravity-cli"
+    printf '%s\n' '{"schemaVersion":3,"present":["toolPermission"],"values":{"toolPermission":"request-review"},"introducedWorkspaces":["/tmp/old"],"trustedWorkspacesKeyWasPresent":false}' >"$agy_mig_backup"
+    printf '%s\n' '{"statusLine":{"type":"command","command":"/custom/statusline.sh"}}' >"$agy_mig_settings"
+    HOME="$agy_mig_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace" >/dev/null
     jq -e '
         .schemaVersion == 4 and
         (.present | index("statusLine") != null) and
         .values.statusLine.command == "/custom/statusline.sh"
-    ' "$agy_backup" >/dev/null ||
+    ' "$agy_mig_backup" >/dev/null ||
         fail "legacy schemaVersion 3 backup was not migrated to schemaVersion 4 with custom statusLine captured"
+
+    # Test that restore also handles legacy schemaVersion 3 rollback state
+    printf '%s\n' '{"schemaVersion":3,"present":["toolPermission"],"values":{"toolPermission":"request-review"},"introducedWorkspaces":["/tmp/old"],"trustedWorkspacesKeyWasPresent":false}' >"$agy_mig_backup"
+    printf '%s\n' '{"toolPermission":"always-proceed","artifactReviewPolicy":"always-proceed","allowNonWorkspaceAccess":true,"enableTerminalSandbox":false,"statusLine":{"type":"command","command":"/etc/claude-code/statusline.sh"},"trustedWorkspaces":["/tmp/old"]}' >"$agy_mig_settings"
+    HOME="$agy_mig_home" bash "$agy_apply" restore >/dev/null
+    jq -e '
+        .toolPermission == "request-review" and
+        has("artifactReviewPolicy") == false and
+        has("allowNonWorkspaceAccess") == false and
+        has("enableTerminalSandbox") == false and
+        has("statusLine") == false and
+        has("trustedWorkspaces") == false
+    ' "$agy_mig_settings" >/dev/null ||
+        fail "Antigravity policy rollback did not handle legacy schemaVersion 3 backup on restore"
 
     HOME="$agy_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace_moved" >/dev/null
     jq -e '.trustedWorkspaces == [$first, $second]' \

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -458,6 +458,10 @@ assert_unit() {
         .artifactReviewPolicy == "always-proceed" and
         .allowNonWorkspaceAccess == true and
         .enableTerminalSandbox == false and
+        .statusLine.type == "command" and
+        .statusLine.command == "/etc/claude-code/statusline.sh" and
+        .statusLine.enabled == true and
+        .statusLine.stack_with_default == false and
         .trustedWorkspaces == [$workspace]
     ' --arg workspace "$agy_workspace" "$agy_settings" >/dev/null ||
         fail "Antigravity dev container policy was not merged correctly"
@@ -489,6 +493,7 @@ assert_unit() {
         has("artifactReviewPolicy") == false and
         has("allowNonWorkspaceAccess") == false and
         has("enableTerminalSandbox") == false and
+        has("statusLine") == false and
         has("trustedWorkspaces") == false
     ' "$agy_settings" >/dev/null ||
         fail "Antigravity policy rollback did not restore only the managed keys"

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -466,13 +466,24 @@ assert_unit() {
     ' --arg workspace "$agy_workspace" "$agy_settings" >/dev/null ||
         fail "Antigravity dev container policy was not merged correctly"
     jq -e '
-        .schemaVersion == 3 and
+        .schemaVersion == 4 and
         .present == ["toolPermission"] and
         .values.toolPermission == "request-review" and
         .introducedWorkspaces == [$workspace] and
         .trustedWorkspacesKeyWasPresent == false
     ' --arg workspace "$agy_workspace" "$agy_backup" >/dev/null ||
         fail "Antigravity policy rollback state was not recorded correctly"
+
+    # Test migration of a legacy schemaVersion 3 backup
+    printf '%s\n' '{"schemaVersion":3,"present":["toolPermission"],"values":{"toolPermission":"request-review"},"introducedWorkspaces":["/tmp/old"],"trustedWorkspacesKeyWasPresent":false}' >"$agy_backup"
+    printf '%s\n' '{"statusLine":{"type":"command","command":"/custom/statusline.sh"}}' >"$agy_settings"
+    HOME="$agy_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace" >/dev/null
+    jq -e '
+        .schemaVersion == 4 and
+        (.present | index("statusLine") != null) and
+        .values.statusLine.command == "/custom/statusline.sh"
+    ' "$agy_backup" >/dev/null ||
+        fail "legacy schemaVersion 3 backup was not migrated to schemaVersion 4 with custom statusLine captured"
 
     HOME="$agy_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace_moved" >/dev/null
     jq -e '.trustedWorkspaces == [$first, $second]' \

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -489,19 +489,19 @@ assert_unit() {
     ' "$agy_mig_backup" >/dev/null ||
         fail "legacy schemaVersion 3 backup was not migrated to schemaVersion 4 with custom statusLine captured"
 
-    # Test that restore also handles legacy schemaVersion 3 rollback state
+    # Test that restore also handles legacy schemaVersion 3 rollback state and preserves user statusLine
     printf '%s\n' '{"schemaVersion":3,"present":["toolPermission"],"values":{"toolPermission":"request-review"},"introducedWorkspaces":["/tmp/old"],"trustedWorkspacesKeyWasPresent":false}' >"$agy_mig_backup"
-    printf '%s\n' '{"toolPermission":"always-proceed","artifactReviewPolicy":"always-proceed","allowNonWorkspaceAccess":true,"enableTerminalSandbox":false,"statusLine":{"type":"command","command":"/etc/claude-code/statusline.sh"},"trustedWorkspaces":["/tmp/old"]}' >"$agy_mig_settings"
+    printf '%s\n' '{"toolPermission":"always-proceed","artifactReviewPolicy":"always-proceed","allowNonWorkspaceAccess":true,"enableTerminalSandbox":false,"statusLine":{"type":"command","command":"/custom/statusline.sh"},"trustedWorkspaces":["/tmp/old"]}' >"$agy_mig_settings"
     HOME="$agy_mig_home" bash "$agy_apply" restore >/dev/null
     jq -e '
         .toolPermission == "request-review" and
         has("artifactReviewPolicy") == false and
         has("allowNonWorkspaceAccess") == false and
         has("enableTerminalSandbox") == false and
-        has("statusLine") == false and
+        .statusLine.command == "/custom/statusline.sh" and
         has("trustedWorkspaces") == false
     ' "$agy_mig_settings" >/dev/null ||
-        fail "Antigravity policy rollback did not handle legacy schemaVersion 3 backup on restore"
+        fail "Antigravity policy rollback did not handle legacy schemaVersion 3 backup on restore while preserving statusLine"
 
     HOME="$agy_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace_moved" >/dev/null
     jq -e '.trustedWorkspaces == [$first, $second]' \

--- a/template/scripts/[% if devcontainer %]test-statusline.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]test-statusline.sh[% endif %]
@@ -79,4 +79,11 @@ echo "==> an empty payload degrades instead of blanking"
 out=$(render '')
 [ -n "$out" ] || fail "an empty payload produced no output at all"
 
+echo "==> Antigravity payload (conversation_id, model, headroom)"
+out=$(render '{"workspace":{"current_dir":"/"},"context_window":{"used_percentage":25,"context_window_size":1000000},"model":{"display_name":"Gemini 3.1 Pro (High)"},"conversation_id":"34ee01b6-2f37-4fe7"}')
+case "$out" in *' 25%'*) ;; *) fail "expected 25%, got: $out" ;; esac
+case "$out" in *'750k left'*) ;; *) fail "expected '750k left', got: $out" ;; esac
+case "$out" in *'Gemini 3.1 Pro (High)'*) ;; *) fail "expected model name, got: $out" ;; esac
+case "$out" in *'34ee01b6'*) ;; *) fail "expected session id, got: $out" ;; esac
+
 echo "statusline: all cases passed"

--- a/template/scripts/[% if devcontainer %]test-statusline.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]test-statusline.sh[% endif %]
@@ -86,4 +86,9 @@ case "$out" in *'750k left'*) ;; *) fail "expected '750k left', got: $out" ;; es
 case "$out" in *'Gemini 3.1 Pro (High)'*) ;; *) fail "expected model name, got: $out" ;; esac
 case "$out" in *'34ee01b6'*) ;; *) fail "expected session id, got: $out" ;; esac
 
+echo "==> scalar-shaped fields (model, effort, cost as string/numbers) do not crash jq"
+out=$(render '{"workspace":"/","model":"gemini-pro","effort":"high","cost":0.12,"thinking":true,"conversation_id":"34ee01b6-2f37-4fe7"}')
+case "$out" in *'gemini-pro'*) ;; *) fail "expected scalar model name, got: $out" ;; esac
+case "$out" in *'34ee01b6'*) ;; *) fail "expected session id, got: $out" ;; esac
+
 echo "statusline: all cases passed"


### PR DESCRIPTION
## Summary
- Configures `statusLine` in `.devcontainer/config/antigravity-settings.json` and template.
- Updates `.devcontainer/config/apply-antigravity-settings.sh` to manage the `statusLine` key and rollback cleanly.
- Updates `.devcontainer/config/claude-statusline.sh` and template to parse Antigravity session payloads alongside Claude Code.
- Adds `/etc/antigravity/statusline.sh` in `images/devcontainer/install-repo-config.sh`.
- Adds unit tests in `scripts/test-statusline.sh` and `scripts/devcontainer-assert.sh`.

## Verification
- `task test:statusline` passed.
- `task verify` passed all linter, dogfood parity, and template test suites.