### PR TITLE
fix: let tools co-own same-name skills via a linker ignore list

### DIFF
--- a/scripts/link-agent-skills.sh
+++ b/scripts/link-agent-skills.sh
@@ -17,12 +17,43 @@ esac
 mkdir -p "$claude_dir" "$portable_dir"
 failed=0
 
+# A tool other than this compatibility layer may legitimately own a skill in
+# BOTH trees at once — a codegen tool that emits a Claude skill under
+# .claude/skills AND a deliberately DIFFERENT portable skill of the same name
+# under .agents/skills (per-harness variants). Such names are declared so this
+# layer neither mirrors them nor mistakes the intended divergence for an
+# accidental same-name clobber. Everything NOT declared stays fail-closed: an
+# undeclared same-name portable skill is still refused below. Declarations come
+# from the AGENT_SKILLS_LINK_IGNORE env var (whitespace-separated globs) and a
+# .link-ignore file in the portable dir (one shell glob per line; text after
+# '#' and blank lines are ignored).
+ignore_globs="${AGENT_SKILLS_LINK_IGNORE:-}"
+ignore_file="$portable_dir/.link-ignore"
+if [ -f "$ignore_file" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+        ignore_globs="$ignore_globs ${line%%#*}"
+    done <"$ignore_file"
+fi
+
+# Word-splitting on $ignore_globs is intentional: it iterates the collected
+# globs and collapses the blank/comment residue left above.
+is_ignored() {
+    _name="$1"
+    for _glob in $ignore_globs; do
+        case "$_name" in
+        $_glob) return 0 ;;
+        esac
+    done
+    return 1
+}
+
 # Refuse ambiguity before changing anything. A native portable skill remains
 # untouched, but it cannot silently override a different Claude-managed skill
 # with the same name.
 for skill_dir in "$claude_dir"/*/; do
     [ -d "$skill_dir" ] || continue
     name="$(basename "${skill_dir%/}")"
+    is_ignored "$name" && continue
     link="$portable_dir/$name"
     target="../../$claude_dir/$name"
     if { [ -e "$link" ] || [ -L "$link" ]; } &&
@@ -36,6 +67,7 @@ done
 for skill_dir in "$claude_dir"/*/; do
     [ -d "$skill_dir" ] || continue
     name="$(basename "${skill_dir%/}")"
+    is_ignored "$name" && continue
     link="$portable_dir/$name"
     target="../../$claude_dir/$name"
 
