### PR TITLE
fix(template): let claude-review's checkout carry the CI App token

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -172,9 +172,16 @@ jobs:
           permission-contents: read
           permission-pull-requests: write
           permission-issues: write
+      # Exception to the repo-wide `persist-credentials: false` hardening:
+      # on a PR comment, claude-code-action itself runs
+      # `git fetch origin <pr-branch>` before reviewing, so the checkout must
+      # carry a git credential or the run dies with "could not read Username
+      # for 'https://github.com'". Persist the short-lived CI App token minted
+      # above — least-privilege (contents: read) and expired with the job —
+      # exactly as claude-implement does for its push.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
       - uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1.0.195
         # Step-level cap. A JOB timeout kills the runner outright and the
         # always() release below never runs; a STEP timeout fails only this

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -820,9 +820,13 @@ if [ -d .github/workflows ]; then
     # An earlier version allowed any checkout that set `token:` — too loose:
     # `token: ${{ github.token }}` is the DEFAULT token spelled out, and
     # actions/checkout persists it just the same, so that rule would have waved
-    # through exactly what it exists to catch. Only claude-implement.yml may
-    # omit the guard, and only for a checkout using the minted App token, which
-    # it must persist so Claude's `git push` can authenticate.
+    # through exactly what it exists to catch. Only two workflows may omit the
+    # guard, each for exactly one checkout using the minted App token:
+    # claude-implement.yml, which must persist it so Claude's `git push` can
+    # authenticate, and claude-review.yml, because on a PR comment
+    # claude-code-action itself runs `git fetch origin <pr-branch>` before
+    # reviewing and dies with "could not read Username" on an unauthenticated
+    # checkout (harmon-infra run 32578369792).
     if have yq; then
         # This is a security audit, so it must fail CLOSED. An earlier version
         # ended each query with `|| echo 0`, which turned any evaluator error
@@ -858,11 +862,13 @@ if [ -d .github/workflows ]; then
                     continue
                 fi
                 allowed=0
-                if [ "$(basename "$workflow")" = "claude-implement.yml" ]; then
-                    # Exactly ONE checkout may claim this exemption. Match the
-                    # token expression exactly: this workflow mints two App
-                    # tokens (`app-token` and `app-token-projects`), so a
-                    # substring test would exempt either.
+                wf_name="$(basename "$workflow")"
+                if [ "$wf_name" = "claude-implement.yml" ] || [ "$wf_name" = "claude-review.yml" ]; then
+                    # Exactly ONE checkout per exempt workflow may claim this
+                    # exemption. Match the token expression exactly:
+                    # claude-implement mints two App tokens (`app-token` and
+                    # `app-token-projects`), so a substring test would exempt
+                    # either.
                     if ! exempt=$(yq_count "$workflow" '
                         [ .jobs[]?.steps[]?
                           | select((.uses // "") | test("actions/checkout@"))
@@ -870,11 +876,11 @@ if [ -d .github/workflows ]; then
                           | select((.with.token // "") == "${{ steps.app-token.outputs.token }}")
                         ] | length
                     '); then
-                        err "claude-implement.yml: could not evaluate the exemption query (see above)"
+                        err "$wf_name: could not evaluate the exemption query (see above)"
                         continue
                     fi
                     if [ "$exempt" -gt 1 ]; then
-                        err "claude-implement.yml: ${exempt} checkouts claim the single documented persisted-credentials exception"
+                        err "$wf_name: ${exempt} checkouts claim the single documented persisted-credentials exception"
                     fi
                     [ "$exempt" -ge 1 ] && allowed=1
                 fi

--- a/template/.github/workflows/claude-review.yml.jinja
+++ b/template/.github/workflows/claude-review.yml.jinja
@@ -174,9 +174,16 @@ jobs:
           permission-contents: read
           permission-pull-requests: write
           permission-issues: write
+      # Exception to the repo-wide `persist-credentials: false` hardening:
+      # on a PR comment, claude-code-action itself runs
+      # `git fetch origin <pr-branch>` before reviewing, so the checkout must
+      # carry a git credential or the run dies with "could not read Username
+      # for 'https://github.com'". Persist the short-lived CI App token minted
+      # above — least-privilege (contents: read) and expired with the job —
+      # exactly as claude-implement does for its push.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
       - uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50 # v1.0.195
         # Step-level cap. A JOB timeout kills the runner outright and the
         # always() release below never runs; a STEP timeout fails only this


### PR DESCRIPTION
## What

- `template/.github/workflows/claude-review.yml.jinja` and the dogfood root twin `.github/workflows/claude-review.yml`: the `actions/checkout` step persists the short-lived CI App token the job already mints (`token: ${{ steps.app-token.outputs.token }}`) instead of `persist-credentials: false`, with a comment recording why — the same documented exception `claude-implement` uses for its push.
- `scripts/test-template.sh`: the checkout audit now admits **exactly one** App-token checkout in `claude-review.yml` as well as `claude-implement.yml`, with the same strict token-expression match (`${{ steps.app-token.outputs.token }}` literally, never a substring or the default token); every other checkout must still set `persist-credentials: false`.

## Why

On a PR comment `claude-code-action` itself runs `git fetch origin <pr-branch>` before reviewing. Since the v4.0.0 `persist-credentials: false` hardening the checkout carries no git credential, so every `@claude review` on a **PR** in a consumer has failed with `fatal: could not read Username for 'https://github.com'` — harmon-infra run [32578369792](https://github.com/harmonops/harmon-infra/actions/runs/32578369792); last success there 2026-04-29. Issue-targeted `claude-plan` is unaffected (no PR fetch) and stays guarded.

**Security-relevant setting change, called out explicitly:** one checkout in one workflow now persists a credential — the App token scoped to contents:read / pull-requests:write / issues:write, expiring with the job — and the template test enforces that it is exactly one and exactly that token.

Consumer-side stopgap with the identical change: harmonops/harmon-infra#515 (so PR reviews work there before the next template release / `copier update`).

## Verification

- `task verify` green on `dc676cf` (all template profiles render and pass the checkout audit; the failing-then-fixed assertion was `FAIL: claude-review.yml: 1 checkout step(s) persist credentials without setting persist-credentials:false`).
- `task lint:shell` clean.

## Budget

Explicit maintainer instruction this session: second-model (Codex) review stages waived (Codex CLI usage limit until 2026-08-23 07:13); below `default_rigor`, by instruction. No deferred findings.
