### PR TITLE
fix(claude-workflows): let claude-code-action fetch the PR branch on private repos

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -169,8 +169,14 @@ jobs:
           permission-issues: write
       # Exception to the repo-wide `persist-credentials: false` hardening:
       # this checkout deliberately persists the short-lived narrow CI App token
-      # so Claude's `git push` of the working branch can authenticate. The token
-      # is least-privilege (minted above) and expires with the job.
+      # for two reasons. Claude's `git push` of the working branch needs it to
+      # authenticate; and — like claude-review/claude-plan — when this workflow
+      # is triggered on an open PR, claude-code-action's tag mode `git fetch`es
+      # the PR head branch BEFORE it configures its own git auth (setupBranch
+      # runs ahead of configureGitAuth — anthropics/claude-code-action#1236),
+      # so a credential-less checkout would fail with "could not read Username"
+      # on a private repo. The token is least-privilege (minted above) and
+      # expires with the job.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0

--- a/.github/workflows/claude-plan.yml
+++ b/.github/workflows/claude-plan.yml
@@ -163,9 +163,18 @@ jobs:
           permission-contents: read
           permission-issues: write
           permission-pull-requests: write
+      # Exception to the repo-wide `persist-credentials: false` hardening:
+      # claude-code-action's tag mode `git fetch`es the PR head branch BEFORE it
+      # configures its own git auth (setupBranch runs ahead of configureGitAuth —
+      # anthropics/claude-code-action#1236), so on a private repo a
+      # credential-less checkout fails with "could not read Username" the first
+      # time the workflow is triggered on an open PR. Persist the short-lived,
+      # read-only CI App token minted above instead: the action strips this
+      # header and substitutes its own token right after the fetch, and this job
+      # uploads no artifacts (the leak vector the hardening guards against).
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
       - uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1.0.195
         # Step-level cap. A JOB timeout kills the runner outright and the
         # always() release below never runs; a STEP timeout fails only this

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -172,9 +172,18 @@ jobs:
           permission-contents: read
           permission-pull-requests: write
           permission-issues: write
+      # Exception to the repo-wide `persist-credentials: false` hardening:
+      # claude-code-action's tag mode `git fetch`es the PR head branch BEFORE it
+      # configures its own git auth (setupBranch runs ahead of configureGitAuth —
+      # anthropics/claude-code-action#1236), so on a private repo a
+      # credential-less checkout fails with "could not read Username" the first
+      # time the workflow is triggered on an open PR. Persist the short-lived,
+      # read-only CI App token minted above instead: the action strips this
+      # header and substitutes its own token right after the fetch, and this job
+      # uploads no artifacts (the leak vector the hardening guards against).
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
       - uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1.0.195
         # Step-level cap. A JOB timeout kills the runner outright and the
         # always() release below never runs; a STEP timeout fails only this

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -816,13 +816,17 @@ if [ -d .github/workflows ]; then
     # guarded. Any comment or unrelated `with:` block could mask a real gap the
     # same way.
     #
-    # The one legitimate exception is named, and must still prove its shape.
+    # The legitimate exceptions are named, and must still prove their shape.
     # An earlier version allowed any checkout that set `token:` — too loose:
     # `token: ${{ github.token }}` is the DEFAULT token spelled out, and
     # actions/checkout persists it just the same, so that rule would have waved
-    # through exactly what it exists to catch. Only claude-implement.yml may
-    # omit the guard, and only for a checkout using the minted App token, which
-    # it must persist so Claude's `git push` can authenticate.
+    # through exactly what it exists to catch. Only the three Claude workflows
+    # may omit the guard, each for exactly one checkout using the minted App
+    # token: claude-implement.yml must persist it so Claude's `git push` can
+    # authenticate, and claude-review.yml / claude-plan.yml must persist it
+    # because claude-code-action's tag mode `git fetch`es the PR head branch
+    # before configuring its own git auth (anthropics/claude-code-action#1236),
+    # which fails on a private repo with no persisted credential.
     if have yq; then
         # This is a security audit, so it must fail CLOSED. An earlier version
         # ended each query with `|| echo 0`, which turned any evaluator error
@@ -858,11 +862,13 @@ if [ -d .github/workflows ]; then
                     continue
                 fi
                 allowed=0
