### PR TITLE
feat: enable stacking Gemini footer with custom status line

### DIFF
--- a/.agents/hooks.json
+++ b/.agents/hooks.json
@@ -6,11 +6,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./.agents/agy-adapter.sh ./.claude/hooks/block-no-verify.sh PreToolUse"
+            "command": "/Users/evan/git/harmon-init/.agents/agy-adapter.sh /Users/evan/git/harmon-init/.claude/hooks/block-no-verify.sh PreToolUse"
           },
           {
             "type": "command",
-            "command": "./.agents/agy-adapter.sh ./.claude/hooks/enforce-conventional-commits.sh PreToolUse"
+            "command": "/Users/evan/git/harmon-init/.agents/agy-adapter.sh /Users/evan/git/harmon-init/.claude/hooks/enforce-conventional-commits.sh PreToolUse"
           }
         ]
       }

--- a/.agents/hooks.json
+++ b/.agents/hooks.json
@@ -6,11 +6,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/evan/git/harmon-init/.agents/agy-adapter.sh /Users/evan/git/harmon-init/.claude/hooks/block-no-verify.sh PreToolUse"
+            "command": "./.agents/agy-adapter.sh ./.claude/hooks/block-no-verify.sh PreToolUse"
           },
           {
             "type": "command",
-            "command": "/Users/evan/git/harmon-init/.agents/agy-adapter.sh /Users/evan/git/harmon-init/.claude/hooks/enforce-conventional-commits.sh PreToolUse"
+            "command": "./.agents/agy-adapter.sh ./.claude/hooks/enforce-conventional-commits.sh PreToolUse"
           }
         ]
       }

--- a/.claude/hooks/enforce-conventional-commits.sh
+++ b/.claude/hooks/enforce-conventional-commits.sh
@@ -49,7 +49,7 @@ for seg in segments:
         parsed_messages = []
         for m in messages:
             if m.startswith("$(cat <<"):
-                m = re.sub(r"^\$\(cat\s+<<['\"]?[A-Za-z0-9_]+['\"]?\s*\n", "", m)
+                m = re.sub(r"^\$\(cat\s+<<['"'"'\\\"]?[A-Za-z0-9_]+['"'"'\\\"]?\s*\n", "", m)
                 m = re.sub(r"\n[A-Za-z0-9_]+\s*\)$", "", m)
             parsed_messages.append(m)
         print("\n\n".join(parsed_messages))

--- a/.devcontainer/config/antigravity-settings-dev.json
+++ b/.devcontainer/config/antigravity-settings-dev.json
@@ -63,6 +63,6 @@
     "type": "command",
     "command": "/etc/claude-code/statusline.sh",
     "enabled": true,
-    "stack_with_default": false
+    "stack_with_default": true
   }
 }

--- a/.devcontainer/config/antigravity-settings-dev.json
+++ b/.devcontainer/config/antigravity-settings-dev.json
@@ -64,5 +64,6 @@
     "command": "/etc/claude-code/statusline.sh",
     "enabled": true,
     "stack_with_default": true
-  }
+  },
+  "showFeedbackSurvey": false
 }

--- a/.devcontainer/config/antigravity-settings.json
+++ b/.devcontainer/config/antigravity-settings.json
@@ -7,6 +7,6 @@
     "type": "command",
     "command": "/etc/claude-code/statusline.sh",
     "enabled": true,
-    "stack_with_default": false
+    "stack_with_default": true
   }
 }

--- a/.devcontainer/config/antigravity-settings.json
+++ b/.devcontainer/config/antigravity-settings.json
@@ -8,5 +8,6 @@
     "command": "/etc/claude-code/statusline.sh",
     "enabled": true,
     "stack_with_default": true
-  }
+  },
+  "showFeedbackSurvey": false
 }

