### PR TITLE
fix: stop baking sibling org names into generated repos

### DIFF
--- a/.claude/hooks/session-start-context.sh
+++ b/.claude/hooks/session-start-context.sh
@@ -44,7 +44,7 @@ owner="${host_owner#* }"
 
 if [ "$host" = "github.com" ]; then
     case "$owner" in
-    "evanharmon1" | "harmonops" | "ponderousdev")
+    "evanharmon1")
         git_out="$(mktemp)"
         gh_out="$(mktemp)"
         creds_out="$(mktemp)"

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -7,7 +7,7 @@ How work is tracked for Harmon Init in **GitHub Projects**.
 The standard strategy is a single default GitHub **Project (V2)** per owner — one
 board for the organization, or (for personal-account repos) one for the user
 account — titled after the owner's GitHub login: `<owner> Project` (here:
-**evanharmon1 Project**; e.g. `harmonops Project`, `evanharmon1 Project`).
+**evanharmon1 Project**; e.g. `acme Project` for an organization, `octocat Project` for a personal account).
 Every repo the owner controls feeds that one board; an issue can belong to
 multiple projects, but this default board is its home. Reach for a second,
 focused project only when a body of work needs its own.

--- a/template/.claude/hooks/session-start-context.sh.jinja
+++ b/template/.claude/hooks/session-start-context.sh.jinja
@@ -44,7 +44,7 @@ owner="${host_owner#* }"
 
 if [ "$host" = "github.com" ]; then
     case "$owner" in
-"[[ github_org ]]" | "evanharmon1" | "harmonops" | "ponderousdev")
+"[[ github_org ]]")
     git_out="$(mktemp)"
     gh_out="$(mktemp)"
     creds_out="$(mktemp)"

--- a/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
+++ b/template/docs/[% if project_management == 'github' %]project-management.md[% endif %].jinja
@@ -7,7 +7,7 @@ How work is tracked for [[ project_name ]] in **GitHub Projects**.
 The standard strategy is a single default GitHub **Project (V2)** per owner — one
 board for the organization, or (for personal-account repos) one for the user
 account — titled after the owner's GitHub login: `<owner> Project` (here:
-**[[ github_org ]] Project**; e.g. `harmonops Project`, `evanharmon1 Project`).
+**[[ github_org ]] Project**; e.g. `acme Project` for an organization, `octocat Project` for a personal account).
 Every repo the owner controls feeds that one board; an issue can belong to
 multiple projects, but this default board is its home. Reach for a second,
 focused project only when a body of work needs its own.


### PR DESCRIPTION
## What

Stop hardcoding Evan's other org identifiers into generated repos.

Two shipped template files baked a fixed list of sibling orgs
(`evanharmon1`, `harmonops`, `ponderousdev`) into **every** consumer's
output:

- **`template/.claude/hooks/session-start-context.sh.jinja`** — the
  owner-gate `case "$owner"` matched that fixed list. Now it matches only
  the consumer's own `[[ github_org ]]`. Each generated repo already
  answers its own org, so the extra alternatives never did anything but
  leak Evan's org topology.
- **`template/docs/…project-management.md….jinja`** — the board-name
  examples used `harmonops Project` / `evanharmon1 Project`. Now generic
  placeholders (`acme Project` for an org, `octocat Project` for a
  personal account).

Both root dogfood twins updated in lockstep.

## Why

The hardcoded siblings violate the template's own independence principle
and trip public consumers' leakage guards for identifiers that mean
nothing in their repo — surfaced concretely by **foreman** (its `#34`
guard blocks harmon-platform siblings), where the generated
session-start hook and PM doc failed on `harmonops`.

## Verification

`check`, `test:dogfood-parity`, `test:dogfood-structure`,
`test:template-independence`, `test:release-title` all green. Render
probe with `github_org=acme-corp` yields a shellcheck-clean,
`bash -n`-valid hook whose case-arm matches only `acme-corp`, and PM-doc
examples with no sibling orgs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)