### PR TITLE
feat(docs): add worktrees and Herdr operating guides

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -24,5 +24,14 @@ Calm, repeatable how-tos read *in advance* (the crisis counterpart is
 - [codex-review.md](codex-review.md) — second-model review via the OpenAI
   Codex CLI: `task challenge` / `task review`, the automatic Claude → Codex
   stop-gate toggle, and where the finding-adjudication protocol lives.
+- [worktrees.md](worktrees.md) — when a piece of work earns its own git
+  worktree (the three-question rule: commits, repo tooling, durability) and
+  the one sanctioned way to create and remove one (`task worktree:new` /
+  `task worktree:rm`), including how it pairs with Herdr.
+- [herdr.md](herdr.md) — using Herdr for real work: workspaces, tabs, panes,
+  agents and sessions and how they relate; everyday workflows; worktrees;
+  fanning out many worker sessions from one orchestrator (subagents vs pane
+  workers, lifecycle, cleanup); and running several harnesses — Claude Code,
+  Codex, Antigravity, OpenCode — side by side on their own subscriptions.
 
 TODO: add more guides, e.g. "local development setup", "add a feature", "how X works".

--- a/docs/guides/herdr.md
+++ b/docs/guides/herdr.md
@@ -1,0 +1,261 @@
+# Herdr — workspaces, panes, agents, and multi-harness orchestration
+
+Herdr is the agent-session runtime in this repo's devcontainers and on your
+laptop: a terminal workspace manager that recognizes the coding agent running
+in each pane, tracks its state, and exposes the whole thing through the
+`herdr` CLI. This guide is how to *use* it for real work — the mental model,
+the everyday workflows, how it pairs with the repo's worktree tooling, running
+several agents (and several harnesses) at once, and the lifecycle and cleanup
+that keep the sidebar meaningful. Installation, the devcontainer volumes, and
+attaching from a laptop are in [devcontainers.md](devcontainers.md) § Persistent
+agent sessions; the decision rule for worktrees is [worktrees.md](worktrees.md).
+
+The installed binary is the authority for syntax: `herdr --help`, then a
+command group without a subcommand (`herdr agent`, `herdr pane`, …) prints its
+commands. Agents inside Herdr have a vendored skill for this (`herdr --skill`);
+what follows is the human's map of the same ground.
+
+## The five nouns and how they relate
+
+| Noun | What it is | ID shape | Created by |
+| --- | --- | --- | --- |
+| **Workspace** | A project root: a directory (or a worktree) plus its tabs | `w1` | `herdr workspace create --cwd PATH` or `herdr worktree create/open` |
+| **Tab** | A layout page inside a workspace | `w1:t1` | `herdr tab create --workspace w1` |
+| **Pane** | One terminal (shell) inside a tab | `w1:p1` | `herdr pane split --pane ID --direction right` or `down` |
+| **Agent** | The coding agent Herdr recognizes *occupying* a pane | pane ID or a unique name | `herdr agent start NAME --kind KIND --pane ID` |
+| **Session** | A whole Herdr server (the `default` one, or `herdr --session NAME`) | name | `herdr` / `herdr --session NAME` |
+
+The relationships that matter:
+
+- **A pane exists whether or not it hosts an agent.** `pane run` drives an
+  ordinary shell; `agent start` requires an *available* shell pane (at its
+  prompt, nothing in the foreground) and never creates layout itself.
+- **An agent is a full, independent process in its pane** — a real `claude`,
+  `codex`, `agy`, `opencode`, … session with its own context, auth, and
+  permissions. Its lifetime is the pane's: close the pane and it dies.
+- **A name follows the pane's current occupant** and is cleared when that
+  agent exits. Names must match `[a-z][a-z0-9_-]{0,31}` and be unique among
+  live agents; agent commands accept a name or the hosting pane ID, never a
+  terminal ID or a bare kind.
+- **Two kinds of workspace.** `workspace create` makes a plain
+  directory-rooted workspace — no git involvement. `worktree create` makes a
+  git worktree *and* a workspace rooted at it, and records the binding; one
+  worktree ↔ one workspace. Creating a workspace never creates a worktree;
+  creating a worktree always creates a workspace.
+- **Caller context.** Herdr injects `HERDR_WORKSPACE_ID`, `HERDR_TAB_ID`,
+  `HERDR_PANE_ID` into every managed pane (and `HERDR_ENV=1`). Prefer
+  `--current` or an explicit ID; an omitted target may resolve to the
+  UI-focused pane, which can be someone else's.
+
+## Agent lifecycle states
+
+Herdr classifies a pane's agent by watching its terminal:
+
+- `working` — producing output / running tools.
+- `blocked` — Herdr recognized an approval or question UI; it needs input.
+- `idle` — ready for input, and its tab has been *seen* in the focused UI.
+- `done` — the same underlying idle state after unseen background work
+  finished. Focusing the tab or targeting the pane/agent with a focus command
+  marks it seen; CLI reads do not. `done` is therefore the sidebar's
+  "to-review" queue.
+- `unknown` — an agent is present but Herdr cannot classify it confidently.
+  It does **not** mean finished.
+
+`herdr agent explain <target>` shows which detection rule fired and on what
+evidence — the first thing to run when a state looks wrong.
+
+## Everyday workflows
+
+**One agent, one repo (the default).** Open or attach with `herdr`, create a
+workspace for the repo if it is not there, start the agent in the root pane
+(or just run `claude` in the shell — Herdr recognizes it either way). Use
+tabs for parallel *contexts* (a second agent on a different task, a shell for
+logs), panes within a tab for things you want side by side.
+
+**A second pane for a command or a helper agent, keeping your focus:**
+
+```bash
+herdr pane split --current --direction right --cwd "$PWD" --no-focus
+#   → read .result.pane.pane_id
+herdr pane run <id> "task verify"
+herdr pane wait-output <id> --match "verify: ok" --timeout 600000
+herdr pane read <id> --source recent-unwrapped --lines 120
+```
+
+Split a wide pane right and a tall one down; avoid repeated same-direction
+splits that leave unusable slivers. `pane run` sends text plus Enter
+atomically; `wait-output` matches the current snapshot immediately, so output
+that already exists counts.
+
+**Starting and steering an agent in that pane:**
+
+```bash
+herdr agent start reviewer --kind codex --pane <id> -- <native args…>
+herdr agent prompt reviewer "Review the current diff; report only actionable findings." --wait --timeout 600000
+herdr agent read reviewer --source recent-unwrapped --lines 120
+```
+
+Native agent arguments go after `--`. `agent prompt --wait` returns at the
+first settled `idle`/`done`/`blocked`; `--until STATE` is for state-specific
+waits. A prompt sent from a non-working state must produce an observed state
+change within about five seconds or Herdr returns `agent_prompt_stalled`
+rather than waiting forever. If a wait returns `blocked`, `agent get` /
+`agent read` first, then `agent send-keys` (logical keys — `esc`, `ctrl+c`,
+`enter`) or `agent attach` to take the pane over yourself.
+
+**Reading long answers.** Many harnesses render on the alternate screen, and
+rows that leave it never enter Herdr's scrollback — raising `--lines` cannot
+recover them. Ask the agent to write its full answer to a file and reply with
+the path, then read the file.
+
+## Worktrees
+
+Herdr's `worktree create` is `git worktree add` plus a workspace, checked out
+under `[worktrees] directory` (default `~/.herdr/worktrees/<repo>/<branch>`);
+`worktree open` binds an *existing* checkout to a new workspace; `worktree
+list` shows worktrees for the repo, including ones Herdr did not create;
+`worktree remove --workspace ID [--force]` tears down the workspace — tabs,
+panes, sessions — and the checkout together. There is **no post-create
+hook**: a fresh tree has no dependencies installed, no local env, and no
+hooks proof, which is the failure everyone hits first.
+
+So for repos generated from this template, **the repo creates and Herdr
+binds**:
+
+```bash
+task worktree:new -- feat-x --branch feat/x
+herdr worktree open --path .worktrees/feat-x --label feat-x --no-focus
+# …work…
+herdr worktree remove --workspace <id>     # panes + sessions
+task worktree:rm -- feat-x                 # repo bookkeeping, gitlink prune
+```
+
+If you use `herdr worktree create` directly, provision before any agent
+starts: `herdr pane run <root-pane> "task install"` and `wait-output` for it,
+then `agent start`. Environment variables are the only "setup" Herdr itself
+offers — `worktree create`, `tab create`, and `pane split` all take
+`--env KEY=VALUE` — which is the right place for gate variables an
+orchestrator sets under explicit human authorization (never in the worker's
+prompt). When to reach for a worktree at all is [worktrees.md](worktrees.md).
+
+## Fan-out: orchestrating many workers from one session
+
+A Claude Code (or any) session running inside a Herdr pane can act as an
+**orchestrator**: it shells out to `herdr` to create panes, start workers,
+prompt them, wait, and harvest. The orchestrator is just another agent in
+another pane; Herdr has no parent/child concept — the topology is conversational.
+
+**Subagents versus pane workers.** These are different things and the words
+matter:
+
+- A **subagent** (Claude Code's `Agent` tool, `.claude/agents/*.md`) runs
+  *inside* the parent session's process: its own context window, no terminal,
+  one structured return value, dies when done. Only the parent can talk to
+  it, and Herdr cannot see it — there is no pane to watch.
+- A **pane worker** (a "worker session", "sibling agent", "teammate") is a
+  full independent session in its own pane, with its own harness, login, and
+  permissions. Herdr sees it, you can click into it, steer it, or take it
+  over, and it can outlive or ignore the orchestrator. Results come back as
+  terminal text and files, not a typed return.
+
+Use subagents for cheap, fast, structured fan-outs you do not need to watch;
+use pane workers when you want visibility, steerability, longer-running work,
+or a **different harness** than the orchestrator's.
+
+**The loop** (each step is a `herdr` command the orchestrator runs):
+
+1. **Lay out** — a fresh tab for the fan-out, one pane per unit, each with
+   its cwd (a worktree for work that edits the repo; the checkout itself for
+   pane jobs): `tab create --workspace … --label … --no-focus`, then
+   `pane split … --cwd … --no-focus`; `--env` for any authorized gate variables.
+2. **Start** — `agent start <name> --kind <kind> --pane <id> -- <native args>`
+   with a distinctive name per unit (`triage-omator`, `prune-site`).
+3. **Prompt** — one self-contained brief per worker, ending with a
+   **file-based report** at a known path and a **sentinel line** (a unique
+   string such as `TRIAGE-WORKER-DONE omator`) printed last. Then
+   `agent prompt … --wait --until working` and re-send if the worker stays
+   `idle` — delivery can silently miss when the harness is mid-render.
+4. **Wait** — `agent wait <name>` per worker (background it; rounds run
+   minutes), or `pane wait-output --match <sentinel>` where detection is
+   weak. `done`/`idle` means *stopped*, not *succeeded*: the sentinel and
+   the report file are the success signals.
+5. **Harvest and verify** — `agent read` / read the report files, then
+   **verify ground truth yourself** (the diff, the labels on GitHub, the test
+   run). Never trust a transcript's claim of success.
+6. **Review** — anything `blocked`, `unknown`, or surprising: `agent focus`
+   to mark it seen and look, `agent attach` to take over, or prompt it again
+   with its context intact (the reason to keep a pane alive).
+7. **Retire** — close what you created: `tab close` (which closes its panes
+   and kills their processes) or `worktree remove --workspace` for
+   worktree-backed units. Never close panes, tabs, or workspaces you did not
+   create unless asked; never `herdr server stop` from a live session.
+8. **Sweep** — the durable leftovers Herdr does not remove: worktrees
+   (`worktree list` + `task worktree:rm`), branches (`task clean:branches`),
+   scratch files and sidecars, and anything a worker deliberately detached.
+   `herdr notification show` can announce the result.
+
+What is mechanical: closing a tab/pane/workspace terminates everything running
+in it (verified — no orphaned agent processes); `worktree remove` removes the
+checkout with the workspace. What is on you: steps 5 and 8.
+
+## Multiple harnesses — supported and sanctioned
+
+The orchestration surface is harness-agnostic. `--kind` accepts every agent
+Herdr can recognize (`herdr agent` lists them: `claude`, `codex`, `gemini`,
+`agy` (Antigravity), `opencode`, `copilot`, `cursor`, `amp`, `droid`, `kimi`,
+`qwen`, `kilo`, `cline`, …), and nothing about the loop above changes except
+the kind and the native arguments after `--`. A Claude Code orchestrator can
+therefore drive Codex, Antigravity, or OpenCode workers — each a separate,
+official client running under **its own provider login and subscription**.
+
+That is the permitted shape, and it is worth being precise about why. Each
+worker is the vendor's **official CLI**, authenticated as you, driven through
+its terminal by a multiplexer that never touches tokens or APIs — the same as
+typing into it yourself. What vendors prohibit is using one product's
+subscription credentials *inside a different product*: Anthropic's consumer
+terms forbid Claude Free/Pro/Max OAuth tokens in any third-party tool or
+harness (enforced by token blocking since early 2026); Google and OpenAI keep
+similar lines. Running the official `claude`, `codex`, `agy`, or `opencode`
+binaries side by side, each on its own plan, is on the right side of every
+one of those lines; pointing OpenCode at a Claude subscription is not. The
+practical constraint is quota: parallel workers spend each plan's 5-hour and
+weekly pools faster, not differently — watch each harness's own usage
+indicator, and move genuinely unattended, high-volume work to that vendor's
+API billing.
+
+Per-harness notes that shape the launch line:
+
+- **`claude`** — `-- --model <m> --allowedTools '<exact list>'` pre-approves
+  the tools the task needs and nothing else, so no permission prompt appears.
+  Detection is clean; gate variables belong on the pane (`--env`).
+- **`codex`** — `-- -a never -s workspace-write -c sandbox_workspace_write.network_access=true`
+  for unattended runs, **plus** a rules file that allows every command the
+  task will run: with `-a never`, any command a rule marks as prompt-worthy is
+  rejected before a shell spawns (`Rejected("approval required by policy, but
+  AskForApproval is set to Never")`) with no stderr, and prefix rules match
+  the first token only, so a wrapped invocation and a bare one can behave
+  differently. Detection is clean (`osc_title_working`); always confirm
+  `working` after a prompt.
+- **`agy`, `opencode`, others** — same loop; check detection with
+  `agent explain` on first use, and fall back to the file report + sentinel
+  where it is `unknown`.
+
+Worker briefs should also say: never set gate or approval variables yourself;
+if a script refuses, stop and report. A capable model will otherwise export
+the variable to get unstuck.
+
+## Cheat sheet
+
+```bash
+herdr workspace list | tab list --workspace W | pane list --workspace W | agent list
+herdr pane split --current --direction right --cwd "$PWD" --no-focus
+herdr agent start NAME --kind KIND --pane ID [--timeout MS] -- ARGS…
+herdr agent prompt NAME "…" --wait [--until working|blocked] --timeout MS
+herdr agent wait NAME [--until STATE] --timeout MS
+herdr agent read NAME --source recent-unwrapped --lines 120
+herdr agent explain NAME          # why Herdr thinks it is in that state
+herdr agent send-keys NAME esc    # logical keys, validated before writing
+herdr tab close T                 # closes panes, kills their processes
+herdr worktree open --path P --label L --no-focus | herdr worktree remove --workspace W
+herdr notification show "title" --body "…"
+```

--- a/docs/guides/herdr.md
+++ b/docs/guides/herdr.md
@@ -79,15 +79,17 @@ logs), panes within a tab for things you want side by side.
 ```bash
 herdr pane split --current --direction right --cwd "$PWD" --no-focus
 #   → read .result.pane.pane_id
-herdr pane run <id> "task verify"
-herdr pane wait-output <id> --match "verify: ok" --timeout 600000
+herdr pane run <id> "task verify && echo VERIFY-OK-7f3a || echo VERIFY-FAILED-7f3a"
+herdr pane wait-output <id> --regex "VERIFY-(OK|FAILED)-7f3a" --timeout 600000
 herdr pane read <id> --source recent-unwrapped --lines 120
 ```
 
 Split a wide pane right and a tall one down; avoid repeated same-direction
 splits that leave unusable slivers. `pane run` sends text plus Enter
 atomically; `wait-output` matches the current snapshot immediately, so output
-that already exists counts.
+that already exists counts. Wait on a marker *you* append (unique per run, one
+alternative per outcome, as above) — most tasks print no stable "done" line of
+their own, and a wait that only matches success sits silent through a failure.
 
 **Starting and steering an agent in that pane:**
 

--- a/docs/guides/herdr.md
+++ b/docs/guides/herdr.md
@@ -197,8 +197,10 @@ belongs in a separate user, container, or VM, not a sibling pane.
    a reused pane's previous sentinel satisfies the next wait and hands you
    the old report. Then
    `agent prompt … --wait --until working --timeout 30000`. If it returns
-   with the worker still `idle`, delivery may have silently missed (it
-   happens when the harness is mid-render) — but before re-sending, check
+   with the worker still `idle`, delivery may have silently missed — Herdr
+   0.8.0 (the devcontainer pin) can report `agent start` ready before the
+   pane's first-run prompts have settled (fixed in 0.8.2), and a harness
+   mid-render swallows input the same way — but before re-sending, check
    the pane and the report path: a fast worker can finish and return to
    `idle` inside the window, and re-sending a brief that performs side
    effects (GitHub writes, deploys) is at-least-once delivery. Re-send only
@@ -273,9 +275,13 @@ Per-harness notes that shape the launch line:
   (often broad `Bash(git:*)`/`Bash(gh:*)` allows) merge in. Detection is
   clean; gate variables belong on the pane (`--env`).
 - **`codex`** — `-- -a never -s workspace-write -c sandbox_workspace_write.network_access=true`
-  for unattended runs, **plus** a rules file that allows every command the
-  task will run: with `-a never`, any command a rule marks as prompt-worthy is
-  rejected before a shell spawns (`Rejected("approval required by policy, but
+  for unattended runs, **plus** rules for exactly the commands Codex's policy
+  would otherwise prompt on (typically network-touching writes like
+  `gh issue edit`) — nothing more. Ordinary build/test commands run inside
+  `workspace-write` without any rule, and an `allow` rule executes its
+  matches *outside* the sandbox, so blanket-allowing the task's whole command
+  set trades the sandbox away. The failure mode to know: with `-a never`,
+  any command a rule marks as prompt-worthy is rejected before a shell spawns (`Rejected("approval required by policy, but
   AskForApproval is set to Never")`) with no stderr. Rules match a leading
   prefix of the argv — `["gh"]` matches every `gh` invocation, `["git",
   "status"]` matches `git status …` — so keep `allow` patterns argument-level
@@ -306,7 +312,7 @@ herdr agent read NAME --source recent-unwrapped --lines 120
 herdr agent explain NAME                      # why Herdr thinks it is in that state
 herdr agent send-keys NAME esc                # logical keys, validated before writing
 herdr tab close T                             # closes panes, kills their processes
-herdr workspace close W                       # same, for a whole workspace; files stay
+herdr workspace close W                       # same, for a whole workspace; files and detached processes stay
 herdr worktree open --path P --label L --no-focus
 herdr worktree remove --workspace W           # ALSO deletes the checkout — Herdr-created trees only
 herdr notification show "title" --body "…"

--- a/docs/guides/herdr.md
+++ b/docs/guides/herdr.md
@@ -8,7 +8,8 @@ the everyday workflows, how it pairs with the repo's worktree tooling, running
 several agents (and several harnesses) at once, and the lifecycle and cleanup
 that keep the sidebar meaningful. Installation, the devcontainer volumes, and
 attaching from a laptop are in [devcontainers.md](devcontainers.md) § Persistent
-agent sessions; the decision rule for worktrees is [worktrees.md](worktrees.md).
+agent sessions; the
+decision rule for worktrees is [worktrees.md](worktrees.md).
 
 The installed binary is the authority for syntax: `herdr --help`, then a
 command group without a subcommand (`herdr agent`, `herdr pane`, …) prints its
@@ -115,7 +116,8 @@ under `[worktrees] directory` (default `~/.herdr/worktrees/<repo>/<branch>`);
 `worktree open` binds an *existing* checkout to a new workspace; `worktree
 list` shows worktrees for the repo, including ones Herdr did not create;
 `worktree remove --workspace ID [--force]` tears down the workspace — tabs,
-panes, sessions — and the checkout together. There is **no post-create
+panes, sessions — **and deletes the checkout** with a plain `git worktree
+remove` (no ignored-file guard). There is **no post-create
 hook**: a fresh tree has no dependencies installed, no local env, and no
 hooks proof, which is the failure everyone hits first.
 
@@ -126,9 +128,14 @@ binds**:
 task worktree:new -- feat-x --branch feat/x
 herdr worktree open --path .worktrees/feat-x --label feat-x --no-focus
 # …work…
-herdr worktree remove --workspace <id>     # panes + sessions
-task worktree:rm -- feat-x                 # repo bookkeeping, gitlink prune
+herdr workspace close <id>                 # panes + sessions; checkout stays
+task worktree:rm -- feat-x                 # guarded removal, gitlink prune
 ```
+
+Order matters: `herdr worktree remove` would delete the checkout before
+`task worktree:rm` could refuse on ignored local state such as a `.env`, so a
+repo-created tree is closed on the Herdr side and removed by the repo task.
+Reserve `herdr worktree remove` for throwaway trees Herdr itself created.
 
 If you use `herdr worktree create` directly, provision before any agent
 starts: `herdr pane run <root-pane> "task install"` and `wait-output` for it,
@@ -173,12 +180,22 @@ or a **different harness** than the orchestrator's.
 3. **Prompt** — one self-contained brief per worker, ending with a
    **file-based report** at a known path and a **sentinel line** (a unique
    string such as `TRIAGE-WORKER-DONE omator`) printed last. Then
-   `agent prompt … --wait --until working` and re-send if the worker stays
-   `idle` — delivery can silently miss when the harness is mid-render.
-4. **Wait** — `agent wait <name>` per worker (background it; rounds run
-   minutes), or `pane wait-output --match <sentinel>` where detection is
-   weak. `done`/`idle` means *stopped*, not *succeeded*: the sentinel and
-   the report file are the success signals.
+   `agent prompt … --wait --until working --timeout 30000`. If it returns
+   with the worker still `idle`, delivery may have silently missed (it
+   happens when the harness is mid-render) — but before re-sending, check
+   the pane and the report path: a fast worker can finish and return to
+   `idle` inside the window, and re-sending a brief that performs side
+   effects (GitHub writes, deploys) is at-least-once delivery. Re-send only
+   when the pane shows the prompt never landed; make briefs idempotent where
+   you can.
+4. **Wait** — `agent wait <name> --timeout <ms>` per worker (background it;
+   rounds run minutes), or `pane wait-output --match <sentinel> --timeout
+   <ms>` where detection is weak. Always bound the wait: a worker whose
+   detection stays `unknown` or whose harness hangs would otherwise block
+   the orchestrator forever. On timeout, `agent get` / `agent read` /
+   `agent explain` it and decide — nudge, take over, or retire — rather than
+   waiting again blind. `done`/`idle` means *stopped*, not *succeeded*: the
+   sentinel and the report file are the success signals.
 5. **Harvest and verify** — `agent read` / read the report files, then
    **verify ground truth yourself** (the diff, the labels on GitHub, the test
    run). Never trust a transcript's claim of success.
@@ -201,10 +218,11 @@ checkout with the workspace. What is on you: steps 5 and 8.
 ## Multiple harnesses — supported and sanctioned
 
 The orchestration surface is harness-agnostic. `--kind` accepts every agent
-Herdr can recognize (`herdr agent` lists them: `claude`, `codex`, `gemini`,
-`agy` (Antigravity), `opencode`, `copilot`, `cursor`, `amp`, `droid`, `kimi`,
-`qwen`, `kilo`, `cline`, …), and nothing about the loop above changes except
-the kind and the native arguments after `--`. A Claude Code orchestrator can
+the installed Herdr can recognize — run `herdr agent` to see the exact list for
+your version; `claude`, `codex`, `gemini`, `agy` (Antigravity), and `opencode`
+are in the 0.8.0 image the devcontainers pin, newer releases add more — and
+nothing about the loop above changes except the kind and the native arguments
+after `--`. A Claude Code orchestrator can
 therefore drive Codex, Antigravity, or OpenCode workers — each a separate,
 official client running under **its own provider login and subscription**.
 
@@ -247,15 +265,20 @@ the variable to get unstuck.
 ## Cheat sheet
 
 ```bash
-herdr workspace list | tab list --workspace W | pane list --workspace W | agent list
+herdr workspace list
+herdr tab list --workspace W
+herdr pane list --workspace W
+herdr agent list
 herdr pane split --current --direction right --cwd "$PWD" --no-focus
-herdr agent start NAME --kind KIND --pane ID [--timeout MS] -- ARGS…
-herdr agent prompt NAME "…" --wait [--until working|blocked] --timeout MS
-herdr agent wait NAME [--until STATE] --timeout MS
+herdr agent start NAME --kind KIND --pane ID --timeout MS -- ARGS…
+herdr agent prompt NAME "…" --wait --until working --timeout MS
+herdr agent wait NAME --timeout MS            # add --until STATE for a specific state
 herdr agent read NAME --source recent-unwrapped --lines 120
-herdr agent explain NAME          # why Herdr thinks it is in that state
-herdr agent send-keys NAME esc    # logical keys, validated before writing
-herdr tab close T                 # closes panes, kills their processes
-herdr worktree open --path P --label L --no-focus | herdr worktree remove --workspace W
+herdr agent explain NAME                      # why Herdr thinks it is in that state
+herdr agent send-keys NAME esc                # logical keys, validated before writing
+herdr tab close T                             # closes panes, kills their processes
+herdr workspace close W                       # same, for a whole workspace; files stay
+herdr worktree open --path P --label L --no-focus
+herdr worktree remove --workspace W           # ALSO deletes the checkout — Herdr-created trees only
 herdr notification show "title" --body "…"
 ```

--- a/docs/guides/herdr.md
+++ b/docs/guides/herdr.md
@@ -224,7 +224,9 @@ belongs in a separate user, container, or VM, not a sibling pane.
    tabs, or workspaces you did not create unless asked; never
    `herdr server stop` from a live session.
 8. **Sweep** — the durable leftovers Herdr does not remove: worktrees
-   (`worktree list` + `task worktree:rm`), branches (`task clean:branches`),
+   (`worktree list` + `task worktree:rm`), branches (`task clean:branches`
+   to review, then `task clean:branches -- --delete` — the bare form is a
+   dry run),
    scratch files and sidecars, and anything a worker deliberately detached.
    `herdr notification show` can announce the result.
 
@@ -260,16 +262,24 @@ API billing.
 
 Per-harness notes that shape the launch line:
 
-- **`claude`** — `-- --model <m> --allowedTools '<exact list>'` pre-approves
-  the tools the task needs and nothing else, so no permission prompt appears.
-  Detection is clean; gate variables belong on the pane (`--env`).
+- **`claude`** — `-- --model <m> --tools '<exact list>' --allowedTools '<the
+  same list>'`. The two flags do different halves of least privilege:
+  `--tools` restricts which tools *exist* in the session, `--allowedTools`
+  pre-approves them so no prompt blocks an unattended worker. `--allowedTools`
+  alone is not a restriction — every other tool is still there behind a
+  prompt, and the repo's and devcontainer's `settings.json` permissions
+  (often broad `Bash(git:*)`/`Bash(gh:*)` allows) merge in. Detection is
+  clean; gate variables belong on the pane (`--env`).
 - **`codex`** — `-- -a never -s workspace-write -c sandbox_workspace_write.network_access=true`
   for unattended runs, **plus** a rules file that allows every command the
   task will run: with `-a never`, any command a rule marks as prompt-worthy is
   rejected before a shell spawns (`Rejected("approval required by policy, but
-  AskForApproval is set to Never")`) with no stderr, and prefix rules match
-  the first token only, so a wrapped invocation and a bare one can behave
-  differently. Detection is clean (`osc_title_working`); always confirm
+  AskForApproval is set to Never")`) with no stderr. Rules match a leading
+  prefix of the argv — `["gh"]` matches every `gh` invocation, `["git",
+  "status"]` matches `git status …` — so keep `allow` patterns argument-level
+  and narrow (an `allow` also runs its matches outside the sandbox), and note
+  that a script invoking `gh` internally has the script as `argv[0]` and
+  bypasses a bare-command rule entirely. Detection is clean (`osc_title_working`); always confirm
   `working` after a prompt.
 - **`agy`, `opencode`, others** — same loop; check detection with
   `agent explain` on first use, and fall back to the file report + sentinel

--- a/docs/guides/herdr.md
+++ b/docs/guides/herdr.md
@@ -1,7 +1,8 @@
 # Herdr — workspaces, panes, agents, and multi-harness orchestration
 
-Herdr is the agent-session runtime in this repo's devcontainers and on your
-laptop: a terminal workspace manager that recognizes the coding agent running
+Herdr is the agent-session runtime for this repo's agents — in the
+devcontainers where the profile ships them, and on your own machine: a
+terminal workspace manager that recognizes the coding agent running
 in each pane, tracks its state, and exposes the whole thing through the
 `herdr` CLI. This guide is how to *use* it for real work — the mental model,
 the everyday workflows, how it pairs with the repo's worktree tooling, running
@@ -140,10 +141,11 @@ Reserve `herdr worktree remove` for throwaway trees Herdr itself created.
 If you use `herdr worktree create` directly, provision before any agent
 starts: `herdr pane run <root-pane> "task install"` and `wait-output` for it,
 then `agent start`. Environment variables are the only "setup" Herdr itself
-offers — `worktree create`, `tab create`, and `pane split` all take
-`--env KEY=VALUE` — which is the right place for gate variables an
-orchestrator sets under explicit human authorization (never in the worker's
-prompt). When to reach for a worktree at all is [worktrees.md](worktrees.md).
+offers — `workspace create`, `tab create`, and `pane split` take
+`--env KEY=VALUE` (`worktree create` does **not**; give a worktree-backed
+workspace its variables on the tabs/panes you create inside it) — and they
+are the right place for gate variables an orchestrator sets under explicit
+human authorization (never in the worker's prompt). When to reach for a worktree at all is [worktrees.md](worktrees.md).
 
 ## Fan-out: orchestrating many workers from one session
 
@@ -169,6 +171,14 @@ Use subagents for cheap, fast, structured fan-outs you do not need to watch;
 use pane workers when you want visibility, steerability, longer-running work,
 or a **different harness** than the orchestrator's.
 
+**Panes are not a security boundary.** Every pane worker runs as the same OS
+user in the same Herdr session: any of them can read, type into, or close any
+other pane by explicit ID, and they share the filesystem and every credential
+on it. "Its own permissions" means each harness's own tool-approval settings,
+not isolation. Fan out only mutually trusted workers over trusted inputs;
+work that chews on untrusted content (third-party repos, inbound issue text)
+belongs in a separate user, container, or VM, not a sibling pane.
+
 **The loop** (each step is a `herdr` command the orchestrator runs):
 
 1. **Lay out** — a fresh tab for the fan-out, one pane per unit, each with
@@ -178,8 +188,12 @@ or a **different harness** than the orchestrator's.
 2. **Start** — `agent start <name> --kind <kind> --pane <id> -- <native args>`
    with a distinctive name per unit (`triage-omator`, `prune-site`).
 3. **Prompt** — one self-contained brief per worker, ending with a
-   **file-based report** at a known path and a **sentinel line** (a unique
-   string such as `TRIAGE-WORKER-DONE omator`) printed last. Then
+   **file-based report** at a known path and a **sentinel line** printed
+   last. Make both unique per *attempt*, not just per worker — a nonce such
+   as `TRIAGE-DONE omator 7f3a` in the sentinel and the report filename —
+   because `pane wait-output` matches the existing snapshot immediately, so
+   a reused pane's previous sentinel satisfies the next wait and hands you
+   the old report. Then
    `agent prompt … --wait --until working --timeout 30000`. If it returns
    with the worker still `idle`, delivery may have silently missed (it
    happens when the harness is mid-render) — but before re-sending, check
@@ -203,9 +217,12 @@ or a **different harness** than the orchestrator's.
    to mark it seen and look, `agent attach` to take over, or prompt it again
    with its context intact (the reason to keep a pane alive).
 7. **Retire** — close what you created: `tab close` (which closes its panes
-   and kills their processes) or `worktree remove --workspace` for
-   worktree-backed units. Never close panes, tabs, or workspaces you did not
-   create unless asked; never `herdr server stop` from a live session.
+   and kills their processes), or for worktree-backed units `workspace close`
+   followed by `task worktree:rm` — the guarded path from § Worktrees.
+   `worktree remove --workspace` is only for throwaway trees Herdr itself
+   created, since it deletes the checkout unguarded. Never close panes,
+   tabs, or workspaces you did not create unless asked; never
+   `herdr server stop` from a live session.
 8. **Sweep** — the durable leftovers Herdr does not remove: worktrees
    (`worktree list` + `task worktree:rm`), branches (`task clean:branches`),
    scratch files and sidecars, and anything a worker deliberately detached.

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -1,0 +1,106 @@
+# Worktrees — when to make one, and how
+
+A linked git worktree gives one line of work its own checked-out branch, so it
+can change files and run the repo's tools without colliding with anyone else's
+working tree — yours included. This guide is the decision rule for *when* a
+worktree is worth its setup cost, and the one sanctioned way to create and
+remove them. The mechanics and footguns of the tooling itself live in
+[../conventions.md](../conventions.md) § Worktrees; running agents in them
+from Herdr is [herdr.md](herdr.md).
+
+## The decision rule
+
+Ask three questions. If any answer is **yes**, make a worktree.
+
+1. **Will this work change tracked files and need to be committed?** Two
+   sessions editing the same checkout step on each other's diffs, staged
+   state, and `git status`, and a pull request needs its own branch checked
+   out somewhere to commit on. This is the "one worktree per intended PR"
+   heuristic — per unit of *committable* work.
+2. **Will it run repo tooling that assumes a private, stable tree?**
+   `task verify`, test suites, dev servers on fixed ports, builds that write
+   `dist/`, codegen, git hooks. They read the working tree at a moment in
+   time; if something else is mid-edit you get phantom failures, and two
+   `task verify` runs in one checkout fight over ports and caches.
+3. **Will it outlive a single turn, or need to be resumable?** A worktree is
+   durable state: if the session dies, the branch and its edits survive on
+   disk and another session can pick them up. Scratch in a pane dies with the
+   pane.
+
+If all three are **no**, you do not need a worktree. Work that *reads* the
+repo and *writes somewhere else* — auditing, reviewing, research, reports,
+label or issue hygiene via `gh`, `terraform plan`, anything whose output is a
+file in a scratch directory or a change upstream on GitHub — is a **pane
+job**: a sibling terminal with the repo as its cwd and no branch of its own.
+
+Compressed: **writes to the repo or runs its tools → worktree (one per PR-sized
+unit); reads the repo and writes elsewhere → pane.** The tell is whether the
+work will ever run `git commit`.
+
+## Refinements
+
+- **A single agent still gets a worktree if you are working in the main
+  checkout.** The collision is with you, not only with other agents.
+- **Serial work on an idle checkout does not need one.** One change at a time
+  with nobody else in the repo is a branch in the main checkout with less
+  ceremony.
+- **Worktree is not workspace.** The worktree decides *where* a session's cwd
+  points; the terminal, panes, and agent still need a home (see
+  [herdr.md](herdr.md)). Pane jobs reuse the workspace you already have.
+- **The cost is the per-tree install.** Every worktree needs its own
+  dependencies (`node_modules/`, `.venv/`, …) and its own hooks proof, which
+  is exactly what `task worktree:new` pays for. Do not mint one for a two-line
+  fix on an idle checkout; do mint one the moment work becomes parallel or
+  long-lived.
+
+## How: create, use, remove
+
+**Create with `task worktree:new -- <name> [--branch <b>] [--base <ref>] [--no-install]`**
+— never a bare `git worktree add`. The task creates `.worktrees/<name>` (the
+one gitignored, lint-excluded location), creates or attaches the branch
+(tracking a same-named remote branch rather than recreating it), bases a new
+branch on the main worktree's verified HEAD, installs **this tree's**
+dependencies, proves the git hooks fire inside it (`.git` is a *file* in a
+linked worktree, so `-c core.hooksPath=.git/hooks` silently resolves to
+nothing — a breaker the task exists to catch), prints the ready path, and
+rolls the tree back if any step fails. The full option semantics and refusal
+cases are in [../conventions.md](../conventions.md) § Worktrees.
+
+**Work in it as a normal checkout.** `cd .worktrees/<name>`, then the ordinary
+Dev Loop from `AGENTS.md`: edit → `task check` → `task verify` → the review
+stages → push → PR. Commit boundaries and pushes are per worktree, so two
+trees never share staged state.
+
+**Remove with `task worktree:rm -- <name> [--force]`.** It refuses on
+uncommitted work and on ignored local files such as a `.env` (which a plain
+`git worktree remove` would silently delete), then prunes the registry and
+clears gitlink debris. Ignored *directories* (`node_modules/`, `.venv/`,
+`dist/`) do not block it — `worktree:new` reinstalls them.
+
+## Pairing with Herdr
+
+Herdr's own `worktree create` is a bare `git worktree add` plus a workspace;
+it has no post-create hook and does not install anything. The sanctioned
+composition is therefore **repo creates, Herdr binds**:
+
+```bash
+task worktree:new -- feat-x --branch feat/x          # runnable tree, hooks proven
+herdr worktree open --path .worktrees/feat-x --label feat-x --no-focus
+```
+
+`worktree open` binds the existing checkout to a new Herdr workspace whose
+root pane is ready for `herdr agent start`. When the work is verified and
+pushed, `herdr worktree remove --workspace <id>` tears down the workspace
+(tabs, panes, sessions) and `task worktree:rm -- feat-x` prunes the repo's
+bookkeeping. See [herdr.md](herdr.md) § Worktrees for the alternatives and
+the sweep.
+
+## The sweep
+
+Closing a pane or workspace kills the processes in it, but nothing about a
+worktree, its branch, or scratch files is removed for you. End every fan-out
+with: verify the results → close the panes/tabs you created → `git worktree
+list` (or `herdr worktree list`, which also shows non-Herdr trees) → remove
+what is finished → delete merged branches (`task clean:branches` where the
+repo ships it) → clear scratch. Anything a worker deliberately detached
+(`nohup`, a background server) survives its pane and is part of the sweep too.

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -23,9 +23,10 @@ Ask three questions. If any answer is **yes**, make a worktree.
    time; if something else is mid-edit you get phantom failures, and two
    `task verify` runs in one checkout fight over ports and caches.
 3. **Will it outlive a single turn, or need to be resumable?** A worktree is
-   durable state: if the session dies, the branch and its edits survive on
-   disk and another session can pick them up. Scratch in a pane dies with the
-   pane.
+   durable, *addressable* state: if the session dies, the branch and its
+   edits survive on disk and another session can pick them up by name. A pane
+   job's terminal context dies with the pane; whatever it wrote to disk
+   (reports, scratch) persists but is nobody's responsibility — see the sweep.
 
 If all three are **no**, you do not need a worktree. Work that *reads* the
 repo and *writes somewhere else* — auditing, reviewing, research, reports,
@@ -90,15 +91,23 @@ herdr worktree open --path .worktrees/feat-x --label feat-x --no-focus
 
 `worktree open` binds the existing checkout to a new Herdr workspace whose
 root pane is ready for `herdr agent start`. When the work is verified and
-pushed, `herdr worktree remove --workspace <id>` tears down the workspace
-(tabs, panes, sessions) and `task worktree:rm -- feat-x` prunes the repo's
-bookkeeping. See [herdr.md](herdr.md) § Worktrees for the alternatives and
-the sweep.
+pushed, close the Herdr side first and let the **repo** remove the tree:
+
+```bash
+herdr workspace close <id>      # panes + sessions only; the checkout stays
+task worktree:rm -- feat-x      # guarded removal, registry prune
+```
+
+Do **not** use `herdr worktree remove` on a tree the repo created: it runs a
+plain `git worktree remove`, which deletes ignored local files such as a
+`.env` without the refusal `task worktree:rm` exists to give, and then the
+task finds nothing left to guard. See [herdr.md](herdr.md) § Worktrees for
+the alternatives and the sweep.
 
 ## The sweep
 
-Closing a pane or workspace kills the processes in it, but nothing about a
-worktree, its branch, or scratch files is removed for you. End every fan-out
+Closing a pane or workspace kills the processes in it, but nothing on disk —
+a worktree, its branch, report or scratch files — is removed for you. End every fan-out
 with: verify the results → close the panes/tabs you created → `git worktree
 list` (or `herdr worktree list`, which also shows non-Herdr trees) → remove
 what is finished → delete merged branches (`task clean:branches` where the

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -18,10 +18,13 @@ Ask three questions. If any answer is **yes**, make a worktree.
    out somewhere to commit on. This is the "one worktree per intended PR"
    heuristic — per unit of *committable* work.
 2. **Will it run repo tooling that assumes a private, stable tree?**
-   `task verify`, test suites, dev servers on fixed ports, builds that write
-   `dist/`, codegen, git hooks. They read the working tree at a moment in
-   time; if something else is mid-edit you get phantom failures, and two
-   `task verify` runs in one checkout fight over ports and caches.
+   `task verify`, test suites, builds that write `dist/`, codegen, git hooks.
+   They read the working tree at a moment in time; if something else is
+   mid-edit you get phantom failures. Note what a worktree does *not*
+   isolate: the host's ports, network, and shared home/global caches. Two
+   parallel units whose tests bind a fixed port, or that share a package
+   cache, still race — give each worker its own port/cache allocation on top
+   of its own tree.
 3. **Will it outlive a single turn, or need to be resumable?** A worktree is
    durable, *addressable* state: if the session dies, the branch and its
    edits survive on disk and another session can pick them up by name. A pane

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -33,13 +33,16 @@ Ask three questions. If any answer is **yes**, make a worktree.
 
 If all three are **no**, you do not need a worktree. Work that *reads* the
 repo and *writes somewhere else* — auditing, reviewing, research, reports,
-label or issue hygiene via `gh`, `terraform plan`, anything whose output is a
-file in a scratch directory or a change upstream on GitHub — is a **pane
-job**: a sibling terminal with the repo as its cwd and no branch of its own.
+label or issue hygiene via `gh`, anything whose output is a file in a scratch
+directory or a change upstream on GitHub — is a **pane job**: a sibling
+terminal with the repo as its cwd and no branch of its own. Commands that
+write checkout-local state even though they feel read-only (`terraform plan`
+writes `.terraform/`, builds write caches) count as *running the repo's
+tooling*, question 2 — not as pane jobs in a shared checkout.
 
-Compressed: **writes to the repo or runs its tools → worktree (one per PR-sized
-unit); reads the repo and writes elsewhere → pane.** The tell is whether the
-work will ever run `git commit`.
+Compressed: **writes to the repo or runs its tooling → worktree (one per
+PR-sized unit); reads the repo and writes elsewhere → pane.** The tell is
+whether the work will ever run `git commit` **or** the repo's own tools.
 
 ## Refinements
 
@@ -67,8 +70,13 @@ branch on the main worktree's verified HEAD, installs **this tree's**
 dependencies, proves the git hooks fire inside it (`.git` is a *file* in a
 linked worktree, so `-c core.hooksPath=.git/hooks` silently resolves to
 nothing — a breaker the task exists to catch), prints the ready path, and
-rolls the tree back if any step fails. The full option semantics and refusal
-cases are in [../conventions.md](../conventions.md) § Worktrees.
+rolls the tree back if any step fails. One default to know: a **new** branch
+is based on the *main worktree's* HEAD — so if the main checkout is sitting
+on another feature branch, an "independent" branch created now stacks on it
+and carries its commits into the PR. For an independent PR, have the main
+worktree on `main` first, or pass the base explicitly
+(`--base origin/main`). The full option semantics and refusal cases are in
+[../conventions.md](../conventions.md) § Worktrees.
 
 **Work in it as a normal checkout.** `cd .worktrees/<name>`, then the ordinary
 Dev Loop from `AGENTS.md`: edit → `task check` → `task verify` → the review
@@ -113,6 +121,7 @@ Closing a pane or workspace kills the processes in it, but nothing on disk —
 a worktree, its branch, report or scratch files — is removed for you. End every fan-out
 with: verify the results → close the panes/tabs you created → `git worktree
 list` (or `herdr worktree list`, which also shows non-Herdr trees) → remove
-what is finished → delete merged branches (`task clean:branches` where the
-repo ships it) → clear scratch. Anything a worker deliberately detached
+what is finished → delete merged branches where the repo ships the task
+(`task clean:branches` to review — it is a dry run by default — then
+`task clean:branches -- --delete`) → clear scratch. Anything a worker deliberately detached
 (`nohup`, a background server) survives its pane and is part of the sweep too.

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -10,7 +10,9 @@ from Herdr is [herdr.md](herdr.md).
 
 ## The decision rule
 
-Ask three questions. If any answer is **yes**, make a worktree.
+Ask three questions. If any answer is **yes**, default to a worktree — the
+refinements below name the exceptions (chiefly: serial work on an otherwise
+idle checkout).
 
 1. **Will this work change tracked files and need to be committed?** Two
    sessions editing the same checkout step on each other's diffs, staged

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -73,9 +73,12 @@ dependencies, proves the git hooks fire inside it (`.git` is a *file* in a
 linked worktree, so `-c core.hooksPath=.git/hooks` silently resolves to
 nothing — a breaker the task exists to catch), prints the ready path, and
 rolls the tree back if any step fails. One default to know: a **new** branch
-is based on the *main worktree's* HEAD — so if the main checkout is sitting
-on another feature branch, an "independent" branch created now stacks on it
-and carries its commits into the PR. For an independent PR, have the main
+is based on the *main worktree's* HEAD — first verified against that branch's
+configured upstream, so a merely *stale* main is upgraded to the fresh
+upstream tip (announced) while a *diverged* one refuses with a `--base`
+remedy. The trap is a main checkout sitting on another feature branch: an
+"independent" branch created now stacks on it and carries its commits into
+the PR. For an independent PR, have the main
 worktree on `main` first, or pass the base explicitly
 (`--base origin/main`). The full option semantics and refusal cases are in
 [../conventions.md](../conventions.md) § Worktrees.

--- a/template/docs/guides/README.md.jinja
+++ b/template/docs/guides/README.md.jinja
@@ -35,5 +35,14 @@ Calm, repeatable how-tos read *in advance* (the crisis counterpart is
   Codex CLI: `task challenge` / `task review`, the automatic Claude → Codex
   stop-gate toggle, and where the finding-adjudication protocol lives.
 [% endif %]
+- [worktrees.md](worktrees.md) — when a piece of work earns its own git
+  worktree (the three-question rule: commits, repo tooling, durability) and
+  the one sanctioned way to create and remove one (`task worktree:new` /
+  `task worktree:rm`), including how it pairs with Herdr.
+- [herdr.md](herdr.md) — using Herdr for real work: workspaces, tabs, panes,
+  agents and sessions and how they relate; everyday workflows; worktrees;
+  fanning out many worker sessions from one orchestrator (subagents vs pane
+  workers, lifecycle, cleanup); and running several harnesses — Claude Code,
+  Codex, Antigravity, OpenCode — side by side on their own subscriptions.
 
 TODO: add more guides, e.g. "local development setup", "add a feature", "how X works".

--- a/template/docs/guides/herdr.md
+++ b/template/docs/guides/herdr.md
@@ -1,0 +1,261 @@
+# Herdr — workspaces, panes, agents, and multi-harness orchestration
+
+Herdr is the agent-session runtime in this repo's devcontainers and on your
+laptop: a terminal workspace manager that recognizes the coding agent running
+in each pane, tracks its state, and exposes the whole thing through the
+`herdr` CLI. This guide is how to *use* it for real work — the mental model,
+the everyday workflows, how it pairs with the repo's worktree tooling, running
+several agents (and several harnesses) at once, and the lifecycle and cleanup
+that keep the sidebar meaningful. Installation, the devcontainer volumes, and
+attaching from a laptop are in [devcontainers.md](devcontainers.md) § Persistent
+agent sessions; the decision rule for worktrees is [worktrees.md](worktrees.md).
+
+The installed binary is the authority for syntax: `herdr --help`, then a
+command group without a subcommand (`herdr agent`, `herdr pane`, …) prints its
+commands. Agents inside Herdr have a vendored skill for this (`herdr --skill`);
+what follows is the human's map of the same ground.
+
+## The five nouns and how they relate
+
+| Noun | What it is | ID shape | Created by |
+| --- | --- | --- | --- |
+| **Workspace** | A project root: a directory (or a worktree) plus its tabs | `w1` | `herdr workspace create --cwd PATH` or `herdr worktree create/open` |
+| **Tab** | A layout page inside a workspace | `w1:t1` | `herdr tab create --workspace w1` |
+| **Pane** | One terminal (shell) inside a tab | `w1:p1` | `herdr pane split --pane ID --direction right` or `down` |
+| **Agent** | The coding agent Herdr recognizes *occupying* a pane | pane ID or a unique name | `herdr agent start NAME --kind KIND --pane ID` |
+| **Session** | A whole Herdr server (the `default` one, or `herdr --session NAME`) | name | `herdr` / `herdr --session NAME` |
+
+The relationships that matter:
+
+- **A pane exists whether or not it hosts an agent.** `pane run` drives an
+  ordinary shell; `agent start` requires an *available* shell pane (at its
+  prompt, nothing in the foreground) and never creates layout itself.
+- **An agent is a full, independent process in its pane** — a real `claude`,
+  `codex`, `agy`, `opencode`, … session with its own context, auth, and
+  permissions. Its lifetime is the pane's: close the pane and it dies.
+- **A name follows the pane's current occupant** and is cleared when that
+  agent exits. Names must match `[a-z][a-z0-9_-]{0,31}` and be unique among
+  live agents; agent commands accept a name or the hosting pane ID, never a
+  terminal ID or a bare kind.
+- **Two kinds of workspace.** `workspace create` makes a plain
+  directory-rooted workspace — no git involvement. `worktree create` makes a
+  git worktree *and* a workspace rooted at it, and records the binding; one
+  worktree ↔ one workspace. Creating a workspace never creates a worktree;
+  creating a worktree always creates a workspace.
+- **Caller context.** Herdr injects `HERDR_WORKSPACE_ID`, `HERDR_TAB_ID`,
+  `HERDR_PANE_ID` into every managed pane (and `HERDR_ENV=1`). Prefer
+  `--current` or an explicit ID; an omitted target may resolve to the
+  UI-focused pane, which can be someone else's.
+
+## Agent lifecycle states
+
+Herdr classifies a pane's agent by watching its terminal:
+
+- `working` — producing output / running tools.
+- `blocked` — Herdr recognized an approval or question UI; it needs input.
+- `idle` — ready for input, and its tab has been *seen* in the focused UI.
+- `done` — the same underlying idle state after unseen background work
+  finished. Focusing the tab or targeting the pane/agent with a focus command
+  marks it seen; CLI reads do not. `done` is therefore the sidebar's
+  "to-review" queue.
+- `unknown` — an agent is present but Herdr cannot classify it confidently.
+  It does **not** mean finished.
+
+`herdr agent explain <target>` shows which detection rule fired and on what
+evidence — the first thing to run when a state looks wrong.
+
+## Everyday workflows
+
+**One agent, one repo (the default).** Open or attach with `herdr`, create a
+workspace for the repo if it is not there, start the agent in the root pane
+(or just run `claude` in the shell — Herdr recognizes it either way). Use
+tabs for parallel *contexts* (a second agent on a different task, a shell for
+logs), panes within a tab for things you want side by side.
+
+**A second pane for a command or a helper agent, keeping your focus:**
+
+```bash
+herdr pane split --current --direction right --cwd "$PWD" --no-focus
+#   → read .result.pane.pane_id
+herdr pane run <id> "task verify"
+herdr pane wait-output <id> --match "verify: ok" --timeout 600000
+herdr pane read <id> --source recent-unwrapped --lines 120
+```
+
+Split a wide pane right and a tall one down; avoid repeated same-direction
+splits that leave unusable slivers. `pane run` sends text plus Enter
+atomically; `wait-output` matches the current snapshot immediately, so output
+that already exists counts.
+
+**Starting and steering an agent in that pane:**
+
+```bash
+herdr agent start reviewer --kind codex --pane <id> -- <native args…>
+herdr agent prompt reviewer "Review the current diff; report only actionable findings." --wait --timeout 600000
+herdr agent read reviewer --source recent-unwrapped --lines 120
+```
+
+Native agent arguments go after `--`. `agent prompt --wait` returns at the
+first settled `idle`/`done`/`blocked`; `--until STATE` is for state-specific
+waits. A prompt sent from a non-working state must produce an observed state
+change within about five seconds or Herdr returns `agent_prompt_stalled`
+rather than waiting forever. If a wait returns `blocked`, `agent get` /
+`agent read` first, then `agent send-keys` (logical keys — `esc`, `ctrl+c`,
+`enter`) or `agent attach` to take the pane over yourself.
+
+**Reading long answers.** Many harnesses render on the alternate screen, and
+rows that leave it never enter Herdr's scrollback — raising `--lines` cannot
+recover them. Ask the agent to write its full answer to a file and reply with
+the path, then read the file.
+
+## Worktrees
+
+Herdr's `worktree create` is `git worktree add` plus a workspace, checked out
+under `[worktrees] directory` (default `~/.herdr/worktrees/<repo>/<branch>`);
+`worktree open` binds an *existing* checkout to a new workspace; `worktree
+list` shows worktrees for the repo, including ones Herdr did not create;
+`worktree remove --workspace ID [--force]` tears down the workspace — tabs,
+panes, sessions — and the checkout together. There is **no post-create
+hook**: a fresh tree has no dependencies installed, no local env, and no
+hooks proof, which is the failure everyone hits first.
+
+So for repos generated from this template, **the repo creates and Herdr
+binds**:
+
+```bash
+task worktree:new -- feat-x --branch feat/x
+herdr worktree open --path .worktrees/feat-x --label feat-x --no-focus
+# …work…
+herdr worktree remove --workspace <id>     # panes + sessions
+task worktree:rm -- feat-x                 # repo bookkeeping, gitlink prune
+```
+
+If you use `herdr worktree create` directly, provision before any agent
+starts: `herdr pane run <root-pane> "task install"` and `wait-output` for it,
+then `agent start`. Environment variables are the only "setup" Herdr itself
+offers — `worktree create`, `tab create`, and `pane split` all take
+`--env KEY=VALUE` — which is the right place for gate variables an
+orchestrator sets under explicit human authorization (never in the worker's
+prompt). When to reach for a worktree at all is [worktrees.md](worktrees.md).
+
+## Fan-out: orchestrating many workers from one session
+
+A Claude Code (or any) session running inside a Herdr pane can act as an
+**orchestrator**: it shells out to `herdr` to create panes, start workers,
+prompt them, wait, and harvest. The orchestrator is just another agent in
+another pane; Herdr has no parent/child concept — the topology is conversational.
+
+**Subagents versus pane workers.** These are different things and the words
+matter:
+
+- A **subagent** (Claude Code's `Agent` tool, `.claude/agents/*.md`) runs
+  *inside* the parent session's process: its own context window, no terminal,
+  one structured return value, dies when done. Only the parent can talk to
+  it, and Herdr cannot see it — there is no pane to watch.
+- A **pane worker** (a "worker session", "sibling agent", "teammate") is a
+  full independent session in its own pane, with its own harness, login, and
+  permissions. Herdr sees it, you can click into it, steer it, or take it
+  over, and it can outlive or ignore the orchestrator. Results come back as
+  terminal text and files, not a typed return.
+
+Use subagents for cheap, fast, structured fan-outs you do not need to watch;
+use pane workers when you want visibility, steerability, longer-running work,
+or a **different harness** than the orchestrator's.
+
+**The loop** (each step is a `herdr` command the orchestrator runs):
+
+1. **Lay out** — a fresh tab for the fan-out, one pane per unit, each with
+   its cwd (a worktree for work that edits the repo; the checkout itself for
+   pane jobs): `tab create --workspace … --label … --no-focus`, then
+   `pane split … --cwd … --no-focus`; `--env` for any authorized gate variables.
+2. **Start** — `agent start <name> --kind <kind> --pane <id> -- <native args>`
+   with a distinctive name per unit (`triage-omator`, `prune-site`).
+3. **Prompt** — one self-contained brief per worker, ending with a
+   **file-based report** at a known path and a **sentinel line** (a unique
+   string such as `TRIAGE-WORKER-DONE omator`) printed last. Then
+   `agent prompt … --wait --until working` and re-send if the worker stays
+   `idle` — delivery can silently miss when the harness is mid-render.
+4. **Wait** — `agent wait <name>` per worker (background it; rounds run
+   minutes), or `pane wait-output --match <sentinel>` where detection is
+   weak. `done`/`idle` means *stopped*, not *succeeded*: the sentinel and
+   the report file are the success signals.
+5. **Harvest and verify** — `agent read` / read the report files, then
+   **verify ground truth yourself** (the diff, the labels on GitHub, the test
+   run). Never trust a transcript's claim of success.
+6. **Review** — anything `blocked`, `unknown`, or surprising: `agent focus`
+   to mark it seen and look, `agent attach` to take over, or prompt it again
+   with its context intact (the reason to keep a pane alive).
+7. **Retire** — close what you created: `tab close` (which closes its panes
+   and kills their processes) or `worktree remove --workspace` for
+   worktree-backed units. Never close panes, tabs, or workspaces you did not
+   create unless asked; never `herdr server stop` from a live session.
+8. **Sweep** — the durable leftovers Herdr does not remove: worktrees
+   (`worktree list` + `task worktree:rm`), branches (`task clean:branches`),
+   scratch files and sidecars, and anything a worker deliberately detached.
+   `herdr notification show` can announce the result.
+
+What is mechanical: closing a tab/pane/workspace terminates everything running
+in it (verified — no orphaned agent processes); `worktree remove` removes the
+checkout with the workspace. What is on you: steps 5 and 8.
+
+## Multiple harnesses — supported and sanctioned
+
+The orchestration surface is harness-agnostic. `--kind` accepts every agent
+Herdr can recognize (`herdr agent` lists them: `claude`, `codex`, `gemini`,
+`agy` (Antigravity), `opencode`, `copilot`, `cursor`, `amp`, `droid`, `kimi`,
+`qwen`, `kilo`, `cline`, …), and nothing about the loop above changes except
+the kind and the native arguments after `--`. A Claude Code orchestrator can
+therefore drive Codex, Antigravity, or OpenCode workers — each a separate,
+official client running under **its own provider login and subscription**.
+
+That is the permitted shape, and it is worth being precise about why. Each
+worker is the vendor's **official CLI**, authenticated as you, driven through
+its terminal by a multiplexer that never touches tokens or APIs — the same as
+typing into it yourself. What vendors prohibit is using one product's
+subscription credentials *inside a different product*: Anthropic's consumer
+terms forbid Claude Free/Pro/Max OAuth tokens in any third-party tool or
+harness (enforced by token blocking since early 2026); Google and OpenAI keep
+similar lines. Running the official `claude`, `codex`, `agy`, or `opencode`
+binaries side by side, each on its own plan, is on the right side of every
+one of those lines; pointing OpenCode at a Claude subscription is not. The
+practical constraint is quota: parallel workers spend each plan's 5-hour and
+weekly pools faster, not differently — watch each harness's own usage
+indicator, and move genuinely unattended, high-volume work to that vendor's
+API billing.
+
+Per-harness notes that shape the launch line:
+
+- **`claude`** — `-- --model <m> --allowedTools '<exact list>'` pre-approves
+  the tools the task needs and nothing else, so no permission prompt appears.
+  Detection is clean; gate variables belong on the pane (`--env`).
+- **`codex`** — `-- -a never -s workspace-write -c sandbox_workspace_write.network_access=true`
+  for unattended runs, **plus** a rules file that allows every command the
+  task will run: with `-a never`, any command a rule marks as prompt-worthy is
+  rejected before a shell spawns (`Rejected("approval required by policy, but
+  AskForApproval is set to Never")`) with no stderr, and prefix rules match
+  the first token only, so a wrapped invocation and a bare one can behave
+  differently. Detection is clean (`osc_title_working`); always confirm
+  `working` after a prompt.
+- **`agy`, `opencode`, others** — same loop; check detection with
+  `agent explain` on first use, and fall back to the file report + sentinel
+  where it is `unknown`.
+
+Worker briefs should also say: never set gate or approval variables yourself;
+if a script refuses, stop and report. A capable model will otherwise export
+the variable to get unstuck.
+
+## Cheat sheet
+
+```bash
+herdr workspace list | tab list --workspace W | pane list --workspace W | agent list
+herdr pane split --current --direction right --cwd "$PWD" --no-focus
+herdr agent start NAME --kind KIND --pane ID [--timeout MS] -- ARGS…
+herdr agent prompt NAME "…" --wait [--until working|blocked] --timeout MS
+herdr agent wait NAME [--until STATE] --timeout MS
+herdr agent read NAME --source recent-unwrapped --lines 120
+herdr agent explain NAME          # why Herdr thinks it is in that state
+herdr agent send-keys NAME esc    # logical keys, validated before writing
+herdr tab close T                 # closes panes, kills their processes
+herdr worktree open --path P --label L --no-focus | herdr worktree remove --workspace W
+herdr notification show "title" --body "…"
+```

--- a/template/docs/guides/herdr.md.jinja
+++ b/template/docs/guides/herdr.md.jinja
@@ -1,7 +1,8 @@
 # Herdr — workspaces, panes, agents, and multi-harness orchestration
 
-Herdr is the agent-session runtime in this repo's devcontainers and on your
-laptop: a terminal workspace manager that recognizes the coding agent running
+Herdr is the agent-session runtime for this repo's agents — in the
+devcontainers where the profile ships them, and on your own machine: a
+terminal workspace manager that recognizes the coding agent running
 in each pane, tracks its state, and exposes the whole thing through the
 `herdr` CLI. This guide is how to *use* it for real work — the mental model,
 the everyday workflows, how it pairs with the repo's worktree tooling, running
@@ -141,10 +142,11 @@ Reserve `herdr worktree remove` for throwaway trees Herdr itself created.
 If you use `herdr worktree create` directly, provision before any agent
 starts: `herdr pane run <root-pane> "task install"` and `wait-output` for it,
 then `agent start`. Environment variables are the only "setup" Herdr itself
-offers — `worktree create`, `tab create`, and `pane split` all take
-`--env KEY=VALUE` — which is the right place for gate variables an
-orchestrator sets under explicit human authorization (never in the worker's
-prompt). When to reach for a worktree at all is [worktrees.md](worktrees.md).
+offers — `workspace create`, `tab create`, and `pane split` take
+`--env KEY=VALUE` (`worktree create` does **not**; give a worktree-backed
+workspace its variables on the tabs/panes you create inside it) — and they
+are the right place for gate variables an orchestrator sets under explicit
+human authorization (never in the worker's prompt). When to reach for a worktree at all is [worktrees.md](worktrees.md).
 
 ## Fan-out: orchestrating many workers from one session
 
@@ -170,6 +172,14 @@ Use subagents for cheap, fast, structured fan-outs you do not need to watch;
 use pane workers when you want visibility, steerability, longer-running work,
 or a **different harness** than the orchestrator's.
 
+**Panes are not a security boundary.** Every pane worker runs as the same OS
+user in the same Herdr session: any of them can read, type into, or close any
+other pane by explicit ID, and they share the filesystem and every credential
+on it. "Its own permissions" means each harness's own tool-approval settings,
+not isolation. Fan out only mutually trusted workers over trusted inputs;
+work that chews on untrusted content (third-party repos, inbound issue text)
+belongs in a separate user, container, or VM, not a sibling pane.
+
 **The loop** (each step is a `herdr` command the orchestrator runs):
 
 1. **Lay out** — a fresh tab for the fan-out, one pane per unit, each with
@@ -179,8 +189,12 @@ or a **different harness** than the orchestrator's.
 2. **Start** — `agent start <name> --kind <kind> --pane <id> -- <native args>`
    with a distinctive name per unit (`triage-omator`, `prune-site`).
 3. **Prompt** — one self-contained brief per worker, ending with a
-   **file-based report** at a known path and a **sentinel line** (a unique
-   string such as `TRIAGE-WORKER-DONE omator`) printed last. Then
+   **file-based report** at a known path and a **sentinel line** printed
+   last. Make both unique per *attempt*, not just per worker — a nonce such
+   as `TRIAGE-DONE omator 7f3a` in the sentinel and the report filename —
+   because `pane wait-output` matches the existing snapshot immediately, so
+   a reused pane's previous sentinel satisfies the next wait and hands you
+   the old report. Then
    `agent prompt … --wait --until working --timeout 30000`. If it returns
    with the worker still `idle`, delivery may have silently missed (it
    happens when the harness is mid-render) — but before re-sending, check
@@ -204,9 +218,12 @@ or a **different harness** than the orchestrator's.
    to mark it seen and look, `agent attach` to take over, or prompt it again
    with its context intact (the reason to keep a pane alive).
 7. **Retire** — close what you created: `tab close` (which closes its panes
-   and kills their processes) or `worktree remove --workspace` for
-   worktree-backed units. Never close panes, tabs, or workspaces you did not
-   create unless asked; never `herdr server stop` from a live session.
+   and kills their processes), or for worktree-backed units `workspace close`
+   followed by `task worktree:rm` — the guarded path from § Worktrees.
+   `worktree remove --workspace` is only for throwaway trees Herdr itself
+   created, since it deletes the checkout unguarded. Never close panes,
+   tabs, or workspaces you did not create unless asked; never
+   `herdr server stop` from a live session.
 8. **Sweep** — the durable leftovers Herdr does not remove: worktrees
    (`worktree list` + `task worktree:rm`), branches (`task clean:branches`),
    scratch files and sidecars, and anything a worker deliberately detached.

--- a/template/docs/guides/herdr.md.jinja
+++ b/template/docs/guides/herdr.md.jinja
@@ -225,7 +225,9 @@ belongs in a separate user, container, or VM, not a sibling pane.
    tabs, or workspaces you did not create unless asked; never
    `herdr server stop` from a live session.
 8. **Sweep** — the durable leftovers Herdr does not remove: worktrees
-   (`worktree list` + `task worktree:rm`), branches (`task clean:branches`),
+   (`worktree list` + `task worktree:rm`), branches (`task clean:branches`
+   to review, then `task clean:branches -- --delete` — the bare form is a
+   dry run),
    scratch files and sidecars, and anything a worker deliberately detached.
    `herdr notification show` can announce the result.
 
@@ -261,16 +263,24 @@ API billing.
 
 Per-harness notes that shape the launch line:
 
-- **`claude`** — `-- --model <m> --allowedTools '<exact list>'` pre-approves
-  the tools the task needs and nothing else, so no permission prompt appears.
-  Detection is clean; gate variables belong on the pane (`--env`).
+- **`claude`** — `-- --model <m> --tools '<exact list>' --allowedTools '<the
+  same list>'`. The two flags do different halves of least privilege:
+  `--tools` restricts which tools *exist* in the session, `--allowedTools`
+  pre-approves them so no prompt blocks an unattended worker. `--allowedTools`
+  alone is not a restriction — every other tool is still there behind a
+  prompt, and the repo's and devcontainer's `settings.json` permissions
+  (often broad `Bash(git:*)`/`Bash(gh:*)` allows) merge in. Detection is
+  clean; gate variables belong on the pane (`--env`).
 - **`codex`** — `-- -a never -s workspace-write -c sandbox_workspace_write.network_access=true`
   for unattended runs, **plus** a rules file that allows every command the
   task will run: with `-a never`, any command a rule marks as prompt-worthy is
   rejected before a shell spawns (`Rejected("approval required by policy, but
-  AskForApproval is set to Never")`) with no stderr, and prefix rules match
-  the first token only, so a wrapped invocation and a bare one can behave
-  differently. Detection is clean (`osc_title_working`); always confirm
+  AskForApproval is set to Never")`) with no stderr. Rules match a leading
+  prefix of the argv — `["gh"]` matches every `gh` invocation, `["git",
+  "status"]` matches `git status …` — so keep `allow` patterns argument-level
+  and narrow (an `allow` also runs its matches outside the sandbox), and note
+  that a script invoking `gh` internally has the script as `argv[0]` and
+  bypasses a bare-command rule entirely. Detection is clean (`osc_title_working`); always confirm
   `working` after a prompt.
 - **`agy`, `opencode`, others** — same loop; check detection with
   `agent explain` on first use, and fall back to the file report + sentinel

--- a/template/docs/guides/herdr.md.jinja
+++ b/template/docs/guides/herdr.md.jinja
@@ -80,15 +80,17 @@ logs), panes within a tab for things you want side by side.
 ```bash
 herdr pane split --current --direction right --cwd "$PWD" --no-focus
 #   → read .result.pane.pane_id
-herdr pane run <id> "task verify"
-herdr pane wait-output <id> --match "verify: ok" --timeout 600000
+herdr pane run <id> "task verify && echo VERIFY-OK-7f3a || echo VERIFY-FAILED-7f3a"
+herdr pane wait-output <id> --regex "VERIFY-(OK|FAILED)-7f3a" --timeout 600000
 herdr pane read <id> --source recent-unwrapped --lines 120
 ```
 
 Split a wide pane right and a tall one down; avoid repeated same-direction
 splits that leave unusable slivers. `pane run` sends text plus Enter
 atomically; `wait-output` matches the current snapshot immediately, so output
-that already exists counts.
+that already exists counts. Wait on a marker *you* append (unique per run, one
+alternative per outcome, as above) — most tasks print no stable "done" line of
+their own, and a wait that only matches success sits silent through a failure.
 
 **Starting and steering an agent in that pane:**
 

--- a/template/docs/guides/herdr.md.jinja
+++ b/template/docs/guides/herdr.md.jinja
@@ -198,8 +198,10 @@ belongs in a separate user, container, or VM, not a sibling pane.
    a reused pane's previous sentinel satisfies the next wait and hands you
    the old report. Then
    `agent prompt … --wait --until working --timeout 30000`. If it returns
-   with the worker still `idle`, delivery may have silently missed (it
-   happens when the harness is mid-render) — but before re-sending, check
+   with the worker still `idle`, delivery may have silently missed — Herdr
+   0.8.0 (the devcontainer pin) can report `agent start` ready before the
+   pane's first-run prompts have settled (fixed in 0.8.2), and a harness
+   mid-render swallows input the same way — but before re-sending, check
    the pane and the report path: a fast worker can finish and return to
    `idle` inside the window, and re-sending a brief that performs side
    effects (GitHub writes, deploys) is at-least-once delivery. Re-send only
@@ -274,9 +276,13 @@ Per-harness notes that shape the launch line:
   (often broad `Bash(git:*)`/`Bash(gh:*)` allows) merge in. Detection is
   clean; gate variables belong on the pane (`--env`).
 - **`codex`** — `-- -a never -s workspace-write -c sandbox_workspace_write.network_access=true`
-  for unattended runs, **plus** a rules file that allows every command the
-  task will run: with `-a never`, any command a rule marks as prompt-worthy is
-  rejected before a shell spawns (`Rejected("approval required by policy, but
+  for unattended runs, **plus** rules for exactly the commands Codex's policy
+  would otherwise prompt on (typically network-touching writes like
+  `gh issue edit`) — nothing more. Ordinary build/test commands run inside
+  `workspace-write` without any rule, and an `allow` rule executes its
+  matches *outside* the sandbox, so blanket-allowing the task's whole command
+  set trades the sandbox away. The failure mode to know: with `-a never`,
+  any command a rule marks as prompt-worthy is rejected before a shell spawns (`Rejected("approval required by policy, but
   AskForApproval is set to Never")`) with no stderr. Rules match a leading
   prefix of the argv — `["gh"]` matches every `gh` invocation, `["git",
   "status"]` matches `git status …` — so keep `allow` patterns argument-level
@@ -307,7 +313,7 @@ herdr agent read NAME --source recent-unwrapped --lines 120
 herdr agent explain NAME                      # why Herdr thinks it is in that state
 herdr agent send-keys NAME esc                # logical keys, validated before writing
 herdr tab close T                             # closes panes, kills their processes
-herdr workspace close W                       # same, for a whole workspace; files stay
+herdr workspace close W                       # same, for a whole workspace; files and detached processes stay
 herdr worktree open --path P --label L --no-focus
 herdr worktree remove --workspace W           # ALSO deletes the checkout — Herdr-created trees only
 herdr notification show "title" --body "…"

--- a/template/docs/guides/herdr.md.jinja
+++ b/template/docs/guides/herdr.md.jinja
@@ -6,9 +6,11 @@ in each pane, tracks its state, and exposes the whole thing through the
 `herdr` CLI. This guide is how to *use* it for real work — the mental model,
 the everyday workflows, how it pairs with the repo's worktree tooling, running
 several agents (and several harnesses) at once, and the lifecycle and cleanup
-that keep the sidebar meaningful. Installation, the devcontainer volumes, and
+that keep the sidebar meaningful. [% if devcontainer %]Installation, the devcontainer volumes, and
 attaching from a laptop are in [devcontainers.md](devcontainers.md) § Persistent
-agent sessions; the decision rule for worktrees is [worktrees.md](worktrees.md).
+agent sessions; [% else %]Install it with `brew install herdr` or the installer at
+https://herdr.dev/ (the server auto-starts on the first `herdr` invocation); [% endif %]the
+decision rule for worktrees is [worktrees.md](worktrees.md).
 
 The installed binary is the authority for syntax: `herdr --help`, then a
 command group without a subcommand (`herdr agent`, `herdr pane`, …) prints its
@@ -115,7 +117,8 @@ under `[worktrees] directory` (default `~/.herdr/worktrees/<repo>/<branch>`);
 `worktree open` binds an *existing* checkout to a new workspace; `worktree
 list` shows worktrees for the repo, including ones Herdr did not create;
 `worktree remove --workspace ID [--force]` tears down the workspace — tabs,
-panes, sessions — and the checkout together. There is **no post-create
+panes, sessions — **and deletes the checkout** with a plain `git worktree
+remove` (no ignored-file guard). There is **no post-create
 hook**: a fresh tree has no dependencies installed, no local env, and no
 hooks proof, which is the failure everyone hits first.
 
@@ -126,9 +129,14 @@ binds**:
 task worktree:new -- feat-x --branch feat/x
 herdr worktree open --path .worktrees/feat-x --label feat-x --no-focus
 # …work…
-herdr worktree remove --workspace <id>     # panes + sessions
-task worktree:rm -- feat-x                 # repo bookkeeping, gitlink prune
+herdr workspace close <id>                 # panes + sessions; checkout stays
+task worktree:rm -- feat-x                 # guarded removal, gitlink prune
 ```
+
+Order matters: `herdr worktree remove` would delete the checkout before
+`task worktree:rm` could refuse on ignored local state such as a `.env`, so a
+repo-created tree is closed on the Herdr side and removed by the repo task.
+Reserve `herdr worktree remove` for throwaway trees Herdr itself created.
 
 If you use `herdr worktree create` directly, provision before any agent
 starts: `herdr pane run <root-pane> "task install"` and `wait-output` for it,
@@ -173,12 +181,22 @@ or a **different harness** than the orchestrator's.
 3. **Prompt** — one self-contained brief per worker, ending with a
    **file-based report** at a known path and a **sentinel line** (a unique
    string such as `TRIAGE-WORKER-DONE omator`) printed last. Then
-   `agent prompt … --wait --until working` and re-send if the worker stays
-   `idle` — delivery can silently miss when the harness is mid-render.
-4. **Wait** — `agent wait <name>` per worker (background it; rounds run
-   minutes), or `pane wait-output --match <sentinel>` where detection is
-   weak. `done`/`idle` means *stopped*, not *succeeded*: the sentinel and
-   the report file are the success signals.
+   `agent prompt … --wait --until working --timeout 30000`. If it returns
+   with the worker still `idle`, delivery may have silently missed (it
+   happens when the harness is mid-render) — but before re-sending, check
+   the pane and the report path: a fast worker can finish and return to
+   `idle` inside the window, and re-sending a brief that performs side
+   effects (GitHub writes, deploys) is at-least-once delivery. Re-send only
+   when the pane shows the prompt never landed; make briefs idempotent where
+   you can.
+4. **Wait** — `agent wait <name> --timeout <ms>` per worker (background it;
+   rounds run minutes), or `pane wait-output --match <sentinel> --timeout
+   <ms>` where detection is weak. Always bound the wait: a worker whose
+   detection stays `unknown` or whose harness hangs would otherwise block
+   the orchestrator forever. On timeout, `agent get` / `agent read` /
+   `agent explain` it and decide — nudge, take over, or retire — rather than
+   waiting again blind. `done`/`idle` means *stopped*, not *succeeded*: the
+   sentinel and the report file are the success signals.
 5. **Harvest and verify** — `agent read` / read the report files, then
    **verify ground truth yourself** (the diff, the labels on GitHub, the test
    run). Never trust a transcript's claim of success.
@@ -201,10 +219,11 @@ checkout with the workspace. What is on you: steps 5 and 8.
 ## Multiple harnesses — supported and sanctioned
 
 The orchestration surface is harness-agnostic. `--kind` accepts every agent
-Herdr can recognize (`herdr agent` lists them: `claude`, `codex`, `gemini`,
-`agy` (Antigravity), `opencode`, `copilot`, `cursor`, `amp`, `droid`, `kimi`,
-`qwen`, `kilo`, `cline`, …), and nothing about the loop above changes except
-the kind and the native arguments after `--`. A Claude Code orchestrator can
+the installed Herdr can recognize — run `herdr agent` to see the exact list for
+your version; `claude`, `codex`, `gemini`, `agy` (Antigravity), and `opencode`
+are in the 0.8.0 image the devcontainers pin, newer releases add more — and
+nothing about the loop above changes except the kind and the native arguments
+after `--`. A Claude Code orchestrator can
 therefore drive Codex, Antigravity, or OpenCode workers — each a separate,
 official client running under **its own provider login and subscription**.
 
@@ -247,15 +266,20 @@ the variable to get unstuck.
 ## Cheat sheet
 
 ```bash
-herdr workspace list | tab list --workspace W | pane list --workspace W | agent list
+herdr workspace list
+herdr tab list --workspace W
+herdr pane list --workspace W
+herdr agent list
 herdr pane split --current --direction right --cwd "$PWD" --no-focus
-herdr agent start NAME --kind KIND --pane ID [--timeout MS] -- ARGS…
-herdr agent prompt NAME "…" --wait [--until working|blocked] --timeout MS
-herdr agent wait NAME [--until STATE] --timeout MS
+herdr agent start NAME --kind KIND --pane ID --timeout MS -- ARGS…
+herdr agent prompt NAME "…" --wait --until working --timeout MS
+herdr agent wait NAME --timeout MS            # add --until STATE for a specific state
 herdr agent read NAME --source recent-unwrapped --lines 120
-herdr agent explain NAME          # why Herdr thinks it is in that state
-herdr agent send-keys NAME esc    # logical keys, validated before writing
-herdr tab close T                 # closes panes, kills their processes
-herdr worktree open --path P --label L --no-focus | herdr worktree remove --workspace W
+herdr agent explain NAME                      # why Herdr thinks it is in that state
+herdr agent send-keys NAME esc                # logical keys, validated before writing
+herdr tab close T                             # closes panes, kills their processes
+herdr workspace close W                       # same, for a whole workspace; files stay
+herdr worktree open --path P --label L --no-focus
+herdr worktree remove --workspace W           # ALSO deletes the checkout — Herdr-created trees only
 herdr notification show "title" --body "…"
 ```

--- a/template/docs/guides/worktrees.md
+++ b/template/docs/guides/worktrees.md
@@ -1,0 +1,106 @@
+# Worktrees — when to make one, and how
+
+A linked git worktree gives one line of work its own checked-out branch, so it
+can change files and run the repo's tools without colliding with anyone else's
+working tree — yours included. This guide is the decision rule for *when* a
+worktree is worth its setup cost, and the one sanctioned way to create and
+remove them. The mechanics and footguns of the tooling itself live in
+[../conventions.md](../conventions.md) § Worktrees; running agents in them
+from Herdr is [herdr.md](herdr.md).
+
+## The decision rule
+
+Ask three questions. If any answer is **yes**, make a worktree.
+
+1. **Will this work change tracked files and need to be committed?** Two
+   sessions editing the same checkout step on each other's diffs, staged
+   state, and `git status`, and a pull request needs its own branch checked
+   out somewhere to commit on. This is the "one worktree per intended PR"
+   heuristic — per unit of *committable* work.
+2. **Will it run repo tooling that assumes a private, stable tree?**
+   `task verify`, test suites, dev servers on fixed ports, builds that write
+   `dist/`, codegen, git hooks. They read the working tree at a moment in
+   time; if something else is mid-edit you get phantom failures, and two
+   `task verify` runs in one checkout fight over ports and caches.
+3. **Will it outlive a single turn, or need to be resumable?** A worktree is
+   durable state: if the session dies, the branch and its edits survive on
+   disk and another session can pick them up. Scratch in a pane dies with the
+   pane.
+
+If all three are **no**, you do not need a worktree. Work that *reads* the
+repo and *writes somewhere else* — auditing, reviewing, research, reports,
+label or issue hygiene via `gh`, `terraform plan`, anything whose output is a
+file in a scratch directory or a change upstream on GitHub — is a **pane
+job**: a sibling terminal with the repo as its cwd and no branch of its own.
+
+Compressed: **writes to the repo or runs its tools → worktree (one per PR-sized
+unit); reads the repo and writes elsewhere → pane.** The tell is whether the
+work will ever run `git commit`.
+
+## Refinements
+
+- **A single agent still gets a worktree if you are working in the main
+  checkout.** The collision is with you, not only with other agents.
+- **Serial work on an idle checkout does not need one.** One change at a time
+  with nobody else in the repo is a branch in the main checkout with less
+  ceremony.
+- **Worktree is not workspace.** The worktree decides *where* a session's cwd
+  points; the terminal, panes, and agent still need a home (see
+  [herdr.md](herdr.md)). Pane jobs reuse the workspace you already have.
+- **The cost is the per-tree install.** Every worktree needs its own
+  dependencies (`node_modules/`, `.venv/`, …) and its own hooks proof, which
+  is exactly what `task worktree:new` pays for. Do not mint one for a two-line
+  fix on an idle checkout; do mint one the moment work becomes parallel or
+  long-lived.
+
+## How: create, use, remove
+
+**Create with `task worktree:new -- <name> [--branch <b>] [--base <ref>] [--no-install]`**
+— never a bare `git worktree add`. The task creates `.worktrees/<name>` (the
+one gitignored, lint-excluded location), creates or attaches the branch
+(tracking a same-named remote branch rather than recreating it), bases a new
+branch on the main worktree's verified HEAD, installs **this tree's**
+dependencies, proves the git hooks fire inside it (`.git` is a *file* in a
+linked worktree, so `-c core.hooksPath=.git/hooks` silently resolves to
+nothing — a breaker the task exists to catch), prints the ready path, and
+rolls the tree back if any step fails. The full option semantics and refusal
+cases are in [../conventions.md](../conventions.md) § Worktrees.
+
+**Work in it as a normal checkout.** `cd .worktrees/<name>`, then the ordinary
+Dev Loop from `AGENTS.md`: edit → `task check` → `task verify` → the review
+stages → push → PR. Commit boundaries and pushes are per worktree, so two
+trees never share staged state.
+
+**Remove with `task worktree:rm -- <name> [--force]`.** It refuses on
+uncommitted work and on ignored local files such as a `.env` (which a plain
+`git worktree remove` would silently delete), then prunes the registry and
+clears gitlink debris. Ignored *directories* (`node_modules/`, `.venv/`,
+`dist/`) do not block it — `worktree:new` reinstalls them.
+
+## Pairing with Herdr
+
+Herdr's own `worktree create` is a bare `git worktree add` plus a workspace;
+it has no post-create hook and does not install anything. The sanctioned
+composition is therefore **repo creates, Herdr binds**:
+
+```bash
+task worktree:new -- feat-x --branch feat/x          # runnable tree, hooks proven
+herdr worktree open --path .worktrees/feat-x --label feat-x --no-focus
+```
+
+`worktree open` binds the existing checkout to a new Herdr workspace whose
+root pane is ready for `herdr agent start`. When the work is verified and
+pushed, `herdr worktree remove --workspace <id>` tears down the workspace
+(tabs, panes, sessions) and `task worktree:rm -- feat-x` prunes the repo's
+bookkeeping. See [herdr.md](herdr.md) § Worktrees for the alternatives and
+the sweep.
+
+## The sweep
+
+Closing a pane or workspace kills the processes in it, but nothing about a
+worktree, its branch, or scratch files is removed for you. End every fan-out
+with: verify the results → close the panes/tabs you created → `git worktree
+list` (or `herdr worktree list`, which also shows non-Herdr trees) → remove
+what is finished → delete merged branches (`task clean:branches` where the
+repo ships it) → clear scratch. Anything a worker deliberately detached
+(`nohup`, a background server) survives its pane and is part of the sweep too.

--- a/template/docs/guides/worktrees.md
+++ b/template/docs/guides/worktrees.md
@@ -23,9 +23,10 @@ Ask three questions. If any answer is **yes**, make a worktree.
    time; if something else is mid-edit you get phantom failures, and two
    `task verify` runs in one checkout fight over ports and caches.
 3. **Will it outlive a single turn, or need to be resumable?** A worktree is
-   durable state: if the session dies, the branch and its edits survive on
-   disk and another session can pick them up. Scratch in a pane dies with the
-   pane.
+   durable, *addressable* state: if the session dies, the branch and its
+   edits survive on disk and another session can pick them up by name. A pane
+   job's terminal context dies with the pane; whatever it wrote to disk
+   (reports, scratch) persists but is nobody's responsibility — see the sweep.
 
 If all three are **no**, you do not need a worktree. Work that *reads* the
 repo and *writes somewhere else* — auditing, reviewing, research, reports,
@@ -90,15 +91,23 @@ herdr worktree open --path .worktrees/feat-x --label feat-x --no-focus
 
 `worktree open` binds the existing checkout to a new Herdr workspace whose
 root pane is ready for `herdr agent start`. When the work is verified and
-pushed, `herdr worktree remove --workspace <id>` tears down the workspace
-(tabs, panes, sessions) and `task worktree:rm -- feat-x` prunes the repo's
-bookkeeping. See [herdr.md](herdr.md) § Worktrees for the alternatives and
-the sweep.
+pushed, close the Herdr side first and let the **repo** remove the tree:
+
+```bash
+herdr workspace close <id>      # panes + sessions only; the checkout stays
+task worktree:rm -- feat-x      # guarded removal, registry prune
+```
+
+Do **not** use `herdr worktree remove` on a tree the repo created: it runs a
+plain `git worktree remove`, which deletes ignored local files such as a
+`.env` without the refusal `task worktree:rm` exists to give, and then the
+task finds nothing left to guard. See [herdr.md](herdr.md) § Worktrees for
+the alternatives and the sweep.
 
 ## The sweep
 
-Closing a pane or workspace kills the processes in it, but nothing about a
-worktree, its branch, or scratch files is removed for you. End every fan-out
+Closing a pane or workspace kills the processes in it, but nothing on disk —
+a worktree, its branch, report or scratch files — is removed for you. End every fan-out
 with: verify the results → close the panes/tabs you created → `git worktree
 list` (or `herdr worktree list`, which also shows non-Herdr trees) → remove
 what is finished → delete merged branches (`task clean:branches` where the

--- a/template/docs/guides/worktrees.md
+++ b/template/docs/guides/worktrees.md
@@ -18,10 +18,13 @@ Ask three questions. If any answer is **yes**, make a worktree.
    out somewhere to commit on. This is the "one worktree per intended PR"
    heuristic — per unit of *committable* work.
 2. **Will it run repo tooling that assumes a private, stable tree?**
-   `task verify`, test suites, dev servers on fixed ports, builds that write
-   `dist/`, codegen, git hooks. They read the working tree at a moment in
-   time; if something else is mid-edit you get phantom failures, and two
-   `task verify` runs in one checkout fight over ports and caches.
+   `task verify`, test suites, builds that write `dist/`, codegen, git hooks.
+   They read the working tree at a moment in time; if something else is
+   mid-edit you get phantom failures. Note what a worktree does *not*
+   isolate: the host's ports, network, and shared home/global caches. Two
+   parallel units whose tests bind a fixed port, or that share a package
+   cache, still race — give each worker its own port/cache allocation on top
+   of its own tree.
 3. **Will it outlive a single turn, or need to be resumable?** A worktree is
    durable, *addressable* state: if the session dies, the branch and its
    edits survive on disk and another session can pick them up by name. A pane

--- a/template/docs/guides/worktrees.md
+++ b/template/docs/guides/worktrees.md
@@ -33,13 +33,16 @@ Ask three questions. If any answer is **yes**, make a worktree.
 
 If all three are **no**, you do not need a worktree. Work that *reads* the
 repo and *writes somewhere else* — auditing, reviewing, research, reports,
-label or issue hygiene via `gh`, `terraform plan`, anything whose output is a
-file in a scratch directory or a change upstream on GitHub — is a **pane
-job**: a sibling terminal with the repo as its cwd and no branch of its own.
+label or issue hygiene via `gh`, anything whose output is a file in a scratch
+directory or a change upstream on GitHub — is a **pane job**: a sibling
+terminal with the repo as its cwd and no branch of its own. Commands that
+write checkout-local state even though they feel read-only (`terraform plan`
+writes `.terraform/`, builds write caches) count as *running the repo's
+tooling*, question 2 — not as pane jobs in a shared checkout.
 
-Compressed: **writes to the repo or runs its tools → worktree (one per PR-sized
-unit); reads the repo and writes elsewhere → pane.** The tell is whether the
-work will ever run `git commit`.
+Compressed: **writes to the repo or runs its tooling → worktree (one per
+PR-sized unit); reads the repo and writes elsewhere → pane.** The tell is
+whether the work will ever run `git commit` **or** the repo's own tools.
 
 ## Refinements
 
@@ -67,8 +70,13 @@ branch on the main worktree's verified HEAD, installs **this tree's**
 dependencies, proves the git hooks fire inside it (`.git` is a *file* in a
 linked worktree, so `-c core.hooksPath=.git/hooks` silently resolves to
 nothing — a breaker the task exists to catch), prints the ready path, and
-rolls the tree back if any step fails. The full option semantics and refusal
-cases are in [../conventions.md](../conventions.md) § Worktrees.
+rolls the tree back if any step fails. One default to know: a **new** branch
+is based on the *main worktree's* HEAD — so if the main checkout is sitting
+on another feature branch, an "independent" branch created now stacks on it
+and carries its commits into the PR. For an independent PR, have the main
+worktree on `main` first, or pass the base explicitly
+(`--base origin/main`). The full option semantics and refusal cases are in
+[../conventions.md](../conventions.md) § Worktrees.
 
 **Work in it as a normal checkout.** `cd .worktrees/<name>`, then the ordinary
 Dev Loop from `AGENTS.md`: edit → `task check` → `task verify` → the review
@@ -113,6 +121,7 @@ Closing a pane or workspace kills the processes in it, but nothing on disk —
 a worktree, its branch, report or scratch files — is removed for you. End every fan-out
 with: verify the results → close the panes/tabs you created → `git worktree
 list` (or `herdr worktree list`, which also shows non-Herdr trees) → remove
-what is finished → delete merged branches (`task clean:branches` where the
-repo ships it) → clear scratch. Anything a worker deliberately detached
+what is finished → delete merged branches where the repo ships the task
+(`task clean:branches` to review — it is a dry run by default — then
+`task clean:branches -- --delete`) → clear scratch. Anything a worker deliberately detached
 (`nohup`, a background server) survives its pane and is part of the sweep too.

--- a/template/docs/guides/worktrees.md
+++ b/template/docs/guides/worktrees.md
@@ -10,7 +10,9 @@ from Herdr is [herdr.md](herdr.md).
 
 ## The decision rule
 
-Ask three questions. If any answer is **yes**, make a worktree.
+Ask three questions. If any answer is **yes**, default to a worktree — the
+refinements below name the exceptions (chiefly: serial work on an otherwise
+idle checkout).
 
 1. **Will this work change tracked files and need to be committed?** Two
    sessions editing the same checkout step on each other's diffs, staged

--- a/template/docs/guides/worktrees.md
+++ b/template/docs/guides/worktrees.md
@@ -73,9 +73,12 @@ dependencies, proves the git hooks fire inside it (`.git` is a *file* in a
 linked worktree, so `-c core.hooksPath=.git/hooks` silently resolves to
 nothing — a breaker the task exists to catch), prints the ready path, and
 rolls the tree back if any step fails. One default to know: a **new** branch
-is based on the *main worktree's* HEAD — so if the main checkout is sitting
-on another feature branch, an "independent" branch created now stacks on it
-and carries its commits into the PR. For an independent PR, have the main
+is based on the *main worktree's* HEAD — first verified against that branch's
+configured upstream, so a merely *stale* main is upgraded to the fresh
+upstream tip (announced) while a *diverged* one refuses with a `--base`
+remedy. The trap is a main checkout sitting on another feature branch: an
+"independent" branch created now stacks on it and carries its commits into
+the PR. For an independent PR, have the main
 worktree on `main` first, or pass the base explicitly
 (`--base origin/main`). The full option semantics and refusal cases are in
 [../conventions.md](../conventions.md) § Worktrees.


### PR DESCRIPTION
## What

Two new guides, shipped as template twins and indexed in `docs/guides/README.md`:

- **`docs/guides/worktrees.md`** — when a piece of work earns its own git worktree (the three-question rule: commits, repo tooling, durability — one per PR-sized unit, with the exceptions named), the sanctioned create/remove path (`task worktree:new` / `task worktree:rm`, base-refresh semantics, the `.git`-is-a-file breaker), how it pairs with Herdr (repo creates, Herdr binds; guarded retirement), and the end-of-fan-out sweep.
- **`docs/guides/herdr.md`** (jinja twin; the devcontainer link renders only when `devcontainer=true`) — workspaces/tabs/panes/agents/sessions and how they relate; lifecycle states (`working`/`blocked`/`idle`/`done`/`unknown`); everyday workflows; Herdr worktrees vs the repo recipe; the fan-out loop (spawn → prompt → wait → harvest → verify → review → retire → sweep) with per-attempt sentinels, bounded waits, and the panes-are-not-a-security-boundary rule; and multi-harness orchestration — Claude Code, Codex, Antigravity, OpenCode side by side on their own subscriptions, with per-harness launch notes (`--tools` + `--allowedTools` for Claude; narrowly-scoped rules and the `-a never` rejection mode for Codex).

## Why

The worktree decision rule and the Herdr operating model existed only as session lore. Both guides are distilled from real cross-harness fan-outs (label provisioning/pruning, backlog triage, issue-type assignment across the ponderousdev repos, tracked in harmon-init#1041) — every per-harness note corresponds to an observed failure mode.

## Verification

- `task verify` ✅ per round; `task ci` ✅ on the final head; dogfood parity + structure gates cover both twins.
- rigor: challenge ≤3 / min_rounds 1 (`default_rigor` standard, no issue bound); **review ≤2 and shepherd ≤2 by explicit maintainer instruction — below the default 3/4; disclosed here per Dev Loop**.
- Challenge ran 3 rounds (5 P1 + 3 P2 → 2 P1 + 3 P2 + 1 P3 → adjudicated 3 P1 + 2 P2), closing at the cap with all findings fixed; the maintainer accepted the capped close. Review ran 2 rounds (1 P1 + 1 P3 → adjudicated 1 P1 + 2 P2 + 1 P3), also closing at cap with all findings fixed and the maintainer choosing to proceed; the shepherd-stage current-head Codex cloud review is the independent pass over the final fixes.
- Author and local reviewer are different model families (Claude authored, Codex reviewed).

## Deferred findings

_(none — every adjudicated finding was fixed in place; nothing was deferred to this stage)_

## Adjudication record

<details><summary>Per-round ledger (challenge r1–r3, review r1–r2)</summary>

```text
template/docs/guides/worktrees.md:93 | herdr worktree remove before task worktree:rm bypasses ignored-file guard | fixed b10c096 (workspace close then task worktree:rm) | challenge r1 | P1→P1
template/docs/guides/herdr.md:259 | cheat-sheet open | remove is a pipeline | fixed b10c096 (separate lines) | challenge r1 | P1→P1
template/docs/guides/herdr.md:9 | unconditional devcontainers.md link on minimal profile | fixed b10c096 (jinja twin, conditional sentence) | challenge r1 | P1→P1
template/docs/guides/herdr.md:203 | qwen kind not in pinned Herdr 0.8.0 | fixed b10c096 (list 0.8.0 kinds, defer to herdr agent) | challenge r1 | P1→P2
template/docs/guides/herdr.md:250 | discovery pipeline runs tab/pane/agent as executables | fixed b10c096 (one command per line) | challenge r1 | P1→P1
template/docs/guides/herdr.md:176 | unbounded fan-out waits | fixed b10c096 (--timeout + handling) | challenge r1 | P2→P2
template/docs/guides/herdr.md:173 | retry-on-idle is at-least-once for side-effecting briefs | fixed b10c096 (check pane/report before re-send) | challenge r1 | P2→P2
template/docs/guides/worktrees.md:25 | pane scratch durability overstated | fixed b10c096 (processes die, files persist) | challenge r1 | P2→P2
challenge r1 | 5 P1 + 3 P2 as labeled; adjudicated 4 P1 + 4 P2; all fixed in b10c096
template/docs/guides/herdr.md.jinja:206 | step-7 retirement still pointed worktree-backed units at herdr worktree remove | fixed 57dfbe0 (workspace close + task worktree:rm; herdr remove = throwaway trees only) | challenge r2 | P1→P1 | subject partly created by r1 fix — inconsistency, not scaffolding
template/docs/guides/herdr.md.jinja:163 | pane workers described as independent principals; no trust boundary stated | fixed 57dfbe0 (panes are not a security boundary paragraph) | challenge r2 | P1→P1 | in scope, original text
template/docs/guides/herdr.md.jinja:181 | sentinel reuse across attempts satisfies stale wait-output | fixed 57dfbe0 (per-attempt nonce) | challenge r2 | P2→P2
template/docs/guides/worktrees.md:20 | implied worktrees isolate ports/caches | fixed 57dfbe0 (explicit non-isolation + per-worker allocation) | challenge r2 | P2→P2
template/docs/guides/herdr.md.jinja:143 | worktree create documented as taking --env (it does not) | fixed 57dfbe0 | challenge r2 | P2→P2
template/docs/guides/herdr.md.jinja:3 | intro assumed devcontainers on minimal profile | fixed 57dfbe0 (profile-neutral opening) | challenge r2 | P3→P3
challenge r2 | 2 P1 + 3 P2 + 1 P3 adjudicated as labeled; all fixed in 57dfbe0
template/docs/guides/herdr.md.jinja:206 | step-7 retirement still pointed at herdr worktree remove | fixed 57dfbe0 (workspace close + task worktree:rm; remove = Herdr-created only) | challenge r2 | P1→P1 (inconsistency introduced by r1 fix)
template/docs/guides/herdr.md.jinja:163 | panes described as own-permission principals; no trust boundary stated | fixed 57dfbe0 (panes are not a security boundary paragraph) | challenge r2 | P1→P1
template/docs/guides/herdr.md.jinja:181 | sentinel not unique per attempt; wait-output matches old snapshot | fixed 57dfbe0 (per-attempt nonce in sentinel + report path) | challenge r2 | P2→P2
template/docs/guides/worktrees.md:20 | rationale implied worktrees fix port/cache races | fixed 57dfbe0 (worktree isolates tree state only; allocate ports/caches per worker) | challenge r2 | P2→P2
template/docs/guides/herdr.md.jinja:143 | worktree create documented as taking --env; it does not | fixed 57dfbe0 (env via workspace/tab/pane create) | challenge r2 | P2→P2
template/docs/guides/herdr.md.jinja:3 | intro assumed devcontainers on all profiles | fixed 57dfbe0 (profile-neutral opening) | challenge r2 | P3→P3
challenge r2 | 2 P1 + 3 P2 + 1 P3 as labeled; adjudicated same; all fixed in 57dfbe0
template/docs/guides/herdr.md.jinja:263 | --allowedTools claimed as least privilege; --tools + merged settings ignored | fixed f4d86df46d9772ed6338128bce2c611da4ace059 | challenge r3 | P1→P1
template/docs/guides/herdr.md.jinja:269 | "prefix rules match first token only" inaccurate (argv-prefix matching) | fixed f4d86df46d9772ed6338128bce2c611da4ace059 | challenge r3 | P1→P2 (advice was narrow; factual sentence wrong)
template/docs/guides/worktrees.md:40 | pane-job tell contradicted criterion 2 (terraform plan/tooling in shared checkout) | fixed f4d86df46d9772ed6338128bce2c611da4ace059 | challenge r3 | P1→P1
template/docs/guides/worktrees.md:65 | new branch bases on main worktree HEAD; stacks on active feature branch | fixed f4d86df46d9772ed6338128bce2c611da4ace059 (warning + --base remedy) | challenge r3 | P1→P1
template/docs/guides/worktrees.md:114 | clean:branches dry-run default; sweep implied deletion | fixed f4d86df46d9772ed6338128bce2c611da4ace059 (--delete form shown) | challenge r3 | P2→P2
challenge r3 | 4 P1 + 1 P2 as labeled; adjudicated 3 P1 + 2 P2; all fixed in f4d86df46d9772ed6338128bce2c611da4ace059; CAP REACHED — escalated to maintainer per Dev Loop
docs/guides/herdr.md:83 | example waits for 'verify: ok' which task verify never prints | fixed 681792fb0cd3d37a2fb2accd66604f618d4bcc0d (self-appended per-outcome marker) | review r1 | P1→P1
docs/guides/worktrees.md:13 | 'any yes → worktree' contradicts serial-idle refinement | fixed 681792fb0cd3d37a2fb2accd66604f618d4bcc0d ('default to' + exceptions pointer) | review r1 | P3→P3
review r1 | 1 P1 + 1 P3; both fixed in 681792fb0cd3d37a2fb2accd66604f618d4bcc0d
docs/guides/herdr.md:275 | recipe demanded rules allowing every task command; allow escapes sandbox | fixed 6d9e996c57588d8726dbbd709b5466b36e4f03ac (rules only for prompt-worthy commands) | review r2 | P1→P1
docs/guides/herdr.md:190 | 0.8.0 agent-start premature readiness can race the brief | fixed 6d9e996c57588d8726dbbd709b5466b36e4f03ac (note added; confirm-working already mandated) | review r2 | P1→P2
docs/guides/worktrees.md:75 | base description omitted upstream refresh/diverge behavior | fixed 6d9e996c57588d8726dbbd709b5466b36e4f03ac | review r2 | P2→P2
docs/guides/herdr.md:235 | workspace close described as killing everything | fixed 6d9e996c57588d8726dbbd709b5466b36e4f03ac (detached processes stay) | review r2 | P3→P3
review r2 | 2 P1 + 1 P2 + 1 P3 as labeled; adjudicated 1 P1 + 2 P2 + 1 P3; all fixed in 6d9e996c57588d8726dbbd709b5466b36e4f03ac; CAP REACHED with adjudicated P1 — escalated to maintainer
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