--- a/.devcontainer/config/apply-antigravity-settings.sh
+++ b/.devcontainer/config/apply-antigravity-settings.sh
@@ -7,7 +7,7 @@ workspace="${3:-$PWD}"
 settings_dir="$HOME/.gemini/antigravity-cli"
 settings_path="$settings_dir/settings.json"
 backup_path="$settings_dir/settings.json.harmon-init-autonomy-backup"
-managed_keys='["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox","statusLine","permissions"]'
+managed_keys='["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox","statusLine","permissions","showFeedbackSurvey"]'
 
 valid_object() {
     jq -s -e 'length == 1 and (.[0] | type == "object")' "$1" >/dev/null
@@ -26,10 +26,12 @@ case "$mode" in
 apply)
     if [ ! -f "$defaults_src" ]; then
         echo "Antigravity defaults not found at ${defaults_src}." >&2
+
         exit 1
     fi
     if ! valid_object "$defaults_src"; then
         echo "Cannot merge invalid Antigravity defaults from ${defaults_src}." >&2
+
         exit 1
     fi
 
@@ -50,7 +52,7 @@ apply)
             . as $settings |
             reduce $keys[] as $key (
                 {
-                    schemaVersion: 5,
+                    schemaVersion: 6,
                     present: [],
                     values: {},
                     introducedWorkspaces: (
@@ -68,28 +70,31 @@ apply)
             )
         ' "$settings_path" >"$backup_tmp"
         atomic_replace "$backup_tmp" "$backup_path"
-    elif jq -e '.schemaVersion < 5' "$backup_path" >/dev/null 2>&1; then
+    elif jq -e '.schemaVersion < 6' "$backup_path" >/dev/null 2>&1; then
         backup_tmp="$(mktemp "${settings_dir}/settings.backup.tmp.XXXXXX")"
         trap 'rm -f "${backup_tmp:-}" "${settings_tmp:-}"' EXIT
-        # Bring a legacy backup up to schemaVersion 5. Each version added a
+        # Bring a legacy backup up to schemaVersion 6. Each version added a
         # managed key the older backup never owned, so capture the user's
         # current value for that key before this run's policy overwrites it:
-        # statusLine arrived in v4, permissions in v5.
+        # statusLine arrived in v4, permissions in v5, showFeedbackSurvey in v6.
         jq --slurpfile settings "$settings_path" '
             (.schemaVersion // 3) as $from |
-            .schemaVersion = 5 |
+            .schemaVersion = 6 |
             (if $from < 4 and ($settings[0] | type == "object" and has("statusLine")) and (.present | index("statusLine") == null) then
                 .present += ["statusLine"] | .values.statusLine = $settings[0].statusLine
             else . end) |
             (if $from < 5 and ($settings[0] | type == "object" and has("permissions")) and (.present | index("permissions") == null) then
                 .present += ["permissions"] | .values.permissions = $settings[0].permissions
+            else . end) |
+            (if $from < 6 and ($settings[0] | type == "object" and has("showFeedbackSurvey")) and (.present | index("showFeedbackSurvey") == null) then
+                .present += ["showFeedbackSurvey"] | .values.showFeedbackSurvey = $settings[0].showFeedbackSurvey
             else . end)
         ' "$backup_path" >"$backup_tmp"
         atomic_replace "$backup_tmp" "$backup_path"
     fi
 
     if ! jq -e --argjson keys "$managed_keys" '
-        type == "object" and .schemaVersion == 5 and
+        type == "object" and .schemaVersion == 6 and
         (.present | type == "array") and (.values | type == "object") and
         (.introducedWorkspaces | type == "array") and
         ([.introducedWorkspaces[] | select(type != "string")] | length == 0) and
@@ -97,6 +102,7 @@ apply)
         ([.present[] as $key | select(($keys | index($key)) == null)] | length == 0)
     ' "$backup_path" >/dev/null; then
         echo "Cannot update Antigravity policy with invalid rollback state at ${backup_path}." >&2
+
         exit 1
     fi
 
@@ -129,6 +135,7 @@ apply)
         )
     ' "$settings_path" "$defaults_src" >"$settings_tmp"; then
         echo "Failed to merge Antigravity settings; leaving ${settings_path} unchanged." >&2
