### PR TITLE
fix: require a visible stage ledger for multi-stage Dev Loop work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,13 +243,13 @@ Creating the draft is a phase transition, not a terminal state, and every stop
 short of the readiness gate leaves the PR **draft** with a blocker report — a
 non-draft PR must always mean the automated work is done.
 
-**Post a visible stage ledger whenever two or more review or shepherd stages
-are in scope.** The loop below has independently capped stages, and after a
-few fix rounds the active one stops being obvious — to the maintainer reading
-along, and to the agent, which then runs one more challenge round after being
-told to move on. The ledger is a short table in the agent's **own
-commentary** (tool output is collapsed and does not count), always in this
-shape, with this legend, in every stage:
+**Post a visible stage ledger whenever the change passes through two or more
+of the stages below.** The loop has several stages, some independently capped,
+and after a few fix rounds the active one stops being obvious — to the
+maintainer reading along, and to the agent, which then runs one more review
+round after being told to move on. The ledger is a short table in the agent's
+**own commentary** (tool output is collapsed and does not count), always in
+this shape, with this legend, in every stage:
 
 | 📍 Ledger | |
 |---|---|
@@ -261,10 +261,11 @@ Stage glyphs: 🔨 implement · 🧪 verify · ⚔️ challenge · 🔍 review �
 🚢 shepherd. Status glyphs: ✅ clean/green · 🔴 P0/P1 open · 🟡 P2 deferred ·
 ⚪ P3 noted · ⏳ waiting on CI or a reviewer · ⛔ blocked/escalating · 🏁 stage
 converged. The same glyph always means the same thing, so a reader can tell
-the state at a glance without parsing prose. `Stage` names the stage **and
-its round as `round n/cap`** from the cap resolved below — challenge, review,
-and shepherd are counted and capped separately and never combined — and says
-whether the round is a local `task challenge`/`task review` run or a cloud
+the state at a glance without parsing prose. `Stage` names the stage and,
+for a capped stage, **its round as `round n/cap`** from the cap resolved
+below — challenge, review, and shepherd are counted and capped separately and
+never combined; implement, verify, and ci have no cap and carry no round —
+and says whether a round is a local `task challenge`/`task review` run or a cloud
 PR-shepherd review cycle. `Next` names the next concrete gate or action,
 including the `task verify` a fix owes before the next round. Post it at every
 stage transition, when a round begins or ends, as the concise progress tick
