### PR TITLE
fix(template): allow .agents/skills/ symlinks in the sync scope guard

### DIFF
--- a/scripts/sync-devkit-release.sh
+++ b/scripts/sync-devkit-release.sh
@@ -242,11 +242,14 @@ changed_paths_nl() {
 }
 
 # assert_expected_scope DEST — fail closed unless every changed path is one of
-# the two manifests, the provenance stamp, or a vendored skill the sync owns.
-# The owned set is the UNION of the pre-sync (HEAD) and post-sync `# managed:`
-# lines: a skill the new pin dropped appears only in the old list, one it added
-# only in the new. Anything else — a local skill, an unrelated file — is an
-# unexpected write and aborts the run before anything is committed or pushed.
+# the two manifests, a provenance stamp, a vendored skill/agent the sync owns,
+# or a portable `.agents/skills/` compatibility symlink that
+# scripts/link-agent-skills.sh maintains as the second command of
+# `task sync:skills`. The owned set is the UNION of the pre-sync (HEAD) and
+# post-sync `# managed:` lines: a skill the new pin dropped appears only in the
+# old list, one it added only in the new. Anything else — a local skill's
+# contents, an unrelated file — is an unexpected write and aborts the run before
+# anything is committed or pushed.
 # managed_from_stamp PROV — the `# managed:` names recorded on a provenance
 # stamp, taken from BOTH the committed and working-tree copies so a name the
 # sync just added or just removed is allowed either way.
@@ -297,6 +300,18 @@ assert_expected_scope() {
     _aes_allow="$(
         managed_from_stamp "$_aes_prov"
     )"
+    # scripts/link-agent-skills.sh (the second command in `task sync:skills`)
+    # writes a `.agents/skills/<name>` compatibility symlink for EVERY Claude
+    # skill — managed or local — so the same skills are visible through the
+    # cross-harness .agents standard. That dest is not in the manifest; it is
+    # link-agent-skills.sh's own, resolved the same way here. An unsafe value
+    # (absolute, or with a `..` component) disarms the allowance rather than
+    # trusting it: portable links then read as rogue writes and abort, which is
+    # the safe failure.
+    _aes_pdir="${AGENT_SKILLS_DIR:-.agents/skills}"
+    case "$_aes_pdir" in
+    "" | "/" | "." | ".." | /* | ../* | */../* | */..) _aes_pdir="" ;;
+    esac
     # Delimited membership test (no `grep` subprocess): a pipeline whose reader
     # exits early can report SIGPIPE under `pipefail` and reject a legitimate
     # path.
@@ -342,13 +357,43 @@ assert_expected_scope() {
                 ;;
             esac
         fi
+        # A portable `.agents/skills/<name>` symlink that link-agent-skills.sh
+        # creates as part of `task sync:skills`. Without this allowance every
+        # NEW managed skill's symlink reads as a rogue write and aborts the
+        # pin-bump PR — latent until a devkit release adds skills the repo never
+        # vendored before (v0.34.0 added three at once, breaking the sync).
+        # Allowed when <name> is managed (a dropped skill's removed symlink
+        # passes too: the name survives on the HEAD stamp) OR a matching skill
+        # directory still exists under the skills dest — a local skill the sync
+        # must never touch, but whose compatibility link is still the sync's to
+        # maintain. A native portable skill at the same path would already have
+        # aborted the run in the link step's divergent-name check.
+        if [ "$_aes_ok" -eq 0 ] && [ -n "$_aes_pdir" ]; then
+            case "$_aes_p" in
+            "$_aes_pdir"/*)
+                _aes_pname="${_aes_p#"$_aes_pdir"/}"
+                _aes_pname="${_aes_pname%%/*}"
+                case "$_aes_pname" in
+                "" | "." | "..") ;;
+                *)
+                    case "$_aes_haystack" in
+                    *"${LF}${_aes_pname}${LF}"*) _aes_ok=1 ;;
+                    esac
+                    if [ "$_aes_ok" -eq 0 ] && [ -d "$_aes_dest/$_aes_pname" ]; then
+                        _aes_ok=1
+                    fi
+                    ;;
+                esac
+                ;;
+            esac
+        fi
         [ "$_aes_ok" -eq 1 ] || _aes_bad="${_aes_bad}  - ${_aes_p}${LF}"
     done < <(changed_paths_z)
 
     if [ -n "$_aes_bad" ]; then
         echo "sync-devkit-release: the sync wrote paths it does not own:" >&2
         printf '%s' "$_aes_bad" >&2
-        die "expected only the two skills-sync manifests, the provenance stamps, managed skills under $_aes_dest/, and managed agents under ${_aes_adest:-<none>}/ — inspect by hand"
+        die "expected only the two skills-sync manifests, the provenance stamps, managed skills under $_aes_dest/, managed agents under ${_aes_adest:-<none>}/, and portable skill links under ${_aes_pdir:-<none>}/ — inspect by hand"
     fi
 }
 

--- a/scripts/sync-devkit-release.sh
+++ b/scripts/sync-devkit-release.sh
@@ -312,6 +312,24 @@ assert_expected_scope() {
     case "$_aes_pdir" in
     "" | "/" | "." | ".." | /* | ../* | */../* | */..) _aes_pdir="" ;;
     esac
