### PR TITLE
feat(antigravity): set Gemini 3.7 Flash (High) as default model

### DIFF
--- a/.devcontainer/config/antigravity-settings-dev.json
+++ b/.devcontainer/config/antigravity-settings-dev.json
@@ -1,4 +1,5 @@
 {
+  "model": "Gemini 3.7 Flash (High)",
   "toolPermission": "request-review",
   "artifactReviewPolicy": "always-proceed",
   "permissions": {

--- a/.devcontainer/config/antigravity-settings.json
+++ b/.devcontainer/config/antigravity-settings.json
@@ -1,4 +1,5 @@
 {
+  "model": "Gemini 3.7 Flash (High)",
   "toolPermission": "always-proceed",
   "artifactReviewPolicy": "always-proceed",
   "allowNonWorkspaceAccess": true,

--- a/.devcontainer/config/apply-antigravity-settings.sh
+++ b/.devcontainer/config/apply-antigravity-settings.sh
@@ -125,9 +125,9 @@ apply)
 
     settings_tmp="$(mktemp "${settings_dir}/settings.json.tmp.XXXXXX")"
     trap 'rm -f "${backup_tmp:-}" "${settings_tmp:-}"' EXIT
-    if ! jq -s --arg workspace "$workspace" '
+    if ! jq -s --arg workspace "$workspace" --argjson keys "$managed_keys" '
         .[0] as $current | .[1] as $policy |
-        ($current * $policy) |
+        ($policy * $current * ($policy | with_entries(select(.key as $k | $keys | index($k) != null)))) |
         .trustedWorkspaces = (
             (if ($current.trustedWorkspaces | type) == "array"
              then $current.trustedWorkspaces else [] end) + [$workspace] |

--- a/scripts/devcontainer-assert.sh
+++ b/scripts/devcontainer-assert.sh
@@ -477,6 +477,16 @@ assert_unit() {
     ' --arg workspace "$agy_workspace" "$agy_backup" >/dev/null ||
         fail "Antigravity policy rollback state was not recorded correctly"
 
+    local agy_fresh_home agy_fresh_settings
+    agy_fresh_home="${work_dir}/agy-fresh-home"
+    agy_fresh_settings="${agy_fresh_home}/.gemini/antigravity-cli/settings.json"
+    HOME="$agy_fresh_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace" >/dev/null
+    jq -e '
+        .model == "Gemini 3.7 Flash (High)" and
+        .toolPermission == "always-proceed"
+    ' "$agy_fresh_settings" >/dev/null ||
+        fail "fresh Antigravity settings did not seed default model Gemini 3.7 Flash (High)"
+
     local agy_mig_home agy_mig_settings agy_mig_backup
     agy_mig_home="${work_dir}/agy-mig-home"
     agy_mig_settings="${agy_mig_home}/.gemini/antigravity-cli/settings.json"
@@ -572,6 +582,16 @@ assert_unit() {
         fail "balanced Antigravity dev policy was not merged correctly"
     jq -e '.schemaVersion == 6' "$agy_dev_backup" >/dev/null ||
         fail "balanced Antigravity dev policy did not record a schemaVersion 6 rollback"
+
+    local agy_dev_fresh_home agy_dev_fresh_settings
+    agy_dev_fresh_home="${work_dir}/agy-dev-fresh-home"
+    agy_dev_fresh_settings="${agy_dev_fresh_home}/.gemini/antigravity-cli/settings.json"
+    HOME="$agy_dev_fresh_home" bash "$agy_apply" apply "$agy_dev_defaults" "$agy_workspace" >/dev/null
+    jq -e '
+        .model == "Gemini 3.7 Flash (High)" and
+        .toolPermission == "request-review"
+    ' "$agy_dev_fresh_settings" >/dev/null ||
+        fail "fresh balanced Antigravity dev settings did not seed default model Gemini 3.7 Flash (High)"
 
     # ── schemaVersion 5 → 6 migration must not discard user permissions ──
     # A pre-permissions (v4) backup never owned `permissions`; migrating and

--- a/scripts/test-statusline.sh
+++ b/scripts/test-statusline.sh
@@ -80,10 +80,10 @@ out=$(render '')
 [ -n "$out" ] || fail "an empty payload produced no output at all"
 
 echo "==> Antigravity payload (conversation_id, model, headroom)"
-out=$(render '{"workspace":{"current_dir":"/"},"context_window":{"used_percentage":25,"context_window_size":1000000},"model":{"display_name":"Gemini 3.1 Pro (High)"},"conversation_id":"34ee01b6-2f37-4fe7"}')
+out=$(render '{"workspace":{"current_dir":"/"},"context_window":{"used_percentage":25,"context_window_size":1000000},"model":{"display_name":"Gemini 3.7 Flash (High)"},"conversation_id":"34ee01b6-2f37-4fe7"}')
 case "$out" in *' 25%'*) ;; *) fail "expected 25%, got: $out" ;; esac
 case "$out" in *'750k left'*) ;; *) fail "expected '750k left', got: $out" ;; esac
-case "$out" in *'Gemini 3.1 Pro (High)'*) ;; *) fail "expected model name, got: $out" ;; esac
+case "$out" in *'Gemini 3.7 Flash (High)'*) ;; *) fail "expected model name, got: $out" ;; esac
 case "$out" in *'34ee01b6'*) ;; *) fail "expected session id, got: $out" ;; esac
 
 echo "==> scalar-shaped fields (model, effort, cost as string/numbers) do not crash jq"

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/antigravity-settings-dev.json
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/antigravity-settings-dev.json
@@ -1,4 +1,5 @@
 {
+  "model": "Gemini 3.7 Flash (High)",
   "toolPermission": "request-review",
   "artifactReviewPolicy": "always-proceed",
   "permissions": {

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/antigravity-settings.json
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/antigravity-settings.json
@@ -1,4 +1,5 @@
 {
+  "model": "Gemini 3.7 Flash (High)",
   "toolPermission": "always-proceed",
   "artifactReviewPolicy": "always-proceed",
   "allowNonWorkspaceAccess": true,

--- a/template/[% if devcontainer %].devcontainer[% endif %]/config/apply-antigravity-settings.sh
+++ b/template/[% if devcontainer %].devcontainer[% endif %]/config/apply-antigravity-settings.sh
@@ -125,9 +125,9 @@ apply)
 
     settings_tmp="$(mktemp "${settings_dir}/settings.json.tmp.XXXXXX")"
     trap 'rm -f "${backup_tmp:-}" "${settings_tmp:-}"' EXIT
-    if ! jq -s --arg workspace "$workspace" '
+    if ! jq -s --arg workspace "$workspace" --argjson keys "$managed_keys" '
         .[0] as $current | .[1] as $policy |
-        ($current * $policy) |
+        ($policy * $current * ($policy | with_entries(select(.key as $k | $keys | index($k) != null)))) |
         .trustedWorkspaces = (
             (if ($current.trustedWorkspaces | type) == "array"
              then $current.trustedWorkspaces else [] end) + [$workspace] |

--- a/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]devcontainer-assert.sh[% endif %]
@@ -477,6 +477,16 @@ assert_unit() {
     ' --arg workspace "$agy_workspace" "$agy_backup" >/dev/null ||
         fail "Antigravity policy rollback state was not recorded correctly"
 
+    local agy_fresh_home agy_fresh_settings
+    agy_fresh_home="${work_dir}/agy-fresh-home"
+    agy_fresh_settings="${agy_fresh_home}/.gemini/antigravity-cli/settings.json"
+    HOME="$agy_fresh_home" bash "$agy_apply" apply "$agy_defaults" "$agy_workspace" >/dev/null
+    jq -e '
+        .model == "Gemini 3.7 Flash (High)" and
+        .toolPermission == "always-proceed"
+    ' "$agy_fresh_settings" >/dev/null ||
+        fail "fresh Antigravity settings did not seed default model Gemini 3.7 Flash (High)"
+
     local agy_mig_home agy_mig_settings agy_mig_backup
     agy_mig_home="${work_dir}/agy-mig-home"
     agy_mig_settings="${agy_mig_home}/.gemini/antigravity-cli/settings.json"
@@ -572,6 +582,16 @@ assert_unit() {
         fail "balanced Antigravity dev policy was not merged correctly"
     jq -e '.schemaVersion == 6' "$agy_dev_backup" >/dev/null ||
         fail "balanced Antigravity dev policy did not record a schemaVersion 6 rollback"
+
+    local agy_dev_fresh_home agy_dev_fresh_settings
+    agy_dev_fresh_home="${work_dir}/agy-dev-fresh-home"
+    agy_dev_fresh_settings="${agy_dev_fresh_home}/.gemini/antigravity-cli/settings.json"
+    HOME="$agy_dev_fresh_home" bash "$agy_apply" apply "$agy_dev_defaults" "$agy_workspace" >/dev/null
+    jq -e '
+        .model == "Gemini 3.7 Flash (High)" and
+        .toolPermission == "request-review"
+    ' "$agy_dev_fresh_settings" >/dev/null ||
+        fail "fresh balanced Antigravity dev settings did not seed default model Gemini 3.7 Flash (High)"
 
     # ── schemaVersion 5 → 6 migration must not discard user permissions ──
     # A pre-permissions (v4) backup never owned `permissions`; migrating and

--- a/template/scripts/[% if devcontainer %]test-statusline.sh[% endif %]
+++ b/template/scripts/[% if devcontainer %]test-statusline.sh[% endif %]
@@ -80,10 +80,10 @@ out=$(render '')
 [ -n "$out" ] || fail "an empty payload produced no output at all"
 
 echo "==> Antigravity payload (conversation_id, model, headroom)"
-out=$(render '{"workspace":{"current_dir":"/"},"context_window":{"used_percentage":25,"context_window_size":1000000},"model":{"display_name":"Gemini 3.1 Pro (High)"},"conversation_id":"34ee01b6-2f37-4fe7"}')
+out=$(render '{"workspace":{"current_dir":"/"},"context_window":{"used_percentage":25,"context_window_size":1000000},"model":{"display_name":"Gemini 3.7 Flash (High)"},"conversation_id":"34ee01b6-2f37-4fe7"}')
 case "$out" in *' 25%'*) ;; *) fail "expected 25%, got: $out" ;; esac
 case "$out" in *'750k left'*) ;; *) fail "expected '750k left', got: $out" ;; esac
-case "$out" in *'Gemini 3.1 Pro (High)'*) ;; *) fail "expected model name, got: $out" ;; esac
+case "$out" in *'Gemini 3.7 Flash (High)'*) ;; *) fail "expected model name, got: $out" ;; esac
 case "$out" in *'34ee01b6'*) ;; *) fail "expected session id, got: $out" ;; esac
 
 echo "==> scalar-shaped fields (model, effort, cost as string/numbers) do not crash jq"


### PR DESCRIPTION
## Summary
- Sets `"model": "Gemini 3.7 Flash (High)"` as default in Antigravity settings (`antigravity-settings.json` and `antigravity-settings-dev.json`) across root and template layers.
- Updates `apply-antigravity-settings.sh` to seed unmanaged defaults like `model` on fresh setup while preserving user changes and enforcing managed autonomy keys.
- Adds assertions to `devcontainer-assert.sh` verifying default model seeding in fresh containers.
- Updates statusline test payload in `test-statusline.sh`.

## Verification
- `task test:dogfood-parity` passed (140 verbatim root<->template twins identical).
- `task verify` passed (all linters, guards, and template profiles passed).