@@ -50,10 +82,11 @@ for skill_dir in "$claude_dir"/*/; do
     fi
 done
 
-# Remove only links this compatibility layer can prove it owns. Native skills
-# and links to any other location are always preserved.
+# Remove only links this compatibility layer can prove it owns. Native skills,
+# declared tool-managed skills, and links to any other location are preserved.
 for link in "$portable_dir"/*; do
     [ -L "$link" ] || continue
+    is_ignored "$(basename "$link")" && continue
     target="$(readlink "$link")"
     case "$target" in
     "../../$claude_dir/"*) ;;

--- a/scripts/test-agent-skill-links.sh
+++ b/scripts/test-agent-skill-links.sh
@@ -34,4 +34,31 @@ fi
 [ ! -L .agents/skills/native ]
 [ "$(cat .agents/skills/native/SKILL.md)" = native ]
 
+# A tool-managed skill declared in .link-ignore (same name in both trees, with
+# deliberately divergent content) is left alone: sync succeeds, the portable
+# dir is untouched, and no compatibility link is created for it.
+printf '%s\n' '# codex-target variants owned by another tool' >.agents/skills/.link-ignore
+printf '%s\n' native >>.agents/skills/.link-ignore
+"$repo_root/scripts/link-agent-skills.sh" sync
+[ ! -L .agents/skills/native ]
+[ "$(cat .agents/skills/native/SKILL.md)" = native ]
+[ "$(cat .claude/skills/native/SKILL.md)" = claude ]
+"$repo_root/scripts/link-agent-skills.sh" verify
+
+# An UNdeclared divergent skill still refuses — the ignore list is opt-in and
+# never a blanket "accept any same-name dir".
+mkdir -p .claude/skills/other .agents/skills/other
+printf '%s\n' claude >.claude/skills/other/SKILL.md
+printf '%s\n' native >.agents/skills/other/SKILL.md
+if "$repo_root/scripts/link-agent-skills.sh" sync >/dev/null 2>&1; then
+    echo "test-agent-skill-links: accepted an undeclared divergent skill" >&2
+    exit 1
+fi
+[ "$(cat .agents/skills/other/SKILL.md)" = native ]
+
+# The env-var form declares the same way; the file and the env var compose.
+AGENT_SKILLS_LINK_IGNORE=other "$repo_root/scripts/link-agent-skills.sh" sync
+[ ! -L .agents/skills/other ]
+[ "$(cat .agents/skills/other/SKILL.md)" = native ]
+
 echo "test-agent-skill-links: PASS"

--- a/template/scripts/link-agent-skills.sh
+++ b/template/scripts/link-agent-skills.sh
@@ -17,12 +17,43 @@ esac
 mkdir -p "$claude_dir" "$portable_dir"
 failed=0
 
+# A tool other than this compatibility layer may legitimately own a skill in
+# BOTH trees at once — a codegen tool that emits a Claude skill under
+# .claude/skills AND a deliberately DIFFERENT portable skill of the same name
+# under .agents/skills (per-harness variants). Such names are declared so this
+# layer neither mirrors them nor mistakes the intended divergence for an
+# accidental same-name clobber. Everything NOT declared stays fail-closed: an
+# undeclared same-name portable skill is still refused below. Declarations come
+# from the AGENT_SKILLS_LINK_IGNORE env var (whitespace-separated globs) and a
+# .link-ignore file in the portable dir (one shell glob per line; text after
+# '#' and blank lines are ignored).
+ignore_globs="${AGENT_SKILLS_LINK_IGNORE:-}"
+ignore_file="$portable_dir/.link-ignore"
+if [ -f "$ignore_file" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+        ignore_globs="$ignore_globs ${line%%#*}"
+    done <"$ignore_file"
+fi
+
+# Word-splitting on $ignore_globs is intentional: it iterates the collected
+# globs and collapses the blank/comment residue left above.
+is_ignored() {
+    _name="$1"
+    for _glob in $ignore_globs; do
+        case "$_name" in
+        $_glob) return 0 ;;
+        esac
+    done
+    return 1
+}
+
 # Refuse ambiguity before changing anything. A native portable skill remains
 # untouched, but it cannot silently override a different Claude-managed skill
 # with the same name.
 for skill_dir in "$claude_dir"/*/; do
     [ -d "$skill_dir" ] || continue
     name="$(basename "${skill_dir%/}")"
+    is_ignored "$name" && continue
     link="$portable_dir/$name"
     target="../../$claude_dir/$name"
     if { [ -e "$link" ] || [ -L "$link" ]; } &&
@@ -36,6 +67,7 @@ done
 for skill_dir in "$claude_dir"/*/; do
     [ -d "$skill_dir" ] || continue
     name="$(basename "${skill_dir%/}")"
+    is_ignored "$name" && continue
     link="$portable_dir/$name"
     target="../../$claude_dir/$name"
 
@@ -50,10 +82,11 @@ for skill_dir in "$claude_dir"/*/; do
     fi
 done
 