+    # An AGENT_SKILLS_DIR overlapping the skills or agents dest would route the
+    # portable-link allowance inside a tree the sync promises never to touch
+    # (or, containing a dest, approve paths the dest's own block already
+    # rejected), so disarm it: those paths then read as rogue writes and abort
+    # — fail-closed. Both directions matter: pdir inside a dest, and a dest
+    # inside pdir.
+    if [ -n "$_aes_pdir" ]; then
+        case "$_aes_pdir" in "$_aes_dest" | "$_aes_dest"/*) _aes_pdir="" ;; esac
+    fi
+    if [ -n "$_aes_pdir" ]; then
+        case "$_aes_dest" in "$_aes_pdir" | "$_aes_pdir"/*) _aes_pdir="" ;; esac
+    fi
+    if [ -n "$_aes_pdir" ] && [ -n "$_aes_adest" ]; then
+        case "$_aes_pdir" in "$_aes_adest" | "$_aes_adest"/*) _aes_pdir="" ;; esac
+    fi
+    if [ -n "$_aes_pdir" ] && [ -n "$_aes_adest" ]; then
+        case "$_aes_adest" in "$_aes_pdir" | "$_aes_pdir"/*) _aes_pdir="" ;; esac
+    fi
     # Delimited membership test (no `grep` subprocess): a pipeline whose reader
     # exits early can report SIGPIPE under `pipefail` and reject a legitimate
     # path.
@@ -372,8 +390,15 @@ assert_expected_scope() {
             case "$_aes_p" in
             "$_aes_pdir"/*)
                 _aes_pname="${_aes_p#"$_aes_pdir"/}"
-                _aes_pname="${_aes_pname%%/*}"
+                # Only a flat .agents/skills/<name> symlink is the link step's
+                # output. A nested path beneath a managed name is not something
+                # it writes — and an entry replaced with a directory or an
+                # arbitrary-target symlink is a rogue object the link step's
+                # divergent-name check does not catch for a dropped skill — so
+                # do not blanket-approve <name>/anything: leave _aes_ok at 0
+                # and let it read as a rogue write (fail-closed).
                 case "$_aes_pname" in
+                */*) ;; # nested path → not a flat symlink → reject
                 "" | "." | "..") ;;
                 *)
                     case "$_aes_haystack" in

--- a/scripts/sync-devkit-release.sh
+++ b/scripts/sync-devkit-release.sh
@@ -309,6 +309,21 @@ assert_expected_scope() {
     # trusting it: portable links then read as rogue writes and abort, which is
     # the safe failure.
     _aes_pdir="${AGENT_SKILLS_DIR:-.agents/skills}"
+    # Normalize the spelling before matching it against git's canonical changed
+    # paths: strip a leading "./", collapse "//" (empty components), and drop a
+    # trailing "/" so an equivalent repo-relative value (./.agents/skills,
+    # .agents/skills/, .agents//skills) matches as it should. "." and ".."
+    # components are left for the safety case below — a `..` traversal must stay
+    # rejected, not be normalized away.
+    while case "$_aes_pdir" in ./*) true ;; *) false ;; esac do
+        _aes_pdir="${_aes_pdir#./}"
+    done
+    while case "$_aes_pdir" in *//*) true ;; *) false ;; esac do
+        _aes_pdir="${_aes_pdir//\/\//\/}"
+    done
+    while case "$_aes_pdir" in */) true ;; *) false ;; esac do
+        _aes_pdir="${_aes_pdir%/}"
+    done
     case "$_aes_pdir" in
     "" | "/" | "." | ".." | /* | ../* | */../* | */..) _aes_pdir="" ;;
     esac

--- a/scripts/test-sync-devkit-release.sh
+++ b/scripts/test-sync-devkit-release.sh
@@ -838,6 +838,23 @@ grep -qF '.agents/skills/issue-title-support/evil' "$LAST_OUT" ||
     fail "the nested path was not named in the rejection: $(cat "$LAST_OUT")"
 ! pushed "$fix" || fail "a nested-path sync still pushed"
 
+start "a noncanonical AGENT_SKILLS_DIR spelling still matches its links"
+# Finding: an equivalent repo-relative AGENT_SKILLS_DIR (a "./" prefix or a
+# trailing "/") left the portable dir noncanonical while git reports changed
+# paths canonically, so the literal prefix match missed every legitimate link
+# and the sync aborted on valid consumer config. Normalize the spelling before
+# the match so the links approve as they do for the canonical default.
+fix="$(new_fixture scope_portable_normalize)"
+STUB_SYNC_ADD_SKILL="issue-title-support"
+AGENT_SKILLS_DIR="./.agents/skills"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "a noncanonical AGENT_SKILLS_DIR spelling was rejected: $(cat "$LAST_OUT")"
+pushed_tree="$(git -C "$fix.origin.git" ls-tree -r --name-only "$SYNC_BRANCH")"
+printf '%s\n' "$pushed_tree" | grep -qx '.agents/skills/issue-title-support' ||
+    fail "the new skill's portable link is missing under a noncanonical pdir: $(cat "$LAST_OUT")"
+printf '%s\n' "$pushed_tree" | grep -qx '.agents/skills/standardize-repo' ||
+    fail "an existing skill's portable link is missing under a noncanonical pdir: $(cat "$LAST_OUT")"
+
 start "an AGENT_SKILLS_DIR overlapping the skills dest fails closed"
 # Finding: a syntactically-safe but overlapping AGENT_SKILLS_DIR routes the
 # portable-link allowance inside a tree the sync promises never to touch. The