-                if [ "$(basename "$workflow")" = "claude-implement.yml" ]; then
-                    # Exactly ONE checkout may claim this exemption. Match the
-                    # token expression exactly: this workflow mints two App
-                    # tokens (`app-token` and `app-token-projects`), so a
-                    # substring test would exempt either.
+                case "$(basename "$workflow")" in
+                claude-implement.yml | claude-review.yml | claude-plan.yml)
+                    # Exactly ONE checkout per workflow may claim this
+                    # exemption. Match the token expression exactly: these
+                    # workflows mint two App tokens (`app-token` and
+                    # `app-token-projects`), so a substring test would exempt
+                    # either.
                     if ! exempt=$(yq_count "$workflow" '
                         [ .jobs[]?.steps[]?
                           | select((.uses // "") | test("actions/checkout@"))
@@ -870,14 +876,15 @@ if [ -d .github/workflows ]; then
                           | select((.with.token // "") == "${{ steps.app-token.outputs.token }}")
                         ] | length
                     '); then
-                        err "claude-implement.yml: could not evaluate the exemption query (see above)"
+                        err "$(basename "$workflow"): could not evaluate the exemption query (see above)"
                         continue
                     fi
                     if [ "$exempt" -gt 1 ]; then
-                        err "claude-implement.yml: ${exempt} checkouts claim the single documented persisted-credentials exception"
+                        err "$(basename "$workflow"): ${exempt} checkouts claim the single documented persisted-credentials exception"
                     fi
                     [ "$exempt" -ge 1 ] && allowed=1
-                fi
+                    ;;
+                esac
                 if [ "$unguarded" -gt "$allowed" ]; then
                     err "$(basename "$workflow"): $((unguarded - allowed)) checkout step(s) persist credentials without setting persist-credentials:false"
                 fi

--- a/template/.github/workflows/claude-implement.yml.jinja
+++ b/template/.github/workflows/claude-implement.yml.jinja
@@ -187,8 +187,14 @@ jobs:
 [% endif %]
       # Exception to the repo-wide `persist-credentials: false` hardening:
       # this checkout deliberately persists the short-lived narrow CI App token
-      # so Claude's `git push` of the working branch can authenticate. The token
-      # is least-privilege (minted above) and expires with the job.
+      # for two reasons. Claude's `git push` of the working branch needs it to
+      # authenticate; and — like claude-review/claude-plan — when this workflow
+      # is triggered on an open PR, claude-code-action's tag mode `git fetch`es
+      # the PR head branch BEFORE it configures its own git auth (setupBranch
+      # runs ahead of configureGitAuth — anthropics/claude-code-action#1236),
+      # so a credential-less checkout would fail with "could not read Username"
+      # on a private repo. The token is least-privilege (minted above) and
+      # expires with the job.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0

--- a/template/.github/workflows/claude-plan.yml.jinja
+++ b/template/.github/workflows/claude-plan.yml.jinja
@@ -180,9 +180,18 @@ jobs:
           permission-organization-projects: write
           permission-issues: read
 [% endif %]
+      # Exception to the repo-wide `persist-credentials: false` hardening:
+      # claude-code-action's tag mode `git fetch`es the PR head branch BEFORE it
+      # configures its own git auth (setupBranch runs ahead of configureGitAuth —
+      # anthropics/claude-code-action#1236), so on a private repo a
+      # credential-less checkout fails with "could not read Username" the first
+      # time the workflow is triggered on an open PR. Persist the short-lived,
+      # read-only CI App token minted above instead: the action strips this
+      # header and substitutes its own token right after the fetch, and this job
+      # uploads no artifacts (the leak vector the hardening guards against).
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
 [% if github_org != author_git_provider_username %]
       - name: Set issue status to Shaping
         if: steps.app-token-projects.outputs.token != ''

--- a/template/.github/workflows/claude-review.yml.jinja
+++ b/template/.github/workflows/claude-review.yml.jinja
@@ -174,9 +174,18 @@ jobs:
           permission-contents: read
           permission-pull-requests: write
           permission-issues: write
+      # Exception to the repo-wide `persist-credentials: false` hardening:
+      # claude-code-action's tag mode `git fetch`es the PR head branch BEFORE it
+      # configures its own git auth (setupBranch runs ahead of configureGitAuth —
+      # anthropics/claude-code-action#1236), so on a private repo a
+      # credential-less checkout fails with "could not read Username" the first
+      # time the workflow is triggered on an open PR. Persist the short-lived,
+      # read-only CI App token minted above instead: the action strips this
+      # header and substitutes its own token right after the fetch, and this job
+      # uploads no artifacts (the leak vector the hardening guards against).
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
       - uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1.0.195
         # Step-level cap. A JOB timeout kills the runner outright and the
         # always() release below never runs; a STEP timeout fails only this


### PR DESCRIPTION
## What

- `template/.github/workflows/claude-review.yml.jinja`, `claude-plan.yml.jinja` and their root twins: the `actions/checkout` step now persists the short-lived, read-only CI App token minted earlier in the job (`token: ${{ steps.app-token.outputs.token }}`) instead of `persist-credentials: false`, with the rationale recorded beside it — the same documented exception `claude-implement` already carries.
- `template/.github/workflows/claude-implement.yml.jinja` + root twin: comment-only — its checkout already persists the App token (for `git push`), which is also what makes the action's pre-auth PR-branch fetch work when implement is triggered on an open PR; the exception comment now records both reasons so the token is not dropped if the push path changes.
- `scripts/test-template.sh`: the parsed checkout audit extends its single-checkout, exact-app-token exemption from `claude-implement.yml` to all three Claude workflows (`case` over the three names; still exactly one exempt checkout per workflow, still only `${{ steps.app-token.outputs.token }}`), with the reason in the comment.

## Why

The first PR-triggered Claude Review run in a generated repo (ponderousdev/omator run 32576600201) failed inside `claude-code-action` with `fatal: could not read Username for 'https://github.com'` on `git fetch origin --depth=20 <pr-branch>`. The action's tag mode fetches the PR head branch **before** it configures its own git auth (`setupBranch` runs ahead of `configureGitAuth`, same in v1.0.189 and v1.0.195; upstream anthropics/claude-code-action#1236), so with no persisted checkout credential the fetch to a private repo has nothing to authenticate with. Issue-triggered runs never fetch, which is why only PR mentions trip it and why it stayed latent since the hardening landed.

Exposure is bounded: the persisted credential is the job's own `contents:read` App token (revoked post-job), the action strips that header and substitutes its own token immediately after the fetch, and neither job uploads artifacts (the leak vector `persist-credentials: false` guards against).

## Verification

- `task check`, `task lint:actions`, `task test:dogfood-parity`, `task test:dogfood-structure`, `task verify` (all template profiles, incl. the checkout audit) green locally; `guard:release-title` ok.
- Consumer mirror: ponderousdev/omator#360 applies the rendered fix directly so the next `copier update` reconciles rather than reverts.
- Real proof is the next `@claude review` on an open PR in a generated private repo (maintainer step).
- Second-model (Codex) stages not run — the Codex CLI is at its usage limit (resets 2026-08-23 07:13); disclosed rather than faked.