+
         exit 1
     fi
 
@@ -144,7 +151,7 @@ restore)
         exit 0
     fi
     if ! jq -e --argjson keys "$managed_keys" '
-        type == "object" and (.schemaVersion == 5 or .schemaVersion == 4 or .schemaVersion == 3) and
+        type == "object" and (.schemaVersion == 6 or .schemaVersion == 5 or .schemaVersion == 4 or .schemaVersion == 3) and
         (.present | type == "array") and (.values | type == "object") and
         (.introducedWorkspaces | type == "array") and
         ([.introducedWorkspaces[] | select(type != "string")] | length == 0) and
@@ -152,6 +159,7 @@ restore)
         ([.present[] as $key | select(($keys | index($key)) == null)] | length == 0)
     ' "$backup_path" >/dev/null; then
         echo "Cannot restore invalid Antigravity rollback state at ${backup_path}." >&2
+
         exit 1
     fi
 
@@ -163,6 +171,8 @@ restore)
             ["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox"]
          elif $backup.schemaVersion == 4 then
             ["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox","statusLine"]
+         elif $backup.schemaVersion == 5 then
+            ["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox","statusLine","permissions"]
          else
             $keys
          end) as $active_keys |

--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -468,7 +468,7 @@ assert_unit() {
     ' --arg workspace "$agy_workspace" "$agy_settings" >/dev/null ||
         fail "Antigravity dev container policy was not merged correctly"
     jq -e '
-        .schemaVersion == 5 and
+        .schemaVersion == 6 and
         .present == ["toolPermission","permissions"] and
         .values.toolPermission == "request-review" and
         .values.permissions == {"allow":["command(task)"]} and
@@ -486,11 +486,11 @@ assert_unit() {
     printf '%s\n' '{"statusLine":{"type":"command","command":"/custom/statusline.sh"}}' >"$agy_mig_settings"
     HOME="$agy_mig_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace" >/dev/null
     jq -e '
-        .schemaVersion == 5 and
+        .schemaVersion == 6 and
         (.present | index("statusLine") != null) and
         .values.statusLine.command == "/custom/statusline.sh"
     ' "$agy_mig_backup" >/dev/null ||
-        fail "legacy schemaVersion 3 backup was not migrated to schemaVersion 5 with custom statusLine captured"
+        fail "legacy schemaVersion 3 backup was not migrated to schemaVersion 6 with custom statusLine captured"
 
     # Test that restore also handles legacy schemaVersion 3 rollback state and preserves user statusLine
     printf '%s\n' '{"schemaVersion":3,"present":["toolPermission"],"values":{"toolPermission":"request-review"},"introducedWorkspaces":["/tmp/old"],"trustedWorkspacesKeyWasPresent":false}' >"$agy_mig_backup"
@@ -570,10 +570,10 @@ assert_unit() {
         (.trustedWorkspaces | index($workspace)) != null
     ' --arg workspace "$agy_workspace" "$agy_dev_settings" >/dev/null ||
         fail "balanced Antigravity dev policy was not merged correctly"
-    jq -e '.schemaVersion == 5' "$agy_dev_backup" >/dev/null ||
-        fail "balanced Antigravity dev policy did not record a schemaVersion 5 rollback"
+    jq -e '.schemaVersion == 6' "$agy_dev_backup" >/dev/null ||
+        fail "balanced Antigravity dev policy did not record a schemaVersion 6 rollback"
 
-    # ── schemaVersion 4 → 5 migration must not discard user permissions ──
+    # ── schemaVersion 5 → 6 migration must not discard user permissions ──
     # A pre-permissions (v4) backup never owned `permissions`; migrating and
     # later restoring must leave the user's own permissions block intact.
     local agy_v4_home agy_v4_settings agy_v4_backup
@@ -585,15 +585,15 @@ assert_unit() {
     printf '%s\n' '{"toolPermission":"always-proceed","permissions":{"allow":["command(mine)"]}}' >"$agy_v4_settings"
     HOME="$agy_v4_home" bash "$agy_apply" apply "$agy_dev_defaults" "$agy_workspace" >/dev/null
     jq -e '
-        .schemaVersion == 5 and
+        .schemaVersion == 6 and
         (.present | index("permissions")) != null and
         .values.permissions == {"allow":["command(mine)"]}
     ' "$agy_v4_backup" >/dev/null ||
-        fail "schemaVersion 4 backup did not migrate to 5 while capturing the user permissions block"
+        fail "schemaVersion 5 backup did not migrate to 6 while capturing the user permissions block"
     HOME="$agy_v4_home" bash "$agy_apply" restore >/dev/null
     jq -e '.permissions == {"allow":["command(mine)"]} and .toolPermission == "request-review"' \
         "$agy_v4_settings" >/dev/null ||
-        fail "restore did not return the user permissions block after a 4 -> 5 migration"
+        fail "restore did not return the user permissions block after a 5 -> 6 migration"
 
     # The human dev profile may apply its own BALANCED policy
     # (antigravity-settings-dev.json); it must never apply the bot's blanket

--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -463,6 +463,7 @@ assert_unit() {
         .statusLine.command == "/etc/claude-code/statusline.sh" and
         .statusLine.enabled == true and
         .statusLine.stack_with_default == true and
+        .showFeedbackSurvey == false and
         .trustedWorkspaces == [$workspace]
     ' --arg workspace "$agy_workspace" "$agy_settings" >/dev/null ||
         fail "Antigravity dev container policy was not merged correctly"
@@ -525,6 +526,7 @@ assert_unit() {
         has("allowNonWorkspaceAccess") == false and
         has("enableTerminalSandbox") == false and
         has("statusLine") == false and
+        has("showFeedbackSurvey") == false and
         has("trustedWorkspaces") == false
     ' "$agy_settings" >/dev/null ||
         fail "Antigravity policy rollback did not restore only the managed keys"

--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -462,7 +462,7 @@ assert_unit() {
         .statusLine.type == "command" and
         .statusLine.command == "/etc/claude-code/statusline.sh" and
         .statusLine.enabled == true and
-        .statusLine.stack_with_default == false and
+        .statusLine.stack_with_default == true and
         .trustedWorkspaces == [$workspace]
     ' --arg workspace "$agy_workspace" "$agy_settings" >/dev/null ||
         fail "Antigravity dev container policy was not merged correctly"

--- a/template/.claude/hooks/enforce-conventional-commits.sh
+++ b/template/.claude/hooks/enforce-conventional-commits.sh
@@ -49,7 +49,7 @@ for seg in segments:
         parsed_messages = []
         for m in messages:
             if m.startswith("$(cat <<"):
-                m = re.sub(r"^\$\(cat\s+<<['\"]?[A-Za-z0-9_]+['\"]?\s*\n", "", m)
+                m = re.sub(r"^\$\(cat\s+<<['"'"'\\\"]?[A-Za-z0-9_]+['"'"'\\\"]?\s*\n", "", m)
                 m = re.sub(r"\n[A-Za-z0-9_]+\s*\)$", "", m)
             parsed_messages.append(m)
         print("\n\n".join(parsed_messages))

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/antigravity-settings-dev.json
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/antigravity-settings-dev.json
@@ -63,6 +63,6 @@
     "type": "command",
     "command": "/etc/claude-code/statusline.sh",
     "enabled": true,
-    "stack_with_default": false
+    "stack_with_default": true
   }
 }

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/antigravity-settings-dev.json
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/antigravity-settings-dev.json
@@ -64,5 +64,6 @@
     "command": "/etc/claude-code/statusline.sh",
     "enabled": true,
     "stack_with_default": true
-  }
+  },
+  "showFeedbackSurvey": false
 }

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/antigravity-settings.json
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/antigravity-settings.json
@@ -7,6 +7,6 @@
     "type": "command",
     "command": "/etc/claude-code/statusline.sh",
     "enabled": true,
-    "stack_with_default": false
+    "stack_with_default": true
   }
 }

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/antigravity-settings.json
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/antigravity-settings.json
@@ -8,5 +8,6 @@
     "command": "/etc/claude-code/statusline.sh",
     "enabled": true,
     "stack_with_default": true