--- a/scripts/test-sync-devkit-release.sh
+++ b/scripts/test-sync-devkit-release.sh
@@ -89,6 +89,10 @@ EOF
 
     cp "$REPO_ROOT/$HELPER" "$_nf_dir/scripts/"
     cp "$REPO_ROOT/scripts/require-release-title.sh" "$_nf_dir/scripts/"
+    # link-agent-skills.sh is the second command in `task sync:skills`; the stub
+    # below runs the REAL one so the scope guard is exercised against the
+    # .agents/skills/ compatibility symlinks it writes, not a mock of them.
+    cp "$REPO_ROOT/scripts/link-agent-skills.sh" "$_nf_dir/scripts/"
 
     git init --quiet --initial-branch=main "$_nf_dir"
     git -C "$_nf_dir" config user.name "fixture"
@@ -275,6 +279,12 @@ sync:skills)
     fi
     [ -z "${STUB_SYNC_TOUCH_UNRELATED:-}" ] || echo "oops" >"${STUB_SYNC_TOUCH_UNRELATED}"
     [ -z "${STUB_SYNC_DELETE_LOCAL:-}" ] || rm -rf .claude/skills/local-only
+    # The real `task sync:skills` runs scripts/link-agent-skills.sh sync as its
+    # second command, creating one .agents/skills/<name> symlink per Claude
+    # skill. Run the real script (copied into the fixture) so the scope guard is
+    # exercised against those symlinks — the previous stub omitted this, which
+    # is exactly why the v0.34.0 sync failure reached CI uncaught.
+    ./scripts/link-agent-skills.sh sync
     ;;
 esac
 exit 0
@@ -401,9 +411,11 @@ logged "gh pr view 42 --json headRefOid,isDraft" ||
 logged "fix(template): sync harmon-devkit skills to v0.9.0" || fail "PR title is not releasing"
 logged "task verify" || fail "verification never ran"
 [ "$(git -C "$fix" rev-parse main)" = "$main_before" ] || fail "main was modified"
-# The commit must contain exactly the expected paths.
+# The commit must contain exactly the expected paths — including the
+# .agents/skills/ compatibility symlinks link-agent-skills.sh wrote for every
+# Claude skill (the managed one AND the local one).
 changed="$(git -C "$fix" diff --no-renames --name-only main "$SYNC_BRANCH" | sort | tr '\n' '|')"
-[ "$changed" = ".claude/skills/.SKILLS_PROVENANCE|.claude/skills/standardize-repo/SKILL.md|.skills-sync.yaml|template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja|" ] ||
+[ "$changed" = ".agents/skills/local-only|.agents/skills/standardize-repo|.claude/skills/.SKILLS_PROVENANCE|.claude/skills/standardize-repo/SKILL.md|.skills-sync.yaml|template/[% if use_skills_sync %].skills-sync.yaml[% endif %].jinja|" ] ||
     fail "unexpected commit contents: $changed"
 
 start "a created PR that lands ready is returned to draft and re-confirmed"
@@ -763,6 +775,25 @@ STUB_SYNC_ADD_SKILL=""
 STUB_SYNC_DROP_SKILL="standardize-repo"
 rc="$(run_helper "$fix" run v0.9.0)"
 [ "$rc" = 0 ] || fail "dropping a previously managed skill was rejected: $(cat "$LAST_OUT")"
+
+start "a new managed skill's portable .agents/skills link stays in scope"
+# The exact CI failure: harmon-devkit v0.34.0 added issue-title-support,
+# label-registry-support and triage, the sync vendored them, and
+# link-agent-skills.sh created their .agents/skills/ symlinks — which the guard
+# rejected as out-of-scope writes, aborting before the PR. A newly added
+# managed skill must carry its portable link into the pushed commit, and the
+# link step links the local skill too.
+fix="$(new_fixture scope_portable_link)"
+STUB_SYNC_ADD_SKILL="issue-title-support"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" = 0 ] || fail "a new managed skill's portable link was rejected: $(cat "$LAST_OUT")"
+pushed_tree="$(git -C "$fix.origin.git" ls-tree -r --name-only "$SYNC_BRANCH")"
+printf '%s\n' "$pushed_tree" | grep -qx '.agents/skills/issue-title-support' ||
+    fail "the new skill's portable link is missing from the pushed commit"
+printf '%s\n' "$pushed_tree" | grep -qx '.agents/skills/standardize-repo' ||
+    fail "an existing skill's portable link is missing from the pushed commit"
+printf '%s\n' "$pushed_tree" | grep -qx '.agents/skills/local-only' ||
+    fail "the local skill's portable link is missing from the pushed commit"
 
 start "a failing sync never pushes or opens a PR"
 fix="$(new_fixture sync_fail)"

--- a/scripts/test-sync-devkit-release.sh
+++ b/scripts/test-sync-devkit-release.sh
@@ -285,6 +285,28 @@ sync:skills)
     # exercised against those symlinks — the previous stub omitted this, which
     # is exactly why the v0.34.0 sync failure reached CI uncaught.
     ./scripts/link-agent-skills.sh sync