@@ -273,7 +274,7 @@ during a long wait (no re-dumping unchanged command output), and
 instruction overrides the default transition at once, a terminal one ("go
 straight to review", "no more challenge rounds") is reflected in the ledger
 before any tool call starts the next stage, and silently returning to the
-default sequence is forbidden. A one-step task with no review stage in scope
+default sequence is forbidden. A one-step task that touches a single stage
 owes no ledger.
 
 **Round caps are resolved, not stated here.** The challenge, review, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,39 @@ Creating the draft is a phase transition, not a terminal state, and every stop
 short of the readiness gate leaves the PR **draft** with a blocker report — a
 non-draft PR must always mean the automated work is done.
 
+**Post a visible stage ledger whenever two or more review or shepherd stages
+are in scope.** The loop below has independently capped stages, and after a
+few fix rounds the active one stops being obvious — to the maintainer reading
+along, and to the agent, which then runs one more challenge round after being
+told to move on. The ledger is a short table in the agent's **own
+commentary** (tool output is collapsed and does not count), always in this
+shape, with this legend, in every stage:
+
+| 📍 Ledger | |
+|---|---|
+| **Stage** | ⚔️ challenge · **round 2/4** · local (`task challenge`) |
+| **Round** | 🔴 1 P1 open · 🟡 2 P2 deferred · ⚪ 1 P3 noted · ✅ verify green |
+| **Next** | fix P1 → `task verify` → ⚔️ challenge round 3 |
+
+Stage glyphs: 🔨 implement · 🧪 verify · ⚔️ challenge · 🔍 review · 🏗️ ci ·
+🚢 shepherd. Status glyphs: ✅ clean/green · 🔴 P0/P1 open · 🟡 P2 deferred ·
+⚪ P3 noted · ⏳ waiting on CI or a reviewer · ⛔ blocked/escalating · 🏁 stage
+converged. The same glyph always means the same thing, so a reader can tell
+the state at a glance without parsing prose. `Stage` names the stage **and
+its round as `round n/cap`** from the cap resolved below — challenge, review,
+and shepherd are counted and capped separately and never combined — and says
+whether the round is a local `task challenge`/`task review` run or a cloud
+PR-shepherd review cycle. `Next` names the next concrete gate or action,
+including the `task verify` a fix owes before the next round. Post it at every
+stage transition, when a round begins or ends, as the concise progress tick
+during a long wait (no re-dumping unchanged command output), and
+**immediately after a maintainer changes the requested workflow** — the latest
+instruction overrides the default transition at once, a terminal one ("go
+straight to review", "no more challenge rounds") is reflected in the ledger
+before any tool call starts the next stage, and silently returning to the
+default sequence is forbidden. A one-step task with no review stage in scope
+owes no ledger.
+
 **Round caps are resolved, not stated here.** The challenge, review, and
 shepherd stages below are each capped, but this file names no numbers: they
 live in [`.devflow.toml`](.devflow.toml) as `rigor` levels, so there is one
@@ -283,8 +316,9 @@ the loop** — "rigor: `<level>` (`<source>`) → challenge ≤`<n>`, review ≤
 shepherd `<n>`, min_rounds `<n>`", filled in by reading the file rather than
 from memory — and
 carry it into the PR body, so a later round or a different session can see
-which budget it is spending instead of inferring one. Everything else about
-these stages is policy rather than a parameter and does not vary by level: the
+which budget it is spending instead of inferring one. The resolved cap is
+also the denominator of every `round n/cap` the stage ledger above shows.
+Everything else about these stages is policy rather than a parameter and does not vary by level: the
 exit condition,
 the round-2 scaffolding checkpoint, the escalation rule, and the deferred-P2
 sidecar all hold identically at every rigor. A cap is a ceiling, never a quota
@@ -736,7 +770,8 @@ run, and nothing waits on it.
    appropriate.
 4. Explain why any rejected finding is incorrect or irrelevant.
 5. Re-run `task verify` (and the other relevant gates) after fixes.
-6. Finish the round with an adjudication table — at minimum finding →
+6. Post the stage ledger for the round (Dev Loop above), then finish the
+   round with an adjudication table — at minimum finding →
    reviewer priority → **adjudicated** priority → classification → evidence →
    action, plus the round-2 provenance column — and record it; the skill
    adds the per-branch ledger the rows are written to.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,10 +277,11 @@ straight to review", "no more challenge rounds") is reflected in the ledger
 before any tool call starts the next stage, and silently returning to the
 default sequence is forbidden. An override is an attributable human decision
 and is followed, but it redirects the loop rather than erasing findings: any
-P0/P1 still open in the stage it ends is carried into the PR body's
-`## Deferred findings` with the override named as its disposition, never
-dropped, and the ledger records the override as the reason for the
-transition. A one-step task that touches a single stage owes no ledger.
+P0/P1 still open in the stage it ends is carried, **unchecked**, into the PR
+body's `## Deferred findings` with the override recorded as the reason it was
+carried — not as a disposition, so the shepherd stage still owes it a normal
+fix / decline-with-evidence / file-as-follow-up — and the ledger records the
+override as the reason for the transition. A one-step task that touches a single stage owes no ledger.
 
 **Round caps are resolved, not stated here.** The challenge, review, and
 shepherd stages below are each capped, but this file names no numbers: they

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,9 +247,10 @@ non-draft PR must always mean the automated work is done.
 of the stages below.** The loop has several stages, some independently capped,
 and after a few fix rounds the active one stops being obvious — to the
 maintainer reading along, and to the agent, which then runs one more review
-round after being told to move on. The ledger is a short table in the agent's
-**own commentary** (tool output is collapsed and does not count), always in
-this shape, with this legend, in every stage:
+round after being told to move on. The stage ledger — distinct from the
+gauntlet's private adjudication ledger, which is a file — is a short table in
+the agent's **own commentary** (tool output is collapsed and does not count),
+always in this shape, with this legend, in every stage:
 
 | 📍 Ledger | |
 |---|---|
@@ -274,8 +275,12 @@ during a long wait (no re-dumping unchanged command output), and
 instruction overrides the default transition at once, a terminal one ("go
 straight to review", "no more challenge rounds") is reflected in the ledger
 before any tool call starts the next stage, and silently returning to the
-default sequence is forbidden. A one-step task that touches a single stage
-owes no ledger.
+default sequence is forbidden. An override is an attributable human decision
+and is followed, but it redirects the loop rather than erasing findings: any
+P0/P1 still open in the stage it ends is carried into the PR body's
+`## Deferred findings` with the override named as its disposition, never
+dropped, and the ledger records the override as the reason for the
+transition. A one-step task that touches a single stage owes no ledger.
 
 **Round caps are resolved, not stated here.** The challenge, review, and
 shepherd stages below are each capped, but this file names no numbers: they
@@ -775,7 +780,7 @@ run, and nothing waits on it.
    round with an adjudication table — at minimum finding →
    reviewer priority → **adjudicated** priority → classification → evidence →
    action, plus the round-2 provenance column — and record it; the skill
-   adds the per-branch ledger the rows are written to.
+   adds the per-branch adjudication ledger the rows are written to.
 
 **Between rounds, check what the findings are about.** Those six steps are all
 *per-finding*, so a reviewer can be right every round while the loop as a whole

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -310,15 +310,33 @@ fi
 # every profile, or a template update can silently drop it.
 grep -qF 'Post a visible stage ledger' AGENTS.md ||
     err "rendered AGENTS.md lost the stage-ledger policy (#965)"
-for row in '| **Stage** |' '| **Round** |' '| **Next** |'; do
-    grep -qF "$row" AGENTS.md ||
-        err "rendered AGENTS.md stage ledger is missing the $row row (#965)"
-done
+# The canonical table must render as one contiguous block: header, rule, then
+# the Stage / Round / Next rows in that order, each carrying a stage glyph and
+# the Stage row a `round n/cap`.
+ledger_block="$(grep -A4 -F '| 📍 Ledger | |' AGENTS.md || true)"
+[ "$(printf '%s\n' "$ledger_block" | wc -l | tr -d ' ')" = "5" ] ||
+    err "rendered AGENTS.md stage-ledger table is not a contiguous 5-line block (#965)"
+printf '%s\n' "$ledger_block" | sed -n 2p | grep -qx '|---|---|' ||
+    err "rendered AGENTS.md stage-ledger table lacks its header rule (#965)"
+printf '%s\n' "$ledger_block" | sed -n 3p | grep -qE '^\| \*\*Stage\*\* \| .*round [0-9]+/[0-9]+' ||
+    err "rendered AGENTS.md stage-ledger Stage row does not show round n/cap (#965)"
+printf '%s\n' "$ledger_block" | sed -n 4p | grep -qF '| **Round** |' ||
+    err "rendered AGENTS.md stage-ledger Round row is missing or out of order (#965)"
+printf '%s\n' "$ledger_block" | sed -n 5p | grep -qF '| **Next** |' ||
+    err "rendered AGENTS.md stage-ledger Next row is missing or out of order (#965)"
+# Profile coherence: a render without the second-model reviewer must not tell
+# the agent to run a task the generated Taskfile does not define.
+if ! grep -qE '^  challenge:' Taskfile.yml; then
+    ! printf '%s\n' "$ledger_block" | grep -qF 'task challenge' ||
+        err "rendered AGENTS.md stage-ledger example cites task challenge in a profile without it (#965)"
+fi
 grep -qF 'round n/cap' AGENTS.md ||
     err "rendered AGENTS.md stage ledger does not show the round against its cap (#965)"
-grep -qF 'silently returning to the' AGENTS.md ||
+# Prose wraps, so flatten before matching the multi-word phrases.
+agents_flat="$(tr '\n' ' ' <AGENTS.md)"
+printf '%s' "$agents_flat" | grep -qF 'silently returning to the default sequence is forbidden' ||
     err "rendered AGENTS.md stage ledger lost the maintainer-override rule (#965)"
-grep -qF 'counted and capped separately and never combined' AGENTS.md ||
+printf '%s' "$agents_flat" | grep -qF 'counted and capped separately and never combined' ||
     err "rendered AGENTS.md stage ledger lost the independent-caps rule (#965)"
 for glyph in '⚔️ challenge' '🔍 review' '🚢 shepherd' '🔴 P0/P1' '🟡 P2' '⚪ P3'; do
     grep -qF "$glyph" AGENTS.md ||

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -306,42 +306,53 @@ if [ ! -L .github/copilot-instructions.md ] ||
     err ".github/copilot-instructions.md should be a symlink to ../AGENTS.md"
 fi
 # The visible stage ledger (#965): the Dev Loop policy must ship the canonical
-# Stage/Round/Next table, its glyph legend, and the maintainer-override rule in
-# every profile, or a template update can silently drop it.
-grep -qF 'Post a visible stage ledger' AGENTS.md ||
-    err "rendered AGENTS.md lost the stage-ledger policy (#965)"
-# The canonical table must render as one contiguous block: header, rule, then
-# the Stage / Round / Next rows in that order, each carrying a stage glyph and
-# the Stage row a `round n/cap`.
-ledger_block="$(grep -A4 -F '| 📍 Ledger | |' AGENTS.md || true)"
-[ "$(printf '%s\n' "$ledger_block" | wc -l | tr -d ' ')" = "5" ] ||
-    err "rendered AGENTS.md stage-ledger table is not a contiguous 5-line block (#965)"
-printf '%s\n' "$ledger_block" | sed -n 2p | grep -qx '|---|---|' ||
-    err "rendered AGENTS.md stage-ledger table lacks its header rule (#965)"
-printf '%s\n' "$ledger_block" | sed -n 3p | grep -qE '^\| \*\*Stage\*\* \| .*round [0-9]+/[0-9]+' ||
-    err "rendered AGENTS.md stage-ledger Stage row does not show round n/cap (#965)"
-printf '%s\n' "$ledger_block" | sed -n 4p | grep -qF '| **Round** |' ||
-    err "rendered AGENTS.md stage-ledger Round row is missing or out of order (#965)"
-printf '%s\n' "$ledger_block" | sed -n 5p | grep -qF '| **Next** |' ||
-    err "rendered AGENTS.md stage-ledger Next row is missing or out of order (#965)"
-# Profile coherence: a render without the second-model reviewer must not tell
-# the agent to run a task the generated Taskfile does not define.
-if ! grep -qE '^  challenge:' Taskfile.yml; then
-    ! printf '%s\n' "$ledger_block" | grep -qF 'task challenge' ||
-        err "rendered AGENTS.md stage-ledger example cites task challenge in a profile without it (#965)"
-fi
-grep -qF 'round n/cap' AGENTS.md ||
-    err "rendered AGENTS.md stage ledger does not show the round against its cap (#965)"
-# Prose wraps, so flatten before matching the multi-word phrases.
-agents_flat="$(tr '\n' ' ' <AGENTS.md)"
-printf '%s' "$agents_flat" | grep -qF 'silently returning to the default sequence is forbidden' ||
-    err "rendered AGENTS.md stage ledger lost the maintainer-override rule (#965)"
-printf '%s' "$agents_flat" | grep -qF 'counted and capped separately and never combined' ||
-    err "rendered AGENTS.md stage ledger lost the independent-caps rule (#965)"
-for glyph in '⚔️ challenge' '🔍 review' '🚢 shepherd' '🔴 P0/P1' '🟡 P2' '⚪ P3'; do
-    grep -qF "$glyph" AGENTS.md ||
-        err "rendered AGENTS.md stage-ledger legend is missing '$glyph' (#965)"
-done
+# Stage/Round/Next table, its full glyph legend, and the maintainer-override
+# rule in every profile — and the root dogfood copy must carry the same, since
+# this test otherwise inspects only the rendered file (see "Dogfood parity").
+assert_stage_ledger() {
+    local file="$1" label="$2" taskfile="$3" block flat glyph
+    grep -qF 'Post a visible stage ledger' "$file" ||
+        err "$label lost the stage-ledger policy (#965)"
+    # The canonical table must be one contiguous block: header, rule, then the
+    # Stage / Round / Next rows in that order, the Stage row carrying round n/cap.
+    block="$(grep -A4 -F '| 📍 Ledger | |' "$file" || true)"
+    [ "$(printf '%s\n' "$block" | wc -l | tr -d ' ')" = "5" ] ||
+        err "$label stage-ledger table is not a contiguous 5-line block (#965)"
+    printf '%s\n' "$block" | sed -n 2p | grep -qx '|---|---|' ||
+        err "$label stage-ledger table lacks its header rule (#965)"
+    printf '%s\n' "$block" | sed -n 3p | grep -qE '^\| \*\*Stage\*\* \| .*round [0-9]+/[0-9]+' ||
+        err "$label stage-ledger Stage row does not show round n/cap (#965)"
+    printf '%s\n' "$block" | sed -n 4p | grep -qF '| **Round** |' ||
+        err "$label stage-ledger Round row is missing or out of order (#965)"
+    printf '%s\n' "$block" | sed -n 5p | grep -qF '| **Next** |' ||
+        err "$label stage-ledger Next row is missing or out of order (#965)"
+    # Profile coherence: a copy without the second-model reviewer must not tell
+    # the agent to run a task its Taskfile does not define.
+    if ! grep -qE '^  challenge:' "$taskfile"; then
+        ! printf '%s\n' "$block" | grep -qF 'task challenge' ||
+            err "$label stage-ledger example cites task challenge in a profile without it (#965)"
+    fi
+    # Prose wraps, so flatten before matching the multi-word phrases.
+    flat="$(tr '\n' ' ' <"$file")"
+    printf '%s' "$flat" | grep -qF 'round n/cap' ||
+        err "$label stage ledger does not show the round against its cap (#965)"
+    printf '%s' "$flat" | grep -qF 'silently returning to the default sequence is forbidden' ||
+        err "$label stage ledger lost the maintainer-override rule (#965)"
+    printf '%s' "$flat" | grep -qF 'counted and capped separately and never combined' ||
+        err "$label stage ledger lost the independent-caps rule (#965)"
+    printf '%s' "$flat" | grep -qF 'not as a disposition' ||
+        err "$label stage ledger lets an override settle an open P0/P1 (#965)"
+    # The complete legend: every glyph keeps its one meaning.
+    for glyph in '🔨 implement' '🧪 verify' '⚔️ challenge' '🔍 review' '🏗️ ci' \
+        '🚢 shepherd' '✅ clean/green' '🔴 P0/P1 open' '🟡 P2 deferred' \
+        '⚪ P3 noted' '⏳ waiting on CI or a reviewer' '⛔ blocked/escalating' \
+        '🏁 stage converged'; do
+        printf '%s' "$flat" | grep -qF "$glyph" ||
+            err "$label stage-ledger legend is missing '$glyph' (#965)"
+    done
+}
+assert_stage_ledger AGENTS.md "rendered AGENTS.md" Taskfile.yml
+assert_stage_ledger "$repo_root/AGENTS.md" "root AGENTS.md" "$repo_root/Taskfile.yml"
 [ -x scripts/check-agent-instructions-size.sh ] ||
     err "AGENTS.md size advisory is missing or not executable"
 [ -x scripts/test-agent-instructions-size.sh ] ||

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -305,6 +305,25 @@ if [ ! -L .github/copilot-instructions.md ] ||
     [ "$(readlink .github/copilot-instructions.md)" != "../AGENTS.md" ]; then
     err ".github/copilot-instructions.md should be a symlink to ../AGENTS.md"
 fi
+# The visible stage ledger (#965): the Dev Loop policy must ship the canonical
+# Stage/Round/Next table, its glyph legend, and the maintainer-override rule in
+# every profile, or a template update can silently drop it.
+grep -qF 'Post a visible stage ledger' AGENTS.md ||
+    err "rendered AGENTS.md lost the stage-ledger policy (#965)"
+for row in '| **Stage** |' '| **Round** |' '| **Next** |'; do
+    grep -qF "$row" AGENTS.md ||
+        err "rendered AGENTS.md stage ledger is missing the $row row (#965)"
+done
+grep -qF 'round n/cap' AGENTS.md ||
+    err "rendered AGENTS.md stage ledger does not show the round against its cap (#965)"
+grep -qF 'silently returning to the' AGENTS.md ||
+    err "rendered AGENTS.md stage ledger lost the maintainer-override rule (#965)"
+grep -qF 'counted and capped separately and never combined' AGENTS.md ||
+    err "rendered AGENTS.md stage ledger lost the independent-caps rule (#965)"
+for glyph in '⚔️ challenge' '🔍 review' '🚢 shepherd' '🔴 P0/P1' '🟡 P2' '⚪ P3'; do
+    grep -qF "$glyph" AGENTS.md ||
+        err "rendered AGENTS.md stage-ledger legend is missing '$glyph' (#965)"
+done
 [ -x scripts/check-agent-instructions-size.sh ] ||
     err "AGENTS.md size advisory is missing or not executable"
 [ -x scripts/test-agent-instructions-size.sh ] ||

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -136,28 +136,35 @@ private repositories to paid plans (docs/CHECKLIST.md). If `gh pr create
 --draft` is rejected, stop and report it — dropping `--draft` to get past the
 error silently reverts the lifecycle rather than fixing anything.
 
-**Post a visible stage ledger whenever two or more review or shepherd stages
-are in scope.** The loop below has independently capped stages, and after a
-few fix rounds the active one stops being obvious — to the maintainer reading
-along, and to the agent, which then runs one more challenge round after being
-told to move on. The ledger is a short table in the agent's **own
-commentary** (tool output is collapsed and does not count), always in this
-shape, with this legend, in every stage:
+**Post a visible stage ledger whenever the change passes through two or more
+of the stages below.** The loop has several stages, some independently capped,
+and after a few fix rounds the active one stops being obvious — to the
+maintainer reading along, and to the agent, which then runs one more review
+round after being told to move on. The ledger is a short table in the agent's
+**own commentary** (tool output is collapsed and does not count), always in
+this shape, with this legend, in every stage:
 
-| 📍 Ledger | |
+[% if use_codex_review %]| 📍 Ledger | |
 |---|---|
 | **Stage** | ⚔️ challenge · **round 2/4** · local (`task challenge`) |
 | **Round** | 🔴 1 P1 open · 🟡 2 P2 deferred · ⚪ 1 P3 noted · ✅ verify green |
 | **Next** | fix P1 → `task verify` → ⚔️ challenge round 3 |
+[% else %]| 📍 Ledger | |
+|---|---|
+| **Stage** | 🚢 shepherd · **round 2/4** · cloud (PR review cycle) |
+| **Round** | 🔴 1 finding open · 🟡 2 P2 deferred · ⚪ 1 P3 noted · ⏳ CI |
+| **Next** | fix finding → `task verify` → push → 🚢 shepherd round 3 |
+[% endif %]
 
 Stage glyphs: 🔨 implement · 🧪 verify · ⚔️ challenge · 🔍 review · 🏗️ ci ·
 🚢 shepherd. Status glyphs: ✅ clean/green · 🔴 P0/P1 open · 🟡 P2 deferred ·
 ⚪ P3 noted · ⏳ waiting on CI or a reviewer · ⛔ blocked/escalating · 🏁 stage
 converged. The same glyph always means the same thing, so a reader can tell
-the state at a glance without parsing prose. `Stage` names the stage **and
-its round as `round n/cap`** from the cap resolved below — challenge, review,
-and shepherd are counted and capped separately and never combined — and says
-whether the round is a local [% if use_codex_review %]`task challenge`/`task review` [% endif %]gate run or a cloud
+the state at a glance without parsing prose. `Stage` names the stage and,
+for a capped stage, **its round as `round n/cap`** from the cap resolved
+below — challenge, review, and shepherd are counted and capped separately and
+never combined; implement, verify, and ci have no cap and carry no round —
+and says whether a round is a local [% if use_codex_review %]`task challenge`/`task review` run[% else %]gate run[% endif %] or a cloud
 PR-shepherd review cycle. `Next` names the next concrete gate or action,
 including the `task verify` a fix owes before the next round. Post it at every
 stage transition, when a round begins or ends, as the concise progress tick
@@ -166,7 +173,7 @@ during a long wait (no re-dumping unchanged command output), and
 instruction overrides the default transition at once, a terminal one ("go
 straight to review", "no more challenge rounds") is reflected in the ledger
 before any tool call starts the next stage, and silently returning to the
-default sequence is forbidden. A one-step task with no review stage in scope
+default sequence is forbidden. A one-step task that touches a single stage
 owes no ledger.
 
 **Round caps are resolved, not stated here.** The stages below are each

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -140,9 +140,10 @@ error silently reverts the lifecycle rather than fixing anything.
 of the stages below.** The loop has several stages, some independently capped,
 and after a few fix rounds the active one stops being obvious — to the
 maintainer reading along, and to the agent, which then runs one more review
-round after being told to move on. The ledger is a short table in the agent's
-**own commentary** (tool output is collapsed and does not count), always in
-this shape, with this legend, in every stage:
+round after being told to move on. The stage ledger — distinct from the
+gauntlet's private adjudication ledger, which is a file — is a short table in
+the agent's **own commentary** (tool output is collapsed and does not count),
+always in this shape, with this legend, in every stage:
 
 [% if use_codex_review %]| 📍 Ledger | |
 |---|---|
@@ -152,8 +153,8 @@ this shape, with this legend, in every stage:
 [% else %]| 📍 Ledger | |
 |---|---|
 | **Stage** | 🚢 shepherd · **round 2/4** · cloud (PR review cycle) |
-| **Round** | 🔴 1 finding open · 🟡 2 P2 deferred · ⚪ 1 P3 noted · ⏳ CI |
-| **Next** | fix finding → `task verify` → push → 🚢 shepherd round 3 |
+| **Round** | 🔴 1 P1 open · 🟡 2 P2 deferred · ⚪ 1 P3 noted · ⏳ CI |
+| **Next** | fix P1 → `task verify` → push → 🚢 shepherd round 3 |
 [% endif %]
 
 Stage glyphs: 🔨 implement · 🧪 verify · ⚔️ challenge · 🔍 review · 🏗️ ci ·
@@ -164,8 +165,9 @@ the state at a glance without parsing prose. `Stage` names the stage and,
 for a capped stage, **its round as `round n/cap`** from the cap resolved
 below — challenge, review, and shepherd are counted and capped separately and
 never combined; implement, verify, and ci have no cap and carry no round —
-and says whether a round is a local [% if use_codex_review %]`task challenge`/`task review` run[% else %]gate run[% endif %] or a cloud
-PR-shepherd review cycle. `Next` names the next concrete gate or action,
+and says [% if use_codex_review %]whether a round is a local `task challenge`/`task review` run or a cloud
+PR-shepherd review cycle[% else %]that a round is a cloud PR-shepherd review cycle — shepherd is the
+only capped stage in this repository's loop[% endif %]. `Next` names the next concrete gate or action,
 including the `task verify` a fix owes before the next round. Post it at every
 stage transition, when a round begins or ends, as the concise progress tick
 during a long wait (no re-dumping unchanged command output), and
@@ -173,11 +175,15 @@ during a long wait (no re-dumping unchanged command output), and
 instruction overrides the default transition at once, a terminal one ("go
 straight to review", "no more challenge rounds") is reflected in the ledger
 before any tool call starts the next stage, and silently returning to the
-default sequence is forbidden. A one-step task that touches a single stage
-owes no ledger.
+default sequence is forbidden. An override is an attributable human decision
+and is followed, but it redirects the loop rather than erasing findings: any
+P0/P1 still open in the stage it ends is carried into the PR body's
+`## Deferred findings` with the override named as its disposition, never
+dropped, and the ledger records the override as the reason for the
+transition. A one-step task that touches a single stage owes no ledger.
 
-**Round caps are resolved, not stated here.** The stages below are each
-capped, but this file names no numbers: the caps live in
+**Round caps are resolved, not stated here.** The capped stages below —
+[% if use_codex_review %]challenge, review, and [% endif %]shepherd — each have a cap, but this file names no numbers: the caps live in
 [`.devflow.toml`](.devflow.toml) as `rigor` levels, so there is one place to
 change them and one place to read them. Resolve in this order — an explicit
 instruction in this session, then [% if project_management == 'github' or use_foreman %]a `rigor:*` label on the issue, then [% endif %]`default_rigor`,
@@ -287,7 +293,7 @@ reviewer instead of silent.
   the backgrounding guidance in
   [docs/guides/codex-review.md](docs/guides/codex-review.md) ("Duration and
   backgrounding"), the sidecar obligation in "Deferring P2s" below, and the
-  Dev Loop's draft-PR bullet — the ledger and the extended ritual are
+  Dev Loop's draft-PR bullet — the adjudication ledger and the extended ritual are
   gauntlet enhancements a no-skill repo simply does not owe. What stays here
   is the policy they run under, and where a **vendored** skill (`/gauntlet`)
   states a different cap, floor, or exit condition, **this file wins** —
@@ -677,7 +683,7 @@ These local tasks do not imply that Codex cloud review is installed or required.
    round with an adjudication table — at minimum finding →
    reviewer priority → **adjudicated** priority → classification → evidence →
    action, plus the round-2 provenance column — and record it; where the
-   `/gauntlet` skill is vendored it adds the per-branch ledger the rows are
+   `/gauntlet` skill is vendored it adds the per-branch adjudication ledger the rows are
    written to.
 
 **Between rounds, check what the findings are about.** Those six steps are all

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -136,6 +136,39 @@ private repositories to paid plans (docs/CHECKLIST.md). If `gh pr create
 --draft` is rejected, stop and report it — dropping `--draft` to get past the
 error silently reverts the lifecycle rather than fixing anything.
 
+**Post a visible stage ledger whenever two or more review or shepherd stages
+are in scope.** The loop below has independently capped stages, and after a
+few fix rounds the active one stops being obvious — to the maintainer reading
+along, and to the agent, which then runs one more challenge round after being
+told to move on. The ledger is a short table in the agent's **own
+commentary** (tool output is collapsed and does not count), always in this
+shape, with this legend, in every stage:
+
+| 📍 Ledger | |
+|---|---|
+| **Stage** | ⚔️ challenge · **round 2/4** · local (`task challenge`) |
+| **Round** | 🔴 1 P1 open · 🟡 2 P2 deferred · ⚪ 1 P3 noted · ✅ verify green |
+| **Next** | fix P1 → `task verify` → ⚔️ challenge round 3 |
+
+Stage glyphs: 🔨 implement · 🧪 verify · ⚔️ challenge · 🔍 review · 🏗️ ci ·
+🚢 shepherd. Status glyphs: ✅ clean/green · 🔴 P0/P1 open · 🟡 P2 deferred ·
+⚪ P3 noted · ⏳ waiting on CI or a reviewer · ⛔ blocked/escalating · 🏁 stage
+converged. The same glyph always means the same thing, so a reader can tell
+the state at a glance without parsing prose. `Stage` names the stage **and
+its round as `round n/cap`** from the cap resolved below — challenge, review,
+and shepherd are counted and capped separately and never combined — and says
+whether the round is a local [% if use_codex_review %]`task challenge`/`task review` [% endif %]gate run or a cloud
+PR-shepherd review cycle. `Next` names the next concrete gate or action,
+including the `task verify` a fix owes before the next round. Post it at every
+stage transition, when a round begins or ends, as the concise progress tick
+during a long wait (no re-dumping unchanged command output), and
+**immediately after a maintainer changes the requested workflow** — the latest
+instruction overrides the default transition at once, a terminal one ("go
+straight to review", "no more challenge rounds") is reflected in the ledger
+before any tool call starts the next stage, and silently returning to the
+default sequence is forbidden. A one-step task with no review stage in scope
+owes no ledger.
+
 **Round caps are resolved, not stated here.** The stages below are each
 capped, but this file names no numbers: the caps live in
 [`.devflow.toml`](.devflow.toml) as `rigor` levels, so there is one place to
@@ -172,7 +205,9 @@ reviewer instead of silent.
 `<level>` (`<source>`) → [% if use_codex_review %]challenge ≤`<n>`, review ≤`<n>`, [% endif %]shepherd `<n>`[% if use_codex_review %], min_rounds `<n>`[% endif %]", filled in
 by reading the file rather than from memory — and carry it into the PR body, so
 a later round or a different session can see which budget it is spending
-instead of inferring one. Everything else about these stages is policy rather
+instead of inferring one. The resolved cap is also the denominator of every
+`round n/cap` the stage ledger above shows. Everything else about these stages
+is policy rather
 than a parameter and does not vary by level: the exit condition, the escalation
 rule, [% if use_codex_review %]the round-2 scaffolding checkpoint, the deferred-P2 sidecar, [% endif %]and the
 readiness gate all hold identically at every rigor. A cap is a ceiling, never a
@@ -631,7 +666,8 @@ These local tasks do not imply that Codex cloud review is installed or required.
    appropriate.
 4. Explain why any rejected finding is incorrect or irrelevant.
 5. Re-run `task verify` (and the other relevant gates) after fixes.
-6. Finish the round with an adjudication table — at minimum finding →
+6. Post the stage ledger for the round (Dev Loop above), then finish the
+   round with an adjudication table — at minimum finding →
    reviewer priority → **adjudicated** priority → classification → evidence →
    action, plus the round-2 provenance column — and record it; where the
    `/gauntlet` skill is vendored it adds the per-branch ledger the rows are

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -177,10 +177,11 @@ straight to review", "no more challenge rounds") is reflected in the ledger
 before any tool call starts the next stage, and silently returning to the
 default sequence is forbidden. An override is an attributable human decision
 and is followed, but it redirects the loop rather than erasing findings: any
-P0/P1 still open in the stage it ends is carried into the PR body's
-`## Deferred findings` with the override named as its disposition, never
-dropped, and the ledger records the override as the reason for the
-transition. A one-step task that touches a single stage owes no ledger.
+P0/P1 still open in the stage it ends is carried, **unchecked**, into the PR
+body's `## Deferred findings` with the override recorded as the reason it was
+carried — not as a disposition, so the shepherd stage still owes it a normal
+fix / decline-with-evidence / file-as-follow-up — and the ledger records the
+override as the reason for the transition. A one-step task that touches a single stage owes no ledger.
 
 **Round caps are resolved, not stated here.** The capped stages below —
 [% if use_codex_review %]challenge, review, and [% endif %]shepherd — each have a cap, but this file names no numbers: the caps live in


### PR DESCRIPTION
Closes #965

## What

Adds a required **visible stage ledger** to the Dev Loop guidance — a small, fixed-shape table agents post in their own commentary during multi-stage work — in both layers (`AGENTS.md` + `template/AGENTS.md.jinja`), and guards it with render assertions.

| 📍 Ledger | |
|---|---|
| **Stage** | ⚔️ challenge · **round 2/4** · local (`task challenge`) |
| **Round** | 🔴 1 P1 open · 🟡 2 P2 deferred · ⚪ 1 P3 noted · ✅ verify green |
| **Next** | fix P1 → `task verify` → ⚔️ challenge round 3 |

- Fixed glyph legend, identical in every stage/context: stages 🔨 implement · 🧪 verify · ⚔️ challenge · 🔍 review · 🏗️ ci · 🚢 shepherd; status ✅ clean/green · 🔴 P0/P1 open · 🟡 P2 deferred · ⚪ P3 noted · ⏳ waiting · ⛔ blocked/escalating · 🏁 converged.
- `Stage` carries `round n/cap` for the capped stages (challenge, review, shepherd — counted and capped separately, never combined; implement/verify/ci carry no round) and says whether a round is local or a cloud PR-shepherd cycle.
- Required whenever the change passes through two or more stages; posted at every transition, round boundary, long-wait tick, and **immediately after a maintainer override** — the latest instruction wins, silently resuming the default sequence is forbidden. An override redirects the loop but never erases findings: open P0/P1 are carried **unchecked** into `## Deferred findings` with the override as the reason (not a disposition), so shepherd still owes them a normal fix/decline/file.
- The template example is jinja-gated: renders without `use_codex_review` show a shepherd-round example and never cite a task their Taskfile lacks; the capped-stage list and round prose are profile-scoped.
- Named the gauntlet's private **adjudication ledger** distinctly from the visible **stage ledger** wherever both appear.
- Wired into the cap announcement ("the resolved cap is the denominator of every `round n/cap`") and the Codex per-round steps.

## Why

#965: during long sessions the active stage becomes ambiguous after fixes or maintainer overrides, costing extra challenge/review rounds and repeated status questions. Evan additionally asked that the ledger be visible in the agent's own session output, be visually distinctive (table + consistent emoji), and always show the round number.

## Verification

- `task verify` green on every commit (lint, guards, full render matrix incl. the new `assert_stage_ledger` checks against both the rendered and the root dogfood `AGENTS.md`: contiguous 5-line table, `round n/cap` on the Stage row, override rule, independent-caps rule, "not as a disposition", all 13 legend glyphs, and a profile-coherence check that a no-Codex render never cites `task challenge`).
- `task ci` (full CI mirror) green before opening this draft.
- Pre-flighted the `fix:` release title (`task guard:release-title`).

## Review budget

rigor: **explicit instruction from Evan** (below `default_rigor` = `standard` 3/3/4/1) → challenge ≤**2**, review ≤**2**, shepherd **2**, min_rounds 1. Disclosed because every cap is below the default.

- ⚔️ challenge: 2/2 rounds — r1 2 P1 + 1 P2, r2 2 P1 + 2 P2, all confirmed and fixed (round-2 provenance: two P2s concerned r1's wording and were restructured, not hardened). Cap reached with fixed-but-unconfirmed P1s → escalated; Evan chose to proceed to review.
- 🔍 review: 1/2 rounds — r1 1 P1 + 2 P2, all fixed. **Round 2 did not run: Codex usage limit until 2026-08-23 07:13**; Evan chose to continue. The shepherd's cloud Codex cycle on the final head is the remaining second-model check.

## Deferred findings

None — every challenge/review finding was fixed in place (see the adjudication ledger below).

## Adjudication ledger

```text
template/AGENTS.md.jinja:139 | ledger example cites task challenge + trigger dead in use_codex_review=false render | fixed: jinja-gated example, trigger = two+ stages | challenge r1
AGENTS.md:264 | round n/cap demanded for uncapped implement/verify/ci | fixed: round only on capped stages | challenge r1
scripts/test-template.sh:311 | substring assertions pass incoherent render | fixed: contiguous block + profile-aware task challenge check | challenge r1
challenge r1 | 2 P1 + 1 P2, all fixed
template/AGENTS.md.jinja:172 | maintainer override vs stage exit gates (P0/P1 left open) | fixed: override redirects, open P0/P1 carried to PR Deferred findings, ledger records reason | challenge r2 | subject: original change
template/AGENTS.md.jinja:139 | "ledger" ambiguous: gauntlet adjudication ledger vs visible stage ledger | fixed: named both; no-skill exemption now names the adjudication ledger | challenge r2 | subject: original change
template/AGENTS.md.jinja:164 | no-codex render calls rounds "gate run"; "stages below are each capped" | fixed: profile-scoped prose, capped-stage list gated | challenge r2 | subject: r1 fix (restructured, not hardened)
template/AGENTS.md.jinja:154 | no-codex example "🔴 1 finding open" breaks glyph meaning | fixed: "🔴 1 P1 open" | challenge r2 | subject: r1 fix
challenge r2 | 2 P1 + 2 P2, all fixed; cap reached (Evan: cap 2) — escalate before review
challenge exit | capped at 2 with fixed P1s; Evan chose: proceed to review (option 1)
template/AGENTS.md.jinja:179 | override "as disposition" lets open P0/P1 look settled | fixed: carried unchecked, override = reason not disposition | review r1
scripts/test-template.sh:311 | ledger asserted only in rendered copy, not root dogfood | fixed: assert_stage_ledger runs on both | review r1
scripts/test-template.sh:341 | legend check covered 6 of 13 glyphs | fixed: full legend asserted | review r1
review r1 | 1 P1 + 2 P2, all fixed
review r2 | NOT RUN — Codex usage limit until 2026-08-23 07:13; Evan: continue → ci/PR with disclosure
```

## Follow-ups

- harmon-devkit: align the vendored `gauntlet` / `shepherd` skills' round announcements with this ledger format (AGENTS.md wins meanwhile).