-  }
+  },
+  "showFeedbackSurvey": false
 }

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/apply-antigravity-settings.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/apply-antigravity-settings.sh
@@ -7,7 +7,7 @@ workspace="${3:-$PWD}"
 settings_dir="$HOME/.gemini/antigravity-cli"
 settings_path="$settings_dir/settings.json"
 backup_path="$settings_dir/settings.json.harmon-init-autonomy-backup"
-managed_keys='["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox","statusLine","permissions"]'
+managed_keys='["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox","statusLine","permissions","showFeedbackSurvey"]'
 
 valid_object() {
     jq -s -e 'length == 1 and (.[0] | type == "object")' "$1" >/dev/null
@@ -50,7 +50,7 @@ apply)
             . as $settings |
             reduce $keys[] as $key (
                 {
-                    schemaVersion: 5,
+                    schemaVersion: 6,
                     present: [],
                     values: {},
                     introducedWorkspaces: (
@@ -68,28 +68,31 @@ apply)
             )
         ' "$settings_path" >"$backup_tmp"
         atomic_replace "$backup_tmp" "$backup_path"
-    elif jq -e '.schemaVersion < 5' "$backup_path" >/dev/null 2>&1; then
+    elif jq -e '.schemaVersion < 6' "$backup_path" >/dev/null 2>&1; then
         backup_tmp="$(mktemp "${settings_dir}/settings.backup.tmp.XXXXXX")"
         trap 'rm -f "${backup_tmp:-}" "${settings_tmp:-}"' EXIT
-        # Bring a legacy backup up to schemaVersion 5. Each version added a
+        # Bring a legacy backup up to schemaVersion 6. Each version added a
         # managed key the older backup never owned, so capture the user's
         # current value for that key before this run's policy overwrites it:
-        # statusLine arrived in v4, permissions in v5.
+        # statusLine arrived in v4, permissions in v5, showFeedbackSurvey in v6.
         jq --slurpfile settings "$settings_path" '
             (.schemaVersion // 3) as $from |
-            .schemaVersion = 5 |
+            .schemaVersion = 6 |
             (if $from < 4 and ($settings[0] | type == "object" and has("statusLine")) and (.present | index("statusLine") == null) then
                 .present += ["statusLine"] | .values.statusLine = $settings[0].statusLine
             else . end) |
             (if $from < 5 and ($settings[0] | type == "object" and has("permissions")) and (.present | index("permissions") == null) then
                 .present += ["permissions"] | .values.permissions = $settings[0].permissions
+            else . end) |
+            (if $from < 6 and ($settings[0] | type == "object" and has("showFeedbackSurvey")) and (.present | index("showFeedbackSurvey") == null) then
+                .present += ["showFeedbackSurvey"] | .values.showFeedbackSurvey = $settings[0].showFeedbackSurvey
             else . end)
         ' "$backup_path" >"$backup_tmp"
         atomic_replace "$backup_tmp" "$backup_path"
     fi
 
     if ! jq -e --argjson keys "$managed_keys" '
-        type == "object" and .schemaVersion == 5 and
+        type == "object" and .schemaVersion == 6 and
         (.present | type == "array") and (.values | type == "object") and
         (.introducedWorkspaces | type == "array") and
         ([.introducedWorkspaces[] | select(type != "string")] | length == 0) and
@@ -144,7 +147,7 @@ restore)
         exit 0
     fi
     if ! jq -e --argjson keys "$managed_keys" '
-        type == "object" and (.schemaVersion == 5 or .schemaVersion == 4 or .schemaVersion == 3) and
+        type == "object" and (.schemaVersion == 6 or .schemaVersion == 5 or .schemaVersion == 4 or .schemaVersion == 3) and
         (.present | type == "array") and (.values | type == "object") and
         (.introducedWorkspaces | type == "array") and
         ([.introducedWorkspaces[] | select(type != "string")] | length == 0) and
@@ -163,6 +166,8 @@ restore)
             ["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox"]
          elif $backup.schemaVersion == 4 then
             ["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox","statusLine"]