+    if [ -n "${STUB_SYNC_PORTABLE_NESTED:-}" ]; then
+        # Simulate a malformed portable entry the link step's divergent-name
+        # check would not catch for a dropped skill: the <name> symlink is
+        # replaced with a directory holding a rogue nested file. The scope
+        # guard must reject the nested path — only flat symlinks are in scope.
+        rm -f ".agents/skills/${STUB_SYNC_PORTABLE_NESTED}"
+        mkdir -p ".agents/skills/${STUB_SYNC_PORTABLE_NESTED}"
+        echo rogue >".agents/skills/${STUB_SYNC_PORTABLE_NESTED}/evil"
+    fi
+    if [ -n "${STUB_SYNC_OVERLAP_ROGUE:-}" ]; then
+        # The link step's portable symlinks use a depth-2 relative target, so
+        # an AGENT_SKILLS_DIR overlapping a dest writes no links there (the
+        # targets dangle and the cleanup loop unlinks them). The overlap is
+        # still a hole: a managed-name path that did appear under the
+        # overlapping dir would be approved by the portable allowance though
+        # the skills block rightly rejected its first segment. Simulate that
+        # managed-name path here — post-link, so it cannot collide with the
+        # link step's own writes — to exercise the overlap disarm, which
+        # blanks the pdir so the path reads as rogue (fail-closed).
+        mkdir -p "$(dirname "${STUB_SYNC_OVERLAP_ROGUE}")"
+        echo rogue >"${STUB_SYNC_OVERLAP_ROGUE}"
+    fi
     ;;
 esac
 exit 0
@@ -331,10 +353,13 @@ run_helper() {
             STUB_SYNC_ADD_AGENT="${STUB_SYNC_ADD_AGENT:-}" \
             STUB_SYNC_DELETE_LOCAL_AGENT="${STUB_SYNC_DELETE_LOCAL_AGENT:-}" \
             STUB_SYNC_DROP_SKILL="${STUB_SYNC_DROP_SKILL:-}" \
+            STUB_SYNC_PORTABLE_NESTED="${STUB_SYNC_PORTABLE_NESTED:-}" \
+            STUB_SYNC_OVERLAP_ROGUE="${STUB_SYNC_OVERLAP_ROGUE:-}" \
             GH_APP_SLUG="${GH_APP_SLUG:-}" \
             GH_TOKEN="${GH_TOKEN:-}" \
             SYNC_DEVKIT_TAG="${SYNC_DEVKIT_TAG:-}" \
             SYNC_DEVKIT_ALLOW_DOWNGRADE="${SYNC_DEVKIT_ALLOW_DOWNGRADE:-}" \
+            AGENT_SKILLS_DIR="${AGENT_SKILLS_DIR:-}" \
             ./scripts/sync-devkit-release.sh "$@"
     ) >"$LAST_OUT" 2>&1 || _rh_rc=$?
     echo "$_rh_rc"
@@ -371,10 +396,13 @@ v1.0.0 true false"
     STUB_SYNC_DELETE_LOCAL=""
     STUB_SYNC_ADD_SKILL=""
     STUB_SYNC_DROP_SKILL=""
+    STUB_SYNC_PORTABLE_NESTED=""
+    STUB_SYNC_OVERLAP_ROGUE=""
     GH_APP_SLUG=""
     GH_TOKEN=""
     SYNC_DEVKIT_TAG=""
     SYNC_DEVKIT_ALLOW_DOWNGRADE=""
+    AGENT_SKILLS_DIR=""
 }
 
 # start NAME — begin a case; echoes a fresh fixture path.
@@ -794,6 +822,44 @@ printf '%s\n' "$pushed_tree" | grep -qx '.agents/skills/standardize-repo' ||
     fail "an existing skill's portable link is missing from the pushed commit"
 printf '%s\n' "$pushed_tree" | grep -qx '.agents/skills/local-only' ||
     fail "the local skill's portable link is missing from the pushed commit"