-# Remove only links this compatibility layer can prove it owns. Native skills
-# and links to any other location are always preserved.
+# Remove only links this compatibility layer can prove it owns. Native skills,
+# declared tool-managed skills, and links to any other location are preserved.
 for link in "$portable_dir"/*; do
     [ -L "$link" ] || continue
+    is_ignored "$(basename "$link")" && continue
     target="$(readlink "$link")"
     case "$target" in
     "../../$claude_dir/"*) ;;

--- a/template/scripts/test-agent-skill-links.sh
+++ b/template/scripts/test-agent-skill-links.sh
@@ -34,4 +34,31 @@ fi
 [ ! -L .agents/skills/native ]
 [ "$(cat .agents/skills/native/SKILL.md)" = native ]
 
+# A tool-managed skill declared in .link-ignore (same name in both trees, with
+# deliberately divergent content) is left alone: sync succeeds, the portable
+# dir is untouched, and no compatibility link is created for it.
+printf '%s\n' '# codex-target variants owned by another tool' >.agents/skills/.link-ignore
+printf '%s\n' native >>.agents/skills/.link-ignore
+"$repo_root/scripts/link-agent-skills.sh" sync
+[ ! -L .agents/skills/native ]
+[ "$(cat .agents/skills/native/SKILL.md)" = native ]
+[ "$(cat .claude/skills/native/SKILL.md)" = claude ]
+"$repo_root/scripts/link-agent-skills.sh" verify
+
+# An UNdeclared divergent skill still refuses — the ignore list is opt-in and
+# never a blanket "accept any same-name dir".
+mkdir -p .claude/skills/other .agents/skills/other
+printf '%s\n' claude >.claude/skills/other/SKILL.md
+printf '%s\n' native >.agents/skills/other/SKILL.md
+if "$repo_root/scripts/link-agent-skills.sh" sync >/dev/null 2>&1; then
+    echo "test-agent-skill-links: accepted an undeclared divergent skill" >&2
+    exit 1
+fi
+[ "$(cat .agents/skills/other/SKILL.md)" = native ]
+
+# The env-var form declares the same way; the file and the env var compose.
+AGENT_SKILLS_LINK_IGNORE=other "$repo_root/scripts/link-agent-skills.sh" sync
+[ ! -L .agents/skills/other ]
+[ "$(cat .agents/skills/other/SKILL.md)" = native ]
+
 echo "test-agent-skill-links: PASS"


### PR DESCRIPTION
## What

Add an opt-in ignore list to `link-agent-skills.sh` so a tool can
legitimately co-own a same-name skill in both the `.claude/skills` and
`.agents/skills` trees.

The linker mirrors each `.claude/skills/<name>` into
`.agents/skills/<name>` and — since the #997 hardening — fail-closes when
a same-name portable skill diverges from that mirror. That is correct for
an accidental clobber, but it also blocks a legitimate pattern: a codegen
tool (e.g. **openspec**) that deliberately emits a Claude skill **and** a
different portable skill of the same name — one per harness target — into
both trees. Such a repo cannot pass `verify:skills` at all.

Names matching `AGENT_SKILLS_LINK_IGNORE` (whitespace-separated globs) or
a `.agents/skills/.link-ignore` glob file are now neither mirrored nor
flagged as divergent, and their portable entries are never removed. The
guard stays **fail-closed for everything not declared** — an undeclared
same-name portable skill is still refused, so this is never a blanket
"accept any same-name dir".

## Why

Surfaced by **ponderous-docs**, whose openspec integration renders
`openspec-*` skills into both trees with genuinely different content; the
new v4.37.0 linker refuses all of them and blocks push/CI. Remedy there:
re-update to this release and add `.agents/skills/.link-ignore` with
`openspec-*`.

## Verification

`test:agent-skill-links` (extended with declared-allow,
undeclared-still-refuse, and env-var cases), `check`,
`test:dogfood-parity` (verbatim template+root twins), `test:template-independence`,
`test:release-title` all green. End-to-end render probe (`use_skills_sync=true`)
reproduces the divergent-skill refusal, then confirms a `.link-ignore` of
`openspec-*` makes `verify` pass with both variants intact and no bogus
symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)