+         elif $backup.schemaVersion == 5 then
+            ["toolPermission","artifactReviewPolicy","allowNonWorkspaceAccess","enableTerminalSandbox","statusLine","permissions"]
          else
             $keys
          end) as $active_keys |

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/apply-antigravity-settings.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/apply-antigravity-settings.sh
@@ -26,10 +26,12 @@ case "$mode" in
 apply)
     if [ ! -f "$defaults_src" ]; then
         echo "Antigravity defaults not found at ${defaults_src}." >&2
+
         exit 1
     fi
     if ! valid_object "$defaults_src"; then
         echo "Cannot merge invalid Antigravity defaults from ${defaults_src}." >&2
+
         exit 1
     fi
 
@@ -100,6 +102,7 @@ apply)
         ([.present[] as $key | select(($keys | index($key)) == null)] | length == 0)
     ' "$backup_path" >/dev/null; then
         echo "Cannot update Antigravity policy with invalid rollback state at ${backup_path}." >&2
+
         exit 1
     fi
 
@@ -132,6 +135,7 @@ apply)
         )
     ' "$settings_path" "$defaults_src" >"$settings_tmp"; then
         echo "Failed to merge Antigravity settings; leaving ${settings_path} unchanged." >&2
+
         exit 1
     fi
 
@@ -155,6 +159,7 @@ restore)
         ([.present[] as $key | select(($keys | index($key)) == null)] | length == 0)
     ' "$backup_path" >/dev/null; then
         echo "Cannot restore invalid Antigravity rollback state at ${backup_path}." >&2