+
+start "a nested path beneath a managed portable link fails closed"
+# Finding: the portable allowance truncated to the first segment, approving
+# <name>/anything beneath a managed link. Only flat .agents/skills/<name>
+# symlinks are the link step's output; a nested path is a rogue object (a
+# symlink replaced with a directory holding a file) and must be rejected.
+fix="$(new_fixture scope_portable_nested)"
+STUB_SYNC_ADD_SKILL="issue-title-support"
+STUB_SYNC_PORTABLE_NESTED="issue-title-support"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "a nested portable path was accepted"
+grep -q "paths it does not own" "$LAST_OUT" || fail "nested-path rejection was not reported: $(cat "$LAST_OUT")"
+grep -qF '.agents/skills/issue-title-support/evil' "$LAST_OUT" ||
+    fail "the nested path was not named in the rejection: $(cat "$LAST_OUT")"
+! pushed "$fix" || fail "a nested-path sync still pushed"
+
+start "an AGENT_SKILLS_DIR overlapping the skills dest fails closed"
+# Finding: a syntactically-safe but overlapping AGENT_SKILLS_DIR routes the
+# portable-link allowance inside a tree the sync promises never to touch. The
+# link step itself writes no links to an overlapping dir — its portable
+# symlinks use a depth-2 relative target, so at a deeper portable dir the
+# targets dangle and the cleanup loop unlinks them (verified separately). The
+# overlap is still a hole: a managed-name path that did appear there is
+# rejected by the skills block on its first segment (local-only is not
+# managed) but re-approved by the portable allowance on its managed tail. The
+# disarm blanks the overlapping pdir so that path reads as rogue instead.
+# Simulate the managed-name path post-link (it cannot collide with the link
+# step, which wrote nothing here) to exercise the disarm — without it the
+# portable block approves the path and the sync pushes.
+fix="$(new_fixture scope_overlapping_pdir)"
+AGENT_SKILLS_DIR=".claude/skills/local-only"
+STUB_SYNC_OVERLAP_ROGUE=".claude/skills/local-only/standardize-repo"
+rc="$(run_helper "$fix" run v0.9.0)"
+[ "$rc" != 0 ] || fail "an overlapping AGENT_SKILLS_DIR was accepted"
+grep -q "paths it does not own" "$LAST_OUT" || fail "overlap rejection was not reported: $(cat "$LAST_OUT")"
+grep -qF '.claude/skills/local-only/standardize-repo' "$LAST_OUT" ||
+    fail "the overlapping path was not named in the rejection: $(cat "$LAST_OUT")"
+! pushed "$fix" || fail "an overlapping-pdir sync still pushed"
 
 start "a failing sync never pushes or opens a PR"
 fix="$(new_fixture sync_fail)"

--- a/template/scripts/[% if use_skills_sync %]sync-devkit-release.sh[% endif %]
+++ b/template/scripts/[% if use_skills_sync %]sync-devkit-release.sh[% endif %]
@@ -222,11 +222,14 @@ changed_paths_z() {
 }
 
 # assert_expected_scope DEST — fail closed unless every changed path is one of
-# the manifest, the provenance stamp, or a vendored skill the sync owns.
-# The owned set is the UNION of the pre-sync (HEAD) and post-sync `# managed:`
-# lines: a skill the new pin dropped appears only in the old list, one it added
-# only in the new. Anything else — a local skill, an unrelated file — is an
-# unexpected write and aborts the run before anything is committed or pushed.
+# the manifest, a provenance stamp, a vendored skill/agent the sync owns, or a
+# portable `.agents/skills/` compatibility symlink that
+# scripts/link-agent-skills.sh maintains as the second command of
+# `task sync:skills`. The owned set is the UNION of the pre-sync (HEAD) and
+# post-sync `# managed:` lines: a skill the new pin dropped appears only in the
+# old list, one it added only in the new. Anything else — a local skill's
+# contents, an unrelated file — is an unexpected write and aborts the run before
+# anything is committed or pushed.
 # managed_from_stamp PROV — the `# managed:` names recorded on a provenance
 # stamp, taken from BOTH the committed and working-tree copies so a name the
 # sync just added or just removed is allowed either way.
@@ -277,6 +280,18 @@ assert_expected_scope() {
     _aes_allow="$(
         managed_from_stamp "$_aes_prov"
     )"
+    # scripts/link-agent-skills.sh (the second command in `task sync:skills`)
+    # writes a `.agents/skills/<name>` compatibility symlink for EVERY Claude
+    # skill — managed or local — so the same skills are visible through the
+    # cross-harness .agents standard. That dest is not in the manifest; it is
+    # link-agent-skills.sh's own, resolved the same way here. An unsafe value
+    # (absolute, or with a `..` component) disarms the allowance rather than
+    # trusting it: portable links then read as rogue writes and abort, which is
+    # the safe failure.
+    _aes_pdir="${AGENT_SKILLS_DIR:-.agents/skills}"
+    case "$_aes_pdir" in
+    "" | "/" | "." | ".." | /* | ../* | */../* | */..) _aes_pdir="" ;;
+    esac
     # Delimited membership test (no `grep` subprocess): a pipeline whose reader
     # exits early can report SIGPIPE under `pipefail` and reject a legitimate
     # path.
@@ -320,13 +335,43 @@ assert_expected_scope() {
                 ;;
             esac
         fi
+        # A portable `.agents/skills/<name>` symlink that link-agent-skills.sh
+        # creates as part of `task sync:skills`. Without this allowance every
+        # NEW managed skill's symlink reads as a rogue write and aborts the
+        # pin-bump PR — latent until a devkit release adds skills the repo never
+        # vendored before (v0.34.0 added three at once, breaking the sync).
+        # Allowed when <name> is managed (a dropped skill's removed symlink
+        # passes too: the name survives on the HEAD stamp) OR a matching skill
+        # directory still exists under the skills dest — a local skill the sync
+        # must never touch, but whose compatibility link is still the sync's to
+        # maintain. A native portable skill at the same path would already have
+        # aborted the run in the link step's divergent-name check.
+        if [ "$_aes_ok" -eq 0 ] && [ -n "$_aes_pdir" ]; then
+            case "$_aes_p" in
+            "$_aes_pdir"/*)
+                _aes_pname="${_aes_p#"$_aes_pdir"/}"
+                _aes_pname="${_aes_pname%%/*}"
+                case "$_aes_pname" in
+                "" | "." | "..") ;;
+                *)
+                    case "$_aes_haystack" in
+                    *"${LF}${_aes_pname}${LF}"*) _aes_ok=1 ;;
+                    esac
+                    if [ "$_aes_ok" -eq 0 ] && [ -d "$_aes_dest/$_aes_pname" ]; then
+                        _aes_ok=1
+                    fi
+                    ;;
+                esac
+                ;;
+            esac
+        fi
         [ "$_aes_ok" -eq 1 ] || _aes_bad="${_aes_bad}  - ${_aes_p}${LF}"
     done < <(changed_paths_z)
 
     if [ -n "$_aes_bad" ]; then
         echo "sync-devkit-release: the sync wrote paths it does not own:" >&2
         printf '%s' "$_aes_bad" >&2
-        die "expected only the skills-sync manifest, the provenance stamps, managed skills under $_aes_dest/, and managed agents under ${_aes_adest:-<none>}/ — inspect by hand"
+        die "expected only the skills-sync manifest, the provenance stamps, managed skills under $_aes_dest/, managed agents under ${_aes_adest:-<none>}/, and portable skill links under ${_aes_pdir:-<none>}/ — inspect by hand"
     fi
 }
 

--- a/template/scripts/[% if use_skills_sync %]sync-devkit-release.sh[% endif %]
+++ b/template/scripts/[% if use_skills_sync %]sync-devkit-release.sh[% endif %]
@@ -289,6 +289,21 @@ assert_expected_scope() {
     # trusting it: portable links then read as rogue writes and abort, which is
     # the safe failure.
     _aes_pdir="${AGENT_SKILLS_DIR:-.agents/skills}"
+    # Normalize the spelling before matching it against git's canonical changed
+    # paths: strip a leading "./", collapse "//" (empty components), and drop a
+    # trailing "/" so an equivalent repo-relative value (./.agents/skills,
+    # .agents/skills/, .agents//skills) matches as it should. "." and ".."
+    # components are left for the safety case below — a `..` traversal must stay
+    # rejected, not be normalized away.
+    while case "$_aes_pdir" in ./*) true ;; *) false ;; esac do
+        _aes_pdir="${_aes_pdir#./}"
+    done
+    while case "$_aes_pdir" in *//*) true ;; *) false ;; esac do
+        _aes_pdir="${_aes_pdir//\/\//\/}"
+    done
+    while case "$_aes_pdir" in */) true ;; *) false ;; esac do
+        _aes_pdir="${_aes_pdir%/}"
+    done
     case "$_aes_pdir" in
     "" | "/" | "." | ".." | /* | ../* | */../* | */..) _aes_pdir="" ;;
     esac

--- a/template/scripts/[% if use_skills_sync %]sync-devkit-release.sh[% endif %]
+++ b/template/scripts/[% if use_skills_sync %]sync-devkit-release.sh[% endif %]
@@ -292,6 +292,24 @@ assert_expected_scope() {
     case "$_aes_pdir" in
     "" | "/" | "." | ".." | /* | ../* | */../* | */..) _aes_pdir="" ;;
     esac
+    # An AGENT_SKILLS_DIR overlapping the skills or agents dest would route the
+    # portable-link allowance inside a tree the sync promises never to touch
+    # (or, containing a dest, approve paths the dest's own block already
+    # rejected), so disarm it: those paths then read as rogue writes and abort
+    # — fail-closed. Both directions matter: pdir inside a dest, and a dest
+    # inside pdir.
+    if [ -n "$_aes_pdir" ]; then
+        case "$_aes_pdir" in "$_aes_dest" | "$_aes_dest"/*) _aes_pdir="" ;; esac
+    fi
+    if [ -n "$_aes_pdir" ]; then
+        case "$_aes_dest" in "$_aes_pdir" | "$_aes_pdir"/*) _aes_pdir="" ;; esac
+    fi
+    if [ -n "$_aes_pdir" ] && [ -n "$_aes_adest" ]; then
+        case "$_aes_pdir" in "$_aes_adest" | "$_aes_adest"/*) _aes_pdir="" ;; esac
+    fi
+    if [ -n "$_aes_pdir" ] && [ -n "$_aes_adest" ]; then
+        case "$_aes_adest" in "$_aes_pdir" | "$_aes_pdir"/*) _aes_pdir="" ;; esac
+    fi
     # Delimited membership test (no `grep` subprocess): a pipeline whose reader
     # exits early can report SIGPIPE under `pipefail` and reject a legitimate
     # path.
@@ -350,8 +368,15 @@ assert_expected_scope() {
             case "$_aes_p" in
             "$_aes_pdir"/*)
                 _aes_pname="${_aes_p#"$_aes_pdir"/}"
-                _aes_pname="${_aes_pname%%/*}"
+                # Only a flat .agents/skills/<name> symlink is the link step's
+                # output. A nested path beneath a managed name is not something
+                # it writes — and an entry replaced with a directory or an
+                # arbitrary-target symlink is a rogue object the link step's
+                # divergent-name check does not catch for a dropped skill — so
+                # do not blanket-approve <name>/anything: leave _aes_ok at 0
+                # and let it read as a rogue write (fail-closed).
                 case "$_aes_pname" in
+                */*) ;; # nested path → not a flat symlink → reject
                 "" | "." | "..") ;;
                 *)
                     case "$_aes_haystack" in