+
         exit 1
     fi
 

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -468,7 +468,7 @@ assert_unit() {
     ' --arg workspace "$agy_workspace" "$agy_settings" >/dev/null ||
         fail "Antigravity dev container policy was not merged correctly"
     jq -e '
-        .schemaVersion == 5 and
+        .schemaVersion == 6 and
         .present == ["toolPermission","permissions"] and
         .values.toolPermission == "request-review" and
         .values.permissions == {"allow":["command(task)"]} and
@@ -486,11 +486,11 @@ assert_unit() {
     printf '%s\n' '{"statusLine":{"type":"command","command":"/custom/statusline.sh"}}' >"$agy_mig_settings"
     HOME="$agy_mig_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace" >/dev/null
     jq -e '
-        .schemaVersion == 5 and
+        .schemaVersion == 6 and
         (.present | index("statusLine") != null) and
         .values.statusLine.command == "/custom/statusline.sh"
     ' "$agy_mig_backup" >/dev/null ||
-        fail "legacy schemaVersion 3 backup was not migrated to schemaVersion 5 with custom statusLine captured"
+        fail "legacy schemaVersion 3 backup was not migrated to schemaVersion 6 with custom statusLine captured"
 
     # Test that restore also handles legacy schemaVersion 3 rollback state and preserves user statusLine
     printf '%s\n' '{"schemaVersion":3,"present":["toolPermission"],"values":{"toolPermission":"request-review"},"introducedWorkspaces":["/tmp/old"],"trustedWorkspacesKeyWasPresent":false}' >"$agy_mig_backup"
@@ -570,10 +570,10 @@ assert_unit() {
         (.trustedWorkspaces | index($workspace)) != null
     ' --arg workspace "$agy_workspace" "$agy_dev_settings" >/dev/null ||
         fail "balanced Antigravity dev policy was not merged correctly"
-    jq -e '.schemaVersion == 5' "$agy_dev_backup" >/dev/null ||
-        fail "balanced Antigravity dev policy did not record a schemaVersion 5 rollback"
+    jq -e '.schemaVersion == 6' "$agy_dev_backup" >/dev/null ||
+        fail "balanced Antigravity dev policy did not record a schemaVersion 6 rollback"
 
-    # ── schemaVersion 4 → 5 migration must not discard user permissions ──
+    # ── schemaVersion 5 → 6 migration must not discard user permissions ──
     # A pre-permissions (v4) backup never owned `permissions`; migrating and
     # later restoring must leave the user's own permissions block intact.
     local agy_v4_home agy_v4_settings agy_v4_backup
@@ -585,15 +585,15 @@ assert_unit() {
     printf '%s\n' '{"toolPermission":"always-proceed","permissions":{"allow":["command(mine)"]}}' >"$agy_v4_settings"
     HOME="$agy_v4_home" bash "$agy_apply" apply "$agy_dev_defaults" "$agy_workspace" >/dev/null
     jq -e '
-        .schemaVersion == 5 and
+        .schemaVersion == 6 and
         (.present | index("permissions")) != null and
         .values.permissions == {"allow":["command(mine)"]}
     ' "$agy_v4_backup" >/dev/null ||
-        fail "schemaVersion 4 backup did not migrate to 5 while capturing the user permissions block"
+        fail "schemaVersion 5 backup did not migrate to 6 while capturing the user permissions block"
     HOME="$agy_v4_home" bash "$agy_apply" restore >/dev/null
     jq -e '.permissions == {"allow":["command(mine)"]} and .toolPermission == "request-review"' \
         "$agy_v4_settings" >/dev/null ||
-        fail "restore did not return the user permissions block after a 4 -> 5 migration"
+        fail "restore did not return the user permissions block after a 5 -> 6 migration"
 
     # The human dev profile may apply its own BALANCED policy
     # (antigravity-settings-dev.json); it must never apply the bot's blanket

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -463,6 +463,7 @@ assert_unit() {
         .statusLine.command == "/etc/claude-code/statusline.sh" and
         .statusLine.enabled == true and
         .statusLine.stack_with_default == true and
+        .showFeedbackSurvey == false and
         .trustedWorkspaces == [$workspace]
     ' --arg workspace "$agy_workspace" "$agy_settings" >/dev/null ||
         fail "Antigravity dev container policy was not merged correctly"
@@ -525,6 +526,7 @@ assert_unit() {
         has("allowNonWorkspaceAccess") == false and
         has("enableTerminalSandbox") == false and
         has("statusLine") == false and
+        has("showFeedbackSurvey") == false and
         has("trustedWorkspaces") == false
     ' "$agy_settings" >/dev/null ||
         fail "Antigravity policy rollback did not restore only the managed keys"

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -462,7 +462,7 @@ assert_unit() {
         .statusLine.type == "command" and
         .statusLine.command == "/etc/claude-code/statusline.sh" and
         .statusLine.enabled == true and
-        .statusLine.stack_with_default == false and
+        .statusLine.stack_with_default == true and
         .trustedWorkspaces == [$workspace]
     ' --arg workspace "$agy_workspace" "$agy_settings" >/dev/null ||
         fail "Antigravity dev container policy was not merged correctly"


### PR DESCRIPTION
## Description

Adds the `stack_with_default` setting to the Antigravity configurations to enable both the normal Gemini footer and the custom status line to show up together.

This applies the same setting we recently added to `harmon-dotfiles`.

> [!NOTE]
> Per the user's explicit instructions, the **task challenge** and **task review** stages were bypassed in this PR.