--- a/template/scripts/[% if use_skills_sync %]test-sync-devkit-release.sh[% endif %]
+++ b/template/scripts/[% if use_skills_sync %]test-sync-devkit-release.sh[% endif %]
@@ -92,6 +92,11 @@ sync:skills)
         echo "# ref: \$(awk '/^[[:space:]]*ref:/{sub(/^[[:space:]]*ref:[[:space:]]*/,""); print}' .skills-sync.yaml)" > .claude/skills/.SKILLS_PROVENANCE
         echo "# categories: universal" >> .claude/skills/.SKILLS_PROVENANCE
         echo "# managed: universal" >> .claude/skills/.SKILLS_PROVENANCE
+        # scripts/link-agent-skills.sh sync is the second command of
+        # 'task sync:skills'; mirror it so the scope guard is exercised
+        # against the .agents/skills/ compatibility symlink it writes.
+        mkdir -p .agents/skills
+        [ -e .agents/skills/universal ] || [ -L .agents/skills/universal ] || ln -s ../../.claude/skills/universal .agents/skills/universal
     else
         echo "sync:skills failed" >&2
         exit 1
@@ -479,7 +484,11 @@ test_noop_when_current() {
     echo "# categories: universal" >>"$FIXTURE/.claude/skills/.SKILLS_PROVENANCE"
     echo "# managed: universal" >>"$FIXTURE/.claude/skills/.SKILLS_PROVENANCE"
     mkdir -p "$FIXTURE/.claude/skills/universal"
-    git -C "$FIXTURE" add .claude/skills/.SKILLS_PROVENANCE .claude/skills/universal >/dev/null 2>&1 || true
+    # A current repo already carries the portable .agents/skills/ link too,
+    # so the stub's link step is a no-op and the run stays a true no-op.
+    mkdir -p "$FIXTURE/.agents/skills"
+    ln -s ../../.claude/skills/universal "$FIXTURE/.agents/skills/universal"
+    git -C "$FIXTURE" add .claude/skills/.SKILLS_PROVENANCE .claude/skills/universal .agents/skills/universal >/dev/null 2>&1 || true
     git -C "$FIXTURE" commit -m "add provenance" >/dev/null 2>&1
     git -C "$FIXTURE" push origin main >/dev/null 2>&1
     run_helper_with_tag v0.1.0 || return 1
@@ -568,6 +577,8 @@ sync:skills)
     mkdir -p .claude/skills/universal
     echo "# ref: $(awk '/^[[:space:]]*ref:/{sub(/^[[:space:]]*ref:[[:space:]]*/,""); print}' .skills-sync.yaml)" > .claude/skills/.SKILLS_PROVENANCE
     echo "# managed: universal" >> .claude/skills/.SKILLS_PROVENANCE
+    mkdir -p .agents/skills
+    [ -e .agents/skills/universal ] || [ -L .agents/skills/universal ] || ln -s ../../.claude/skills/universal .agents/skills/universal
     ;;
 verify:skills:offline) echo "verify failed" >&2; exit 1;;
 security:secrets) ;;


### PR DESCRIPTION
## What

`task sync:skills` runs two commands — `sync-skills.sh` (vendors skills into `.claude/skills/`) then `link-agent-skills.sh` (creates a `.agents/skills/<name>` compatibility symlink for **every** Claude skill, managed or local). The fail-closed scope guard in `sync-devkit-release.sh` (`assert_expected_scope`) allowed `.claude/skills/` and `.claude/agents/` paths but **not** the `.agents/skills/` symlinks the second command creates, so a devkit release that added a new skill aborted the rolling sync branch:

```
sync-devkit-release: the sync wrote paths it does not own:
.agents/skills/issue-title-support, .agents/skills/label-registry-support, .agents/skills/triage
```

Run: https://github.com/evanharmon1/harmon-init/actions/runs/32396335630

## Why

The blind spot was latent from PR #708 (which added `link-agent-skills.sh` to `sync:skills`) until **v0.34.0**, which added 3 skills (`issue-title-support`, `label-registry-support`, `triage`). That was the first sync to add a new skill since the link step landed — v0.34.0 is what tripped the guard, not a regression in the link script itself.

`link-agent-skills.sh` is correct as-is (it links every skill, which is the intent). The guard is what needs to learn about the dir it writes.

## How

Teach `assert_expected_scope` about the portable-skills dir. A path under `.agents/skills/` is in scope when its top segment is:
- a **managed** skill (read from the provenance haystack — handles add+drop via the HEAD+working-tree stamp read), **or**
- a **local** skill dir that exists under `.claude/skills/` (link-agent-skills links ALL skills, managed or local).

Unsafe `AGENT_SKILLS_DIR` values (empty, absolute, `..` traversal) **disarm** the allowance so the guard stays fail-closed.

## Two layers

Applied to both the root guard (`scripts/sync-devkit-release.sh`) and its template twin (`template/scripts/…sync-devkit-release.sh`). Taught both test twins to simulate the link step — the stubs modeled only the vendoring command, so the bug was never caught locally — and added a focused regression test for a new managed skill's portable link.

## Verification

- `task check` — clean (shellcheck/shfmt/yaml/markdown)
- `task verify` — exit 0:
  - `sync-devkit-release: all 46 cases passed` (root, incl. new regression tests)
  - `test:sync-devkit-release` inside all 6 render profiles PASS (24 template cases each)
  - `test:dogfood-parity` — 138 verbatim twins identical (`link-agent-skills.sh` untouched, no verbatim drift)
  - `test:dogfood-structure` — 225 rendered sections/tasks present (both jinja-twin edits aligned)
  - skills-pin-parity OK
- `task ci` — exit 0 (full mirror: lint, security 0 findings, all parity/template tests)
- release-title guard — `fix(template): …` passes (`scripts/require-release-title.sh template`)

## Codex review (shepherd round)

Three Codex cloud-review rounds (heads f8e3930, e3bb2a0, b96d4ce) surfaced 7 P2s; all adjudicated:
- **P2 — nested portable path** (`scripts/sync-devkit-release.sh:375`): the portable allowance truncated the path to its first segment, approving `<name>/anything`. Fixed in e3bb2a0 — reject nested paths, require an exact one-segment match. Regression case `scope_portable_nested`. [thread](https://github.com/evanharmon1/harmon-init/pull/997#discussion_r3824224895)
- **P2 — overlapping `AGENT_SKILLS_DIR`** (`scripts/sync-devkit-release.sh:314`): a safe-but-overlapping pdir would route the portable allowance inside a protected tree. Fixed in e3bb2a0 — disarm the pdir when it overlaps either dest (both directions). Regression case `scope_overlapping_pdir`. (Note: the real link step's depth-2 relative target produces no valid links for an overlapping pdir, so the finding's premise does not occur in practice; the disarm is defense-in-depth.) [thread](https://github.com/evanharmon1/harmon-init/pull/997#discussion_r3824224909)
- **P2 — template test fidelity** (template test twin): hardcodes the `universal` symlink instead of running the real `link-agent-skills.sh`. Filed as #998 (root suite covers the production writer; template twin is an intentional parity divergence). [thread](https://github.com/evanharmon1/harmon-init/pull/997#discussion_r3824224902)
- **P2 — noncanonical `AGENT_SKILLS_DIR`** (`scripts/sync-devkit-release.sh:314`): a `./` prefix or trailing `/` left the portable dir noncanonical while git reports paths canonically, so the prefix match missed every legitimate link and false-aborted on valid consumer config. Fixed in b96d4ce — normalize the spelling (strip `./`, collapse `//`, drop trailing `/`) before the checks. Regression case `scope_portable_normalize`. [thread](https://github.com/evanharmon1/harmon-init/pull/997#discussion_r3824739923)
- **P2 — flat portable-entry validation** (`scripts/sync-devkit-release.sh:405`): the flat-name approval validates a `.agents/skills/<name>` path by name alone, without confirming the surviving object is the expected symlink (the un-addressed half of the nested-path finding). Filed as #999 — the full fix (symlink + target validation) is new logic that risks re-feeding the review loop; the attack needs an external rogue writer at a managed-name path, and the root suite covers the production writer. [thread](https://github.com/evanharmon1/harmon-init/pull/997#discussion_r3824739914)
- **P2 — internal dot components** (`scripts/sync-devkit-release.sh:320`): the normalize added in b96d4ce handles leading `./`, `//`, trailing `/` but not internal `.` (`.agents/./skills`) or terminal `.` (`.agents/skills/.`). Declined — degenerate spellings no consumer writes; the realistic equivalents are handled, and the portable allowance has attracted nested/overlap/normalize/internal-dot findings in succession (the loop-feeding tell); a complete component-walk canonicalization is the invariant form if it ever matters. [thread](https://github.com/evanharmon1/harmon-init/pull/997#discussion_r3825071295)
- **P2 — CLAUDE_SKILLS_DIR awareness** (`scripts/sync-devkit-release.sh:423`): the guard uses the manifest dest for the local-skill/overlap checks while the link step reads `CLAUDE_SKILLS_DIR`; they diverge only in an already-broken config (managed skills invisible to Claude). Declined, filed as #1000 — the full fix needs a second claude-dir notion and the template twin can't exercise it (#998); declining is the loop-converging move. [thread](https://github.com/evanharmon1/harmon-init/pull/997#discussion_r3825071300)

## Deferred findings

- [x] `template/scripts/…test-sync-devkit-release.sh` — generated-repo test twin hardcodes the `universal` symlink instead of invoking the shipped `link-agent-skills.sh`, so the scope guard is not regression-tested against its production writer in the template suite — filed as #998.
- [x] `scripts/sync-devkit-release.sh:405` — the flat portable-name approval validates a `.agents/skills/<name>` path by name alone without confirming the surviving object is the expected symlink; a rogue regular file / arbitrary-target symlink at a managed-name path would be approved and pushed — filed as #999 (full fix tracked there; the nested-path half was fixed in e3bb2a0).
- [x] `scripts/sync-devkit-release.sh:423` — the guard uses the manifest dest for the local-skill/overlap checks while the link step reads `CLAUDE_SKILLS_DIR`; they diverge only in an already-broken config (managed skills invisible to Claude), so the false-reject is a secondary symptom — filed as #1000 (declined in-PR; full fix tracked there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)